### PR TITLE
fix(faiss): EISDIR on FAISS index recovery (RFC 012 M0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.1.2] — 2026-04-25
+
+### Fixed
+
+- **EISDIR on FAISS index recovery (RFC 012 M0).** `FaissIndexManager.initialize()` called `fsp.unlink(indexFilePath)` on the model-switch and corrupt-index recovery branches. Modern `@langchain/community` `FaissStore.save()` writes a *directory* at `indexFilePath` (containing `faiss.index` + `docstore.json`), not a file, so `unlink` threw `EISDIR` and the recovery never ran. Replaced with `fsp.rm(indexFilePath, { recursive: true, force: true })` which handles both the modern directory layout and the legacy single-file layout. Latent bug: only triggered on embedding-model switch or on a corrupt index. Two new tests cover the directory-layout case for both branches; existing tests for the legacy file layout continue to pass. Pre-requisite for RFC 012 M1 (CLI). See [`docs/rfcs/012-cli-distribution.md`](./docs/rfcs/012-cli-distribution.md) §5.1.
+
 ## [Unreleased]
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jeanibarz/knowledge-base-mcp-server",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jeanibarz/knowledge-base-mcp-server",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "Unlicense",
       "dependencies": {
         "@huggingface/inference": "^4.13.15",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jeanibarz/knowledge-base-mcp-server",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "MCP server for retrieving data from different knowledge bases",
   "type": "module",
   "main": "build/index.js",

--- a/src/FaissIndexManager.test.ts
+++ b/src/FaissIndexManager.test.ts
@@ -424,6 +424,87 @@ describe('FaissIndexManager permission handling', () => {
     }
   });
 
