### PR TITLE
chore: add funding link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+buy_me_a_coffee: jeanibarz


### PR DESCRIPTION
## Summary
Add a GitHub funding configuration so the repository Sponsor button points to the existing Buy Me a Coffee page.

## Verification
- `npm test`
  - 3 test suites passed
  - 8 tests passed

## Notes
- Added `.github/FUNDING.yml` with `buy_me_a_coffee: jeanibarz`
- No runtime code changes