### PR TITLE
feat: RFC 010 M1 — foundations (path guard, frontmatter parser, richer metadata)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- RFC 010 M1 foundations: path-traversal guard (`resolveKbPath`), KB-name validator (`isValidKbName` / `assertValidKbName`), frontmatter parser (`parseFrontmatter`), and richer chunk metadata (`tags`, `relativePath`, `chunkIndex`, `extension`, `knowledgeBase`). No user-visible API change. Partial work toward #49, #51, #53, #54.
 - Ollama embedding provider support as a local alternative to HuggingFace API for embeddings.
 - Environment variable configuration for embedding provider selection (`EMBEDDING_PROVIDER`, `OLLAMA_BASE_URL`, `OLLAMA_MODEL`).
 - End-to-end test evidence file: `ollama-embedding-e2e-results.md`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,12 +17,14 @@
         "@modelcontextprotocol/sdk": "^1.17.2",
         "axios": "^1.6.7",
         "faiss-node": "latest",
+        "js-yaml": "^4.1.1",
         "langchain": "^0.3.15",
         "pickleparser": "^0.2.1",
         "zod": "^3.23.8"
       },
       "devDependencies": {
         "@types/jest": "^30.0.0",
+        "@types/js-yaml": "^4.0.9",
         "@types/node": "^20.11.5",
         "jest": "^29.7.0",
         "nodemon": "^3.0.3",
@@ -2480,6 +2482,13 @@
         "expect": "^30.0.0",
         "pretty-format": "^30.0.0"
       }
+    },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/ms": {
       "version": "2.1.0",
@@ -6101,9 +6110,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -23,12 +23,14 @@
     "@modelcontextprotocol/sdk": "^1.17.2",
     "axios": "^1.6.7",
     "faiss-node": "latest",
+    "js-yaml": "^4.1.1",
     "langchain": "^0.3.15",
     "pickleparser": "^0.2.1",
     "zod": "^3.23.8"
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",
+    "@types/js-yaml": "^4.0.9",
     "@types/node": "^20.11.5",
     "jest": "^29.7.0",
     "nodemon": "^3.0.3",

--- a/src/FaissIndexManager.test.ts
+++ b/src/FaissIndexManager.test.ts
@@ -608,6 +608,30 @@ describe('FaissIndexManager chunk metadata (RFC 010 M1)', () => {
     }
   });
 
+  it('also strips YAML frontmatter from non-markdown files (universal-strip contract)', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-meta-txt-fm-'));
+    const kbDir = path.join(tempDir, 'kb');
+    const defaultKb = path.join(kbDir, 'default');
+    await fsp.mkdir(defaultKb, { recursive: true });
+    const docPath = path.join(defaultKb, 'note.txt');
+    await fsp.writeFile(
+      docPath,
+      '---\ntags: [nontext]\n---\nPlain-text body after frontmatter.\n'
+    );
+
+    const [texts, metadatas] = await runHappyPath(kbDir);
+
+    expect(texts.length).toBeGreaterThan(0);
+    for (const text of texts) {
+      expect(text).not.toContain('---');
+      expect(text).not.toContain('tags:');
+    }
+    for (const md of metadatas) {
+      expect(md.tags).toEqual(['nontext']);
+      expect(md.extension).toBe('.txt');
+    }
+  });
+
   it('applies the same metadata shape in the fallback rebuild branch', async () => {
     const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-meta-fallback-'));
     const kbDir = path.join(tempDir, 'kb');

--- a/src/FaissIndexManager.test.ts
+++ b/src/FaissIndexManager.test.ts
@@ -478,3 +478,193 @@ describe('FaissIndexManager permission handling', () => {
     await expect(fsp.stat(`${sidecarPath}.tmp`)).rejects.toMatchObject({ code: 'ENOENT' });
   });
 });