+  // RFC 012 M0 — pre-existing EISDIR bug surfaces under modern FAISS layouts
+  // where indexFilePath is a *directory* (containing faiss.index +
+  // docstore.json), not a file. fsp.unlink throws EISDIR on directories;
+  // fsp.rm({recursive,force}) handles both shapes.
+  it('recovers from a corrupt FAISS index when indexFilePath is a directory (modern layout)', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-faiss-corrupt-dir-'));
+    const kbDir = path.join(tempDir, 'kb');
+    const defaultKb = path.join(kbDir, 'default');
+    await fsp.mkdir(defaultKb, { recursive: true });
+    await fsp.writeFile(path.join(defaultKb, 'doc.md'), '# Title\n\nContent.');
+
+    const faissDir = path.join(tempDir, '.faiss');
+    await fsp.mkdir(faissDir, { recursive: true });
+    const indexFilePath = path.join(faissDir, 'faiss.index');
+    // Modern langchain layout: indexFilePath is a directory.
+    await fsp.mkdir(indexFilePath, { recursive: true });
+    await fsp.writeFile(path.join(indexFilePath, 'faiss.index'), 'corrupt-bytes');
+    await fsp.writeFile(path.join(indexFilePath, 'docstore.json'), '{"docstore":"corrupt"}');
+
+    process.env.KNOWLEDGE_BASES_ROOT_DIR = kbDir;
+    process.env.FAISS_INDEX_PATH = faissDir;
+    process.env.EMBEDDING_PROVIDER = 'huggingface';
+    process.env.HUGGINGFACE_API_KEY = 'test-key';
+
+    loadMock.mockImplementationOnce(() => {
+      throw new Error('invalid faiss index header');
+    });
+
+    jest.resetModules();
+    const { FaissIndexManager } = await import('./FaissIndexManager.js');
+    const manager = new FaissIndexManager();
+
+    // Pre-fix this throws EISDIR from the fsp.unlink call on a directory.
+    await expect(manager.initialize()).resolves.toBeUndefined();
+
+    // Whole directory removed, including inner files.
+    await expect(fsp.stat(indexFilePath)).rejects.toMatchObject({ code: 'ENOENT' });
+
+    // End-to-end: rebuild branch hands off correctly.
+    await manager.updateIndex();
+    expect(fromTextsMock).toHaveBeenCalledTimes(1);
+    expect(saveMock).toHaveBeenCalledWith(indexFilePath);
+  });
+
+  it('recreates the index on model switch when indexFilePath is a directory (modern layout)', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-faiss-modelswitch-dir-'));
+    const kbDir = path.join(tempDir, 'kb');
+    const defaultKb = path.join(kbDir, 'default');
+    await fsp.mkdir(defaultKb, { recursive: true });
+    await fsp.writeFile(path.join(defaultKb, 'doc.md'), '# Title\n\nContent.');
+
+    const faissDir = path.join(tempDir, '.faiss');
+    await fsp.mkdir(faissDir, { recursive: true });
+    const indexFilePath = path.join(faissDir, 'faiss.index');
+    await fsp.mkdir(indexFilePath, { recursive: true });
+    await fsp.writeFile(path.join(indexFilePath, 'faiss.index'), 'old-model-bytes');
+    await fsp.writeFile(path.join(indexFilePath, 'docstore.json'), '{"old":"docstore"}');
+    // Stored model name differs from configured model → triggers recreate path.
+    await fsp.writeFile(path.join(faissDir, 'model_name.txt'), 'sentence-transformers/all-MiniLM-L6-v2');
+
+    process.env.KNOWLEDGE_BASES_ROOT_DIR = kbDir;
+    process.env.FAISS_INDEX_PATH = faissDir;
+    process.env.EMBEDDING_PROVIDER = 'huggingface';
+    process.env.HUGGINGFACE_API_KEY = 'test-key';
+    // Default huggingface model is bge-small-en-v1.5 — different from stored.
+
+    jest.resetModules();
+    const { FaissIndexManager } = await import('./FaissIndexManager.js');
+    const manager = new FaissIndexManager();
+
+    // Pre-fix this throws EISDIR from the model-switch fsp.unlink branch.
+    await expect(manager.initialize()).resolves.toBeUndefined();
+
+    // Old directory wiped.
+    await expect(fsp.stat(indexFilePath)).rejects.toMatchObject({ code: 'ENOENT' });
+
+    // model_name.txt rewritten with the new model.
+    const newName = await fsp.readFile(path.join(faissDir, 'model_name.txt'), 'utf-8');
+    expect(newName).toBe('BAAI/bge-small-en-v1.5');
+  });
+
   it('does not fail when the corrupt FAISS index has no .json sibling', async () => {
     const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-faiss-corrupt-nojson-'));
     const kbDir = path.join(tempDir, 'kb');

--- a/src/FaissIndexManager.ts
+++ b/src/FaissIndexManager.ts
@@ -314,7 +314,11 @@ export class FaissIndexManager {
         logger.warn(`Model name has changed from ${storedModelName} to ${this.modelName}. Recreating index.`);
         if (await pathExists(indexFilePath)) {
           try {
-            await fsp.unlink(indexFilePath);
+            // Modern @langchain/community emits a *directory* at indexFilePath
+            // (containing faiss.index + docstore.json); older versions wrote a
+            // single file. fsp.rm(recursive, force) handles both shapes and is
+            // also ENOENT-tolerant in case of races with another writer.
+            await fsp.rm(indexFilePath, { recursive: true, force: true });
             logger.info('Existing FAISS index deleted.');
           } catch (error) {
             handleFsOperationError('delete stale FAISS index', indexFilePath, error);
@@ -336,13 +340,18 @@ export class FaissIndexManager {
             error
           );
           try {
-            await fsp.unlink(indexFilePath);
+            // See model-switch branch above for why fsp.rm(recursive, force) is
+            // required: the modern langchain layout makes indexFilePath a
+            // directory, on which fsp.unlink throws EISDIR.
+            await fsp.rm(indexFilePath, { recursive: true, force: true });
           } catch (unlinkErr) {
             handleFsOperationError('delete corrupt FAISS index', indexFilePath, unlinkErr);
           }
-          // Best-effort: the .json docstore sibling may not exist (older index layouts
-          // wrote only faiss.index) and any failure here is non-fatal - the rebuild
-          // path will overwrite it on the next save.
+          // Legacy cleanup: very old index layouts wrote a sibling
+          // `<indexFilePath>.json` docstore file. The modern directory layout
+          // keeps docstore.json inside indexFilePath (already removed by the rm
+          // above). This best-effort unlink is a no-op for modern layouts and
+          // only matters when migrating from a pre-RFC-010 install.
           await fsp.unlink(`${indexFilePath}.json`).catch(() => {});
           this.faissIndex = null;
         }


### PR DESCRIPTION
## Summary

Pre-existing latent bug in `FaissIndexManager.initialize()`: the model-switch and corrupt-index recovery branches called `fsp.unlink(indexFilePath)`, but modern `@langchain/community` `FaissStore.save()` writes a **directory** at `indexFilePath` (containing `faiss.index` + `docstore.json`), not a file. `unlink` throws `EISDIR` on directories, so the recovery never ran.

Replaced with `fsp.rm(indexFilePath, { recursive: true, force: true })`. This is the M0 prerequisite for RFC 012 (the `kb` CLI), tracked in PR #95.

Bumps to **0.1.2** (patch — bug fix only).

## Verification

**Before fix:** running `initialize()` with a directory-layout `indexFilePath` and triggering either branch (model switch or `FaissStore.load` failure) throws `EISDIR: illegal operation on a directory, unlink '...faiss.index'`.

**After fix:** the same scenarios complete successfully — the directory is removed, `model_name.txt` is rewritten, and the next `updateIndex()` rebuilds via `fromTexts`.

Two new regression tests cover the directory-layout case:

- `recovers from a corrupt FAISS index when indexFilePath is a directory (modern layout)`
- `recreates the index on model switch when indexFilePath is a directory (modern layout)`

Both fail pre-fix (EISDIR), pass post-fix.

The existing tests for the legacy file layout continue to pass — `fsp.rm` with `recursive: true, force: true` is fully backwards-compatible with files. The existing permission-error test also passes because `force` only suppresses `ENOENT`, not `EACCES`.

## Test plan

- [x] `npm install && npm run build && npm test` — all 147 tests pass.
- [x] Two new tests added that fail pre-fix (EISDIR).
- [x] Existing legacy-layout tests still pass.
- [x] CHANGELOG entry under `## [0.1.2]`.
- [x] Version bumped in `package.json` and `package-lock.json`.
- [ ] Reviewer to confirm: `fsp.rm` with `force` still surfaces real permission errors (existing test "surfaces a permission error when the corrupt FAISS index cannot be unlinked" verifies this).

## Why a separate PR before M1

Per RFC 012 §5.1, this fix is a precondition for M1 because both the read-only `initialize` seam and `--refresh` exercise the same recovery path. Shipping the fix first as a patch keeps M1 focused on the CLI work and lets users on 0.1.x get the fix without waiting for the bigger 0.2.0 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)