### PR TITLE
fix(huggingface): route embeddings through Inference Providers router

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@
 ### Fixed
 
 - Addressed reliability issues (timeouts, hanging) with HuggingFace API by providing a local fallback.
+- HuggingFace embedding provider was broken by HuggingFace retiring the legacy
+  `api-inference.huggingface.co/models/...` serverless endpoint. Feature-extraction
+  calls are now routed through the Inference Providers router at
+  `router.huggingface.co/hf-inference/models/<model>/pipeline/feature-extraction`.
+  A new `HUGGINGFACE_ENDPOINT_URL` env var lets users override the endpoint
+  (e.g. for self-hosted or dedicated HuggingFace Inference Endpoints).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ npx -y @smithery/cli install @jeanibarz/knowledge-base-mcp-server --client claud
         HUGGINGFACE_MODEL_NAME=sentence-transformers/all-MiniLM-L6-v2
         KNOWLEDGE_BASES_ROOT_DIR=$HOME/knowledge_bases
         ```
+    *   HuggingFace retired the legacy `api-inference.huggingface.co/models/...`
+        endpoint in 2025. Feature-extraction calls are now routed through the
+        Inference Providers router at
+        `https://router.huggingface.co/hf-inference/models/<model>/pipeline/feature-extraction`
+        by default. To target a self-hosted or dedicated Inference Endpoint,
+        set `HUGGINGFACE_ENDPOINT_URL` to the full POST URL.
 
     ### Additional Configuration
     

--- a/src/FaissIndexManager.ts
+++ b/src/FaissIndexManager.ts
@@ -14,6 +14,7 @@ import {
   FAISS_INDEX_PATH,
   EMBEDDING_PROVIDER,
   HUGGINGFACE_MODEL_NAME,
+  HUGGINGFACE_ENDPOINT_URL,
   OLLAMA_BASE_URL,
   OLLAMA_MODEL,
   OPENAI_MODEL_NAME,
@@ -101,6 +102,7 @@ export class FaissIndexManager {
       this.embeddings = new HuggingFaceInferenceEmbeddings({
         apiKey: huggingFaceApiKey,
         model: this.modelName,
+        endpointUrl: HUGGINGFACE_ENDPOINT_URL,
       });
     }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,6 +14,18 @@ export const EMBEDDING_PROVIDER = process.env.EMBEDDING_PROVIDER || 'huggingface
 export const DEFAULT_HUGGINGFACE_MODEL_NAME = 'sentence-transformers/all-MiniLM-L6-v2';
 export const HUGGINGFACE_MODEL_NAME = process.env.HUGGINGFACE_MODEL_NAME || DEFAULT_HUGGINGFACE_MODEL_NAME;
 
+// The legacy api-inference.huggingface.co endpoint that older versions of
+// @huggingface/inference target has been retired in favour of the
+// Inference Providers router. Route feature-extraction calls through the
+// router by default; allow a full override via HUGGINGFACE_ENDPOINT_URL
+// for self-hosted or Inference Endpoints deployments.
+export function huggingFaceRouterUrl(model: string): string {
+  return `https://router.huggingface.co/hf-inference/models/${model}/pipeline/feature-extraction`;
+}
+
+export const HUGGINGFACE_ENDPOINT_URL = process.env.HUGGINGFACE_ENDPOINT_URL
+  || huggingFaceRouterUrl(HUGGINGFACE_MODEL_NAME);
+
 // Ollama configuration
 export const OLLAMA_BASE_URL = process.env.OLLAMA_BASE_URL || 'http://localhost:11434';
 export const OLLAMA_MODEL = process.env.OLLAMA_MODEL || 'dengcao/Qwen3-Embedding-0.6B:Q8_0';


### PR DESCRIPTION
## Summary

- HuggingFace retired the legacy `api-inference.huggingface.co/models/<model>` serverless endpoint that `@huggingface/inference@2.x` POSTs to. Every `retrieve_knowledge` call via the HuggingFace provider now fails with `An error occurred while fetching the blob` after 7 retries — the endpoint returns HTTP 404 with an HTML error page.
- Routes feature-extraction calls through the new HuggingFace Inference Providers router at `router.huggingface.co/hf-inference/models/<model>/pipeline/feature-extraction` by passing `endpointUrl` to `HuggingFaceInferenceEmbeddings`. No SDK bump required — the pinned `@huggingface/inference@2.8.1` exposes `.endpoint()` which does exactly what we need.
- Adds `HUGGINGFACE_ENDPOINT_URL` env var so users can override the endpoint for self-hosted or dedicated HuggingFace Inference Endpoints.

## Why not bump `@huggingface/inference`?

The package is a transitive dep of `@langchain/community`, and the existing 2.8.1 already supports pointing at an arbitrary endpoint via `.endpoint(url)`. A major bump to v4 would change the public API shape and isn't necessary to restore functionality. Keeping the change scope minimal.

## Evidence

Direct probe of the two endpoints with the same valid HF token:

| Endpoint | Status |
|---|---|
| POST api-inference.huggingface.co/models/sentence-transformers/all-MiniLM-L6-v2 | HTTP 404 — "Cannot POST" |
| POST router.huggingface.co/hf-inference/models/sentence-transformers/all-MiniLM-L6-v2/pipeline/feature-extraction | HTTP 200 — returns 384-dim embedding |

## Verification

End-to-end check: built the MCP server, seeded two sample knowledge bases with HR policy + company facts, exercised `retrieve_knowledge` over stdio JSON-RPC with query `"How many vacation days do employees get?"`.

**Before this PR** (on `main`):
```
retrieve_knowledge → {
  "isError": true,
  "text": "Error retrieving knowledge: An error occurred while fetching the blob"
}
```

**After this PR**:
```
retrieve_knowledge → {
  "text": "## Semantic Search Results\n\n**Result 1:**\n**Score:** 0.83\n# HR Policies\nEmployees accrue 20 vacation days per calendar year.\n..."
}
```

Top result is the HR doc with cosine distance 0.83 — semantically correct match.

## Test plan

- [x] `npm install` — clean
- [x] `npm run build` — clean
- [x] `npm test` — 3 suites / 8 tests pass (unchanged from main)
- [x] End-to-end stdio MCP: `initialize` + `tools/list` + `list_knowledge_bases` + `retrieve_knowledge` all succeed via HuggingFace provider
- [ ] Optional maintainer-side override check: set `HUGGINGFACE_ENDPOINT_URL=https://your-endpoint` and confirm the server POSTs there

## Follow-ups (out of scope)

- `@huggingface/inference` v3/v4 eventually deserves a dedicated migration PR — it would unlock non-`hf-inference` providers (Together, Replicate, etc.) via the same router.