### PR TITLE
docs: kb CLI quickstart + npx @latest correction (RFC 012 M2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## [0.2.0] — 2026-04-25
+
+### Added
+
+- **`kb` CLI bin (RFC 012 M1).** A new bin alongside `knowledge-base-mcp-server`, invoked from PATH so updates via `npm install -g @jeanibarz/knowledge-base-mcp-server@latest` are picked up on every invocation — no AI-client (Claude Code, Codex CLI, Cursor, Continue, Cline) restart needed for the operator's fix-and-test loop. Two subcommands: `kb list` and `kb search <query>`. The `search` path defaults to **read-only** (loads the existing FAISS index, runs similarity search, no writes); pass `--refresh` to also re-scan KB files under the write lock. `--stdin` reads the query from stdin (multi-line safe — no shell escaping bugs for AI-agent-generated queries with newlines/quotes). `--format=md` (default) reproduces MCP `retrieve_knowledge`'s wire output plus a single-line freshness footer; `--format=json` returns a structured object with `results`, `index_mtime`, `stale`, `modified_files`, `new_files`. See [`docs/rfcs/012-cli-distribution.md`](./docs/rfcs/012-cli-distribution.md).
+
+- **CLI freshness footer.** Default `kb search` runs a cheap stat-only walk of every KB and emits one of two footers per call: `> _Index up-to-date as of <iso8601>._` or `> _Index may be stale: N modified, M new file(s) since <iso8601>. Run \`kb search --refresh\` to update._`. Mtime source is the inner FAISS binary file (`${FAISS_INDEX_PATH}/faiss.index/faiss.index`), not the directory — directory mtime doesn't update on file overwrites. ~50–100 ms cost added; `--refresh` mode emits "Index refreshed at …" instead.
+
+- **CLI model-mismatch check.** `kb search` reads `model_name.txt` and exits `2` with a clear stderr message if the on-disk index was built with a different embedding model than the CLI's env points at. Closes the silent vector-space-mismatch failure mode that arose from MCP-server `mcp.json` env diverging from shell `~/.bashrc` env. `--refresh` emits a warning instead and proceeds (the existing model-switch path triggers a full re-embed).
+
+- **`FaissIndexManager.initialize({ readOnly?: boolean })`.** Method-level flag. When `true`, suppresses the previously unconditional `model_name.txt` write. `FaissStore.load` is itself read-only, so this is the single seam needed to make the entire init path safe to run alongside a separate writer (e.g. the MCP server) without write-lock contention. The CLI default uses this; MCP and `kb search --refresh` use the unchanged write-path.
+
+- **Atomic `model_name.txt` write.** `FaissIndexManager.initialize` (write path) now writes `model_name.txt` via tmp + atomic rename instead of `fsp.writeFile`. The previous truncate-then-write pattern caused false-positive CLI mismatch errors when a CLI invocation landed in the truncate window of an MCP server's `initialize`.
+
+- **Split-lock coordination via `proper-lockfile` (new dep).** Two distinct mechanisms in `src/lock.ts`:
+  - **PID advisory** at `${FAISS_INDEX_PATH}/.kb-mcp.pid`. Acquired atomically with `O_CREAT | O_EXCL` (mode 0o600) by `KnowledgeBaseServer.run()` on startup; released on graceful shutdown. Two concurrent MCP servers against the same `FAISS_INDEX_PATH` are now refused — the second fails-fast with a clear "another instance running (PID N)" message. Stale PID files (recorded PID is dead) are silently overwritten.
+  - **Write lock** at `${FAISS_INDEX_PATH}/.kb-write.lock`. Acquired only around `updateIndex` calls inside `KnowledgeBaseServer`, `ReindexTriggerWatcher`, and `kb search --refresh`. Released immediately after. Default `kb search` (read-only) does NOT acquire it. Heartbeat enabled (5 s) so long-running re-embeds aren't false-stale.
+
+- New extracted modules `src/formatter.ts` (markdown/JSON formatters + `sanitizeMetadataForWire`) and `src/kb-fs.ts` (`listKnowledgeBases`). Both surfaces (MCP + CLI) import from them; the CLI no longer drags in MCP-SDK transitive imports just to format output.
+
+### Changed
+
+- **Single MCP-server-per-`FAISS_INDEX_PATH` is now enforced (technically breaking).** The constraint was previously documented in the README and `docs/architecture/threat-model.md` but not enforced. Users who (against documented guidance) ran two MCP servers against the same `FAISS_INDEX_PATH` will now see the second one fail-fast with `InstanceAlreadyRunningError`. No change for users who follow the documented guidance. If you genuinely need two servers, give them separate `FAISS_INDEX_PATH` values.
+
+- `KnowledgeBaseServer.handleRetrieveKnowledge`, the `ReindexTriggerWatcher` callback, and `kb search --refresh` all wrap `updateIndex()` in the new write lock. Behavior is unchanged in the steady state; concurrent writers serialize instead of racing.
+
+- The markdown formatter and `sanitizeMetadataForWire` move from `KnowledgeBaseServer.ts` to `src/formatter.ts`. The old export path is preserved as a re-export for backward compat with existing code that imported from `KnowledgeBaseServer`. MCP wire output is byte-equal to before.
+
+- `package.json` `bin` adds `kb` → `build/cli.js`. The existing `knowledge-base-mcp-server` → `build/index.js` is unchanged. Build script chmods both bins.
+
 ## [0.1.2] — 2026-04-25
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -23,10 +23,28 @@ These instructions assume you have Node.js (version 20 or higher) and npm instal
 ### Install (one command)
 
 ```bash
-npx -y @jeanibarz/knowledge-base-mcp-server
+npx -y @jeanibarz/knowledge-base-mcp-server@latest
 ```
 
-`npx` fetches the package from npm and launches the stdio server. Point your MCP client at `npx -y @jeanibarz/knowledge-base-mcp-server` and configure the environment variables documented below. See [docs/clients.md](docs/clients.md) for copy-pasteable snippets (Claude Desktop, Codex CLI, Cursor, Continue, Cline).
+`npx` fetches the package from npm and launches the stdio server. Point your MCP client at `npx -y @jeanibarz/knowledge-base-mcp-server@latest` and configure the environment variables documented below. See [docs/clients.md](docs/clients.md) for copy-pasteable snippets (Claude Desktop, Codex CLI, Cursor, Continue, Cline).
+
+> **Pin `@latest`, not the unversioned spec.** `npx -y @jeanibarz/knowledge-base-mcp-server` (no version) caches the resolved version in `~/.npm/_npx/` indefinitely — subsequent client launches reuse that cached version even after a new release ships. The `@latest` form hashes to a different cache key and re-resolves on every launch, so new fixes arrive on the next client restart instead of requiring a manual `~/.npm/_npx/` clear. See RFC 012 §2.4.
+
+### Install (CLI alongside the MCP server, RFC 012)
+
+For an interactive shell or AI-agent shell-tool flow, install globally and use the `kb` bin directly. The OS resolves the binary on every invocation, so `npm i -g …@latest` is picked up without restarting any AI client that has the MCP server loaded:
+
+```bash
+npm install -g @jeanibarz/knowledge-base-mcp-server@latest
+kb list                       # list available knowledge bases
+kb search "your query"        # read-only search; cheap, fast (~0.6 s)
+kb search "query" --refresh   # also re-scan KB files (write path)
+kb --help
+```
+
+The `kb` bin shares the same env vars as the MCP server (`KNOWLEDGE_BASES_ROOT_DIR`, `FAISS_INDEX_PATH`, `EMBEDDING_PROVIDER`, `OLLAMA_*`, `OPENAI_*`, `HUGGINGFACE_*`). `kb search` defaults to read-only — it loads the existing FAISS index but does not re-scan KB files. Pass `--refresh` to re-index. Output includes a freshness footer indicating whether the index is up-to-date relative to KB file mtimes.
+
+The MCP server (`knowledge-base-mcp-server` bin) is unchanged and still works with all the configurations in [docs/clients.md](docs/clients.md). The CLI is additive.
 
 ### Install via Smithery
 

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -14,6 +14,16 @@ This server speaks stdio MCP and works with any stdio MCP client. Pick the block
 
 The blocks below alternate embedding providers so you can see all three configured at least once. Any client can use any provider — see the [README](../README.md) "Configure environment variables" step for the full env-var matrix.
 
+## Upgrade model — pin `@latest` if you wire via `npx`
+
+The snippets below use `command: "node"` + an absolute path, so upgrades happen when *you* rebuild from source. If instead you wire the server via `command: "npx"` + `args: ["-y", "@jeanibarz/knowledge-base-mcp-server@latest"]` (a common shorthand for users on the README "Install (one command)" path), **always include `@latest` explicitly**. The bare unversioned spec `@jeanibarz/knowledge-base-mcp-server` caches the resolved version in `~/.npm/_npx/` indefinitely — your client keeps using the old version after a new release ships. The `@latest` form hashes to a different cache key and re-resolves on every spawn. See RFC 012 §2.4.
+
+Alternatively, install once globally (`npm install -g @jeanibarz/knowledge-base-mcp-server@latest`) and use the resulting absolute bin path: `which knowledge-base-mcp-server`.
+
+## See also: `kb` CLI
+
+For shell-driven workflows (REPL queries, scripted ingest checks, agent Bash-tool calls), the same package ships a `kb` bin that doesn't require an MCP client at all. Each `kb` invocation is a fresh process, so global upgrades are picked up immediately. See the README "Install (CLI alongside the MCP server)" section.
+
 ## Claude Desktop
 
 Config file:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jeanibarz/knowledge-base-mcp-server",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jeanibarz/knowledge-base-mcp-server",
-      "version": "0.1.2",
+      "version": "0.2.0",
       "license": "Unlicense",
       "dependencies": {
         "@huggingface/inference": "^4.13.15",
@@ -21,15 +21,18 @@
         "langchain": "^0.3.15",
         "minimatch": "^10.2.5",
         "pickleparser": "^0.2.1",
+        "proper-lockfile": "^4.1.2",
         "zod": "^3.23.8"
       },
       "bin": {
+        "kb": "build/cli.js",
         "knowledge-base-mcp-server": "build/index.js"
       },
       "devDependencies": {
         "@types/jest": "^30.0.0",
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^20.11.5",
+        "@types/proper-lockfile": "^4.1.4",
         "jest": "^29.7.0",
         "nodemon": "^3.0.3",
         "ts-jest": "^29.4.1",
@@ -2519,6 +2522,16 @@
         "form-data": "^4.0.0"
       }
     },
