### PR TITLE
Upgrade Hugging Face inference provider support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - Refactored embedding logic to support provider abstraction and selection.
 - Improved error handling and logging for embedding operations.
+- Upgraded `@huggingface/inference` to the v4 client path through a compatible `@langchain/community` release.
 
 ### Fixed
 
@@ -23,6 +24,7 @@
   `router.huggingface.co/hf-inference/models/<model>/pipeline/feature-extraction`.
   A new `HUGGINGFACE_ENDPOINT_URL` env var lets users override the endpoint
   (e.g. for self-hosted or dedicated HuggingFace Inference Endpoints).
+- Added `HUGGINGFACE_PROVIDER` so non-default Inference Providers can be selected without custom glue while preserving `hf-inference` as the default.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -74,14 +74,21 @@ npx -y @smithery/cli install @jeanibarz/knowledge-base-mcp-server --client claud
         EMBEDDING_PROVIDER=huggingface          # Optional, this is the default
         HUGGINGFACE_API_KEY=your_api_key_here
         HUGGINGFACE_MODEL_NAME=sentence-transformers/all-MiniLM-L6-v2
+        HUGGINGFACE_PROVIDER=hf-inference       # Optional, router provider for serverless inference
         KNOWLEDGE_BASES_ROOT_DIR=$HOME/knowledge_bases
         ```
     *   HuggingFace retired the legacy `api-inference.huggingface.co/models/...`
         endpoint in 2025. Feature-extraction calls are now routed through the
         Inference Providers router at
         `https://router.huggingface.co/hf-inference/models/<model>/pipeline/feature-extraction`
-        by default. To target a self-hosted or dedicated Inference Endpoint,
-        set `HUGGINGFACE_ENDPOINT_URL` to the full POST URL.
+        by default. Set `HUGGINGFACE_PROVIDER` to choose a different supported
+        Inference Provider such as `together`, `replicate`, `fireworks-ai`,
+        `sambanova`, `nebius`, or `novita`. The existing
+        `HUGGINGFACE_API_KEY` value can be either a Hugging Face token or a
+        compatible provider key, depending on how the request is authenticated
+        upstream. To target a self-hosted or dedicated Inference Endpoint, set
+        `HUGGINGFACE_ENDPOINT_URL` to the full POST URL; explicit endpoint URLs
+        bypass router provider selection.
 
     ### Additional Configuration
     
@@ -154,7 +161,8 @@ npx -y @smithery/cli install @jeanibarz/knowledge-base-mcp-server --client claud
         "KNOWLEDGE_BASES_ROOT_DIR": "/path/to/knowledge_bases",
         "EMBEDDING_PROVIDER": "huggingface",
         "HUGGINGFACE_API_KEY": "YOUR_HUGGINGFACE_API_KEY",
-        "HUGGINGFACE_MODEL_NAME": "sentence-transformers/all-MiniLM-L6-v2"
+        "HUGGINGFACE_MODEL_NAME": "sentence-transformers/all-MiniLM-L6-v2",
+        "HUGGINGFACE_PROVIDER": "hf-inference"
       },
       "description": "Retrieves similar chunks from the knowledge base based on a query using HuggingFace."
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "0.1.0",
       "license": "UNLICENSED",
       "dependencies": {
-        "@huggingface/inference": "^2.8.1",
-        "@langchain/community": "^0.3.29",
-        "@langchain/core": "^0.3.39",
+        "@huggingface/inference": "^4.13.15",
+        "@langchain/community": "^0.3.59",
+        "@langchain/core": "^0.3.62",
         "@langchain/ollama": "^0.2.3",
         "@langchain/openai": "^0.4.3",
         "@modelcontextprotocol/sdk": "^1.17.2",
@@ -647,23 +647,79 @@
       "integrity": "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==",
       "license": "MIT"
     },
