### PR TITLE
docs(architecture): add behaviour + data views

### DIFF
--- a/docs/architecture/data-model.md
+++ b/docs/architecture/data-model.md
@@ -1,0 +1,92 @@
+# Data model
+
+Every artifact that survives a process restart lives in one of two directories. This page enumerates the files and the schema of what's inside them.
+
+## On-disk layout
+
+```mermaid
+flowchart LR
+  subgraph kbs["$KNOWLEDGE_BASES_ROOT_DIR<br/>src/config.ts:5-6"]
+    direction TB
+    subgraph kb1["&lt;kb_name&gt;/  (user-authored)"]
+      Md["*.md, *.txt<br/>(any non-dot ext)"]
+      IdxDir[".index/<br/>(written by this server)"]
+      IdxFile["&lt;subdir&gt;/&lt;basename&gt;<br/>one sha256 hex per source file"]
+      Md -.sha256.-> IdxFile
+    end
+    kb2["&lt;other_kb&gt;/"]
+  end
+
+  subgraph faiss["$FAISS_INDEX_PATH<br/>src/config.ts:8-9"]
+    direction TB
+    Faiss["faiss.index<br/>binary vector index<br/>faiss-node format"]
+    Docs["docstore.json<br/>(pickle-format sibling<br/>written by FaissStore.save)"]
+    Model["model_name.txt<br/>src/FaissIndexManager.ts:25"]
+  end
+```
+
+The two trees are independent (see [`c4-container.md`](./c4-container.md) for lifecycle notes). Sidecars travel with the source file, not with the vector index — so a user can safely `rm -rf $FAISS_INDEX_PATH/` to force a full rebuild without invalidating the sidecar sha tree, and moving a KB between roots doesn't orphan vectors of unrelated KBs.
+
+## Artifacts
+
+### Per-file hash sidecar
+
+Written by `src/FaissIndexManager.ts:362-377`. One text file per indexed source file; content is a lowercase sha256 hex digest of the source bytes.
+
+| Field   | Type                     | Source                                      |
+| ------- | ------------------------ | ------------------------------------------- |
+| path    | `<kb>/.index/<rel_dir>/<basename>` | derived at `src/FaissIndexManager.ts:230-231` |
+| content | sha256 hex string (64 chars) | `calculateSHA256` at `src/utils.ts:6-11`     |
+| atomicity | tmp+rename              | `src/FaissIndexManager.ts:363-374`          |
+
+The path structure mirrors the source tree under `<kb>/` — so a file at `<kb>/a/b/c.md` gets a sidecar at `<kb>/.index/a/b/c.md`. ADR [`0002-per-file-hash-sidecars.md`](./adr/0002-per-file-hash-sidecars.md) covers why this layout was chosen over a single `hashes.json` manifest.
+
+### `faiss.index`
+
+The binary vector index in `faiss-node`'s native format. Produced by `FaissStore.save(path)` (`src/FaissIndexManager.ts:351`), loaded by `FaissStore.load(path, embeddings)` (`src/FaissIndexManager.ts:169`). Endianness and float layout are platform-dependent; a fixture built on one arch may not load on another.
+
+### Docstore sibling
+
+`FaissStore.save` emits a JSON-serialized docstore alongside `faiss.index` (written to the same directory). The serialization path uses `pickleparser@0.2.1` (`package.json:27`) for cross-language compatibility with Python LangChain on load. This is the **code-exec trust boundary** — loading an attacker-controlled file here is arbitrary-code-execution-shaped; see [`threat-model.md`](./threat-model.md).
+
+### `model_name.txt`
+
+Single-line text file containing the current configured embedding model name. Written once per `initialize()` at `src/FaissIndexManager.ts:181`. Compared to `this.modelName` on the next startup at `:153`. If they differ, `faiss.index` is unlinked and the next `updateIndex` rebuilds — see [`sequence-reindex.md`](./sequence-reindex.md) and ADR [`0005-auto-rebuild-on-model-change.md`](./adr/0005-auto-rebuild-on-model-change.md).
+
+## In-memory: chunk metadata schema
+
+Documents are created at two call sites with identical schemas:
+
+- Changed-file branch (`src/FaissIndexManager.ts:261-275`): either split by `MarkdownTextSplitter` (`.md`) or wrapped as a single `Document` (everything else).
+- Fallback branch (`src/FaissIndexManager.ts:317-332`): same logic re-applied during a full rebuild.
+
+### Current schema (today)
+
+```ts
+type ChunkMetadata = {
+  source: string;   // absolute path to the originating file on disk
+};
+```
+
+**That's the whole schema.** The only field set by this server is `source`. It's consumed by:
+
+- `handleRetrieveKnowledge` (`src/KnowledgeBaseServer.ts:98-100`), which serializes `metadata` as pretty-printed JSON in the tool response.
+- Any downstream consumer that wants to dedup, group, or filter by source file — today, none inside this repo.
+
+### Forthcoming (per RFC 006 M1.3)
+
+The multi-provider tiered-retrieval RFC plans to extend the schema with:
+
+| Field           | Type                       | Purpose                                                         |
+| --------------- | -------------------------- | --------------------------------------------------------------- |
+| `tags`          | `string[]`                 | Allow-list / deny-list filtering at query time.                 |
+| `chunkIndex`    | `number`                   | Ordinal within the source file, for reconstructing context.     |
+| `knowledgeBase` | `string`                   | Cheap KB-scope filter without string-matching `source`.         |
+
+RFC 006 specifies this; it is **not** live in the current code. When it lands, this section flips from "forthcoming" to "current" in the same PR.
+
+## Not persisted
+
+- Query text is **not** logged or stored anywhere; it flows straight to `embedQuery` (`src/FaissIndexManager.ts:402`) and is gone when the request returns.
+- Embedding provider keys (`HUGGINGFACE_API_KEY`, `OPENAI_API_KEY`) are held in `process.env` for the life of the process. They are not written to sidecars, `model_name.txt`, or any log payload.
+- There is no cache / queue / scratch dir outside the two trees above.

