### PR TITLE
refactor: save FAISS index once per updateIndex call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 - Refactored embedding logic to support provider abstraction and selection.
 - Improved error handling and logging for embedding operations.
 - Upgraded `@huggingface/inference` to the v4 client path through a compatible `@langchain/community` release.
+- `FaissIndexManager.updateIndex` now saves the FAISS index once per call instead of once per changed file, and writes hash sidecars atomically (tmp + rename) only after the index has persisted successfully. Behavior on the happy path is unchanged; a crash between save and sidecar writes now leaves the unclaimed files to be re-embedded on the next run rather than claiming hashes for vectors that never landed. (RFC 007 PR 1.1)
+- Replaced blocking `fs.existsSync` calls in `FaissIndexManager` with non-blocking `fsp.stat`-based checks. (RFC 007 PR 1.1)
 
 ### Fixed
 

--- a/benchmarks/results/stage-1.1-stub-node24-linux-x64.json
+++ b/benchmarks/results/stage-1.1-stub-node24-linux-x64.json
@@ -1,0 +1,103 @@
+{
+  "arch": "x64",
+  "git_sha": "ec94dfb",
+  "node_version": "v24.11.1",
+  "os": "linux",
+  "provider": "stub",
+  "scenarios": {
+    "cold_index": {
+      "add_documents_calls": 99,
+      "chunks": 600,
+      "files": 100,
+      "from_texts_calls": 1,
+      "ms": 12307.429,
+      "save_calls": 1
+    },
+    "cold_start": {
+      "fixture_documents": 120,
+      "ms": 37.123,
+      "rss_bytes": 127848448
+    },
+    "memory_peak": {
+      "chunk_count": 600,
+      "files": 100,
+      "heap_used_bytes": 27643944,
+      "rss_bytes": 143896576
+    },
+    "retrieval_quality": {
+      "default_fanout_factor": 3,
+      "default_loaded_kbs": 5,
+      "default_recall_at_10": 1,
+      "query_count": 50,
+      "sweep": [
+        {
+          "expected_hit_rate_at_10": 0.5,
+          "fanout_factor": 1,
+          "loaded_kbs": 3,
+          "recall_at_10": 0.604
+        },
+        {
+          "expected_hit_rate_at_10": 0.68,
+          "fanout_factor": 1,
+          "loaded_kbs": 5,
+          "recall_at_10": 1
+        },
+        {
+          "expected_hit_rate_at_10": 0.5,
+          "fanout_factor": 2,
+          "loaded_kbs": 3,
+          "recall_at_10": 0.604
+        },
+        {
+          "expected_hit_rate_at_10": 0.68,
+          "fanout_factor": 2,
+          "loaded_kbs": 5,
+          "recall_at_10": 1
+        },
+        {
+          "expected_hit_rate_at_10": 0.5,
+          "fanout_factor": 3,
+          "loaded_kbs": 3,
+          "recall_at_10": 0.604
+        },
+        {
+          "expected_hit_rate_at_10": 0.68,
+          "fanout_factor": 3,
+          "loaded_kbs": 5,
+          "recall_at_10": 1
+        },
+        {
+          "expected_hit_rate_at_10": 0.5,
+          "fanout_factor": 5,
+          "loaded_kbs": 3,
+          "recall_at_10": 0.604
+        },
+        {
+          "expected_hit_rate_at_10": 0.68,
+          "fanout_factor": 5,
+          "loaded_kbs": 5,
+          "recall_at_10": 1
+        },
+        {
+          "expected_hit_rate_at_10": 0.5,
+          "fanout_factor": 10,
+          "loaded_kbs": 3,
+          "recall_at_10": 0.604
+        },
+        {
+          "expected_hit_rate_at_10": 0.68,
+          "fanout_factor": 10,
+          "loaded_kbs": 5,
+          "recall_at_10": 1
+        }
+      ]
+    },
+    "warm_query": {
+      "p50_ms": 91.618,
+      "p95_ms": 100.515,
+      "p99_ms": 107.016,
+      "repetitions": 30
+    }
+  },
+  "version": 1
+}