+    "node_modules/@datastructures-js/deque": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@datastructures-js/deque/-/deque-1.0.8.tgz",
+      "integrity": "sha512-PSBhJ2/SmeRPRHuBv7i/fHWIdSC3JTyq56qb+Rq0wjOagi0/fdV5/B/3Md5zFZus/W6OkSPMaxMKKMNMrSmubg==",
+      "license": "MIT"
+    },
+    "node_modules/@graphql-typed-document-node/core": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
+      "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.3.tgz",
+      "integrity": "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.8.0",
+        "@js-sdsl/ordered-map": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=12.10.0"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.0.tgz",
+      "integrity": "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.5.3",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/@huggingface/inference": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/@huggingface/inference/-/inference-2.8.1.tgz",
-      "integrity": "sha512-EfsNtY9OR6JCNaUa5bZu2mrs48iqeTz0Gutwf+fU0Kypx33xFQB4DKMhp8u4Ee6qVbLbNWvTHuWwlppLQl4p4Q==",
+      "version": "4.13.15",
+      "resolved": "https://registry.npmjs.org/@huggingface/inference/-/inference-4.13.15.tgz",
+      "integrity": "sha512-V7B13KFDVhYkQqgx8vpMcmtEG+PoePlh65IUvpphTTItHAq6zRLcsS4torh1QavUaT+6nEwho4wFXzBQNGBwKQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@huggingface/tasks": "^0.12.9"
+        "@huggingface/jinja": "^0.5.5",
+        "@huggingface/tasks": "^0.19.90"
       },
       "engines": {
         "node": ">=18"
       }
     },
