### PR TITLE
docs(multimodel): RFC 013 M4 — README + clients.md + threat-model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,12 @@
 - **Response envelope `model_id` footer** when `model_name` is passed (round-1 minimalist F5 — envelope, not per-chunk). When `model_name` is omitted, the wire format is byte-equal to 0.2.x for back-compat.
 - `LIST_MODELS_DESCRIPTION` env var override for the `list_models` tool description (matches RFC 010 M2 / #52 pattern).
 
+### Documentation (RFC 013 M4)
+
+- README: new "Comparing embedding models (RFC 013)" section walking through `kb models {list, add, set-active, remove}`, `kb search --model=<id>`, `kb compare`, with a paragraph on the auto-migration from 0.2.x and the upgrade-window operator action ("fully exit any AI client before upgrading").
+- `docs/clients.md`: new "Multi-model setups" section explaining `KB_ACTIVE_MODEL` env-var pinning per MCP client vs. per-call `model_name` override. Notes the Smithery single-model limitation.
+- `docs/architecture/threat-model.md`: §1 trust boundary extended to every `models/<id>/` subdirectory + `active.txt`. §4 Concurrency rewritten for RFC 012 single-instance enforcement + RFC 013 per-model write locks + migration coordination via `.kb-migration.lock`.
+
 ### Status
 
 Build clean. **237 / 237 tests pass across 15 suites.** Existing tests rebased for the new `models/<id>/` layout. New module tests added: `model-id.test.ts` (15 tests), `active-model.test.ts` (18 tests including writer single-writer invariant, robust BOM/CRLF reader with hard-fail on regex-fail, full precedence matrix). New CLI tests cover `kb models list/add/set-active/remove`, `kb compare`, and the migration smoke path. M3 MCP tests cover `list_models` happy path + `.adding` skip + empty registry, plus `retrieve_knowledge` `model_name` override (unregistered → isError, valid → envelope footer, omitted → byte-equal back-compat).

--- a/README.md
+++ b/README.md
@@ -46,6 +46,39 @@ The `kb` bin shares the same env vars as the MCP server (`KNOWLEDGE_BASES_ROOT_D
 
 The MCP server (`knowledge-base-mcp-server` bin) is unchanged and still works with all the configurations in [docs/clients.md](docs/clients.md). The CLI is additive.
 
+### Comparing embedding models (RFC 013)
+
+Once on 0.3.0, you can keep multiple embedding models side-by-side and query each by id. Useful for retrieval-quality A/B without losing the previous model:
+
+```bash
+# List registered models. The * marks the active one.
+kb models list
+
+# Add a second model — embeds your KB once under the new model.
+# For paid providers, prints an estimated cost and prompts before any HTTP traffic.
+kb models add ollama nomic-embed-text          # local, free
+kb models add openai text-embedding-3-small    # paid; estimate first
+kb models add huggingface BAAI/bge-small-en-v1.5
+
+# Query a specific model without changing the default.
+kb search "your query" --model=openai__text-embedding-3-small
+
+# Side-by-side comparison: unified rank/score table over both models' top-k.
+kb compare "your query" ollama__nomic-embed-text-latest openai__text-embedding-3-small
+
+# Switch the default model.
+kb models set-active openai__text-embedding-3-small
+
+# Remove a model (refuses to remove the active one).
+kb models remove huggingface__BAAI-bge-small-en-v1.5
+```
+
+`<model_id>` is `<provider>__<filesystem-safe-slug>`, derived deterministically from `(provider, model_name)` as typed (e.g. `OLLAMA_MODEL=nomic-embed-text:latest` → `ollama__nomic-embed-text-latest`). On-disk layout: each model lives at `${FAISS_INDEX_PATH}/models/<id>/`. The active model is recorded in `${FAISS_INDEX_PATH}/active.txt` and overridable per-process via `KB_ACTIVE_MODEL`. See [`docs/rfcs/013-multimodel-support.md`](docs/rfcs/013-multimodel-support.md) for the full design.
+
+**Migration from 0.2.x → 0.3.0** is automatic on first server (or `kb`) start: the existing single-model index is moved into `${FAISS_INDEX_PATH}/models/<derived_id>/` and `active.txt` is written. Atomic, ~12 ms measured. **Before upgrading**, fully exit any AI client (Claude Code, Cursor, Continue, Cline) that has the MCP server loaded — the migration acquires the single-instance PID advisory before any rename, so it cannot run while a 0.2.x MCP child is still using the directory. See [CHANGELOG](CHANGELOG.md) for rollback recipes.
+
+**MCP surface** — `retrieve_knowledge` gains an optional `model_name` argument; a new `list_models` tool returns the registered models. Tools that don't pass `model_name` keep working unchanged (wire format is byte-equal to 0.2.x).
+
 ### Install via Smithery
 
 To install Knowledge Base Server for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@jeanibarz/knowledge-base-mcp-server):

--- a/docs/architecture/threat-model.md
+++ b/docs/architecture/threat-model.md
@@ -17,14 +17,16 @@ Sections below go one level deeper on each.
 
 ## 1. `$FAISS_INDEX_PATH` is a code-execution boundary (#43)
 
-`FaissStore.load()` at `src/FaissIndexManager.ts:169` deserializes the docstore that lives alongside `faiss.index`. The deserialization path inside `@langchain/community` uses `pickleparser@0.2.1` (`package.json:27`) to stay wire-compatible with Python LangChain. **Loading an attacker-controlled docstore is arbitrary-code-execution-shaped** on the platforms where pickle-style streams deserialize to native objects.
+`FaissStore.load()` deserializes the docstore that lives alongside `faiss.index`. The deserialization path inside `@langchain/community` uses `pickleparser@0.2.1` (`package.json:27`) to stay wire-compatible with Python LangChain. **Loading an attacker-controlled docstore is arbitrary-code-execution-shaped** on the platforms where pickle-style streams deserialize to native objects.
 
-**Requirement.** Every file inside `$FAISS_INDEX_PATH` must have been written by this server running against this user's configured embedding model. Specifically:
+**RFC 013 multi-model layout** (0.3.0+): the trust boundary now extends to every `${FAISS_INDEX_PATH}/models/<model_id>/` subdirectory. Each model has its own `faiss.index/` + `model_name.txt`, and the same code-execution risk applies to each model's docstore independently. `${FAISS_INDEX_PATH}/active.txt` is also operator-trusted state — tampering with it can redirect agent retrievals to a wrong model (the slug regex hard-fails on malformed content, so the failure mode is "exit 2" rather than "silent vector-space mismatch", but the file should still be treated as security-sensitive).
 
-- Do **not** restore `$FAISS_INDEX_PATH` from an untrusted backup, container image, or package.
+**Requirement.** Every file inside `$FAISS_INDEX_PATH` (including every `models/<id>/` subtree and `active.txt`) must have been written by this server running against this user's configured embedding model. Specifically:
+
+- Do **not** restore `$FAISS_INDEX_PATH` (or any `models/<id>/`) from an untrusted backup, container image, or package.
 - Do **not** mount `$FAISS_INDEX_PATH` on a shared filesystem with write access for untrusted peers.
 - Do **not** point `$FAISS_INDEX_PATH` at a directory another tool writes to.
-- **Do** treat deletion as safe: removing `$FAISS_INDEX_PATH/faiss.index` forces a rebuild from source on the next `retrieve_knowledge` call (see [`sequence-reindex.md`](./sequence-reindex.md) and [`state-index.md`](./state-index.md)).
+- **Do** treat deletion as safe: `kb models remove <id>` (or `rm -rf ${FAISS_INDEX_PATH}/models/<id>/`) forces a rebuild on the next `kb models add`. The in-memory FaissStore in a running MCP server keeps working until process exit — verified empirically (RFC 013 §10 E6), `faiss-node` reads the index into memory at `.load()` time and does not mmap.
 
 The surface is permanent until upstream swaps the docstore format away from pickle. ADR [`0001-faiss-over-qdrant.md`](./adr/0001-faiss-over-qdrant.md) explains why we stay with FAISS despite this cost; a future RFC may migrate the docstore to a JSON-only format.
 
@@ -50,19 +52,17 @@ Three env vars are read at construction time (`src/FaissIndexManager.ts:98-121`,
 
 Query text and knowledge-base chunks leave the machine over TLS to the configured provider. The provider sees everything the server sees. Choose Ollama (local) if that matters.
 
-## 4. Concurrency — single process per `$FAISS_INDEX_PATH` (#44)
+## 4. Concurrency — single MCP per `$FAISS_INDEX_PATH`, per-model write locks (#44)
 
-`FaissIndexManager.updateIndex` at `src/FaissIndexManager.ts:202-389` has **no file-level locking**. Two server processes pointing at the same `$FAISS_INDEX_PATH` will race on:
+**Single-MCP-instance enforcement** (RFC 012 M1 — landed in 0.2.0). `acquireInstanceAdvisory` at `src/instance-lock.ts` writes a PID file at `${FAISS_INDEX_PATH}/.kb-mcp.pid` atomically (`O_CREAT | O_EXCL`, mode `0o600`) on `KnowledgeBaseServer.run()`. Two concurrent MCP servers against the same `$FAISS_INDEX_PATH` are refused — the second exits with `InstanceAlreadyRunningError`. Stale PID files (recorded PID is dead) are silently overwritten.
 
-- `FaissStore.save` at `src/FaissIndexManager.ts:351` — there is no `.tmp` + rename for the index itself; a partial write from one process can be read by the other.
-- Hash-sidecar tmp+rename at `src/FaissIndexManager.ts:362-377` — safe per-file, not safe across interleaved writers.
-- The upcoming pending-manifest protocol (RFC 007 §6.2.1) — single-writer assumption is load-bearing there.
+**Per-model write coordination** (RFC 013 M0 + M1+M2 — landed in 0.2.2 + 0.3.0). Short-lived `proper-lockfile` write locks at `${FAISS_INDEX_PATH}/models/<id>/.kb-write.lock`. Acquired around each `updateIndex` call (MCP `handleRetrieveKnowledge`, `ReindexTriggerWatcher`, `kb search --refresh`, `kb models add`); released immediately after. **Per-model granularity** means a long-running `kb models add B` (multi-minute embedding pass) does NOT block `kb search` against model A. Default `kb search` (read-only) does not acquire any lock.
 
-**Current requirement.** One server process per `$FAISS_INDEX_PATH`. Running two against the same path **will corrupt the index**.
+**Migration coordination** (RFC 013 §4.8). `FaissIndexManager.bootstrapLayout` runs the 0.2.x→0.3.0 migration at most once per Node process (module-level Promise cache). Cross-process: piggybacks on the instance advisory if held, else acquires a short-lived `${FAISS_INDEX_PATH}/.kb-migration.lock` for CLI invocations to coordinate with peers.
 
-This is a documented constraint, not an enforced one. Users deploying under systemd with `Restart=on-failure`, pm2, Kubernetes with `replicas > 1`, or containerized with a shared volume, need to configure their orchestrator to keep the process count at 1 (or give each replica its own `FAISS_INDEX_PATH`).
+**Current requirement.** Still **one MCP server** per `$FAISS_INDEX_PATH`. Multiple `kb` CLI invocations against the same path are safe — they coordinate via the per-model write lock. Users deploying under systemd / pm2 / Kubernetes still need to keep MCP-server replicas at 1 per `FAISS_INDEX_PATH` or give each replica its own.
 
-**Planned fix.** An `O_EXCL` lockfile at `$FAISS_INDEX_PATH/.lock` containing the PID, written in `initialize()` and removed in the SIGINT handler (`src/KnowledgeBaseServer.ts:27-30`). On startup, if `.lock` exists and its PID is alive, refuse to start with a clear error; if the PID is dead, warn and reclaim. Tracked in issue #44 for a follow-up RFC.
+**Known limitation.** `FaissStore.save()` from `@langchain/community` is non-atomic (`mkdir -p + Promise.all([index.write, writeFile(docstore.json)])`, no rename). A read concurrent with a save can see partial `docstore.json`; the CLI's `loadWithJsonRetry` handles this with a 100 ms retry. Documented in RFC 012 §7 N4. Per-model isolation in 0.3.0 narrows the blast radius (only that one model's reads can race).
 
 ## 5. Path-traversal (forward-looking)
 

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -11,6 +11,7 @@ This server speaks stdio MCP and works with any stdio MCP client. Pick the block
 | `<FAISS_INDEX_PATH>` | Optional. Absolute path for the FAISS index. Defaults to `$HOME/knowledge_bases/.faiss` if omitted. |
 | `<HF_API_KEY>` | HuggingFace API token (or a compatible Inference Provider key). |
 | `<OPENAI_API_KEY>` | OpenAI API key. |
+| `<MODEL_ID>` | Optional (RFC 013, 0.3.0+). The `<provider>__<slug>` id of a registered model — used in `KB_ACTIVE_MODEL` to pin a per-MCP-process active model. Run `kb models list` to see what's registered. |
 
 The blocks below alternate embedding providers so you can see all three configured at least once. Any client can use any provider — see the [README](../README.md) "Configure environment variables" step for the full env-var matrix.
 
@@ -23,6 +24,27 @@ Alternatively, install once globally (`npm install -g @jeanibarz/knowledge-base-
 ## See also: `kb` CLI
 
 For shell-driven workflows (REPL queries, scripted ingest checks, agent Bash-tool calls), the same package ships a `kb` bin that doesn't require an MCP client at all. Each `kb` invocation is a fresh process, so global upgrades are picked up immediately. See the README "Install (CLI alongside the MCP server)" section.
+
+## Multi-model setups (RFC 013, 0.3.0+)
+
+The default config in the snippets below resolves to a single embedding model via the legacy env vars (`EMBEDDING_PROVIDER` + `OLLAMA_MODEL`/`OPENAI_MODEL_NAME`/`HUGGINGFACE_MODEL_NAME`). On 0.3.0+, you can keep multiple models registered side-by-side and have the MCP server use any of them per-call.
+
+Two ways to control which model the MCP server uses:
+
+1. **Set `KB_ACTIVE_MODEL`** in the env block of your client config to pin a specific model for that MCP-child's lifetime (highest precedence after a per-call `model_name` arg). Useful when you want one client to consistently use one model regardless of `active.txt`.
+
+   ```json
+   "env": {
+     "KNOWLEDGE_BASES_ROOT_DIR": "<KB_ROOT>",
+     "FAISS_INDEX_PATH": "<FAISS_INDEX_PATH>",
+     "KB_ACTIVE_MODEL": "openai__text-embedding-3-small",
+     "OPENAI_API_KEY": "<OPENAI_API_KEY>"
+   }
+   ```
+
+2. **Let the agent choose per-call** by passing `model_name` on each `retrieve_knowledge` invocation. The agent can call `list_models` first to discover registered ids. The active model (from `${FAISS_INDEX_PATH}/active.txt`) is the default when `model_name` is omitted. Manage the active model from the shell with `kb models set-active <id>`.
+
+> **Smithery deployments are single-model only** in 0.3.0 — the hosted runner doesn't expose a CLI, so `kb models add` cannot register additional models. The `kbActiveModel` Smithery config maps to `KB_ACTIVE_MODEL` and selects which (single, env-derived) model is active. Multi-model side-by-side on hosted MCP requires a follow-up RFC.
 
 ## Claude Desktop
 


### PR DESCRIPTION
## Summary

RFC 013 M4 — operator-facing documentation for the multi-model embedding feature landed in #103/#104.

- **README** "Comparing embedding models (RFC 013)" section: walkthrough of `kb models {list, add, set-active, remove}`, `kb search --model=<id>`, `kb compare`. Notes auto-migration from 0.2.x and the operator action required at upgrade ("fully exit any AI client before upgrading").
- **docs/clients.md** "Multi-model setups": `KB_ACTIVE_MODEL` env-var pinning per-MCP-client vs. per-call `model_name` override. Notes Smithery single-model limitation.
- **docs/architecture/threat-model.md** §1 trust boundary extended to every `models/<id>/` subdirectory + `active.txt`. §4 Concurrency rewritten for RFC 012 single-instance enforcement + RFC 013 per-model write locks + migration coordination via `.kb-migration.lock`.
- **CHANGELOG** entry under `[Unreleased]` (0.3.x).

Refs #100. Builds on #103, #104.

## Test plan
- [x] `npm test` — 237 passed (no source changes; sanity check)
- [x] `npm run build` — clean
- [x] Diff inspected; docs-only, no accidental files / debug leftovers