--- a/src/FaissIndexManager.test.ts
+++ b/src/FaissIndexManager.test.ts
@@ -181,4 +181,67 @@ describe('FaissIndexManager permission handling', () => {
     const logContents = await fsp.readFile(logFile, 'utf-8');
     expect(logContents).toContain('Permission denied while attempting to save FAISS index at');
   });
+
+  it('saves the FAISS index exactly once per updateIndex call when multiple files change', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-faiss-save-once-'));
+    const kbDir = path.join(tempDir, 'kb');
+    const defaultKb = path.join(kbDir, 'default');
+    await fsp.mkdir(defaultKb, { recursive: true });
+    const fileCount = 3;
+    const docPaths: string[] = [];
+    for (let i = 0; i < fileCount; i += 1) {
+      const docPath = path.join(defaultKb, `doc-${i}.md`);
+      await fsp.writeFile(docPath, `# Doc ${i}\n\nContents for document number ${i}.`);
+      docPaths.push(docPath);
+    }
+
+    process.env.KNOWLEDGE_BASES_ROOT_DIR = kbDir;
+    process.env.FAISS_INDEX_PATH = path.join(tempDir, '.faiss');
+    process.env.EMBEDDING_PROVIDER = 'huggingface';
+    process.env.HUGGINGFACE_API_KEY = 'test-key';
+
+    jest.resetModules();
+    const { FaissIndexManager } = await import('./FaissIndexManager.js');
+    const manager = new FaissIndexManager();
+    await manager.initialize();
+    await manager.updateIndex();
+
+    expect(saveMock).toHaveBeenCalledTimes(1);
+    expect(saveMock).toHaveBeenCalledWith(path.join(process.env.FAISS_INDEX_PATH!, 'faiss.index'));
+
+    for (const docPath of docPaths) {
+      const relativePath = path.relative(defaultKb, docPath);
+      const sidecarPath = path.join(defaultKb, '.index', path.dirname(relativePath), path.basename(docPath));
+      const sidecarContent = await fsp.readFile(sidecarPath, 'utf-8');
+      expect(sidecarContent).toMatch(/^[0-9a-f]{64}$/);
+      await expect(fsp.stat(`${sidecarPath}.tmp`)).rejects.toMatchObject({ code: 'ENOENT' });
+    }
+  });
+
+  it('does not write hash sidecars when the FAISS save fails', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-faiss-save-fail-'));
+    const kbDir = path.join(tempDir, 'kb');
+    const defaultKb = path.join(kbDir, 'default');
+    await fsp.mkdir(defaultKb, { recursive: true });
+    const docPath = path.join(defaultKb, 'doc.md');
+    await fsp.writeFile(docPath, '# Title\n\nContent for the failing-save case.');
+
+    process.env.KNOWLEDGE_BASES_ROOT_DIR = kbDir;
+    process.env.FAISS_INDEX_PATH = path.join(tempDir, '.faiss');
+    process.env.EMBEDDING_PROVIDER = 'huggingface';
+    process.env.HUGGINGFACE_API_KEY = 'test-key';
+
+    saveMock.mockRejectedValue(createPermissionError('cannot write index'));
+
+    jest.resetModules();
+    const { FaissIndexManager } = await import('./FaissIndexManager.js');
+    const manager = new FaissIndexManager();
+    await manager.initialize();
+
+    await expect(manager.updateIndex()).rejects.toThrow(/Permission denied/);
+
+    const sidecarPath = path.join(defaultKb, '.index', 'doc.md');
+    await expect(fsp.stat(sidecarPath)).rejects.toMatchObject({ code: 'ENOENT' });
+    await expect(fsp.stat(`${sidecarPath}.tmp`)).rejects.toMatchObject({ code: 'ENOENT' });
+  });
 });

