### PR TITLE
feat(dev): one-shot local install + post-merge auto-rebuild

### DIFF
--- a/.githooks/post-merge
+++ b/.githooks/post-merge
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Auto-rebuild after `git pull` / `git merge` so the linked global `kb` /
+# `knowledge-base-mcp-server` bins reflect the latest checkout.
+#
+# Enable once with:  npm run dev:setup
+# Manual enable:     git config core.hooksPath .githooks
+#
+# A symlink at .githooks/post-rewrite delegates here so `git pull --rebase`
+# (which fires post-rewrite, not post-merge) is also covered.
+
+set -uo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+# Don't fail the pull if the rebuild fails — git ignores post-merge exit codes
+# but the user sees the stderr and may think the pull broke. Turn an early
+# `set -e` exit into a clean warning instead.
+trap 'echo "[post-merge] WARNING: auto-rebuild failed (exit $?). Run \`npm install && npm run build\` manually." >&2; exit 0' ERR
+
+# ORIG_HEAD is unset on the first merge in a fresh clone, after `git gc`
+# pruning, or when invoked via post-rewrite without an ORIG_HEAD. Without this
+# guard, `git diff ORIG_HEAD HEAD` exits 128 with a noisy "fatal: bad
+# revision" message and we'd treat that as "files changed" and reinstall every
+# time. When we have no comparison point, just rebuild unconditionally — it's
+# the safe default.
+if ! git rev-parse --verify --quiet ORIG_HEAD >/dev/null; then
+  echo "[post-merge] no ORIG_HEAD — rebuilding unconditionally"
+  npm install
+  npm run build
+  echo "[post-merge] done — global bins now reflect $(git rev-parse --short HEAD)"
+  exit 0
+fi
+
+# Scope the install trigger to package.json only. Lockfile-only changes
+# (transitive bumps) get picked up by `npm install` during a future
+# package.json change or manual run; meanwhile we avoid regenerating the
+# lockfile and creating local drift on every dep-pin pull.
+if ! git diff --quiet ORIG_HEAD HEAD -- package.json; then
+  echo "[post-merge] package.json changed — running npm install"
+  npm install
+fi
+
+if git diff --quiet ORIG_HEAD HEAD -- src/ tsconfig.json package.json; then
+  echo "[post-merge] no source changes — skipping rebuild"
+  exit 0
+fi
+
+echo "[post-merge] rebuilding (kb / knowledge-base-mcp-server will pick up automatically)"
+npm run build
+echo "[post-merge] done — global bins now reflect $(git rev-parse --short HEAD)"

--- a/.githooks/post-rewrite
+++ b/.githooks/post-rewrite
@@ -1,0 +1,1 @@
+post-merge

--- a/README.md
+++ b/README.md
@@ -204,6 +204,47 @@ Use this path if you want to develop against the repo or pin an unreleased commi
 *   The content of each chunk is then added to a FAISS index, which is used for similarity search.
 *   The FAISS index is automatically initialized when the server starts. It checks for changes in the knowledge base files and updates the index accordingly.
 