+
+describe('FaissIndexManager chunk metadata (RFC 010 M1)', () => {
+  const originalEnv = {
+    KNOWLEDGE_BASES_ROOT_DIR: process.env.KNOWLEDGE_BASES_ROOT_DIR,
+    FAISS_INDEX_PATH: process.env.FAISS_INDEX_PATH,
+    EMBEDDING_PROVIDER: process.env.EMBEDDING_PROVIDER,
+    HUGGINGFACE_API_KEY: process.env.HUGGINGFACE_API_KEY,
+  };
+
+  beforeEach(() => {
+    saveMock.mockReset();
+    addDocumentsMock.mockReset();
+    fromTextsMock.mockReset();
+    loadMock.mockReset();
+    similaritySearchMock.mockReset();
+    embeddingConstructorMock.mockReset();
+  });
+
+  afterEach(() => {
+    const keys = Object.keys(originalEnv) as Array<keyof typeof originalEnv>;
+    for (const key of keys) {
+      const value = originalEnv[key];
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+    jest.restoreAllMocks();
+  });
+
+  async function runHappyPath(kbRoot: string) {
+    process.env.KNOWLEDGE_BASES_ROOT_DIR = kbRoot;
+    process.env.FAISS_INDEX_PATH = path.join(kbRoot, '..', '.faiss');
+    process.env.EMBEDDING_PROVIDER = 'huggingface';
+    process.env.HUGGINGFACE_API_KEY = 'test-key';
+
+    jest.resetModules();
+    const { FaissIndexManager } = await import('./FaissIndexManager.js');
+    const manager = new FaissIndexManager();
+    await manager.initialize();
+    await manager.updateIndex();
+    return fromTextsMock.mock.calls[0] as [string[], Record<string, unknown>[]];
+  }
+
+  it('extracts frontmatter tags and strips the fence from the embedded body', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-meta-tags-'));
+    const kbDir = path.join(tempDir, 'kb');
+    const defaultKb = path.join(kbDir, 'default');
+    await fsp.mkdir(defaultKb, { recursive: true });
+    const docPath = path.join(defaultKb, 'doc.md');
+    await fsp.writeFile(
+      docPath,
+      '---\ntags: [foo, bar]\n---\n# Heading\n\nReal content that should embed.\n'
+    );
+
+    const [texts, metadatas] = await runHappyPath(kbDir);
+
+    expect(texts.length).toBeGreaterThan(0);
+    for (const text of texts) {
+      expect(text).not.toContain('---');
+      expect(text).not.toContain('tags:');
+    }
+    expect(metadatas.length).toBe(texts.length);
+    for (const md of metadatas) {
+      expect(md.tags).toEqual(['foo', 'bar']);
+      expect(md.source).toBe(docPath);
+      expect(md.knowledgeBase).toBe('default');
+      expect(md.extension).toBe('.md');
+      expect(md.relativePath).toBe('default/doc.md');
+      expect(typeof md.chunkIndex).toBe('number');
+    }
+  });
+
+  it('produces `tags: []` when the file has no frontmatter', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-meta-notags-'));
+    const kbDir = path.join(tempDir, 'kb');
+    const defaultKb = path.join(kbDir, 'default');
+    await fsp.mkdir(defaultKb, { recursive: true });
+    await fsp.writeFile(path.join(defaultKb, 'plain.md'), '# Plain\n\nNo frontmatter.\n');
+
+    const [, metadatas] = await runHappyPath(kbDir);
+    for (const md of metadatas) {
+      expect(md.tags).toEqual([]);
+    }
+  });
+
+  it('assigns deterministic 0-based chunkIndex within a single source file', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-meta-chunkidx-'));
+    const kbDir = path.join(tempDir, 'kb');
+    const defaultKb = path.join(kbDir, 'default');
+    await fsp.mkdir(defaultKb, { recursive: true });
+
+    // Payload large enough to force the splitter to produce >1 chunk.
+    const paragraphs = Array.from(
+      { length: 20 },
+      (_, i) => `Paragraph ${i}: ${'lorem ipsum dolor sit amet '.repeat(10)}`
+    );
+    const content = paragraphs.join('\n\n');
+    const filePath = path.join(defaultKb, 'long.txt');
+    await fsp.writeFile(filePath, content);
+
+    const [texts, metadatas] = await runHappyPath(kbDir);
+    expect(texts.length).toBeGreaterThan(1);
+    // All metadatas are for the same source, so chunkIndex should be [0, 1, …, N-1].
+    const perFile = metadatas.filter((m) => m.source === filePath);
+    expect(perFile.length).toBe(texts.length);
+    for (let i = 0; i < perFile.length; i += 1) {
+      expect(perFile[i].chunkIndex).toBe(i);
+    }
+  });
+
+  it('derives `knowledgeBase` from the first path segment under the KB root', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-meta-kbname-'));
+    const kbDir = path.join(tempDir, 'kb');
+    const teamKb = path.join(kbDir, 'team-notes');
+    await fsp.mkdir(path.join(teamKb, 'company'), { recursive: true });
+    await fsp.writeFile(
+      path.join(teamKb, 'company', 'onboarding.md'),
+      '# Onboarding\n\nHello.\n'
+    );
+
+    const [, metadatas] = await runHappyPath(kbDir);
+    expect(metadatas.length).toBeGreaterThan(0);
+    for (const md of metadatas) {
+      expect(md.knowledgeBase).toBe('team-notes');
+      expect(md.relativePath).toBe('team-notes/company/onboarding.md');
+    }
+  });
+
+  it('applies the same metadata shape in the fallback rebuild branch', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-meta-fallback-'));
+    const kbDir = path.join(tempDir, 'kb');
+    const defaultKb = path.join(kbDir, 'default');
+    await fsp.mkdir(defaultKb, { recursive: true });
+    const docPath = path.join(defaultKb, 'doc.md');
+    await fsp.writeFile(
+      docPath,
+      '---\ntags: [fallback]\n---\n# Title\n\nFallback branch content.\n'
+    );
+
+    process.env.KNOWLEDGE_BASES_ROOT_DIR = kbDir;
+    process.env.FAISS_INDEX_PATH = path.join(tempDir, '.faiss');
+    process.env.EMBEDDING_PROVIDER = 'huggingface';
+    process.env.HUGGINGFACE_API_KEY = 'test-key';
+
+    // First pass: seed sidecars so the second run sees hashes match.
+    jest.resetModules();
+    {
+      const { FaissIndexManager } = await import('./FaissIndexManager.js');
+      const first = new FaissIndexManager();
+      await first.initialize();
+      await first.updateIndex();
+    }
+
+    // Precondition: faiss.index is not on disk (the mocked save never writes
+    // it), so a fresh manager will take the fallback rebuild branch.
+    await expect(
+      fsp.stat(path.join(process.env.FAISS_INDEX_PATH!, 'faiss.index'))
+    ).rejects.toMatchObject({ code: 'ENOENT' });
+
+    saveMock.mockReset();
+    addDocumentsMock.mockReset();
+    fromTextsMock.mockReset();
+    loadMock.mockReset();
+
+    jest.resetModules();
+    const { FaissIndexManager } = await import('./FaissIndexManager.js');
+    const second = new FaissIndexManager();
+    await second.initialize();
+    await second.updateIndex();
+
+    // The fallback branch must have fired and must produce the same enriched shape.
+    expect(fromTextsMock).toHaveBeenCalledTimes(1);
+    expect(addDocumentsMock).not.toHaveBeenCalled();
+    const [texts, metadatas] = fromTextsMock.mock.calls[0] as [string[], Record<string, unknown>[]];
+    expect(texts.length).toBeGreaterThan(0);
+    for (const text of texts) {
+      expect(text).not.toContain('---');
+    }
+    for (const md of metadatas) {
+      expect(md.source).toBe(docPath);
+      expect(md.knowledgeBase).toBe('default');
+      expect(md.extension).toBe('.md');
+      expect(md.relativePath).toBe('default/doc.md');
+      expect(md.tags).toEqual(['fallback']);
+      expect(typeof md.chunkIndex).toBe('number');
+    }
+  });
+});

