### PR TITLE
feat: RFC 010 M2 — tool description overrides via env vars (#52)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- RFC 010 M2: `RETRIEVE_KNOWLEDGE_DESCRIPTION` and `LIST_KNOWLEDGE_BASES_DESCRIPTION` env vars override the built-in tool descriptions, so the same binary can present as "search engineering runbooks" vs. "search personal notes" to different clients without a recompile. Unset/empty falls back to the existing strings — no behaviour change for current deployments. Closes #52.
 - RFC 010 M1 foundations: path-traversal guard (`resolveKbPath`), KB-name validator (`isValidKbName` / `assertValidKbName`), frontmatter parser (`parseFrontmatter`), and richer chunk metadata (`tags`, `relativePath`, `chunkIndex`, `extension`, `knowledgeBase`). No user-visible API change. Partial work toward #49, #51, #53, #54.
 - Optional SSE transport behind `MCP_TRANSPORT=sse`. Stdio remains the default; setting `MCP_TRANSPORT=sse` plus `MCP_AUTH_TOKEN` exposes the same two tools over an HTTP/SSE endpoint with bearer-token auth, an origin allow-list, and an unauthenticated `GET /health` probe. See the new "Remote transport (optional)" section in the README and [`docs/rfcs/008-remote-transport.md`](./docs/rfcs/008-remote-transport.md) for the full design. Partial closure of #48 — streamable-http follows.
 - Ollama embedding provider support as a local alternative to HuggingFace API for embeddings.

--- a/README.md
+++ b/README.md
@@ -105,6 +105,11 @@ npx -y @smithery/cli install @jeanibarz/knowledge-base-mcp-server --client claud
     
     *   The server supports the `FAISS_INDEX_PATH` environment variable to specify the path to the FAISS index. If not set, it will default to `$HOME/knowledge_bases/.faiss`.
     *   Logging can be routed to a file by setting `LOG_FILE=/path/to/logs/knowledge-base.log`. Log verbosity defaults to `info` and can be adjusted with `LOG_LEVEL=debug|info|warn|error`.
+    *   **Tailor tool descriptions per deployment.** The `retrieve_knowledge` and `list_knowledge_bases` descriptions the agent reads when picking tools can be overridden via `RETRIEVE_KNOWLEDGE_DESCRIPTION` and `LIST_KNOWLEDGE_BASES_DESCRIPTION`. Unset or empty falls back to the built-in defaults. Example:
+        ```bash
+        RETRIEVE_KNOWLEDGE_DESCRIPTION="Search engineering runbooks, RFCs, and postmortems."
+        LIST_KNOWLEDGE_BASES_DESCRIPTION="List available engineering knowledge bases."
+        ```
     *   You can set these environment variables in your `.bashrc` or `.zshrc` file, or directly in the MCP settings.
 
 4.  **Build the server:**

--- a/src/KnowledgeBaseServer.test.ts
+++ b/src/KnowledgeBaseServer.test.ts
@@ -26,6 +26,8 @@ describe('KnowledgeBaseServer handlers', () => {
     EMBEDDING_PROVIDER: process.env.EMBEDDING_PROVIDER,
     HUGGINGFACE_API_KEY: process.env.HUGGINGFACE_API_KEY,
     LOG_FILE: process.env.LOG_FILE,
+    RETRIEVE_KNOWLEDGE_DESCRIPTION: process.env.RETRIEVE_KNOWLEDGE_DESCRIPTION,
+    LIST_KNOWLEDGE_BASES_DESCRIPTION: process.env.LIST_KNOWLEDGE_BASES_DESCRIPTION,
   };
 
   beforeEach(() => {
@@ -270,5 +272,80 @@ describe('KnowledgeBaseServer handlers', () => {
     // The bug: before the fix, beta's source also leaks into the scoped
     // result. Asserting it does NOT appear is what proves the fix works.
     expect(text).not.toContain(`"source": ${JSON.stringify(betaSource)}`);
+  });
+
+  // --- tool description overrides (#52, RFC 010 M2) -------------------------
+  //
+  // These tests assert behaviour visible at the MCP wire surface: the
+  // `description` field the agent reads when picking which tool to call.
+  // Inspecting `mcp.server._registeredTools` is the only path to that field
+  // without spinning up a real client/transport — the SDK exposes neither a
+  // public getter nor a `tools/list` shortcut on the server instance. The
+  // shape is internal, so if a future SDK upgrade renames it these tests
+  // fail loudly rather than silently passing on an empty map.
+
+  function describeOf(server: any, toolName: string): string {
+    const registered = server['mcp']._registeredTools as Record<string, { description?: string }>;
+    expect(registered).toBeDefined();
+    expect(registered[toolName]).toBeDefined();
+    return registered[toolName].description ?? '';
+  }
+
+  it('with neither override env set, tool descriptions match the legacy hard-coded strings', async () => {
+    delete process.env.RETRIEVE_KNOWLEDGE_DESCRIPTION;
+    delete process.env.LIST_KNOWLEDGE_BASES_DESCRIPTION;
+    await setRetrieveEnv();
+
+    const server = await freshServer();
+
+    expect(describeOf(server, 'list_knowledge_bases')).toBe(
+      'Lists the available knowledge bases.'
+    );
+    expect(describeOf(server, 'retrieve_knowledge')).toBe(
+      'Retrieves similar chunks from the knowledge base based on a query. Optionally, if a knowledge base is specified, only that one is searched; otherwise, all available knowledge bases are considered. By default, at most 10 documents are returned with a score below a threshold of 2. A different threshold can optionally be provided.'
+    );
+  });
+
+  it('RETRIEVE_KNOWLEDGE_DESCRIPTION overrides only the retrieve_knowledge description', async () => {
+    await setRetrieveEnv();
+    process.env.RETRIEVE_KNOWLEDGE_DESCRIPTION = 'custom retrieve desc';
+    delete process.env.LIST_KNOWLEDGE_BASES_DESCRIPTION;
+
+    const server = await freshServer();
+
+    expect(describeOf(server, 'retrieve_knowledge')).toBe('custom retrieve desc');
+    // list_knowledge_bases must not be affected by the retrieve override.
+    expect(describeOf(server, 'list_knowledge_bases')).toBe(
+      'Lists the available knowledge bases.'
+    );
+  });
+
+  it('LIST_KNOWLEDGE_BASES_DESCRIPTION overrides only the list_knowledge_bases description', async () => {
+    await setRetrieveEnv();
+    process.env.LIST_KNOWLEDGE_BASES_DESCRIPTION = 'custom list desc';
+    delete process.env.RETRIEVE_KNOWLEDGE_DESCRIPTION;
+
+    const server = await freshServer();
+
+    expect(describeOf(server, 'list_knowledge_bases')).toBe('custom list desc');
+    // retrieve_knowledge must not be affected by the list override.
+    expect(describeOf(server, 'retrieve_knowledge')).toBe(
+      'Retrieves similar chunks from the knowledge base based on a query. Optionally, if a knowledge base is specified, only that one is searched; otherwise, all available knowledge bases are considered. By default, at most 10 documents are returned with a score below a threshold of 2. A different threshold can optionally be provided.'
+    );
+  });
+
+  it('empty-string override env vars fall back to the defaults, not the empty string', async () => {
+    await setRetrieveEnv();
+    process.env.RETRIEVE_KNOWLEDGE_DESCRIPTION = '';
+    process.env.LIST_KNOWLEDGE_BASES_DESCRIPTION = '';
+
+    const server = await freshServer();
+
+    expect(describeOf(server, 'retrieve_knowledge')).toBe(
+      'Retrieves similar chunks from the knowledge base based on a query. Optionally, if a knowledge base is specified, only that one is searched; otherwise, all available knowledge bases are considered. By default, at most 10 documents are returned with a score below a threshold of 2. A different threshold can optionally be provided.'
+    );
+    expect(describeOf(server, 'list_knowledge_bases')).toBe(
+      'Lists the available knowledge bases.'
+    );
   });
 });

--- a/src/KnowledgeBaseServer.ts
+++ b/src/KnowledgeBaseServer.ts
@@ -7,7 +7,9 @@ import * as fsp from 'fs/promises';
 import { FaissIndexManager } from './FaissIndexManager.js';
 import {
   KNOWLEDGE_BASES_ROOT_DIR,
+  LIST_KNOWLEDGE_BASES_DESCRIPTION,
   loadTransportConfig,
+  RETRIEVE_KNOWLEDGE_DESCRIPTION,
   TransportConfigError,
   type TransportConfig,
 } from './config.js';
@@ -48,13 +50,13 @@ export class KnowledgeBaseServer {
   private registerTools(mcp: McpServer) {
     mcp.tool(
       'list_knowledge_bases',
-      'Lists the available knowledge bases.',
+      LIST_KNOWLEDGE_BASES_DESCRIPTION,
       async () => this.handleListKnowledgeBases()
     );
 
     mcp.tool(
       'retrieve_knowledge',
-      'Retrieves similar chunks from the knowledge base based on a query. Optionally, if a knowledge base is specified, only that one is searched; otherwise, all available knowledge bases are considered. By default, at most 10 documents are returned with a score below a threshold of 2. A different threshold can optionally be provided.',
+      RETRIEVE_KNOWLEDGE_DESCRIPTION,
       {
         query: z.string().describe('The search query to use for retrieving similar chunks from the knowledge base.'),
         knowledge_base_name: z.string().optional().describe('The name of the knowledge base to search. If omitted, all available knowledge bases are considered.'),

--- a/src/config.ts
+++ b/src/config.ts
@@ -42,6 +42,28 @@ export const DEFAULT_OPENAI_MODEL_NAME = 'text-embedding-3-small';
 export const OPENAI_MODEL_NAME = process.env.OPENAI_MODEL_NAME || DEFAULT_OPENAI_MODEL_NAME;
 
 // ---------------------------------------------------------------------------
+// Tool description overrides (RFC 010 M2 / #52).
+// Operators can repurpose the same binary for different deployments (eng
+// docs vs. personal notes vs. postmortems) by overriding the model-facing
+// description the agent sees during tool selection. Read once at module
+// load; set the env vars BEFORE the server process starts.
+// ---------------------------------------------------------------------------
+
+export const DEFAULT_RETRIEVE_KNOWLEDGE_DESCRIPTION =
+  'Retrieves similar chunks from the knowledge base based on a query. Optionally, if a knowledge base is specified, only that one is searched; otherwise, all available knowledge bases are considered. By default, at most 10 documents are returned with a score below a threshold of 2. A different threshold can optionally be provided.';
+export const RETRIEVE_KNOWLEDGE_DESCRIPTION =
+  process.env.RETRIEVE_KNOWLEDGE_DESCRIPTION && process.env.RETRIEVE_KNOWLEDGE_DESCRIPTION.length > 0
+    ? process.env.RETRIEVE_KNOWLEDGE_DESCRIPTION
+    : DEFAULT_RETRIEVE_KNOWLEDGE_DESCRIPTION;
+
+export const DEFAULT_LIST_KNOWLEDGE_BASES_DESCRIPTION =
+  'Lists the available knowledge bases.';
+export const LIST_KNOWLEDGE_BASES_DESCRIPTION =
+  process.env.LIST_KNOWLEDGE_BASES_DESCRIPTION && process.env.LIST_KNOWLEDGE_BASES_DESCRIPTION.length > 0
+    ? process.env.LIST_KNOWLEDGE_BASES_DESCRIPTION
+    : DEFAULT_LIST_KNOWLEDGE_BASES_DESCRIPTION;
+
+// ---------------------------------------------------------------------------
 // Transport configuration (RFC 008 stage 1: stdio + SSE).
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Adds two env vars so operators can override the model-facing descriptions of the two MCP tools without rebuilding:

- `RETRIEVE_KNOWLEDGE_DESCRIPTION` — overrides the description for `retrieve_knowledge`.
- `LIST_KNOWLEDGE_BASES_DESCRIPTION` — overrides the description for `list_knowledge_bases`.

Unset or empty falls back to the existing hard-coded strings — current deployments are byte-identical (regression-guarded by a test). The same binary can now present as "search engineering runbooks" vs. "search personal notes" vs. "search incident postmortems" to different MCP clients, which steers the agent's tool-selection differently — a behaviour change, not just cosmetics.

This is M2 of [RFC 010](./docs/rfcs/010-mcp-surface-v2.md) (see §5.5). Per-arg description overrides are deferred to v2 by RFC §5.5.3, matching the optional-v2 note in #52.

## Why

`qdrant-mcp` ships this knob and it's the lowest-risk milestone of RFC 010 — one env-var read per tool at construction. The agent's tool-selection policy is description-driven, so this is the smallest change that lets a single binary serve materially different agent personas.

## What changed

- `src/config.ts` — exports `RETRIEVE_KNOWLEDGE_DESCRIPTION` / `LIST_KNOWLEDGE_BASES_DESCRIPTION` plus their `DEFAULT_*` siblings, mirroring the existing `EMBEDDING_PROVIDER` / `HUGGINGFACE_*` pattern.
- `src/KnowledgeBaseServer.ts` — `registerTools()` now reads the two constants instead of the literal strings (`:51`, `:57` on `main`).
- `src/KnowledgeBaseServer.test.ts` — four new tests: default regression guard, retrieve override, list override, empty-string fallback. Uses the existing `freshServer()` + `jest.resetModules()` idiom so env vars are read at the right time.
- `README.md` — one bullet under "Additional Configuration" with an example.
- `CHANGELOG.md` — one entry under `[Unreleased] → ### Added`.

## Out of scope

- `smithery.yaml` — this is a per-deployment string, not a schema-y thing; operators set it in the MCP client's `env` block.
- The four tools added by RFC 010 §5.4 / §5.7 (`add_document`, `delete_document`, `refresh_knowledge_base`, `kb_stats`) — RFC §5.5.2 explicitly limits M2 to the two model-facing top-level tools.
- Per-arg (Zod `.describe()`) overrides — deferred to v2 per RFC §5.5.3 / issue #52's "optional v2" note.

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 82/82 green (4 new tests added on top of the existing 78)
- [x] Default regression guard: with neither env var set, both tool descriptions are byte-identical to `main`'s hard-coded strings
- [x] Override path: setting either env var swaps only the corresponding tool's description; the other is untouched
- [x] Empty-string fallback: `RETRIEVE_KNOWLEDGE_DESCRIPTION=''` falls back to default, not the empty string
- [ ] Manual MCP wire-protocol smoke test deferred to release validation — the four unit tests inspect the same `_registeredTools` map the SDK serialises into `tools/list` responses

Closes #52.