+    "node_modules/@huggingface/jinja": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/@huggingface/jinja/-/jinja-0.5.7.tgz",
+      "integrity": "sha512-OosMEbF/R6zkKNNzqhI7kvKYCpo1F0UeIv46/h4D4UjVEKKd6k3TiV8sgu6fkreX4lbBiRI+lZG8UnXnqVQmEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@huggingface/tasks": {
-      "version": "0.12.30",
-      "resolved": "https://registry.npmjs.org/@huggingface/tasks/-/tasks-0.12.30.tgz",
-      "integrity": "sha512-A1ITdxbEzx9L8wKR8pF7swyrTLxWNDFIGDLUWInxvks2ruQ8PLRBZe8r0EcjC3CDdtlj9jV1V4cgV35K/iy3GQ==",
+      "version": "0.19.90",
+      "resolved": "https://registry.npmjs.org/@huggingface/tasks/-/tasks-0.19.90.tgz",
+      "integrity": "sha512-nfV9luJbvwGQ/5oKXkKhCV9h4X7mwh1YaGG3ORd6UMLDSwr1OFSSatcBX0O9OtBtmNK19aGSjbLFqqgcIR6+IA==",
       "license": "MIT"
     },
     "node_modules/@ibm-cloud/watsonx-ai": {
@@ -1563,22 +1619,32 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
+      }
+    },
     "node_modules/@langchain/community": {
-      "version": "0.3.29",
-      "resolved": "https://registry.npmjs.org/@langchain/community/-/community-0.3.29.tgz",
-      "integrity": "sha512-6XIPGctpH3KziFpdVDEvYBEQMMsNomffqy545shoxOLoMkZqgn1wfMs6R7ltzzS0p3LJUXW1RbwAUEuWp0rbuA==",
+      "version": "0.3.59",
+      "resolved": "https://registry.npmjs.org/@langchain/community/-/community-0.3.59.tgz",
+      "integrity": "sha512-lYoVFC9wArWMXaixDgIadTE22jk4ZYAvSHHmwaMRagkGr5f4kyqMeJ83UUeW76XPx2cBy2fRSO+acSgqSuWE6A==",
       "license": "MIT",
       "dependencies": {
-        "@langchain/openai": ">=0.2.0 <0.5.0",
+        "@langchain/openai": ">=0.2.0 <0.7.0",
+        "@langchain/weaviate": "^0.2.0",
         "binary-extensions": "^2.2.0",
-        "expr-eval": "^2.0.2",
         "flat": "^5.0.2",
         "js-yaml": "^4.1.0",
         "langchain": ">=0.2.3 <0.3.0 || >=0.3.4 <0.4.0",
-        "langsmith": ">=0.2.8 <0.4.0",
+        "langsmith": "^0.3.67",
+        "math-expression-evaluator": "^2.0.0",
         "uuid": "^10.0.0",
-        "zod": "^3.22.3",
-        "zod-to-json-schema": "^3.22.5"
+        "zod": "^3.25.32"
       },
       "engines": {
         "node": ">=18"
@@ -1586,14 +1652,14 @@
       "peerDependencies": {
         "@arcjet/redact": "^v1.0.0-alpha.23",
         "@aws-crypto/sha256-js": "^5.0.0",
-        "@aws-sdk/client-bedrock-agent-runtime": "^3.583.0",
-        "@aws-sdk/client-bedrock-runtime": "^3.422.0",
-        "@aws-sdk/client-dynamodb": "^3.310.0",
-        "@aws-sdk/client-kendra": "^3.352.0",
-        "@aws-sdk/client-lambda": "^3.310.0",
-        "@aws-sdk/client-s3": "^3.310.0",
-        "@aws-sdk/client-sagemaker-runtime": "^3.310.0",
-        "@aws-sdk/client-sfn": "^3.310.0",
+        "@aws-sdk/client-bedrock-agent-runtime": "^3.749.0",
+        "@aws-sdk/client-bedrock-runtime": "^3.749.0",
+        "@aws-sdk/client-dynamodb": "^3.749.0",
+        "@aws-sdk/client-kendra": "^3.749.0",
+        "@aws-sdk/client-lambda": "^3.749.0",
+        "@aws-sdk/client-s3": "^3.749.0",
+        "@aws-sdk/client-sagemaker-runtime": "^3.749.0",
+        "@aws-sdk/client-sfn": "^3.749.0",
         "@aws-sdk/credential-provider-node": "^3.388.0",
         "@azure/search-documents": "^12.0.0",
         "@azure/storage-blob": "^12.15.0",
@@ -1611,11 +1677,11 @@
         "@google-ai/generativelanguage": "*",
         "@google-cloud/storage": "^6.10.1 || ^7.7.0",
         "@gradientai/nodejs-sdk": "^1.2.0",
-        "@huggingface/inference": "^2.6.4",
-        "@huggingface/transformers": "^3.2.3",
+        "@huggingface/inference": "^4.0.5",
+        "@huggingface/transformers": "^3.5.2",
         "@ibm-cloud/watsonx-ai": "*",
-        "@lancedb/lancedb": "^0.12.0",
-        "@langchain/core": ">=0.2.21 <0.4.0",
+        "@lancedb/lancedb": "^0.19.1",
+        "@langchain/core": ">=0.3.58 <0.4.0",
         "@layerup/layerup-security": "^1.5.12",
         "@libsql/client": "^0.14.0",
         "@mendable/firecrawl-js": "^1.4.3",
@@ -1627,7 +1693,7 @@
         "@pinecone-database/pinecone": "*",
         "@planetscale/database": "^1.8.0",
         "@premai/prem-sdk": "^0.3.25",
-        "@qdrant/js-client-rest": "^1.8.2",
+        "@qdrant/js-client-rest": "^1.15.0",
         "@raycast/api": "^1.55.2",
         "@rockset/client": "^0.9.1",
         "@smithy/eventstream-codec": "^2.0.5",
@@ -1649,6 +1715,7 @@
         "@zilliz/milvus2-sdk-node": ">=2.3.5",
         "apify-client": "^2.7.1",
         "assemblyai": "^4.6.0",
+        "azion": "^1.11.1",
         "better-sqlite3": ">=9.4.0 <12.0.0",
         "cassandra-driver": "^4.7.2",
         "cborg": "^4.1.1",
@@ -1662,12 +1729,10 @@
         "crypto-js": "^4.2.0",
         "d3-dsv": "^2.0.0",
         "discord.js": "^14.14.1",
-        "dria": "^0.0.3",
         "duck-duck-scrape": "^2.2.5",
         "epub2": "^3.0.1",
-        "faiss-node": "^0.5.1",
         "fast-xml-parser": "*",
-        "firebase-admin": "^11.9.0 || ^12.0.0",
+        "firebase-admin": "^11.9.0 || ^12.0.0 || ^13.0.0",
         "google-auth-library": "*",
         "googleapis": "*",
         "hnswlib-node": "^3.0.0",
@@ -1683,7 +1748,9 @@
         "lodash": "^4.17.21",
         "lunary": "^0.7.10",
         "mammoth": "^1.6.0",
-        "mongodb": ">=5.2.0",
+        "mariadb": "^3.4.0",
+        "mem0ai": "^2.1.8",
+        "mongodb": "^6.17.0",
         "mysql2": "^3.9.8",
         "neo4j-driver": "*",
         "notion-to-md": "^3.1.0",
@@ -1705,7 +1772,7 @@
         "typesense": "^1.5.3",
         "usearch": "^1.1.1",
         "voy-search": "0.6.2",
-        "weaviate-ts-client": "*",
+        "weaviate-client": "^3.5.2",
         "web-auth-library": "^1.0.3",
         "word-extractor": "*",
         "ws": "^8.14.2",
@@ -1743,6 +1810,9 @@
           "optional": true
         },
         "@aws-sdk/credential-provider-node": {
+          "optional": true
+        },
+        "@aws-sdk/dsql-signer": {
           "optional": true
         },
         "@azure/search-documents": {
@@ -1898,6 +1968,9 @@
         "assemblyai": {
           "optional": true
         },
+        "azion": {
+          "optional": true
+        },
         "better-sqlite3": {
           "optional": true
         },
@@ -1937,16 +2010,10 @@
         "discord.js": {
           "optional": true
         },
-        "dria": {
-          "optional": true
-        },
         "duck-duck-scrape": {
           "optional": true
         },
         "epub2": {
-          "optional": true
-        },
-        "faiss-node": {
           "optional": true
         },
         "fast-xml-parser": {
@@ -1995,6 +2062,12 @@
           "optional": true
         },
         "mammoth": {
+          "optional": true
+        },
+        "mariadb": {
+          "optional": true
+        },
+        "mem0ai": {
           "optional": true
         },
         "mongodb": {
@@ -2060,7 +2133,7 @@
         "voy-search": {
           "optional": true
         },
-        "weaviate-ts-client": {
+        "weaviate-client": {
           "optional": true
         },
         "web-auth-library": {
@@ -2151,6 +2224,22 @@
         "@langchain/core": ">=0.2.21 <0.4.0"
       }
     },
+    "node_modules/@langchain/weaviate": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@langchain/weaviate/-/weaviate-0.2.3.tgz",
+      "integrity": "sha512-WqNGn1eSrI+ZigJd7kZjCj3fvHBYicKr054qts2nNJ+IyO5dWmY3oFTaVHFq1OLFVZJJxrFeDnxSEOC3JnfP0w==",
+      "license": "MIT",
+      "dependencies": {
+        "uuid": "^10.0.0",
+        "weaviate-client": "^3.5.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@langchain/core": ">=0.2.21 <0.4.0"
+      }
+    },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.20.1.tgz",
@@ -2189,6 +2278,70 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
@@ -2404,6 +2557,12 @@
         "node": ">=6.5"
       }
     },
+    "node_modules/abort-controller-x": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/abort-controller-x/-/abort-controller-x-0.5.0.tgz",
+      "integrity": "sha512-yTt9CI0x+nRfX6BFMenEGP8ooPvErGH6AbFz20C2IeOLIlDsrw/VHpgne3GsCEuTA410IiFiaLVFKmgM4bKEPQ==",
+      "license": "MIT"
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -2486,7 +2645,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3065,7 +3223,6 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
@@ -3237,6 +3394,15 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/cross-fetch": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.2.0.tgz",
+      "integrity": "sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.7.0"
       }
     },
     "node_modules/cross-spawn": {
@@ -3441,7 +3607,6 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -3520,7 +3685,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -3670,12 +3834,6 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
-    "node_modules/expr-eval": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/expr-eval/-/expr-eval-2.0.2.tgz",
-      "integrity": "sha512-4EMSHGOPSwAfBiibw3ndnP0AvjDWLsMvGOvWEZ2F96IGk0bIVdjQisOHxReSkE13mHcfbuCiXw+G4y0zv6N8Eg==",
-      "license": "MIT"
-    },
     "node_modules/express": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
