### PR TITLE
fix(cli): kb silent-exit when invoked via npm-install-g symlink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.2.1] — 2026-04-25
+
+### Fixed
+
+- **`kb` CLI silently exits 0 when invoked via the `npm install -g` symlink.** The 0.2.0 driver guard (`process.argv[1]?.endsWith('/cli.js')`) was correct for direct invocations (`node build/cli.js`, `./build/cli.js`) but failed for the production install path: when invoked through the symlink at `~/.nvm/.../bin/kb`, `process.argv[1]` is the symlink path (ends in `/kb`), not the canonical `cli.js`, so the driver block never ran. Replaced with `realpathSync(process.argv[1]) === fileURLToPath(import.meta.url)` which collapses the symlink and matches in all four cases (direct, shebang, install-g symlink, test import). New regression test exercises the symlink case via `fs.symlink`. RFC 012 §6.2 specified a `npm pack && npm install -g` smoke gate that would have caught this; wiring that into CI is tracked separately.
+
 ## [0.2.0] — 2026-04-25
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jeanibarz/knowledge-base-mcp-server",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jeanibarz/knowledge-base-mcp-server",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "Unlicense",
       "dependencies": {
         "@huggingface/inference": "^4.13.15",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jeanibarz/knowledge-base-mcp-server",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "MCP server for retrieving data from different knowledge bases",
   "type": "module",
   "main": "build/index.js",

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -58,6 +58,25 @@ describe('kb CLI — argv parsing and dispatch', () => {
     expect(r.stdout.trim()).toMatch(/^\d+\.\d+\.\d+/);
   });
 
+  // Regression: 0.2.0 had a driver guard `argv[1].endsWith('/cli.js')` that
+  // failed under the npm-install-g symlink (argv[1] is `.../bin/kb`, not
+  // `.../cli.js`), causing `kb` to silently exit 0 without running anything.
+  // Reproduce by invoking through a symlink.
+  it('runs main() when invoked through a symlink (regression for 0.2.0 npm-i-g bug)', async () => {
+    const linkPath = path.join(os.tmpdir(), `kb-symlink-${process.pid}-${Date.now()}`);
+    await fsp.symlink(cliPath, linkPath);
+    try {
+      const r = spawnSync('node', [linkPath, '--version'], {
+        env: { PATH: process.env.PATH ?? '' },
+        encoding: 'utf-8',
+      });
+      expect(r.status).toBe(0);
+      expect((r.stdout ?? '').trim()).toMatch(/^\d+\.\d+\.\d+/);
+    } finally {
+      await fsp.unlink(linkPath).catch(() => {});
+    }
+  });
+
   it('unknown subcommand exits 2 with help', () => {
     const r = runCli(['notacommand']);
     expect(r.code).toBe(2);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -28,7 +28,7 @@ import { listKnowledgeBases } from './kb-fs.js';
 import { withWriteLock } from './lock.js';
 import { logger } from './logger.js';
 import { filterIngestablePaths, getFilesRecursively } from './utils.js';
-import { readFileSync } from 'fs';
+import { readFileSync, realpathSync } from 'fs';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
 
@@ -435,8 +435,28 @@ function getPackageVersion(): string {
 }
 
 // ----- driver ---------------------------------------------------------------
+//
+// Detect whether this module is being run as a script or imported. Naive
+// string comparison of `import.meta.url` against `process.argv[1]` fails
+// when invoked through the npm-install-g symlink: argv[1] is the symlink
+// path (e.g. `~/.nvm/.../bin/kb`) while import.meta.url resolves to the
+// canonical `build/cli.js`. realpathSync collapses the symlink so the
+// comparison works in all four cases:
+//   - `node build/cli.js`              (direct, dev)
+//   - `./build/cli.js`                 (direct via shebang)
+//   - `kb` (npm install -g symlink)    (the production case)
+//   - `import { main } from './cli.js'` (test imports — driver does NOT run)
+function isMainModule(): boolean {
+  if (!process.argv[1]) return false;
+  try {
+    const resolved = realpathSync(process.argv[1]);
+    return resolved === fileURLToPath(import.meta.url);
+  } catch {
+    return false;
+  }
+}
 
-if (import.meta.url === `file://${process.argv[1]}` || process.argv[1]?.endsWith('/cli.js')) {
+if (isMainModule()) {
   void main(process.argv).then((code) => {
     process.exit(code);
   }).catch((err) => {


### PR DESCRIPTION
## Summary

Real bug discovered immediately after publishing 0.2.0: `kb` (installed via `npm install -g`) silently exits 0 with no output. Reproduced by running `kb --version` against `0.2.0` from `~/.nvm/.../bin/kb`.

**Root cause.** The driver guard at the bottom of `src/cli.ts` was:

```ts
if (import.meta.url === `file://${process.argv[1]}` || process.argv[1]?.endsWith('/cli.js')) {
  void main(...);
}
```

This is correct for direct invocations (`node build/cli.js`, `./build/cli.js`) but fails for the production case: when invoked through the npm-install-g symlink at `~/.nvm/.../bin/kb`, `process.argv[1]` is the symlink path ending in `/kb`, not the canonical `cli.js`. Neither side of the OR matches → the driver block never runs → silent exit 0.

## Fix

Replace with a `realpathSync` + `fileURLToPath` comparison that collapses the symlink to its canonical target:

```ts
function isMainModule(): boolean {
  if (!process.argv[1]) return false;
  try {
    return realpathSync(process.argv[1]) === fileURLToPath(import.meta.url);
  } catch {
    return false;
  }
}
```

Matches in all four invocation modes:

- `node build/cli.js` (direct, dev)
- `./build/cli.js` (shebang)
- `kb` (npm install -g symlink) — **the production case**
- `import { main } from './cli.js'` (test import — driver does NOT run)

## Verification

```bash
$ ./build/cli.js --version
0.2.1
$ ln -sf $(pwd)/build/cli.js /tmp/kb-link && /tmp/kb-link --version
0.2.1
```

Pre-fix, the symlink invocation produced no output and exited 0.

## Test added

`src/cli.test.ts` — new regression test that creates an `fs.symlink` to the built CLI and asserts `node <symlink> --version` exits 0 with a version string. Future driver-guard regressions are caught at unit-test time without requiring a full `npm pack && npm install -g` smoke loop.

## Why this slipped through 0.2.0

RFC 012 §6.2 specified an `npm pack && npm install -g <tarball>` + `kb --version` smoke gate as a hard pre-publish step. That gate was specified but **not wired into CI** — only `npm test` runs in the release workflow, which does not exercise the global-install symlink path. The local CLI tests in 0.2.0 spawn `node build/cli.js` directly, where `argv[1]` ends in `cli.js` and the guard works.

Wiring the smoke gate into CI is tracked as a follow-up issue.

## Test plan

- [x] Build clean (`npm run build`)
- [x] All 184 tests pass (183 from 0.2.0 + 1 new regression test)
- [x] Manual verification: direct + symlink invocation both return `0.2.1`
- [ ] After merge + 0.2.1 publish: `npm i -g @jeanibarz/knowledge-base-mcp-server@latest && kb --version` should print `0.2.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)