--- a/docs/architecture/qa-budgets.md
+++ b/docs/architecture/qa-budgets.md
@@ -1,0 +1,70 @@
+# Quality attributes — latency, memory, cost budgets
+
+Current budgets and scale ceiling. All figures below come from RFC 007 §5 (the stubbed benchmark harness at `benchmarks/`); real-provider numbers will replace them in stage 0.2 of the RFC's rollout. Until then, treat wall-time numbers as structural (call counts and ratios) rather than as wall-clock promises.
+
+If you are changing indexing, embeddings, or the request path, re-run `npm run bench` and diff the JSON output against the committed `benchmarks/results/` baseline.
+
+## Latency budgets
+
+| Phase                                                 | Today        | Source                       | Notes |
+| ----------------------------------------------------- | ------------ | ---------------------------- | ----- |
+| Constructor + module import (stub env)                | **170 ms**   | RFC 007 §5.1                 | Dominated by `@langchain/*` module load. No lazy imports today. |
+| `initialize()` when `faiss.index` is absent           | **~2 ms**    | RFC 007 §5.1                 | Just creates the dir and writes `model_name.txt`. |
+| `initialize()` when loading existing index            | **not measured in-repo** | —                | RFC 007 §5.5 flags this as a deferred measurement; depends on index size + disk. |
+| **Cold build**, 100 files × ~500 chunks, stubbed 20 ms/embedding | **10 761 ms**| RFC 007 §5.2                 | ~10 000 ms is the serial-embedding floor (500 × 20 ms); rest is 100 `save()` calls (now collapsed to 1 by PR #27). |
+| **Warm no-op** (all hashes match), 100 files          | **84 ms p50** | RFC 007 §5.3                | Fixed floor from async-loop + per-file sha + sidecar read. |
+| **Warm no-op**, 500 files                             | **84 ms p50** | RFC 007 §5.3                | Floor still dominates; per-file cost ~167 µs. |
+| **Warm no-op**, 2 000 files                           | **87 ms p50** | RFC 007 §5.3                | Per-file cost drops to 44 µs; fixed floor still dominates. |
+| `similaritySearch` (stubbed FAISS, k=10)              | **0.26 ms**  | RFC 007 §5.4                 | FAISS itself is not the bottleneck; the query-vector embedding round-trip is (not stubbed out). |
+
+**Interpretation.** The request-path cost on a warm index is dominated by the mandatory `updateIndex()` scan at `src/KnowledgeBaseServer.ts:84`, not by FAISS search. That is the lever RFC 007 §6.3 / §7.5 is pulling. For now, budget every `retrieve_knowledge` call at **80–100 ms warm + query-embedding RTT**; cold builds are proportional to `total_chunks × per_chunk_embedding_latency`.
+
+## Memory budgets
+
+| Condition                         | Peak RSS   | Source         |
+| --------------------------------- | ---------- | -------------- |
+| After `new KnowledgeBaseServer()` | ~81 MB     | RFC 007 §5.1   |
+| After cold build of 100 files     | ~112 MB    | RFC 007 §5.2 (Δ ≈ 31 MB) |
+| After much larger KBs             | grows linearly with total chunks — **single global FAISS store** holds every KB's vectors today (`src/FaissIndexManager.ts:81`). RFC 007 §6.4 plans per-KB isolation + bounded LRU. |
+
+## Cost budgets (embedding-provider calls)
+
+Today's embedding call pattern, per `updateIndex` call:
+
+| Scenario                           | `embedDocuments` calls | Batched? |
+| ---------------------------------- | ---------------------: | -------- |
+| Warm no-op                         | 0                       | N/A      |
+| 1 changed file                     | 1                       | Yes (one call per file, carrying that file's chunks) |
+| N changed files                    | N                       | **No** — each file goes through `addDocuments`/`fromTexts` serially at `src/FaissIndexManager.ts:278-287`. RFC 007 §6.2 batches this. |
+| Fallback rebuild                   | 1                       | Yes — one call with every chunk at `:338-343` |
+
+**Provider-rate implication.** A user with 100 modified files on HuggingFace (~100 ms/call) pays 10 s minimum regardless of chunk count per file — because the calls are sequential. The fallback-rebuild path is faster per chunk than the changed-file path because it packs everything into one call.
+
+## Supported scale
+
+Current ceiling (informal, from code + §5 measurements, **not** a tested guarantee):
+
+| Dimension                    | Ceiling                                           |
+| ---------------------------- | ------------------------------------------------- |
+| Number of files              | **Thousands.** Warm scan stays sub-100 ms up to ~2 000 (§5.3); beyond that, per-file sha256 cost starts to dominate. |
+| Number of knowledge bases    | **Tens**, informally. No hard cap in code; a global FAISS store means memory is the practical limit. |
+| Index size on disk           | **Tens of MB.** Larger is fine on modern disks; the not-yet-measured risk is `FaissStore.load` time at startup (RFC 007 §5.5). |
+| Concurrent server processes  | **1 per `$FAISS_INDEX_PATH`.** See [`threat-model.md`](./threat-model.md#concurrency) — multiple processes race on `save()` and sidecar tmp+rename, and will corrupt state. |
+
+## Known cliffs
+
+- **Per-query scan** (`src/KnowledgeBaseServer.ts:84` → `src/FaissIndexManager.ts:202-389`). Every `retrieve_knowledge` pays the ~85 ms scan floor even when nothing changed. RFC 007 §6.3 (scan-on-signal) and §7.5 (mtime+size short-circuit) are the two candidate fixes.
+- **Per-file embedding round-trip** (`src/FaissIndexManager.ts:278-287`). Changed-file calls are serial, not batched. RFC 007 §6.2 tracks the batch refactor.
+- **Global FAISS store memory** (`src/FaissIndexManager.ts:81`). Querying one KB still loads vectors from every KB into RAM. RFC 007 §6.4 tracks the per-KB split.
+- **No concurrency guard** across processes. One process per `$FAISS_INDEX_PATH` is a documented constraint, not an enforced one — see [`threat-model.md`](./threat-model.md) and issue #44.
+
+## How to re-measure
+
+```bash
+npm install
+npm run bench                          # stub provider; writes benchmarks/results/*.json
+BENCH_PROVIDER=ollama npm run bench    # real provider (requires daemon)
+BENCH_PROVIDER=openai npm run bench    # real provider (requires OPENAI_API_KEY)
+```
+
+Baselines in `benchmarks/results/` are keyed by `{provider}-{node_version}-{os}-{arch}`; compare apples to apples.

--- a/docs/architecture/sequence-reindex.md
+++ b/docs/architecture/sequence-reindex.md
@@ -1,0 +1,87 @@
+# Sequence — model-change reindex
+
+What happens when the user changes `EMBEDDING_PROVIDER`, `HUGGINGFACE_MODEL_NAME`, `OLLAMA_MODEL`, or `OPENAI_MODEL_NAME` with an existing index on disk. The triggering comparison is at `src/FaissIndexManager.ts:153`; the teardown at `:154-164`; the reconstruction at `src/FaissIndexManager.ts:302-346` on the next `updateIndex` call.
+
+This is a **destructive** path — the old `faiss.index` is deleted, then rebuilt from source markdown using the new model. ADR [`0005-auto-rebuild-on-model-change.md`](./adr/0005-auto-rebuild-on-model-change.md) explains why the current code wipes rather than refuses, and why that choice is debatable.
+
+## Diagram
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant Entry as index.ts:5
+  participant Server as KnowledgeBaseServer
+  participant FIM as FaissIndexManager
+  participant Store as $FAISS_INDEX_PATH
+  participant FS as $KNOWLEDGE_BASES_ROOT_DIR
+  participant Provider as Embedding provider<br/>(NEW model)
+
+  Note over Entry,Provider: User changed OLLAMA_MODEL<br/>and restarted the server
+  Entry->>Server: new KnowledgeBaseServer().run()
+  Server->>FIM: new FaissIndexManager()<br/>:86-131
+  Note over FIM: constructor picks new model<br/>from config.ts env vars
+
+  Server->>Server: McpServer.connect(stdio)<br/>:126-127
+  Note over Server: MCP handshake completes<br/>BEFORE initialize() runs
+
+  Server->>FIM: initialize()<br/>:133-194
+  FIM->>Store: pathExists(FAISS_INDEX_PATH)<br/>:135
+  FIM->>Store: readFile(model_name.txt)<br/>:146-148
+  Store-->>FIM: "old-model-name"
+
+  alt stored != current (MISMATCH)
+    Note over FIM: warn: "Model name has changed..."<br/>:154
+    FIM->>Store: unlink(faiss.index)<br/>:157
+    Note over FIM: this.faissIndex = null<br/>:163
+  end
+
+  FIM->>Store: pathExists(faiss.index)
+  Note over FIM,Store: file just deleted → branch at :174-177
+  Note over FIM: faissIndex stays null
+
+  FIM->>Store: writeFile(model_name.txt, NEW-model)<br/>:181
+  Note over FIM: initialize() returns
+
+  Note over Server,Provider: Time passes — first retrieve_knowledge request arrives
+
+  Server->>FIM: updateIndex(kb?)<br/>:202-389
+  loop for each file in each KB
+    FIM->>FS: sha256 + read sidecar
+    Note over FIM: sidecars still reflect OLD-model<br/>content (hash of source file, not embedding)
+    Note over FIM: hashes match → NOT re-embedded<br/>via the changed-file branch
+  end
+
+  Note over FIM: indexMutated==false, faissIndex==null,<br/>anyFileProcessed==true → fallback branch
+  rect rgba(255, 235, 200, 0.6)
+    Note over FIM,Provider: Fallback rebuild from all files<br/>:302-346
+    FIM->>FS: re-walk every KB (second pass)
+    loop for each file
+      FIM->>FS: readFile + split
+    end
+    FIM->>Provider: embedDocuments([...all chunks, new model])
+    Provider-->>FIM: new vectors
+    FIM->>Store: FaissStore.fromTexts(all)<br/>:338-343
+  end
+  FIM->>Store: faissIndex.save(faiss.index)<br/>:348-355
+  par tmp+rename sidecars (unchanged hashes)
+    FIM->>FS: overwrite sidecar (.tmp → rename)
+  end
+```
+
+## Why the fallback runs
+
+The sha256 sidecars are hashes of the **source file content**, not of the embedding — so changing the embedding model does **not** invalidate them (`src/utils.ts:6-11`). On the first call after a model change:
+
+- Every file's hash matches its sidecar, so the changed-file branch at `src/FaissIndexManager.ts:250-293` is skipped.
+- But `this.faissIndex` is still `null` (cleared by the model-change block at `:163`, not replaced by the `FaissStore.load` branch at `:166-177` because `faiss.index` no longer exists).
+- The combination — "some files scanned AND `faissIndex === null`" — triggers the fallback at `src/FaissIndexManager.ts:302-346`, which unconditionally re-embeds every file.
+
+That fallback is also what recovers from a user manually deleting `$FAISS_INDEX_PATH/faiss.index`.
+
+## Cost
+
+Proportional to `total_chunks × per_chunk_embedding_latency` plus one `save()`. RFC 007 §5.2 measured 10 761 ms for 100 files / 500 chunks against a 20 ms/chunk stub; real providers range from 50 to 200 ms/chunk — see [`qa-budgets.md`](./qa-budgets.md).
+
+## Partial-model switch (e.g. wrong provider env)
+
+If the user sets `EMBEDDING_PROVIDER=openai` but forgets `OPENAI_API_KEY`, construction throws at `src/FaissIndexManager.ts:100` before `initialize()` runs — so the on-disk index is **not** touched. Same for HuggingFace at `:112`. The `.faiss/` directory survives, and reverting the env on the next start restores the prior behaviour with no rebuild cost.

--- a/docs/architecture/sequence-retrieve.md
+++ b/docs/architecture/sequence-retrieve.md
@@ -1,0 +1,104 @@
+# Sequence — `retrieve_knowledge`
+
+End-to-end flow for the `retrieve_knowledge` tool. The handler lives at `src/KnowledgeBaseServer.ts:74-122` and always runs two steps in order: refresh the index (`updateIndex` at `src/FaissIndexManager.ts:202-389`), then query it (`similaritySearch` at `src/FaissIndexManager.ts:394-408`).
+
+There are two paths through the same handler, distinguished by **whether the in-memory `faissIndex` is already populated when the request arrives**. Both land at the same `similaritySearch` call.
+
+## Warm path — index loaded, all hashes match
+
+This is the cheap case: every file's on-disk sha matches the sidecar, so no embedding calls happen.
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant Client as MCP client
+  participant Server as KnowledgeBaseServer<br/>:74-122
+  participant FIM as FaissIndexManager
+  participant FS as $KNOWLEDGE_BASES_ROOT_DIR
+  participant Faiss as faissIndex (in-memory)
+  participant Provider as Embedding provider
+
+  Client->>Server: tools/call retrieve_knowledge<br/>{query, knowledge_base_name?, threshold?}
+  Server->>FIM: updateIndex(knowledge_base_name?)<br/>:202-389
+  FIM->>FS: readdir + getFilesRecursively<br/>:209, :223
+  loop for each file
+    FIM->>FS: readFile + sha256<br/>utils.ts:6-11
+    FIM->>FS: read sidecar hash<br/>:242-247
+    Note over FIM: hashes match → skip branch<br/>:294-296
+  end
+  Note over FIM,Faiss: indexMutated == false → no save
+  Server->>FIM: similaritySearch(query, 10, threshold)<br/>:394-408
+  FIM->>Provider: embedQuery(query)
+  Provider-->>FIM: query vector
+  FIM->>Faiss: similaritySearchWithScore(vec, 10, filter)
+  Faiss-->>FIM: [(doc, score), ...]
+  FIM-->>Server: ScoredDocument[]
+  Server-->>Client: markdown-formatted results
+```
+
+**Cost profile.** No embedding batches for documents, no FAISS save, no sidecar writes. The scan is O(files-across-selected-KBs) with one `stat` + `readFile` + sha256 + sidecar-read per file. See [`qa-budgets.md`](./qa-budgets.md) for the ~85 ms warm floor measured in RFC 007 §5.3.
+
+## Cold path — no persisted index (or first-touch files)
+
+Either `initialize()` found no `faiss.index` on disk (`src/FaissIndexManager.ts:174-177`), so `this.faissIndex` is `null` at request time, **or** some file hashes don't match. Both land in the same branch: changed chunks are embedded, `faissIndex` is built or extended, then persisted once.
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant Client as MCP client
+  participant Server as KnowledgeBaseServer<br/>:74-122
+  participant FIM as FaissIndexManager
+  participant FS as $KNOWLEDGE_BASES_ROOT_DIR
+  participant Faiss as faissIndex (in-memory)
+  participant Store as $FAISS_INDEX_PATH
+  participant Provider as Embedding provider
+
+  Client->>Server: tools/call retrieve_knowledge
+  Server->>FIM: updateIndex(knowledge_base_name?)<br/>:202-389
+  FIM->>FS: readdir KBs + recursive file walk<br/>:209, :223
+  loop for each file with mismatched/absent hash
+    FIM->>FS: readFile<br/>:253-258
+    alt *.md
+      FIM->>FIM: MarkdownTextSplitter.createDocuments<br/>:261-267
+    else other ext
+      FIM->>FIM: new Document({pageContent, metadata: {source}})<br/>:268-275
+    end
+    alt faissIndex == null (first chunk)
+      FIM->>Provider: embedDocuments(chunks)
+      FIM->>Faiss: FaissStore.fromTexts(...)<br/>:278-284
+    else index exists
+      FIM->>Provider: embedDocuments(chunks)
+      FIM->>Faiss: addDocuments(chunks)<br/>:285-287
+    end
+    Note over FIM: pendingHashWrites.push({path, hash})<br/>:289
+  end
+  opt faissIndex still null && any file scanned
+    FIM->>FS: re-walk all KBs<br/>:302-337<br/>(fallback rebuild from every file)
+    FIM->>Provider: embedDocuments(all chunks)
+    FIM->>Faiss: FaissStore.fromTexts(all)<br/>:338-345
+  end
+  FIM->>Store: faissIndex.save(FAISS_INDEX_PATH/faiss.index)<br/>:348-355
+  par write hash sidecars (tmp + rename)
+    FIM->>FS: writeFile <sidecar>.tmp + rename<br/>:362-377
+  end
+  Server->>FIM: similaritySearch(query, 10, threshold)<br/>:394-408
+  FIM->>Provider: embedQuery(query)
+  FIM->>Faiss: similaritySearchWithScore(vec, 10, filter)
+  Faiss-->>FIM: [(doc, score), ...]
+  FIM-->>Server: ScoredDocument[]
+  Server-->>Client: markdown-formatted results
+```
+
+### Ordering invariant
+
+One `save()` per `updateIndex` call; hash sidecars are written **after** `save()` completes and use tmp+rename so each is atomic. If the process dies between `save()` and finishing sidecar writes, the un-sidecar'd files are re-embedded on the next call and their vectors are duplicated. RFC 007 §6.2.1 tracks the pending-manifest protocol that will close this gap; the current state is documented at `src/FaissIndexManager.ts:356-377` and in [`state-index.md`](./state-index.md) under **Recovering**.
+
+### Fallback rebuild edge case
+
+If the hash-scan phase embedded nothing (e.g. first call after a fresh restart with a `faiss.index` that failed to load, or an index-less directory that also has stale sidecar state) but files exist, the branch at `src/FaissIndexManager.ts:302-346` re-walks every KB and embeds **all** chunks unconditionally. This is the path that makes cold starts slow on large KBs — see [`qa-budgets.md`](./qa-budgets.md) for the 10 761 ms measurement at 100 files / 500 chunks.
+
+## Error paths (not drawn)
+
+- Permission error during save/sidecar → `handleFsOperationError` at `src/FaissIndexManager.ts:50-78` marks the error `__alreadyLogged` and rethrows. The tool handler catches it at `src/KnowledgeBaseServer.ts:114-121` and returns `{ isError: true }`.
+- `similaritySearch` called when `faissIndex` is still `null` (e.g. empty `$KNOWLEDGE_BASES_ROOT_DIR`) → throws `"FAISS index is not initialized"` from `src/FaissIndexManager.ts:395-397`; the same handler converts it to `isError: true`.
+- Provider call failure → unwound through the `throw error` at `src/FaissIndexManager.ts:380-388`; same handler path.

--- a/docs/architecture/state-index.md
+++ b/docs/architecture/state-index.md
@@ -1,0 +1,96 @@
+# State — FAISS index lifecycle
+
+Lifecycle of the in-memory `this.faissIndex: FaissStore | null` field (`src/FaissIndexManager.ts:81`) and its on-disk counterpart at `$FAISS_INDEX_PATH/faiss.index`. The diagram describes observable states from the caller's perspective — the field is either `null` or a `FaissStore`; the lifecycle enriches that single bit with the *reason* for its current value.
+
+`Recovering` is planned-but-not-yet-implemented state gated on RFC 007 §6.2.1 (pending-manifest protocol). It is drawn so this doc tracks the direction of travel; see the footnote below.
+
+## Diagram
+
+```mermaid
+stateDiagram-v2
+  [*] --> None: process start<br/>before initialize()
+
+  state "None" as None
+  note left of None
+    faissIndex = null
+    $FAISS_INDEX_PATH may or may not exist
+    src/FaissIndexManager.ts:81
+  end note
+
+  None --> Loading: initialize() sees faiss.index on disk<br/>:166
+
+  state "Loading" as Loading
+  note right of Loading
+    FaissStore.load(path, embeddings)
+    src/FaissIndexManager.ts:169
+    (may throw → handleFsOperationError)
+  end note
+
+  Loading --> Loaded: load() resolves<br/>:173
+  Loading --> None: load() fails → re-thrown; next init retries
+
+  None --> Rebuilding: initialize() sees model_name.txt mismatch<br/>:153-164
+  Loaded --> Rebuilding: (not today — index is kept; rebuild happens only via initialize())
+
+  state "Rebuilding" as Rebuilding
+  note right of Rebuilding
+    unlink(faiss.index)
+    faissIndex = null
+    model_name.txt rewritten on exit of initialize()
+    src/FaissIndexManager.ts:154-164, :181
+  end note
+
+  Rebuilding --> None: initialize() returns<br/>(next updateIndex hits fallback :302-346)
+
+  None --> Loaded: updateIndex fallback rebuild<br/>:302-346 → FaissStore.fromTexts
+  None --> Loaded: first updateIndex call with changed files<br/>:278-284
+
+  state "Loaded" as Loaded
+  note left of Loaded
+    faissIndex is a FaissStore
+    $FAISS_INDEX_PATH/faiss.index persisted
+    ready to answer similaritySearch :394-408
+  end note
+
+  Loaded --> Loaded: updateIndex with new / changed files<br/>addDocuments + save :285-287, :348-355
+  Loaded --> Loaded: updateIndex with all-matching hashes<br/>(no-op save path :348)
+
+  Loaded --> Recovering: [RFC 007 §6.2.1 — not yet]<br/>initialize() sees pending-manifest.json
+  Recovering --> Loaded: finish pending hash-sidecar writes
+
+  state "Recovering" as Recovering
+  note right of Recovering
+    PLANNED, not implemented
+    save() persisted vectors but
+    sidecar writes did not complete →
+    pending-manifest.json is the flag
+  end note
+
+  Loaded --> [*]: SIGINT → McpServer.close()<br/>src/KnowledgeBaseServer.ts:27-30
+```
+
+## Transition triggers
+
+| From → To                     | Trigger                                                                                   | Anchor                                             |
+| ----------------------------- | ----------------------------------------------------------------------------------------- | -------------------------------------------------- |
+| `[*]` → `None`                | Process start; constructor runs but does not touch disk.                                  | `src/FaissIndexManager.ts:81, :86-131`             |
+| `None` → `Loading`            | `initialize()` finds `faiss.index` and no model-name mismatch.                            | `src/FaissIndexManager.ts:166`                     |
+| `Loading` → `Loaded`          | `FaissStore.load` resolves.                                                               | `src/FaissIndexManager.ts:169-173`                 |
+| `Loading` → `None`            | `FaissStore.load` rejects (permission / corrupt / incompatible). Error propagated; caller retries. | `src/FaissIndexManager.ts:170-172`                 |
+| `None` → `Rebuilding`         | `initialize()` sees `model_name.txt` ≠ `this.modelName`.                                  | `src/FaissIndexManager.ts:153-154`                 |
+| `Rebuilding` → `None`         | `unlink` completes, `faissIndex = null`, `initialize()` returns; next `updateIndex` will rebuild. | `src/FaissIndexManager.ts:157-163, :181`           |
+| `None` → `Loaded` (build)     | Changed-file branch creates the store with `FaissStore.fromTexts`.                        | `src/FaissIndexManager.ts:278-284`                 |
+| `None` → `Loaded` (fallback)  | All hashes match but `faissIndex` was null → full rebuild from every file.                | `src/FaissIndexManager.ts:302-346`                 |
+| `Loaded` → `Loaded` (delta)   | Subsequent `updateIndex` with new/changed files; `addDocuments` + one `save()`.           | `src/FaissIndexManager.ts:285-287, :348-355`       |
+| `Loaded` → `Recovering`       | **Planned.** `initialize()` detects `pending-manifest.json` on disk.                     | RFC 007 §6.2.1 (not yet implemented).              |
+| `Loaded` → `[*]`              | SIGINT handler closes the MCP server.                                                     | `src/KnowledgeBaseServer.ts:27-30`                 |
+
+## Invariants
+
+- **`model_name.txt` is written only in `initialize()`** (`src/FaissIndexManager.ts:181`). Consequence: between a successful rebuild and the subsequent save in `updateIndex`, a crash leaves a `model_name.txt` matching the *new* model but no `faiss.index` — which is the exact scenario the `None → Loaded (fallback)` transition is built to handle.
+- **`faissIndex === null` and `$FAISS_INDEX_PATH/faiss.index` exists** is only possible between `initialize()`'s `unlink` call (`:157`) and the eventual `save()` in the next `updateIndex`.
+- **`Loaded → Loaded` with all hashes matching does NOT write** (`indexMutated` stays `false`, so the block at `src/FaissIndexManager.ts:348-378` is skipped).
+
+## Footnote — Recovering is drawn but not live
+
+The `Recovering` state is on the diagram so that future readers of this page see that the crash-safety story is *incomplete today*. The current code atomically renames each sidecar but has no manifest that survives a crash between `save()` and the last rename — a crash there causes the un-renamed files to be re-embedded on next startup, duplicating their vectors in the FAISS store (FAISS does not dedup by source). Details in RFC 007 §6.2.1.


### PR DESCRIPTION
## Summary

Second of three docs-only PRs for the architecture scaffold. Adds the behaviour and data layer of `docs/architecture/` on top of the C4 scaffold from #61.

## Files

- `docs/architecture/sequence-retrieve.md` — cold + warm paths through `retrieve_knowledge`, with the mandatory `updateIndex` scan drawn explicitly.
- `docs/architecture/sequence-reindex.md` — what happens when `EMBEDDING_PROVIDER` / `*_MODEL` changes with an existing index on disk (destructive rebuild via the fallback branch at `FaissIndexManager.ts:302-346`).
- `docs/architecture/state-index.md` — `stateDiagram-v2` of the FAISS-index lifecycle: None → Loading → Loaded → Rebuilding, with a planned `Recovering` state tied to RFC 007 §6.2.1.
- `docs/architecture/data-model.md` — on-disk artifacts (hash sidecars, `faiss.index`, docstore, `model_name.txt`) and the current + forthcoming chunk metadata schema.
- `docs/architecture/qa-budgets.md` — RFC 007 §5 measurements (170 ms cold start, 10 761 ms cold build for 100/500, 85 ms warm floor), the current scale ceiling, and the three known cliffs.

## Test plan

- [x] ``npm test`` — 13/13 passing (no source changes).
- [x] Every `file.ts:line` anchor resolves against current `main`.
- [ ] Every mermaid block renders on GitHub preview.

References #42. The threat-model + ADRs + README Security section are the third and final PR in this series.