@@ -3766,7 +3924,6 @@
       "integrity": "sha512-zD8wobJn8C6OLWo68Unho+Ih8l6nSRB2w3Amj01a+xc4bsEvd2mBDLklAn7VocA9XO3WDvQL/bLpi5flkCn/XQ==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bindings": "^1.5.0",
         "node-addon-api": "^6.0.0",
@@ -4006,7 +4163,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -4131,6 +4287,29 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/graphql": {
+      "version": "16.13.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.2.tgz",
+      "integrity": "sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
+    "node_modules/graphql-request": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-6.1.0.tgz",
+      "integrity": "sha512-p+XPfS4q7aIpKVcgmnZKhMNqhltk20hfXtkaIkTfjjmiKMJ5xrt5c743cL03y/K7y1rg3WrIC49xGiEQ4mxdNw==",
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.2.0",
+        "cross-fetch": "^3.1.5"
+      },
+      "peerDependencies": {
+        "graphql": "14 - 16"
+      }
     },
     "node_modules/handlebars": {
       "version": "4.7.8",
@@ -4437,7 +4616,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6125,16 +6303,15 @@
       }
     },
     "node_modules/langsmith": {
-      "version": "0.3.39",
-      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.3.39.tgz",
-      "integrity": "sha512-dzrsERzrDh/jSuhOACcZaZf3zENSROk+1XGWFdBxeBa/aFuV7sQzG+wYH+Pdr+VOw2RUoFzl+PHzkuWZw1zuRQ==",
+      "version": "0.3.87",
+      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.3.87.tgz",
+      "integrity": "sha512-XXR1+9INH8YX96FKWc5tie0QixWz6tOqAsAKfcJyPkE0xPep+NDz0IQLR32q4bn10QK3LqD2HN6T3n6z1YLW7Q==",
       "license": "MIT",
       "dependencies": {
         "@types/uuid": "^10.0.0",
         "chalk": "^4.1.2",
         "console-table-printer": "^2.12.1",
         "p-queue": "^6.6.2",
-        "p-retry": "4",
         "semver": "^7.6.3",
         "uuid": "^10.0.0"
       },
@@ -6189,6 +6366,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT"
+    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -6238,6 +6421,12 @@
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -6280,6 +6469,12 @@
       "dependencies": {
         "tmpl": "1.0.5"
       }
+    },
+    "node_modules/math-expression-evaluator": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-2.0.7.tgz",
+      "integrity": "sha512-uwliJZ6BPHRq4eiqNWxZBDzKUiS5RIynFFcgchqhBOloVLVBpZpNG8jRYkedLcBvhph8TnRyWEuxPqiQcwIdog==",
+      "license": "MIT"
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -6446,6 +6641,36 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/nice-grpc": {
+      "version": "2.1.15",
+      "resolved": "https://registry.npmjs.org/nice-grpc/-/nice-grpc-2.1.15.tgz",
+      "integrity": "sha512-agPIt7dtQASnN5p1X3c2S5amDhWRWRT0Jp62trmpMBKSbkm87l8bG2slqxSthlrGa4AnRPG8+lFf4y8nn+Pogw==",
+      "license": "MIT",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.14.0",
+        "abort-controller-x": "^0.5.0",
+        "nice-grpc-common": "^2.0.3"
+      }
+    },
+    "node_modules/nice-grpc-client-middleware-retry": {
+      "version": "3.1.14",
+      "resolved": "https://registry.npmjs.org/nice-grpc-client-middleware-retry/-/nice-grpc-client-middleware-retry-3.1.14.tgz",
+      "integrity": "sha512-n/E3n73R6N59Ef7YJ34NvCOQs45ZK4JhlKQn1uV5HuM2PktUoG2KKhoAaxn+7zdtV9dwstPLSv5IT/XxMle0og==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller-x": "^0.5.0",
+        "nice-grpc-common": "^2.0.3"
+      }
+    },
+    "node_modules/nice-grpc-common": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/nice-grpc-common/-/nice-grpc-common-2.0.3.tgz",
+      "integrity": "sha512-MEhnD3JMah0mgyivpb9hpRDbOBuXBxI/TVO+OK1h6rC97WM42HsPMR+zzRNQ0C5BqYJTw1nyWiQRD0DucO+pjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ts-error": "^1.0.6"
+      }
     },
     "node_modules/node-abi": {
       "version": "3.74.0",
@@ -7071,6 +7296,30 @@
         "node": ">= 6"
       }
     },