+### Install (local development, live `kb` from your checkout)
+
+Use this when you're actively developing on the repo and want your global `kb` and `knowledge-base-mcp-server` bins to always reflect the current state of `main` (or your feature branch) — without `npm publish` and without manual reinstalls after each `git pull`.
+
+```bash
+git clone https://github.com/jeanibarz/knowledge-base-mcp-server.git
+cd knowledge-base-mcp-server
+npm run dev:setup
+```
+
+`dev:setup` does three things, all idempotent:
+
+1.  **`npm install` + `npm run build`** — first build, so the bins exist before linking.
+2.  **`npm link`** — symlinks `kb` and `knowledge-base-mcp-server` into the global node prefix (printed during setup so you can verify it lands where you expect). From then on, every `npm run build` overwrites `build/` in place and the global bins pick up the new code on the next invocation. **No re-link needed** after rebuilds.
+3.  **`git config core.hooksPath .githooks`** — points git at the tracked [`.githooks/`](./.githooks) directory so the `post-merge` and `post-rewrite` hooks fire after every `git pull` (merge or rebase) and `git merge`. The hook re-runs `npm install` if `package.json` changed and `npm run build` if any source changed. Skips quietly when nothing relevant moved. The hook order puts this **last**, so a failed install/build leaves the repo in its original state.
+
+After setup, the daily loop is just:
+
+```bash
+git pull            # hook rebuilds automatically (merge or rebase)
+kb search "..."     # uses the freshly-built bin from this checkout
+```
+
+Or, when editing locally:
+
+```bash
+# edit src/...
+npm run build       # global `kb` immediately reflects your change
+```
+
+**Switching back to the published npm release** (e.g. to compare behaviour):
+
+```bash
+npm unlink -g @jeanibarz/knowledge-base-mcp-server
+npm install -g @jeanibarz/knowledge-base-mcp-server@latest
+```
+
+**Why `npm link` instead of `npm install -g .`?** `npm link` is a symlink, so `npm run build` is reflected without reinstalling. `npm install -g .` copies the build snapshot, so every change requires a re-install.
+
+**Hook scope.** The hooks trigger on `git pull` / `git merge` / `git pull --rebase`, not on `git checkout` between branches. Run `npm run build` manually after a branch switch if needed. If a rebuild fails, the hook prints a warning and exits 0 so the pull itself isn't reported as failed — fix the build, then run `npm run build` manually.
+
 ## Usage
 
 The server exposes two tools:

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "bench:compare": "npm run build && tsc -p tsconfig.bench.json && node build/benchmarks/compare/run.js",
     "test": "jest --runInBand",
     "start": "node build/index.js",
