### PR TITLE
refactor(lock): RFC 013 M0 — split lock.ts into instance-lock.ts + write-lock.ts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.2.2] — 2026-04-25
+
+### Changed (internal — no surface change)
+
+- **Lock module split (RFC 013 M0).** `src/lock.ts` is split into `src/instance-lock.ts` (PID advisory — `acquireInstanceAdvisory`, `releaseInstanceAdvisory`, `InstanceAlreadyRunningError`, `PID_FILE_PATH_FOR_TESTS`) and `src/write-lock.ts` (`withWriteLock`). The two mechanisms had different lifecycles (long-lived single-instance advisory vs. short-lived per-write coordination) and were conceptually mixed; round-3 of RFC 012 review flagged the boundary nit and deferred it. RFC 013 M0 acts on it now because RFC 013 M1+M2 will narrow the write lock from `FAISS_INDEX_PATH` to `${PATH}/models/<id>/` for per-model isolation, which is cleaner against a single-purpose `write-lock.ts` than a mixed module. **No external API change** — the previous `withWriteLock(fn)` signature changes to `withWriteLock(resource, fn)` with all in-tree callers (KnowledgeBaseServer, ReindexTriggerWatcher path, CLI `--refresh`) passing `FAISS_INDEX_PATH` as the resource for behavior parity. See [`docs/rfcs/013-multimodel-support.md`](./docs/rfcs/013-multimodel-support.md) §4.6.
+
 ## [0.2.1] — 2026-04-25
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jeanibarz/knowledge-base-mcp-server",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jeanibarz/knowledge-base-mcp-server",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "Unlicense",
       "dependencies": {
         "@huggingface/inference": "^4.13.15",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jeanibarz/knowledge-base-mcp-server",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "MCP server for retrieving data from different knowledge bases",
   "type": "module",
   "main": "build/index.js",

--- a/src/KnowledgeBaseServer.ts
+++ b/src/KnowledgeBaseServer.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 import type { CallToolResult, TextContent } from '@modelcontextprotocol/sdk/types.js';
 import { FaissIndexManager } from './FaissIndexManager.js';
 import {
+  FAISS_INDEX_PATH,
   FRONTMATTER_EXTRAS_WIRE_VISIBLE,
   KNOWLEDGE_BASES_ROOT_DIR,
   LIST_KNOWLEDGE_BASES_DESCRIPTION,
@@ -21,8 +22,8 @@ import {
   acquireInstanceAdvisory,
   InstanceAlreadyRunningError,
   releaseInstanceAdvisory,
-  withWriteLock,
-} from './lock.js';
+} from './instance-lock.js';
+import { withWriteLock } from './write-lock.js';
 import { logger } from './logger.js';
 import { SseHost } from './transport/sse.js';
 import { ReindexTriggerWatcher } from './triggerWatcher.js';
@@ -116,7 +117,9 @@ export class KnowledgeBaseServer {
       // RFC 012 §4.8.2 — wrap the write-path updateIndex in the short-lived
       // write lock. The MCP server, the trigger watcher, and `kb search
       // --refresh` all serialize through this single primitive.
-      await withWriteLock(() => this.faissManager.updateIndex(knowledgeBaseName));
+      // RFC 013 M0: lock resource is FAISS_INDEX_PATH (single-model);
+      // M1+M2 narrows to ${PATH}/models/<id>/ for per-model isolation.
+      await withWriteLock(FAISS_INDEX_PATH, () => this.faissManager.updateIndex(knowledgeBaseName));
       logger.debug(`[${Date.now()}] FAISS index update completed`);
 
       // Perform similarity search using the provided query.
@@ -227,7 +230,7 @@ export class KnowledgeBaseServer {
       REINDEX_TRIGGER_PATH,
       // RFC 012 §4.8.2 — trigger-driven updateIndex also serializes through
       // the write lock so a CLI `--refresh` doesn't race a watcher cycle.
-      () => withWriteLock(() => this.faissManager.updateIndex(undefined)),
+      () => withWriteLock(FAISS_INDEX_PATH, () => this.faissManager.updateIndex(undefined)),
       REINDEX_TRIGGER_POLL_MS,
     );
     this.triggerWatcher.start();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -25,7 +25,7 @@ import {
 } from './config.js';
 import { formatRetrievalAsJson, formatRetrievalAsMarkdown } from './formatter.js';
 import { listKnowledgeBases } from './kb-fs.js';
-import { withWriteLock } from './lock.js';
+import { withWriteLock } from './write-lock.js';
 import { logger } from './logger.js';
 import { filterIngestablePaths, getFilesRecursively } from './utils.js';
 import { readFileSync, realpathSync } from 'fs';
@@ -164,7 +164,9 @@ async function runSearch(rest: string[]): Promise<number> {
 
   try {
     if (parsed.refresh) {
-      await withWriteLock(async () => {
+      // RFC 013 M0: lock resource is FAISS_INDEX_PATH; M1+M2 narrows to
+      // ${PATH}/models/<id>/ for per-model isolation.
+      await withWriteLock(FAISS_INDEX_PATH, async () => {
         await manager.initialize();
         await manager.updateIndex(parsed.kb);
       });

--- a/src/instance-lock.test.ts
+++ b/src/instance-lock.test.ts
@@ -4,8 +4,8 @@ import * as os from 'os';
 import * as path from 'path';
 
 // All env state is read at module load by config.ts → so each test resets
-// modules and re-imports lock.ts after setting env. Pattern matches the
-// rest of the suite.
+// modules and re-imports instance-lock.ts after setting env. Pattern matches
+// the rest of the suite.
 
 const originalEnv = {
   FAISS_INDEX_PATH: process.env.FAISS_INDEX_PATH,
@@ -19,14 +19,14 @@ afterEach(() => {
 describe('acquireInstanceAdvisory / releaseInstanceAdvisory', () => {
   let tempDir: string;
   beforeEach(async () => {
-    tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-lock-pid-'));
+    tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-instance-lock-'));
     process.env.FAISS_INDEX_PATH = tempDir;
   });
 
   it('writes a PID file with current pid and mode 0o600', async () => {
     jest.resetModules();
     const { acquireInstanceAdvisory, PID_FILE_PATH_FOR_TESTS, releaseInstanceAdvisory } =
-      await import('./lock.js');
+      await import('./instance-lock.js');
 
     await acquireInstanceAdvisory();
 
@@ -42,7 +42,7 @@ describe('acquireInstanceAdvisory / releaseInstanceAdvisory', () => {
   it('throws InstanceAlreadyRunningError when a live PID is recorded', async () => {
     jest.resetModules();
     const { acquireInstanceAdvisory, InstanceAlreadyRunningError, PID_FILE_PATH_FOR_TESTS } =
-      await import('./lock.js');
+      await import('./instance-lock.js');
 
     // Seed a live PID — process.ppid is reliably alive (the shell that spawned us).
     await fsp.writeFile(PID_FILE_PATH_FOR_TESTS, `${process.ppid}\n`, { mode: 0o600 });
@@ -53,7 +53,7 @@ describe('acquireInstanceAdvisory / releaseInstanceAdvisory', () => {
   it('overwrites a stale PID file (recorded pid is dead)', async () => {
     jest.resetModules();
     const { acquireInstanceAdvisory, PID_FILE_PATH_FOR_TESTS, releaseInstanceAdvisory } =
-      await import('./lock.js');
+      await import('./instance-lock.js');
 
     // PID 1 is init/systemd — alive on most systems. Use a clearly-dead PID
     // instead: spawn a child, wait for exit, capture its PID. Once the child
@@ -76,7 +76,7 @@ describe('acquireInstanceAdvisory / releaseInstanceAdvisory', () => {
 
   it('release is idempotent and refuses to delete other-process PID files', async () => {
     jest.resetModules();
-    const { releaseInstanceAdvisory, PID_FILE_PATH_FOR_TESTS } = await import('./lock.js');
+    const { releaseInstanceAdvisory, PID_FILE_PATH_FOR_TESTS } = await import('./instance-lock.js');
 
     // No PID file → release is a no-op.
     await releaseInstanceAdvisory();
@@ -88,67 +88,5 @@ describe('acquireInstanceAdvisory / releaseInstanceAdvisory', () => {
     await expect(fsp.stat(PID_FILE_PATH_FOR_TESTS)).resolves.toBeDefined();
     // Cleanup so afterEach doesn't see ours.
     await fsp.unlink(PID_FILE_PATH_FOR_TESTS);
-  });
-});
-
-describe('withWriteLock', () => {
-  let tempDir: string;
-  beforeEach(async () => {
-    tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-lock-write-'));
-    process.env.FAISS_INDEX_PATH = tempDir;
-  });
-
-  it('acquires the lock, runs fn, releases', async () => {
-    jest.resetModules();
-    const { withWriteLock, WRITE_LOCK_PATH_FOR_TESTS } = await import('./lock.js');
-
-    let observed: { lockedDuringFn: boolean } = { lockedDuringFn: false };
-    const result = await withWriteLock(async () => {
-      // Lock dir should exist while fn runs.
-      observed.lockedDuringFn = await fsp
-        .stat(WRITE_LOCK_PATH_FOR_TESTS)
-        .then(() => true)
-        .catch(() => false);
-      return 'value';
-    });
-    expect(result).toBe('value');
-    expect(observed.lockedDuringFn).toBe(true);
-    // Lock released after fn.
-    await expect(fsp.stat(WRITE_LOCK_PATH_FOR_TESTS)).rejects.toMatchObject({ code: 'ENOENT' });
-  });
-
-  it('serializes concurrent callers (second waits for the first)', async () => {
-    jest.resetModules();
-    const { withWriteLock } = await import('./lock.js');
-
-    const events: string[] = [];
-    const slow = withWriteLock(async () => {
-      events.push('slow:start');
-      await new Promise((r) => setTimeout(r, 200));
-      events.push('slow:end');
-    });
-    // Tiny gap so the slow one definitely owns the lock first.
-    await new Promise((r) => setTimeout(r, 20));
-    const fast = withWriteLock(async () => {
-      events.push('fast:start');
-      events.push('fast:end');
-    });
-    await Promise.all([slow, fast]);
-    // The fast one must observe slow:end before its own start.
-    expect(events).toEqual(['slow:start', 'slow:end', 'fast:start', 'fast:end']);
-  });
-
-  it('releases the lock even if fn throws', async () => {
-    jest.resetModules();
-    const { withWriteLock, WRITE_LOCK_PATH_FOR_TESTS } = await import('./lock.js');
-
-    await expect(
-      withWriteLock(async () => {
-        throw new Error('boom');
-      }),
-    ).rejects.toThrow('boom');
-
-    // No stranded lock.
-    await expect(fsp.stat(WRITE_LOCK_PATH_FOR_TESTS)).rejects.toMatchObject({ code: 'ENOENT' });
   });
 });

--- a/src/instance-lock.ts
+++ b/src/instance-lock.ts
@@ -1,34 +1,18 @@
-// RFC 012 §4.8 — split-lock coordination for the FAISS index.
+// RFC 013 §4.6 — single-instance advisory PID file.
 //
-// Two distinct mechanisms share this module by design (and by the RFC's
-// §4.9 boundary call): they touch the same FAISS_INDEX_PATH directory and
-// share lifecycle concerns (process exit must clean both up), but their
-// purposes are different.
+// Enforces "one MCP server per FAISS_INDEX_PATH" (the constraint documented
+// in `docs/architecture/threat-model.md`). Acquired with O_EXCL so two
+// concurrent starts cannot both pass the check (TOCTOU-safe).
 //
-// 1. INSTANCE ADVISORY — a long-lived PID file at
-//    `${FAISS_INDEX_PATH}/.kb-mcp.pid`. Written by `KnowledgeBaseServer.run()`
-//    at startup; removed on graceful shutdown. Enforces "one MCP server per
-//    FAISS_INDEX_PATH" (the constraint documented in
-//    `docs/architecture/threat-model.md`). Acquired with O_EXCL so two
-//    concurrent starts cannot both pass the check (TOCTOU-safe).
-//
-// 2. WRITE LOCK — a short-lived `proper-lockfile` lock at
-//    `${FAISS_INDEX_PATH}/.kb-write.lock`. Acquired around each
-//    `updateIndex()` call (in MCP, in ReindexTriggerWatcher, in CLI
-//    `--refresh`). Released immediately after the write. Default `kb search`
-//    (read-only) does NOT acquire this lock — concurrent reads are fine.
-//
-// The split was the round-2 design fix: an earlier draft had a single
-// lifetime-scoped lock that broke `kb search --refresh` whenever the MCP
-// server was running (the dogfood workflow the CLI exists to support).
+// Lifted from `src/lock.ts` in RFC 013 M0. The previous module conflated
+// process-lifetime advisory with short-lived write coordination; the split
+// lets each concern evolve independently and matches RFC 012 round-3's
+// deferred boundary nit.
 
 import * as fsp from 'fs/promises';
 import * as path from 'path';
-import * as properLockfile from 'proper-lockfile';
 import { FAISS_INDEX_PATH } from './config.js';
 import { logger } from './logger.js';
-
-// ----- Instance advisory (long-lived PID file) ------------------------------
 
 const PID_FILE_PATH = path.join(FAISS_INDEX_PATH, '.kb-mcp.pid');
 
@@ -156,62 +140,6 @@ export async function releaseInstanceAdvisory(): Promise<void> {
     logger.warn(`Error releasing instance advisory: ${(err as Error).message}`);
   }
 }
-
-// ----- Write lock (short-lived, around updateIndex calls) ------------------
-
-const WRITE_LOCK_PATH = path.join(FAISS_INDEX_PATH, '.kb-write.lock');
-const WRITE_LOCK_OPTS: properLockfile.LockOptions = {
-  // proper-lockfile requires the LOCKED resource to exist; it locks a
-  // sibling .lock directory. We point it at FAISS_INDEX_PATH itself
-  // (which always exists by the time this runs) and let it manage the
-  // lockfile internally. lockfilePath overrides the auto-derived path
-  // so we get a stable, predictable file we can find from tests.
-  lockfilePath: WRITE_LOCK_PATH,
-  // Heartbeat keeps the lock alive across long-running updateIndex calls
-  // (e.g., a model-switch full re-embed that takes minutes). proper-lockfile
-  // uses mtime-based stale detection; without heartbeat, a long write would
-  // false-positive as stale at the 10s default and another writer could
-  // acquire.
-  update: 5000,
-  stale: 10_000,
-  // Brief retry budget for fast-path contention (MCP and CLI both want
-  // the lock for ~280 ms). Slow-path (model-switch re-embed) callers will
-  // exhaust this and error with a clear message — that's the documented
-  // RFC 012 §4.8.3 slow-path behavior.
-  retries: { retries: 5, factor: 1.5, minTimeout: 100, maxTimeout: 1000 },
-};
-
-/**
- * Acquire the write lock, run `fn`, release the lock. The lock is held
- * for exactly the duration of `fn` — not longer.
- *
- * Throws if the lock can't be acquired within the retry budget. The
- * caller decides whether to surface that error or fall back to a
- * read-only path.
- */
-export async function withWriteLock<T>(fn: () => Promise<T>): Promise<T> {
-  // Ensure target exists — proper-lockfile requires the resource path to
-  // be lockable. FAISS_INDEX_PATH is always present in normal operation
-  // (FaissIndexManager.initialize ensures it), but mkdir-p is cheap.
-  await fsp.mkdir(FAISS_INDEX_PATH, { recursive: true });
-
-  const release = await properLockfile.lock(FAISS_INDEX_PATH, WRITE_LOCK_OPTS);
-  try {
-    return await fn();
-  } finally {
-    try {
-      await release();
-    } catch (err) {
-      logger.warn(`Error releasing write lock: ${(err as Error).message}`);
-    }
-  }
-}
-
-/**
- * Test-only export: the path the write lock occupies. Tests assert on
- * its existence/non-existence to verify acquire/release behavior.
- */
-export const WRITE_LOCK_PATH_FOR_TESTS = WRITE_LOCK_PATH;
 
 /** Test-only export: the PID file path for advisory tests. */
 export const PID_FILE_PATH_FOR_TESTS = PID_FILE_PATH;

--- a/src/write-lock.test.ts
+++ b/src/write-lock.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import * as fsp from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+
+// All env state is read at module load by config.ts → so each test resets
+// modules and re-imports write-lock.ts after setting env. Pattern matches
+// the rest of the suite.
+
+const originalEnv = {
+  FAISS_INDEX_PATH: process.env.FAISS_INDEX_PATH,
+};
+
+afterEach(() => {
+  if (originalEnv.FAISS_INDEX_PATH === undefined) delete process.env.FAISS_INDEX_PATH;
+  else process.env.FAISS_INDEX_PATH = originalEnv.FAISS_INDEX_PATH;
+});
+
+describe('withWriteLock', () => {
+  let tempDir: string;
+  let lockPath: string;
+  beforeEach(async () => {
+    tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-write-lock-'));
+    process.env.FAISS_INDEX_PATH = tempDir;
+    lockPath = path.join(tempDir, '.kb-write.lock');
+  });
+
+  it('acquires the lock, runs fn, releases', async () => {
+    jest.resetModules();
+    const { withWriteLock } = await import('./write-lock.js');
+
+    let observed: { lockedDuringFn: boolean } = { lockedDuringFn: false };
+    const result = await withWriteLock(tempDir, async () => {
+      // Lock dir should exist while fn runs.
+      observed.lockedDuringFn = await fsp
+        .stat(lockPath)
+        .then(() => true)
+        .catch(() => false);
+      return 'value';
+    });
+    expect(result).toBe('value');
+    expect(observed.lockedDuringFn).toBe(true);
+    // Lock released after fn.
+    await expect(fsp.stat(lockPath)).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('serializes concurrent callers (second waits for the first)', async () => {
+    jest.resetModules();
+    const { withWriteLock } = await import('./write-lock.js');
+
+    const events: string[] = [];
+    const slow = withWriteLock(tempDir, async () => {
+      events.push('slow:start');
+      await new Promise((r) => setTimeout(r, 200));
+      events.push('slow:end');
+    });
+    // Tiny gap so the slow one definitely owns the lock first.
+    await new Promise((r) => setTimeout(r, 20));
+    const fast = withWriteLock(tempDir, async () => {
+      events.push('fast:start');
+      events.push('fast:end');
+    });
+    await Promise.all([slow, fast]);
+    // The fast one must observe slow:end before its own start.
+    expect(events).toEqual(['slow:start', 'slow:end', 'fast:start', 'fast:end']);
+  });
+
+  it('releases the lock even if fn throws', async () => {
+    jest.resetModules();
+    const { withWriteLock } = await import('./write-lock.js');
+
+    await expect(
+      withWriteLock(tempDir, async () => {
+        throw new Error('boom');
+      }),
+    ).rejects.toThrow('boom');
+
+    // No stranded lock.
+    await expect(fsp.stat(lockPath)).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('isolates per-resource: two different resources do not contend (RFC 013 M1+M2 prep)', async () => {
+    jest.resetModules();
+    const { withWriteLock } = await import('./write-lock.js');
+
+    const resA = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-write-lock-a-'));
+    const resB = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-write-lock-b-'));
+
+    const events: string[] = [];
+    const a = withWriteLock(resA, async () => {
+      events.push('a:start');
+      await new Promise((r) => setTimeout(r, 100));
+      events.push('a:end');
+    });
+    // B starts while A holds A's lock; different resource, must not block.
+    await new Promise((r) => setTimeout(r, 10));
+    const b = withWriteLock(resB, async () => {
+      events.push('b:start');
+      events.push('b:end');
+    });
+    await Promise.all([a, b]);
+    // B's start must precede A's end (no contention across resources).
+    const bStart = events.indexOf('b:start');
+    const aEnd = events.indexOf('a:end');
+    expect(bStart).toBeLessThan(aEnd);
+  });
+});

--- a/src/write-lock.ts
+++ b/src/write-lock.ts
@@ -1,0 +1,72 @@
+// RFC 013 §4.6 — short-lived write lock.
+//
+// Acquired around each `updateIndex()` call (in MCP, in
+// ReindexTriggerWatcher, in CLI `--refresh`). Released immediately after
+// the write. Default `kb search` (read-only) does NOT acquire this lock —
+// concurrent reads are fine.
+//
+// Lifted from `src/lock.ts` in RFC 013 M0. Signature changes from
+// `withWriteLock(fn)` to `withWriteLock(resource, fn)` so the lock primitive
+// no longer hardcodes `FAISS_INDEX_PATH`. M0 callers pass `FAISS_INDEX_PATH`
+// for now; M1+M2 will pass per-model directories (`models/<id>/`) to enable
+// concurrent operations on different models.
+
+import * as fsp from 'fs/promises';
+import * as path from 'path';
+import * as properLockfile from 'proper-lockfile';
+import { logger } from './logger.js';
+
+const WRITE_LOCK_OPTS_BASE: Omit<properLockfile.LockOptions, 'lockfilePath'> = {
+  // Heartbeat keeps the lock alive across long-running updateIndex calls
+  // (e.g., a model-switch full re-embed that takes minutes). proper-lockfile
+  // uses mtime-based stale detection; without heartbeat, a long write would
+  // false-positive as stale at the 10s default and another writer could
+  // acquire.
+  update: 5000,
+  stale: 10_000,
+  // Brief retry budget for fast-path contention (MCP and CLI both want
+  // the lock for ~280 ms). Slow-path (model-switch re-embed) callers will
+  // exhaust this and error with a clear message — that's the documented
+  // RFC 012 §4.8.3 slow-path behavior.
+  retries: { retries: 5, factor: 1.5, minTimeout: 100, maxTimeout: 1000 },
+};
+
+/**
+ * Acquire the write lock on `resource`, run `fn`, release the lock. The
+ * lock is held for exactly the duration of `fn` — not longer.
+ *
+ * `resource` is an absolute directory path; the function does not interpret
+ * it. M0 callers pass `FAISS_INDEX_PATH`. M1+M2 will pass
+ * `${FAISS_INDEX_PATH}/models/<id>/` for per-model isolation.
+ *
+ * Throws if the lock can't be acquired within the retry budget.
+ */
+export async function withWriteLock<T>(resource: string, fn: () => Promise<T>): Promise<T> {
+  // proper-lockfile requires the locked resource path to exist; mkdir-p
+  // handles both first-run and subdirectory cases (M1+M2's per-model dirs).
+  await fsp.mkdir(resource, { recursive: true });
+
+  const lockfilePath = path.join(resource, '.kb-write.lock');
+  const release = await properLockfile.lock(resource, {
+    ...WRITE_LOCK_OPTS_BASE,
+    lockfilePath,
+  });
+  try {
+    return await fn();
+  } finally {
+    try {
+      await release();
+    } catch (err) {
+      logger.warn(`Error releasing write lock: ${(err as Error).message}`);
+    }
+  }
+}
+
+/**
+ * Test-only helper: the lockfile path that `withWriteLock(resource, ...)`
+ * would create. Tests assert on its existence/non-existence to verify
+ * acquire/release behavior.
+ */
+export function writeLockPathFor(resource: string): string {
+  return path.join(resource, '.kb-write.lock');
+}


### PR DESCRIPTION
## Summary

RFC 013 M0 — mechanical lock-module split, no surface change. Precursor PR landing ahead of M1+M2 to de-risk the larger 0.3.0 migration PR.

- **`src/lock.ts`** → split into **`src/instance-lock.ts`** (PID advisory, single-instance enforcement) + **`src/write-lock.ts`** (short-lived write coordination).
- **`withWriteLock(fn)` → `withWriteLock(resource, fn)`.** The lock primitive no longer hardcodes `FAISS_INDEX_PATH`. M0 callers pass `FAISS_INDEX_PATH`; M1+M2 will pass `${PATH}/models/<id>/` for per-model isolation.
- All 13 test suites / 185 tests green. New per-resource isolation test in `write-lock.test.ts` prep-tests the M1+M2 invariant.

Refs #100. RFC 013 §4.6 / §6.1 — the operator approved this as a separate 0.2.2 patch ahead of M1+M2's 0.3.0.

## Background

RFC 012 round-3 boundary-critic flagged the two-mechanism `lock.ts` module as conceptually mixed (process-lifetime PID advisory + per-write coordination). The decision to split was deferred at the time as a "mechanical refactor — M1 author's call" (see RFC 012 §11). RFC 013 acts on it now because M1+M2 narrows the write lock from `FAISS_INDEX_PATH` to per-model directories — that change is cleaner against a single-purpose `write-lock.ts` than a mixed module, and decoupling the concerns means a future bug in one doesn't force a patch to the other.

## What stays unchanged

- All exported names: `acquireInstanceAdvisory`, `releaseInstanceAdvisory`, `InstanceAlreadyRunningError`, `PID_FILE_PATH_FOR_TESTS`, `withWriteLock`. Importers update their `from './lock.js'` to `from './instance-lock.js'` / `from './write-lock.js'`.
- All behavior: PID-file location (`${FAISS_INDEX_PATH}/.kb-mcp.pid`), write lock path (`${resource}/.kb-write.lock`), retry budgets, heartbeat semantics, mode 0o600 on the PID file.
- All in-tree callers (`KnowledgeBaseServer`, `ReindexTriggerWatcher` callback, CLI `--refresh`) pass `FAISS_INDEX_PATH` as the resource, preserving 0.2.x behavior byte-for-byte.

## What technically changes (internal-only)

- `withWriteLock` signature is now `(resource: string, fn) => Promise<T>`. No external importers exist outside this repo (verified by grep against the published tarball — only `build/index.js` and `build/cli.js` import it transitively, both ship bundled). If a third-party were importing internals, this is technically breaking; the patch-level bump 0.2.1 → 0.2.2 reflects the internal nature.
- Test-only export `WRITE_LOCK_PATH_FOR_TESTS` is replaced with a per-resource lookup in tests (each test computes `path.join(tempDir, '.kb-write.lock')` from its own resource).

## Test plan

- [x] `npm run build` — clean (`tsc -p tsconfig.json`).
- [x] `npm test` — all 13 suites, 185 tests green.
- [x] New test in `write-lock.test.ts`: "isolates per-resource — two different resources do not contend." Prep for M1+M2's per-model lock invariant.
- [x] Pre-PR gate file created at `/dev/shm/.pr-gate-knowledge-base-mcp-server-m0-lock-split-pre-done`.
- [x] No external API change — `npm pack` install would behave identically.

## Out of scope

- Multi-model layout. Lands in M1+M2 (`models/<id>/` subtree, migration, `kb models *` family). M0 is the lock split only.
- `tryAcquireInstanceAdvisory` (M1+M2 introduces it for the bootstrap-without-throwing case). Not needed yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)