### PR TITLE
feat(embeddings): upgrade default models — bge-small-en-v1.5, text-embedding-3-small

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Replaced blocking `fs.existsSync` calls in `FaissIndexManager` with non-blocking `fsp.stat`-based checks. (RFC 007 PR 1.1)
 - `package.json` license field changed from `UNLICENSED` (SPDX: proprietary) to `Unlicense` (SPDX: public-domain), matching the `UNLICENSE` file already in the repo. Fixes false-positive "proprietary" flags from license scanners. (#32)
 - Declared `engines.node >=20` in `package.json` so installs on unsupported Node versions fail fast. README prerequisite bumped from Node 16+ to Node 20+ to match — both 16 and 18 are EOL. (#35)
+- Default embedding models upgraded: HuggingFace default is now `BAAI/bge-small-en-v1.5` (was `sentence-transformers/all-MiniLM-L6-v2` from 2021); OpenAI default is now `text-embedding-3-small` (was `text-embedding-ada-002`). Vector dimensions are unchanged (384 for HF, 1536 for OpenAI), so callers downstream of the FAISS store keep working. **Migration impact:** the model-name change trips the auto-rebuild guard in `FaissIndexManager.initialize` (`src/FaissIndexManager.ts:153-164`), so existing indexes will be rebuilt once on the next `retrieve_knowledge` call — expect a one-time delay while every file is re-embedded. No user action required; pin the previous defaults via `HUGGINGFACE_MODEL_NAME` / `OPENAI_MODEL_NAME` if you want to skip the rebuild. (#47)
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -70,9 +70,10 @@ npx -y @smithery/cli install @jeanibarz/knowledge-base-mcp-server --client claud
         ```bash
         EMBEDDING_PROVIDER=openai
         OPENAI_API_KEY=your_api_key_here
-        OPENAI_MODEL_NAME=text-embedding-ada-002
+        OPENAI_MODEL_NAME=text-embedding-3-small
         KNOWLEDGE_BASES_ROOT_DIR=$HOME/knowledge_bases
         ```
+    *   As of this release, the OpenAI default is `text-embedding-3-small` (up from `text-embedding-ada-002`). Both produce 1536-dim vectors, but the model name change will trigger a one-time FAISS index rebuild on the next query. Override with `OPENAI_MODEL_NAME=...` if you prefer the old default. See the [CHANGELOG](./CHANGELOG.md) for details.
 
     ### Option 3: HuggingFace Configuration (Fallback)
     
@@ -82,10 +83,11 @@ npx -y @smithery/cli install @jeanibarz/knowledge-base-mcp-server --client claud
         ```bash
         EMBEDDING_PROVIDER=huggingface          # Optional, this is the default
         HUGGINGFACE_API_KEY=your_api_key_here
-        HUGGINGFACE_MODEL_NAME=sentence-transformers/all-MiniLM-L6-v2
+        HUGGINGFACE_MODEL_NAME=BAAI/bge-small-en-v1.5
         HUGGINGFACE_PROVIDER=hf-inference       # Optional, router provider for serverless inference
         KNOWLEDGE_BASES_ROOT_DIR=$HOME/knowledge_bases
         ```
+    *   As of this release, the HuggingFace default is `BAAI/bge-small-en-v1.5` (up from `sentence-transformers/all-MiniLM-L6-v2`). Both produce 384-dim vectors, but the model name change will trigger a one-time FAISS index rebuild on the next query. Override with `HUGGINGFACE_MODEL_NAME=...` if you prefer the old default. See the [CHANGELOG](./CHANGELOG.md) for details.
     *   HuggingFace retired the legacy `api-inference.huggingface.co/models/...`
         endpoint in 2025. Feature-extraction calls are now routed through the
         Inference Providers router at

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -19,7 +19,7 @@ startCommand:
         description: Path to FAISS index file
       huggingfaceModelName:
         type: string
-        default: sentence-transformers/all-MiniLM-L6-v2
+        default: BAAI/bge-small-en-v1.5
         description: Hugging Face model for embeddings
       huggingfaceProvider:
         type: string
@@ -43,7 +43,7 @@ startCommand:
         description: OpenAI API key for embeddings
       openaiModelName:
         type: string
-        default: text-embedding-ada-002
+        default: text-embedding-3-small
         description: OpenAI model to use for embeddings
       mcpTransport:
         type: string
@@ -117,10 +117,10 @@ startCommand:
     huggingfaceApiKey: hf_example_key_123
     knowledgeBasesRootDir: /data/knowledge_bases
     faissIndexPath: /data/knowledge_bases/.faiss
-    huggingfaceModelName: sentence-transformers/all-MiniLM-L6-v2
+    huggingfaceModelName: BAAI/bge-small-en-v1.5
     huggingfaceProvider: hf-inference
     embeddingProvider: huggingface
     ollamaBaseUrl: http://localhost:11434
     ollamaModel: dengcao/Qwen3-Embedding-0.6B:Q8_0
     openaiApiKey: sk-example_key_123
-    openaiModelName: text-embedding-ada-002
+    openaiModelName: text-embedding-3-small

--- a/src/FaissIndexManager.test.ts
+++ b/src/FaissIndexManager.test.ts
@@ -126,7 +126,7 @@ describe('FaissIndexManager permission handling', () => {
 
     expect(embeddingConstructorMock).toHaveBeenCalledWith(expect.objectContaining({
       apiKey: 'test-key',
-      model: 'sentence-transformers/all-MiniLM-L6-v2',
+      model: 'BAAI/bge-small-en-v1.5',
       provider: 'replicate',
     }));
   });

--- a/src/HuggingFaceInferenceEmbeddings.integration.test.ts
+++ b/src/HuggingFaceInferenceEmbeddings.integration.test.ts
@@ -44,7 +44,7 @@ describe('HuggingFaceInferenceEmbeddings compatibility', () => {
     try {
       const embeddings = new HuggingFaceInferenceEmbeddings({
         apiKey: 'test-key',
-        model: 'sentence-transformers/all-MiniLM-L6-v2',
+        model: 'BAAI/bge-small-en-v1.5',
         endpointUrl,
       });
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,7 +12,7 @@ export const FAISS_INDEX_PATH = process.env.FAISS_INDEX_PATH || DEFAULT_FAISS_IN
 export const EMBEDDING_PROVIDER = process.env.EMBEDDING_PROVIDER || 'huggingface';
 
 // HuggingFace configuration
-export const DEFAULT_HUGGINGFACE_MODEL_NAME = 'sentence-transformers/all-MiniLM-L6-v2';
+export const DEFAULT_HUGGINGFACE_MODEL_NAME = 'BAAI/bge-small-en-v1.5';
 export const HUGGINGFACE_MODEL_NAME = process.env.HUGGINGFACE_MODEL_NAME || DEFAULT_HUGGINGFACE_MODEL_NAME;
 export const DEFAULT_HUGGINGFACE_PROVIDER = 'hf-inference';
 export const HUGGINGFACE_PROVIDER = (
@@ -38,7 +38,8 @@ export const OLLAMA_BASE_URL = process.env.OLLAMA_BASE_URL || 'http://localhost:
 export const OLLAMA_MODEL = process.env.OLLAMA_MODEL || 'dengcao/Qwen3-Embedding-0.6B:Q8_0';
 
 // OpenAI configuration
-export const OPENAI_MODEL_NAME = process.env.OPENAI_MODEL_NAME || 'text-embedding-ada-002';
+export const DEFAULT_OPENAI_MODEL_NAME = 'text-embedding-3-small';
+export const OPENAI_MODEL_NAME = process.env.OPENAI_MODEL_NAME || DEFAULT_OPENAI_MODEL_NAME;
 
 // ---------------------------------------------------------------------------
 // Transport configuration (RFC 008 stage 1: stdio + SSE).


### PR DESCRIPTION
Closes #47.

## Summary

Bump two stale provider defaults to modern equivalents at the same vector dimension, so existing callers downstream of the FAISS store keep working.

- **HuggingFace:** `sentence-transformers/all-MiniLM-L6-v2` (2021, 384-dim) → `BAAI/bge-small-en-v1.5` (2023, 384-dim). ~5–10% better on MTEB at the same latency class.
- **OpenAI:** `text-embedding-ada-002` (legacy) → `text-embedding-3-small` (1536-dim by default). Better quality, ~5x cheaper per token.
- **Ollama:** unchanged — `dengcao/Qwen3-Embedding-0.6B:Q8_0` is already modern.

A `DEFAULT_OPENAI_MODEL_NAME` constant was added to `src/config.ts` to mirror the existing `DEFAULT_HUGGINGFACE_MODEL_NAME` pattern.

## Migration notes

The model-name change trips the auto-rebuild guard in `FaissIndexManager.initialize` (`src/FaissIndexManager.ts:153-164`), so existing indexes will be rebuilt once on the next `retrieve_knowledge` call — expect a one-time delay while every file is re-embedded. No user action required.

To skip the rebuild and stay on the old defaults, pin them via env:

- `HUGGINGFACE_MODEL_NAME=sentence-transformers/all-MiniLM-L6-v2`
- `OPENAI_MODEL_NAME=text-embedding-ada-002`

## Files touched

- `src/config.ts` — new HF default + new `DEFAULT_OPENAI_MODEL_NAME` constant used by `OPENAI_MODEL_NAME`.
- `README.md` — model strings in the OpenAI and HuggingFace setup blocks; one short migration paragraph after each.
- `smithery.yaml` — both `default:` lines and both `exampleConfig:` lines.
- `CHANGELOG.md` — entry under `[Unreleased] / ### Changed` with the migration impact.
- `src/FaissIndexManager.test.ts`, `src/HuggingFaceInferenceEmbeddings.integration.test.ts` — assertion literals updated to match the new default (no behavior change in production code outside `config.ts`).

## Test plan

- [x] `npm run build` — clean.
- [x] `npm test` — 57 passed, 5 suites.
- [x] `grep -r 'all-MiniLM\|ada-002' src/` returns no hits.