### PR TITLE
fix(reliability): recover from corrupt FAISS index by rebuilding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 ### Fixed
 
 - Non-markdown text files (`.txt`, `.rst`, source code, logs, …) are now split with `RecursiveCharacterTextSplitter` (same `chunkSize: 1000, chunkOverlap: 200` defaults as the markdown path) instead of being wrapped in a single `Document`. Previously, a large non-markdown file produced one embedding and one retrieval result, collapsing recall to near-zero on any content other than `.md`. (#45)
+- A corrupt or unreadable FAISS index file no longer wedges startup. `FaissIndexManager.initialize` now logs a warning, deletes the corrupt `faiss.index` (and its `.json` sidecar, best-effort), and falls through to the existing rebuild path so the next `retrieve_knowledge` call re-embeds from source instead of failing. Previously the only recovery was a manual `rm -rf $FAISS_INDEX_PATH`. (#57)
 - Retrieval-quality benchmark now simulates approximate-nearest-neighbor behavior per KB so the `fanout_factor` sweep is actually sensitive across `f ∈ {1, 2, 3, 5, 10}` — exact per-KB search made the sweep collapse to a single value. Baseline regenerated. (RFC 007 PR 0.1, #26)
 - Addressed reliability issues (timeouts, hanging) with HuggingFace API by providing a local fallback.
 - HuggingFace embedding provider was broken by HuggingFace retiring the legacy

--- a/src/FaissIndexManager.test.ts
+++ b/src/FaissIndexManager.test.ts
@@ -347,6 +347,110 @@ describe('FaissIndexManager permission handling', () => {
     }
   });
 
+  it('recovers from a corrupt FAISS index by unlinking it and falling back to rebuild', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-faiss-corrupt-'));
+    const kbDir = path.join(tempDir, 'kb');
+    const defaultKb = path.join(kbDir, 'default');
+    await fsp.mkdir(defaultKb, { recursive: true });
+    const docPath = path.join(defaultKb, 'doc.md');
+    await fsp.writeFile(docPath, '# Title\n\nContent for the corrupt-recovery case.');
+
+    const faissDir = path.join(tempDir, '.faiss');
+    await fsp.mkdir(faissDir, { recursive: true });
+    const indexFilePath = path.join(faissDir, 'faiss.index');
+    const indexJsonPath = `${indexFilePath}.json`;
+    await fsp.writeFile(indexFilePath, 'corrupt-bytes');
+    await fsp.writeFile(indexJsonPath, '{"docstore":"corrupt"}');
+
+    process.env.KNOWLEDGE_BASES_ROOT_DIR = kbDir;
+    process.env.FAISS_INDEX_PATH = faissDir;
+    process.env.EMBEDDING_PROVIDER = 'huggingface';
+    process.env.HUGGINGFACE_API_KEY = 'test-key';
+
+    loadMock.mockImplementationOnce(() => {
+      throw new Error('invalid faiss index header');
+    });
+
+    jest.resetModules();
+    const { FaissIndexManager } = await import('./FaissIndexManager.js');
+    const manager = new FaissIndexManager();
+
+    await expect(manager.initialize()).resolves.toBeUndefined();
+
+    expect(loadMock).toHaveBeenCalledWith(indexFilePath, expect.anything());
+    await expect(fsp.stat(indexFilePath)).rejects.toMatchObject({ code: 'ENOENT' });
+    await expect(fsp.stat(indexJsonPath)).rejects.toMatchObject({ code: 'ENOENT' });
+
+    // End-to-end: the next updateIndex must actually rebuild via fromTexts,
+    // not just observe a null faissIndex. This proves the corrupt-recovery
+    // path hands off correctly to the existing rebuild branch.
+    await manager.updateIndex();
+    expect(fromTextsMock).toHaveBeenCalledTimes(1);
+    expect(saveMock).toHaveBeenCalledWith(indexFilePath);
+  });
+
+  it('surfaces a permission error when the corrupt FAISS index cannot be unlinked', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-faiss-corrupt-eacces-'));
+    const kbDir = path.join(tempDir, 'kb');
+    await fsp.mkdir(kbDir, { recursive: true });
+
+    const faissDir = path.join(tempDir, '.faiss');
+    await fsp.mkdir(faissDir, { recursive: true });
+    const indexFilePath = path.join(faissDir, 'faiss.index');
+    await fsp.writeFile(indexFilePath, 'corrupt-bytes');
+
+    process.env.KNOWLEDGE_BASES_ROOT_DIR = kbDir;
+    process.env.FAISS_INDEX_PATH = faissDir;
+    process.env.EMBEDDING_PROVIDER = 'huggingface';
+    process.env.HUGGINGFACE_API_KEY = 'test-key';
+
+    loadMock.mockImplementationOnce(() => {
+      throw new Error('invalid faiss index header');
+    });
+
+    // 0o500 on the containing directory keeps stat/read permitted (so the
+    // load branch fires) but denies unlink, forcing the handleFsOperationError
+    // rethrow path in the corrupt-recovery catch.
+    await fsp.chmod(faissDir, 0o500);
+
+    try {
+      jest.resetModules();
+      const { FaissIndexManager } = await import('./FaissIndexManager.js');
+      const manager = new FaissIndexManager();
+
+      await expect(manager.initialize()).rejects.toThrow(/Permission denied/);
+    } finally {
+      await fsp.chmod(faissDir, 0o700);
+    }
+  });
+
+  it('does not fail when the corrupt FAISS index has no .json sibling', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-faiss-corrupt-nojson-'));
+    const kbDir = path.join(tempDir, 'kb');
+    await fsp.mkdir(kbDir, { recursive: true });
+
+    const faissDir = path.join(tempDir, '.faiss');
+    await fsp.mkdir(faissDir, { recursive: true });
+    const indexFilePath = path.join(faissDir, 'faiss.index');
+    await fsp.writeFile(indexFilePath, 'corrupt-bytes');
+
+    process.env.KNOWLEDGE_BASES_ROOT_DIR = kbDir;
+    process.env.FAISS_INDEX_PATH = faissDir;
+    process.env.EMBEDDING_PROVIDER = 'huggingface';
+    process.env.HUGGINGFACE_API_KEY = 'test-key';
+
+    loadMock.mockImplementationOnce(() => {
+      throw new Error('invalid faiss index header');
+    });
+
+    jest.resetModules();
+    const { FaissIndexManager } = await import('./FaissIndexManager.js');
+    const manager = new FaissIndexManager();
+
+    await expect(manager.initialize()).resolves.toBeUndefined();
+    await expect(fsp.stat(indexFilePath)).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
   it('does not write hash sidecars when the FAISS save fails', async () => {
     const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-faiss-save-fail-'));
     const kbDir = path.join(tempDir, 'kb');

--- a/src/FaissIndexManager.ts
+++ b/src/FaissIndexManager.ts
@@ -167,10 +167,25 @@ export class FaissIndexManager {
         logger.info('Loading existing FAISS index from:', indexFilePath);
         try {
           this.faissIndex = await FaissStore.load(indexFilePath, this.embeddings);
+          logger.info('FAISS index loaded.');
         } catch (error) {
-          handleFsOperationError('load FAISS index from', indexFilePath, error);
+          logger.warn(
+            'Existing FAISS index at',
+            indexFilePath,
+            'is corrupt or unreadable - rebuilding from source. Error:',
+            error
+          );
+          try {
+            await fsp.unlink(indexFilePath);
+          } catch (unlinkErr) {
+            handleFsOperationError('delete corrupt FAISS index', indexFilePath, unlinkErr);
+          }
+          // Best-effort: the .json docstore sibling may not exist (older index layouts
+          // wrote only faiss.index) and any failure here is non-fatal - the rebuild
+          // path will overwrite it on the next save.
+          await fsp.unlink(`${indexFilePath}.json`).catch(() => {});
+          this.faissIndex = null;
         }
-        logger.info('FAISS index loaded.');
       } else {
         logger.info('FAISS index file not found at', indexFilePath, '. It will be created if documents are available.');
         this.faissIndex = null;


### PR DESCRIPTION
## Summary

A corrupt or unreadable `faiss.index` file previously wedged startup: `FaissStore.load` threw, `handleFsOperationError` rethrew, and the only recovery was manual `rm -rf $FAISS_INDEX_PATH`. `initialize()` now treats a load failure as a recoverable soft failure — warn, unlink, fall through to the existing rebuild path.

## What changed

- `src/FaissIndexManager.ts:171-189` — load-failure catch no longer rethrows. Logs a warning with the underlying error, unlinks `faiss.index` (real fs errors here still route through `handleFsOperationError` so permission issues surface loudly), best-effort unlinks the `.json` docstore sibling (older index layouts may not have one), and sets `faissIndex = null` so the existing fallback-rebuild branch at `:302-346` takes over on the next `retrieve_knowledge` call.
- `src/FaissIndexManager.test.ts` — three new cases mirroring the existing mock style:
  1. `FaissStore.load` throws with a `.json` sibling present → both files unlinked, `initialize()` resolves, and the following `updateIndex()` actually rebuilds via `fromTexts` (end-to-end hand-off check, not just a null assertion).
  2. Same scenario without the `.json` sibling → best-effort cleanup doesn't raise.
  3. Corrupt index whose containing dir is `chmod 0o500` → primary unlink fails with EACCES, `handleFsOperationError` rethrows, `initialize()` rejects with "Permission denied".
- `CHANGELOG.md` — `## [Unreleased] → ### Fixed` entry.

## Verification

- `npm run build` — clean (`tsc -p tsconfig.json`).
- `npm test` — 17/17 pass across 4 suites, including all three new cases.
- Bug reproduction: test 1 mocks `FaissStore.load` to throw, confirms pre-fix behaviour (rethrow) is absent on the new code path and that `updateIndex` downstream hits `fromTextsMock` once — i.e. the index is actually rebuilt, not just marked null.

## Follow-ups

- None. Complementary to RFC 007 §6.2.1's pending-manifest protocol (which will reduce partial-write corruptions), not superseded by it — binary format drift and bit rot still hit this path.

Closes #57.