### PR TITLE
fix(chunking): split non-markdown text files with RecursiveCharacterTextSplitter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 
 ### Fixed
 
+- Non-markdown text files (`.txt`, `.rst`, source code, logs, …) are now split with `RecursiveCharacterTextSplitter` (same `chunkSize: 1000, chunkOverlap: 200` defaults as the markdown path) instead of being wrapped in a single `Document`. Previously, a large non-markdown file produced one embedding and one retrieval result, collapsing recall to near-zero on any content other than `.md`. (#45)
 - Retrieval-quality benchmark now simulates approximate-nearest-neighbor behavior per KB so the `fanout_factor` sweep is actually sensitive across `f ∈ {1, 2, 3, 5, 10}` — exact per-KB search made the sweep collapse to a single value. Baseline regenerated. (RFC 007 PR 0.1, #26)
 - Addressed reliability issues (timeouts, hanging) with HuggingFace API by providing a local fallback.
 - HuggingFace embedding provider was broken by HuggingFace retiring the legacy

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ npx -y @smithery/cli install @jeanibarz/knowledge-base-mcp-server --client claud
 *   The server recursively reads all text files (e.g., `.txt`, `.md`) within the specified knowledge base subdirectories.
 *   The server skips hidden files and directories (those starting with a `.`).
 *   For each file, the server calculates the SHA256 hash and stores it in a file with the same name in a hidden `.index` subdirectory. This hash is used to determine if the file has been modified since the last indexing.
-*   The file content is splitted into chunks using the `MarkdownTextSplitter` from `langchain/text_splitter`.
+*   File content is split into chunks before indexing: `.md` files use `MarkdownTextSplitter` (heading-aware), and every other text file uses `RecursiveCharacterTextSplitter`. Both splitters share the same `chunkSize: 1000, chunkOverlap: 200` defaults, so a large `.txt`, `.rst`, or source file produces many chunks rather than a single embedding.
 *   The content of each chunk is then added to a FAISS index, which is used for similarity search.
 *   The FAISS index is automatically initialized when the server starts. It checks for changes in the knowledge base files and updates the index accordingly.
 

--- a/src/FaissIndexManager.test.ts
+++ b/src/FaissIndexManager.test.ts
@@ -220,6 +220,48 @@ describe('FaissIndexManager permission handling', () => {
     }
   });
 
+  it('splits non-markdown text files into multiple chunks when content exceeds chunkSize', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-faiss-nonmd-chunks-'));
+    const kbDir = path.join(tempDir, 'kb');
+    const defaultKb = path.join(kbDir, 'default');
+    await fsp.mkdir(defaultKb, { recursive: true });
+
+    // Build a .txt payload well above the 1000-char chunkSize, with natural
+    // paragraph breaks so RecursiveCharacterTextSplitter's default separators
+    // (\n\n, \n, " ", "") produce multiple chunks rather than one.
+    const paragraphs = Array.from(
+      { length: 20 },
+      (_, i) => `Paragraph ${i}: ${'lorem ipsum dolor sit amet '.repeat(10)}`
+    );
+    const txtContent = paragraphs.join('\n\n');
+    expect(txtContent.length).toBeGreaterThan(1000);
+    const txtPath = path.join(defaultKb, 'large.txt');
+    await fsp.writeFile(txtPath, txtContent);
+
+    process.env.KNOWLEDGE_BASES_ROOT_DIR = kbDir;
+    process.env.FAISS_INDEX_PATH = path.join(tempDir, '.faiss');
+    process.env.EMBEDDING_PROVIDER = 'huggingface';
+    process.env.HUGGINGFACE_API_KEY = 'test-key';
+
+    jest.resetModules();
+    const { FaissIndexManager } = await import('./FaissIndexManager.js');
+    const manager = new FaissIndexManager();
+    await manager.initialize();
+    await manager.updateIndex();
+
+    // Pre-fix behaviour: the whole file was wrapped in a single Document, so
+    // fromTexts received a one-element array. Post-fix: RecursiveCharacterTextSplitter
+    // splits by \n\n and produces multiple chunks for this payload.
+    expect(fromTextsMock).toHaveBeenCalledTimes(1);
+    const [texts, metadatas] = fromTextsMock.mock.calls[0] as [string[], Array<{ source: string }>];
+    expect(Array.isArray(texts)).toBe(true);
+    expect(texts.length).toBeGreaterThan(1);
+    expect(metadatas).toHaveLength(texts.length);
+    for (const metadata of metadatas) {
+      expect(metadata.source).toBe(txtPath);
+    }
+  });
+
   it('rebuilds via fromTexts once when the FAISS index is missing but sidecars are up to date', async () => {
     const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-faiss-fallback-'));
     const kbDir = path.join(tempDir, 'kb');

--- a/src/FaissIndexManager.ts
+++ b/src/FaissIndexManager.ts
@@ -6,7 +6,7 @@ import { OllamaEmbeddings } from "@langchain/ollama";
 import { OpenAIEmbeddings } from "@langchain/openai";
 import { FaissStore } from "@langchain/community/vectorstores/faiss";
 import { Document } from "@langchain/core/documents";
-import { MarkdownTextSplitter } from "langchain/text_splitter";
+import { MarkdownTextSplitter, RecursiveCharacterTextSplitter } from "langchain/text_splitter";
 import { calculateSHA256, getFilesRecursively } from './utils.js';
 import {
   KNOWLEDGE_BASES_ROOT_DIR,
@@ -258,21 +258,18 @@ export class FaissIndexManager {
             }
 
             let documentsToAdd: Document[] = [];
-            if (path.extname(filePath).toLowerCase() === '.md') {
-              const splitter = new MarkdownTextSplitter({
-                chunkSize: 1000,
-                chunkOverlap: 200,
-                keepSeparator: false,
-              });
-              documentsToAdd = await splitter.createDocuments([content], [{ source: filePath }]);
-            } else {
-              documentsToAdd = [
-                new Document({
-                  pageContent: content,
-                  metadata: { source: filePath },
-                }),
-              ];
-            }
+            const ext = path.extname(filePath).toLowerCase();
+            const splitter = ext === '.md'
+              ? new MarkdownTextSplitter({
+                  chunkSize: 1000,
+                  chunkOverlap: 200,
+                  keepSeparator: false,
+                })
+              : new RecursiveCharacterTextSplitter({
+                  chunkSize: 1000,
+                  chunkOverlap: 200,
+                });
+            documentsToAdd = await splitter.createDocuments([content], [{ source: filePath }]);
 
             if (documentsToAdd.length > 0) {
               if (this.faissIndex === null) {
@@ -314,22 +311,18 @@ export class FaissIndexManager {
               logger.error(`Error reading file ${filePath}:`, error);
               continue;
             }
-            let documents: Document[];
-            if (path.extname(filePath).toLowerCase() === '.md') {
-              const splitter = new MarkdownTextSplitter({
-                chunkSize: 1000,
-                chunkOverlap: 200,
-                keepSeparator: false,
-              });
-              documents = await splitter.createDocuments([content], [{ source: filePath }]);
-            } else {
-              documents = [
-                new Document({
-                  pageContent: content,
-                  metadata: { source: filePath },
-                }),
-              ];
-            }
+            const ext = path.extname(filePath).toLowerCase();
+            const splitter = ext === '.md'
+              ? new MarkdownTextSplitter({
+                  chunkSize: 1000,
+                  chunkOverlap: 200,
+                  keepSeparator: false,
+                })
+              : new RecursiveCharacterTextSplitter({
+                  chunkSize: 1000,
+                  chunkOverlap: 200,
+                });
+            const documents = await splitter.createDocuments([content], [{ source: filePath }]);
             if (documents.length > 0) {
               allDocuments.push(...documents);
             }


### PR DESCRIPTION
## Summary
Non-markdown text files (`.txt`, `.rst`, source code, logs) were being wrapped in a single `Document` regardless of size — one embedding per file, collapsing retrieval recall to near-zero for any content that isn't markdown. Now falls back to `RecursiveCharacterTextSplitter` with the same `chunkSize: 1000, chunkOverlap: 200` defaults the markdown path already uses.

## What changed
- `src/FaissIndexManager.ts:260-272` — primary indexing path now picks `MarkdownTextSplitter` for `.md` and `RecursiveCharacterTextSplitter` for everything else, then calls `createDocuments` once.
- `src/FaissIndexManager.ts:314-325` — same fix applied to the fallback rebuild branch (index missing but sidecars intact).
- `src/FaissIndexManager.ts:9` — added `RecursiveCharacterTextSplitter` to the existing `langchain/text_splitter` import.
- `src/FaissIndexManager.test.ts` — new case: a `.txt` file with content > `chunkSize` produces >1 chunk; asserts on the `fromTexts` call's `texts.length` and that every metadata `source` points back at the `.txt` file.
- `README.md` (around line 185) — wording updated to reflect both splitter paths and the shared chunk defaults.
- `CHANGELOG.md` — entry added under `## [Unreleased]` → `### Fixed`.

## Verification
Against the pre-fix source (`git checkout origin/main -- src/FaissIndexManager.ts`) with the new test applied, the test fails as expected:

```
expect(received).toBeGreaterThan(expected)
    Expected: > 1
    Received:   1
      > 258 |     expect(texts.length).toBeGreaterThan(1);
```

Against the fixed source, the same test passes — so the new test is a genuine reproduction, not just additional coverage.

## Testing
- [x] `npm run build` — clean
- [x] `npm test` — 15 passed, 15 total (14 existing + 1 new)

## Scope discipline
- Chunk sizes and overlap unchanged — parity with the markdown path is the point of this fix.
- No PDF/HTML loader additions (issue #46, out of scope).
- No unrelated refactors.

## Follow-ups
- None.

Closes #45.