+    "node_modules/protobufjs": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
+      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -7300,7 +7549,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7763,7 +8011,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -7778,7 +8025,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -7976,6 +8222,12 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/ts-error": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/ts-error/-/ts-error-1.0.6.tgz",
+      "integrity": "sha512-tLJxacIQUM82IR7JO1UUkKlYuUTmoY9HBJAmNWFzheSlDS5SPMcNIepejHJa4BpPQLAcbRhRf3GDJzyj6rbKvA==",
       "license": "MIT"
     },
     "node_modules/ts-jest": {
@@ -8290,6 +8542,39 @@
         "makeerror": "1.0.12"
       }
     },
+    "node_modules/weaviate-client": {
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/weaviate-client/-/weaviate-client-3.12.1.tgz",
+      "integrity": "sha512-rpkWkJlrhmMqJrfva7uKmGgr3oIbw717yQ440Sxo/5CXdSDMFFJ5KAo02ij1a1RgtqrT9D4sbGK966yxhro96g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@datastructures-js/deque": "^1.0.8",
+        "abort-controller-x": "^0.5.0",
+        "graphql": "^16.12.0",
+        "graphql-request": "^6.1.0",
+        "long": "^5.3.2",
+        "nice-grpc": "^2.1.14",
+        "nice-grpc-client-middleware-retry": "^3.1.13",
+        "nice-grpc-common": "^2.0.2",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/weaviate-client/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -8338,7 +8623,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -8356,7 +8640,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -8413,7 +8696,6 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"
@@ -8442,7 +8724,6 @@
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
       "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
@@ -8461,7 +8742,6 @@
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
   "author": "jean.ibarz",
   "license": "UNLICENSED",
   "dependencies": {
-    "@huggingface/inference": "^2.8.1",
-    "@langchain/community": "^0.3.29",
-    "@langchain/core": "^0.3.39",
+    "@huggingface/inference": "^4.13.15",
+    "@langchain/community": "^0.3.59",
+    "@langchain/core": "^0.3.62",
     "@langchain/ollama": "^0.2.3",
     "@langchain/openai": "^0.4.3",
     "@modelcontextprotocol/sdk": "^1.17.2",

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -21,6 +21,10 @@ startCommand:
         type: string
         default: sentence-transformers/all-MiniLM-L6-v2
         description: Hugging Face model for embeddings
+      huggingfaceProvider:
+        type: string
+        default: hf-inference
+        description: Hugging Face Inference Provider to use when routing through the HF router (examples: hf-inference, together, replicate, fireworks-ai, sambanova)
       embeddingProvider:
         type: string
         enum: ["huggingface", "ollama"]
@@ -63,6 +67,7 @@ startCommand:
         KNOWLEDGE_BASES_ROOT_DIR: config.knowledgeBasesRootDir,
         FAISS_INDEX_PATH: config.faissIndexPath,
         HUGGINGFACE_MODEL_NAME: config.huggingfaceModelName,
+        HUGGINGFACE_PROVIDER: config.huggingfaceProvider,
         EMBEDDING_PROVIDER: config.embeddingProvider,
         OLLAMA_BASE_URL: config.ollamaBaseUrl,
         OLLAMA_MODEL: config.ollamaModel
@@ -73,6 +78,7 @@ startCommand:
     knowledgeBasesRootDir: /data/knowledge_bases
     faissIndexPath: /data/knowledge_bases/.faiss
     huggingfaceModelName: sentence-transformers/all-MiniLM-L6-v2
+    huggingfaceProvider: hf-inference
     embeddingProvider: huggingface
     ollamaBaseUrl: http://localhost:11434
     ollamaModel: dengcao/Qwen3-Embedding-0.6B:Q8_0

--- a/src/FaissIndexManager.test.ts
+++ b/src/FaissIndexManager.test.ts
@@ -7,6 +7,7 @@ const addDocumentsMock = jest.fn();
 const fromTextsMock = jest.fn();
 const loadMock = jest.fn();
 const similaritySearchMock = jest.fn();
+const embeddingConstructorMock = jest.fn();
 
 class MockFaissStore {
   async addDocuments(...args: unknown[]) {
@@ -35,7 +36,9 @@ class MockFaissStore {
 jest.mock('@langchain/community/embeddings/hf', () => ({
   __esModule: true,
   HuggingFaceInferenceEmbeddings: class MockEmbedding {
-    constructor(public _config: unknown) {}
+    constructor(public _config: unknown) {
+      embeddingConstructorMock(_config);
+    }
   },
 }));
 
@@ -56,6 +59,8 @@ describe('FaissIndexManager permission handling', () => {
     FAISS_INDEX_PATH: process.env.FAISS_INDEX_PATH,
     EMBEDDING_PROVIDER: process.env.EMBEDDING_PROVIDER,
     HUGGINGFACE_API_KEY: process.env.HUGGINGFACE_API_KEY,
+    HUGGINGFACE_ENDPOINT_URL: process.env.HUGGINGFACE_ENDPOINT_URL,
+    HUGGINGFACE_PROVIDER: process.env.HUGGINGFACE_PROVIDER,
     LOG_FILE: process.env.LOG_FILE,
   };
 
@@ -66,6 +71,7 @@ describe('FaissIndexManager permission handling', () => {
     fromTextsMock.mockReset();
     loadMock.mockReset();
     similaritySearchMock.mockReset();
+    embeddingConstructorMock.mockReset();
   });
 
   afterEach(() => {
@@ -104,6 +110,45 @@ describe('FaissIndexManager permission handling', () => {
     } finally {
       await fsp.chmod(lockedDir, 0o700);
     }
+  });
+
+  it('passes the configured Hugging Face provider to the embeddings wrapper', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-hf-provider-'));
+    process.env.KNOWLEDGE_BASES_ROOT_DIR = tempDir;
+    process.env.FAISS_INDEX_PATH = path.join(tempDir, '.faiss');
+    process.env.EMBEDDING_PROVIDER = 'huggingface';
+    process.env.HUGGINGFACE_API_KEY = 'test-key';
+    process.env.HUGGINGFACE_PROVIDER = 'replicate';
+
+    jest.resetModules();
+    const { FaissIndexManager } = await import('./FaissIndexManager.js');
+    new FaissIndexManager();
+
+    expect(embeddingConstructorMock).toHaveBeenCalledWith(expect.objectContaining({
+      apiKey: 'test-key',
+      model: 'sentence-transformers/all-MiniLM-L6-v2',
+      provider: 'replicate',
+    }));
+  });
+
+  it('does not pass a Hugging Face provider when a custom endpoint URL is set', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-hf-endpoint-'));
+    process.env.KNOWLEDGE_BASES_ROOT_DIR = tempDir;
+    process.env.FAISS_INDEX_PATH = path.join(tempDir, '.faiss');
+    process.env.EMBEDDING_PROVIDER = 'huggingface';
+    process.env.HUGGINGFACE_API_KEY = 'test-key';
+    process.env.HUGGINGFACE_PROVIDER = 'replicate';
+    process.env.HUGGINGFACE_ENDPOINT_URL = 'http://127.0.0.1:9999/custom/embed';
+
+    jest.resetModules();
+    const { FaissIndexManager } = await import('./FaissIndexManager.js');
+    new FaissIndexManager();
+
+    expect(embeddingConstructorMock).toHaveBeenCalledWith(expect.objectContaining({
+      apiKey: 'test-key',
+      endpointUrl: 'http://127.0.0.1:9999/custom/embed',
+      provider: undefined,
+    }));
   });
 
   it('logs permission errors to file when saving FAISS index fails', async () => {

--- a/src/FaissIndexManager.ts
+++ b/src/FaissIndexManager.ts
@@ -14,7 +14,9 @@ import {
   FAISS_INDEX_PATH,
   EMBEDDING_PROVIDER,
   HUGGINGFACE_MODEL_NAME,
+  HUGGINGFACE_PROVIDER,
   HUGGINGFACE_ENDPOINT_URL,
+  HUGGINGFACE_ENDPOINT_URL_OVERRIDDEN,
   OLLAMA_BASE_URL,
   OLLAMA_MODEL,
   OPENAI_MODEL_NAME,
@@ -103,10 +105,17 @@ export class FaissIndexManager {
         apiKey: huggingFaceApiKey,
         model: this.modelName,
         endpointUrl: HUGGINGFACE_ENDPOINT_URL,
+        provider: HUGGINGFACE_ENDPOINT_URL_OVERRIDDEN ? undefined : HUGGINGFACE_PROVIDER,
       });
     }
 
-    logger.info(`Using embedding provider: ${this.embeddingProvider}, model: ${this.modelName}`);
+    if (this.embeddingProvider === 'huggingface') {
+      logger.info(
+        `Using embedding provider: ${this.embeddingProvider}, model: ${this.modelName}, huggingface provider: ${HUGGINGFACE_ENDPOINT_URL_OVERRIDDEN ? 'endpoint override' : HUGGINGFACE_PROVIDER}`
+      );
+    } else {
+      logger.info(`Using embedding provider: ${this.embeddingProvider}, model: ${this.modelName}`);
+    }
   }
 
   async initialize(): Promise<void> {

--- a/src/HuggingFaceInferenceEmbeddings.integration.test.ts
+++ b/src/HuggingFaceInferenceEmbeddings.integration.test.ts
@@ -1,0 +1,67 @@
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import { once } from 'node:events';
+
+import { HuggingFaceInferenceEmbeddings } from '@langchain/community/embeddings/hf';
+
+async function readJsonBody(req: IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return JSON.parse(Buffer.concat(chunks).toString('utf-8'));
+}
+
+describe('HuggingFaceInferenceEmbeddings compatibility', () => {
+  it('posts to an explicit endpoint override using the v4 client', async () => {
+    const requests: Array<{
+      url: string | undefined;
+      authorization: string | undefined;
+      body: unknown;
+    }> = [];
+
+    const server = createServer(async (req: IncomingMessage, res: ServerResponse) => {
+      requests.push({
+        url: req.url,
+        authorization: req.headers.authorization,
+        body: await readJsonBody(req),
+      });
+
+      res.statusCode = 200;
+      res.setHeader('content-type', 'application/json');
+      res.end(JSON.stringify([[0.5, 0.25, 0.125]]));
+    });
+
+    server.listen(0, '127.0.0.1');
+    await once(server, 'listening');
+
+    const address = server.address();
+    if (!address || typeof address === 'string') {
+      throw new Error('Expected server to listen on an ephemeral TCP port');
+    }
+
+    const endpointUrl = `http://127.0.0.1:${address.port}/custom/embed`;
+
+    try {
+      const embeddings = new HuggingFaceInferenceEmbeddings({
+        apiKey: 'test-key',
+        model: 'sentence-transformers/all-MiniLM-L6-v2',
+        endpointUrl,
+      });
+
+      const result = await embeddings.embedQuery('hello endpoint');
+
+      expect(result).toEqual([0.5, 0.25, 0.125]);
+      expect(requests).toHaveLength(1);
+      expect(requests[0]).toEqual({
+        url: '/custom/embed',
+        authorization: 'Bearer test-key',
+        body: {
+          inputs: ['hello endpoint'],
+        },
+      });
+    } finally {
+      server.close();
+      await once(server, 'close');
+    }
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,6 @@
 import * as path from 'path';
 import * as os from 'os';
+import type { InferenceProviderOrPolicy } from '@huggingface/inference';
 
 export const KNOWLEDGE_BASES_ROOT_DIR = process.env.KNOWLEDGE_BASES_ROOT_DIR ||
   path.join(os.homedir(), 'knowledge_bases');
@@ -13,6 +14,12 @@ export const EMBEDDING_PROVIDER = process.env.EMBEDDING_PROVIDER || 'huggingface
 // HuggingFace configuration
 export const DEFAULT_HUGGINGFACE_MODEL_NAME = 'sentence-transformers/all-MiniLM-L6-v2';
 export const HUGGINGFACE_MODEL_NAME = process.env.HUGGINGFACE_MODEL_NAME || DEFAULT_HUGGINGFACE_MODEL_NAME;
+export const DEFAULT_HUGGINGFACE_PROVIDER = 'hf-inference';
+export const HUGGINGFACE_PROVIDER = (
+  process.env.HUGGINGFACE_PROVIDER || DEFAULT_HUGGINGFACE_PROVIDER
+) as InferenceProviderOrPolicy;
+const HUGGINGFACE_ENDPOINT_URL_OVERRIDE = process.env.HUGGINGFACE_ENDPOINT_URL?.trim();
+export const HUGGINGFACE_ENDPOINT_URL_OVERRIDDEN = Boolean(HUGGINGFACE_ENDPOINT_URL_OVERRIDE);
 
 // The legacy api-inference.huggingface.co endpoint that older versions of
 // @huggingface/inference target has been retired in favour of the
@@ -23,7 +30,7 @@ export function huggingFaceRouterUrl(model: string): string {
   return `https://router.huggingface.co/hf-inference/models/${model}/pipeline/feature-extraction`;
 }
 
-export const HUGGINGFACE_ENDPOINT_URL = process.env.HUGGINGFACE_ENDPOINT_URL
+export const HUGGINGFACE_ENDPOINT_URL = HUGGINGFACE_ENDPOINT_URL_OVERRIDE
   || huggingFaceRouterUrl(HUGGINGFACE_MODEL_NAME);
 
 // Ollama configuration


### PR DESCRIPTION
Upgrades Hugging Face inference support to the current client stack.

Changes:
- bump `@huggingface/inference` to v4
- align `@langchain/community` and `@langchain/core` with the new HF client
- add `HUGGINGFACE_PROVIDER` support for router-based inference providers
- preserve explicit `HUGGINGFACE_ENDPOINT_URL` override behavior
- add tests covering provider plumbing and endpoint override behavior

Verification:
- `npm run build`
- `npm test`

Closes #21