### PR TITLE
feat(mcp): RFC 013 M3 — list_models tool + model_name arg on retrieve_knowledge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,16 @@
 
 - **`kb compare <query> <model_a> <model_b>`** (G11) — unified rank/score table over both models' top-k. Hard-fails if either model is unresolvable (round-2 failure N5 — never renders a half-table). Header notes scores are not directly comparable across models with different dim/distance metrics.
 
+### Added (RFC 013 M3 — MCP surface)
+
+- **`list_models` MCP tool.** Surfaces registered embedding models so an agent can pre-flight a `model_name` override before invoking `retrieve_knowledge`. Returns `[{model_id, provider, model_name, active}]`. Skips models with `.adding` sentinel (round-1 failure F6 — half-built models are not exposed to the agent).
+- **`retrieve_knowledge` gains optional `model_name` argument.** When passed, queries the named registered model instead of the active default. Validates against the slug regex before any path-join (round-1 failure F12 — path-traversal protection). Unknown / `.adding` model returns `isError: true` with the registered list (RFC §4.5).
+- **Response envelope `model_id` footer** when `model_name` is passed (round-1 minimalist F5 — envelope, not per-chunk). When `model_name` is omitted, the wire format is byte-equal to 0.2.x for back-compat.
+- `LIST_MODELS_DESCRIPTION` env var override for the `list_models` tool description (matches RFC 010 M2 / #52 pattern).
+
 ### Status
 
-Build clean. **231 / 231 tests pass across 15 suites.** Existing tests rebased for the new `models/<id>/` layout. New module tests added: `model-id.test.ts` (15 tests), `active-model.test.ts` (18 tests including writer single-writer invariant, robust BOM/CRLF reader with hard-fail on regex-fail, full precedence matrix). New CLI tests cover `kb models list/add/set-active/remove`, `kb compare`, and the migration smoke path.
+Build clean. **237 / 237 tests pass across 15 suites.** Existing tests rebased for the new `models/<id>/` layout. New module tests added: `model-id.test.ts` (15 tests), `active-model.test.ts` (18 tests including writer single-writer invariant, robust BOM/CRLF reader with hard-fail on regex-fail, full precedence matrix). New CLI tests cover `kb models list/add/set-active/remove`, `kb compare`, and the migration smoke path. M3 MCP tests cover `list_models` happy path + `.adding` skip + empty registry, plus `retrieve_knowledge` `model_name` override (unregistered → isError, valid → envelope footer, omitted → byte-equal back-compat).
 
 ## [0.2.2] — 2026-04-25
 

--- a/src/KnowledgeBaseServer.test.ts
+++ b/src/KnowledgeBaseServer.test.ts
@@ -121,6 +121,115 @@ describe('KnowledgeBaseServer handlers', () => {
     expect(parsed).not.toContain('.config');
   });
 
+  // --- handleListModels (RFC 013 M3 §4.5) ----------------------------------
+
+  it('handleListModels returns registered models with active marker', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-server-listmodels-'));
+    const faissDir = path.join(tempDir, '.faiss');
+    process.env.KNOWLEDGE_BASES_ROOT_DIR = tempDir;
+    process.env.FAISS_INDEX_PATH = faissDir;
+    process.env.EMBEDDING_PROVIDER = 'huggingface';
+    process.env.HUGGINGFACE_API_KEY = 'test-key';
+
+    const idA = 'huggingface__BAAI-bge-small-en-v1.5';
+    const idB = 'ollama__nomic-embed-text-latest';
+    for (const [id, name] of [[idA, 'BAAI/bge-small-en-v1.5'], [idB, 'nomic-embed-text:latest']] as const) {
+      await fsp.mkdir(path.join(faissDir, 'models', id), { recursive: true });
+      await fsp.writeFile(path.join(faissDir, 'models', id, 'model_name.txt'), name);
+    }
+    await fsp.writeFile(path.join(faissDir, 'active.txt'), idA);
+
+    const server = await freshServer();
+    const result = await server['handleListModels']();
+
+    expect(result.isError).toBeUndefined();
+    expect(result.content).toHaveLength(1);
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed).toHaveLength(2);
+    const a = parsed.find((m: any) => m.model_id === idA);
+    const b = parsed.find((m: any) => m.model_id === idB);
+    expect(a).toMatchObject({ provider: 'huggingface', model_name: 'BAAI/bge-small-en-v1.5', active: true });
+    expect(b).toMatchObject({ provider: 'ollama', model_name: 'nomic-embed-text:latest', active: false });
+  });
+
+  it('handleListModels skips models with .adding sentinel', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-server-listmodels-skip-'));
+    const faissDir = path.join(tempDir, '.faiss');
+    process.env.KNOWLEDGE_BASES_ROOT_DIR = tempDir;
+    process.env.FAISS_INDEX_PATH = faissDir;
+    process.env.EMBEDDING_PROVIDER = 'huggingface';
+    process.env.HUGGINGFACE_API_KEY = 'test-key';
+
+    const idA = 'huggingface__BAAI-bge-small-en-v1.5';
+    const idB = 'ollama__nomic-embed-text-latest';
+    for (const [id, name] of [[idA, 'BAAI/bge-small-en-v1.5'], [idB, 'nomic-embed-text:latest']] as const) {
+      await fsp.mkdir(path.join(faissDir, 'models', id), { recursive: true });
+      await fsp.writeFile(path.join(faissDir, 'models', id, 'model_name.txt'), name);
+    }
+    await fsp.writeFile(path.join(faissDir, 'models', idB, '.adding'), `${process.pid}\n`);
+    await fsp.writeFile(path.join(faissDir, 'active.txt'), idA);
+
+    const server = await freshServer();
+    const result = await server['handleListModels']();
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.map((m: any) => m.model_id)).toEqual([idA]);
+  });
+
+  it('handleListModels returns empty array when no models registered', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-server-listmodels-empty-'));
+    const faissDir = path.join(tempDir, '.faiss');
+    process.env.KNOWLEDGE_BASES_ROOT_DIR = tempDir;
+    process.env.FAISS_INDEX_PATH = faissDir;
+    process.env.EMBEDDING_PROVIDER = 'huggingface';
+    process.env.HUGGINGFACE_API_KEY = 'test-key';
+
+    const server = await freshServer();
+    const result = await server['handleListModels']();
+    expect(result.isError).toBeUndefined();
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed).toEqual([]);
+  });
+
+  // --- handleRetrieveKnowledge model_name override (RFC 013 M3) -------------
+
+  it('handleRetrieveKnowledge with model_name=<unregistered> returns isError: true with hint', async () => {
+    await setRetrieveEnv();
+    const server = await freshServer();
+    const result = await server['handleRetrieveKnowledge']({ query: 'q', model_name: 'ollama__not-here' });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('not registered');
+  });
+
+  it('handleRetrieveKnowledge with valid model_name override prepends model_id footer', async () => {
+    await setRetrieveEnv();
+    const faissDir = process.env.FAISS_INDEX_PATH!;
+    const idB = 'ollama__nomic-embed-text-latest';
+    await fsp.mkdir(path.join(faissDir, 'models', idB), { recursive: true });
+    await fsp.writeFile(path.join(faissDir, 'models', idB, 'model_name.txt'), 'nomic-embed-text:latest');
+
+    updateIndexMock.mockResolvedValue(undefined);
+    similaritySearchMock.mockResolvedValue([
+      { pageContent: 'hello', metadata: { source: '/tmp/x.md' }, score: 0.5 },
+    ]);
+
+    const server = await freshServer();
+    const result = await server['handleRetrieveKnowledge']({ query: 'q', model_name: idB });
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0].text).toContain(`Model: ${idB}`);
+  });
+
+  it('handleRetrieveKnowledge without model_name does NOT prepend model_id footer (back-compat)', async () => {
+    await setRetrieveEnv();
+    updateIndexMock.mockResolvedValue(undefined);
+    similaritySearchMock.mockResolvedValue([
+      { pageContent: 'hello', metadata: { source: '/tmp/x.md' }, score: 0.5 },
+    ]);
+
+    const server = await freshServer();
+    const result = await server['handleRetrieveKnowledge']({ query: 'q' });
+    expect(result.content[0].text).not.toContain('Model:');
+  });
+
   it('handleListKnowledgeBases surfaces readdir errors as { isError: true } naming the failure', async () => {
     const missingDir = path.join(os.tmpdir(), `kb-server-missing-${Date.now()}-${Math.random()}`);
     process.env.KNOWLEDGE_BASES_ROOT_DIR = missingDir;

--- a/src/KnowledgeBaseServer.ts
+++ b/src/KnowledgeBaseServer.ts
@@ -6,6 +6,7 @@ import type { CallToolResult, TextContent } from '@modelcontextprotocol/sdk/type
 import { FaissIndexManager } from './FaissIndexManager.js';
 import {
   ActiveModelResolutionError,
+  listRegisteredModels,
   modelDir,
   parseModelId,
   readStoredModelName,
@@ -16,6 +17,7 @@ import {
   FRONTMATTER_EXTRAS_WIRE_VISIBLE,
   KNOWLEDGE_BASES_ROOT_DIR,
   LIST_KNOWLEDGE_BASES_DESCRIPTION,
+  LIST_MODELS_DESCRIPTION,
   loadTransportConfig,
   REINDEX_TRIGGER_PATH,
   REINDEX_TRIGGER_POLL_MS,
@@ -110,9 +112,55 @@ export class KnowledgeBaseServer {
         query: z.string().describe('The search query to use for retrieving similar chunks from the knowledge base.'),
         knowledge_base_name: z.string().optional().describe('The name of the knowledge base to search. If omitted, all available knowledge bases are considered.'),
         threshold: z.number().optional().describe('The maximum similarity score threshold for returned documents. Defaults to 2 if not specified.'),
+        // RFC 013 M3 §4.5 — optional override of the active embedding model.
+        // When omitted, the server uses the model recorded in active.txt.
+        // When passed, must be a registered model_id (see list_models).
+        model_name: z.string().optional().describe('The model_id of an alternate embedding model to query (e.g. "openai__text-embedding-3-small"). If omitted, the active model is used. Run list_models for available ids.'),
       },
       async (args) => this.handleRetrieveKnowledge(args)
     );
+
+    // RFC 013 M3 §4.5 — list_models surfaces what's registered so an agent
+    // can pre-flight a model_name override before invoking retrieve_knowledge.
+    mcp.tool(
+      'list_models',
+      LIST_MODELS_DESCRIPTION,
+      async () => this.handleListModels()
+    );
+  }
+
+  /**
+   * RFC 013 M3 §4.5 — list registered embedding models. Returns a JSON array
+   * of `{ model_id, provider, model_name, active }` objects. `.adding`
+   * sentinels are skipped (round-1 failure F6 — half-built models are not
+   * surfaced to the agent).
+   */
+  private async handleListModels(): Promise<CallToolResult> {
+    try {
+      const models = await listRegisteredModels();
+      let activeId: string | null = null;
+      try {
+        activeId = await resolveActiveModel();
+      } catch {
+        // No active resolvable; return all models with active: false.
+      }
+      const enriched = models.map((m) => ({
+        model_id: m.model_id,
+        provider: m.provider,
+        model_name: m.model_name,
+        active: m.model_id === activeId,
+      }));
+      return {
+        content: [{ type: 'text', text: JSON.stringify(enriched, null, 2) }],
+      };
+    } catch (error: any) {
+      logger.error('Error listing models:', error);
+      const content: TextContent = {
+        type: 'text',
+        text: `Error listing models: ${error.message}`,
+      };
+      return { content: [content], isError: true };
+    }
   }
 
   private async handleListKnowledgeBases(): Promise<CallToolResult> {
@@ -136,19 +184,31 @@ export class KnowledgeBaseServer {
     }
   }
 
-  private async handleRetrieveKnowledge(args: { query: string; knowledge_base_name?: string; threshold?: number; }): Promise<CallToolResult> {
+  private async handleRetrieveKnowledge(args: { query: string; knowledge_base_name?: string; threshold?: number; model_name?: string; }): Promise<CallToolResult> {
     const query: string = args.query;
     const knowledgeBaseName: string | undefined = args.knowledge_base_name;
     const threshold: number | undefined = args.threshold;
+    const modelNameOverride: string | undefined = args.model_name;
 
     try {
       const startTime = Date.now();
       logger.debug(`[${startTime}] handleRetrieveKnowledge started`);
 
-      // RFC 013 §4.7 — resolve active model per call. Future M3 will accept
-      // `args.model_name` as an explicit override here; for now the active
-      // model is always used.
-      const activeModelId = await resolveActiveModel();
+      // RFC 013 §4.7 — resolve active model per call. M3 honors args.model_name
+      // as the explicit per-call override (resolveActiveModel validates it +
+      // hard-fails with a registered-list hint if not on disk).
+      let activeModelId: string;
+      try {
+        activeModelId = await resolveActiveModel({ explicitOverride: modelNameOverride });
+      } catch (err) {
+        if (err instanceof ActiveModelResolutionError) {
+          return {
+            content: [{ type: 'text', text: err.message }],
+            isError: true,
+          };
+        }
+        throw err;
+      }
       const manager = await this.getManagerFor(activeModelId);
 
       // RFC 013 §4.6 — write lock is per-model (resource = `models/<id>/`).
@@ -161,10 +221,19 @@ export class KnowledgeBaseServer {
       logger.debug(`[${Date.now()}] Similarity search completed`);
 
       // Build a nicely formatted markdown response including the similarity score.
-      const responseText = formatRetrievalAsMarkdown(
+      let responseText = formatRetrievalAsMarkdown(
         similaritySearchResults,
         FRONTMATTER_EXTRAS_WIRE_VISIBLE,
       );
+
+      // RFC 013 M3 §4.5 + round-1 minimalist F5 — emit `model_id` on the
+      // response envelope (NOT per-chunk) so an agent comparing two models
+      // can attribute results when explicit model_name was passed. When
+      // model_name was NOT passed, the wire format is byte-equal to 0.2.x
+      // (no envelope field, no per-chunk metadata change) for back-compat.
+      if (modelNameOverride !== undefined) {
+        responseText = `> _Model: ${activeModelId}_\n\n${responseText}`;
+      }
 
       const endTime = Date.now();
       logger.debug(`[${endTime}] handleRetrieveKnowledge completed in ${endTime - startTime}ms`);

--- a/src/config.ts
+++ b/src/config.ts
@@ -146,6 +146,14 @@ export const LIST_KNOWLEDGE_BASES_DESCRIPTION =
     ? process.env.LIST_KNOWLEDGE_BASES_DESCRIPTION
     : DEFAULT_LIST_KNOWLEDGE_BASES_DESCRIPTION;
 
+// RFC 013 M3 §4.5 — list_models tool description.
+export const DEFAULT_LIST_MODELS_DESCRIPTION =
+  'Lists the embedding models registered for retrieval. Returns an array of {model_id, provider, model_name, active}. Use the model_id as the optional `model_name` argument to retrieve_knowledge to query a specific model instead of the active default.';
+export const LIST_MODELS_DESCRIPTION =
+  process.env.LIST_MODELS_DESCRIPTION && process.env.LIST_MODELS_DESCRIPTION.length > 0
+    ? process.env.LIST_MODELS_DESCRIPTION
+    : DEFAULT_LIST_MODELS_DESCRIPTION;
+
 // ---------------------------------------------------------------------------
 // Transport configuration (RFC 008 stage 1: stdio + SSE).
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

RFC 013 M3 — MCP surface for multi-model. Builds on #103 (M1+M2). Refs #100.

- **`list_models` MCP tool.** Returns `[{model_id, provider, model_name, active}, ...]`. Skips directories with `.adding` sentinel.
- **`retrieve_knowledge` gains optional `model_name` arg.** When passed, queries the named registered model instead of the active default. Path-traversal-safe (round-1 failure F12). Unknown / `.adding` model → `isError: true` with the registered list.
- **Response envelope `model_id` footer** when `model_name` is passed (round-1 minimalist F5 — envelope, not per-chunk). Wire format is byte-equal to 0.2.x when `model_name` is omitted.
- `LIST_MODELS_DESCRIPTION` env var override (matches RFC 010 M2 pattern).

## Test plan

- [x] Build clean (`npm run build`).
- [x] 237 / 237 tests across 15 suites green.
- [x] M3-specific tests: `handleListModels` (registered + active marker, `.adding` skip, empty registry), `handleRetrieveKnowledge` `model_name` override (unregistered → isError, valid → envelope footer, omitted → byte-equal back-compat).
- [ ] Operator validates the wire format from a real MCP client (Claude Code, Codex, etc.) against the operator's actual KBs.

## Out of scope

- M4 docs (separate PR — README, threat-model, clients.md updates).
- Future work: MCP elicitation-gated `add_model` / `set_active_model` tools (RFC §8.4 + OQ8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)