### PR TITLE
refactor: save FAISS index once per updateIndex (RFC 007 PR 1.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 - Refactored embedding logic to support provider abstraction and selection.
 - Improved error handling and logging for embedding operations.
 - Upgraded `@huggingface/inference` to the v4 client path through a compatible `@langchain/community` release.
+- `FaissIndexManager.updateIndex` now saves the FAISS index once per call instead of once per changed file, and writes hash sidecars atomically (tmp + rename) only after the index has persisted successfully. Behavior on the happy path is unchanged; a crash between save and sidecar writes now leaves the unclaimed files to be re-embedded on the next run rather than claiming hashes for vectors that never landed. (RFC 007 PR 1.1)
+- Replaced blocking `fs.existsSync` calls in `FaissIndexManager` with non-blocking `fsp.stat`-based checks. (RFC 007 PR 1.1)
 
 ### Fixed
 

--- a/benchmarks/results/stage-1.1-stub-node24-linux-x64.json
+++ b/benchmarks/results/stage-1.1-stub-node24-linux-x64.json
@@ -1,0 +1,103 @@
+{
+  "arch": "x64",
+  "git_sha": "ec94dfb",
+  "node_version": "v24.11.1",
+  "os": "linux",
+  "provider": "stub",
+  "scenarios": {
+    "cold_index": {
+      "add_documents_calls": 99,
+      "chunks": 600,
+      "files": 100,
+      "from_texts_calls": 1,
+      "ms": 12307.429,
+      "save_calls": 1
+    },
+    "cold_start": {
+      "fixture_documents": 120,
+      "ms": 37.123,
+      "rss_bytes": 127848448
+    },
+    "memory_peak": {
+      "chunk_count": 600,
+      "files": 100,
+      "heap_used_bytes": 27643944,
+      "rss_bytes": 143896576
+    },
+    "retrieval_quality": {
+      "default_fanout_factor": 3,
+      "default_loaded_kbs": 5,
+      "default_recall_at_10": 1,
+      "query_count": 50,
+      "sweep": [
+        {
+          "expected_hit_rate_at_10": 0.5,
+          "fanout_factor": 1,
+          "loaded_kbs": 3,
+          "recall_at_10": 0.604
+        },
+        {
+          "expected_hit_rate_at_10": 0.68,
+          "fanout_factor": 1,
+          "loaded_kbs": 5,
+          "recall_at_10": 1
+        },
+        {
+          "expected_hit_rate_at_10": 0.5,
+          "fanout_factor": 2,
+          "loaded_kbs": 3,
+          "recall_at_10": 0.604
+        },
+        {
+          "expected_hit_rate_at_10": 0.68,
+          "fanout_factor": 2,
+          "loaded_kbs": 5,
+          "recall_at_10": 1
+        },
+        {
+          "expected_hit_rate_at_10": 0.5,
+          "fanout_factor": 3,
+          "loaded_kbs": 3,
+          "recall_at_10": 0.604
+        },
+        {
+          "expected_hit_rate_at_10": 0.68,
+          "fanout_factor": 3,
+          "loaded_kbs": 5,
+          "recall_at_10": 1
+        },
+        {
+          "expected_hit_rate_at_10": 0.5,
+          "fanout_factor": 5,
+          "loaded_kbs": 3,
+          "recall_at_10": 0.604
+        },
+        {
+          "expected_hit_rate_at_10": 0.68,
+          "fanout_factor": 5,
+          "loaded_kbs": 5,
+          "recall_at_10": 1
+        },
+        {
+          "expected_hit_rate_at_10": 0.5,
+          "fanout_factor": 10,
+          "loaded_kbs": 3,
+          "recall_at_10": 0.604
+        },
+        {
+          "expected_hit_rate_at_10": 0.68,
+          "fanout_factor": 10,
+          "loaded_kbs": 5,
+          "recall_at_10": 1
+        }
+      ]
+    },
+    "warm_query": {
+      "p50_ms": 91.618,
+      "p95_ms": 100.515,
+      "p99_ms": 107.016,
+      "repetitions": 30
+    }
+  },
+  "version": 1
+}

--- a/src/FaissIndexManager.test.ts
+++ b/src/FaissIndexManager.test.ts
@@ -181,4 +181,67 @@ describe('FaissIndexManager permission handling', () => {
     const logContents = await fsp.readFile(logFile, 'utf-8');
     expect(logContents).toContain('Permission denied while attempting to save FAISS index at');
   });
+
+  it('saves the FAISS index exactly once per updateIndex call when multiple files change', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-faiss-save-once-'));
+    const kbDir = path.join(tempDir, 'kb');
+    const defaultKb = path.join(kbDir, 'default');
+    await fsp.mkdir(defaultKb, { recursive: true });
+    const fileCount = 3;
+    const docPaths: string[] = [];
+    for (let i = 0; i < fileCount; i += 1) {
+      const docPath = path.join(defaultKb, `doc-${i}.md`);
+      await fsp.writeFile(docPath, `# Doc ${i}\n\nContents for document number ${i}.`);
+      docPaths.push(docPath);
+    }
+
+    process.env.KNOWLEDGE_BASES_ROOT_DIR = kbDir;
+    process.env.FAISS_INDEX_PATH = path.join(tempDir, '.faiss');
+    process.env.EMBEDDING_PROVIDER = 'huggingface';
+    process.env.HUGGINGFACE_API_KEY = 'test-key';
+
+    jest.resetModules();
+    const { FaissIndexManager } = await import('./FaissIndexManager.js');
+    const manager = new FaissIndexManager();
+    await manager.initialize();
+    await manager.updateIndex();
+
+    expect(saveMock).toHaveBeenCalledTimes(1);
+    expect(saveMock).toHaveBeenCalledWith(path.join(process.env.FAISS_INDEX_PATH!, 'faiss.index'));
+
+    for (const docPath of docPaths) {
+      const relativePath = path.relative(defaultKb, docPath);
+      const sidecarPath = path.join(defaultKb, '.index', path.dirname(relativePath), path.basename(docPath));
+      const sidecarContent = await fsp.readFile(sidecarPath, 'utf-8');
+      expect(sidecarContent).toMatch(/^[0-9a-f]{64}$/);
+      await expect(fsp.stat(`${sidecarPath}.tmp`)).rejects.toMatchObject({ code: 'ENOENT' });
+    }
+  });
+
+  it('does not write hash sidecars when the FAISS save fails', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-faiss-save-fail-'));
+    const kbDir = path.join(tempDir, 'kb');
+    const defaultKb = path.join(kbDir, 'default');
+    await fsp.mkdir(defaultKb, { recursive: true });
+    const docPath = path.join(defaultKb, 'doc.md');
+    await fsp.writeFile(docPath, '# Title\n\nContent for the failing-save case.');
+
+    process.env.KNOWLEDGE_BASES_ROOT_DIR = kbDir;
+    process.env.FAISS_INDEX_PATH = path.join(tempDir, '.faiss');
+    process.env.EMBEDDING_PROVIDER = 'huggingface';
+    process.env.HUGGINGFACE_API_KEY = 'test-key';
+
+    saveMock.mockRejectedValue(createPermissionError('cannot write index'));
+
+    jest.resetModules();
+    const { FaissIndexManager } = await import('./FaissIndexManager.js');
+    const manager = new FaissIndexManager();
+    await manager.initialize();
+
+    await expect(manager.updateIndex()).rejects.toThrow(/Permission denied/);
+
+    const sidecarPath = path.join(defaultKb, '.index', 'doc.md');
+    await expect(fsp.stat(sidecarPath)).rejects.toMatchObject({ code: 'ENOENT' });
+    await expect(fsp.stat(`${sidecarPath}.tmp`)).rejects.toMatchObject({ code: 'ENOENT' });
+  });
 });