--- a/src/FaissIndexManager.ts
+++ b/src/FaissIndexManager.ts
@@ -7,7 +7,7 @@ import { OpenAIEmbeddings } from "@langchain/openai";
 import { FaissStore } from "@langchain/community/vectorstores/faiss";
 import { Document } from "@langchain/core/documents";
 import { MarkdownTextSplitter, RecursiveCharacterTextSplitter } from "langchain/text_splitter";
-import { calculateSHA256, getFilesRecursively } from './utils.js';
+import { calculateSHA256, getFilesRecursively, parseFrontmatter } from './utils.js';
 import {
   KNOWLEDGE_BASES_ROOT_DIR,
   FAISS_INDEX_PATH,
@@ -209,6 +209,55 @@ export class FaissIndexManager {
   }
 
   /**
+   * Splits `content` into chunks and tags each chunk with the RFC 010 M1
+   * metadata shape. Frontmatter (if any) is stripped before splitting so
+   * the `---` fence does not leak into the embedding text.
+   *
+   * Both the incremental update loop and the fallback rebuild loop call
+   * this helper so the metadata shape stays identical across paths.
+   */
+  private async buildChunkDocuments(
+    filePath: string,
+    content: string,
+    knowledgeBaseName: string
+  ): Promise<Document[]> {
+    const ext = path.extname(filePath).toLowerCase();
+    const splitter = ext === '.md'
+      ? new MarkdownTextSplitter({
+          chunkSize: 1000,
+          chunkOverlap: 200,
+          keepSeparator: false,
+        })
+      : new RecursiveCharacterTextSplitter({
+          chunkSize: 1000,
+          chunkOverlap: 200,
+        });
+
+    const { tags, body } = parseFrontmatter(content);
+    const relativePath = path
+      .relative(KNOWLEDGE_BASES_ROOT_DIR, filePath)
+      .split(path.sep)
+      .join('/');
+
+    const documents = await splitter.createDocuments(
+      [body],
+      [{ source: filePath }]
+    );
+    for (let i = 0; i < documents.length; i += 1) {
+      documents[i].metadata = {
+        ...documents[i].metadata,
+        source: filePath,
+        relativePath,
+        knowledgeBase: knowledgeBaseName,
+        extension: ext,
+        chunkIndex: i,
+        tags,
+      };
+    }
+    return documents;
+  }
+
+  /**
    * Updates the FAISS index.
    * If `specificKnowledgeBase` is provided, only files from that knowledge base will be checked and updated.
    * If no update occurs (and the FAISS index remains uninitialized) but there are documents,
@@ -272,19 +321,11 @@ export class FaissIndexManager {
               continue;
             }
 
-            let documentsToAdd: Document[] = [];
-            const ext = path.extname(filePath).toLowerCase();
-            const splitter = ext === '.md'
-              ? new MarkdownTextSplitter({
-                  chunkSize: 1000,
-                  chunkOverlap: 200,
-                  keepSeparator: false,
-                })
-              : new RecursiveCharacterTextSplitter({
-                  chunkSize: 1000,
-                  chunkOverlap: 200,
-                });
-            documentsToAdd = await splitter.createDocuments([content], [{ source: filePath }]);
+            const documentsToAdd: Document[] = await this.buildChunkDocuments(
+              filePath,
+              content,
+              knowledgeBaseName
+            );
 
             if (documentsToAdd.length > 0) {
               if (this.faissIndex === null) {
@@ -326,18 +367,11 @@ export class FaissIndexManager {
               logger.error(`Error reading file ${filePath}:`, error);
               continue;
             }
-            const ext = path.extname(filePath).toLowerCase();
-            const splitter = ext === '.md'
-              ? new MarkdownTextSplitter({
-                  chunkSize: 1000,
-                  chunkOverlap: 200,
-                  keepSeparator: false,
-                })
-              : new RecursiveCharacterTextSplitter({
-                  chunkSize: 1000,
-                  chunkOverlap: 200,
-                });
-            const documents = await splitter.createDocuments([content], [{ source: filePath }]);
+            const documents = await this.buildChunkDocuments(
+              filePath,
+              content,
+              knowledgeBaseName
+            );
             if (documents.length > 0) {
               allDocuments.push(...documents);
             }

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,9 +1,18 @@
-import { getFilesRecursively } from './utils.js';
+import {
+  assertValidKbName,
+  getFilesRecursively,
+  isValidKbName,
+  parseFrontmatter,
+  resolveKbPath,
+} from './utils.js';
 import * as fsp from 'fs/promises';
 import * as fs from 'fs'; // Import fs for PathLike and Dirent
+import * as os from 'os';
 import * as path from 'path';
 
-// Mock fs/promises
+// Mock fs/promises readdir for getFilesRecursively tests only. The
+// resolveKbPath tests need the real fs, so we import and retain actual
+// behavior for every other method.
 jest.mock('fs/promises', () => ({
   ...jest.requireActual('fs/promises'), // Import and retain default behavior
   readdir: jest.fn(), // Mock readdir specifically
@@ -45,7 +54,7 @@ describe('getFilesRecursively', () => {
     });
 
     const files = await getFilesRecursively('test_dir');
-    
+
     expect(files).toEqual([
       path.join('test_dir', 'file1.txt'),
       path.join('test_dir', 'sub_dir', 'file2.txt'),
@@ -73,7 +82,7 @@ describe('getFilesRecursively', () => {
     });
 
     const files = await getFilesRecursively('test_dir');
-    
+
     expect(files).toEqual([
       path.join('test_dir', 'file1.txt'),
       path.join('test_dir', 'visible_dir', 'file2.txt')
@@ -84,7 +93,7 @@ describe('getFilesRecursively', () => {
     mockReaddir.mockResolvedValue([] as any);
 
     const files = await getFilesRecursively('empty_dir');
-    
+
     expect(files).toEqual([]);
   });
 
@@ -92,7 +101,196 @@ describe('getFilesRecursively', () => {
     mockReaddir.mockRejectedValue(new Error('Permission denied'));
 
     const files = await getFilesRecursively('error_dir');
-    
+
     expect(files).toEqual([]);
+  });
+});
+
+describe('isValidKbName / assertValidKbName', () => {
+  it('accepts simple lowercase names', () => {
+    expect(isValidKbName('default')).toBe(true);
+    expect(isValidKbName('a')).toBe(true);
+    expect(isValidKbName('kb-2025')).toBe(true);
+    expect(isValidKbName('notes.v1')).toBe(true);
+    expect(isValidKbName('a_b.c-d')).toBe(true);
+    expect(() => assertValidKbName('default')).not.toThrow();
+  });
+
+  it('rejects names with a leading dot', () => {
+    expect(isValidKbName('.hidden')).toBe(false);
+    expect(isValidKbName('.')).toBe(false);
+    expect(() => assertValidKbName('.hidden')).toThrow(/invalid KB name/);
+  });
+
+  it('rejects `..` explicitly', () => {
+    expect(isValidKbName('..')).toBe(false);
+    expect(() => assertValidKbName('..')).toThrow(/invalid KB name/);
+  });
+
+  it('rejects path separators', () => {
+    expect(isValidKbName('foo/bar')).toBe(false);
+    expect(isValidKbName('foo\\bar')).toBe(false);
+    expect(() => assertValidKbName('foo/bar')).toThrow(/invalid KB name/);
+  });
+
+  it('rejects the empty string', () => {
+    expect(isValidKbName('')).toBe(false);
+    expect(() => assertValidKbName('')).toThrow(/invalid KB name/);
+  });
+
+  it('rejects names longer than 64 characters', () => {
+    const tooLong = 'a'.repeat(65);
+    expect(isValidKbName(tooLong)).toBe(false);
+    expect(() => assertValidKbName(tooLong)).toThrow(/invalid KB name/);
+    // Boundary: 64 is accepted.
+    expect(isValidKbName('a'.repeat(64))).toBe(true);
+  });
+
+  it('rejects names containing a null byte', () => {
+    expect(isValidKbName('foo\0bar')).toBe(false);
+    expect(() => assertValidKbName('foo\0bar')).toThrow(/invalid KB name/);
+  });
+
+  it('rejects uppercase (case-folding filesystems) and leading hyphen', () => {
+    expect(isValidKbName('Foo')).toBe(false);
+    expect(isValidKbName('-foo')).toBe(false);
+  });
+});
+
+describe('resolveKbPath', () => {
+  let tempRoot: string;
+  let kbName: string;
+  let kbRoot: string;
+
+  beforeEach(async () => {
+    tempRoot = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-resolve-'));
+    kbName = 'default';
+    kbRoot = path.join(tempRoot, kbName);
+    await fsp.mkdir(kbRoot, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fsp.rm(tempRoot, { recursive: true, force: true });
+  });
+
+  it('resolves a legal inner path to its realpath under the KB root', async () => {
+    const filePath = path.join(kbRoot, 'docs', 'hello.md');
+    await fsp.mkdir(path.dirname(filePath), { recursive: true });
+    await fsp.writeFile(filePath, 'hi');
+
+    const resolved = await resolveKbPath(kbName, 'docs/hello.md', tempRoot);
+    expect(resolved).toBe(await fsp.realpath(filePath));
+  });
+
+  it('resolves the KB root itself when given an empty relative path', async () => {
+    const resolved = await resolveKbPath(kbName, '', tempRoot);
+    expect(resolved).toBe(await fsp.realpath(kbRoot));
+  });
+
+  it('throws on `..` escape that resolves outside the KB', async () => {
+    // Create a sibling file next to the KB root so realpath succeeds,
+    // guaranteeing the prefix check (not ENOENT) is what fails.
+    const sibling = path.join(tempRoot, 'secret.txt');
+    await fsp.writeFile(sibling, 'nope');
+
+    await expect(resolveKbPath(kbName, '../secret.txt', tempRoot)).rejects.toThrow(
+      /path escapes KB root/
+    );
+  });
+
+  it('throws on a symlink pointing outside the KB', async () => {
+    const outside = path.join(tempRoot, 'outside.txt');
+    await fsp.writeFile(outside, 'nope');
+    const linkPath = path.join(kbRoot, 'escape.txt');
+    await fsp.symlink(outside, linkPath);
+
+    await expect(resolveKbPath(kbName, 'escape.txt', tempRoot)).rejects.toThrow(
+      /path escapes KB root/
+    );
+  });
+
+  it('throws when an intermediate directory in the walked chain is a symlink to outside', async () => {
+    const outsideDir = path.join(tempRoot, 'elsewhere');
+    await fsp.mkdir(outsideDir);
+    await fsp.writeFile(path.join(outsideDir, 'target.md'), 'nope');
+    const linkDir = path.join(kbRoot, 'shortcut');
+    await fsp.symlink(outsideDir, linkDir, 'dir');
+
+    await expect(resolveKbPath(kbName, 'shortcut/target.md', tempRoot)).rejects.toThrow(
+      /path escapes KB root/
+    );
+  });
+
+  it('throws when the KB directory is missing', async () => {
+    await expect(resolveKbPath('does-not-exist', 'any.md', tempRoot)).rejects.toThrow();
+  });
+
+  it('throws on a null byte in the relative path', async () => {
+    await expect(resolveKbPath(kbName, 'foo\0bar', tempRoot)).rejects.toThrow(
+      /null byte/
+    );
+  });
+});
+
+describe('parseFrontmatter', () => {
+  it('returns `{ tags: [], body: content }` when there is no frontmatter', () => {
+    const content = '# Just a heading\n\nSome text.\n';
+    const result = parseFrontmatter(content);
+    expect(result).toEqual({ tags: [], body: content });
+  });
+
+  it('extracts `tags` given as an array', () => {
+    const content = '---\ntags: [alpha, beta]\n---\n# Body\n';
+    const result = parseFrontmatter(content);
+    expect(result.tags).toEqual(['alpha', 'beta']);
+    expect(result.body).toBe('# Body\n');
+  });
+
+  it('coerces a scalar `tags: foo` to `[foo]`', () => {
+    const content = '---\ntags: foo\n---\nBody here\n';
+    const result = parseFrontmatter(content);
+    expect(result.tags).toEqual(['foo']);
+    expect(result.body).toBe('Body here\n');
+  });
+
+  it('returns `{ tags: [], body: original }` on malformed YAML — never throws', () => {
+    // Unterminated YAML flow sequence — parser throws; we must not.
+    const content = '---\ntags: [unterminated\nmore\n---\nBody\n';
+    let result: { tags: string[]; body: string } | undefined;
+    expect(() => {
+      result = parseFrontmatter(content);
+    }).not.toThrow();
+    expect(result!.tags).toEqual([]);
+    expect(result!.body).toBe(content);
+  });
+
+  it('strips frontmatter from the body on successful parse', () => {
+    const content = '---\ntags:\n  - one\n  - two\n---\nReal body\n';
+    const result = parseFrontmatter(content);
+    expect(result.tags).toEqual(['one', 'two']);
+    expect(result.body).toBe('Real body\n');
+    expect(result.body).not.toContain('---');
+    expect(result.body).not.toContain('tags:');
+  });
+
+  it('returns `{ tags: [], body: content }` when frontmatter has no closing fence', () => {
+    const content = '---\ntags: [a, b]\nno close here\n';
+    const result = parseFrontmatter(content);
+    expect(result.tags).toEqual([]);
+    expect(result.body).toBe(content);
+  });
+
+  it('handles CRLF line endings in frontmatter', () => {
+    const content = '---\r\ntags: [crlf]\r\n---\r\nBody\r\n';
+    const result = parseFrontmatter(content);
+    expect(result.tags).toEqual(['crlf']);
+    expect(result.body).toBe('Body\r\n');
+  });
+
+  it('returns `{ tags: [] }` when frontmatter lacks a `tags` key', () => {
+    const content = '---\ntitle: hello\n---\nBody\n';
+    const result = parseFrontmatter(content);
+    expect(result.tags).toEqual([]);
+    expect(result.body).toBe('Body\n');
   });
 });

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -230,6 +230,18 @@ describe('resolveKbPath', () => {
       /null byte/
     );
   });
+
+  it('rejects an invalid kbName before touching the filesystem', async () => {
+    // Without the internal assertValidKbName guard, kbName === '..' would make
+    // kbRoot === tempRoot's parent and the prefix check would cover every
+    // absolute path on disk. Lock that defence in.
+    await expect(resolveKbPath('..', 'anything.md', tempRoot)).rejects.toThrow(
+      /invalid KB name/
+    );
+    await expect(resolveKbPath('foo/bar', 'anything.md', tempRoot)).rejects.toThrow(
+      /invalid KB name/
+    );
+  });
 });
 
 describe('parseFrontmatter', () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -94,11 +94,34 @@ export async function resolveKbPath(
     throw new Error('path contains null byte');
   }
 
+  // RFC 010 §5.1.1 steps 3+4: normalize backslashes, then lexical traversal
+  // check (defence-in-depth before realpath). Catches Windows-style payloads
+  // on POSIX hosts and absolute/`..` injections even when intermediate
+  // realpath chains would resolve back inside the KB.
+  const normalizedRelative = relativePath.replace(/\\/g, '/');
+  if (path.posix.isAbsolute(normalizedRelative)) {
+    throw new Error(`path escapes KB root: ${JSON.stringify(relativePath)}`);
+  }
+  const posixNormalized = path.posix.normalize(normalizedRelative);
+  const segments = posixNormalized.split('/');
+  if (segments.some((s) => s === '..')) {
+    throw new Error(`path escapes KB root: ${JSON.stringify(relativePath)}`);
+  }
+
   const kbRoot = path.join(kbRootDir, kbName);
-  const kbRootReal = await fsp.realpath(kbRoot);
+  let kbRootReal: string;
+  try {
+    kbRootReal = await fsp.realpath(kbRoot);
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException | undefined)?.code;
+    if (code === 'ENOENT' || code === 'ENOTDIR') {
+      throw new Error(`knowledge base not found: ${JSON.stringify(kbName)}`);
+    }
+    throw error;
+  }
   const prefix = kbRootReal.endsWith(path.sep) ? kbRootReal : kbRootReal + path.sep;
 
-  const candidate = path.join(kbRoot, relativePath);
+  const candidate = path.join(kbRoot, normalizedRelative);
   let resolved: string;
   try {
     resolved = await fsp.realpath(candidate);
@@ -111,15 +134,16 @@ export async function resolveKbPath(
       // candidate is missing.
       const lexical = path.resolve(candidate);
       if (lexical !== kbRootReal && !lexical.startsWith(prefix)) {
-        throw new Error('path escapes KB root');
+        throw new Error(`path escapes KB root: ${JSON.stringify(relativePath)}`);
       }
-      throw error;
+      // RFC 010 §5.1.1: error messages MUST NOT leak absolute paths.
+      throw new Error(`path not found: ${JSON.stringify(relativePath)}`);
     }
     throw error;
   }
 
   if (resolved !== kbRootReal && !resolved.startsWith(prefix)) {
-    throw new Error('path escapes KB root');
+    throw new Error(`path escapes KB root: ${JSON.stringify(relativePath)}`);
   }
   return resolved;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -82,6 +82,11 @@ export async function resolveKbPath(
   relativePath: string,
   kbRootDir: string,
 ): Promise<string> {
+  // Reject `kbName === '..'` and friends before path.join can walk out of
+  // kbRootDir. Without this, a `..` kbName would make kbRoot === kbRootDir's
+  // parent and `prefix` would cover every path on disk.
+  assertValidKbName(kbName);
+
   if (typeof relativePath !== 'string') {
     throw new Error('relativePath must be a string');
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,7 @@
 import * as crypto from 'crypto';
 import * as fsp from 'fs/promises';
 import * as path from 'path';
+import yaml from 'js-yaml';
 import { logger } from './logger.js';
 
 export async function calculateSHA256(filePath: string): Promise<string> {
@@ -17,19 +18,19 @@ export async function calculateSHA256(filePath: string): Promise<string> {
  */
 export async function getFilesRecursively(dirPath: string): Promise<string[]> {
   const files: string[] = [];
-  
+
   async function traverse(currentPath: string): Promise<void> {
     try {
       const entries = await fsp.readdir(currentPath, { withFileTypes: true });
-      
+
       for (const entry of entries) {
         // Skip hidden files and directories
         if (entry.name.startsWith('.')) {
           continue;
         }
-        
+
         const fullPath = path.join(currentPath, entry.name);
-        
+
         if (entry.isDirectory()) {
           await traverse(fullPath);
         } else if (entry.isFile()) {
@@ -40,7 +41,143 @@ export async function getFilesRecursively(dirPath: string): Promise<string[]> {
       logger.error(`Error traversing directory ${currentPath}:`, error);
     }
   }
-  
+
   await traverse(dirPath);
   return files;
+}
+
+/**
+ * KB-name grammar: `^[a-z0-9][a-z0-9._-]*$`, length 1-64.
+ *
+ * The leading-char rule rejects dotfiles (`.hidden`), relative traversal
+ * (`..`), CLI-flag ambiguity (`-foo`), and the empty string. The tail rule
+ * forbids `/`, `\\`, uppercase, and any other separator the filesystem
+ * could split on. Null bytes are rejected as a side-effect of the regex
+ * character class.
+ */
+export const KB_NAME_REGEX = /^[a-z0-9][a-z0-9._-]*$/;
+
+export function isValidKbName(name: string): boolean {
+  if (typeof name !== 'string') return false;
+  if (name.length < 1 || name.length > 64) return false;
+  return KB_NAME_REGEX.test(name);
+}
+
+export function assertValidKbName(name: string): void {
+  if (!isValidKbName(name)) {
+    throw new Error(`invalid KB name: ${JSON.stringify(name)}`);
+  }
+}
+
+/**
+ * Resolves a user-supplied relative path against `<kbRootDir>/<kbName>/` and
+ * asserts the real path stays inside the KB. Throws on null bytes, escapes,
+ * or a missing KB directory. The returned path is realpath-resolved so
+ * callers can use it directly for fs reads.
+ *
+ * Symlinks are followed — a link pointing outside the KB is rejected.
+ */
+export async function resolveKbPath(
+  kbName: string,
+  relativePath: string,
+  kbRootDir: string,
+): Promise<string> {
+  if (typeof relativePath !== 'string') {
+    throw new Error('relativePath must be a string');
+  }
+  if (relativePath.includes('\0')) {
+    throw new Error('path contains null byte');
+  }
+
+  const kbRoot = path.join(kbRootDir, kbName);
+  const kbRootReal = await fsp.realpath(kbRoot);
+  const prefix = kbRootReal.endsWith(path.sep) ? kbRootReal : kbRootReal + path.sep;
+
+  const candidate = path.join(kbRoot, relativePath);
+  let resolved: string;
+  try {
+    resolved = await fsp.realpath(candidate);
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException | undefined)?.code;
+    if (code === 'ENOENT' || code === 'ENOTDIR') {
+      // If the target does not exist, a lexical escape is still detectable:
+      // compare the (non-real) candidate against the kbRoot prefix. The
+      // realpath of the KB root itself was successful above, so only the
+      // candidate is missing.
+      const lexical = path.resolve(candidate);
+      if (lexical !== kbRootReal && !lexical.startsWith(prefix)) {
+        throw new Error('path escapes KB root');
+      }
+      throw error;
+    }
+    throw error;
+  }
+
+  if (resolved !== kbRootReal && !resolved.startsWith(prefix)) {
+    throw new Error('path escapes KB root');
+  }
+  return resolved;
+}
+
+const FRONTMATTER_MAX_BYTES = 8192;
+
+/**
+ * Parses YAML frontmatter bounded at `---` delimiters. Returns extracted
+ * `tags` (array or scalar-coerced) and the `body` with frontmatter stripped.
+ * Never throws: malformed YAML, oversized frontmatter, or no fence all
+ * degrade to `{ tags: [], body: content }`.
+ */
+export function parseFrontmatter(content: string): { tags: string[]; body: string } {
+  if (typeof content !== 'string' || content.length === 0) {
+    return { tags: [], body: content };
+  }
+
+  // Opening fence must be `---\n` (or `---\r\n`) at byte 0.
+  const openMatch = content.match(/^---\r?\n/);
+  if (!openMatch) {
+    return { tags: [], body: content };
+  }
+  const openEnd = openMatch[0].length;
+
+  // Search for the closing fence within the size cap. The closing fence
+  // `---` must sit at the start of a line — either at position 0 of the
+  // slice (empty frontmatter: `---\n---\n`) or right after a `\n`.
+  const searchLimit = Math.min(content.length, FRONTMATTER_MAX_BYTES);
+  const searchSlice = content.slice(openEnd, searchLimit);
+  const closeMatch = searchSlice.match(/(^|\n)---(\r?\n|$)/);
+  if (!closeMatch || closeMatch.index === undefined) {
+    return { tags: [], body: content };
+  }
+  const leadNL = closeMatch[1]; // '' or '\n'
+  // YAML ends at matchStart when there is a leading `\n` (the `\n` is part
+  // of the fence, not the YAML). With no leading `\n` the match sits at
+  // position 0, so YAML is empty.
+  const yamlEnd = leadNL === '\n' ? closeMatch.index : 0;
+  const fenceEnd = closeMatch.index + closeMatch[0].length;
+  const yamlRaw = searchSlice.slice(0, yamlEnd);
+  const body = content.slice(openEnd + fenceEnd);
+
+  let parsed: unknown;
+  try {
+    parsed = yaml.load(yamlRaw, { schema: yaml.FAILSAFE_SCHEMA });
+  } catch {
+    return { tags: [], body: content };
+  }
+
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return { tags: [], body };
+  }
+
+  const raw = (parsed as Record<string, unknown>).tags;
+  let tags: string[] = [];
+  if (Array.isArray(raw)) {
+    tags = raw
+      .filter((x): x is string => typeof x === 'string')
+      .map((x) => x.trim())
+      .filter((x) => x.length > 0);
+  } else if (typeof raw === 'string') {
+    const trimmed = raw.trim();
+    if (trimmed.length > 0) tags = [trimmed];
+  }
+  return { tags, body };
 }


### PR DESCRIPTION
## Summary

Implements milestone **M1** of [RFC 010 — MCP surface v2](docs/rfcs/010-mcp-surface-v2.md). These are the shared foundations that every later M (Resources, ingest tools, metadata filters, kb_stats) depends on. **No user-visible MCP change** — this milestone is invisible at the tool level; the proof it works is entirely in unit tests.

## What landed

- `resolveKbPath(kbName, relativePath, kbRootDir)` in `src/utils.ts` — path-traversal guard used by every downstream file-touching feature. Combines a lexical check (POSIX normalize + segment-`..` / absolute-path reject), backslash normalization, null-byte reject, and an `fs.realpath` + trailing-slash-prefix check to defeat sibling-collision attacks (`/root/kbfoo` vs `/root/kb`).
- `isValidKbName` / `assertValidKbName` — regex-anchored, length-bounded, ASCII-only KB-name validator.
- `parseFrontmatter(content)` — bounded YAML frontmatter parser using `js-yaml` with `FAILSAFE_SCHEMA` (rejects `!!js/function` and every other dangerous tag). Returns `{ tags, body }`; never throws.
- Chunk metadata enrichment at both ingest sites (`FaissIndexManager.ts:261-275` happy path AND `:317-332` fallback rebuild): every `Document.metadata` now carries `relativePath`, `knowledgeBase`, `extension`, `chunkIndex`, and `tags`. Coordinates with RFC 006 M1.3.
- `js-yaml` added as a direct dependency.

## Tests

55 tests pass. New coverage in `src/utils.test.ts` (path guard, validator, frontmatter parser) and `src/FaissIndexManager.test.ts` (chunk metadata shape on both ingest paths, monotonic `chunkIndex`, `tags` populated from frontmatter).

## Security review

Before opening this PR I ran a focused security review. Three RFC-deviation findings were caught and fixed in commit `6e7149d`:

1. Missing **lexical traversal check** (RFC §5.1.1 step 4) — the original relied entirely on `realpath` + prefix compare, leaving a defence-in-depth gap when realpath chains land back inside the KB via benign symlinks. Added POSIX-normalize + segment-`..` + `isAbsolute` reject before `path.join`.
2. Missing **backslash normalization** (RFC §5.1.1 step 3) — Windows-style payloads like `..\\..\\etc\\passwd` were passing as legal-but-meaningless POSIX filenames. Now normalized to `/` before the lexical check.
3. **Error messages leaked absolute paths** — rethrown `ENOENT` surfaced `/abs/path/to/kbRoot/...` to MCP clients. Rewrote to `path not found: <relativePath>` and `knowledge base not found: <kbName>`.

Reviewer also confirmed clean on: null-byte handling, trailing-slash sibling attack, symlink-to-outside rejection, js-yaml FAILSAFE_SCHEMA, `knowledgeBase` derivation from trusted iteration variable.

## References

References #49, #51, #53, #54 — M1 unblocks all four. Later milestones will close them.

## Operational notes

Autonomous Looper task crashed after pushing commits but before opening this PR. Intervened manually: ran the quality gate, ran an out-of-band security review (findings + fixes in commit 6e7149d), now opening the PR. Treat as a normal subagent-reviewed submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)