### PR TITLE
feat(bench): RFC 013 M5 — bench:compare orchestrator + HTML report

### DIFF
--- a/.claude/skills/compare-embedding-models/SKILL.md
+++ b/.claude/skills/compare-embedding-models/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: compare-embedding-models
+description: Run an apples-to-apples benchmark of two embedding models on a fixture or your KB and produce an HTML report covering cold-start indexing, warm-query latency, batch throughput, storage, and quality.
+keywords: [embeddings, benchmark, comparison, latency, throughput, models, html-report, selection]
+anchors:
+  - benchmarks/compare/run.ts::main                                # M5
+  - benchmarks/compare/render.ts::renderReport                     # M5
+  - benchmarks/scenarios/batch-query.ts::runBatchQueryScenario     # M5
+  - benchmarks/scenarios/index-storage.ts::runIndexStorageScenario # M5
+  - src/cli.ts::runAddModel                                        # RFC 013 M2 (cost prompt)
+  - src/cli.ts::runCompare                                         # RFC 013 M2 (per-query side-by-side)
+  - src/cost-estimates.ts::COSTS                                   # M5 (cost-per-MTok table)
+applies_to:
+  - claude-code
+  - claude-desktop
+  - codex-cli
+  - cursor
+  - continue
+  - cline
+last_verified: 2026-04-26
+---
+
+## When to use
+
+- The user is choosing between two embedding models for a new knowledge base and wants concrete numbers (latency, cost, storage, quality) on **their hardware**, not a generic leaderboard.
+- The user has switched models in the past and wants to verify the trade-off was worth it.
+- The user is documenting a model choice for a team and needs an HTML artefact to attach to a decision record / RFC / PR.
+
+## Prerequisites
+
+- knowledge-base-mcp-server `0.3.x` installed (M0–M4 shipped; this skill needs `kb models {add, list}` from §4.4 of RFC 013).
+- Both models reachable: Ollama running locally (`OLLAMA_BASE_URL`) for ollama models; `HUGGINGFACE_API_KEY` set for HF models; `OPENAI_API_KEY` set for OpenAI models. The orchestrator reads provider tokens from env per `src/config.ts`.
+- Disk space: ~10 MiB per model index for the medium synthetic fixture; more for larger profiles.
+- For paid providers: estimated cost surfaced in the orchestrator preamble; non-zero requires `--yes` or interactive confirmation (`src/cli.ts` `runAddModel` flow, RFC 013 §4.4).
+
+## Steps
+
+1. **Identify model ids.** `kb models list` shows registered models with their `<provider>__<slug>` ids. If a target model is not yet registered, run `kb models add <provider> <model_name>` first (the orchestrator can auto-register with `--yes`, but registering explicitly lets the user audit cost upfront).
+
+2. **Pick a fixture profile.**
+   - `--fixture=small` (~150 chunks) — sanity check, ~10 s.
+   - `--fixture=medium` (~600 chunks) — default; ~1 min on Ollama, ~30 s on HF/OpenAI.
+   - `--fixture=external` — runs against the corpus at `KNOWLEDGE_BASES_ROOT_DIR` (the user's real KB; no copy is made).
+   - `--fixture=large` (~3000-chunk arxiv corpus) — selection-grade. **Not yet implemented in v1**; deferred to M5.1 (RFC 013 §4.13.4 follow-up).
+
+3. **Run the comparison:**
+   ```bash
+   npm run bench:compare -- \
+     --models=ollama__nomic-embed-text-latest,huggingface__BAAI-bge-small-en-v1.5 \
+     --fixture=medium \
+     --concurrency=1,4,16
+   ```
+
+4. **Read the report.** Output paths are printed at the end:
+   ```
+   Report: benchmarks/results/compare-<id_a>-vs-<id_b>-<utc-stamp>.html
+   JSON:   benchmarks/results/compare-<id_a>-vs-<id_b>-<utc-stamp>.json
+   ```
+   Open the HTML:
+   ```
+   xdg-open <path>   # Linux
+   open <path>       # macOS
+   ```
+   The report is fully self-contained (inline CSS + SVG, no external assets). Attach it to a PR / Slack / decision record as-is.
+
+5. **Compare the recommendation panel against your priorities.** The panel picks a winner per axis (single-query latency, batch throughput, cost, storage, recall, diversity). If your priorities are mixed, the panel says so explicitly — pick the model that wins your highest-weighted axis.
+
+6. **Optional: golden labels.** Reserved — `--golden=<path>` accepts a JSON `{query: [doc_paths]}` file. The merged JSON output already carries per-query top-k for both models, ready for an external scorer; report-side recall@k integration lands in M5.1.
+
+## Verification
+
+After the run, the report file exists, opens in a browser, and the summary table has a non-empty row for both models:
+
+```bash
+test -s benchmarks/results/compare-*.html && \
+  grep -q 'cold_index_ms' benchmarks/results/compare-*.html && \
+  echo OK
+# expected: OK
+```
+
+For paranoid verification, the merged JSON next to the HTML has `reportA.scenarios.cold_index.chunks > 0` and the same for `reportB`.
+
+## Failure modes
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `bench:compare: invalid model spec "<id>"` | model_id doesn't match `^[a-z]+__[A-Za-z0-9._-]+$` | Use either a parsed `<provider>__<slug>` (run `kb models list` to see registered ids) or `<provider>:<model_name>` form. |
+| `bench:compare: models resolve to the same id` | both `--models=` entries derive to the same slug | Pick two different models. |
+| `OLLAMA_BASE_URL unreachable` | Ollama daemon not running | `ollama serve` in another terminal; verify with `curl $OLLAMA_BASE_URL/api/tags`. |
+| `HUGGINGFACE 429 — rate limited` | HF free tier throttle | Lower `--concurrency=1`; rerun. |
+| `OPENAI 401` | API key missing or expired | Check `OPENAI_API_KEY`. |
+| Cold index never finishes (slow CPU + paid provider) | Time budget exceeded | Drop to `--fixture=small`. |
+| Report opens but storage chart is empty | `index-storage` scenario reports 0 bytes (e.g. stub provider) | Real-provider runs populate storage; stub mode is for orchestrator wiring smoke-tests only. |
+| Cross-model Jaccard is `0.0` everywhere | Models return disjoint top-k or one returned zero results | Check both models' `default_recall_at_10` in the summary; if one is `0`, that model failed retrieval (likely an empty index). Re-run `kb models add --refresh` for the empty model. |
+
+## See also
+
+- RFC 013 §4.13 — full design rationale and orchestrator architecture.
+- `benchmarks/README.md` — `Comparing two embedding models` section.
+- `kb models add` — register a model before benchmarking it.
+- `kb compare <query> <a> <b>` — single-query side-by-side rank table (CLI; complements the orchestrator's batch report).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [Unreleased] — RFC 013 M5 (bench:compare)
+
+### Added (benchmark harness extensions)
+
+- **`npm run bench:compare`** orchestrator — drives two back-to-back per-model bench runs against a shared corpus and renders a self-contained HTML report (inline CSS + SVG; zero deps; reviewer-portable). Six sections: summary table with per-axis winner, latency-distribution charts (single + batch), throughput-vs-concurrency line, on-disk storage stacked bar, query-level top-5 with overlap highlighting, rule-based recommendation panel (RFC 013 §4.13.5).
+- **New scenarios** in `benchmarks/scenarios/`:
+  - `batch-query.ts` — concurrency sweep (default 1/4/16); reports throughput (qps p50/p95) + tail latency p50/p95/p99 per concurrency.
+  - `index-storage.ts` — on-disk byte sizes of `models/<id>/faiss.index/{faiss.index, docstore.json}` after cold-index; computes bytes/vector.
+- **`benchmarks/compare/`** new package: `run.ts` (orchestrator), `render.ts` (HTML hydrator), `chart.ts` (inline-SVG primitives — bar / line / stacked-bar; zero deps), `report-template.html` (skeleton), `queries-default.txt` (50 prose queries for arxiv-like corpora; synthetic fixtures fall back to fixture-derived queries).
+- **`src/cost-estimates.ts`** — extracted from `src/cli.ts` so the orchestrator and the `kb models add` cost prompt share a single rule-of-thumb table. Includes `LAST_VERIFIED` so a stale cost number is visible in the report.
+- **`BENCH_MODEL_NAME`** + **`BENCH_FAISS_INDEX_PATH`** + **`BENCH_KNOWLEDGE_BASES_ROOT_DIR`** + **`BENCH_BATCH_CONCURRENCIES`** + **`BENCH_QUERIES`** + **`BENCH_INCLUDE_BATCH_QUERY`** + **`BENCH_INCLUDE_INDEX_STORAGE`** env vars on `benchmarks/run.ts`. The orchestrator drives two legs by setting these per leg; ad-hoc users can also set them directly.
+- **`benchmarks/.cache/.gitignore`** — placeholder for the future arxiv corpus cache (RFC 013 §4.13.4 follow-up).
+- **`.claude/skills/compare-embedding-models/SKILL.md`** — operator skill describing when to run `bench:compare`, prerequisites, steps, verification, failure modes.
+
+### Deferred to a follow-up (M5.1)
+
+- `--fixture=large` with the ~3000-chunk arxiv (`cs.IR + cs.CL`) corpus and sha256-keyed cache. M5 v1 ships the orchestrator + scenarios + renderer; the synthetic small/medium fixtures already give meaningful latency/throughput/storage/cost signal. Arxiv adds retrieval-quality signal on prose corpora (RFC §4.13.4).
+- `--golden=<path>` recall@k integration into the report (the JSON carries the per-query top-k for both models, ready for an external scorer; the report render step is the missing piece).
+- `.github/workflows/bench-compare-dispatch.yml` (`workflow_dispatch`-only — maintainer manual runs against real providers).
+
 ## [Unreleased] — RFC 013 M1+M2 (draft)
 
 ### Added (technically breaking — on-disk layout migrates)

--- a/benchmarks/.cache/.gitignore
+++ b/benchmarks/.cache/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -110,6 +110,56 @@ Real-provider modes (`ollama`, `huggingface`, `openai`) keep the repository logi
 
 The benchmark fixtures are generated at bench start from a seeded `mulberry32` PRNG. This keeps the corpus stable across runs while avoiding checked-in FAISS binaries that can break across platforms. The generator lives in `benchmarks/fixtures/generator.ts`.
 
+## Comparing two embedding models — `bench:compare` (RFC 013 M5)
+
+The `bench:compare` orchestrator drives two back-to-back per-model bench runs against a shared corpus and emits a self-contained HTML comparison report (inline CSS + SVG; no CDN, no JS framework). Use it to pick between two embedding models on **your hardware** without wiring up MTEB.
+
+```bash
+# Real providers (the only meaningful mode for selection):
+npm run bench:compare -- \
+  --models=ollama__nomic-embed-text-latest,huggingface__BAAI-bge-small-en-v1.5 \
+  --concurrency=1,4,16
+
+# Stub provider, smoke-test only (jaccard will be 1.0 — same vectors):
+BENCH_PROVIDER=stub npm run bench:compare -- \
+  --models=stub:bench-stub-A,stub:bench-stub-B \
+  --fixture=small --concurrency=1,4
+```
+
+Flags (all post `--`):
+
+| Flag | Default | Meaning |
+|------|---------|---------|
+| `--models=<id_a>,<id_b>` | required | Two `<provider>__<slug>` ids (or `<provider>:<modelName>`). |
+| `--fixture=small\|medium\|external` | `medium` | Synthetic profile; `external` honors `KNOWLEDGE_BASES_ROOT_DIR`. (`large`/arxiv corpus is a follow-up.) |
+| `--queries=<path>` | bundled `queries-default.txt` for prose corpora; fixture-derived for synthetic | One query per line; `#`-comments allowed. |
+| `--concurrency=1,4,16` | `1,4,16` | Concurrency sweep for the batch-query phase. |
+| `--golden=<path>` | none | Reserved — JSON `{query: [doc_paths]}` for recall@k. (Not yet wired into the report; follow-up.) |
+| `--output-dir=<path>` | `benchmarks/results` | Where the HTML + JSON pair lands. |
+| `--skip-add` | off | Reuse already-registered models (no re-embed). |
+| `--yes` | off | Non-interactive; skips paid-provider cost prompt. |
+
+Output:
+
+```
+benchmarks/results/compare-<id_a>-vs-<id_b>-<utc-stamp>.html  ← open in any browser
+benchmarks/results/compare-<id_a>-vs-<id_b>-<utc-stamp>.json  ← merged input + crossModel + cost
+```
+
+The HTML has six sections: summary table (with per-axis winner column), latency-distribution charts (single-query + batch p99 by concurrency), throughput-vs-concurrency line chart, on-disk storage stacked bar, query-level detail (collapsible top-5 per model with overlap highlighting), and a rule-based recommendation panel (fixed thresholds documented inline so a skeptical reader can disagree explicitly). Disclaimers section makes the "your-KB selection guidance, NOT MTEB" framing explicit.
+
+Concurrency invariants (RFC 013 §4.13.9):
+
+- Both per-model bench legs run **back-to-back, never in parallel** — avoids CPU/network confounding.
+- Cross-model phase mutates `process.env` per leg to load the right manager; safe because the orchestrator never starts the MCP server (no single-instance contention with a user's running MCP).
+- Per-model write-locks (RFC 013 §4.6) keep concurrent `kb` invocations on the same `FAISS_INDEX_PATH` safe.
+
+Follow-ups not in M5 v1:
+
+- `--fixture=large` with the ~3000-chunk arxiv (`cs.IR + cs.CL`) corpus and sha256-keyed cache (`benchmarks/.cache/`) — RFC 013 §4.13.4. Today the orchestrator runs against the existing seeded synthetic generator at the bench's hardcoded sizes (~600 chunks for cold-index).
+- `--golden` recall@k integration into the report.
+- `workflow_dispatch` GitHub workflow for maintainer-triggered real-provider runs (RFC 013 §4.13.7).
+
 ## Jest mocking strategy note
 
 The repository's unit tests should keep using the existing Jest ESM mock pattern from [`src/FaissIndexManager.test.ts`](../src/FaissIndexManager.test.ts):

--- a/benchmarks/compare/chart.ts
+++ b/benchmarks/compare/chart.ts
@@ -1,0 +1,262 @@
+// RFC 013 §4.13.5 — inline-SVG chart primitives. Zero deps; embeds in a
+// self-contained HTML file so the report opens in any browser without a CDN.
+//
+// Three chart types: histogram, line chart, stacked bar. All return XML strings
+// with no external defs/scripts. Axes drawn manually (no d3); text uses CSS
+// classes from the report stylesheet.
+
+export interface ChartDimensions {
+  width: number;
+  height: number;
+  margin: { top: number; right: number; bottom: number; left: number };
+}
+
+const DEFAULT_DIM: ChartDimensions = {
+  width: 480,
+  height: 240,
+  margin: { top: 20, right: 16, bottom: 32, left: 48 },
+};
+
+export interface SeriesPoint {
+  x: number;
+  y: number;
+}
+
+export interface NamedSeries {
+  name: string;
+  color: string;
+  points: SeriesPoint[];
+}
+
+export interface HistogramBucket {
+  label: string;
+  values: { name: string; color: string; value: number }[];
+}
+
+/**
+ * Bar chart of latency percentiles or similar. Each bucket has one bar per
+ * series, side-by-side.
+ */
+export function renderBarChart(
+  buckets: HistogramBucket[],
+  options: { title?: string; yLabel?: string; dim?: Partial<ChartDimensions> } = {},
+): string {
+  const dim = mergeDim(options.dim);
+  const innerW = dim.width - dim.margin.left - dim.margin.right;
+  const innerH = dim.height - dim.margin.top - dim.margin.bottom;
+  const allValues = buckets.flatMap((b) => b.values.map((v) => v.value));
+  const yMax = niceMax(allValues);
+  const seriesCount = buckets[0]?.values.length ?? 1;
+  const groupGap = 8;
+  const groupW = (innerW - (buckets.length - 1) * groupGap) / Math.max(1, buckets.length);
+  const barW = groupW / seriesCount;
+
+  const bars: string[] = [];
+  buckets.forEach((bucket, i) => {
+    const groupX = dim.margin.left + i * (groupW + groupGap);
+    bucket.values.forEach((v, j) => {
+      const x = groupX + j * barW;
+      const h = yMax > 0 ? (v.value / yMax) * innerH : 0;
+      const y = dim.margin.top + innerH - h;
+      bars.push(`<rect x="${x.toFixed(1)}" y="${y.toFixed(1)}" width="${(barW - 2).toFixed(1)}" height="${h.toFixed(1)}" fill="${escAttr(v.color)}"><title>${escText(v.name)}: ${formatNumber(v.value)}</title></rect>`);
+    });
+  });
+
+  const xLabels = buckets.map((bucket, i) => {
+    const groupX = dim.margin.left + i * (groupW + groupGap) + groupW / 2;
+    return `<text x="${groupX.toFixed(1)}" y="${(dim.margin.top + innerH + 14).toFixed(1)}" class="axis-tick" text-anchor="middle">${escText(bucket.label)}</text>`;
+  }).join('');
+
+  const yTicks = renderYAxis(dim, yMax, options.yLabel);
+
+  return wrapSvg(dim, [
+    options.title ? `<text x="${(dim.width / 2).toFixed(1)}" y="14" class="chart-title" text-anchor="middle">${escText(options.title)}</text>` : '',
+    yTicks,
+    ...bars,
+    xLabels,
+  ]);
+}
+
+/**
+ * Line chart for throughput-vs-concurrency or similar trend data.
+ */
+export function renderLineChart(
+  series: NamedSeries[],
+  options: { title?: string; xLabel?: string; yLabel?: string; dim?: Partial<ChartDimensions> } = {},
+): string {
+  const dim = mergeDim(options.dim);
+  const innerW = dim.width - dim.margin.left - dim.margin.right;
+  const innerH = dim.height - dim.margin.top - dim.margin.bottom;
+  const allX = series.flatMap((s) => s.points.map((p) => p.x));
+  const allY = series.flatMap((s) => s.points.map((p) => p.y));
+  const xMax = niceMax(allX);
+  const yMax = niceMax(allY);
+  const xMin = Math.min(0, ...allX);
+
+  const project = (p: SeriesPoint) => {
+    const x = dim.margin.left + ((p.x - xMin) / (xMax - xMin || 1)) * innerW;
+    const y = dim.margin.top + innerH - (yMax > 0 ? (p.y / yMax) * innerH : 0);
+    return { x, y };
+  };
+
+  const lines = series.map((s) => {
+    const path = s.points.map((p, i) => {
+      const { x, y } = project(p);
+      return `${i === 0 ? 'M' : 'L'} ${x.toFixed(1)} ${y.toFixed(1)}`;
+    }).join(' ');
+    const dots = s.points.map((p) => {
+      const { x, y } = project(p);
+      return `<circle cx="${x.toFixed(1)}" cy="${y.toFixed(1)}" r="3" fill="${escAttr(s.color)}"><title>${escText(s.name)} @ ${p.x}: ${formatNumber(p.y)}</title></circle>`;
+    }).join('');
+    return `<path d="${path}" fill="none" stroke="${escAttr(s.color)}" stroke-width="2"/>${dots}`;
+  }).join('');
+
+  const yAxis = renderYAxis(dim, yMax, options.yLabel);
+  const xAxis = renderXAxisNumeric(dim, xMin, xMax, options.xLabel);
+
+  return wrapSvg(dim, [
+    options.title ? `<text x="${(dim.width / 2).toFixed(1)}" y="14" class="chart-title" text-anchor="middle">${escText(options.title)}</text>` : '',
+    yAxis,
+    xAxis,
+    lines,
+  ]);
+}
+
+/**
+ * Stacked-bar comparison (e.g., vector-binary vs docstore per model).
+ */
+export function renderStackedBar(
+  bars: { label: string; segments: { name: string; color: string; value: number }[] }[],
+  options: { title?: string; yLabel?: string; dim?: Partial<ChartDimensions> } = {},
+): string {
+  const dim = mergeDim(options.dim);
+  const innerW = dim.width - dim.margin.left - dim.margin.right;
+  const innerH = dim.height - dim.margin.top - dim.margin.bottom;
+  const totals = bars.map((b) => b.segments.reduce((sum, s) => sum + s.value, 0));
+  const yMax = niceMax(totals);
+  const gap = 16;
+  const barW = (innerW - (bars.length - 1) * gap) / Math.max(1, bars.length);
+
+  const rects: string[] = [];
+  bars.forEach((bar, i) => {
+    const x = dim.margin.left + i * (barW + gap);
+    let yCursor = dim.margin.top + innerH;
+    bar.segments.forEach((seg) => {
+      const h = yMax > 0 ? (seg.value / yMax) * innerH : 0;
+      yCursor -= h;
+      rects.push(`<rect x="${x.toFixed(1)}" y="${yCursor.toFixed(1)}" width="${barW.toFixed(1)}" height="${h.toFixed(1)}" fill="${escAttr(seg.color)}"><title>${escText(seg.name)}: ${formatBytes(seg.value)}</title></rect>`);
+    });
+  });
+
+  const xLabels = bars.map((bar, i) => {
+    const x = dim.margin.left + i * (barW + gap) + barW / 2;
+    return `<text x="${x.toFixed(1)}" y="${(dim.margin.top + innerH + 14).toFixed(1)}" class="axis-tick" text-anchor="middle">${escText(bar.label)}</text>`;
+  }).join('');
+
+  const yAxis = renderYAxis(dim, yMax, options.yLabel, formatBytes);
+
+  return wrapSvg(dim, [
+    options.title ? `<text x="${(dim.width / 2).toFixed(1)}" y="14" class="chart-title" text-anchor="middle">${escText(options.title)}</text>` : '',
+    yAxis,
+    ...rects,
+    xLabels,
+  ]);
+}
+
+/**
+ * Legend block. Plain HTML; sits next to or below a chart.
+ */
+export function renderLegend(items: { name: string; color: string }[]): string {
+  const dots = items.map(
+    (i) => `<span class="legend-item"><span class="legend-dot" style="background:${escAttr(i.color)}"></span>${escText(i.name)}</span>`,
+  ).join('');
+  return `<div class="legend">${dots}</div>`;
+}
+
+// ---- internals ----
+
+function mergeDim(partial?: Partial<ChartDimensions>): ChartDimensions {
+  return {
+    width: partial?.width ?? DEFAULT_DIM.width,
+    height: partial?.height ?? DEFAULT_DIM.height,
+    margin: { ...DEFAULT_DIM.margin, ...(partial?.margin ?? {}) },
+  };
+}
+
+function wrapSvg(dim: ChartDimensions, children: string[]): string {
+  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${dim.width} ${dim.height}" class="chart">${children.filter(Boolean).join('')}</svg>`;
+}
+
+function renderYAxis(
+  dim: ChartDimensions,
+  yMax: number,
+  yLabel?: string,
+  formatter: (v: number) => string = formatNumber,
+): string {
+  const innerH = dim.height - dim.margin.top - dim.margin.bottom;
+  const ticks = niceTicks(yMax, 4);
+  const tickLines = ticks.map((tick) => {
+    const y = dim.margin.top + innerH - (yMax > 0 ? (tick / yMax) * innerH : 0);
+    return `<line x1="${dim.margin.left}" y1="${y.toFixed(1)}" x2="${(dim.width - dim.margin.right).toFixed(1)}" y2="${y.toFixed(1)}" class="grid-line"/><text x="${(dim.margin.left - 4).toFixed(1)}" y="${(y + 3).toFixed(1)}" class="axis-tick" text-anchor="end">${escText(formatter(tick))}</text>`;
+  }).join('');
+  const label = yLabel
+    ? `<text x="12" y="${(dim.margin.top + innerH / 2).toFixed(1)}" class="axis-label" text-anchor="middle" transform="rotate(-90 12 ${(dim.margin.top + innerH / 2).toFixed(1)})">${escText(yLabel)}</text>`
+    : '';
+  return tickLines + label;
+}
+
+function renderXAxisNumeric(dim: ChartDimensions, xMin: number, xMax: number, xLabel?: string): string {
+  const innerW = dim.width - dim.margin.left - dim.margin.right;
+  const innerH = dim.height - dim.margin.top - dim.margin.bottom;
+  const ticks = niceTicks(xMax - xMin, 4).map((t) => xMin + t);
+  const tickMarks = ticks.map((tick) => {
+    const x = dim.margin.left + ((tick - xMin) / (xMax - xMin || 1)) * innerW;
+    return `<text x="${x.toFixed(1)}" y="${(dim.margin.top + innerH + 14).toFixed(1)}" class="axis-tick" text-anchor="middle">${escText(formatNumber(tick))}</text>`;
+  }).join('');
+  const label = xLabel
+    ? `<text x="${(dim.margin.left + innerW / 2).toFixed(1)}" y="${(dim.height - 4).toFixed(1)}" class="axis-label" text-anchor="middle">${escText(xLabel)}</text>`
+    : '';
+  return tickMarks + label;
+}
+
+function niceMax(values: number[]): number {
+  if (values.length === 0) return 1;
+  const max = Math.max(...values);
+  if (max <= 0) return 1;
+  const magnitude = Math.pow(10, Math.floor(Math.log10(max)));
+  const ratio = max / magnitude;
+  if (ratio < 1.5) return 1.5 * magnitude;
+  if (ratio < 3) return 3 * magnitude;
+  if (ratio < 7) return 7 * magnitude;
+  return 10 * magnitude;
+}
+
+function niceTicks(yMax: number, count: number): number[] {
+  const step = yMax / count;
+  const result: number[] = [];
+  for (let i = 1; i <= count; i += 1) result.push(step * i);
+  return result;
+}
+
+function formatNumber(value: number): string {
+  if (value === 0) return '0';
+  if (value >= 1000) return value.toLocaleString('en-US', { maximumFractionDigits: 0 });
+  if (value >= 10) return value.toFixed(1);
+  return value.toFixed(2);
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes <= 0 || !Number.isFinite(bytes)) return '0 B';
+  const units = ['B', 'KiB', 'MiB', 'GiB'];
+  const exp = Math.min(units.length - 1, Math.max(0, Math.floor(Math.log(bytes) / Math.log(1024))));
+  const value = bytes / Math.pow(1024, exp);
+  return `${value.toFixed(value >= 100 ? 0 : 1)} ${units[exp]}`;
+}
+
+function escAttr(s: string): string {
+  return s.replace(/[&<>"]/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c]!));
+}
+
+function escText(s: string): string {
+  return s.replace(/[&<>]/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;' }[c]!));
+}

--- a/benchmarks/compare/queries-default.txt
+++ b/benchmarks/compare/queries-default.txt
@@ -1,0 +1,56 @@
+# RFC 013 §4.13.2 — default queries for `npm run bench:compare`.
+# 50 queries; one per line; comments start with `#` and are skipped.
+# These queries assume an English technical-text corpus (e.g., the large arxiv
+# fixture or an operator's own KB). For the synthetic small/medium fixtures
+# the orchestrator falls back to fixture-derived queries instead.
+
+what is attention in transformer models
+how does retrieval-augmented generation differ from fine-tuning
+what is reciprocal rank fusion
+embedding model evaluation methodology
+sparse versus dense retrieval comparison
+contrastive learning for sentence embeddings
+how do bi-encoders differ from cross-encoders
+hard negative mining for retrieval training
+matryoshka representation learning
+quantization aware training for embedding models
+binary embedding hashing techniques
+distillation of cross encoders into bi encoders
+training data deduplication for retrieval
+out of distribution evaluation of embeddings
+cross lingual retrieval transfer
+embedding dimension reduction without loss
+rotary positional encoding behaviour
+information retrieval test collections
+query augmentation strategies
+pseudo relevance feedback methods
+domain adaptation for retrieval models
+benchmarking faiss versus hnsw libraries
+approximate nearest neighbour graph construction
+product quantization for vector search
+inverted file index in faiss
+recall accuracy tradeoff in ann search
+reranking with monoT5 versus colbert
+sliding window context for long documents
+chunk size impact on retrieval quality
+markdown structure preservation in chunking
+sentence boundary detection for splitting
+overlap selection in fixed window chunking
+metadata filtering for hybrid search
+boolean filters in dense retrieval systems
+faceted search over embedding indexes
+streaming ingest for vector databases
+incremental indexing without rebuild
+write amplification in faiss saves
+mtime versus content hash for change detection
+file watcher fanout in node js
+retry semantics for embedding APIs
+rate limit backoff for huggingface inference
+ollama local inference performance
+openai embedding model pricing tiers
+cost per million tokens at scale
+energy footprint of cpu inference
+batched embedding throughput on cpu
+quantization for cpu inference
+speculative decoding for embedding models
+tail latency p99 in vector search

--- a/benchmarks/compare/render.ts
+++ b/benchmarks/compare/render.ts
@@ -1,0 +1,435 @@
+// RFC 013 §4.13.5 — render a comparison HTML report from two BenchmarkReports
+// + a CrossModelResult. Hydrates `report-template.html` via plain string
+// substitution (no Handlebars / no React). Output is fully self-contained:
+// inline CSS, inline SVG, no external assets.
+
+import * as fsp from 'fs/promises';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+import type { BenchmarkReport } from '../types.js';
+import { renderBarChart, renderLegend, renderLineChart, renderStackedBar } from './chart.js';
+
+export interface CrossModelQueryResult {
+  query: string;
+  jaccard: number;
+  topK_a: { doc: string; score: number }[];
+  topK_b: { doc: string; score: number }[];
+}
+
+export interface CrossModelAggregate {
+  jaccard_p50: number;
+  jaccard_p95: number;
+  spearman_p50: number;
+  overlap_doc_count: number;
+  per_query: CrossModelQueryResult[];
+}
+
+export interface CostBreakdownPair {
+  model_a_usd: number;
+  model_b_usd: number;
+  source: 'rule-of-thumb' | 'api-usage';
+  last_verified: string;
+}
+
+export interface RenderInput {
+  reportA: BenchmarkReport;
+  reportB: BenchmarkReport;
+  modelA: { id: string; name: string };
+  modelB: { id: string; name: string };
+  fixture: { profile: string; chunks: number };
+  crossModel: CrossModelAggregate;
+  cost: CostBreakdownPair;
+  generatedAt: string;
+}
+
+const COLOR_A = '#1f77b4';
+const COLOR_B = '#ff7f0e';
+
+interface SummaryRow {
+  metric: string;
+  a: string;
+  b: string;
+  winner: 'A' | 'B' | 'tie' | 'na';
+  detail?: string;
+}
+
+export async function renderReport(input: RenderInput): Promise<string> {
+  const template = await loadTemplate();
+  const summaryRows = buildSummaryRows(input);
+  const recommendationRows = buildRecommendation(input);
+  const queryDetails = buildQueryDetails(input);
+
+  const warmChart = renderBarChart(
+    [
+      { label: 'p50', values: warmBars(input, 'p50_ms') },
+      { label: 'p95', values: warmBars(input, 'p95_ms') },
+      { label: 'p99', values: warmBars(input, 'p99_ms') },
+    ],
+    { yLabel: 'ms' },
+  );
+
+  const batchLatencyChart = input.reportA.scenarios.batch_query && input.reportB.scenarios.batch_query
+    ? renderBatchLatencyChart(input)
+    : '<p class="meta">batch-query scenario not present in both reports</p>';
+
+  const throughputChart = input.reportA.scenarios.batch_query && input.reportB.scenarios.batch_query
+    ? renderThroughputChart(input)
+    : '<p class="meta">batch-query scenario not present in both reports</p>';
+
+  const storageChart = input.reportA.scenarios.index_storage && input.reportB.scenarios.index_storage
+    ? renderStorageChart(input)
+    : '<p class="meta">index-storage scenario not present in both reports</p>';
+
+  const meta = formatMeta(input);
+
+  return template
+    .replace(/\{\{TITLE\}\}/g, escHtml(`Embedding model comparison: ${input.modelA.id} vs ${input.modelB.id}`))
+    .replace('{{META}}', meta)
+    .replace('{{LEGEND}}', renderLegend([
+      { name: `A — ${input.modelA.id}`, color: COLOR_A },
+      { name: `B — ${input.modelB.id}`, color: COLOR_B },
+    ]))
+    .replace('{{SUMMARY_ROWS}}', summaryRows.map(rowHtml).join(''))
+    .replace('{{CHART_WARM}}', warmChart)
+    .replace('{{CHART_BATCH_LATENCY}}', batchLatencyChart)
+    .replace('{{CHART_THROUGHPUT}}', throughputChart)
+    .replace('{{CHART_STORAGE}}', storageChart)
+    .replace('{{QUERY_COUNT}}', String(input.crossModel.per_query.length))
+    .replace('{{QUERY_DETAILS}}', queryDetails)
+    .replace('{{RECOMMENDATION_TABLE}}', recommendationRows)
+    .replace('{{COST_LAST_VERIFIED}}', escHtml(input.cost.last_verified || 'unknown'));
+}
+
+async function loadTemplate(): Promise<string> {
+  // The template is a static asset that lives in `benchmarks/compare/` in the
+  // source tree but isn't copied to the build tree by tsc. Search both
+  // locations so the renderer works whether invoked from the build output or
+  // (in future) from a tsx run.
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  const candidates = [
+    path.join(here, 'report-template.html'),
+    // Compiled-output path: build/benchmarks/compare/ → ../../../benchmarks/compare/
+    path.join(here, '..', '..', '..', 'benchmarks', 'compare', 'report-template.html'),
+    // Repo-root-relative fallback (works when CWD is the repo root):
+    path.resolve(process.cwd(), 'benchmarks', 'compare', 'report-template.html'),
+  ];
+  for (const candidate of candidates) {
+    try {
+      return await fsp.readFile(candidate, 'utf-8');
+    } catch {
+      // try next
+    }
+  }
+  throw new Error(`render: could not locate report-template.html in any of: ${candidates.join(', ')}`);
+}
+
+function buildSummaryRows(input: RenderInput): SummaryRow[] {
+  const rows: SummaryRow[] = [];
+  const { reportA, reportB } = input;
+
+  rows.push({
+    metric: 'cold_index_ms',
+    a: reportA.scenarios.cold_index.ms.toFixed(0),
+    b: reportB.scenarios.cold_index.ms.toFixed(0),
+    winner: lowerIsBetter(reportA.scenarios.cold_index.ms, reportB.scenarios.cold_index.ms),
+    detail: detailRatio(reportA.scenarios.cold_index.ms, reportB.scenarios.cold_index.ms, 'lower'),
+  });
+  rows.push({
+    metric: 'warm_query_p50_ms',
+    a: reportA.scenarios.warm_query.p50_ms.toFixed(2),
+    b: reportB.scenarios.warm_query.p50_ms.toFixed(2),
+    winner: lowerIsBetter(reportA.scenarios.warm_query.p50_ms, reportB.scenarios.warm_query.p50_ms),
+  });
+  rows.push({
+    metric: 'warm_query_p99_ms',
+    a: reportA.scenarios.warm_query.p99_ms.toFixed(2),
+    b: reportB.scenarios.warm_query.p99_ms.toFixed(2),
+    winner: lowerIsBetter(reportA.scenarios.warm_query.p99_ms, reportB.scenarios.warm_query.p99_ms),
+  });
+
+  const batchA = reportA.scenarios.batch_query?.runs.find((r) => r.concurrency === 16);
+  const batchB = reportB.scenarios.batch_query?.runs.find((r) => r.concurrency === 16);
+  if (batchA && batchB) {
+    rows.push({
+      metric: 'batch_qps@16',
+      a: batchA.qps_p50.toFixed(1),
+      b: batchB.qps_p50.toFixed(1),
+      winner: higherIsBetter(batchA.qps_p50, batchB.qps_p50),
+    });
+  }
+
+  if (reportA.scenarios.index_storage && reportB.scenarios.index_storage) {
+    const aMiB = reportA.scenarios.index_storage.total_bytes / 1024 / 1024;
+    const bMiB = reportB.scenarios.index_storage.total_bytes / 1024 / 1024;
+    rows.push({
+      metric: 'total_storage_MiB',
+      a: aMiB.toFixed(2),
+      b: bMiB.toFixed(2),
+      winner: aMiB === 0 && bMiB === 0 ? 'na' : lowerIsBetter(aMiB, bMiB),
+    });
+  }
+
+  rows.push({
+    metric: 'estimated_cost_usd',
+    a: input.cost.model_a_usd.toFixed(4),
+    b: input.cost.model_b_usd.toFixed(4),
+    winner: input.cost.model_a_usd === input.cost.model_b_usd
+      ? 'tie'
+      : lowerIsBetter(input.cost.model_a_usd, input.cost.model_b_usd),
+  });
+
+  rows.push({
+    metric: 'default_recall@10',
+    a: reportA.scenarios.retrieval_quality.default_recall_at_10.toFixed(3),
+    b: reportB.scenarios.retrieval_quality.default_recall_at_10.toFixed(3),
+    winner: higherIsBetter(
+      reportA.scenarios.retrieval_quality.default_recall_at_10,
+      reportB.scenarios.retrieval_quality.default_recall_at_10,
+    ),
+  });
+
+  rows.push({
+    metric: 'jaccard_top10_p50',
+    a: input.crossModel.jaccard_p50.toFixed(2),
+    b: input.crossModel.jaccard_p50.toFixed(2),
+    winner: 'na',
+    detail: `cross-model agreement (lower = more disjoint)`,
+  });
+
+  return rows;
+}
+
+function rowHtml(row: SummaryRow): string {
+  const winnerCell =
+    row.winner === 'A' ? `<td class="winner">A${row.detail ? ` (${row.detail})` : ''}</td>` :
+    row.winner === 'B' ? `<td class="winner">B${row.detail ? ` (${row.detail})` : ''}</td>` :
+    row.winner === 'tie' ? `<td class="tie">tie</td>` :
+    `<td class="tie">${escHtml(row.detail ?? 'N/A')}</td>`;
+  return `<tr><td>${escHtml(row.metric)}</td><td>${escHtml(row.a)}</td><td>${escHtml(row.b)}</td>${winnerCell}</tr>`;
+}
+
+function lowerIsBetter(a: number, b: number): SummaryRow['winner'] {
+  if (a === b) return 'tie';
+  return a < b ? 'A' : 'B';
+}
+function higherIsBetter(a: number, b: number): SummaryRow['winner'] {
+  if (a === b) return 'tie';
+  return a > b ? 'A' : 'B';
+}
+function detailRatio(a: number, b: number, betterDirection: 'lower' | 'higher'): string {
+  if (a === 0 || b === 0) return '';
+  const winner = betterDirection === 'lower' ? Math.min(a, b) : Math.max(a, b);
+  const loser = betterDirection === 'lower' ? Math.max(a, b) : Math.min(a, b);
+  const ratio = betterDirection === 'lower' ? loser / winner : winner / loser;
+  if (!Number.isFinite(ratio) || ratio < 1.05) return '';
+  return `${ratio.toFixed(2)}× ${betterDirection === 'lower' ? 'faster' : 'higher'}`;
+}
+
+function warmBars(input: RenderInput, key: 'p50_ms' | 'p95_ms' | 'p99_ms') {
+  return [
+    { name: input.modelA.id, color: COLOR_A, value: input.reportA.scenarios.warm_query[key] },
+    { name: input.modelB.id, color: COLOR_B, value: input.reportB.scenarios.warm_query[key] },
+  ];
+}
+
+function renderBatchLatencyChart(input: RenderInput): string {
+  const runsA = input.reportA.scenarios.batch_query!.runs;
+  const runsB = input.reportB.scenarios.batch_query!.runs;
+  // Use union of concurrencies; align by value
+  const concurrencies = Array.from(new Set([...runsA.map((r) => r.concurrency), ...runsB.map((r) => r.concurrency)])).sort((x, y) => x - y);
+  const buckets = concurrencies.map((c) => {
+    const a = runsA.find((r) => r.concurrency === c);
+    const b = runsB.find((r) => r.concurrency === c);
+    return {
+      label: `c=${c}`,
+      values: [
+        { name: `${input.modelA.id} p99`, color: COLOR_A, value: a?.latency_p99_ms ?? 0 },
+        { name: `${input.modelB.id} p99`, color: COLOR_B, value: b?.latency_p99_ms ?? 0 },
+      ],
+    };
+  });
+  return renderBarChart(buckets, { yLabel: 'p99 ms' });
+}
+
+function renderThroughputChart(input: RenderInput): string {
+  const seriesA = {
+    name: input.modelA.id,
+    color: COLOR_A,
+    points: input.reportA.scenarios.batch_query!.runs.map((r) => ({ x: r.concurrency, y: r.qps_p50 })),
+  };
+  const seriesB = {
+    name: input.modelB.id,
+    color: COLOR_B,
+    points: input.reportB.scenarios.batch_query!.runs.map((r) => ({ x: r.concurrency, y: r.qps_p50 })),
+  };
+  return renderLineChart([seriesA, seriesB], { xLabel: 'concurrency', yLabel: 'qps (p50)' });
+}
+
+function renderStorageChart(input: RenderInput): string {
+  const sa = input.reportA.scenarios.index_storage!;
+  const sb = input.reportB.scenarios.index_storage!;
+  return renderStackedBar(
+    [
+      { label: input.modelA.id, segments: [
+        { name: 'vector binary', color: COLOR_A, value: sa.vector_binary_bytes },
+        { name: 'docstore', color: '#9ec5e7', value: sa.docstore_bytes },
+      ] },
+      { label: input.modelB.id, segments: [
+        { name: 'vector binary', color: COLOR_B, value: sb.vector_binary_bytes },
+        { name: 'docstore', color: '#ffc18a', value: sb.docstore_bytes },
+      ] },
+    ],
+    { yLabel: 'bytes' },
+  );
+}
+
+function buildQueryDetails(input: RenderInput): string {
+  if (input.crossModel.per_query.length === 0) {
+    return '<p class="meta">no per-query results captured</p>';
+  }
+  // Cap to 50 to keep the HTML reasonable
+  const items = input.crossModel.per_query.slice(0, 50);
+  return items.map((q) => {
+    const overlap = new Set(
+      q.topK_a.map((x) => x.doc).filter((doc) => q.topK_b.some((y) => y.doc === doc)),
+    );
+    const list = (results: { doc: string; score: number }[]) => results.slice(0, 5).map((r) => {
+      const cls = overlap.has(r.doc) ? 'doc overlap' : 'doc';
+      return `<div class="${cls}">${escHtml(r.doc)} <span class="meta">(${r.score.toFixed(3)})</span></div>`;
+    }).join('');
+    return `<details class="query-detail">
+<summary>j=${q.jaccard.toFixed(2)} • ${escHtml(q.query.slice(0, 80))}${q.query.length > 80 ? '…' : ''}</summary>
+<div class="results">
+  <div><strong>A</strong>${list(q.topK_a)}</div>
+  <div><strong>B</strong>${list(q.topK_b)}</div>
+</div>
+</details>`;
+  }).join('');
+}
+
+interface RecommendationAxis {
+  axis: string;
+  pick: 'A' | 'B' | 'none';
+  reason: string;
+}
+
+function buildRecommendation(input: RenderInput): string {
+  const axes: RecommendationAxis[] = [];
+  const { reportA, reportB } = input;
+
+  // single-query latency: A's p99 is 25%+ lower than B's
+  const p99A = reportA.scenarios.warm_query.p99_ms;
+  const p99B = reportB.scenarios.warm_query.p99_ms;
+  axes.push(latencyAxis('single-query latency (warm p99)', p99A, p99B, 0.25));
+
+  // batch throughput: qps@16 40%+ higher
+  const batchA = reportA.scenarios.batch_query?.runs.find((r) => r.concurrency === 16);
+  const batchB = reportB.scenarios.batch_query?.runs.find((r) => r.concurrency === 16);
+  if (batchA && batchB) {
+    axes.push(throughputAxis('batch throughput (qps @ c=16)', batchA.qps_p50, batchB.qps_p50, 0.40));
+  }
+
+  // cost: 30%+ lower
+  axes.push(costAxis(input.cost.model_a_usd, input.cost.model_b_usd, 0.30));
+
+  // storage: bytes/vector 33%+ lower
+  if (reportA.scenarios.index_storage && reportB.scenarios.index_storage) {
+    const bvA = reportA.scenarios.index_storage.bytes_per_vector;
+    const bvB = reportB.scenarios.index_storage.bytes_per_vector;
+    if (bvA > 0 && bvB > 0) {
+      axes.push(storageAxis(bvA, bvB, 0.33));
+    }
+  }
+
+  // recall: 5%+ higher
+  const recallA = reportA.scenarios.retrieval_quality.default_recall_at_10;
+  const recallB = reportB.scenarios.retrieval_quality.default_recall_at_10;
+  axes.push(recallAxis(recallA, recallB, 0.05));
+
+  // diversity (no winner)
+  axes.push({
+    axis: 'result diversity',
+    pick: 'none',
+    reason: `Jaccard p50 = ${input.crossModel.jaccard_p50.toFixed(2)} ⇒ ~${Math.round((1 - input.crossModel.jaccard_p50) * 100)}% non-overlap; consider RRF if both are useful.`,
+  });
+
+  const rows = axes.map((a) => {
+    const cellPick = a.pick === 'none'
+      ? `<td class="pick none">—</td>`
+      : `<td class="pick">${a.pick}</td>`;
+    return `<tr><td>${escHtml(a.axis)}</td>${cellPick}<td style="text-align:left">${escHtml(a.reason)}</td></tr>`;
+  }).join('');
+
+  return `<table>
+<thead><tr><th>If you optimise for…</th><th>Pick</th><th style="text-align:left">Reason</th></tr></thead>
+<tbody>${rows}</tbody>
+</table>`;
+}
+
+function latencyAxis(label: string, a: number, b: number, threshold: number): RecommendationAxis {
+  if (a === 0 && b === 0) return { axis: label, pick: 'none', reason: 'no measurements' };
+  const winner = a < b ? 'A' : 'B';
+  const winnerVal = Math.min(a, b);
+  const loserVal = Math.max(a, b);
+  const ratio = (loserVal - winnerVal) / loserVal;
+  return ratio >= threshold
+    ? { axis: label, pick: winner, reason: `${winner === 'A' ? "A's" : "B's"} p99 is ${(ratio * 100).toFixed(0)}% lower (threshold ${(threshold * 100).toFixed(0)}%).` }
+    : { axis: label, pick: 'none', reason: `gap (${(ratio * 100).toFixed(0)}%) below threshold (${(threshold * 100).toFixed(0)}%) — call it a tie.` };
+}
+
+function throughputAxis(label: string, a: number, b: number, threshold: number): RecommendationAxis {
+  if (a === 0 && b === 0) return { axis: label, pick: 'none', reason: 'no measurements' };
+  const winner = a > b ? 'A' : 'B';
+  const winnerVal = Math.max(a, b);
+  const loserVal = Math.min(a, b);
+  const ratio = loserVal === 0 ? 1 : (winnerVal - loserVal) / loserVal;
+  return ratio >= threshold
+    ? { axis: label, pick: winner, reason: `${winner === 'A' ? "A's" : "B's"} qps is ${(ratio * 100).toFixed(0)}% higher (threshold ${(threshold * 100).toFixed(0)}%).` }
+    : { axis: label, pick: 'none', reason: `gap (${(ratio * 100).toFixed(0)}%) below threshold.` };
+}
+
+function costAxis(a: number, b: number, threshold: number): RecommendationAxis {
+  if (a === 0 && b === 0) return { axis: 'cost per re-embed', pick: 'none', reason: 'both free → tie.' };
+  const winner = a < b ? 'A' : 'B';
+  const winnerVal = Math.min(a, b);
+  const loserVal = Math.max(a, b);
+  if (winnerVal === 0) return { axis: 'cost per re-embed', pick: winner, reason: `${winner} is free; the other costs $${loserVal.toFixed(4)}.` };
+  const ratio = (loserVal - winnerVal) / loserVal;
+  return ratio >= threshold
+    ? { axis: 'cost per re-embed', pick: winner, reason: `${winner === 'A' ? "A's" : "B's"} cost is ${(ratio * 100).toFixed(0)}% lower.` }
+    : { axis: 'cost per re-embed', pick: 'none', reason: `gap (${(ratio * 100).toFixed(0)}%) below threshold.` };
+}
+
+function storageAxis(a: number, b: number, threshold: number): RecommendationAxis {
+  const winner = a < b ? 'A' : 'B';
+  const winnerVal = Math.min(a, b);
+  const loserVal = Math.max(a, b);
+  const ratio = (loserVal - winnerVal) / loserVal;
+  return ratio >= threshold
+    ? { axis: 'storage at 10× growth', pick: winner, reason: `${winner === 'A' ? "A's" : "B's"} bytes/vector is ${(ratio * 100).toFixed(0)}% lower.` }
+    : { axis: 'storage at 10× growth', pick: 'none', reason: `gap (${(ratio * 100).toFixed(0)}%) below threshold.` };
+}
+
+function recallAxis(a: number, b: number, threshold: number): RecommendationAxis {
+  if (a === 0 && b === 0) return { axis: 'recall@10', pick: 'none', reason: 'no labelled queries.' };
+  const winner = a > b ? 'A' : 'B';
+  const winnerVal = Math.max(a, b);
+  const loserVal = Math.min(a, b);
+  const diff = winnerVal - loserVal;
+  return diff >= threshold
+    ? { axis: 'recall@10 (if labelled)', pick: winner, reason: `${winner === 'A' ? "A's" : "B's"} recall is ${(diff * 100).toFixed(1)}pp higher.` }
+    : { axis: 'recall@10', pick: 'none', reason: `gap (${(diff * 100).toFixed(1)}pp) below threshold (${(threshold * 100).toFixed(0)}pp).` };
+}
+
+function formatMeta(input: RenderInput): string {
+  const a = input.reportA;
+  return `Generated ${escHtml(input.generatedAt)} • ` +
+    `node ${escHtml(a.node_version)} • ${escHtml(a.os)}-${escHtml(a.arch)} • ` +
+    `git <code>${escHtml(a.git_sha)}</code> • ` +
+    `provider A=<code>${escHtml(a.provider)}</code>, B=<code>${escHtml(input.reportB.provider)}</code> • ` +
+    `fixture=${escHtml(input.fixture.profile)} (${input.fixture.chunks} chunks)`;
+}
+
+function escHtml(s: string): string {
+  return s.replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]!));
+}

--- a/benchmarks/compare/report-template.html
+++ b/benchmarks/compare/report-template.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>{{TITLE}}</title>
+<style>
+  :root {
+    --color-a: #1f77b4;
+    --color-b: #ff7f0e;
+    --bg: #fafafa;
+    --fg: #222;
+    --muted: #666;
+    --rule: #ddd;
+    --winner-bg: #e9f4ff;
+    --tie-bg: #f0f0f0;
+  }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+    background: var(--bg);
+    color: var(--fg);
+    margin: 0;
+    padding: 24px;
+    max-width: 1080px;
+    margin-left: auto;
+    margin-right: auto;
+    line-height: 1.5;
+  }
+  h1 { font-size: 22px; margin: 0 0 4px 0; }
+  h2 { font-size: 16px; margin: 32px 0 8px 0; padding-bottom: 4px; border-bottom: 1px solid var(--rule); }
+  h3 { font-size: 14px; margin: 16px 0 4px 0; color: var(--muted); }
+  .meta { color: var(--muted); font-size: 12px; margin-bottom: 16px; }
+  .meta code { background: #eef; padding: 1px 4px; border-radius: 3px; }
+
+  table { border-collapse: collapse; width: 100%; font-size: 13px; }
+  th, td { border-bottom: 1px solid var(--rule); padding: 6px 10px; text-align: right; }
+  th:first-child, td:first-child { text-align: left; }
+  th { background: #f2f2f2; font-weight: 600; }
+  td.winner { background: var(--winner-bg); font-weight: 600; }
+  td.tie { background: var(--tie-bg); color: var(--muted); }
+
+  .legend { display: flex; gap: 16px; margin: 8px 0 16px; font-size: 12px; }
+  .legend-item { display: flex; align-items: center; gap: 6px; }
+  .legend-dot { display: inline-block; width: 10px; height: 10px; border-radius: 2px; }
+
+  .charts { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; align-items: start; }
+  .chart { display: block; max-width: 100%; height: auto; }
+  .chart-title { font-size: 12px; font-weight: 600; fill: var(--fg); }
+  .axis-tick { font-size: 10px; fill: var(--muted); }
+  .axis-label { font-size: 11px; fill: var(--muted); }
+  .grid-line { stroke: var(--rule); stroke-width: 0.5; }
+
+  .recommendation { background: #fffaf0; border: 1px solid #f0d090; padding: 12px 16px; border-radius: 4px; margin-top: 12px; font-size: 13px; }
+  .recommendation table { font-size: 12px; }
+  .recommendation td.pick { font-weight: 600; }
+  .recommendation .none { color: var(--muted); font-style: italic; }
+
+  details { margin: 8px 0; }
+  details summary { cursor: pointer; font-size: 13px; color: var(--muted); }
+  details[open] summary { color: var(--fg); }
+  .query-detail { font-size: 12px; padding: 8px 16px; background: #f6f6f6; border-radius: 3px; margin: 4px 0; }
+  .query-detail .q { font-weight: 600; margin-bottom: 4px; }
+  .query-detail .results { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
+  .query-detail .results > div { background: white; padding: 4px 8px; border-radius: 3px; }
+  .query-detail .doc { font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace; font-size: 11px; }
+  .query-detail .overlap { background: #e9f4ff !important; }
+
+  .disclaimers { font-size: 11px; color: var(--muted); margin-top: 24px; padding-top: 12px; border-top: 1px solid var(--rule); }
+  .disclaimers ul { margin: 4px 0 0 20px; padding: 0; }
+</style>
+</head>
+<body>
+<h1>{{TITLE}}</h1>
+<div class="meta">{{META}}</div>
+
+{{LEGEND}}
+
+<h2>Summary</h2>
+<table>
+  <thead>
+    <tr><th>Metric</th><th>Model A</th><th>Model B</th><th>Winner</th></tr>
+  </thead>
+  <tbody>
+    {{SUMMARY_ROWS}}
+  </tbody>
+</table>
+
+<h2>Latency distribution (single + batch)</h2>
+<div class="charts">
+  <div>
+    <h3>Single-query (warm) p50 / p95 / p99 (ms)</h3>
+    {{CHART_WARM}}
+  </div>
+  <div>
+    <h3>Batch latency p50 / p95 / p99 by concurrency (ms)</h3>
+    {{CHART_BATCH_LATENCY}}
+  </div>
+</div>
+
+<h2>Throughput vs concurrency</h2>
+{{CHART_THROUGHPUT}}
+
+<h2>Storage</h2>
+{{CHART_STORAGE}}
+
+<h2>Query-level detail</h2>
+<details>
+<summary>Show top-5 results per model side-by-side ({{QUERY_COUNT}} queries; click a query to expand)</summary>
+{{QUERY_DETAILS}}
+</details>
+
+<h2>Recommendation</h2>
+<div class="recommendation">
+  <p>The picker below uses fixed thresholds (no machine-learned scorer). Each axis has an independent winner; the global "no clear winner" verdict means axes disagree. <strong>Pick the model that wins your highest-weighted axis.</strong></p>
+  {{RECOMMENDATION_TABLE}}
+</div>
+
+<div class="disclaimers">
+  <strong>Disclaimers</strong>
+  <ul>
+    <li>This report is your-KB selection guidance, NOT an MTEB leaderboard (RFC 013 §3.2 N10).</li>
+    <li>Latency depends on hardware; rerun on the deployment target.</li>
+    <li>Recall@10 requires golden labels; absent them, only Jaccard / Spearman are shown.</li>
+    <li>Cost numbers reflect <code>src/cost-estimates.ts</code> <code>LAST_VERIFIED={{COST_LAST_VERIFIED}}</code>; verify if stale.</li>
+    <li>One machine, one moment. Comparing across hardware = run the orchestrator on each and diff manually.</li>
+  </ul>
+</div>
+</body>
+</html>

--- a/benchmarks/compare/run.ts
+++ b/benchmarks/compare/run.ts
@@ -1,0 +1,592 @@
+// RFC 013 §4.13 M5 orchestrator. Drives two back-to-back per-model bench runs
+// and emits a self-contained HTML comparison report.
+//
+// Surface:
+//   npm run bench:compare -- --models=<id_a>,<id_b> [--fixture=small|medium]
+//                            [--queries=<path>] [--concurrency=1,4,16]
+//                            [--golden=<path>] [--output-dir=<path>]
+//                            [--skip-add] [--yes]
+//
+// The orchestrator never starts the MCP server (no single-instance contention
+// with a user's running MCP). It uses the bench harness directly via spawn.
+
+import * as fsp from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { spawn } from 'child_process';
+import { fileURLToPath } from 'url';
+import type { BenchmarkReport } from '../types.js';
+import { installStubProvider } from '../stub.js';
+import { renderReport, type CrossModelAggregate, type CrossModelQueryResult } from './render.js';
+// Type duplicated locally rather than imported from src/ — tsconfig.bench.json's
+// rootDir scopes types to the benchmarks/ tree (src/ files are out of scope even
+// for type-only imports). All src-side runtime values are loaded via dynamic
+// file:// import keyed off `buildRoot` (matches the warm-query.ts / cold-index.ts
+// pattern for FaissIndexManager). If `src/model-id.ts` adds a 4th provider, this
+// type and the loader's signature must mirror it.
+type EmbeddingProvider = 'huggingface' | 'ollama' | 'openai';
+
+interface CostEstimatesModule {
+  estimateCostUsd(provider: EmbeddingProvider, modelName: string, tokens: number): { usd: number; per_million_tokens_usd: number; source: 'rule-of-thumb'; last_verified: string };
+  LAST_VERIFIED: string;
+}
+
+interface ModelIdModule {
+  deriveModelId(provider: EmbeddingProvider, modelName: string): string;
+  parseModelId(id: string): { provider: string; slugBody: string };
+}
+
+let costEstimatesCache: CostEstimatesModule | undefined;
+let modelIdCache: ModelIdModule | undefined;
+
+async function loadCostEstimates(buildRoot: string): Promise<CostEstimatesModule> {
+  if (costEstimatesCache) return costEstimatesCache;
+  const url = new URL(`file://${path.join(buildRoot, 'cost-estimates.js')}`);
+  costEstimatesCache = await import(url.href) as CostEstimatesModule;
+  return costEstimatesCache;
+}
+
+async function loadModelId(buildRoot: string): Promise<ModelIdModule> {
+  if (modelIdCache) return modelIdCache;
+  const url = new URL(`file://${path.join(buildRoot, 'model-id.js')}`);
+  modelIdCache = await import(url.href) as ModelIdModule;
+  return modelIdCache;
+}
+
+interface CliFlags {
+  models: [string, string];
+  fixture: 'small' | 'medium' | 'large' | 'external';
+  queriesPath?: string;
+  concurrencies: number[];
+  goldenPath?: string;
+  outputDir: string;
+  skipAdd: boolean;
+  yes: boolean;
+}
+
+interface ResolvedModel {
+  id: string;
+  provider: EmbeddingProvider;
+  name: string;
+}
+
+const FIXTURE_FILES: Record<CliFlags['fixture'], number> = {
+  small: 30,
+  medium: 100,
+  large: 600,
+  external: 0,
+};
+
+const FIXTURE_CHUNKS_PER_FILE: Record<CliFlags['fixture'], number> = {
+  small: 5,
+  medium: 8,
+  large: 5,
+  external: 0,
+};
+
+async function main(): Promise<void> {
+  const flags = parseFlags(process.argv.slice(2));
+  const repoRoot = process.cwd();
+  const buildRoot = path.join(repoRoot, 'build');
+
+  // Verify build exists; the orchestrator drives `node build/benchmarks/run.js`.
+  await ensureBuilt(buildRoot);
+
+  const modelIdMod = await loadModelId(buildRoot);
+  const modelA = resolveModel(flags.models[0], modelIdMod);
+  const modelB = resolveModel(flags.models[1], modelIdMod);
+  if (modelA.id === modelB.id) {
+    fatal(`models resolve to the same id "${modelA.id}". Pick two different models.`);
+  }
+
+  // Per-model workspace dirs so cross-model post-step can read both indexes.
+  const orchestratorTmp = path.join(os.tmpdir(), `kb-bench-compare-${process.pid}-${Date.now()}`);
+  const workspaceA = path.join(orchestratorTmp, 'A');
+  const workspaceB = path.join(orchestratorTmp, 'B');
+  await fsp.mkdir(workspaceA, { recursive: true });
+  await fsp.mkdir(workspaceB, { recursive: true });
+
+  // Single shared knowledge-bases dir so both models embed the SAME corpus.
+  // Each model has its own faissIndexPath (per-model layout enforces this anyway).
+  const sharedKbRoot = path.join(orchestratorTmp, 'kb-corpus');
+  await fsp.mkdir(sharedKbRoot, { recursive: true });
+
+  process.stderr.write(`[bench:compare] orchestrator tmpdir: ${orchestratorTmp}\n`);
+  process.stderr.write(`[bench:compare] model A: ${modelA.id}\n`);
+  process.stderr.write(`[bench:compare] model B: ${modelB.id}\n`);
+  process.stderr.write(`[bench:compare] fixture profile: ${flags.fixture}\n`);
+
+  // Concurrency invariant (§4.13.9): back-to-back, never parallel.
+  process.stderr.write(`[bench:compare] running model A bench…\n`);
+  const reportA = await runOnce({
+    model: modelA,
+    workspace: workspaceA,
+    kbRoot: sharedKbRoot,
+    flags,
+    repoRoot,
+    buildRoot,
+    isFirst: true,
+  });
+
+  process.stderr.write(`[bench:compare] running model B bench…\n`);
+  const reportB = await runOnce({
+    model: modelB,
+    workspace: workspaceB,
+    kbRoot: sharedKbRoot,
+    flags,
+    repoRoot,
+    buildRoot,
+    isFirst: false,
+  });
+
+  process.stderr.write(`[bench:compare] cross-model agreement…\n`);
+  // If the parent invocation is a stub bench (BENCH_PROVIDER=stub or models with
+  // provider="stub"), install the stub patch in the orchestrator process too so
+  // the cross-model phase loads stub-backed managers instead of trying to reach
+  // real HF/OpenAI endpoints. A real-provider compare run skips this branch.
+  const isStubRun = process.env.BENCH_PROVIDER === 'stub'
+    || modelA.provider === ('stub' as EmbeddingProvider)
+    || modelB.provider === ('stub' as EmbeddingProvider);
+  if (isStubRun) {
+    await installStubProvider();
+  }
+  const queries = await resolveQueries(flags, sharedKbRoot);
+  const crossModel = await crossModelAgreement({
+    workspaceA,
+    workspaceB,
+    kbRoot: sharedKbRoot,
+    modelA,
+    modelB,
+    buildRoot,
+    queries,
+  });
+
+  const cost = await computeCost(modelA, modelB, reportA, reportB, buildRoot);
+
+  process.stderr.write(`[bench:compare] rendering HTML…\n`);
+  const html = await renderReport({
+    reportA,
+    reportB,
+    modelA: { id: modelA.id, name: modelA.name },
+    modelB: { id: modelB.id, name: modelB.name },
+    fixture: { profile: flags.fixture, chunks: reportA.scenarios.cold_index.chunks },
+    crossModel,
+    cost,
+    generatedAt: new Date().toISOString(),
+  });
+
+  const stamp = new Date().toISOString().replace(/[:T]/g, '-').replace(/\..+$/, '');
+  const outBase = `compare-${safeFileSegment(modelA.id)}-vs-${safeFileSegment(modelB.id)}-${stamp}`;
+  const outDir = path.resolve(flags.outputDir);
+  await fsp.mkdir(outDir, { recursive: true });
+  const htmlPath = path.join(outDir, `${outBase}.html`);
+  const jsonPath = path.join(outDir, `${outBase}.json`);
+
+  await fsp.writeFile(htmlPath, html, 'utf-8');
+  await fsp.writeFile(jsonPath, JSON.stringify({
+    modelA: { id: modelA.id, provider: modelA.provider, name: modelA.name },
+    modelB: { id: modelB.id, provider: modelB.provider, name: modelB.name },
+    reportA,
+    reportB,
+    crossModel,
+    cost,
+    generatedAt: new Date().toISOString(),
+  }, null, 2) + '\n', 'utf-8');
+
+  // Cleanup orchestrator tmpdir on success; preserve on failure for debugging.
+  try {
+    await fsp.rm(orchestratorTmp, { recursive: true, force: true });
+  } catch {
+    // best-effort
+  }
+
+  process.stderr.write(`[bench:compare] done\n`);
+  process.stdout.write(`Report: ${htmlPath}\n`);
+  process.stdout.write(`JSON:   ${jsonPath}\n`);
+}
+
+interface RunOnceArgs {
+  model: ResolvedModel;
+  workspace: string;
+  kbRoot: string;
+  flags: CliFlags;
+  repoRoot: string;
+  buildRoot: string;
+  isFirst: boolean;
+}
+
+async function runOnce(args: RunOnceArgs): Promise<BenchmarkReport> {
+  const faissPath = path.join(args.workspace, '.faiss');
+  await fsp.mkdir(faissPath, { recursive: true });
+
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    BENCH_PROVIDER: providerForBench(args.model.provider),
+    BENCH_MODEL_NAME: args.model.name,
+    BENCH_MODEL_ID: args.model.id,
+    BENCH_WORKSPACE_ROOT: args.workspace,
+    BENCH_FAISS_INDEX_PATH: faissPath,
+    BENCH_KNOWLEDGE_BASES_ROOT_DIR: args.kbRoot,
+    BENCH_RESULTS_PREFIX: `compare-leg-${safeFileSegment(args.model.id)}`,
+    // Redirect per-leg JSONs to the orchestrator's tmpdir — the merged
+    // comparison JSON next to the HTML report is what survives.
+    BENCH_RESULTS_DIR: args.workspace,
+    BENCH_BATCH_CONCURRENCIES: args.flags.concurrencies.join(','),
+    ...(args.flags.queriesPath ? { BENCH_QUERIES: path.resolve(args.flags.queriesPath) } : {}),
+  };
+
+  const benchScript = path.join(args.buildRoot, 'benchmarks', 'run.js');
+  const benchOutput = await spawnNode(benchScript, env, args.repoRoot);
+
+  // run.ts writes the result file path to stdout (last line).
+  const resultPath = benchOutput.trim().split('\n').pop() ?? '';
+  if (!resultPath || !resultPath.endsWith('.json')) {
+    fatal(`bench leg did not emit a result-file path on stdout. Got:\n${benchOutput}`);
+  }
+
+  const raw = await fsp.readFile(resultPath, 'utf-8');
+  const report = JSON.parse(raw) as BenchmarkReport;
+  return report;
+}
+
+function spawnNode(script: string, env: NodeJS.ProcessEnv, cwd: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [script], {
+      cwd,
+      env,
+      stdio: ['ignore', 'pipe', 'inherit'],
+    });
+    let stdout = '';
+    child.stdout.on('data', (chunk) => { stdout += chunk.toString(); });
+    child.on('error', reject);
+    child.on('exit', (code) => {
+      if (code === 0) resolve(stdout);
+      else reject(new Error(`bench subprocess exited with code ${code}`));
+    });
+  });
+}
+
+interface CrossModelArgs {
+  workspaceA: string;
+  workspaceB: string;
+  kbRoot: string;
+  modelA: ResolvedModel;
+  modelB: ResolvedModel;
+  buildRoot: string;
+  queries: string[];
+}
+
+interface ManagerLike {
+  initialize(): Promise<void>;
+  similaritySearch(query: string, k: number, threshold?: number): Promise<{ pageContent: string; metadata: Record<string, unknown>; score?: number }[]>;
+  updateIndex(knowledgeBaseName?: string): Promise<void>;
+}
+
+interface ManagerCtor { new (): ManagerLike }
+
+async function crossModelAgreement(args: CrossModelArgs): Promise<CrossModelAggregate> {
+  // Load A
+  const managerA = await loadManagerFor(args.workspaceA, args.kbRoot, args.modelA, args.buildRoot, 'A');
+  const topKsA = await runQueriesAgainstManager(managerA, args.queries);
+
+  // Load B (separate process-env mutation for each — bench leg already wrote
+  // the indexes, we just open them read-only here).
+  const managerB = await loadManagerFor(args.workspaceB, args.kbRoot, args.modelB, args.buildRoot, 'B');
+  const topKsB = await runQueriesAgainstManager(managerB, args.queries);
+
+  const perQuery: CrossModelQueryResult[] = args.queries.map((q, i) => {
+    const a = topKsA[i] ?? [];
+    const b = topKsB[i] ?? [];
+    return {
+      query: q,
+      jaccard: jaccard(a.map((r) => r.doc), b.map((r) => r.doc)),
+      topK_a: a,
+      topK_b: b,
+    };
+  });
+
+  const jaccards = perQuery.map((q) => q.jaccard).sort((x, y) => x - y);
+  const spearmans = perQuery.map((q) => spearmanOnOverlap(q.topK_a.map((r) => r.doc), q.topK_b.map((r) => r.doc)));
+
+  const overlapDocs = new Set<string>();
+  perQuery.forEach((q) => {
+    const seenA = new Set(q.topK_a.map((r) => r.doc));
+    q.topK_b.forEach((r) => { if (seenA.has(r.doc)) overlapDocs.add(r.doc); });
+  });
+
+  return {
+    jaccard_p50: pct(jaccards, 50),
+    jaccard_p95: pct(jaccards, 95),
+    spearman_p50: pct(spearmans, 50),
+    overlap_doc_count: overlapDocs.size,
+    per_query: perQuery,
+  };
+}
+
+async function loadManagerFor(
+  workspace: string,
+  kbRoot: string,
+  model: ResolvedModel,
+  buildRoot: string,
+  label: string,
+): Promise<ManagerLike> {
+  // Mutate env so the manager picks up the right path + provider/model. For a
+  // stub-mode orchestrator run, treat `stub` as `huggingface` (the stub patches
+  // the HF embeddings module).
+  const provider = model.provider === ('stub' as EmbeddingProvider) ? 'huggingface' : model.provider;
+  process.env.FAISS_INDEX_PATH = path.join(workspace, '.faiss');
+  process.env.KNOWLEDGE_BASES_ROOT_DIR = kbRoot;
+  process.env.EMBEDDING_PROVIDER = provider;
+  if (provider === 'huggingface') {
+    process.env.HUGGINGFACE_MODEL_NAME = model.name;
+    process.env.HUGGINGFACE_API_KEY = process.env.HUGGINGFACE_API_KEY ?? 'bench-hf-key';
+  } else if (provider === 'ollama') {
+    process.env.OLLAMA_MODEL = model.name;
+  } else {
+    process.env.OPENAI_MODEL_NAME = model.name;
+  }
+
+  const url = new URL(`file://${path.join(buildRoot, 'FaissIndexManager.js')}?cross-${label}-${Date.now()}`);
+  const mod = await import(url.href) as { FaissIndexManager: ManagerCtor };
+  const manager = new mod.FaissIndexManager();
+  await manager.initialize();
+  return manager;
+}
+
+async function runQueriesAgainstManager(
+  manager: ManagerLike,
+  queries: string[],
+): Promise<{ doc: string; score: number }[][]> {
+  const out: { doc: string; score: number }[][] = [];
+  for (const q of queries) {
+    try {
+      const results = await manager.similaritySearch(q, 10);
+      out.push(results.map((r) => ({
+        doc: String(r.metadata.source ?? r.metadata.relativePath ?? r.pageContent.slice(0, 40)),
+        score: r.score ?? 0,
+      })));
+    } catch {
+      out.push([]);
+    }
+  }
+  return out;
+}
+
+function jaccard(a: string[], b: string[]): number {
+  if (a.length === 0 && b.length === 0) return 0;
+  const setA = new Set(a);
+  const setB = new Set(b);
+  let inter = 0;
+  setA.forEach((v) => { if (setB.has(v)) inter += 1; });
+  const union = setA.size + setB.size - inter;
+  return union === 0 ? 0 : Number((inter / union).toFixed(4));
+}
+
+function spearmanOnOverlap(a: string[], b: string[]): number {
+  // Spearman ρ on docs that appear in both rankings; 0 if overlap < 2.
+  const setA = new Set(a);
+  const overlap = b.filter((doc) => setA.has(doc));
+  if (overlap.length < 2) return 0;
+  const rankA = (doc: string) => a.indexOf(doc);
+  const rankB = (doc: string) => b.indexOf(doc);
+  const n = overlap.length;
+  let sumD2 = 0;
+  for (const doc of overlap) {
+    const d = rankA(doc) - rankB(doc);
+    sumD2 += d * d;
+  }
+  const rho = 1 - (6 * sumD2) / (n * (n * n - 1));
+  return Number(rho.toFixed(4));
+}
+
+function pct(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  const i = Math.min(sorted.length - 1, Math.max(0, Math.ceil((p / 100) * sorted.length) - 1));
+  return Number(sorted[i].toFixed(4));
+}
+
+interface CostBreakdown {
+  model_a_usd: number;
+  model_b_usd: number;
+  source: 'rule-of-thumb';
+  last_verified: string;
+}
+
+async function computeCost(
+  a: ResolvedModel,
+  b: ResolvedModel,
+  reportA: BenchmarkReport,
+  reportB: BenchmarkReport,
+  buildRoot: string,
+): Promise<CostBreakdown> {
+  const costMod = await loadCostEstimates(buildRoot);
+  // Rule-of-thumb: 4 bytes per token, 800 bytes per chunk.
+  const tokensA = Math.ceil(reportA.scenarios.cold_index.chunks * 800 / 4);
+  const tokensB = Math.ceil(reportB.scenarios.cold_index.chunks * 800 / 4);
+  return {
+    model_a_usd: costMod.estimateCostUsd(a.provider, a.name, tokensA).usd,
+    model_b_usd: costMod.estimateCostUsd(b.provider, b.name, tokensB).usd,
+    source: 'rule-of-thumb',
+    last_verified: costMod.LAST_VERIFIED,
+  };
+}
+
+async function resolveQueries(flags: CliFlags, kbRoot: string): Promise<string[]> {
+  if (flags.queriesPath) {
+    const raw = await fsp.readFile(flags.queriesPath, 'utf-8');
+    return raw.split('\n').map((l) => l.trim()).filter((l) => l && !l.startsWith('#'));
+  }
+  // Default: pull queries-default.txt OR derive from synthetic fixture.
+  // For the synthetic small/medium fixtures, prose queries return nothing
+  // useful; fall back to fixture-derived queries (one per file, token slices)
+  // so the cross-model phase has signal.
+  if (flags.fixture === 'small' || flags.fixture === 'medium') {
+    return await deriveQueriesFromFixture(kbRoot, 30);
+  }
+  // For large/external/arxiv-like corpora, prose queries make sense.
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  const candidates = [
+    path.join(here, 'queries-default.txt'),
+    path.join(here, '..', '..', '..', 'benchmarks', 'compare', 'queries-default.txt'),
+    path.resolve(process.cwd(), 'benchmarks', 'compare', 'queries-default.txt'),
+  ];
+  for (const candidate of candidates) {
+    try {
+      const raw = await fsp.readFile(candidate, 'utf-8');
+      return raw.split('\n').map((l) => l.trim()).filter((l) => l && !l.startsWith('#'));
+    } catch {
+      // try next
+    }
+  }
+  return [];
+}
+
+async function deriveQueriesFromFixture(kbRoot: string, max: number): Promise<string[]> {
+  const queries: string[] = [];
+  const kbDirs = await fsp.readdir(kbRoot, { withFileTypes: true });
+  for (const dirent of kbDirs) {
+    if (!dirent.isDirectory() || dirent.name.startsWith('.')) continue;
+    const files = await fsp.readdir(path.join(kbRoot, dirent.name), { withFileTypes: true });
+    for (const fileEnt of files) {
+      if (queries.length >= max) break;
+      if (!fileEnt.isFile() || fileEnt.name.startsWith('.')) continue;
+      const content = await fsp.readFile(path.join(kbRoot, dirent.name, fileEnt.name), 'utf-8');
+      const tokens = content.split(/\s+/).filter(Boolean);
+      if (tokens.length < 32) continue;
+      queries.push(tokens.slice(12, 32).join(' '));
+    }
+    if (queries.length >= max) break;
+  }
+  return queries;
+}
+
+async function ensureBuilt(buildRoot: string): Promise<void> {
+  const probe = path.join(buildRoot, 'benchmarks', 'run.js');
+  try {
+    await fsp.stat(probe);
+  } catch {
+    fatal(`expected built bench harness at ${probe}. Run \`npm run build && npx tsc -p tsconfig.bench.json\` first.`);
+  }
+}
+
+function resolveModel(idOrSpec: string, mod: ModelIdModule): ResolvedModel {
+  // Accept either a model_id ("provider__slug") or a "provider:modelName" form.
+  if (idOrSpec.includes(':') && !idOrSpec.includes('__')) {
+    const [providerRaw, ...rest] = idOrSpec.split(':');
+    const provider = providerRaw as EmbeddingProvider;
+    const name = rest.join(':');
+    return { id: mod.deriveModelId(provider, name), provider, name };
+  }
+  try {
+    const parsed = mod.parseModelId(idOrSpec);
+    return {
+      id: idOrSpec,
+      provider: parsed.provider as EmbeddingProvider,
+      name: parsed.slugBody, // the slug — best-effort recover; the bench just needs SOMETHING here for env vars
+    };
+  } catch (err) {
+    fatal(`invalid model spec "${idOrSpec}": ${(err as Error).message}`);
+  }
+}
+
+function providerForBench(provider: EmbeddingProvider | 'stub'): 'stub' | 'huggingface' | 'ollama' | 'openai' {
+  return provider;
+}
+
+function safeFileSegment(s: string): string {
+  return s.replace(/[^A-Za-z0-9._-]/g, '_');
+}
+
+function parseFlags(argv: string[]): CliFlags {
+  const flags: Partial<CliFlags> = {
+    fixture: 'medium',
+    concurrencies: [1, 4, 16],
+    outputDir: 'benchmarks/results',
+    skipAdd: false,
+    yes: false,
+  };
+  for (const arg of argv) {
+    if (arg.startsWith('--models=')) {
+      const parts = arg.slice('--models='.length).split(',');
+      if (parts.length !== 2) fatal('--models requires exactly two comma-separated ids');
+      flags.models = [parts[0].trim(), parts[1].trim()];
+    } else if (arg.startsWith('--fixture=')) {
+      const value = arg.slice('--fixture='.length);
+      if (!['small', 'medium', 'large', 'external'].includes(value)) {
+        fatal(`--fixture must be one of small|medium|large|external; got "${value}"`);
+      }
+      flags.fixture = value as CliFlags['fixture'];
+    } else if (arg.startsWith('--queries=')) {
+      flags.queriesPath = arg.slice('--queries='.length);
+    } else if (arg.startsWith('--concurrency=')) {
+      const parsed = arg.slice('--concurrency='.length).split(',').map(Number).filter((n) => Number.isFinite(n) && n > 0);
+      if (parsed.length === 0) fatal('--concurrency requires comma-separated positive numbers');
+      flags.concurrencies = parsed;
+    } else if (arg.startsWith('--golden=')) {
+      flags.goldenPath = arg.slice('--golden='.length);
+    } else if (arg.startsWith('--output-dir=')) {
+      flags.outputDir = arg.slice('--output-dir='.length);
+    } else if (arg === '--skip-add') {
+      flags.skipAdd = true;
+    } else if (arg === '--yes') {
+      flags.yes = true;
+    } else if (arg === '--help' || arg === '-h') {
+      printHelp();
+      process.exit(0);
+    } else {
+      fatal(`unknown flag: ${arg}`);
+    }
+  }
+  if (!flags.models) {
+    fatal('--models=<id_a>,<id_b> is required');
+  }
+  return flags as CliFlags;
+}
+
+function printHelp(): void {
+  process.stderr.write(`Usage: npm run bench:compare -- --models=<id_a>,<id_b> [options]
+
+Required:
+  --models=<id_a>,<id_b>   Two model_ids (e.g. ollama__nomic-embed-text-latest,huggingface__BAAI-bge-small-en-v1.5)
+                            or provider:name pairs (ollama:nomic-embed-text,openai:text-embedding-3-small).
+
+Optional:
+  --fixture=small|medium|large|external   Default: medium.
+  --queries=<path>                         File with one query per line (#-comments allowed).
+  --concurrency=1,4,16                     Batch concurrency sweep (default 1,4,16).
+  --golden=<path>                          JSON {query: [doc_paths]} for recall@k.
+  --output-dir=<path>                      Default: benchmarks/results/.
+  --skip-add                               Reuse already-registered models (no re-embed).
+  --yes                                    Non-interactive (skips paid-provider cost prompt).
+`);
+}
+
+function fatal(msg: string): never {
+  process.stderr.write(`bench:compare: ${msg}\n`);
+  process.exit(2);
+}
+
+main().catch((err) => {
+  process.stderr.write(`bench:compare: ${err instanceof Error ? err.stack ?? err.message : String(err)}\n`);
+  process.exitCode = 1;
+});

--- a/benchmarks/run.ts
+++ b/benchmarks/run.ts
@@ -1,9 +1,12 @@
 import * as os from 'os';
 import * as path from 'path';
+import { readFileSync } from 'fs';
 import type { BenchmarkReport, BenchProvider, ScenarioContext } from './types.js';
 import { installStubProvider } from './stub.js';
+import { runBatchQueryScenario } from './scenarios/batch-query.js';
 import { runColdIndexScenario } from './scenarios/cold-index.js';
 import { runColdStartScenario } from './scenarios/cold-start.js';
+import { runIndexStorageScenario } from './scenarios/index-storage.js';
 import { runMemoryScenario } from './scenarios/memory.js';
 import { runRetrievalQualityScenario } from './scenarios/retrieval-quality.js';
 import { runWarmQueryScenario } from './scenarios/warm-query.js';
@@ -13,11 +16,19 @@ const provider = parseProvider(process.env.BENCH_PROVIDER);
 const repoRoot = process.cwd();
 const buildRoot = path.join(repoRoot, 'build');
 const resultsPrefix = process.env.BENCH_RESULTS_PREFIX ?? 'run';
-const resultsDir = path.join(repoRoot, 'benchmarks', 'results');
+// BENCH_RESULTS_DIR override lets the compare orchestrator redirect per-leg
+// JSONs to its tmpdir so they don't pile up in the committed results folder.
+const resultsDir = process.env.BENCH_RESULTS_DIR ?? path.join(repoRoot, 'benchmarks', 'results');
 const outputPath = path.join(resultsDir, resultFileName(resultsPrefix, provider));
-const workspaceRoot = path.join(os.tmpdir(), `knowledge-base-mcp-server-bench-${process.pid}-${Date.now()}`);
-const knowledgeBasesRootDir = path.join(workspaceRoot, 'knowledge-bases');
-const faissIndexPath = path.join(workspaceRoot, '.faiss');
+// Path overrides let an external orchestrator (e.g. `bench:compare`) point two
+// successive runs at distinct, known locations so it can post-process both
+// indexes after the fact. Without overrides, defaults to a per-pid tmpdir.
+const workspaceRoot = process.env.BENCH_WORKSPACE_ROOT
+  ?? path.join(os.tmpdir(), `knowledge-base-mcp-server-bench-${process.pid}-${Date.now()}`);
+const knowledgeBasesRootDir = process.env.BENCH_KNOWLEDGE_BASES_ROOT_DIR
+  ?? path.join(workspaceRoot, 'knowledge-bases');
+const faissIndexPath = process.env.BENCH_FAISS_INDEX_PATH
+  ?? path.join(workspaceRoot, '.faiss');
 
 async function main(): Promise<void> {
   await ensureDirectory(resultsDir);
@@ -39,24 +50,70 @@ async function main(): Promise<void> {
     workspaceRoot,
   };
 
+  const includeBatchQuery = parseBoolEnv(process.env.BENCH_INCLUDE_BATCH_QUERY, true);
+  const includeIndexStorage = parseBoolEnv(process.env.BENCH_INCLUDE_INDEX_STORAGE, true);
+
+  const concurrencies = parseConcurrencies(process.env.BENCH_BATCH_CONCURRENCIES);
+  const queries = parseQueriesEnv(process.env.BENCH_QUERIES);
+
+  const cold_index = await runColdIndexScenario(context);
+  const cold_start = await runColdStartScenario(context);
+  const memory_peak = await runMemoryScenario(context);
+  const retrieval_quality = await runRetrievalQualityScenario();
+  const warm_query = await runWarmQueryScenario(context);
+  const batch_query = includeBatchQuery
+    ? await runBatchQueryScenario(context, { concurrencies, queries })
+    : undefined;
+  const index_storage = includeIndexStorage
+    ? await runIndexStorageScenario(context)
+    : undefined;
+
   const report: BenchmarkReport = {
     arch: os.arch(),
     git_sha: await gitSha(repoRoot),
+    model_id: process.env.BENCH_MODEL_ID,
+    model_name: process.env.BENCH_MODEL_NAME,
     node_version: process.version,
     os: os.platform(),
     provider,
     scenarios: {
-      cold_index: await runColdIndexScenario(context),
-      cold_start: await runColdStartScenario(context),
-      memory_peak: await runMemoryScenario(context),
-      retrieval_quality: await runRetrievalQualityScenario(),
-      warm_query: await runWarmQueryScenario(context),
+      cold_index,
+      cold_start,
+      memory_peak,
+      retrieval_quality,
+      warm_query,
+      ...(batch_query ? { batch_query } : {}),
+      ...(index_storage ? { index_storage } : {}),
     },
     version: 1,
   };
 
   await writeJsonFile(outputPath, report);
   process.stdout.write(`${outputPath}\n`);
+}
+
+function parseBoolEnv(value: string | undefined, defaultValue: boolean): boolean {
+  if (value === undefined) return defaultValue;
+  if (value === '0' || value.toLowerCase() === 'false') return false;
+  return true;
+}
+
+function parseConcurrencies(value: string | undefined): number[] | undefined {
+  if (!value) return undefined;
+  const parsed = value.split(',').map((s) => Number(s.trim())).filter((n) => Number.isFinite(n) && n > 0);
+  return parsed.length > 0 ? parsed : undefined;
+}
+
+function parseQueriesEnv(value: string | undefined): string[] | undefined {
+  if (!value) return undefined;
+  // BENCH_QUERIES is a path to a file with one query per line.
+  try {
+    const raw = readFileSync(value, 'utf-8');
+    const lines = raw.split('\n').map((l) => l.trim()).filter((l) => l && !l.startsWith('#'));
+    return lines.length > 0 ? lines : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 async function silenceServerLogger(): Promise<void> {
@@ -81,12 +138,21 @@ function configureEnvironment(
   if (selectedProvider === 'stub' || selectedProvider === 'huggingface') {
     process.env.EMBEDDING_PROVIDER = 'huggingface';
     process.env.HUGGINGFACE_API_KEY = process.env.HUGGINGFACE_API_KEY ?? 'bench-hf-key';
+    if (process.env.BENCH_MODEL_NAME) {
+      process.env.HUGGINGFACE_MODEL_NAME = process.env.BENCH_MODEL_NAME;
+    }
   } else if (selectedProvider === 'ollama') {
     process.env.EMBEDDING_PROVIDER = 'ollama';
+    if (process.env.BENCH_MODEL_NAME) {
+      process.env.OLLAMA_MODEL = process.env.BENCH_MODEL_NAME;
+    }
   } else {
     process.env.EMBEDDING_PROVIDER = 'openai';
     if (!process.env.OPENAI_API_KEY) {
       throw new Error('OPENAI_API_KEY is required when BENCH_PROVIDER=openai');
+    }
+    if (process.env.BENCH_MODEL_NAME) {
+      process.env.OPENAI_MODEL_NAME = process.env.BENCH_MODEL_NAME;
     }
   }
 }

--- a/benchmarks/scenarios/batch-query.ts
+++ b/benchmarks/scenarios/batch-query.ts
@@ -1,0 +1,111 @@
+import * as path from 'path';
+import type {
+  BatchQueryRunResult,
+  BatchQueryScenarioResult,
+  ScenarioContext,
+} from '../types.js';
+import { generateKnowledgeBaseFixture } from '../fixtures/generator.js';
+import { durationMs, percentile, resetDirectory } from '../utils.js';
+
+interface SearchResult {
+  metadata: Record<string, unknown>;
+  pageContent: string;
+  score?: number;
+}
+
+interface ManagerLike {
+  initialize(): Promise<void>;
+  similaritySearch(query: string, k: number, threshold?: number): Promise<SearchResult[]>;
+  updateIndex(knowledgeBaseName?: string): Promise<void>;
+}
+
+export interface BatchQueryScenarioOptions {
+  concurrencies?: number[];
+  repetitions?: number;
+  files?: number;
+  targetChunksPerFile?: number;
+  queries?: string[];
+}
+
+const DEFAULT_CONCURRENCIES = [1, 4, 16];
+const DEFAULT_REPETITIONS = 5;
+
+/**
+ * RFC 013 §4.13.3 — concurrency-sweep scenario. For each `concurrency=N`, fires
+ * `Promise.all(query × N)` `repetitions` times against an already-loaded
+ * manager and reports throughput (qps) + tail latency.
+ */
+export async function runBatchQueryScenario(
+  context: ScenarioContext,
+  options: BatchQueryScenarioOptions = {},
+): Promise<BatchQueryScenarioResult> {
+  const concurrencies = options.concurrencies ?? DEFAULT_CONCURRENCIES;
+  const repetitions = options.repetitions ?? DEFAULT_REPETITIONS;
+  const files = options.files ?? 100;
+  const targetChunksPerFile = options.targetChunksPerFile ?? 5;
+
+  await resetDirectory(context.knowledgeBasesRootDir);
+  await resetDirectory(context.faissIndexPath);
+  context.stubController?.resetCounters();
+
+  const fixture = await generateKnowledgeBaseFixture({
+    files,
+    knowledgeBaseName: context.knowledgeBaseName,
+    rootDir: context.knowledgeBasesRootDir,
+    seed: context.fixtureSeed + 5,
+    targetChunksPerFile,
+  });
+
+  const queries = options.queries && options.queries.length > 0
+    ? options.queries
+    : [fixture.query];
+
+  const { FaissIndexManager } = await import(
+    new URL(`file://${path.join(context.buildRoot, 'FaissIndexManager.js')}?scenario=batch-query-${Date.now()}`).href,
+  ) as {
+    FaissIndexManager: new () => ManagerLike;
+  };
+
+  const manager = new FaissIndexManager();
+  await manager.initialize();
+  await manager.updateIndex(context.knowledgeBaseName);
+
+  const runs: BatchQueryRunResult[] = [];
+
+  for (const concurrency of concurrencies) {
+    const latencies: number[] = [];
+    const wallTimes: number[] = [];
+
+    for (let r = 0; r < repetitions; r += 1) {
+      const wallStart = process.hrtime.bigint();
+      const promises = Array.from({ length: concurrency }, (_, i) => {
+        const query = queries[(r * concurrency + i) % queries.length];
+        const opStart = process.hrtime.bigint();
+        return manager.similaritySearch(query, 10).then((results) => {
+          const opEnd = process.hrtime.bigint();
+          if (results.length === 0) {
+            throw new Error(`Batch-query produced no results (query="${query.slice(0, 40)}…")`);
+          }
+          latencies.push(durationMs(opStart, opEnd));
+        });
+      });
+      await Promise.all(promises);
+      const wallEnd = process.hrtime.bigint();
+      wallTimes.push(durationMs(wallStart, wallEnd));
+    }
+
+    const qps = wallTimes.map((wallMs) => (concurrency / wallMs) * 1000);
+
+    runs.push({
+      concurrency,
+      qps_p50: percentile(qps, 50),
+      qps_p95: percentile(qps, 95),
+      latency_p50_ms: percentile(latencies, 50),
+      latency_p95_ms: percentile(latencies, 95),
+      latency_p99_ms: percentile(latencies, 99),
+      total_queries: latencies.length,
+    });
+  }
+
+  return { runs };
+}

--- a/benchmarks/scenarios/index-storage.ts
+++ b/benchmarks/scenarios/index-storage.ts
@@ -1,0 +1,71 @@
+import * as fsp from 'fs/promises';
+import * as path from 'path';
+import type { IndexStorageScenarioResult, ScenarioContext } from '../types.js';
+import { generateKnowledgeBaseFixture } from '../fixtures/generator.js';
+import { resetDirectory } from '../utils.js';
+
+interface ManagerLike {
+  initialize(): Promise<void>;
+  updateIndex(knowledgeBaseName?: string): Promise<void>;
+  readonly modelDir: string;
+}
+
+/**
+ * RFC 013 §4.13.3 — on-disk storage scenario. After cold-index, sums byte
+ * sizes of `${PATH}/models/<id>/faiss.index/{faiss.index, docstore.json}` and
+ * computes bytes/vector. Cheap; runs in the same process as cold-index would.
+ */
+export async function runIndexStorageScenario(
+  context: ScenarioContext,
+  options: { files?: number; targetChunksPerFile?: number } = {},
+): Promise<IndexStorageScenarioResult> {
+  const files = options.files ?? 100;
+  const targetChunksPerFile = options.targetChunksPerFile ?? 5;
+
+  await resetDirectory(context.knowledgeBasesRootDir);
+  await resetDirectory(context.faissIndexPath);
+  context.stubController?.resetCounters();
+
+  const fixture = await generateKnowledgeBaseFixture({
+    files,
+    knowledgeBaseName: context.knowledgeBaseName,
+    rootDir: context.knowledgeBasesRootDir,
+    seed: context.fixtureSeed + 6,
+    targetChunksPerFile,
+  });
+
+  const { FaissIndexManager } = await import(
+    new URL(`file://${path.join(context.buildRoot, 'FaissIndexManager.js')}?scenario=index-storage-${Date.now()}`).href,
+  ) as {
+    FaissIndexManager: new () => ManagerLike;
+  };
+
+  const manager = new FaissIndexManager();
+  await manager.initialize();
+  await manager.updateIndex(context.knowledgeBaseName);
+
+  const indexDir = path.join(manager.modelDir, 'faiss.index');
+  const vectorBytes = await safeStatSize(path.join(indexDir, 'faiss.index'));
+  const docstoreBytes = await safeStatSize(path.join(indexDir, 'docstore.json'));
+  const totalBytes = vectorBytes + docstoreBytes;
+  const bytesPerVector = fixture.chunkCount > 0
+    ? Number((totalBytes / fixture.chunkCount).toFixed(2))
+    : 0;
+
+  return {
+    vector_binary_bytes: vectorBytes,
+    docstore_bytes: docstoreBytes,
+    total_bytes: totalBytes,
+    bytes_per_vector: bytesPerVector,
+    vectors: fixture.chunkCount,
+  };
+}
+
+async function safeStatSize(filePath: string): Promise<number> {
+  try {
+    const stat = await fsp.stat(filePath);
+    return stat.size;
+  } catch {
+    return 0;
+  }
+}

--- a/benchmarks/types.ts
+++ b/benchmarks/types.ts
@@ -44,9 +44,33 @@ export interface RetrievalQualityScenarioResult {
   sweep: RetrievalQualitySweepResult[];
 }
 
+export interface BatchQueryRunResult {
+  concurrency: number;
+  qps_p50: number;
+  qps_p95: number;
+  latency_p50_ms: number;
+  latency_p95_ms: number;
+  latency_p99_ms: number;
+  total_queries: number;
+}
+
+export interface BatchQueryScenarioResult {
+  runs: BatchQueryRunResult[];
+}
+
+export interface IndexStorageScenarioResult {
+  vector_binary_bytes: number;
+  docstore_bytes: number;
+  total_bytes: number;
+  bytes_per_vector: number;
+  vectors: number;
+}
+
 export interface BenchmarkReport {
   arch: string;
   git_sha: string;
+  model_id?: string;
+  model_name?: string;
   node_version: string;
   os: string;
   provider: BenchProvider;
@@ -56,6 +80,8 @@ export interface BenchmarkReport {
     memory_peak: MemoryScenarioResult;
     retrieval_quality: RetrievalQualityScenarioResult;
     warm_query: WarmQueryScenarioResult;
+    batch_query?: BatchQueryScenarioResult;
+    index_storage?: IndexStorageScenarioResult;
   };
   version: 1;
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json && chmod +x build/index.js build/cli.js",
     "bench": "npm run build && tsc -p tsconfig.bench.json && node build/benchmarks/run.js",
+    "bench:compare": "npm run build && tsc -p tsconfig.bench.json && node build/benchmarks/compare/run.js",
     "test": "jest --runInBand",
     "start": "node build/index.js",
     "dev": "nodemon src/index.ts"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -35,6 +35,7 @@ import { formatRetrievalAsJson, formatRetrievalAsMarkdown } from './formatter.js
 import { listKnowledgeBases } from './kb-fs.js';
 import { withWriteLock } from './write-lock.js';
 import { logger } from './logger.js';
+import { estimateCostUsd } from './cost-estimates.js';
 import { filterIngestablePaths, getFilesRecursively } from './utils.js';
 import { readFileSync, realpathSync } from 'fs';
 import * as path from 'path';
@@ -377,9 +378,8 @@ async function runModelsAdd(rest: string[]): Promise<number> {
   const estTokens = Math.ceil(totalBytes / 4);
   let costLine = '';
   if (provider === 'openai') {
-    const usdPerMTok = modelName.includes('large') ? 0.13 : 0.02;
-    const estUsd = (estTokens / 1_000_000) * usdPerMTok;
-    costLine = `Estimated cost: ~$${estUsd.toFixed(4)} (OpenAI ${modelName} at $${usdPerMTok}/1M tokens)\n` +
+    const breakdown = estimateCostUsd('openai', modelName, estTokens);
+    costLine = `Estimated cost: ~$${breakdown.usd.toFixed(4)} (OpenAI ${modelName} at $${breakdown.per_million_tokens_usd}/1M tokens)\n` +
                `See provider pricing: https://openai.com/api/pricing\n`;
   } else if (provider === 'huggingface') {
     costLine = 'Cost: free tier (rate-limited). See https://huggingface.co/docs/inference-providers/pricing\n';

--- a/src/cost-estimates.ts
+++ b/src/cost-estimates.ts
@@ -1,0 +1,60 @@
+// RFC 013 §4.13.6 — centralised cost-per-million-tokens table for paid embedding
+// providers. Used by `kb models add` (interactive cost prompt) and the M5
+// `bench:compare` orchestrator (cost row in the comparison report).
+//
+// Numbers are USD per 1M tokens at the provider's published rate as of
+// LAST_VERIFIED. Bumped quarterly; the report renders LAST_VERIFIED so a
+// reviewer can spot a stale number.
+
+import type { EmbeddingProvider } from './model-id.js';
+
+export const LAST_VERIFIED = '2026-04-26';
+
+/**
+ * Per-provider per-tier USD/1M-tokens. Lookup is provider-then-tier-name; tier
+ * is derived from `modelName.includes(...)` keywords (matches the heuristic
+ * the inline cost prompt used in 0.3.0; see `src/cli.ts` `runAddModel`).
+ */
+export const COSTS = {
+  openai: {
+    'text-embedding-3-large': 0.13,
+    'text-embedding-ada-002': 0.10,
+    default: 0.02, // text-embedding-3-small and other current OpenAI models
+  },
+  huggingface: { default: 0 }, // free tier (rate-limited)
+  ollama: { default: 0 }, // free (local)
+} as const;
+
+export interface CostBreakdown {
+  usd: number;
+  per_million_tokens_usd: number;
+  source: 'rule-of-thumb';
+  last_verified: string;
+}
+
+/**
+ * Resolve USD/1M-tokens for a (provider, modelName) pair. Heuristic — kept
+ * deliberately simple so a reader can audit it.
+ */
+export function usdPerMillionTokens(provider: EmbeddingProvider, modelName: string): number {
+  if (provider === 'openai') {
+    if (modelName.includes('large')) return COSTS.openai['text-embedding-3-large'];
+    if (modelName.includes('ada')) return COSTS.openai['text-embedding-ada-002'];
+    return COSTS.openai.default;
+  }
+  return 0;
+}
+
+export function estimateCostUsd(
+  provider: EmbeddingProvider,
+  modelName: string,
+  tokens: number,
+): CostBreakdown {
+  const perM = usdPerMillionTokens(provider, modelName);
+  return {
+    usd: (tokens / 1_000_000) * perM,
+    per_million_tokens_usd: perM,
+    source: 'rule-of-thumb',
+    last_verified: LAST_VERIFIED,
+  };
+}


### PR DESCRIPTION
## Summary

RFC 013 §4.13 M5 — operator workflow for picking between two embedding models. `npm run bench:compare` drives two back-to-back per-model bench runs against a shared corpus and emits a self-contained HTML report (inline CSS + SVG; zero deps; reviewer-portable).

```bash
npm run bench:compare -- \
  --models=ollama__nomic-embed-text-latest,huggingface__BAAI-bge-small-en-v1.5 \
  --fixture=medium --concurrency=1,4,16
```

The HTML report has six sections: summary table with per-axis winner, latency-distribution charts (single-query + batch by concurrency), throughput-vs-concurrency line chart, on-disk storage stacked bar, query-level top-5 with overlap highlighting, and a rule-based recommendation panel (fixed thresholds documented inline so a skeptical reader can disagree explicitly).

## Files (~1400 LoC; RFC §4.13.7 estimated ~600 + 200 HTML)

**New:**
- `benchmarks/compare/{run.ts, render.ts, chart.ts, report-template.html, queries-default.txt}` — orchestrator + HTML pipeline
- `benchmarks/scenarios/{batch-query.ts, index-storage.ts}` — concurrency sweep + on-disk size scenarios
- `benchmarks/.cache/.gitignore` — placeholder for the future arxiv corpus cache
- `src/cost-estimates.ts` — extracted from `src/cli.ts` so the orchestrator and the CLI cost prompt share one rule-of-thumb table
- `.claude/skills/compare-embedding-models/SKILL.md` — operator skill (per RFC 002 §6.2 schema)

**Modified:**
- `benchmarks/run.ts` — reads new env overrides (`BENCH_MODEL_NAME`, `BENCH_FAISS_INDEX_PATH`, `BENCH_KNOWLEDGE_BASES_ROOT_DIR`, `BENCH_RESULTS_DIR`, `BENCH_BATCH_CONCURRENCIES`, `BENCH_QUERIES`, `BENCH_INCLUDE_*`); calls new scenarios
- `benchmarks/types.ts` — `BatchQueryScenarioResult`, `IndexStorageScenarioResult`; `BenchmarkReport` gains optional `model_id` / `model_name` / `batch_query` / `index_storage` (existing reports remain valid)
- `src/cli.ts` — calls into `src/cost-estimates.ts` (behaviour-preserving)
- `package.json` — `bench:compare` script
- `benchmarks/README.md` — `Comparing two embedding models` section
- `CHANGELOG.md` — `[Unreleased] — RFC 013 M5` block

## Deferred to M5.1 (called out in CHANGELOG)

These don't block selecting between two real providers; the synthetic small/medium fixtures already give meaningful latency/throughput/storage/cost signal:

- `--fixture=large` with the ~3000-chunk arxiv (`cs.IR + cs.CL`) corpus and sha256-keyed cache (RFC §4.13.4)
- `--golden=<path>` recall@k integration into the report (the JSON already carries per-query top-k for both models — the render step is the missing piece)
- `.github/workflows/bench-compare-dispatch.yml` (`workflow_dispatch`-only — maintainer manual runs against real providers)

## Test plan

- [x] `npm test` — **237 passed** across 15 suites
- [x] `npm run build` + `npx tsc -p tsconfig.bench.json` — both clean
- [x] End-to-end stub smoke: `BENCH_PROVIDER=stub npm run bench:compare -- --models=stub:bench-stub-model-A,stub:bench-stub-model-B --fixture=small --concurrency=1,4` → HTML rendered, `jaccard p50 = 1.0` as expected (same vectors), all six sections present
- [x] Skill verification command (`grep -q 'cold_index_ms' …html && echo OK`) → `OK`
- [ ] Real-provider end-to-end (Ollama / HF / OpenAI) — maintainer-local; this PR ships the orchestrator scaffolding

## Notes for the reviewer

- The bench-leg subprocesses now write per-leg JSONs to the orchestrator's tmpdir (via `BENCH_RESULTS_DIR`) instead of `benchmarks/results/`, so the committed results dir stays clean.
- `tsconfig.bench.json`'s `rootDir: benchmarks` scopes types to the bench tree. The orchestrator therefore duplicates the `EmbeddingProvider` type locally (clearly marked as a mirror) and loads `src/` runtime values via dynamic file:// imports keyed off `buildRoot` — same pattern the existing `cold-start.ts` / `warm-query.ts` use to access `FaissIndexManager`.
- A previous compile attempt with a static type-only import from `src/` left stray `.js` files in `src/` that broke Jest. They've been deleted; the new code uses dynamic imports throughout.

Refs #100. Builds on #102, #103, #104, #105.