--- a/src/FaissIndexManager.test.ts
+++ b/src/FaissIndexManager.test.ts
@@ -208,6 +208,8 @@ describe('FaissIndexManager permission handling', () => {
 
     expect(saveMock).toHaveBeenCalledTimes(1);
     expect(saveMock).toHaveBeenCalledWith(path.join(process.env.FAISS_INDEX_PATH!, 'faiss.index'));
+    expect(fromTextsMock).toHaveBeenCalledTimes(1);
+    expect(addDocumentsMock).toHaveBeenCalledTimes(fileCount - 1);
 
     for (const docPath of docPaths) {
       const relativePath = path.relative(defaultKb, docPath);

--- a/src/FaissIndexManager.ts
+++ b/src/FaissIndexManager.ts
@@ -1,6 +1,5 @@
 // FaissIndexManager.ts
 import * as fsp from 'fs/promises';
-import * as fs from 'fs';
 import * as path from 'path';
 import { HuggingFaceInferenceEmbeddings } from "@langchain/community/embeddings/hf";
 import { OllamaEmbeddings } from "@langchain/ollama";
@@ -26,6 +25,19 @@ import { logger } from './logger.js';
 const MODEL_NAME_FILE = path.join(FAISS_INDEX_PATH, 'model_name.txt');
 
 type FsError = NodeJS.ErrnoException & { code?: string };
+
+async function pathExists(target: string): Promise<boolean> {
+  try {
+    await fsp.stat(target);
+    return true;
+  } catch (error) {
+    const code = (error as FsError | undefined)?.code;
+    if (code === 'ENOENT' || code === 'ENOTDIR') {
+      return false;
+    }
+    throw error;
+  }
+}
 
 function isPermissionError(error: unknown): error is FsError {
   if (!error || typeof error !== 'object') {
@@ -120,7 +132,7 @@ export class FaissIndexManager {
 
   async initialize(): Promise<void> {
     try {
-      if (!fs.existsSync(FAISS_INDEX_PATH)) {
+      if (!(await pathExists(FAISS_INDEX_PATH))) {
         try {
           await fsp.mkdir(FAISS_INDEX_PATH, { recursive: true });
         } catch (error) {
@@ -131,14 +143,16 @@ export class FaissIndexManager {
       let storedModelName: string | null = null;
 
       try {
-        storedModelName = fs.existsSync(MODEL_NAME_FILE) ? (await fsp.readFile(MODEL_NAME_FILE, 'utf-8')) : null;
+        storedModelName = (await pathExists(MODEL_NAME_FILE))
+          ? (await fsp.readFile(MODEL_NAME_FILE, 'utf-8'))
+          : null;
       } catch (error) {
         logger.warn('Error reading stored model name:', error);
       }
 
       if (storedModelName && storedModelName !== this.modelName) {
         logger.warn(`Model name has changed from ${storedModelName} to ${this.modelName}. Recreating index.`);
-        if (fs.existsSync(indexFilePath)) {
+        if (await pathExists(indexFilePath)) {
           try {
             await fsp.unlink(indexFilePath);
             logger.info('Existing FAISS index deleted.');
@@ -149,7 +163,7 @@ export class FaissIndexManager {
         this.faissIndex = null; // Ensure index is recreated
       }
 
-      if (fs.existsSync(indexFilePath)) {
+      if (await pathExists(indexFilePath)) {
         logger.info('Loading existing FAISS index from:', indexFilePath);
         try {
           this.faissIndex = await FaissStore.load(indexFilePath, this.embeddings);
@@ -196,6 +210,8 @@ export class FaissIndexManager {
       }
 
       let anyFileProcessed = false;
+      let indexMutated = false;
+      const pendingHashWrites: { path: string; hash: string }[] = [];
 
       // Process each knowledge base directory.
       for (const knowledgeBaseName of knowledgeBases) {
@@ -214,7 +230,7 @@ export class FaissIndexManager {
           const indexDirPath = path.join(knowledgeBasePath, '.index', path.dirname(relativePath));
           const indexFilePath = path.join(indexDirPath, path.basename(filePath));
 
-          if (!fs.existsSync(indexDirPath)) {
+          if (!(await pathExists(indexDirPath))) {
             try {
               await fsp.mkdir(indexDirPath, { recursive: true });
             } catch (error) {
@@ -269,19 +285,9 @@ export class FaissIndexManager {
               } else {
                 await this.faissIndex.addDocuments(documentsToAdd);
               }
-              const indexFileSavePath = path.join(FAISS_INDEX_PATH, 'faiss.index');
-              try {
-                await this.faissIndex.save(indexFileSavePath);
-                logger.info('FAISS index saved successfully to', indexFileSavePath);
-              } catch (saveError: any) {
-                handleFsOperationError('save FAISS index at', indexFileSavePath, saveError);
-              }
-              try {
-                await fsp.writeFile(indexFilePath, fileHash, { encoding: 'utf-8' });
-              } catch (error) {
-                handleFsOperationError('write file hash metadata to', indexFilePath, error);
-              }
-              logger.info(`Index updated for ${filePath}.`);
+              indexMutated = true;
+              pendingHashWrites.push({ path: indexFilePath, hash: fileHash });
+              logger.debug(`Index updated in-memory for ${filePath}.`);
             } else {
               logger.debug(`No documents generated from ${filePath}. Skipping index update.`);
             }
@@ -335,14 +341,40 @@ export class FaissIndexManager {
             allDocuments.map((doc) => doc.metadata),
             this.embeddings
           );
-          const indexFileSavePath = path.join(FAISS_INDEX_PATH, 'faiss.index');
-          try {
-            await this.faissIndex.save(indexFileSavePath);
-            logger.info('FAISS index saved successfully to', indexFileSavePath);
-          } catch (saveError: any) {
-            handleFsOperationError('save FAISS index at', indexFileSavePath, saveError);
-          }
+          indexMutated = true;
         }
+      }
+
+      if (indexMutated && this.faissIndex !== null) {
+        const indexFileSavePath = path.join(FAISS_INDEX_PATH, 'faiss.index');
+        try {
+          await this.faissIndex.save(indexFileSavePath);
+          logger.info('FAISS index saved successfully to', indexFileSavePath);
+        } catch (saveError: any) {
+          handleFsOperationError('save FAISS index at', indexFileSavePath, saveError);
+        }
+        // Sidecar hashes are written only after the index has persisted so we
+        // never claim a hash for vectors that never landed on disk. tmp+rename
+        // keeps each sidecar atomic. A crash after save() but before every
+        // rename completes will re-embed the unhashed files on next start,
+        // duplicating their vectors until RFC 007 PR 2.1 lands the pending
+        // manifest protocol.
+        await Promise.all(
+          pendingHashWrites.map(async ({ path: target, hash }) => {
+            const tmpPath = `${target}.tmp`;
+            try {
+              await fsp.writeFile(tmpPath, hash, { encoding: 'utf-8' });
+              await fsp.rename(tmpPath, target);
+            } catch (error) {
+              try {
+                await fsp.unlink(tmpPath);
+              } catch {
+                // best-effort cleanup; original error is what matters
+              }
+              handleFsOperationError('write file hash metadata to', target, error);
+            }
+          })
+        );
       }
       logger.debug('FAISS index update process completed.');
     } catch (error: any) {


### PR DESCRIPTION
## Summary

Implements **RFC 007 PR 1.1** — save-once hoist + non-blocking `existsSync` removal in `FaissIndexManager`. No user-facing contract change; same inputs, same outputs, fewer `save()` calls and no blocking I/O on the async path.

- Hoists `FaissStore.save()` out of the per-file loop in `updateIndex`, gated by a new `indexMutated` flag so warm no-op runs don't rewrite the index.
- Hash sidecars are accumulated during the loop and written via `tmp + rename` **after** the single successful `save()`. On save failure no sidecar claims a hash for vectors that never landed on disk.
- Replaces all **five** blocking `fs.existsSync` call sites in `FaissIndexManager` with a small async `pathExists` helper built on `fsp.stat`. (The RFC text cites four — the fifth lives inside the `updateIndex` per-file hot path and is the highest-impact one.)
- Preserves the existing permission-error path, the three-test coverage on the HuggingFace constructor, and the "no documents generated → skip save" short-circuit.

## Structural gate (RFC 007 §10.1)

`BENCH_PROVIDER=stub npm run bench` — `benchmarks/results/stage-1.1-stub-node24-linux-x64.json` vs `benchmarks/results/baseline-stub-node24-linux-x64.json`:

| Metric | Baseline (`ec94dfb`) | Stage 1.1 | Note |
| --- | ---: | ---: | --- |
| `cold_index.save_calls` | 100 | **1** | Headline assertion — RFC §10.1 stage-1.1 row. |
| `cold_index.from_texts_calls` | 1 | 1 | Unchanged; batching is PR 2.1. |
| `cold_index.add_documents_calls` | 99 | 99 | Unchanged; batching is PR 2.1. |
| `cold_index.ms` | 12607.6 | 12307.4 | ~2.4 % drop (see note). |
| `warm_query.p50_ms` | 70.5 | 91.6 | Within stub/run noise, unrelated to this PR. |

**On the `cold_index.ms` "≥40 %" line in §9.** The stub harness counts `save_calls` but does not model real save cost — each call is a counter bump, not an index serialization + fsync. At `BENCH_PROVIDER=stub`, cold-index time is dominated by the 20 ms-per-chunk embedding delay (600 chunks × 20 ms ≈ 12 s), so dropping `save_calls` 100 → 1 has almost no wall-time effect in stub mode. The wall-time win lands when real providers actually pay for each save — that measurement belongs to RFC 007 PR 0.2 (real-provider baselines, not yet captured). The structural win here (save_calls 100 → 1) is the piece that gates PR 2.1.

## Crash-safety note

Before this PR: per-file save + hash write — either both on disk or neither, per file.

After this PR: one save at the end + a batch of `tmp + rename` hash writes. If the process dies between `save()` succeeding and every rename finishing, the FAISS file on disk contains vectors for files whose sidecars were not yet renamed. Those files are re-embedded on next startup and their vectors are duplicated (FAISS does no dedup). This is the regression window disclosed in the `CHANGELOG` entry; full crash-safety is restored by the `pending-manifest.json` protocol in RFC 007 PR 2.1 (§6.2.1). The honest tradeoff at this stage is 100× fewer saves in exchange for a narrow duplicate-vector window that the manifest will close shortly.

## Small semantics change worth flagging

The new `pathExists` helper collapses `ENOENT` / `ENOTDIR` to `false` and **re-throws** any other error (notably `EACCES` on the parent directory). The old `fs.existsSync` swallowed these silently. For every call site converted here (`FAISS_INDEX_PATH`, `MODEL_NAME_FILE`, `indexFilePath`, `indexDirPath`), surfacing a permission problem early is preferable to the silent `mkdir`/`readFile` retry that followed. No user-visible regression expected; flagging for reviewer awareness.

## Test plan

- [x] `npm test` — 4 suites, 13 tests pass. Two new cases:
  - `saves the FAISS index exactly once per updateIndex call when multiple files change` — asserts `saveMock=1`, `fromTextsMock=1`, `addDocumentsMock=N-1`, sidecars present, no `.tmp` left.
  - `does not write hash sidecars when the FAISS save fails` — asserts `updateIndex` rejects and neither sidecar nor `.tmp` sibling exist.
- [x] `npm run build` — clean.
- [x] `BENCH_PROVIDER=stub npm run bench` — `save_calls` drops from 100 to 1 on the committed baseline fixture.
- [x] 4 specialist reviewers (conventions / correctness / dead-code / tests) — no blocking findings.
- [ ] Real-provider (OpenAI / Ollama) wall-time validation — deferred to PR 0.2.
- [ ] End-to-end stdio MCP smoke test — not exercised; no behavior change to the tool handlers or transport.

## Scope guard

Explicitly **not** in this PR (per RFC §11 checklist): `chunked()` in `utils.ts`, `INDEXING_BATCH_SIZE` in `config.ts`, the `pending-manifest.json` crash-safety protocol, any changes to `KnowledgeBaseServer.ts`, any README change, and the stale `src/knowledge-base-server-flow.md` cleanup. Those belong to PRs 2.1 / 3.1 / housekeeping.

## Follow-ups

- Add a Jest case exercising the `faissIndex === null && anyFileProcessed` fallback rebuild branch under save-once — previously untested, now load-bearing. Tracked in #28.
- Multi-file variant of the save-fail test to prove the "no partial sidecars" invariant across more than one pending write.
- Narrow `catch (saveError: any)` → `unknown` for stylistic consistency with the newly added `pathExists` helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
