### PR TITLE
docs: multi-client setup + adoption badges (closes #38, refs #40)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Changed
 
+- README now links to a dedicated `docs/clients.md` with setup snippets for Claude Desktop, Codex CLI, Cursor, Continue, and Cline. Closes #38. References #40 (badges only — demo recording pending).
 - Refactored embedding logic to support provider abstraction and selection.
 - Improved error handling and logging for embedding operations.
 - Upgraded `@huggingface/inference` to the v4 client path through a compatible `@langchain/community` release.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,16 @@
 # Knowledge Base MCP Server
 
-[![smithery badge](https://smithery.ai/badge/@jeanibarz/knowledge-base-mcp-server)](https://smithery.ai/server/@jeanibarz/knowledge-base-mcp-server)
+[![Tests](https://github.com/jeanibarz/knowledge-base-mcp-server/actions/workflows/test.yml/badge.svg)](https://github.com/jeanibarz/knowledge-base-mcp-server/actions/workflows/test.yml)
+[![License](https://img.shields.io/github/license/jeanibarz/knowledge-base-mcp-server)](./UNLICENSE)
+[![Node.js >= 20](https://img.shields.io/badge/node-%3E%3D20-brightgreen)](./package.json)
+
 This MCP server provides tools for listing and retrieving content from different knowledge bases.
+
+### Demo
+
+Live demo recording coming soon ([tracking #40](https://github.com/jeanibarz/knowledge-base-mcp-server/issues/40)).
+
+[![smithery badge](https://smithery.ai/badge/@jeanibarz/knowledge-base-mcp-server)](https://smithery.ai/server/@jeanibarz/knowledge-base-mcp-server)
 
 <a href="https://glama.ai/mcp/servers/n0p6v0o0a4">
   <img width="380" height="200" src="https://glama.ai/mcp/servers/n0p6v0o0a4/badge" alt="Knowledge Base Server MCP server" />
@@ -102,77 +111,9 @@ npx -y @smithery/cli install @jeanibarz/knowledge-base-mcp-server --client claud
     npm run build
     ```
 
-5.  **Add the server to the MCP settings:**
+5.  **Add the server to your MCP client:**
 
-    *   Edit the `cline_mcp_settings.json` file located at `/home/jean/.vscode-server/data/User/globalStorage/saoudrizwan.claude-dev/settings/`.
-    *   Add the following configuration to the `mcpServers` object:
-
-    *   **Option 1: Ollama Configuration**
-
-    ```json
-    "knowledge-base-mcp-ollama": {
-      "command": "node",
-      "args": [
-        "/path/to/knowledge-base-mcp-server/build/index.js"
-      ],
-      "disabled": false,
-      "autoApprove": [],
-      "env": {
-        "KNOWLEDGE_BASES_ROOT_DIR": "/path/to/knowledge_bases",
-        "EMBEDDING_PROVIDER": "ollama",
-        "OLLAMA_BASE_URL": "http://localhost:11434",
-        "OLLAMA_MODEL": "dengcao/Qwen3-Embedding-0.6B:Q8_0"
-      },
-      "description": "Retrieves similar chunks from the knowledge base based on a query using Ollama."
-    },
-    ```
-
-    *   **Option 2: OpenAI Configuration**
-
-    ```json
-    "knowledge-base-mcp-openai": {
-      "command": "node",
-      "args": [
-        "/path/to/knowledge-base-mcp-server/build/index.js"
-      ],
-      "disabled": false,
-      "autoApprove": [],
-      "env": {
-        "KNOWLEDGE_BASES_ROOT_DIR": "/path/to/knowledge_bases",
-        "EMBEDDING_PROVIDER": "openai",
-        "OPENAI_API_KEY": "YOUR_OPENAI_API_KEY",
-        "OPENAI_MODEL_NAME": "text-embedding-ada-002"
-      },
-      "description": "Retrieves similar chunks from the knowledge base based on a query using OpenAI."
-    },
-    ```
-
-    *   **Option 3: HuggingFace Configuration**
-
-    ```json
-    "knowledge-base-mcp-huggingface": {
-      "command": "node",
-      "args": [
-        "/path/to/knowledge-base-mcp-server/build/index.js"
-      ],
-      "disabled": false,
-      "autoApprove": [],
-      "env": {
-        "KNOWLEDGE_BASES_ROOT_DIR": "/path/to/knowledge_bases",
-        "EMBEDDING_PROVIDER": "huggingface",
-        "HUGGINGFACE_API_KEY": "YOUR_HUGGINGFACE_API_KEY",
-        "HUGGINGFACE_MODEL_NAME": "sentence-transformers/all-MiniLM-L6-v2",
-        "HUGGINGFACE_PROVIDER": "hf-inference"
-      },
-      "description": "Retrieves similar chunks from the knowledge base based on a query using HuggingFace."
-    },
-    ```
-
-    *   **Note:** You only need to add one of the above configurations (either Ollama, OpenAI or HuggingFace) to your `cline_mcp_settings.json` file, depending on your preferred embedding provider.
-    ```
-
-    *   Replace `/path/to/knowledge-base-mcp-server` with the actual path to the server directory.
-    *   Replace `/path/to/knowledge_bases` with the actual path to the knowledge bases directory.
+    See [docs/clients.md](docs/clients.md) for copy-pasteable configuration snippets for Claude Desktop, Codex CLI, Cursor, Continue, and Cline.
 
 6.  **Create knowledge base directories:**
 

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -1,0 +1,193 @@
+# MCP Client Configuration
+
+This server speaks stdio MCP and works with any stdio MCP client. Pick the block below that matches your client, paste it into the listed config file, and replace the placeholders with paths and credentials that match your environment.
+
+## Placeholders used in every snippet
+
+| Placeholder | What to substitute |
+| --- | --- |
+| `<PATH_TO_BUILD_INDEX>` | Absolute path to `build/index.js` after `npm run build` (e.g. `/Users/you/code/knowledge-base-mcp-server/build/index.js`). |
+| `<KB_ROOT>` | Absolute path to the directory that holds your knowledge-base subfolders. |
+| `<FAISS_INDEX_PATH>` | Optional. Absolute path for the FAISS index. Defaults to `$HOME/knowledge_bases/.faiss` if omitted. |
+| `<HF_API_KEY>` | HuggingFace API token (or a compatible Inference Provider key). |
+| `<OPENAI_API_KEY>` | OpenAI API key. |
+
+The blocks below alternate embedding providers so you can see all three configured at least once. Any client can use any provider — see the [README](../README.md) "Configure environment variables" step for the full env-var matrix.
+
+## Claude Desktop
+
+Config file:
+
+- macOS — `~/Library/Application Support/Claude/claude_desktop_config.json`
+- Windows — `%APPDATA%\Claude\claude_desktop_config.json`
+
+Add to the `mcpServers` object (Ollama provider shown):
+
+```json
+{
+  "mcpServers": {
+    "knowledge-base": {
+      "command": "node",
+      "args": ["<PATH_TO_BUILD_INDEX>"],
+      "env": {
+        "KNOWLEDGE_BASES_ROOT_DIR": "<KB_ROOT>",
+        "EMBEDDING_PROVIDER": "ollama",
+        "OLLAMA_BASE_URL": "http://localhost:11434",
+        "OLLAMA_MODEL": "dengcao/Qwen3-Embedding-0.6B:Q8_0"
+      }
+    }
+  }
+}
+```
+
+Restart Claude Desktop after editing the file. The server appears in the tools menu once the handshake succeeds.
+
+## Codex CLI
+
+Config file: `~/.codex/config.toml`
+
+Add an `[mcp_servers.<name>]` table (OpenAI provider shown):
+
+```toml
+[mcp_servers.knowledge-base]
+command = "node"
+args = ["<PATH_TO_BUILD_INDEX>"]
+
+[mcp_servers.knowledge-base.env]
+KNOWLEDGE_BASES_ROOT_DIR = "<KB_ROOT>"
+EMBEDDING_PROVIDER = "openai"
+OPENAI_API_KEY = "<OPENAI_API_KEY>"
+OPENAI_MODEL_NAME = "text-embedding-ada-002"
+```
+
+Codex CLI rereads `config.toml` on each invocation, so no restart is needed.
+
+## Cursor
+
+Config file:
+
+- Global — `~/.cursor/mcp.json`
+- Per project — `<project>/.cursor/mcp.json` (overrides global for that workspace)
+
+Add to the `mcpServers` object (HuggingFace provider shown):
+
+```json
+{
+  "mcpServers": {
+    "knowledge-base": {
+      "command": "node",
+      "args": ["<PATH_TO_BUILD_INDEX>"],
+      "env": {
+        "KNOWLEDGE_BASES_ROOT_DIR": "<KB_ROOT>",
+        "EMBEDDING_PROVIDER": "huggingface",
+        "HUGGINGFACE_API_KEY": "<HF_API_KEY>",
+        "HUGGINGFACE_MODEL_NAME": "sentence-transformers/all-MiniLM-L6-v2",
+        "HUGGINGFACE_PROVIDER": "hf-inference"
+      }
+    }
+  }
+}
+```
+
+Toggle the server on in **Cursor Settings → Features → MCP** after saving.
+
+## Continue
+
+Config file: `~/.continue/config.json`
+
+Add the server under `experimental.modelContextProtocolServers` (Ollama provider shown):
+
+```json
+{
+  "experimental": {
+    "modelContextProtocolServers": [
+      {
+        "transport": {
+          "type": "stdio",
+          "command": "node",
+          "args": ["<PATH_TO_BUILD_INDEX>"],
+          "env": {
+            "KNOWLEDGE_BASES_ROOT_DIR": "<KB_ROOT>",
+            "EMBEDDING_PROVIDER": "ollama",
+            "OLLAMA_BASE_URL": "http://localhost:11434",
+            "OLLAMA_MODEL": "dengcao/Qwen3-Embedding-0.6B:Q8_0"
+          }
+        }
+      }
+    ]
+  }
+}
+```
+
+Reload the Continue extension after saving.
+
+## Cline
+
+Config file: `cline_mcp_settings.json` inside the Cline extension's global storage directory. The exact path depends on your editor and OS — open the Cline extension, run **MCP: Edit Settings**, and it will open the right file. (Historically `.../globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json`.)
+
+Add to the `mcpServers` object. Three provider variants are shown — use only one:
+
+**Ollama**
+
+```json
+"knowledge-base-mcp-ollama": {
+  "command": "node",
+  "args": ["<PATH_TO_BUILD_INDEX>"],
+  "disabled": false,
+  "autoApprove": [],
+  "env": {
+    "KNOWLEDGE_BASES_ROOT_DIR": "<KB_ROOT>",
+    "EMBEDDING_PROVIDER": "ollama",
+    "OLLAMA_BASE_URL": "http://localhost:11434",
+    "OLLAMA_MODEL": "dengcao/Qwen3-Embedding-0.6B:Q8_0"
+  },
+  "description": "Retrieves similar chunks from the knowledge base based on a query using Ollama."
+}
+```
+
+**OpenAI**
+
+```json
+"knowledge-base-mcp-openai": {
+  "command": "node",
+  "args": ["<PATH_TO_BUILD_INDEX>"],
+  "disabled": false,
+  "autoApprove": [],
+  "env": {
+    "KNOWLEDGE_BASES_ROOT_DIR": "<KB_ROOT>",
+    "EMBEDDING_PROVIDER": "openai",
+    "OPENAI_API_KEY": "<OPENAI_API_KEY>",
+    "OPENAI_MODEL_NAME": "text-embedding-ada-002"
+  },
+  "description": "Retrieves similar chunks from the knowledge base based on a query using OpenAI."
+}
+```
+
+**HuggingFace**
+
+```json
+"knowledge-base-mcp-huggingface": {
+  "command": "node",
+  "args": ["<PATH_TO_BUILD_INDEX>"],
+  "disabled": false,
+  "autoApprove": [],
+  "env": {
+    "KNOWLEDGE_BASES_ROOT_DIR": "<KB_ROOT>",
+    "EMBEDDING_PROVIDER": "huggingface",
+    "HUGGINGFACE_API_KEY": "<HF_API_KEY>",
+    "HUGGINGFACE_MODEL_NAME": "sentence-transformers/all-MiniLM-L6-v2",
+    "HUGGINGFACE_PROVIDER": "hf-inference"
+  },
+  "description": "Retrieves similar chunks from the knowledge base based on a query using HuggingFace."
+}
+```
+
+## Verifying the connection
+
+Once the client launches the server, run a quick smoke test from the client UI:
+
+1. Ask the client to list the `knowledge-base` server's tools — you should see `list_knowledge_bases` and `retrieve_knowledge`.
+2. Call `list_knowledge_bases`. Each subdirectory of `<KB_ROOT>` (excluding dotfiles) is one knowledge base.
+3. Call `retrieve_knowledge` with a query that should hit your seeded content.
+
+If no tools show up, the most common causes are: a wrong absolute path in `args`, the `node` binary not on the client's `PATH`, or a missing `npm run build` on the server. Logs go to stderr and to `LOG_FILE` if set — see the [Troubleshooting](../README.md#troubleshooting--logging) section.


### PR DESCRIPTION
## Summary

Two adoption blockers from the recent doc audit, bundled into one docs-only PR.

- **#38 — multi-client config**: README only documented Cline at the maintainer's hard-coded `/home/jean/.vscode-server/...` storage path. Replaced with a new `docs/clients.md` carrying copy-pasteable snippets for **Claude Desktop, Codex CLI, Cursor, Continue, and Cline** — all using `<PATH_TO_BUILD_INDEX>` / `<KB_ROOT>` / `<HF_API_KEY>` placeholders. The blocks alternate embedding providers (Ollama / OpenAI / HuggingFace) so the reader sees all three configured at least once.
- **#40 — badges + demo**: Added three top-of-README badges (Tests / License / Node ≥ 20). The Tests workflow landed in #63 (`.github/workflows/test.yml`); the License shield now resolves cleanly because #63 also fixed `package.json` to `"license": "Unlicense"`; the Node badge is a static shields.io badge until the package is on npm. Skipped the npm-version badge — package isn't published yet (tracked in #41); broken badges hurt more than missing ones.

The README "Add the server to the MCP settings" step is now a two-line pointer to `docs/clients.md`. The `## Security` section added in #64 is untouched.

## Why two commits

The first commit is the doc changes (`README.md` + `docs/clients.md`). The second is the `CHANGELOG.md` entry, kept isolated so a concurrent reliability-bundle PR that may also be touching `CHANGELOG.md` rebases cleanly.

## Issues

- `Closes #38`
- `References #40` — **partial closure: badges landed, demo recording still pending.** Issue #40 stays open until a live Claude Desktop capture lands; a `### Demo` placeholder section in the README links back to #40 so visitors know it's tracked.

## Test plan

- [x] `npm run build` — clean.
- [x] `npm test` — 14/14 pass.
- [x] No edits to \`src/**\`, \`package.json\`, \`smithery.yaml\`, \`.github/**\`, \`benchmarks/**\`, \`docs/rfcs/**\`, \`docs/architecture/**\`.
- [x] All 5 client snippets use placeholders, no \`/home/jean/...\` paths anywhere in the diff.
- [x] All 4 self-contained JSON snippets parse cleanly; the 3 Cline fragments parse when wrapped in \`{}\`; no trailing commas.
- [x] Codex \`config.toml\` block parses cleanly with a TOML parser.
- [x] Reviewed before push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)