+    "node_modules/@types/proper-lockfile": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@types/proper-lockfile/-/proper-lockfile-4.1.4.tgz",
+      "integrity": "sha512-uo2ABllncSqg9F1D4nugVl9v93RmjxF6LJzQLMLDdPaXCUIDPeOJ21Gbqi43xNKzBi/WQ0Q0dICqufzQbMjipQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "*"
+      }
+    },
     "node_modules/@types/retry": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
@@ -4335,7 +4348,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/graphql": {
@@ -7379,6 +7391,26 @@
         "node": ">= 6"
       }
     },
+    "node_modules/proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/proper-lockfile/node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/protobufjs": {
       "version": "7.5.5",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
@@ -7933,7 +7965,6 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/simple-concat": {

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "@jeanibarz/knowledge-base-mcp-server",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "MCP server for retrieving data from different knowledge bases",
   "type": "module",
   "main": "build/index.js",
   "bin": {
-    "knowledge-base-mcp-server": "build/index.js"
+    "knowledge-base-mcp-server": "build/index.js",
+    "kb": "build/cli.js"
   },
   "files": [
     "build/",
@@ -13,7 +14,7 @@
     "UNLICENSE"
   ],
   "scripts": {
-    "build": "tsc -p tsconfig.json && chmod +x build/index.js",
+    "build": "tsc -p tsconfig.json && chmod +x build/index.js build/cli.js",
     "bench": "npm run build && tsc -p tsconfig.bench.json && node build/benchmarks/run.js",
     "test": "jest --runInBand",
     "start": "node build/index.js",
@@ -39,12 +40,14 @@
     "langchain": "^0.3.15",
     "minimatch": "^10.2.5",
     "pickleparser": "^0.2.1",
+    "proper-lockfile": "^4.1.2",
     "zod": "^3.23.8"
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^20.11.5",
+    "@types/proper-lockfile": "^4.1.4",
     "jest": "^29.7.0",
     "nodemon": "^3.0.3",
     "ts-jest": "^29.4.1",

--- a/src/FaissIndexManager.test.ts
+++ b/src/FaissIndexManager.test.ts
@@ -558,6 +558,55 @@ describe('FaissIndexManager permission handling', () => {
     await expect(fsp.stat(sidecarPath)).rejects.toMatchObject({ code: 'ENOENT' });
     await expect(fsp.stat(`${sidecarPath}.tmp`)).rejects.toMatchObject({ code: 'ENOENT' });
   });
+
+  // RFC 012 §4.5 — readOnly seam
+  it('initialize({ readOnly: true }) does not write model_name.txt', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-faiss-readonly-'));
+    const kbDir = path.join(tempDir, 'kb');
+    await fsp.mkdir(kbDir, { recursive: true });
+    const faissDir = path.join(tempDir, '.faiss');
+
+    process.env.KNOWLEDGE_BASES_ROOT_DIR = kbDir;
+    process.env.FAISS_INDEX_PATH = faissDir;
+    process.env.EMBEDDING_PROVIDER = 'huggingface';
+    process.env.HUGGINGFACE_API_KEY = 'test-key';
+
+    jest.resetModules();
+    const { FaissIndexManager } = await import('./FaissIndexManager.js');
+    const manager = new FaissIndexManager();
+
+    await manager.initialize({ readOnly: true });
+
+    // model_name.txt must NOT exist after a read-only init.
+    const modelNameFile = path.join(faissDir, 'model_name.txt');
+    await expect(fsp.stat(modelNameFile)).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('initialize() (default) writes model_name.txt atomically', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-faiss-atomic-'));
+    const kbDir = path.join(tempDir, 'kb');
+    await fsp.mkdir(kbDir, { recursive: true });
+    const faissDir = path.join(tempDir, '.faiss');
+
+    process.env.KNOWLEDGE_BASES_ROOT_DIR = kbDir;
+    process.env.FAISS_INDEX_PATH = faissDir;
+    process.env.EMBEDDING_PROVIDER = 'huggingface';
+    process.env.HUGGINGFACE_API_KEY = 'test-key';
+
+    jest.resetModules();
+    const { FaissIndexManager } = await import('./FaissIndexManager.js');
+    const manager = new FaissIndexManager();
+    await manager.initialize();
+
+    // model_name.txt exists with the configured model.
+    const modelNameFile = path.join(faissDir, 'model_name.txt');
+    expect(await fsp.readFile(modelNameFile, 'utf-8')).toBe('BAAI/bge-small-en-v1.5');
+
+    // No leftover .tmp file from the atomic rename.
+    const entries = await fsp.readdir(faissDir);
+    const tmpEntries = entries.filter((e) => e.startsWith('model_name.txt.') && e.endsWith('.tmp'));
+    expect(tmpEntries).toEqual([]);
+  });
 });
 
 describe('FaissIndexManager chunk metadata (RFC 010 M1)', () => {

--- a/src/FaissIndexManager.ts
+++ b/src/FaissIndexManager.ts
@@ -32,6 +32,40 @@ import { logger } from './logger.js';
 
 const MODEL_NAME_FILE = path.join(FAISS_INDEX_PATH, 'model_name.txt');
 
+/**
+ * RFC 012 §4.7 — atomic write for `model_name.txt`. Prior implementation used
+ * `fsp.writeFile` which truncates the file to 0 bytes before writing; a CLI
+ * invocation that reads the file in the truncate window saw an empty string
+ * and produced a false-positive embedding-model mismatch error. tmp+rename
+ * is atomic on POSIX — readers see either the old contents or the new
+ * contents, never a partial state.
+ */
+async function writeModelNameAtomic(modelName: string): Promise<void> {
+  const tmp = `${MODEL_NAME_FILE}.${process.pid}.tmp`;
+  await fsp.writeFile(tmp, modelName, 'utf-8');
+  await fsp.rename(tmp, MODEL_NAME_FILE);
+}
+
+/** Test/CLI helper: read the recorded model name. Returns null when the file
+ * is absent (fresh index never written). Read errors propagate so callers
+ * can distinguish "no file" from "permission denied". */
+export async function readStoredModelName(): Promise<string | null> {
+  try {
+    return (await fsp.readFile(MODEL_NAME_FILE, 'utf-8')).trim();
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null;
+    throw err;
+  }
+}
+
+/** Test/CLI helper: the absolute path to the FAISS binary file inside
+ * `${FAISS_INDEX_PATH}/faiss.index/`. Round-3 fix: callers reading mtime
+ * for staleness signals must target this inner file, NOT the directory
+ * itself (directory mtime doesn't update on file overwrites). */
+export function faissIndexBinaryPath(): string {
+  return path.join(FAISS_INDEX_PATH, 'faiss.index', 'faiss.index');
+}
+
 // -----------------------------------------------------------------------------
 // RFC 011 §5.4 — whitelisted frontmatter lift + sibling PDF detection.
 //
@@ -290,7 +324,16 @@ export class FaissIndexManager {
     }
   }
 
-  async initialize(): Promise<void> {
+  /**
+   * RFC 012 §4.5 — `readOnly: true` skips the unconditional
+   * `model_name.txt` write at the bottom of this method. `FaissStore.load`
+   * is itself read-only (verified in node_modules/@langchain/community/dist/vectorstores/faiss.js
+   * lines 219-230 — readFile + InMemoryDocstore, no writes), so suppressing
+   * that one write makes the entire init path safe to run alongside a
+   * separate writer (e.g. the MCP server) without lockfile contention.
+   * Default behavior (read-write) is unchanged.
+   */
+  async initialize(opts: { readOnly?: boolean } = {}): Promise<void> {
     try {
       if (!(await pathExists(FAISS_INDEX_PATH))) {
         try {
@@ -360,11 +403,15 @@ export class FaissIndexManager {
         this.faissIndex = null;
       }
 
-      // Save the current model name for future checks
-      try {
-        await fsp.writeFile(MODEL_NAME_FILE, this.modelName, 'utf-8');
-      } catch (error) {
-        handleFsOperationError('persist embedding model metadata in', MODEL_NAME_FILE, error);
+      // Save the current model name for future checks. Skipped under
+      // readOnly:true (RFC 012 §4.5) so a CLI invocation can load the
+      // index without contending with a running MCP server.
+      if (!opts.readOnly) {
+        try {
+          await writeModelNameAtomic(this.modelName);
+        } catch (error) {
+          handleFsOperationError('persist embedding model metadata in', MODEL_NAME_FILE, error);
+        }
       }
     } catch (error: any) {
       if (!error?.__alreadyLogged) {

--- a/src/KnowledgeBaseServer.ts
+++ b/src/KnowledgeBaseServer.ts
@@ -3,7 +3,6 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { z } from 'zod';
 import type { CallToolResult, TextContent } from '@modelcontextprotocol/sdk/types.js';
-import * as fsp from 'fs/promises';
 import { FaissIndexManager } from './FaissIndexManager.js';
 import {
   FRONTMATTER_EXTRAS_WIRE_VISIBLE,
@@ -16,6 +15,14 @@ import {
   TransportConfigError,
   type TransportConfig,
 } from './config.js';
+import { formatRetrievalAsMarkdown, sanitizeMetadataForWire } from './formatter.js';
+import { listKnowledgeBases } from './kb-fs.js';
+import {
+  acquireInstanceAdvisory,
+  InstanceAlreadyRunningError,
+  releaseInstanceAdvisory,
+  withWriteLock,
+} from './lock.js';
 import { logger } from './logger.js';
 import { SseHost } from './transport/sse.js';
 import { ReindexTriggerWatcher } from './triggerWatcher.js';
@@ -23,31 +30,10 @@ import { ReindexTriggerWatcher } from './triggerWatcher.js';
 const SERVER_NAME = 'knowledge-base-server';
 const SERVER_VERSION = '0.1.0';
 
-/**
- * Strips `frontmatter.extras` from a chunk's metadata before wire
- * serialization unless the operator has opted back in via
- * `FRONTMATTER_EXTRAS_WIRE_VISIBLE=true`. RFC 011 §7.1 R1 — extras are a
- * leak surface the operator owns; the default posture is to suppress.
- *
- * Shallow-clones only the branches it mutates to avoid touching the
- * original `Document.metadata` (which is cached in the FAISS store).
- */
-export function sanitizeMetadataForWire(
-  metadata: Record<string, unknown>,
-  extrasVisible: boolean,
-): Record<string, unknown> {
-  if (extrasVisible) return metadata;
-  const fm = metadata.frontmatter;
-  if (!fm || typeof fm !== 'object') return metadata;
-  const fmObj = fm as Record<string, unknown>;
-  if (!('extras' in fmObj)) return metadata;
-  const { extras, ...fmWithoutExtras } = fmObj;
-  void extras;
-  return {
-    ...metadata,
-    frontmatter: fmWithoutExtras,
-  };
-}
+// Re-export for backward compatibility: existing tests import
+// `sanitizeMetadataForWire` from this module. The canonical home is now
+// `src/formatter.ts` (RFC 012 §4.9 boundary fix).
+export { sanitizeMetadataForWire };
 
 export class KnowledgeBaseServer {
   private mcp: McpServer;
@@ -99,8 +85,7 @@ export class KnowledgeBaseServer {
 
   private async handleListKnowledgeBases(): Promise<CallToolResult> {
     try {
-      const entries = await fsp.readdir(KNOWLEDGE_BASES_ROOT_DIR);
-      const knowledgeBases = entries.filter((entry) => !entry.startsWith('.'));
+      const knowledgeBases = await listKnowledgeBases(KNOWLEDGE_BASES_ROOT_DIR);
       const content: TextContent = {
         type: 'text',
         text: JSON.stringify(knowledgeBases, null, 2),
@@ -128,8 +113,10 @@ export class KnowledgeBaseServer {
       const startTime = Date.now();
       logger.debug(`[${startTime}] handleRetrieveKnowledge started`);
 
-      // Update FAISS index: if a specific knowledge base is provided, update only that one; otherwise update all.
-      await this.faissManager.updateIndex(knowledgeBaseName);
+      // RFC 012 §4.8.2 — wrap the write-path updateIndex in the short-lived
+      // write lock. The MCP server, the trigger watcher, and `kb search
+      // --refresh` all serialize through this single primitive.
+      await withWriteLock(() => this.faissManager.updateIndex(knowledgeBaseName));
       logger.debug(`[${Date.now()}] FAISS index update completed`);
 
       // Perform similarity search using the provided query.
@@ -137,26 +124,10 @@ export class KnowledgeBaseServer {
       logger.debug(`[${Date.now()}] Similarity search completed`);
 
       // Build a nicely formatted markdown response including the similarity score.
-      let formattedResults = '';
-      if (similaritySearchResults && similaritySearchResults.length > 0) {
-        formattedResults = similaritySearchResults
-          .map((doc, idx) => {
-            const resultHeader = `**Result ${idx + 1}:**`;
-            const content = doc.pageContent.trim();
-            const sanitizedMetadata = sanitizeMetadataForWire(
-              doc.metadata as Record<string, unknown>,
-              FRONTMATTER_EXTRAS_WIRE_VISIBLE,
-            );
-            const metadata = JSON.stringify(sanitizedMetadata, null, 2);
-            const scoreText = doc.score !== undefined ? `**Score:** ${doc.score.toFixed(2)}\n\n` : '';
-            return `${resultHeader}\n\n${scoreText}${content}\n\n**Source:**\n\`\`\`json\n${metadata}\n\`\`\``;
-          })
-          .join('\n\n---\n\n');
-      } else {
-        formattedResults = '_No similar results found._';
-      }
-      const disclaimer = '\n\n> **Disclaimer:** The provided results might not all be relevant. Please cross-check the relevance of the information.';
-      const responseText = `## Semantic Search Results\n\n${formattedResults}${disclaimer}`;
+      const responseText = formatRetrievalAsMarkdown(
+        similaritySearchResults,
+        FRONTMATTER_EXTRAS_WIRE_VISIBLE,
+      );
 
       const endTime = Date.now();
       logger.debug(`[${endTime}] handleRetrieveKnowledge completed in ${endTime - startTime}ms`);
@@ -187,6 +158,21 @@ export class KnowledgeBaseServer {
       throw err;
     }
 
+    // RFC 012 §4.8.1 — claim the single-instance advisory before any
+    // index work. Two concurrent MCP servers against the same
+    // FAISS_INDEX_PATH would corrupt the index; the PID file makes that
+    // impossible (one process wins atomically via O_EXCL).
+    try {
+      await acquireInstanceAdvisory();
+    } catch (err) {
+      if (err instanceof InstanceAlreadyRunningError) {
+        logger.error(err.message);
+        process.exitCode = 1;
+        return;
+      }
+      throw err;
+    }
+
     try {
       if (transportConfig.transport === 'stdio') {
         await this.runStdio();
@@ -198,6 +184,10 @@ export class KnowledgeBaseServer {
       if (error?.stack) {
         logger.error(error.stack);
       }
+      // Best-effort release on startup failure so a crashed start doesn't
+      // strand the PID file and block the next run for a stale-detection
+      // cycle.
+      await releaseInstanceAdvisory();
       process.exitCode = 1;
     }
   }
@@ -235,7 +225,9 @@ export class KnowledgeBaseServer {
     }
     this.triggerWatcher = new ReindexTriggerWatcher(
       REINDEX_TRIGGER_PATH,
-      () => this.faissManager.updateIndex(undefined),
+      // RFC 012 §4.8.2 — trigger-driven updateIndex also serializes through
+      // the write lock so a CLI `--refresh` doesn't race a watcher cycle.
+      () => withWriteLock(() => this.faissManager.updateIndex(undefined)),
       REINDEX_TRIGGER_POLL_MS,
     );
     this.triggerWatcher.start();
@@ -272,5 +264,8 @@ export class KnowledgeBaseServer {
     } catch (err) {
       logger.warn(`Error closing root mcp: ${(err as Error).message}`);
     }
+    // RFC 012 §4.8.1 — release advisory last so a slow MCP shutdown
+    // doesn't cause a fast restart to false-fire "another instance".
+    await releaseInstanceAdvisory();
   }
 }

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1,0 +1,174 @@
+// Integration test for `bin/kb` — spawned as a child process so we exercise
+// the actual chmod, shebang, ESM resolution, and env-var inheritance.
+//
+// Slow tests (each spawn is ~150-400 ms cold-start), so we keep the matrix
+// minimal: argv parsing, list, model-mismatch error path. The full search
+// path against a real FAISS index is out of scope (would require a real
+// embedding provider or extensive mocking that doesn't survive child-process
+// boundaries).
+
+import { describe, expect, it } from '@jest/globals';
+import { spawnSync } from 'child_process';
+import * as fsp from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+
+// Jest runs from the project root; the built CLI lives at build/cli.js.
+// Avoiding import.meta.url here because ts-jest's emit doesn't support it
+// under the project's tsconfig module setting.
+const cliPath = path.join(process.cwd(), 'build', 'cli.js');
+
+interface RunResult {
+  code: number;
+  stdout: string;
+  stderr: string;
+}
+
+function runCli(args: string[], env: Record<string, string> = {}): RunResult {
+  const result = spawnSync('node', [cliPath, ...args], {
+    env: { PATH: process.env.PATH ?? '', ...env },
+    encoding: 'utf-8',
+  });
+  if (result.error) throw result.error;
+  return {
+    code: result.status ?? -1,
+    stdout: result.stdout,
+    stderr: result.stderr,
+  };
+}
+
+describe('kb CLI — argv parsing and dispatch', () => {
+  it('--help exits 0 with usage text', () => {
+    const r = runCli(['--help']);
+    expect(r.code).toBe(0);
+    expect(r.stdout).toContain('kb — knowledge-base CLI');
+    expect(r.stdout).toContain('kb list');
+    expect(r.stdout).toContain('kb search');
+  });
+
+  it('no args exits 0 with usage text', () => {
+    const r = runCli([]);
+    expect(r.code).toBe(0);
+    expect(r.stdout).toContain('kb — knowledge-base CLI');
+  });
+
+  it('--version exits 0 with package version', () => {
+    const r = runCli(['--version']);
+    expect(r.code).toBe(0);
+    expect(r.stdout.trim()).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
+  it('unknown subcommand exits 2 with help', () => {
+    const r = runCli(['notacommand']);
+    expect(r.code).toBe(2);
+    expect(r.stderr).toContain("unknown subcommand 'notacommand'");
+  });
+
+  it('search without query (and no --stdin) exits 2', () => {
+    const r = runCli(['search']);
+    expect(r.code).toBe(2);
+    expect(r.stderr).toContain('missing <query>');
+  });
+
+  it('search with bogus flag exits 2', () => {
+    const r = runCli(['search', 'q', '--zzz=1']);
+    expect(r.code).toBe(2);
+    expect(r.stderr).toContain('unknown flag');
+  });
+
+  it('search with invalid --threshold exits 2', () => {
+    const r = runCli(['search', 'q', '--threshold=notanumber']);
+    expect(r.code).toBe(2);
+    expect(r.stderr).toContain('invalid --threshold');
+  });
+});
+
+describe('kb list', () => {
+  it('returns KB names one per line, dot-prefixed entries filtered', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-cli-list-'));
+    try {
+      await fsp.mkdir(path.join(tempDir, 'engineering'));
+      await fsp.mkdir(path.join(tempDir, 'personal'));
+      await fsp.mkdir(path.join(tempDir, '.faiss'));
+
+      const r = runCli(['list'], {
+        KNOWLEDGE_BASES_ROOT_DIR: tempDir,
+        FAISS_INDEX_PATH: path.join(tempDir, '.faiss'),
+      });
+      expect(r.code).toBe(0);
+      const names = r.stdout.trim().split('\n').sort();
+      expect(names).toEqual(['engineering', 'personal']);
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns 1 when KNOWLEDGE_BASES_ROOT_DIR does not exist', () => {
+    const r = runCli(['list'], {
+      KNOWLEDGE_BASES_ROOT_DIR: '/nonexistent/kb/dir/never/exists',
+    });
+    expect(r.code).toBe(1);
+    expect(r.stderr).toContain('kb list:');
+  });
+});
+
+describe('kb search — model-mismatch check (RFC §4.7)', () => {
+  it('exits 2 with clear stderr when index was built with a different model', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-cli-mismatch-'));
+    try {
+      const faissDir = path.join(tempDir, '.faiss');
+      await fsp.mkdir(faissDir, { recursive: true });
+      // Seed model_name.txt with a different model than what the CLI
+      // would configure for huggingface defaults (BAAI/bge-small-en-v1.5).
+      await fsp.writeFile(
+        path.join(faissDir, 'model_name.txt'),
+        'sentence-transformers/all-MiniLM-L6-v2',
+      );
+      // Also need a KB so the rest of the path works.
+      const kbDir = path.join(tempDir, 'kb');
+      await fsp.mkdir(kbDir);
+
+      const r = runCli(['search', 'hello'], {
+        KNOWLEDGE_BASES_ROOT_DIR: kbDir,
+        FAISS_INDEX_PATH: faissDir,
+        EMBEDDING_PROVIDER: 'huggingface',
+        HUGGINGFACE_API_KEY: 'test-key',
+      });
+      expect(r.code).toBe(2);
+      expect(r.stderr).toContain('Embedding model mismatch');
+      expect(r.stderr).toContain('sentence-transformers/all-MiniLM-L6-v2');
+      expect(r.stderr).toContain('BAAI/bge-small-en-v1.5');
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('emits warning but proceeds with --refresh on model mismatch', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-cli-mismatch-refresh-'));
+    try {
+      const faissDir = path.join(tempDir, '.faiss');
+      await fsp.mkdir(faissDir, { recursive: true });
+      await fsp.writeFile(
+        path.join(faissDir, 'model_name.txt'),
+        'sentence-transformers/all-MiniLM-L6-v2',
+      );
+      const kbDir = path.join(tempDir, 'kb');
+      await fsp.mkdir(kbDir);
+
+      const r = runCli(['search', 'hello', '--refresh'], {
+        KNOWLEDGE_BASES_ROOT_DIR: kbDir,
+        FAISS_INDEX_PATH: faissDir,
+        EMBEDDING_PROVIDER: 'huggingface',
+        HUGGINGFACE_API_KEY: 'test-key',
+      });
+      // --refresh proceeds; the warning should be printed.
+      expect(r.stderr).toContain('Embedding model mismatch');
+      // It will fail later because there's no actual KB content + embeddings;
+      // just verify the warning path was hit. Either 0 (empty results) or
+      // 1 (network failure to embedding API) is acceptable here.
+      expect([0, 1]).toContain(r.code);
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,456 @@
+#!/usr/bin/env node
+// RFC 012 — `kb` CLI alongside the MCP server.
+//
+// Two subcommands:
+//   - `kb list`               → list ingested knowledge bases (one per line)
+//   - `kb search <query>`     → similarity search; default read-only
+//                               (skips updateIndex, no write lock)
+//   - `kb search --refresh`   → also runs updateIndex under the write lock
+//
+// Both subcommands check `model_name.txt` against the configured embedding
+// model on every invocation and exit non-zero on mismatch (RFC §4.7) so a
+// shell-launched CLI with different env from the MCP server's mcp.json
+// can't silently return wrong-vector-space results.
+
+import * as fsp from 'fs/promises';
+import { FaissIndexManager, faissIndexBinaryPath, readStoredModelName } from './FaissIndexManager.js';
+import {
+  EMBEDDING_PROVIDER,
+  FAISS_INDEX_PATH,
+  FRONTMATTER_EXTRAS_WIRE_VISIBLE,
+  HUGGINGFACE_MODEL_NAME,
+  KNOWLEDGE_BASES_ROOT_DIR,
+  OLLAMA_MODEL,
+  OPENAI_MODEL_NAME,
+} from './config.js';
+import { formatRetrievalAsJson, formatRetrievalAsMarkdown } from './formatter.js';
+import { listKnowledgeBases } from './kb-fs.js';
+import { withWriteLock } from './lock.js';
+import { logger } from './logger.js';
+import { filterIngestablePaths, getFilesRecursively } from './utils.js';
+import { readFileSync } from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+// ----- Argv types ------------------------------------------------------------
+
+interface SearchArgs {
+  query: string | null; // null when --stdin and stdin not yet read
+  kb?: string;
+  threshold?: number;
+  k: number;
+  format: 'md' | 'json';
+  refresh: boolean;
+  stdin: boolean;
+}
+
+// ----- Entry point -----------------------------------------------------------
+
+const HELP = `kb — knowledge-base CLI (RFC 012)
+
+Usage:
+  kb list                         List available knowledge bases.
+  kb search <query> [opts]        Semantic search (read-only).
+  kb search <query> --refresh     Also re-scan KB files (write path).
+  kb search --stdin               Read query from stdin.
+  kb --version
+  kb --help
+
+Search options:
+  --kb=<name>           Scope to one knowledge base.
+  --threshold=<float>   Max similarity score (default 2).
+  --k=<int>             Top-K results (default 10).
+  --format=md|json      Output format (default md).
+  --refresh             Re-scan KB files; acquires write lock briefly.
+  --stdin               Read query from stdin (multi-line safe).
+
+Env vars (same as MCP server): KNOWLEDGE_BASES_ROOT_DIR, FAISS_INDEX_PATH,
+EMBEDDING_PROVIDER, OLLAMA_*, OPENAI_*, HUGGINGFACE_*.
+
+Exit codes:
+  0  success (results found or empty)
+  1  runtime / index error
+  2  argv / env / model-mismatch error
+`;
+
+export async function main(argv: string[]): Promise<number> {
+  // Strip the conventional argv[0]/argv[1] before delegating.
+  const args = argv.slice(2);
+
+  if (args.length === 0 || args[0] === '--help' || args[0] === '-h') {
+    process.stdout.write(HELP);
+    return 0;
+  }
+  if (args[0] === '--version' || args[0] === '-v') {
+    process.stdout.write(`${getPackageVersion()}\n`);
+    return 0;
+  }
+
+  const sub = args[0];
+  const rest = args.slice(1);
+
+  if (sub === 'list') {
+    return runList();
+  }
+  if (sub === 'search') {
+    return runSearch(rest);
+  }
+
+  process.stderr.write(`kb: unknown subcommand '${sub}'\n${HELP}`);
+  return 2;
+}
+
+// ----- list ------------------------------------------------------------------
+
+async function runList(): Promise<number> {
+  try {
+    const kbs = await listKnowledgeBases(KNOWLEDGE_BASES_ROOT_DIR);
+    for (const name of kbs) {
+      process.stdout.write(`${name}\n`);
+    }
+    return 0;
+  } catch (err) {
+    process.stderr.write(`kb list: ${(err as Error).message}\n`);
+    return 1;
+  }
+}
+
+// ----- search ----------------------------------------------------------------
+
+async function runSearch(rest: string[]): Promise<number> {
+  let parsed: SearchArgs;
+  try {
+    parsed = parseSearchArgs(rest);
+  } catch (err) {
+    process.stderr.write(`kb search: ${(err as Error).message}\n`);
+    return 2;
+  }
+
+  // Stdin path: if --stdin and no positional query, read from stdin.
+  if (parsed.stdin && parsed.query === null) {
+    parsed.query = await readAllStdin();
+    if (parsed.query.trim() === '') {
+      process.stderr.write('kb search: empty query from stdin\n');
+      return 2;
+    }
+  } else if (parsed.query === null) {
+    process.stderr.write('kb search: missing <query> (or use --stdin)\n');
+    return 2;
+  }
+
+  // Model-mismatch check (RFC §4.7). Both default and --refresh paths.
+  // --refresh handles the recreate; default exits with a clear error.
+  const mismatch = await checkModelMismatch();
+  if (mismatch) {
+    if (!parsed.refresh) {
+      process.stderr.write(mismatch.errorMessage);
+      return 2;
+    }
+    // --refresh: emit warning, let updateIndex trigger the recreate path.
+    process.stderr.write(mismatch.warningMessage);
+  }
+
+  // Suppress logger noise on stdout; everything goes to stderr but the
+  // existing logger already only writes to stderr. Reading the env-driven
+  // LOG_LEVEL is the operator's control.
+
+  let manager: FaissIndexManager;
+  try {
+    manager = new FaissIndexManager();
+  } catch (err) {
+    process.stderr.write(`kb search: ${(err as Error).message}\n`);
+    return 2;
+  }
+
+  try {
+    if (parsed.refresh) {
+      await withWriteLock(async () => {
+        await manager.initialize();
+        await manager.updateIndex(parsed.kb);
+      });
+    } else {
+      await loadWithJsonRetry(manager);
+    }
+  } catch (err) {
+    process.stderr.write(`kb search: ${(err as Error).message}\n`);
+    return 1;
+  }
+
+  let results;
+  try {
+    results = await manager.similaritySearch(
+      parsed.query!,
+      parsed.k,
+      parsed.threshold,
+      parsed.kb,
+    );
+  } catch (err) {
+    process.stderr.write(`kb search: ${(err as Error).message}\n`);
+    return 1;
+  }
+
+  // Staleness pre-check (RFC §4.10). Cheap stat-only walk; computes
+  // modified + new file counts vs. the inner FAISS binary's mtime.
+  const staleness = await computeStaleness();
+
+  if (parsed.format === 'json') {
+    const body = formatRetrievalAsJson(results, FRONTMATTER_EXTRAS_WIRE_VISIBLE);
+    const payload = {
+      results: body,
+      index_mtime: staleness.indexMtime,
+      stale: parsed.refresh ? false : staleness.modifiedFiles + staleness.newFiles > 0,
+      modified_files: parsed.refresh ? 0 : staleness.modifiedFiles,
+      new_files: parsed.refresh ? 0 : staleness.newFiles,
+    };
+    process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+  } else {
+    const md = formatRetrievalAsMarkdown(results, FRONTMATTER_EXTRAS_WIRE_VISIBLE);
+    process.stdout.write(md);
+    process.stdout.write('\n\n');
+    process.stdout.write(formatFreshnessFooter(staleness, parsed.refresh));
+    process.stdout.write('\n');
+  }
+
+  return 0;
+}
+
+// ----- argv parsing ----------------------------------------------------------
+
+function parseSearchArgs(rest: string[]): SearchArgs {
+  const out: SearchArgs = {
+    query: null,
+    k: 10,
+    format: 'md',
+    refresh: false,
+    stdin: false,
+  };
+  for (const raw of rest) {
+    if (raw === '--refresh') { out.refresh = true; continue; }
+    if (raw === '--stdin')   { out.stdin = true; continue; }
+    if (raw.startsWith('--kb=')) { out.kb = raw.slice('--kb='.length); continue; }
+    if (raw.startsWith('--threshold=')) {
+      const n = Number(raw.slice('--threshold='.length));
+      if (!Number.isFinite(n)) throw new Error(`invalid --threshold: ${raw}`);
+      out.threshold = n; continue;
+    }
+    if (raw.startsWith('--k=')) {
+      const n = Number(raw.slice('--k='.length));
+      if (!Number.isInteger(n) || n <= 0) throw new Error(`invalid --k: ${raw}`);
+      out.k = n; continue;
+    }
+    if (raw.startsWith('--format=')) {
+      const v = raw.slice('--format='.length);
+      if (v !== 'md' && v !== 'json') throw new Error(`invalid --format: ${raw}`);
+      out.format = v; continue;
+    }
+    if (raw.startsWith('--')) throw new Error(`unknown flag: ${raw}`);
+    // First positional becomes the query.
+    if (out.query === null) { out.query = raw; continue; }
+    throw new Error(`unexpected argument: ${raw}`);
+  }
+  return out;
+}
+
+// ----- model-mismatch check (RFC §4.7) --------------------------------------
+
+interface ModelMismatch {
+  errorMessage: string;
+  warningMessage: string;
+}
+
+function configuredModelName(): string {
+  switch (EMBEDDING_PROVIDER) {
+    case 'openai': return OPENAI_MODEL_NAME;
+    case 'ollama': return OLLAMA_MODEL;
+    default: return HUGGINGFACE_MODEL_NAME;
+  }
+}
+
+async function checkModelMismatch(): Promise<ModelMismatch | null> {
+  const stored = await readStoredModelName().catch(() => null);
+  if (stored === null) return null; // fresh index — no mismatch possible
+  const configured = configuredModelName();
+  if (stored === configured) return null;
+
+  const errorMessage =
+    `Error: Embedding model mismatch.\n` +
+    `  Index built with: ${stored}\n` +
+    `  Current config:   ${configured}\n` +
+    `These produce different vector spaces; query results would be meaningless.\n` +
+    `Options:\n` +
+    `  1. Set EMBEDDING_PROVIDER / model env vars to match the index, or\n` +
+    `  2. Run \`kb search --refresh\` to rebuild the index with the current model\n` +
+    `     (multi-minute on first call).\n`;
+  const warningMessage =
+    `Warning: Embedding model mismatch (index: ${stored}, configured: ${configured}). ` +
+    `--refresh will trigger a full re-embed.\n`;
+  return { errorMessage, warningMessage };
+}
+
+// ----- staleness pre-check (RFC §4.10) --------------------------------------
+
+interface Staleness {
+  indexMtime: string | null;
+  modifiedFiles: number;
+  newFiles: number;
+}
+
+async function computeStaleness(): Promise<Staleness> {
+  // Index mtime — target the inner binary file (NOT the directory; round-3
+  // mtime correction).
+  const binaryPath = faissIndexBinaryPath();
+  let indexStat;
+  try {
+    indexStat = await fsp.stat(binaryPath);
+  } catch {
+    return { indexMtime: null, modifiedFiles: 0, newFiles: 0 };
+  }
+  const indexMtimeMs = indexStat.mtimeMs;
+  const indexMtime = new Date(indexMtimeMs).toISOString();
+
+  // Walk KBs; count modified (mtime > index mtime) and new (file count vs
+  // sidecar count). Pure stat — no SHA256.
+  let modified = 0;
+  let added = 0;
+  let kbs: string[];
+  try {
+    kbs = await listKnowledgeBases(KNOWLEDGE_BASES_ROOT_DIR);
+  } catch {
+    return { indexMtime, modifiedFiles: 0, newFiles: 0 };
+  }
+
+  for (const kbName of kbs) {
+    const kbDir = path.join(KNOWLEDGE_BASES_ROOT_DIR, kbName);
+    let allFiles: string[];
+    try {
+      allFiles = await getFilesRecursively(kbDir);
+    } catch {
+      continue;
+    }
+    const ingestable = await filterIngestablePaths(allFiles, kbDir);
+
+    // Modified files: mtime advanced past index mtime.
+    for (const f of ingestable) {
+      try {
+        const st = await fsp.stat(f);
+        if (st.mtimeMs > indexMtimeMs) modified += 1;
+      } catch {
+        // file vanished between getFilesRecursively and stat — ignore
+      }
+    }
+
+    // New files: count vs hash sidecars.
+    const sidecarDir = path.join(kbDir, '.index');
+    let sidecarCount = 0;
+    try {
+      const sidecars = await fsp.readdir(sidecarDir);
+      sidecarCount = sidecars.length;
+    } catch {
+      // .index missing — every file is "new" relative to nothing-indexed.
+      // But that case is handled by indexMtime===null above; if we got
+      // here with a present index but no sidecar dir, treat as count diff.
+    }
+    if (ingestable.length > sidecarCount) {
+      added += ingestable.length - sidecarCount;
+    }
+  }
+
+  return { indexMtime, modifiedFiles: modified, newFiles: added };
+}
+
+function formatFreshnessFooter(s: Staleness, refreshed: boolean): string {
+  if (s.indexMtime === null) {
+    return `> _Index not yet built. Run \`kb search --refresh\` to create it._`;
+  }
+  if (refreshed) {
+    return `> _Index refreshed at ${s.indexMtime}._`;
+  }
+  if (s.modifiedFiles === 0 && s.newFiles === 0) {
+    return `> _Index up-to-date as of ${s.indexMtime}._`;
+  }
+  return (
+    `> _Index may be stale: ${s.modifiedFiles} modified, ${s.newFiles} new ` +
+    `file(s) since ${s.indexMtime}. Run \`kb search --refresh\` to update._`
+  );
+}
+
+// ----- JSON-parse retry (RFC §7 N4 mitigation) -------------------------------
+
+async function loadWithJsonRetry(manager: FaissIndexManager): Promise<void> {
+  // FaissStore.save is non-atomic (mkdir-p + parallel writes of faiss.index +
+  // docstore.json, no rename). A concurrent CLI read can land mid-write and
+  // see partial JSON. Retry once after 100 ms; if the second attempt also
+  // fails with a SyntaxError, surface the documented "index appears mid-write"
+  // message so the operator knows to retry.
+  const isJsonParseError = (err: unknown): boolean =>
+    err instanceof SyntaxError ||
+    /JSON|unexpected|parse/i.test((err as Error)?.message ?? '');
+
+  try {
+    await manager.initialize({ readOnly: true });
+    return;
+  } catch (err) {
+    if (!isJsonParseError(err)) throw err;
+    logger.warn(`kb search: JSON parse error on FAISS load (likely concurrent writer); retrying in 100ms`);
+  }
+  await new Promise((r) => setTimeout(r, 100));
+  try {
+    await manager.initialize({ readOnly: true });
+  } catch (err) {
+    if (isJsonParseError(err)) {
+      throw new Error(
+        `Index appears to be mid-write (concurrent writer is updating it). ` +
+        `Please retry in a moment. Underlying error: ${(err as Error).message}`,
+      );
+    }
+    throw err;
+  }
+}
+
+// ----- stdin reader ---------------------------------------------------------
+
+async function readAllStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  return new Promise((resolve, reject) => {
+    process.stdin.on('data', (chunk) => chunks.push(Buffer.from(chunk)));
+    process.stdin.on('end', () => resolve(Buffer.concat(chunks).toString('utf-8')));
+    process.stdin.on('error', reject);
+  });
+}
+
+// ----- version --------------------------------------------------------------
+
+function getPackageVersion(): string {
+  // package.json sits two levels above this file in build/ (build/cli.js
+  // → ../package.json). Cheap synchronous read; runs once per CLI start.
+  try {
+    const here = fileURLToPath(import.meta.url);
+    const pkgPath = path.join(path.dirname(here), '..', 'package.json');
+    const raw = readFileSync(pkgPath, 'utf-8');
+    const parsed = JSON.parse(raw) as { version?: string };
+    return parsed.version ?? 'unknown';
+  } catch {
+    return 'unknown';
+  }
+}
+
+// ----- driver ---------------------------------------------------------------
+
+if (import.meta.url === `file://${process.argv[1]}` || process.argv[1]?.endsWith('/cli.js')) {
+  void main(process.argv).then((code) => {
+    process.exit(code);
+  }).catch((err) => {
+    // Catastrophic top-level (transitive import failure, etc.). Emit a
+    // hint about half-installed npm i -g (RFC §7 F11).
+    const msg = (err as Error)?.message ?? String(err);
+    if (/Cannot find module|ERR_MODULE_NOT_FOUND/.test(msg)) {
+      process.stderr.write(
+        `kb: ${msg}\nThis can happen mid-\`npm install -g\`. ` +
+        `Wait a moment and retry.\n`,
+      );
+    } else {
+      process.stderr.write(`kb: fatal: ${msg}\n`);
+    }
+    process.exit(1);
+  });
+}

--- a/src/formatter.test.ts
+++ b/src/formatter.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+  formatRetrievalAsJson,
+  formatRetrievalAsMarkdown,
+  sanitizeMetadataForWire,
+  ScoredDocument,
+} from './formatter.js';
+
+describe('sanitizeMetadataForWire', () => {
+  it('strips frontmatter.extras when extras visibility is disabled', () => {
+    const input = {
+      source: 'doc.md',
+      frontmatter: { title: 'Hi', extras: { secret: 'value' } },
+    };
+    const out = sanitizeMetadataForWire(input, false) as typeof input;
+    expect(out.frontmatter).toEqual({ title: 'Hi' });
+    expect(out.frontmatter).not.toHaveProperty('extras');
+  });
+
+  it('preserves frontmatter.extras when visibility is enabled', () => {
+    const input = {
+      source: 'doc.md',
+      frontmatter: { title: 'Hi', extras: { secret: 'value' } },
+    };
+    const out = sanitizeMetadataForWire(input, true);
+    expect(out).toBe(input); // pass-through, no clone
+  });
+
+  it('does not clone metadata that has no frontmatter.extras', () => {
+    const input = { source: 'doc.md' };
+    const out = sanitizeMetadataForWire(input, false);
+    expect(out).toBe(input);
+  });
+
+  it('does not mutate the original metadata object', () => {
+    const original = {
+      source: 'doc.md',
+      frontmatter: { title: 'Hi', extras: { secret: 'value' } },
+    };
+    const snapshot = JSON.parse(JSON.stringify(original));
+    sanitizeMetadataForWire(original, false);
+    expect(original).toEqual(snapshot);
+  });
+});
+
+describe('formatRetrievalAsMarkdown', () => {
+  const sampleDoc: ScoredDocument = {
+    pageContent: 'sample content',
+    metadata: { source: 'kb/doc.md' },
+    score: 0.42,
+    id: undefined,
+  } as unknown as ScoredDocument;
+
+  it('emits a "no results" body when results are empty', () => {
+    const out = formatRetrievalAsMarkdown([], false);
+    expect(out).toContain('## Semantic Search Results');
+    expect(out).toContain('_No similar results found._');
+    expect(out).toContain('Disclaimer');
+  });
+
+  it('handles null/undefined gracefully', () => {
+    expect(formatRetrievalAsMarkdown(null, false)).toContain('No similar results');
+    expect(formatRetrievalAsMarkdown(undefined, false)).toContain('No similar results');
+  });
+
+  it('renders one result with score, content, and source block', () => {
+    const out = formatRetrievalAsMarkdown([sampleDoc], false);
+    expect(out).toContain('**Result 1:**');
+    expect(out).toContain('**Score:** 0.42');
+    expect(out).toContain('sample content');
+    expect(out).toContain('"source": "kb/doc.md"');
+  });
+
+  it('separates multiple results with --- and numbers them', () => {
+    const docs = [sampleDoc, { ...sampleDoc, pageContent: 'second' } as ScoredDocument];
+    const out = formatRetrievalAsMarkdown(docs, false);
+    expect(out).toContain('**Result 1:**');
+    expect(out).toContain('**Result 2:**');
+    expect(out).toContain('---');
+  });
+
+  it('strips frontmatter.extras by default in the rendered metadata block', () => {
+    const docWithExtras: ScoredDocument = {
+      pageContent: 'x',
+      metadata: { source: 'doc.md', frontmatter: { title: 'T', extras: { secret: 'shh' } } },
+    } as unknown as ScoredDocument;
+    const out = formatRetrievalAsMarkdown([docWithExtras], false);
+    expect(out).not.toContain('secret');
+    expect(out).not.toContain('shh');
+    expect(out).toContain('"title": "T"');
+  });
+});
+
+describe('formatRetrievalAsJson', () => {
+  it('returns [] for empty results', () => {
+    expect(formatRetrievalAsJson([], false)).toEqual([]);
+    expect(formatRetrievalAsJson(null, false)).toEqual([]);
+    expect(formatRetrievalAsJson(undefined, false)).toEqual([]);
+  });
+
+  it('returns shape { score, content, metadata } per result', () => {
+    const doc: ScoredDocument = {
+      pageContent: 'c',
+      metadata: { source: 'doc.md' },
+      score: 1.5,
+    } as unknown as ScoredDocument;
+    expect(formatRetrievalAsJson([doc], false)).toEqual([
+      { score: 1.5, content: 'c', metadata: { source: 'doc.md' } },
+    ]);
+  });
+
+  it('exposes score as null when missing', () => {
+    const doc: ScoredDocument = {
+      pageContent: 'c',
+      metadata: {},
+    } as unknown as ScoredDocument;
+    expect(formatRetrievalAsJson([doc], false)[0].score).toBeNull();
+  });
+
+  it('strips extras by default', () => {
+    const doc: ScoredDocument = {
+      pageContent: 'c',
+      metadata: { frontmatter: { title: 'T', extras: { s: 'x' } } },
+    } as unknown as ScoredDocument;
+    const out = formatRetrievalAsJson([doc], false);
+    expect(out[0].metadata).toEqual({ frontmatter: { title: 'T' } });
+  });
+});

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -1,0 +1,92 @@
+// RFC 012 §4.9 — extracted from KnowledgeBaseServer.ts so both the MCP
+// surface and the CLI can produce byte-equal markdown output without the
+// CLI having to import the MCP class (which would drag in McpServer,
+// StdioServerTransport, SseHost, ReindexTriggerWatcher, and zod).
+
+import type { Document } from '@langchain/core/documents';
+
+/**
+ * Score-bearing search result. Mirrors the shape `FaissIndexManager.similaritySearch`
+ * returns (Document + score grafted on as a non-standard field).
+ */
+export interface ScoredDocument extends Document {
+  score?: number;
+}
+
+/**
+ * Strips `frontmatter.extras` from a chunk's metadata before wire
+ * serialization unless the operator has opted back in via
+ * `FRONTMATTER_EXTRAS_WIRE_VISIBLE=true`. RFC 011 §7.1 R1 — extras are a
+ * leak surface the operator owns; the default posture is to suppress.
+ *
+ * Shallow-clones only the branches it mutates to avoid touching the
+ * original `Document.metadata` (which is cached in the FAISS store).
+ */
+export function sanitizeMetadataForWire(
+  metadata: Record<string, unknown>,
+  extrasVisible: boolean,
+): Record<string, unknown> {
+  if (extrasVisible) return metadata;
+  const fm = metadata.frontmatter;
+  if (!fm || typeof fm !== 'object') return metadata;
+  const fmObj = fm as Record<string, unknown>;
+  if (!('extras' in fmObj)) return metadata;
+  const { extras, ...fmWithoutExtras } = fmObj;
+  void extras;
+  return {
+    ...metadata,
+    frontmatter: fmWithoutExtras,
+  };
+}
+
+/**
+ * Produces the markdown body of a `retrieve_knowledge` / `kb search` response.
+ * Byte-equal to the previous inline KnowledgeBaseServer formatting. Adding a
+ * trailing freshness footer (CLI-only, RFC 012 §4.10) is the caller's
+ * responsibility; this function owns body format only.
+ */
+export function formatRetrievalAsMarkdown(
+  results: ScoredDocument[] | null | undefined,
+  extrasVisible: boolean,
+): string {
+  let formattedResults = '';
+  if (results && results.length > 0) {
+    formattedResults = results
+      .map((doc, idx) => {
+        const resultHeader = `**Result ${idx + 1}:**`;
+        const content = doc.pageContent.trim();
+        const sanitizedMetadata = sanitizeMetadataForWire(
+          doc.metadata as Record<string, unknown>,
+          extrasVisible,
+        );
+        const metadata = JSON.stringify(sanitizedMetadata, null, 2);
+        const scoreText = doc.score !== undefined ? `**Score:** ${doc.score.toFixed(2)}\n\n` : '';
+        return `${resultHeader}\n\n${scoreText}${content}\n\n**Source:**\n\`\`\`json\n${metadata}\n\`\`\``;
+      })
+      .join('\n\n---\n\n');
+  } else {
+    formattedResults = '_No similar results found._';
+  }
+  const disclaimer = '\n\n> **Disclaimer:** The provided results might not all be relevant. Please cross-check the relevance of the information.';
+  return `## Semantic Search Results\n\n${formattedResults}${disclaimer}`;
+}
+
+/**
+ * Produces the JSON shape the CLI emits with `--format=json`. Includes the
+ * sanitized metadata and the score as a top-level field so callers don't
+ * have to dig into a nested object.
+ */
+export function formatRetrievalAsJson(
+  results: ScoredDocument[] | null | undefined,
+  extrasVisible: boolean,
+): Array<{ score: number | null; content: string; metadata: Record<string, unknown> }> {
+  if (!results || results.length === 0) return [];
+  return results.map((doc) => ({
+    score: doc.score ?? null,
+    content: doc.pageContent,
+    metadata: sanitizeMetadataForWire(
+      doc.metadata as Record<string, unknown>,
+      extrasVisible,
+    ),
+  }));
+}

--- a/src/kb-fs.test.ts
+++ b/src/kb-fs.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from '@jest/globals';
+import * as fsp from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { listKnowledgeBases } from './kb-fs.js';
+
+describe('listKnowledgeBases', () => {
+  it('returns names of subdirectories, filtering dot-prefixed entries', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-fs-list-'));
+    try {
+      await fsp.mkdir(path.join(tempDir, 'engineering'));
+      await fsp.mkdir(path.join(tempDir, 'personal'));
+      await fsp.mkdir(path.join(tempDir, '.faiss'));            // dot-prefixed: skipped
+      await fsp.writeFile(path.join(tempDir, '.reindex-trigger'), '');  // dot-file: skipped
+
+      const out = await listKnowledgeBases(tempDir);
+      expect(out.sort()).toEqual(['engineering', 'personal']);
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns empty array when only dot entries exist', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-fs-empty-'));
+    try {
+      await fsp.mkdir(path.join(tempDir, '.faiss'));
+      const out = await listKnowledgeBases(tempDir);
+      expect(out).toEqual([]);
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('throws on missing root directory (caller decides surfacing)', async () => {
+    await expect(
+      listKnowledgeBases('/nonexistent/path/that/should/not/exist'),
+    ).rejects.toThrow();
+  });
+});

--- a/src/kb-fs.ts
+++ b/src/kb-fs.ts
@@ -1,0 +1,21 @@
+// RFC 012 §4.9 — pure filesystem helpers shared by MCP and CLI surfaces.
+//
+// Extracted from KnowledgeBaseServer.handleListKnowledgeBases so the CLI
+// can call the same logic without going through the MCP CallToolResult
+// envelope.
+
+import * as fsp from 'fs/promises';
+
+/**
+ * Returns the names of available knowledge bases under `rootDir` (one per
+ * subdirectory). Hidden entries (dot-prefixed) are filtered — they include
+ * the `.faiss` index, the `.reindex-trigger`, the `.kb-mcp.pid`, and any
+ * user-created `.drafts/` etc. that the embedding walker also skips.
+ *
+ * Throws on filesystem errors (caller decides how to surface them — MCP
+ * wraps in `CallToolResult.isError`; CLI exits non-zero).
+ */
+export async function listKnowledgeBases(rootDir: string): Promise<string[]> {
+  const entries = await fsp.readdir(rootDir);
+  return entries.filter((entry) => !entry.startsWith('.'));
+}

--- a/src/lock.test.ts
+++ b/src/lock.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import * as fsp from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+
+// All env state is read at module load by config.ts → so each test resets
+// modules and re-imports lock.ts after setting env. Pattern matches the
+// rest of the suite.
+
+const originalEnv = {
+  FAISS_INDEX_PATH: process.env.FAISS_INDEX_PATH,
+};
+
+afterEach(() => {
+  if (originalEnv.FAISS_INDEX_PATH === undefined) delete process.env.FAISS_INDEX_PATH;
+  else process.env.FAISS_INDEX_PATH = originalEnv.FAISS_INDEX_PATH;
+});
+
+describe('acquireInstanceAdvisory / releaseInstanceAdvisory', () => {
+  let tempDir: string;
+  beforeEach(async () => {
+    tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-lock-pid-'));
+    process.env.FAISS_INDEX_PATH = tempDir;
+  });
+
+  it('writes a PID file with current pid and mode 0o600', async () => {
+    jest.resetModules();
+    const { acquireInstanceAdvisory, PID_FILE_PATH_FOR_TESTS, releaseInstanceAdvisory } =
+      await import('./lock.js');
+
+    await acquireInstanceAdvisory();
+
+    const stat = await fsp.stat(PID_FILE_PATH_FOR_TESTS);
+    expect((stat.mode & 0o777).toString(8)).toBe('600');
+    const recorded = (await fsp.readFile(PID_FILE_PATH_FOR_TESTS, 'utf-8')).trim();
+    expect(Number.parseInt(recorded, 10)).toBe(process.pid);
+
+    await releaseInstanceAdvisory();
+    await expect(fsp.stat(PID_FILE_PATH_FOR_TESTS)).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('throws InstanceAlreadyRunningError when a live PID is recorded', async () => {
+    jest.resetModules();
+    const { acquireInstanceAdvisory, InstanceAlreadyRunningError, PID_FILE_PATH_FOR_TESTS } =
+      await import('./lock.js');
+
+    // Seed a live PID — process.ppid is reliably alive (the shell that spawned us).
+    await fsp.writeFile(PID_FILE_PATH_FOR_TESTS, `${process.ppid}\n`, { mode: 0o600 });
+
+    await expect(acquireInstanceAdvisory()).rejects.toBeInstanceOf(InstanceAlreadyRunningError);
+  });
+
+  it('overwrites a stale PID file (recorded pid is dead)', async () => {
+    jest.resetModules();
+    const { acquireInstanceAdvisory, PID_FILE_PATH_FOR_TESTS, releaseInstanceAdvisory } =
+      await import('./lock.js');
+
+    // PID 1 is init/systemd — alive on most systems. Use a clearly-dead PID
+    // instead: spawn a child, wait for exit, capture its PID. Once the child
+    // is reaped, that PID is dead until reused.
+    const { spawn } = await import('child_process');
+    const child = spawn('node', ['-e', 'process.exit(0)']);
+    const deadPid: number = await new Promise((resolve) => {
+      child.once('exit', () => resolve(child.pid!));
+    });
+    // Tiny wait to ensure reaper has run.
+    await new Promise((r) => setTimeout(r, 50));
+
+    await fsp.writeFile(PID_FILE_PATH_FOR_TESTS, `${deadPid}\n`, { mode: 0o600 });
+
+    await acquireInstanceAdvisory(); // should overwrite, not throw
+    const recorded = (await fsp.readFile(PID_FILE_PATH_FOR_TESTS, 'utf-8')).trim();
+    expect(Number.parseInt(recorded, 10)).toBe(process.pid);
+    await releaseInstanceAdvisory();
+  });
+
+  it('release is idempotent and refuses to delete other-process PID files', async () => {
+    jest.resetModules();
+    const { releaseInstanceAdvisory, PID_FILE_PATH_FOR_TESTS } = await import('./lock.js');
+
+    // No PID file → release is a no-op.
+    await releaseInstanceAdvisory();
+
+    // Foreign PID file → release refuses to delete.
+    await fsp.writeFile(PID_FILE_PATH_FOR_TESTS, `${process.ppid}\n`, { mode: 0o600 });
+    await releaseInstanceAdvisory();
+    // Foreign file still there.
+    await expect(fsp.stat(PID_FILE_PATH_FOR_TESTS)).resolves.toBeDefined();
+    // Cleanup so afterEach doesn't see ours.
+    await fsp.unlink(PID_FILE_PATH_FOR_TESTS);
+  });
+});
+
+describe('withWriteLock', () => {
+  let tempDir: string;
+  beforeEach(async () => {
+    tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-lock-write-'));
+    process.env.FAISS_INDEX_PATH = tempDir;
+  });
+
+  it('acquires the lock, runs fn, releases', async () => {
+    jest.resetModules();
+    const { withWriteLock, WRITE_LOCK_PATH_FOR_TESTS } = await import('./lock.js');
+
+    let observed: { lockedDuringFn: boolean } = { lockedDuringFn: false };
+    const result = await withWriteLock(async () => {
+      // Lock dir should exist while fn runs.
+      observed.lockedDuringFn = await fsp
+        .stat(WRITE_LOCK_PATH_FOR_TESTS)
+        .then(() => true)
+        .catch(() => false);
+      return 'value';
+    });
+    expect(result).toBe('value');
+    expect(observed.lockedDuringFn).toBe(true);
+    // Lock released after fn.
+    await expect(fsp.stat(WRITE_LOCK_PATH_FOR_TESTS)).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('serializes concurrent callers (second waits for the first)', async () => {
+    jest.resetModules();
+    const { withWriteLock } = await import('./lock.js');
+
+    const events: string[] = [];
+    const slow = withWriteLock(async () => {
+      events.push('slow:start');
+      await new Promise((r) => setTimeout(r, 200));
+      events.push('slow:end');
+    });
+    // Tiny gap so the slow one definitely owns the lock first.
+    await new Promise((r) => setTimeout(r, 20));
+    const fast = withWriteLock(async () => {
+      events.push('fast:start');
+      events.push('fast:end');
+    });
+    await Promise.all([slow, fast]);
+    // The fast one must observe slow:end before its own start.
+    expect(events).toEqual(['slow:start', 'slow:end', 'fast:start', 'fast:end']);
+  });
+
+  it('releases the lock even if fn throws', async () => {
+    jest.resetModules();
+    const { withWriteLock, WRITE_LOCK_PATH_FOR_TESTS } = await import('./lock.js');
+
+    await expect(
+      withWriteLock(async () => {
+        throw new Error('boom');
+      }),
+    ).rejects.toThrow('boom');
+
+    // No stranded lock.
+    await expect(fsp.stat(WRITE_LOCK_PATH_FOR_TESTS)).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+});

--- a/src/lock.ts
+++ b/src/lock.ts
@@ -1,0 +1,217 @@
+// RFC 012 §4.8 — split-lock coordination for the FAISS index.
+//
+// Two distinct mechanisms share this module by design (and by the RFC's
+// §4.9 boundary call): they touch the same FAISS_INDEX_PATH directory and
+// share lifecycle concerns (process exit must clean both up), but their
+// purposes are different.
+//
+// 1. INSTANCE ADVISORY — a long-lived PID file at
+//    `${FAISS_INDEX_PATH}/.kb-mcp.pid`. Written by `KnowledgeBaseServer.run()`
+//    at startup; removed on graceful shutdown. Enforces "one MCP server per
+//    FAISS_INDEX_PATH" (the constraint documented in
+//    `docs/architecture/threat-model.md`). Acquired with O_EXCL so two
+//    concurrent starts cannot both pass the check (TOCTOU-safe).
+//
+// 2. WRITE LOCK — a short-lived `proper-lockfile` lock at
+//    `${FAISS_INDEX_PATH}/.kb-write.lock`. Acquired around each
+//    `updateIndex()` call (in MCP, in ReindexTriggerWatcher, in CLI
+//    `--refresh`). Released immediately after the write. Default `kb search`
+//    (read-only) does NOT acquire this lock — concurrent reads are fine.
+//
+// The split was the round-2 design fix: an earlier draft had a single
+// lifetime-scoped lock that broke `kb search --refresh` whenever the MCP
+// server was running (the dogfood workflow the CLI exists to support).
+
+import * as fsp from 'fs/promises';
+import * as path from 'path';
+import * as properLockfile from 'proper-lockfile';
+import { FAISS_INDEX_PATH } from './config.js';
+import { logger } from './logger.js';
+
+// ----- Instance advisory (long-lived PID file) ------------------------------
+
+const PID_FILE_PATH = path.join(FAISS_INDEX_PATH, '.kb-mcp.pid');
+
+export class InstanceAlreadyRunningError extends Error {
+  constructor(pid: number) {
+    super(
+      `Another knowledge-base-mcp-server is already running (PID ${pid}) ` +
+      `against FAISS_INDEX_PATH=${FAISS_INDEX_PATH}. ` +
+      `Stop it before starting a new instance, or set a different ` +
+      `FAISS_INDEX_PATH for this server.`,
+    );
+    this.name = 'InstanceAlreadyRunningError';
+  }
+}
+
+function pidIsAlive(pid: number): boolean {
+  try {
+    // Signal 0 just probes for the process; doesn't actually signal.
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    // EPERM = process exists but we can't signal it (still "alive" for
+    // single-instance purposes — another user owns it). ESRCH = no such
+    // process.
+    if (code === 'EPERM') return true;
+    return false;
+  }
+}
+
+/**
+ * Atomically claim the single-instance advisory file. Throws
+ * `InstanceAlreadyRunningError` when another live instance is detected.
+ * Stale PID files (from a crashed previous run) are silently overwritten.
+ *
+ * Uses `O_CREAT | O_EXCL` so two simultaneous startups cannot both pass
+ * the check — exactly one wins atomically. Mode 0o600 so the PID isn't
+ * world-readable on shared filesystems.
+ */
+export async function acquireInstanceAdvisory(): Promise<void> {
+  // Ensure FAISS_INDEX_PATH exists — the PID file lives inside it. The
+  // FaissIndexManager.initialize() also handles this, but we need it before
+  // initialize runs.
+  await fsp.mkdir(FAISS_INDEX_PATH, { recursive: true });
+
+  const pid = process.pid;
+  const pidStr = `${pid}\n`;
+
+  try {
+    // O_EXCL: fail if file exists. Atomic.
+    const fh = await fsp.open(PID_FILE_PATH, 'wx', 0o600);
+    try {
+      await fh.write(pidStr);
+      await fh.sync();
+    } finally {
+      await fh.close();
+    }
+    logger.info(`Acquired instance advisory at ${PID_FILE_PATH} (pid ${pid})`);
+    return;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code !== 'EEXIST') throw err;
+  }
+
+  // EEXIST: read the recorded PID and check liveness.
+  const recorded = (await fsp.readFile(PID_FILE_PATH, 'utf-8')).trim();
+  const recordedPid = Number.parseInt(recorded, 10);
+  if (Number.isFinite(recordedPid) && pidIsAlive(recordedPid)) {
+    throw new InstanceAlreadyRunningError(recordedPid);
+  }
+
+  // Stale PID file. Replace atomically: unlink + create-O_EXCL.
+  logger.warn(
+    `Removing stale instance advisory at ${PID_FILE_PATH} ` +
+    `(recorded PID ${recorded} is no longer alive)`,
+  );
+  await fsp.unlink(PID_FILE_PATH).catch(() => {});
+
+  // One retry. If a third process raced in between unlink and create-O_EXCL,
+  // they own it now and we should fail-fast with the same error UX.
+  try {
+    const fh = await fsp.open(PID_FILE_PATH, 'wx', 0o600);
+    try {
+      await fh.write(pidStr);
+      await fh.sync();
+    } finally {
+      await fh.close();
+    }
+    logger.info(`Acquired instance advisory at ${PID_FILE_PATH} (pid ${pid})`);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'EEXIST') {
+      // Race: another process took the slot. Treat as "another instance
+      // running" with whatever PID is now there.
+      const racePid = Number.parseInt(
+        (await fsp.readFile(PID_FILE_PATH, 'utf-8')).trim(),
+        10,
+      );
+      throw new InstanceAlreadyRunningError(Number.isFinite(racePid) ? racePid : -1);
+    }
+    throw err;
+  }
+}
+
+/**
+ * Remove the instance advisory file. Idempotent. Safe to call from
+ * shutdown handlers even if `acquireInstanceAdvisory` was never called
+ * (e.g., process started before the lock module loaded).
+ */
+export async function releaseInstanceAdvisory(): Promise<void> {
+  try {
+    // Only delete if we actually own it — refuse to delete another
+    // process's PID file even if we somehow got here.
+    const recorded = (await fsp.readFile(PID_FILE_PATH, 'utf-8').catch(() => '')).trim();
+    const recordedPid = Number.parseInt(recorded, 10);
+    if (Number.isFinite(recordedPid) && recordedPid !== process.pid) {
+      logger.warn(
+        `Refusing to delete instance advisory ${PID_FILE_PATH}: recorded PID ` +
+        `${recordedPid} is not us (${process.pid}).`,
+      );
+      return;
+    }
+    await fsp.unlink(PID_FILE_PATH).catch(() => {});
+  } catch (err) {
+    logger.warn(`Error releasing instance advisory: ${(err as Error).message}`);
+  }
+}
+
+// ----- Write lock (short-lived, around updateIndex calls) ------------------
+
+const WRITE_LOCK_PATH = path.join(FAISS_INDEX_PATH, '.kb-write.lock');
+const WRITE_LOCK_OPTS: properLockfile.LockOptions = {
+  // proper-lockfile requires the LOCKED resource to exist; it locks a
+  // sibling .lock directory. We point it at FAISS_INDEX_PATH itself
+  // (which always exists by the time this runs) and let it manage the
+  // lockfile internally. lockfilePath overrides the auto-derived path
+  // so we get a stable, predictable file we can find from tests.
+  lockfilePath: WRITE_LOCK_PATH,
+  // Heartbeat keeps the lock alive across long-running updateIndex calls
+  // (e.g., a model-switch full re-embed that takes minutes). proper-lockfile
+  // uses mtime-based stale detection; without heartbeat, a long write would
+  // false-positive as stale at the 10s default and another writer could
+  // acquire.
+  update: 5000,
+  stale: 10_000,
+  // Brief retry budget for fast-path contention (MCP and CLI both want
+  // the lock for ~280 ms). Slow-path (model-switch re-embed) callers will
+  // exhaust this and error with a clear message — that's the documented
+  // RFC 012 §4.8.3 slow-path behavior.
+  retries: { retries: 5, factor: 1.5, minTimeout: 100, maxTimeout: 1000 },
+};
+
+/**
+ * Acquire the write lock, run `fn`, release the lock. The lock is held
+ * for exactly the duration of `fn` — not longer.
+ *
+ * Throws if the lock can't be acquired within the retry budget. The
+ * caller decides whether to surface that error or fall back to a
+ * read-only path.
+ */
+export async function withWriteLock<T>(fn: () => Promise<T>): Promise<T> {
+  // Ensure target exists — proper-lockfile requires the resource path to
+  // be lockable. FAISS_INDEX_PATH is always present in normal operation
+  // (FaissIndexManager.initialize ensures it), but mkdir-p is cheap.
+  await fsp.mkdir(FAISS_INDEX_PATH, { recursive: true });
+
+  const release = await properLockfile.lock(FAISS_INDEX_PATH, WRITE_LOCK_OPTS);
+  try {
+    return await fn();
+  } finally {
+    try {
+      await release();
+    } catch (err) {
+      logger.warn(`Error releasing write lock: ${(err as Error).message}`);
+    }
+  }
+}
+
+/**
+ * Test-only export: the path the write lock occupies. Tests assert on
+ * its existence/non-existence to verify acquire/release behavior.
+ */
+export const WRITE_LOCK_PATH_FOR_TESTS = WRITE_LOCK_PATH;
+
+/** Test-only export: the PID file path for advisory tests. */
+export const PID_FILE_PATH_FOR_TESTS = PID_FILE_PATH;


### PR DESCRIPTION
## Summary

Implements RFC 012 M2 (#95). **Stacked on PR #97** (M1 CLI implementation); merge that first.

Two doc updates:

- **README** — new "Install (CLI alongside the MCP server)" section showing the `kb list` / `kb search` / `kb search --refresh` flow for global-install users who want restart-free upgrades without an MCP client. The existing "Install (one command)" section now uses `@latest` and includes a callout explaining the npm-cache pinning behavior of the bare unversioned spec (RFC 012 §2.4 — verified empirically that `npx -y @scope/pkg` caches the resolved version in `~/.npm/_npx/` indefinitely).
- **docs/clients.md** — new "Upgrade model" section explaining when the `@latest` pinning gotcha applies (the documented snippets all use absolute build paths so they're unaffected, but anyone who copy-pastes from the README's npx form into a client config needs the warning). New "See also: kb CLI" cross-link.

The MCP-side client snippets themselves are unchanged.

## Why this isn't bundled with M1

Per RFC 012 §6.1, M2 ships separately so docs land after the M1 release is **published** (not just merged). A user who reads the new README before 0.2.0 hits npm would see a `kb` bin that doesn't exist in their installed version. M2 should merge after M1's npm publish.

## Test plan

- [x] Read both files end-to-end; no broken links, consistent tone with existing sections.
- [x] Code blocks compile-mentally (commands runnable as written).
- [ ] Reviewer to verify: do they want me to also update the SKILL.md at `~/.claude/skills/knowledge-base/SKILL.md` to mention the CLI? That's a separate PR in the user's `.claude` config repo.

## Stacking note

Built on top of `feat/cli-and-readonly-seam` (PR #97). After M1 merges and 0.2.0 is published, this PR can rebase onto main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)