--- a/src/FaissIndexManager.test.ts
+++ b/src/FaissIndexManager.test.ts
@@ -208,6 +208,8 @@ describe('FaissIndexManager permission handling', () => {
 
     expect(saveMock).toHaveBeenCalledTimes(1);
     expect(saveMock).toHaveBeenCalledWith(path.join(process.env.FAISS_INDEX_PATH!, 'faiss.index'));
+    expect(fromTextsMock).toHaveBeenCalledTimes(1);
+    expect(addDocumentsMock).toHaveBeenCalledTimes(fileCount - 1);
 
     for (const docPath of docPaths) {
       const relativePath = path.relative(defaultKb, docPath);

--- a/src/FaissIndexManager.ts
+++ b/src/FaissIndexManager.ts
@@ -1,6 +1,5 @@
 // FaissIndexManager.ts
 import * as fsp from 'fs/promises';
-import * as fs from 'fs';
 import * as path from 'path';
 import { HuggingFaceInferenceEmbeddings } from "@langchain/community/embeddings/hf";
 import { OllamaEmbeddings } from "@langchain/ollama";
@@ -26,6 +25,19 @@ import { logger } from './logger.js';
 const MODEL_NAME_FILE = path.join(FAISS_INDEX_PATH, 'model_name.txt');
 
 type FsError = NodeJS.ErrnoException & { code?: string };
+
+async function pathExists(target: string): Promise<boolean> {
+  try {
+    await fsp.stat(target);
+    return true;
+  } catch (error) {
+    const code = (error as FsError | undefined)?.code;
+    if (code === 'ENOENT' || code === 'ENOTDIR') {
+      return false;
+    }
+    throw error;
+  }
+}
 
 function isPermissionError(error: unknown): error is FsError {
   if (!error || typeof error !== 'object') {
@@ -120,7 +132,7 @@ export class FaissIndexManager {
 
   async initialize(): Promise<void> {
     try {
-      if (!fs.existsSync(FAISS_INDEX_PATH)) {
+      if (!(await pathExists(FAISS_INDEX_PATH))) {
         try {
           await fsp.mkdir(FAISS_INDEX_PATH, { recursive: true });
         } catch (error) {
@@ -131,14 +143,16 @@ export class FaissIndexManager {
       let storedModelName: string | null = null;
 
       try {
-        storedModelName = fs.existsSync(MODEL_NAME_FILE) ? (await fsp.readFile(MODEL_NAME_FILE, 'utf-8')) : null;
+        storedModelName = (await pathExists(MODEL_NAME_FILE))
+          ? (await fsp.readFile(MODEL_NAME_FILE, 'utf-8'))
+          : null;
       } catch (error) {
         logger.warn('Error reading stored model name:', error);
       }
 
       if (storedModelName && storedModelName !== this.modelName) {
         logger.warn(`Model name has changed from ${storedModelName} to ${this.modelName}. Recreating index.`);
-        if (fs.existsSync(indexFilePath)) {
+        if (await pathExists(indexFilePath)) {
           try {
             await fsp.unlink(indexFilePath);
             logger.info('Existing FAISS index deleted.');
@@ -149,7 +163,7 @@ export class FaissIndexManager {
         this.faissIndex = null; // Ensure index is recreated
       }
 
-      if (fs.existsSync(indexFilePath)) {
+      if (await pathExists(indexFilePath)) {
         logger.info('Loading existing FAISS index from:', indexFilePath);
         try {
           this.faissIndex = await FaissStore.load(indexFilePath, this.embeddings);
@@ -196,6 +210,8 @@ export class FaissIndexManager {
       }
 
       let anyFileProcessed = false;
+      let indexMutated = false;
+      const pendingHashWrites: { path: string; hash: string }[] = [];
 
       // Process each knowledge base directory.
       for (const knowledgeBaseName of knowledgeBases) {
@@ -214,7 +230,7 @@ export class FaissIndexManager {
           const indexDirPath = path.join(knowledgeBasePath, '.index', path.dirname(relativePath));
           const indexFilePath = path.join(indexDirPath, path.basename(filePath));
 
-          if (!fs.existsSync(indexDirPath)) {
+          if (!(await pathExists(indexDirPath))) {
             try {
               await fsp.mkdir(indexDirPath, { recursive: true });
             } catch (error) {
@@ -269,19 +285,9 @@ export class FaissIndexManager {
               } else {
                 await this.faissIndex.addDocuments(documentsToAdd);
               }
-              const indexFileSavePath = path.join(FAISS_INDEX_PATH, 'faiss.index');
-              try {
-                await this.faissIndex.save(indexFileSavePath);
-                logger.info('FAISS index saved successfully to', indexFileSavePath);
-              } catch (saveError: any) {
-                handleFsOperationError('save FAISS index at', indexFileSavePath, saveError);
-              }
-              try {
-                await fsp.writeFile(indexFilePath, fileHash, { encoding: 'utf-8' });
-              } catch (error) {
-                handleFsOperationError('write file hash metadata to', indexFilePath, error);
-              }
-              logger.info(`Index updated for ${filePath}.`);
+              indexMutated = true;
+              pendingHashWrites.push({ path: indexFilePath, hash: fileHash });
+              logger.debug(`Index updated in-memory for ${filePath}.`);
             } else {
               logger.debug(`No documents generated from ${filePath}. Skipping index update.`);
             }
@@ -335,14 +341,40 @@ export class FaissIndexManager {
             allDocuments.map((doc) => doc.metadata),
             this.embeddings
           );
-          const indexFileSavePath = path.join(FAISS_INDEX_PATH, 'faiss.index');
-          try {
-            await this.faissIndex.save(indexFileSavePath);
-            logger.info('FAISS index saved successfully to', indexFileSavePath);
-          } catch (saveError: any) {
-            handleFsOperationError('save FAISS index at', indexFileSavePath, saveError);
-          }
+          indexMutated = true;
         }
+      }
+
+      if (indexMutated && this.faissIndex !== null) {
+        const indexFileSavePath = path.join(FAISS_INDEX_PATH, 'faiss.index');
+        try {
+          await this.faissIndex.save(indexFileSavePath);
+          logger.info('FAISS index saved successfully to', indexFileSavePath);
+        } catch (saveError: any) {
+          handleFsOperationError('save FAISS index at', indexFileSavePath, saveError);
+        }
+        // Sidecar hashes are written only after the index has persisted so we
+        // never claim a hash for vectors that never landed on disk. tmp+rename
+        // keeps each sidecar atomic. A crash after save() but before every
+        // rename completes will re-embed the unhashed files on next start,
+        // duplicating their vectors until RFC 007 PR 2.1 lands the pending
+        // manifest protocol.
+        await Promise.all(
+          pendingHashWrites.map(async ({ path: target, hash }) => {
+            const tmpPath = `${target}.tmp`;
+            try {
+              await fsp.writeFile(tmpPath, hash, { encoding: 'utf-8' });
+              await fsp.rename(tmpPath, target);
+            } catch (error) {
+              try {
+                await fsp.unlink(tmpPath);
+              } catch {
+                // best-effort cleanup; original error is what matters
+              }
+              handleFsOperationError('write file hash metadata to', target, error);
+            }
+          })
+        );
       }
       logger.debug('FAISS index update process completed.');
     } catch (error: any) {


### PR DESCRIPTION
## Summary

Implements RFC 007 stage 1.1 — *Save-once + non-blocking `existsSync` removal* — tracked in `docs/rfcs/007-architecture-performance.md` (§6.5 + §6.7 + §11 PR 1.1 checklist).

- Hoist `FaissStore.save()` out of the per-file loop in `FaissIndexManager.updateIndex`. With N changed files the method now issues one `save()` at the end instead of N serial saves.
- Reorder hash-sidecar writes to run **after** a successful `save()` using `tmp + rename` for atomicity. If `save()` fails, no sidecar is written; if a rename fails mid-batch, the `.tmp` file is best-effort unlinked. The unhashed-but-saved crash window (unique to this stage) is documented in the source and resolved by the pending-manifest protocol in RFC 007 PR 2.1.
- Replace all five `fs.existsSync` calls in `FaissIndexManager.ts` with non-blocking `fsp.stat(...).catch(...)`-style checks (`pathExists` helper). The blocking `import * as fs from 'fs'` is gone.
- Add two `FaissIndexManager.test.ts` cases: (a) save-exactly-once with >=2 changed files plus sidecar-content assertions and no leftover `.tmp` files, (b) failed save writes no sidecar.
- CHANGELOG entry under `[Unreleased] Changed`.

## Evidence

### Structural gate (RFC 007 §10.1)

Stub benchmark `benchmarks/results/stage-1.1-stub-node24-linux-x64.json` vs checked-in baseline `benchmarks/results/baseline-stub-node24-linux-x64.json`:

| metric | baseline | stage 1.1 |
| --- | ---: | ---: |
| save_calls on 100-file cold build | 100 | **1** |
| from_texts_calls | 1 | 1 |
| add_documents_calls | 99 | 99 |
| cold_index.ms | 12607 | 12307 |

`save_calls` drop is the gate. Cold-index wall time is not the stage 1.1 gate (batching is PR 2.1); the small drop here is stub-mode variance + fewer serialize round-trips.

### Tests

```
Test Suites: 4 passed, 4 total
Tests:       13 passed, 13 total
```

New cases in `src/FaissIndexManager.test.ts`:
- `saves the FAISS index exactly once per updateIndex call when multiple files change` — seeds 3 changed markdown files, asserts `saveMock` called once, asserts sidecars contain 64-hex hashes, asserts no orphaned `.tmp` files remain.
- `does not write hash sidecars when the FAISS save fails` — stubs save to reject with EACCES, asserts neither sidecar nor `.tmp` exists afterwards.

## Scope & non-goals

- No batching of embedding calls — that is PR 2.1.
- No `mtime+size` short-circuit — that is PR 1.2.
- No per-query-scan removal — that is PR 3.1 (and may be rejected at decision gate A).
- No watcher, no per-KB index isolation.

## Checklist (RFC 007 §11 PR 1.1)

- [x] **1.1.1** Hoist `FaissStore.save()` out of the per-file loop
- [x] **1.1.2** Order hash-sidecar writes after successful `save()` with tmp+rename (initial form; full manifest lands in PR 2.1)
- [x] **1.1.3** Replace the five blocking `fs.existsSync` calls with `fsp.stat`-based checks
- [x] **1.1.4** Test: `save` called exactly once per `updateIndex` when >=2 files change
- [x] **1.1.5** Commit `benchmarks/results/stage-1.1-stub-node24-linux-x64.json`

## Test plan

- [x] `npm test` — 13/13 pass
- [x] `BENCH_PROVIDER=stub BENCH_RESULTS_PREFIX=stage-1.1 npm run bench` — emits the checked-in stage-1.1 JSON
- [x] `npm run build` — clean tsc

🤖 Generated with [Claude Code](https://claude.com/claude-code)