### PR TITLE
test: cover fallback rebuild branch in FaissIndexManager.updateIndex

### DIFF
--- a/src/FaissIndexManager.test.ts
+++ b/src/FaissIndexManager.test.ts
@@ -220,6 +220,85 @@ describe('FaissIndexManager permission handling', () => {
     }
   });
 
+  it('rebuilds via fromTexts once when the FAISS index is missing but sidecars are up to date', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-faiss-fallback-'));
+    const kbDir = path.join(tempDir, 'kb');
+    const defaultKb = path.join(kbDir, 'default');
+    await fsp.mkdir(defaultKb, { recursive: true });
+    const fileCount = 2;
+    const docPaths: string[] = [];
+    for (let i = 0; i < fileCount; i += 1) {
+      const docPath = path.join(defaultKb, `doc-${i}.md`);
+      await fsp.writeFile(docPath, `# Doc ${i}\n\nFallback rebuild coverage content ${i}.`);
+      docPaths.push(docPath);
+    }
+
+    process.env.KNOWLEDGE_BASES_ROOT_DIR = kbDir;
+    process.env.FAISS_INDEX_PATH = path.join(tempDir, '.faiss');
+    process.env.EMBEDDING_PROVIDER = 'huggingface';
+    process.env.HUGGINGFACE_API_KEY = 'test-key';
+
+    // First pass: let a fresh manager populate sidecars and the in-memory index.
+    jest.resetModules();
+    const firstImport = await import('./FaissIndexManager.js');
+    const firstManager = new firstImport.FaissIndexManager();
+    await firstManager.initialize();
+    await firstManager.updateIndex();
+
+    // Capture sidecar state so we can confirm the fallback branch leaves them untouched.
+    const sidecarSnapshots: { path: string; content: string }[] = [];
+    for (const docPath of docPaths) {
+      const relativePath = path.relative(defaultKb, docPath);
+      const sidecarPath = path.join(defaultKb, '.index', path.dirname(relativePath), path.basename(docPath));
+      const content = await fsp.readFile(sidecarPath, 'utf-8');
+      sidecarSnapshots.push({ path: sidecarPath, content });
+    }
+
+    // The mocked FaissStore.save never writes faiss.index, so a fresh manager
+    // will see it missing on disk — exactly the state the fallback branch is
+    // meant to recover from. Assert that precondition explicitly.
+    await expect(
+      fsp.stat(path.join(process.env.FAISS_INDEX_PATH!, 'faiss.index'))
+    ).rejects.toMatchObject({ code: 'ENOENT' });
+
+    // Reset mocks so the fallback-branch call counts are isolated.
+    saveMock.mockReset();
+    addDocumentsMock.mockReset();
+    fromTextsMock.mockReset();
+    loadMock.mockReset();
+
+    // Second pass: a new manager with faiss.index missing and sidecars intact.
+    jest.resetModules();
+    const secondImport = await import('./FaissIndexManager.js');
+    const secondManager = new secondImport.FaissIndexManager();
+    await secondManager.initialize();
+    expect(loadMock).not.toHaveBeenCalled();
+
+    await secondManager.updateIndex();
+
+    // Fallback branch: one rebuild, zero per-file additions, one save.
+    expect(fromTextsMock).toHaveBeenCalledTimes(1);
+    expect(addDocumentsMock).not.toHaveBeenCalled();
+    expect(saveMock).toHaveBeenCalledTimes(1);
+    expect(saveMock).toHaveBeenCalledWith(path.join(process.env.FAISS_INDEX_PATH!, 'faiss.index'));
+
+    // fromTexts must receive documents from every file at once.
+    const [texts, metadatas] = fromTextsMock.mock.calls[0] as [string[], Array<{ source: string }>];
+    expect(Array.isArray(texts)).toBe(true);
+    expect(texts.length).toBeGreaterThanOrEqual(fileCount);
+    const sources = new Set(metadatas.map((m) => m.source));
+    for (const docPath of docPaths) {
+      expect(sources.has(docPath)).toBe(true);
+    }
+
+    // Sidecars must remain byte-for-byte identical and no .tmp files left behind.
+    for (const snapshot of sidecarSnapshots) {
+      const content = await fsp.readFile(snapshot.path, 'utf-8');
+      expect(content).toBe(snapshot.content);
+      await expect(fsp.stat(`${snapshot.path}.tmp`)).rejects.toMatchObject({ code: 'ENOENT' });
+    }
+  });
+
   it('does not write hash sidecars when the FAISS save fails', async () => {
     const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-faiss-save-fail-'));
     const kbDir = path.join(tempDir, 'kb');

--- a/src/FaissIndexManager.test.ts
+++ b/src/FaissIndexManager.test.ts
@@ -240,10 +240,12 @@ describe('FaissIndexManager permission handling', () => {
 
     // First pass: let a fresh manager populate sidecars and the in-memory index.
     jest.resetModules();
-    const firstImport = await import('./FaissIndexManager.js');
-    const firstManager = new firstImport.FaissIndexManager();
-    await firstManager.initialize();
-    await firstManager.updateIndex();
+    {
+      const { FaissIndexManager } = await import('./FaissIndexManager.js');
+      const firstManager = new FaissIndexManager();
+      await firstManager.initialize();
+      await firstManager.updateIndex();
+    }
 
     // Capture sidecar state so we can confirm the fallback branch leaves them untouched.
     const sidecarSnapshots: { path: string; content: string }[] = [];
@@ -269,8 +271,8 @@ describe('FaissIndexManager permission handling', () => {
 
     // Second pass: a new manager with faiss.index missing and sidecars intact.
     jest.resetModules();
-    const secondImport = await import('./FaissIndexManager.js');
-    const secondManager = new secondImport.FaissIndexManager();
+    const { FaissIndexManager } = await import('./FaissIndexManager.js');
+    const secondManager = new FaissIndexManager();
     await secondManager.initialize();
     expect(loadMock).not.toHaveBeenCalled();
 
@@ -282,10 +284,14 @@ describe('FaissIndexManager permission handling', () => {
     expect(saveMock).toHaveBeenCalledTimes(1);
     expect(saveMock).toHaveBeenCalledWith(path.join(process.env.FAISS_INDEX_PATH!, 'faiss.index'));
 
-    // fromTexts must receive documents from every file at once.
+    // fromTexts must receive documents from every file at once. With content
+    // well under the 1000-char chunkSize, each file produces exactly one chunk,
+    // so the count is deterministic and a regression that double-collects docs
+    // or skips one would be caught immediately.
     const [texts, metadatas] = fromTextsMock.mock.calls[0] as [string[], Array<{ source: string }>];
     expect(Array.isArray(texts)).toBe(true);
-    expect(texts.length).toBeGreaterThanOrEqual(fileCount);
+    expect(texts).toHaveLength(fileCount);
+    expect(metadatas).toHaveLength(fileCount);
     const sources = new Set(metadatas.map((m) => m.source));
     for (const docPath of docPaths) {
       expect(sources.has(docPath)).toBe(true);


### PR DESCRIPTION
## Summary

Adds a regression test for the `this.faissIndex === null && anyFileProcessed` fallback branch in `FaissIndexManager.updateIndex` (`src/FaissIndexManager.ts:302-346`). After #27 this branch sets `indexMutated = true` and participates in the single-save flow, but nothing exercised it — the existing save-once test goes through the per-file changed branch, not the fallback.

## What the test asserts

Seeds two markdown files, runs `updateIndex()` once to populate the hash sidecars + in-memory index, reinstantiates the manager, then on the second `updateIndex()` (with `faiss.index` never materialised on disk, since `FaissStore.save` is mocked) checks that:

- `fromTextsMock` is called **exactly once** with documents from both files (single rebuild, all documents) — distinguishes the fallback from the per-file path which would call `fromTexts` once and `addDocuments` N-1 times
- `addDocumentsMock` is **never** called
- `saveMock` is called **exactly once** at the canonical `faiss.index` path
- every hash sidecar remains byte-for-byte identical and no `.tmp` siblings leak
- `fromTexts` receives **exactly** `fileCount` texts+metadatas (short markdown bodies are well under the 1000-char chunkSize so the count is deterministic)

## Test plan

- [x] `npm test` — 4 suites, 14 tests pass (13 existing + the new one)
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — clean
- [x] 3 reviewer specialists (test / correctness / conventions) run against the diff — no blocking findings; applied the worthwhile suggestions (tightened chunk-count assertion, matched import-destructuring style)

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)