-    "dev": "nodemon src/index.ts"
+    "dev": "nodemon src/index.ts",
+    "dev:setup": "bash scripts/dev-setup.sh"
   },
   "repository": {
     "type": "git",

--- a/scripts/dev-setup.sh
+++ b/scripts/dev-setup.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# One-shot local-development setup:
+#   1. Install dependencies and build once.
+#   2. Symlink this checkout's `kb` and `knowledge-base-mcp-server` bins into
+#      the global node prefix via `npm link`. Subsequent rebuilds (manual or
+#      via the post-merge hook) overwrite build/ in place — the global bins
+#      pick up the new code without re-linking.
+#   3. Point git at the tracked .githooks/ directory so the post-merge /
+#      post-rewrite hooks fire after every `git pull` / `git merge` /
+#      `git pull --rebase`.
+#
+# Step 3 runs LAST so that a failure in install/build/link leaves the repo
+# in its original state instead of pointing at a hook that would run against
+# a half-built tree.
+#
+# Idempotent: safe to re-run.
+
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+# Guard against npm_config_prefix leaking in from an outer pnpm/npm script
+# context (e.g. running this from inside another package's `npm run`). When
+# set, npm link installs into the wrong global prefix and the bin symlinks
+# never get created in your real Node prefix.
+if [[ -n "${npm_config_prefix:-}" ]]; then
+  cat >&2 <<EOF
+ERROR: npm_config_prefix is set to '${npm_config_prefix}' in this shell.
+       This usually means you are running inside a pnpm / npm script context
+       from another project. npm link would target the wrong prefix.
+       Open a fresh shell and re-run, or unset the variable:
+           unset npm_config_prefix npm_config_dir
+EOF
+  exit 1
+fi
+
+echo "==> Installing npm dependencies"
+npm install
+
+echo "==> Building"
+npm run build
+
+resolved_prefix="$(npm prefix -g)"
+echo "==> Linking bins into npm global prefix: ${resolved_prefix}"
+echo "    (override with PREFIX, NPM_CONFIG_PREFIX, or ~/.npmrc 'prefix=' if wrong)"
+npm link
+
+echo "==> Configuring git hooks path -> .githooks (post-merge + post-rewrite)"
+chmod +x .githooks/post-merge scripts/*.sh 2>/dev/null || true
+git config core.hooksPath .githooks
+
+cat <<EOF
+
+Done. The global \`kb\` and \`knowledge-base-mcp-server\` bins now point at
+this checkout (${resolved_prefix}/bin/). From now on:
+
+  - \`git pull\` (merge or rebase) auto-rebuilds via the post-merge /
+    post-rewrite hooks.
+  - Edit src/, run \`npm run build\`, and the global bins reflect it
+    immediately — no re-link needed.
+  - To unlink: \`npm unlink -g @jeanibarz/knowledge-base-mcp-server\`
+  - To switch back to the published npm version:
+        npm unlink -g @jeanibarz/knowledge-base-mcp-server
+        npm i -g @jeanibarz/knowledge-base-mcp-server@latest
+
+EOF


### PR DESCRIPTION
## Summary

- Adds `npm run dev:setup` so contributors can wire their global `kb` / `knowledge-base-mcp-server` bins to track this checkout instead of the published npm release.
- Adds tracked `.githooks/post-merge` (with `post-rewrite` symlinked to it) that re-runs `npm install` when `package.json` changed and `npm run build` when source changed, after every `git pull` (merge or rebase) and `git merge`. Quiet no-op otherwise.
- New "Install (local development, live `kb` from your checkout)" section in the README explains the daily loop and the rollback to the published release.
- Two new top-level dirs: `.githooks/` (target for `core.hooksPath`, intentionally avoids the `.husky/` devDep) and `scripts/` (npm-script shell helpers, ecosystem-standard). First time this repo introduces either.

## Why

While iterating on the repo locally, the published `npm i -g @jeanibarz/knowledge-base-mcp-server@latest` lags the checkout — local `main` is at `0.2.2` but the latest npm release is `0.2.1`, so RFC 013 features (`kb models *`, `--model` flag) aren't visible without a manual reinstall after every pull. After `npm run dev:setup` + this hook, `git pull` is enough.

## How it works

`npm link` symlinks `lib/node_modules/@jeanibarz/knowledge-base-mcp-server` to the repo root, so `npm run build` overwrites `build/` in place and the global bins pick up the new code on the next invocation — no re-link needed. The setup script orders `git config core.hooksPath` **last**, so a failed install/build/link leaves the repo in its original state instead of pointing at a hook that runs against a half-built tree.

The hook covers both `git pull` (post-merge) and `git pull --rebase` (post-rewrite, via symlink) — common because `pull.rebase=true` is many users' default. It does **not** trigger on `git checkout` between branches (run `npm run build` manually after a switch). Build failure prints a warning and exits 0 so the pull itself isn't reported as failed.

## Edge cases handled

- **Missing `ORIG_HEAD`** (fresh clone, post-`git gc`, post-rewrite without an old tip) — falls back to unconditional rebuild instead of bombing out with `fatal: bad revision`. Verified in `/tmp` against a stub `npm`.
- **Leaked `npm_config_prefix`** from outer pnpm/npm script contexts — would silently misroute `npm link`. Setup script aborts with a clear remediation. (Hit during testing.)
- **Lockfile-only changes** — install trigger is scoped to `package.json` only, not `package-lock.json`, to avoid lockfile drift on transitive bumps.

## Verification

- [x] Build clean: `npm run build` (worktree).
- [x] Test suite: 245/245 jest tests pass.
- [x] `npm run dev:setup` succeeds on the main checkout; `kb --version` reports `0.2.2` (matching `package.json`); symlink lands at `~/.nvm/.../lib/node_modules/@jeanibarz/knowledge-base-mcp-server -> ~/git/knowledge-base-mcp-server`.
- [x] Hook syntax: `bash -n` clean on both `.githooks/post-merge` and `scripts/dev-setup.sh`.
- [x] Hook behaviour, all three branches (with stubbed `npm` in `/tmp`):
  - No `ORIG_HEAD` → "rebuilding unconditionally" → `npm install` + `npm run build`.
  - `ORIG_HEAD` set, source changed, `package.json` unchanged → "rebuilding" → `npm run build` only.
  - `ORIG_HEAD` set, only `unrelated.md` changed → "no source changes — skipping rebuild" → no `npm` calls.
- [x] Reviewer specialists (correctness + conventions) — 2 blocking findings (post-rewrite gap, ORIG_HEAD 128 exit) and 4 suggestions all addressed before push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)