### PR TITLE
feat(rfc-014): atomic FAISS save via versioned dirs + symlink swap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,29 @@
 # Changelog
 
-## [Unreleased] — RFC 013 M5 (bench:compare)
+## [Unreleased] — RFC 014 (atomic FAISS save)
+
+### Added
+
+- **Atomic FAISS save** (RFC 014). New per-model on-disk layout: `${FAISS_INDEX_PATH}/models/<id>/index → index.vN/` symlink swapped atomically via POSIX `rename(2)`. Save+load are now directory-atomic for the versioned layout: a reader and writer running concurrently against the same model can never observe a torn `(faiss.index, docstore.json)` pair or a docid mismatch. Implements RFC 013 §11 N4 (lifted).
+- **Reader-side pre-resolve.** `loadAtomic` calls `realpath` ONCE on the symlink before delegating to `FaissStore.load(resolvedAbsolutePath)`, which prevents the docid-mismatch race introduced by `@langchain/community`'s internal `Promise.all([open(faiss.index), open(docstore.json)])` (each open would otherwise re-resolve the symlink independently).
+- **Downgrade-hazard surfacing.** When both the new versioned layout AND the legacy `faiss.index/` directory coexist for a model, a `.downgrade-hazard` marker file is written, a `logger.warn` is emitted at `initialize`, and `kb models list` prints `[downgrade-hazard]` next to the model id with an explainer footer. Bounds the silent-data-loss blast radius if a user downgrades after embedding new content under v014.
+- **`resolveFaissIndexBinaryPath(modelId)`** in `src/active-model.ts` — resolves the FAISS binary path through the new versioned layout when present, falls back to the legacy path. Used by `kb search`'s staleness/freshness footer (`computeStaleness`).
+
+### Changed
+
+- **No migration step.** The new layout is purely additive — existing installs keep `faiss.index/` untouched. The first save under v014 creates `index.v0/` and the `index` symlink. Downgrading the npm package falls back to the legacy directory (with any post-upgrade embeddings unreachable until re-saved under the older version, surfaced via the downgrade-hazard signal).
+- **Disk usage temporarily ~2x per model** (legacy + new versioned dirs) until you remove `faiss.index/` manually. A future `kb models migrate` CLI (planned) will wrap this. Today: `rm -rf "${FAISS_INDEX_PATH}/models/<id>/faiss.index"` after confirming the new layout works.
+- **GC retention is N=3 versions.** Saves keep `index.vN/`, `index.vN-1/`, `index.vN-2/`; older versioned dirs are removed best-effort during the same write-lock that performs the save.
+- **`loadWithJsonRetry` (CLI)** is retained as a defensive belt for legacy-layout reads only — its inline comment is updated to name which path it still defends. Will be removed in a follow-up release once the legacy load path is dropped.
+- **`docs/architecture/threat-model.md §4`** — updated to describe the post-RFC-014 invariant. The single-MCP-instance enforcement (`src/instance-lock.ts`) is now an operational preference rather than a data-integrity requirement; its removal is the immediate follow-up release.
+
+### Compatibility
+
+- **Power-cut durability is unchanged from prior releases** — atomicity is guaranteed by `rename(2)`, durability is best-effort across the codebase (no fsync on hash sidecars or anywhere else; matches existing repo policy). A power-cut may lose the most recent save (the symlink reverts to the prior version, the staging dir is cleaned up by the next save's EEXIST recovery); no half-written state is ever observed by readers.
+- **Linux + macOS only** — symlinks on Windows require admin/dev mode and are not in the existing CI matrix.
+- **Backup tools may double-count** `faiss.index/` and `index.vN/` until the legacy directory is removed.
+
+## [Unreleased — earlier] — RFC 013 M5 (bench:compare)
 
 ### Fixed
 

--- a/docs/architecture/threat-model.md
+++ b/docs/architecture/threat-model.md
@@ -60,9 +60,9 @@ Query text and knowledge-base chunks leave the machine over TLS to the configure
 
 **Migration coordination** (RFC 013 §4.8). `FaissIndexManager.bootstrapLayout` runs the 0.2.x→0.3.0 migration at most once per Node process (module-level Promise cache). Cross-process: piggybacks on the instance advisory if held, else acquires a short-lived `${FAISS_INDEX_PATH}/.kb-migration.lock` for CLI invocations to coordinate with peers.
 
-**Current requirement.** Still **one MCP server** per `$FAISS_INDEX_PATH`. Multiple `kb` CLI invocations against the same path are safe — they coordinate via the per-model write lock. Users deploying under systemd / pm2 / Kubernetes still need to keep MCP-server replicas at 1 per `FAISS_INDEX_PATH` or give each replica its own.
+**Atomic save** (RFC 014, landed in 0.x.y). New per-model layout `index → index.vN/` makes save+load directory-atomic via symlink-swap with reader-side pre-resolution. Torn reads are eliminated for the versioned layout. The legacy `faiss.index/` load path retains the prior hazard until and unless a write under v014 (`updateIndex`, `kb search --refresh`, or `kb models add`) creates the versioned layout for that model. Single-instance advisory is now an operational preference (not a safety requirement) and will be removed in the next release. `loadWithJsonRetry` (CLI) is retained for one release as a defensive belt for legacy-layout reads only.
 
-**Known limitation.** `FaissStore.save()` from `@langchain/community` is non-atomic (`mkdir -p + Promise.all([index.write, writeFile(docstore.json)])`, no rename). A read concurrent with a save can see partial `docstore.json`; the CLI's `loadWithJsonRetry` handles this with a 100 ms retry. Documented in RFC 012 §7 N4. Per-model isolation in 0.3.0 narrows the blast radius (only that one model's reads can race).
+**Current operational guideline (post-RFC-014).** With atomic save in place, multiple MCP servers per `$FAISS_INDEX_PATH` are now safe at the data-integrity layer for the versioned layout — they serialize writes via the per-model lock and never produce torn reads. The `src/instance-lock.ts` advisory still rejects a second concurrent MCP, pending its removal in the next release. Multiple `kb` CLI invocations have always been safe.
 
 ## 5. Path-traversal (forward-looking)
 

--- a/docs/rfcs/013-multimodel-support.md
+++ b/docs/rfcs/013-multimodel-support.md
@@ -114,7 +114,7 @@ RFC 012 §4.7 (model-mismatch check) and §4.8.2 (write lock) **assume one model
 - **N1.** Cross-model retrieval fusion (RRF, ensemble re-ranking). The user can query each model and `kb compare` externally; fusion is its own design space.
 - **N2.** Re-embedding optimisation (incremental, batch-resumable). `kb models add` reuses the existing per-file SHA256 sidecar logic at `src/FaissIndexManager.ts:528-589`; if it crashes, the next call resumes.
 - **N3.** Per-KB model selection. Out of scope here; would require a per-KB config file. Round-1 ambition F2 pushed back; deferred to **a future RFC seed in §8.9** rather than buried.
-- **N4.** Atomic `FaissStore.save()`. RFC 012 N7 already deferred this; per-model isolation narrows the blast radius (a save mid-write only affects readers of that one model). Tracked separately.
+- **N4.** ~~Atomic `FaissStore.save()`. RFC 012 N7 already deferred this; per-model isolation narrows the blast radius (a save mid-write only affects readers of that one model). Tracked separately.~~ **Lifted by [RFC 014](./014-atomic-faiss-save.md)** — versioned-dir layout with symlink swap and reader-side pre-resolution makes save+load directory-atomic for the versioned layout.
 - **N5.** Removing the existing `EMBEDDING_PROVIDER`/`OLLAMA_MODEL`/etc. env vars. They keep their meaning ("default model when nothing else is specified"). `KB_ACTIVE_MODEL` overrides; `active.txt` is the persisted default.
 - **N6.** GUI / dashboard. Pure CLI + MCP surface.
 - **N7.** Quantized index types (`IndexIVFPQ`). Storage isn't the binding constraint per §2.4. Tracked separately if it ever is.

--- a/docs/rfcs/014-atomic-faiss-save.md
+++ b/docs/rfcs/014-atomic-faiss-save.md
@@ -1,0 +1,290 @@
+# RFC 014 — Atomic FAISS Save
+
+**Status:** Draft (lifts RFC 013 §11 N4)
+**Depends on:** RFC 013 (per-model layout, write locks, instance advisory)
+**Unblocks:** removal of single-instance enforcement (`src/instance-lock.ts`) — separate follow-up PR
+
+## Problem
+
+`FaissStore.save(directory)` from `@langchain/community` is non-atomic:
+
+```js
+async save(directory) {
+  await fs.mkdir(directory, { recursive: true });
+  await Promise.all([
+    this.index.write(path.join(directory, "faiss.index")),
+    fs.writeFile(path.join(directory, "docstore.json"), JSON.stringify(...)),
+  ]);
+}
+```
+
+Two failure modes:
+1. **Read-during-write torn data** — partial JSON, or N-vector index paired with N±k-doc store → silent retrieval bugs.
+2. **Write-during-write corruption** — two writers interleave bytes; no retry recovers.
+
+The codebase compensates with per-model write locks (solves #2), the single-instance advisory (closes the cross-process write hazard), and `loadWithJsonRetry` (catches torn JSON only, not docid mismatch). The single-instance advisory is the user-visible pain — only one MCP server per `$FAISS_INDEX_PATH` means concurrent Claude sessions queue.
+
+## Goal
+
+Make save+load directory-atomic at the **caller** level so:
+
+- Any reader sees a consistent `(faiss.index, docstore.json)` pair — never the partial or mixed-version state.
+- The single-instance advisory becomes redundant overhead, removable in a follow-up PR.
+- `loadWithJsonRetry` becomes redundant for the versioned layout (kept one release as defensive belt with corrected comment that names which layout still uses it).
+
+**Non-goals:**
+- Power-cut durability stronger than the existing repo policy. The codebase doesn't `fsync` today (per-file hash sidecars rely on `tmp+rename` for atomicity but not durability — `src/FaissIndexManager.ts:807-822`). RFC 014 matches this: atomicity guaranteed, durability is best-effort. A power-cut may lose the most recent save; no save is ever observed half-written.
+- Migration / rewrite of the legacy `faiss.index/` layout. v3 is purely additive.
+
+## Design
+
+### Layout — additive, no migration
+
+```
+${FAISS_INDEX_PATH}/
+├── active.txt
+└── models/<model_id>/
+    ├── faiss.index/                 # legacy directory (preserved on upgrade)
+    ├── index → index.v3             # NEW: stable symlink, atomically swapped
+    ├── index.v3/                    # current data
+    │   ├── faiss.index
+    │   └── docstore.json
+    ├── index.v2/                    # previous (kept by GC)
+    ├── index.v1/                    # one more for GC slack
+    └── model_name.txt
+```
+
+**Key choice: never touch the legacy `faiss.index/`.** Old server versions reading it after a downgrade still find their data (slightly stale by saves the new server made — documented). The new server only writes through `index.vN/` + the `index` symlink.
+
+After a release cycle of stability post-advisory-removal, a future PR adds a one-time `legacy-cleanup` that removes `faiss.index/`.
+
+### Save algorithm
+
+```typescript
+// Inside FaissIndexManager — file-private. Per-model write lock is held by
+// every caller of updateIndex (verified: KnowledgeBaseServer.ts:216,374 and
+// cli.ts:436,646 all wrap updateIndex in withWriteLock(manager.modelDir, ...)).
+// atomicSave's precondition: caller holds withWriteLock(this.modelDir).
+private async atomicSave(): Promise<void> {
+  const symlinkPath = path.join(this.modelDir, 'index');
+  const currentTarget = await readSymlinkOrNull(symlinkPath);   // 'index.v3' | null
+  const nextVersion = nextVersionAfter(currentTarget);          // 'index.v4'
+  const stagingDir = path.join(this.modelDir, nextVersion);
+
+  // 1. Write the new version into a fresh dir. FaissStore.save is
+  //    non-atomic but isolated — staging is exclusive (write lock + unique
+  //    version number). EEXIST recovery: rmrf+retry once for orphan staging.
+  try {
+    await this.faissIndex!.save(stagingDir);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'EEXIST') throw err;
+    logger.warn(`atomicSave: orphan staging dir ${stagingDir} — clearing and retrying`);
+    await fsp.rm(stagingDir, { recursive: true, force: true });
+    await this.faissIndex!.save(stagingDir);                    // throws if still failing
+  }
+
+  // 2. Atomic symlink swap. POSIX rename(2) replaces an existing symlink
+  //    atomically. Tmp name includes pid + monotonic counter to prevent
+  //    cross-process collision under the (impossible-given-the-write-lock)
+  //    case of concurrent same-modelDir saves.
+  const tmpLink = path.join(this.modelDir, `.index.tmp.${process.pid}.${++this.swapCounter}`);
+  await fsp.symlink(nextVersion, tmpLink);                      // relative target
+  await fsp.rename(tmpLink, symlinkPath);                       // atomic on POSIX
+
+  logger.info(`atomicSave: ${this.modelId} ${currentTarget ?? '(none)'} → ${nextVersion}`);
+
+  // 3. Best-effort GC of versions older than N=3. Synchronous (inside the
+  //    write lock) so the write-lock release happens AFTER GC completes,
+  //    which makes the contract simple: when withWriteLock returns, the
+  //    on-disk state is "current = vN, plus up to 2 immediately prior
+  //    versions kept; everything else is gone."
+  await gcOldVersions(this.modelDir, { keep: 3, current: nextVersion });
+}
+```
+
+**No fsync.** Matches the existing per-file-hash sidecar pattern (`src/FaissIndexManager.ts:807-822` does `tmp+rename` without fsync). Atomicity comes from `rename(2)`; durability is best-effort across the whole codebase. Power-cut during save: staging dir possibly partial → next save's EEXIST recovery cleans it. Power-cut during rename: symlink either reverts or commits; no partial state. Power-cut after rename but before page cache flush: rename reverts to v3 on reboot, staging v4 survives → next save uses v5. **No torn data ever; no special platform handling needed.**
+
+### Load algorithm — pre-resolve at the caller
+
+```typescript
+// Replaces FaissIndexManager.initialize()'s load step (src/FaissIndexManager.ts:539-557).
+private async loadAtomic(): Promise<FaissStore | null> {
+  const symlinkPath = path.join(this.modelDir, 'index');
+  const legacyPath = path.join(this.modelDir, 'faiss.index');
+
+  // lstat (NOT stat / pathExists) so we detect symlink presence regardless
+  // of whether the target resolves. pathExists follows symlinks
+  // (FaissIndexManager.ts:206-216) and would silently return false if the
+  // target was GC'd, falsely falling through to the legacy branch with
+  // STALE data. lstat avoids that hazard.
+  const symStat = await fsp.lstat(symlinkPath).catch(err => {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null;
+    throw err;
+  });
+
+  if (symStat?.isSymbolicLink()) {
+    // realpath dereferences the symlink ONCE here. The resolved absolute
+    // path is then passed to FaissStore.load, whose internal Promise.all
+    // opens both files via the absolute path — no symlink in the open
+    // path → no race with a concurrent swap. (Round-2 review confirmed
+    // this against @langchain/community/dist/vectorstores/faiss.js:215-228.)
+    let resolved: string;
+    try {
+      resolved = await fsp.realpath(symlinkPath);
+    } catch (err) {
+      // realpath ENOENT here means the symlink target was GC'd between our
+      // lstat and realpath. With N=3 retention, this requires ≥3 writes
+      // completed in the JS-event-loop microsecond gap between lstat and
+      // realpath while THIS reader was paused — impossible under the
+      // existing write-lock cadence. Surface loudly: it indicates the
+      // retention contract was somehow violated and the operator should
+      // investigate (concurrent rmrf? manual filesystem surgery?).
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+        throw new Error(
+          `loadAtomic: symlink ${symlinkPath} target vanished between lstat and realpath — ` +
+          `N=3 retention contract violated. Check for concurrent gc, manual surgery, or filesystem issues.`,
+        );
+      }
+      throw err;
+    }
+    return FaissStore.load(resolved, this.embeddings);
+  }
+
+  // Legacy path — pre-RFC-014 layout. Read directly. Keeps existing
+  // (non-atomic) behavior for users who haven't yet saved under v014.
+  // The torn-read hazard described in the threat model still applies to
+  // THIS branch until the first updateIndex migrates the model to
+  // versioned layout.
+  if (await pathExists(legacyPath)) {
+    logger.info(`loadAtomic: ${this.modelId} loading legacy faiss.index/ — first save will create versioned layout`);
+    return FaissStore.load(legacyPath, this.embeddings);
+  }
+
+  return null;
+}
+```
+
+### Reader-vs-writer concurrency analysis
+
+| t | Reader | Writer | Effect |
+|---|---|---|---|
+| 0 | `lstat(index)` → `isSymbolicLink: true` | — | |
+| 1 | `realpath(index)` → `/abs/.../index.v3` | — | Reader pinned to v3 |
+| 2 | `Promise.all([open(/abs/.../index.v3/faiss.index), open(/abs/.../index.v3/docstore.json)])` | `store.save(index.v4)` running | Both opens hit v3 directly. No symlink in the open path. |
+| 3 | reads continue from v3 fds | `rename(.tmp, index)` → symlink now points at v4 | Reader's fds continue to reference v3. New readers see v4. |
+| 4 | reads complete from v3 | `gcOldVersions` runs synchronously inside write lock | GC keeps v4 (current), v3, v2; deletes v1 and earlier. No reader holds a fd to a deleted file. |
+
+The earlier F1 hazard ("v3 docstore + v4 index → docid mismatch") is structurally eliminated because the symlink is dereferenced exactly once, before any file open.
+
+**GC race window analysis.** The reader is between t=1 (`realpath`) and t=2 (`open(2)`). To make GC delete v3 in that window requires THREE consecutive writes (advancing current to v(N+3), making v3 the (N-2) GC target) while the reader is paused between two adjacent JS-event-loop syscalls. Each write requires acquiring the per-model write lock + running `FaissStore.save` (multi-second on real models). Reader resolution between syscalls is microseconds. **Not a real-world hazard.** N=3 retention is the safety margin; the explicit `realpath`-ENOENT throw above is the loud detection mechanism if the assumption ever breaks.
+
+### Migration — none
+
+No two-step rename; no migration lock; no peer-process race. The new layout is **additive**:
+
+- Existing installs keep `faiss.index/` untouched.
+- The first `updateIndex` after upgrade writes `index.v0/`, creates the `index` symlink. Atomic. No prior state is mutated.
+- `faiss.index/` is preserved as rollback-safety. A user who downgrades the npm package finds their pre-upgrade data intact (any saves the new code made are in `index.vN/` and ignored by the old code).
+
+### Downgrade-hazard surface
+
+A `logger.warn` alone is not enough — operators commonly miss MCP server stderr. So the discoverability is two-tier:
+
+1. **Marker file.** When `loadAtomic` finds BOTH a versioned symlink AND a non-empty legacy `faiss.index/`, write `${modelDir}/.downgrade-hazard` containing the timestamp and a one-line reason. Idempotent (overwrite). Removed automatically by `loadAtomic` when only one layout remains. This file is the durable signal.
+
+2. **`kb models list` surfaces it.** The existing CLI command iterates models; v014 adds a column or trailing flag (e.g., a `[downgrade-hazard]` suffix) when `.downgrade-hazard` is present for that model. One-line code change in `src/active-model.ts` model-listing path.
+
+3. **Log warning** at `initialize` time as belt-and-suspenders:
+   ```typescript
+   if (await pathExists(legacyPath)) {
+     logger.warn(
+       `model ${this.modelId} has both versioned (${path.basename(resolved)}) and legacy ` +
+       `(faiss.index/) layouts present. Downgrading the npm package will silently ignore ` +
+       `any embeddings added since the RFC 014 upgrade — they exist only in the versioned ` +
+       `layout. To reclaim disk and remove the hazard once you're confident in the new layout: ` +
+       `\`rm -rf "${this.modelDir}/faiss.index"\`.`,
+     );
+   }
+   ```
+
+The warning gives a runnable shell command users can act on immediately (no reference to an unimplemented `kb models migrate` CLI). The `kb models migrate` follow-up PR will wrap this in an idempotent helper, but is not a precondition for users to act on the hazard today.
+
+### `nextVersionAfter` and `gcOldVersions`
+
+```typescript
+// Pure function. Idempotent across processes that read the same currentTarget.
+function nextVersionAfter(currentTarget: string | null): string {
+  if (!currentTarget) return 'index.v0';
+  const m = currentTarget.match(/^index\.v(\d+)$/);
+  if (!m) throw new Error(`atomicSave: unrecognized symlink target: ${currentTarget}`);
+  return `index.v${parseInt(m[1], 10) + 1}`;
+}
+
+async function gcOldVersions(modelDir: string, opts: {keep: number, current: string}): Promise<void> {
+  const entries = await fsp.readdir(modelDir);
+  const versions = entries
+    .map(e => ({ name: e, n: parseInt(e.match(/^index\.v(\d+)$/)?.[1] ?? '', 10) }))
+    .filter(v => Number.isFinite(v.n))
+    .sort((a, b) => b.n - a.n);                 // newest first
+
+  const toDelete = versions.slice(opts.keep);   // keep top N
+  for (const v of toDelete) {
+    if (v.name === opts.current) continue;      // never delete what symlink points at (defensive)
+    await fsp.rm(path.join(modelDir, v.name), { recursive: true, force: true })
+      .catch(err => logger.warn(`gc: failed to remove ${v.name}: ${err.message}`));
+  }
+}
+```
+
+**Concurrent same-modelDir saves are prevented by the per-model write lock** (`withWriteLock(manager.modelDir, ...)` at each `updateIndex` call site, verified above). `nextVersionAfter` reads the symlink AFTER lock acquisition, so two writers cannot pick the same version number.
+
+**Orphan staging dirs from prior crashes** do NOT shift `nextVersionAfter` (it reads the symlink, not the directory listing). On EEXIST during `store.save(stagingDir)`, recovery is rmrf+retry-once. If rmrf fails, the error propagates — operator must investigate. Documented.
+
+### File placement
+
+All of `atomicSave`, `loadAtomic`, `nextVersionAfter`, `gcOldVersions`, `readSymlinkOrNull` are **file-private inside `src/FaissIndexManager.ts`**. No new module. They operate on the manager's private layout and are not callable from outside.
+
+### `loadWithJsonRetry` and threat-model.md updates IN this PR
+
+Doc updates are conditional on layout: the versioned path is safe; the legacy path retains the prior hazard until the model is rewritten under v014.
+
+- **`src/cli.ts:842-849`** — replace the comment to read:
+  > "Pre-RFC-014 defensive belt for the LEGACY `faiss.index/` load path only. The versioned `index → index.vN/` layout pre-resolves the symlink before any file open, so torn-JSON is structurally impossible there. Legacy reads still go through `FaissStore.load(legacyPath)` directly and CAN race with a concurrent legacy writer (extremely rare since new code never writes to the legacy path). Slated for removal in the same follow-up PR that drops the single-instance advisory, after the legacy-cleanup task confirms no remaining users on legacy layout."
+- **`docs/architecture/threat-model.md §4`** — replace the "Known limitation" paragraph and the "single MCP server" requirement statement with:
+  > "**Atomic save** (RFC 014, landed in 0.x.y). New per-model layout `index → index.vN/` makes save+load directory-atomic via symlink-swap with reader-side pre-resolution. Torn reads are eliminated for the versioned layout. The legacy `faiss.index/` load path retains the prior hazard until and unless a write under v014 (`updateIndex`, `kb search --refresh`, or `kb models add`) creates the versioned layout for that model. Single-instance advisory is now an operational preference (not a safety requirement) and will be removed in the next release."
+
+The advisory itself stays in `src/instance-lock.ts`. Removing it is the explicit follow-up PR (one-line change + threat-model update); keeping it for one release cycle gives time to detect any field issues with atomic save.
+
+## Test plan
+
+1. **Atomicity smoke.** Two saves; assert symlink advances `index.v0 → index.v1`; legacy `faiss.index/` untouched.
+2. **F1 invariant — reader-during-writer.** Spawn N=20 reader workers; one writer doing `updateIndex` repeatedly. Each reader, after `FaissStore.load`, asserts `index.ntotal() === store.docstore._docs.size` AND every mapping id in `_mapping` resolves. **Use jest mocks for both the embedder and `FaissStore.load`/`fromTexts`** — the existing `FaissIndexManager.test.ts:49-61` pattern (`jest.mock('@langchain/community/embeddings/hf', ...)`) is the template. Mocking lets us return controllable counters for `index.ntotal()` and `docstore._docs.size`, so a docid mismatch is a deterministic test failure. Target wall-clock <30s for 1000 iterations; **validate empirically during implementation** before merging — this is the load-bearing test for F1, and an unstable timing budget would mask its signal. (v1's test would have passed even with the F1 bug because docid mismatch doesn't raise; this invariant is the assertion that catches it.)
+3. **GC retention.** Save 6 times; assert exactly `index.v3, v4, v5` remain.
+4. **Crash recovery — partial save.** Use a test hook to throw between `store.save(staging)` and `rename`. Restart, verify symlink unchanged, verify next save's EEXIST recovery clears the orphan and proceeds.
+5. **Lazy migration.** Build a 0.3.0-layout fixture (real `faiss.index/` directory, no `index` symlink). Call `loadAtomic` — verify it loads from legacy. Call one `updateIndex` — verify `index.v0/` and `index` symlink exist, `faiss.index/` untouched.
+6. **Downgrade compatibility.** After step 5, point a stub "old reader" (just `FaissStore.load(faiss.index)`) at the model dir — verify it still loads the original data.
+7. **Two-process write contention.** Spawn two processes, each call `updateIndex` against the same model dir. Verify per-model write lock serializes; both saves succeed; final symlink points at the second writer's version; no orphan dirs leaked.
+8. **`pathExists` vs `lstat` regression test.** Build a fixture with a dangling `index` symlink (target dir manually rm'd). Call `loadAtomic` — verify it throws the documented error, NOT silently falls through to legacy.
+9. **Startup warning.** Build a fixture with both versioned + legacy. Call `initialize`. Assert the warn log line is emitted exactly once.
+
+## Documentation updates IN this PR
+
+- `docs/architecture/threat-model.md §4`: update text per above.
+- `src/cli.ts:842` comment: update text per above.
+- `docs/rfcs/013-multimodel-support.md §11`: strike N4, link to RFC 014.
+- `CHANGELOG.md`: entry: "Atomic FAISS save (RFC 014). New per-model layout: `index → index.vN/` symlink. Old `faiss.index/` directory preserved untouched for downgrade safety; will be removed in a future release after the single-instance advisory is dropped. No migration step required. Disk usage temporarily ~2x per model until the future cleanup; embed a `kb models migrate` (planned) to reclaim space sooner. Power-cut durability is unchanged from prior releases (best-effort, matches existing repo policy); torn reads are now structurally impossible for the versioned layout."
+
+## Out of scope (separate follow-up PRs)
+
+- **Remove `src/instance-lock.ts`** — one release after this lands.
+- **Remove `loadWithJsonRetry`** — same.
+- **`kb models migrate` CLI** — manual migration tool that re-saves under v014, removes legacy `faiss.index/`. Lets users reclaim disk and bound their downgrade-loss window.
+- **Remove legacy `faiss.index/` load path entirely** — after `kb models migrate` proves stable.
+
+## Risks
+
+- **Symlink portability.** Linux + macOS only (matches repo CI matrix). Windows symlinks need admin/dev mode — not supported.
+- **Backup tools may double-count `faiss.index/` and `index.vN/`.** CHANGELOG note. Reasonable for users to add `index.v[0-9]*/` to backup excludes once the legacy path is dropped in a future release.
+- **Disk usage doubles temporarily** (legacy `faiss.index/` + new `index.vN/`). Bounded by the future `kb models migrate` and `legacy-cleanup` PRs.
+- **Downgrade silent data loss** — saves made under v014 are not visible to a downgraded server. Mitigated by the startup warning emitted when both layouts coexist.
+- **Per-model write lock acquisition is a precondition of `atomicSave`.** Any future caller that bypasses `updateIndex` must wrap in `withWriteLock(manager.modelDir, ...)`. Documented in the function's preamble. A test-mode runtime check uses `properLockfile.check(modelDir, { lockfilePath })` (cheap — single `fs.stat`) to assert the lock is held when `process.env.NODE_ENV === 'test'`. Production builds skip the check to avoid the syscall on the hot path; the four verified call sites in `KnowledgeBaseServer.ts` and `cli.ts` are the contract surface.

--- a/src/FaissIndexManager.test.ts
+++ b/src/FaissIndexManager.test.ts
@@ -11,6 +11,11 @@ function modelDirIn(faissPath: string): string {
 function modelIndexPathIn(faissPath: string): string {
   return path.join(modelDirIn(faissPath), 'faiss.index');
 }
+// RFC 014 — atomic save writes to versioned dirs (index.vN/) and swaps a
+// symlink. First save under v014 always lands at index.v0.
+function versionedIndexPathIn(faissPath: string, version = 'v0'): string {
+  return path.join(modelDirIn(faissPath), `index.${version}`);
+}
 function modelNameFileIn(faissPath: string): string {
   return path.join(modelDirIn(faissPath), 'model_name.txt');
 }
@@ -241,11 +246,12 @@ describe('FaissIndexManager permission handling', () => {
     await manager.initialize();
 
     await expect(manager.updateIndex()).rejects.toThrow(/Permission denied/);
-    expect(saveMock).toHaveBeenCalledWith(modelIndexPathIn(process.env.FAISS_INDEX_PATH!));
+    // RFC 014 — first save under v014 writes to index.v0/ via atomicSave.
+    expect(saveMock).toHaveBeenCalledWith(versionedIndexPathIn(process.env.FAISS_INDEX_PATH!));
 
     await new Promise((resolve) => setImmediate(resolve));
     const logContents = await fsp.readFile(logFile, 'utf-8');
-    expect(logContents).toContain('Permission denied while attempting to save FAISS index at');
+    expect(logContents).toContain('Permission denied while attempting to save FAISS index for model');
   });
 
   it('saves the FAISS index exactly once per updateIndex call when multiple files change', async () => {
@@ -273,7 +279,8 @@ describe('FaissIndexManager permission handling', () => {
     await manager.updateIndex();
 
     expect(saveMock).toHaveBeenCalledTimes(1);
-    expect(saveMock).toHaveBeenCalledWith(modelIndexPathIn(process.env.FAISS_INDEX_PATH!));
+    // RFC 014 — first save under v014 writes to index.v0/ via atomicSave.
+    expect(saveMock).toHaveBeenCalledWith(versionedIndexPathIn(process.env.FAISS_INDEX_PATH!));
     expect(fromTextsMock).toHaveBeenCalledTimes(1);
     expect(addDocumentsMock).toHaveBeenCalledTimes(fileCount - 1);
 
@@ -364,11 +371,23 @@ describe('FaissIndexManager permission handling', () => {
       sidecarSnapshots.push({ path: sidecarPath, content });
     }
 
-    // The mocked FaissStore.save never writes faiss.index, so a fresh manager
-    // will see it missing on disk — exactly the state the fallback branch is
-    // meant to recover from. Assert that precondition explicitly.
+    // The mocked FaissStore.save never writes any data files, but RFC 014's
+    // atomicSave creates a real `index` symlink + versioned dir during the
+    // first pass — even with a mocked store. Wipe both layouts now to
+    // recreate the "no on-disk index" condition the rebuild branch is
+    // meant to recover from. (Pre-RFC-014 the mock save was a complete
+    // no-op so this cleanup wasn't needed; post-RFC-014 the symlink
+    // creation is real.)
+    const modelDirPath = modelDirIn(process.env.FAISS_INDEX_PATH!);
+    for (const entry of await fsp.readdir(modelDirPath)) {
+      if (entry === 'model_name.txt') continue;
+      await fsp.rm(path.join(modelDirPath, entry), { recursive: true, force: true });
+    }
     await expect(
       fsp.stat(modelIndexPathIn(process.env.FAISS_INDEX_PATH!))
+    ).rejects.toMatchObject({ code: 'ENOENT' });
+    await expect(
+      fsp.lstat(path.join(modelDirIn(process.env.FAISS_INDEX_PATH!), 'index'))
     ).rejects.toMatchObject({ code: 'ENOENT' });
 
     // Reset mocks so the fallback-branch call counts are isolated.
@@ -390,7 +409,8 @@ describe('FaissIndexManager permission handling', () => {
     expect(fromTextsMock).toHaveBeenCalledTimes(1);
     expect(addDocumentsMock).not.toHaveBeenCalled();
     expect(saveMock).toHaveBeenCalledTimes(1);
-    expect(saveMock).toHaveBeenCalledWith(modelIndexPathIn(process.env.FAISS_INDEX_PATH!));
+    // RFC 014 — first save under v014 writes to index.v0/ via atomicSave.
+    expect(saveMock).toHaveBeenCalledWith(versionedIndexPathIn(process.env.FAISS_INDEX_PATH!));
 
     // fromTexts must receive documents from every file at once. With content
     // well under the 1000-char chunkSize, each file produces exactly one chunk,
@@ -448,9 +468,10 @@ describe('FaissIndexManager permission handling', () => {
     // End-to-end: the next updateIndex must actually rebuild via fromTexts,
     // not just observe a null faissIndex. This proves the corrupt-recovery
     // path hands off correctly to the existing rebuild branch.
+    // RFC 014 — rebuild now saves to index.v0/, not the legacy faiss.index/.
     await manager.updateIndex();
     expect(fromTextsMock).toHaveBeenCalledTimes(1);
-    expect(saveMock).toHaveBeenCalledWith(indexFilePath);
+    expect(saveMock).toHaveBeenCalledWith(versionedIndexPathIn(faissDir));
   });
 
   it('surfaces a permission error when the corrupt FAISS index cannot be unlinked', async () => {
@@ -531,9 +552,10 @@ describe('FaissIndexManager permission handling', () => {
     await expect(fsp.stat(indexFilePath)).rejects.toMatchObject({ code: 'ENOENT' });
 
     // End-to-end: rebuild branch hands off correctly.
+    // RFC 014 — rebuild now saves to index.v0/, not the legacy faiss.index/.
     await manager.updateIndex();
     expect(fromTextsMock).toHaveBeenCalledTimes(1);
-    expect(saveMock).toHaveBeenCalledWith(indexFilePath);
+    expect(saveMock).toHaveBeenCalledWith(versionedIndexPathIn(faissDir));
   });
 
   it('migrates 0.2.x layout into models/<id>/ on bootstrapLayout (RFC 013 §4.8)', async () => {
@@ -886,8 +908,15 @@ describe('FaissIndexManager chunk metadata (RFC 010 M1)', () => {
       await first.updateIndex();
     }
 
-    // Precondition: faiss.index is not on disk (the mocked save never writes
-    // it), so a fresh manager will take the fallback rebuild branch.
+    // Precondition: no on-disk index, so a fresh manager will take the
+    // fallback rebuild branch. RFC 014 — the mocked save never writes the
+    // staging dir, but atomicSave creates a real `index` symlink anyway.
+    // Wipe both layouts to recreate the "no on-disk index" condition.
+    const _modelDirA = modelDirIn(process.env.FAISS_INDEX_PATH!);
+    for (const entry of await fsp.readdir(_modelDirA)) {
+      if (entry === 'model_name.txt') continue;
+      await fsp.rm(path.join(_modelDirA, entry), { recursive: true, force: true });
+    }
     await expect(
       fsp.stat(modelIndexPathIn(process.env.FAISS_INDEX_PATH!))
     ).rejects.toMatchObject({ code: 'ENOENT' });
@@ -1240,8 +1269,15 @@ describe('FaissIndexManager ingest filter (RFC 011 M1)', () => {
       await first.updateIndex();
     }
 
-    // Precondition: faiss.index is not on disk (mocked save never writes),
-    // so a fresh manager takes the fallback rebuild branch (line 375).
+    // Precondition: no on-disk index, so a fresh manager takes the fallback
+    // rebuild branch. RFC 014 — the mocked save never writes the staging
+    // dir, but atomicSave creates a real `index` symlink anyway. Wipe both
+    // layouts to recreate the "no on-disk index" condition.
+    const _modelDirB = modelDirIn(process.env.FAISS_INDEX_PATH!);
+    for (const entry of await fsp.readdir(_modelDirB)) {
+      if (entry === 'model_name.txt') continue;
+      await fsp.rm(path.join(_modelDirB, entry), { recursive: true, force: true });
+    }
     await expect(
       fsp.stat(modelIndexPathIn(process.env.FAISS_INDEX_PATH!)),
     ).rejects.toMatchObject({ code: 'ENOENT' });

--- a/src/FaissIndexManager.ts
+++ b/src/FaissIndexManager.ts
@@ -49,6 +49,81 @@ async function writeModelNameAtomic(modelNameFile: string, modelName: string): P
   await fsp.rename(tmp, modelNameFile);
 }
 
+// ---------------------------------------------------------------------------
+// RFC 014 — atomic FAISS save via versioned dirs + symlink swap.
+//
+// Layout (per model):
+//   ${modelDir}/index               → symlink to index.vN
+//   ${modelDir}/index.vN/{faiss.index, docstore.json}   (current)
+//   ${modelDir}/index.vN-1/...      (kept for GC slack)
+//   ${modelDir}/index.vN-2/...      (kept for GC slack)
+//   ${modelDir}/faiss.index/        (legacy, untouched on upgrade)
+//
+// Save path: write into ${modelDir}/index.v(N+1) → atomic symlink swap
+// (rename(2) of a symlink is atomic on POSIX) → GC versions older than N=3.
+//
+// Read path: lstat the symlink (NOT pathExists which follows symlinks);
+// realpath ONCE at the caller; pass the resolved absolute path to
+// FaissStore.load. Eliminates the F1 docid-mismatch race that arises
+// because @langchain/community's FaissStore.load does Promise.all of two
+// independent open(2) calls — each would re-resolve a symlink given the
+// path, but an absolute resolved path has no symlink to re-resolve.
+// ---------------------------------------------------------------------------
+
+const VERSION_DIR_PATTERN = /^index\.v(\d+)$/;
+const SYMLINK_NAME = 'index';
+const LEGACY_INDEX_NAME = 'faiss.index';
+const DOWNGRADE_HAZARD_MARKER = '.downgrade-hazard';
+
+/** Read the symlink target if `p` is a symlink; otherwise null. */
+async function readSymlinkOrNull(p: string): Promise<string | null> {
+  try {
+    return await fsp.readlink(p);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT' || code === 'EINVAL') return null;
+    throw err;
+  }
+}
+
+/** Pure: derive the next versioned directory name from the current target. */
+export function nextVersionAfter(currentTarget: string | null): string {
+  if (!currentTarget) return 'index.v0';
+  const m = currentTarget.match(VERSION_DIR_PATTERN);
+  if (!m) throw new Error(`atomicSave: unrecognized symlink target "${currentTarget}"`);
+  return `index.v${parseInt(m[1], 10) + 1}`;
+}
+
+/**
+ * Best-effort GC: keep the `keep` newest `index.vN` dirs (current included);
+ * remove older ones. Never deletes the directory the symlink currently
+ * points at, even if that violates the keep budget (defensive).
+ */
+async function gcOldVersions(
+  modelDirPath: string,
+  opts: { keep: number; current: string },
+): Promise<void> {
+  let entries: string[];
+  try {
+    entries = await fsp.readdir(modelDirPath);
+  } catch {
+    return;
+  }
+  const versions = entries
+    .map((e) => ({ name: e, n: parseInt(e.match(VERSION_DIR_PATTERN)?.[1] ?? '', 10) }))
+    .filter((v) => Number.isFinite(v.n))
+    .sort((a, b) => b.n - a.n);
+
+  for (const v of versions.slice(opts.keep)) {
+    if (v.name === opts.current) continue;
+    await fsp
+      .rm(path.join(modelDirPath, v.name), { recursive: true, force: true })
+      .catch((err) =>
+        logger.warn(`gc: failed to remove ${v.name} in ${modelDirPath}: ${(err as Error).message}`),
+      );
+  }
+}
+
 // -----------------------------------------------------------------------------
 // RFC 011 §5.4 — whitelisted frontmatter lift + sibling PDF detection.
 //
@@ -394,6 +469,11 @@ export interface FaissIndexManagerOptions {
 export class FaissIndexManager {
   private faissIndex: FaissStore | null = null;
   private embeddings: HuggingFaceInferenceEmbeddings | OllamaEmbeddings | OpenAIEmbeddings;
+  // RFC 014 — monotonic counter for unique tmp-symlink names within this
+  // process. Incremented on every atomicSave; combined with PID it guarantees
+  // no collision between concurrent saves on the same modelDir (which the
+  // per-model write lock already prevents, but the counter is cheap).
+  private swapCounter = 0;
   readonly modelName: string;
   readonly embeddingProvider: EmbeddingProvider;
   readonly modelId: string;
@@ -529,36 +609,14 @@ export class FaissIndexManager {
           handleFsOperationError('create FAISS model directory', this.modelDir, error);
         }
       }
-      const indexFilePath = path.join(this.modelDir, 'faiss.index');
-
       // RFC 013: no model-switch wipe at initialize time. Each model has its
       // own dir; a different provider+model goes to a different `models/<id>/`.
-      // The single-model wipe at lines 356-371 of the 0.2.x file was a
-      // single-model artifact; multi-model dispenses with it.
-
-      if (await pathExists(indexFilePath)) {
-        logger.info('Loading existing FAISS index from:', indexFilePath);
-        try {
-          this.faissIndex = await FaissStore.load(indexFilePath, this.embeddings);
-          logger.info(`FAISS index loaded for model ${this.modelId}.`);
-        } catch (error) {
-          logger.warn(
-            'Existing FAISS index at',
-            indexFilePath,
-            'is corrupt or unreadable - rebuilding from source. Error:',
-            error,
-          );
-          try {
-            await fsp.rm(indexFilePath, { recursive: true, force: true });
-          } catch (unlinkErr) {
-            handleFsOperationError('delete corrupt FAISS index', indexFilePath, unlinkErr);
-          }
-          this.faissIndex = null;
-        }
-      } else {
-        logger.info('FAISS index file not found at', indexFilePath, '. It will be created on the next updateIndex.');
-        this.faissIndex = null;
-      }
+      // RFC 014: load via the new versioned layout if present, fall back to
+      // the legacy faiss.index/ directory otherwise. loadAtomic handles its
+      // own corruption recovery — only the FAILED layout is removed, never
+      // the other one (preserves legacy as rollback safety even when the
+      // versioned layout is corrupt, and vice versa).
+      this.faissIndex = await this.loadAtomic();
 
       // Save the current model name for this model's dir. Skipped under
       // readOnly:true (RFC 012 §4.5).
@@ -578,6 +636,201 @@ export class FaissIndexManager {
       }
       throw error;
     }
+  }
+
+  /**
+   * RFC 014 — load the FAISS store via the new versioned layout when present,
+   * fall back to the legacy `faiss.index/` directory otherwise. Returns null
+   * if neither layout has any data (fresh install).
+   *
+   * The reader-side fix for F1 (docid mismatch under concurrent symlink
+   * swap): we lstat the symlink (NOT pathExists, which follows symlinks and
+   * would silently return false for a dangling symlink), realpath ONCE here,
+   * and pass the resolved absolute path to FaissStore.load. FaissStore.load
+   * then does its internal Promise.all(open(faiss.index), open(docstore.json))
+   * against an absolute path with no symlink in it — both opens hit the same
+   * pinned version even if a writer atomically swaps the symlink in between.
+   *
+   * Side effect: writes / clears `${modelDir}/.downgrade-hazard` based on
+   * coexistence of versioned + legacy layouts, and emits a one-time warn
+   * when the hazard is present.
+   */
+  private async loadAtomic(): Promise<FaissStore | null> {
+    const symlinkPath = path.join(this.modelDir, SYMLINK_NAME);
+    const legacyPath = path.join(this.modelDir, LEGACY_INDEX_NAME);
+    const hazardMarker = path.join(this.modelDir, DOWNGRADE_HAZARD_MARKER);
+
+    // lstat (NOT stat) — detects symlink presence without following it.
+    const symStat = await fsp.lstat(symlinkPath).catch((err) => {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null;
+      throw err;
+    });
+
+    if (symStat?.isSymbolicLink()) {
+      let resolved: string;
+      try {
+        resolved = await fsp.realpath(symlinkPath);
+      } catch (err) {
+        // realpath ENOENT after lstat confirmed a symlink means the target
+        // was removed between syscalls — N=3 retention contract violated.
+        // Surface loudly per RFC 014 §"Load algorithm".
+        if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+          throw new Error(
+            `loadAtomic: symlink ${symlinkPath} target vanished between lstat and realpath — ` +
+              `N=3 retention contract violated. Check for concurrent gc, manual filesystem ` +
+              `surgery, or unexpected rmrf.`,
+          );
+        }
+        throw err;
+      }
+
+      let store: FaissStore;
+      try {
+        logger.info(
+          `Loading FAISS index for model ${this.modelId} from ${path.basename(resolved)}`,
+        );
+        store = await FaissStore.load(resolved, this.embeddings);
+      } catch (err) {
+        // Versioned layout corrupt. Remove ONLY the symlink (which makes
+        // the current versioned layout unreachable) — do NOT touch the
+        // legacy `faiss.index/` directory, which is the operator's
+        // rollback safety net and is independently valid. Orphan
+        // index.vN/ dirs are left in place; the next save's EEXIST
+        // recovery clears them.
+        logger.warn(
+          `Versioned FAISS index ${resolved} is corrupt or unreadable — ` +
+            `removing symlink and falling back to rebuild. Legacy faiss.index/ ` +
+            `(if present) is preserved. Error:`,
+          err,
+        );
+        try {
+          await fsp.rm(symlinkPath, { force: true });
+        } catch (unlinkErr) {
+          handleFsOperationError('delete corrupt index symlink', symlinkPath, unlinkErr);
+        }
+        // Best-effort clear marker — versioned layout is gone, hazard no
+        // longer applies in its prior form.
+        await fsp.rm(hazardMarker, { force: true }).catch(() => undefined);
+        return null;
+      }
+
+      // Hazard surface: both layouts coexist → write marker + warn once.
+      if (await pathExists(legacyPath)) {
+        await fsp
+          .writeFile(
+            hazardMarker,
+            `${new Date().toISOString()}\nlegacy faiss.index/ coexists with versioned ${path.basename(resolved)}\n`,
+            'utf-8',
+          )
+          .catch(() => undefined);
+        logger.warn(
+          `model ${this.modelId} has both versioned (${path.basename(resolved)}) and legacy ` +
+            `(faiss.index/) layouts present. Downgrading the npm package will silently ignore ` +
+            `any embeddings added since the RFC 014 upgrade — they exist only in the versioned ` +
+            `layout. To reclaim disk and remove the hazard once you're confident in the new ` +
+            `layout: \`rm -rf "${legacyPath}"\`.`,
+        );
+      } else {
+        // Hazard cleared (legacy was removed by operator). Best-effort clean.
+        await fsp.rm(hazardMarker, { force: true }).catch(() => undefined);
+      }
+
+      return store;
+    }
+
+    // No versioned layout — clear any stale hazard marker before any
+    // legacy fallback or null return. The marker only makes sense when
+    // both layouts coexist, which requires the symlink branch above.
+    await fsp.rm(hazardMarker, { force: true }).catch(() => undefined);
+
+    // Legacy path — pre-RFC-014 layout. Read directly. The torn-read hazard
+    // described in the threat model still applies HERE until the first
+    // updateIndex writes the versioned layout for this model.
+    if (await pathExists(legacyPath)) {
+      try {
+        logger.info(
+          `Loading legacy FAISS index for model ${this.modelId} from faiss.index/. ` +
+            `First save will create versioned layout (${SYMLINK_NAME} → index.v0).`,
+        );
+        return await FaissStore.load(legacyPath, this.embeddings);
+      } catch (err) {
+        // Legacy corrupt. Remove ONLY the legacy directory — there's no
+        // versioned layout to preserve, and the next updateIndex will
+        // rebuild from source into index.v0/.
+        logger.warn(
+          `Legacy FAISS index at ${legacyPath} is corrupt or unreadable — ` +
+            `removing and falling back to rebuild. Error:`,
+          err,
+        );
+        try {
+          await fsp.rm(legacyPath, { recursive: true, force: true });
+        } catch (unlinkErr) {
+          handleFsOperationError('delete corrupt legacy FAISS index', legacyPath, unlinkErr);
+        }
+        return null;
+      }
+    }
+
+    logger.info(
+      `FAISS index not found for model ${this.modelId}. It will be created on the next updateIndex.`,
+    );
+    return null;
+  }
+
+  /**
+   * RFC 014 — atomic save via versioned dirs + symlink swap.
+   *
+   * PRECONDITION: caller MUST hold withWriteLock(this.modelDir). Verified
+   * call sites: KnowledgeBaseServer.ts:216,374 and cli.ts:436,646. Any
+   * future caller that bypasses updateIndex must wrap in withWriteLock.
+   * In NODE_ENV=test we assert the lock is held via proper-lockfile.check().
+   */
+  private async atomicSave(): Promise<void> {
+    if (!this.faissIndex) throw new Error('atomicSave called with null faissIndex');
+
+    // PRECONDITION: caller MUST hold withWriteLock(this.modelDir). The four
+    // verified call sites are KnowledgeBaseServer.ts:216,374 and
+    // cli.ts:436,646. A runtime check via proper-lockfile.check() was
+    // considered (RFC 014 §Risks) but proved to false-negative in tests
+    // (proper-lockfile distinguishes lockfilePath args inconsistently across
+    // call patterns). Documented contract + grep-able call sites is the
+    // safer enforcement; future violations are caught by reviewers, not by
+    // runtime assertion that itself misfires.
+
+    const symlinkPath = path.join(this.modelDir, SYMLINK_NAME);
+    const currentTarget = await readSymlinkOrNull(symlinkPath);
+    const nextVersion = nextVersionAfter(currentTarget);
+    const stagingDir = path.join(this.modelDir, nextVersion);
+
+    // 1. Active orphan cleanup BEFORE save. langchain's FaissStore.save calls
+    //    `mkdir({recursive: true})` which silently no-ops on existing dirs —
+    //    so an orphan from a prior crash would NOT EEXIST, it would be merged
+    //    with the new write (stale docstore + fresh faiss.index → torn dir
+    //    written under the new symlink target). Rmrf the staging dir
+    //    upfront; safe because per-model write lock is held and version
+    //    number monotonically advances, so no other writer is using it.
+    if (await pathExists(stagingDir)) {
+      logger.warn(`atomicSave: clearing orphan staging dir ${stagingDir} from prior crash`);
+      await fsp.rm(stagingDir, { recursive: true, force: true });
+    }
+    await this.faissIndex.save(stagingDir);
+
+    // 2. Atomic symlink swap. POSIX rename(2) replaces the existing symlink
+    //    atomically. Tmp name is unique within this process; per-model write
+    //    lock prevents concurrent same-modelDir saves anyway.
+    const tmpLink = path.join(
+      this.modelDir,
+      `.${SYMLINK_NAME}.tmp.${process.pid}.${++this.swapCounter}`,
+    );
+    await fsp.symlink(nextVersion, tmpLink);
+    await fsp.rename(tmpLink, symlinkPath);
+    logger.info(
+      `atomicSave: ${this.modelId} ${currentTarget ?? '(none)'} → ${nextVersion}`,
+    );
+
+    // 3. Synchronous GC inside the write lock — caller contract is "lock
+    //    release = no orphans (kept N=3) and no half-state".
+    await gcOldVersions(this.modelDir, { keep: 3, current: nextVersion });
   }
 
   /**
@@ -791,12 +1044,19 @@ export class FaissIndexManager {
       }
 
       if (indexMutated && this.faissIndex !== null) {
-        const indexFileSavePath = path.join(this.modelDir, 'faiss.index');
+        // RFC 014 — atomicSave writes to a versioned `index.vN/` and swaps
+        // the `index` symlink atomically. The legacy `faiss.index/` directory
+        // (if present from a pre-RFC-014 install) is intentionally NOT
+        // updated; first save under v014 effectively migrates the model to
+        // versioned layout.
         try {
-          await this.faissIndex.save(indexFileSavePath);
-          logger.info('FAISS index saved successfully to', indexFileSavePath);
+          await this.atomicSave();
         } catch (saveError: any) {
-          handleFsOperationError('save FAISS index at', indexFileSavePath, saveError);
+          handleFsOperationError(
+            'save FAISS index for model',
+            this.modelId,
+            saveError,
+          );
         }
         // Sidecar hashes are written only after the index has persisted so we
         // never claim a hash for vectors that never landed on disk. tmp+rename

--- a/src/active-model.ts
+++ b/src/active-model.ts
@@ -42,10 +42,48 @@ export function modelDir(modelId: string): string {
 }
 
 export function faissIndexBinaryPath(modelId: string): string {
-  // The inner binary file inside `${PATH}/models/<id>/faiss.index/` — used
-  // for staleness mtime detection (round-3 of RFC 012 §4.10 — directory
-  // mtime doesn't update on file overwrites).
+  // The inner binary file inside `${PATH}/models/<id>/faiss.index/` — legacy
+  // pre-RFC-014 layout. Used for staleness mtime detection on models that
+  // have not yet been written under v014. New consumers should prefer
+  // `resolveFaissIndexBinaryPath` which handles both layouts.
   return path.join(modelDir(modelId), 'faiss.index', 'faiss.index');
+}
+
+/**
+ * RFC 014 — return the path to the FAISS binary file for staleness checks,
+ * preferring the versioned layout (`index → index.vN/faiss.index`) when
+ * present and falling back to the legacy path. Returns null if neither
+ * layout has data.
+ *
+ * Async because we follow the symlink with `realpath` to get a stable path
+ * (the returned string is what `fs.stat` should target). A concurrent symlink
+ * swap after this call returns is harmless — the caller stat's a path that
+ * was valid at resolve time.
+ */
+export async function resolveFaissIndexBinaryPath(modelId: string): Promise<string | null> {
+  const dir = modelDir(modelId);
+  const symlinkPath = path.join(dir, 'index');
+  // lstat-guard before realpath: if `index` exists as something OTHER than a
+  // symlink (operator surgery — replaced symlink with a regular file or
+  // directory), realpath would still return its absolute path but the
+  // returned faiss.index inside it likely doesn't exist. Fall back to
+  // legacy in that case rather than returning a doomed path.
+  try {
+    const st = await fsp.lstat(symlinkPath);
+    if (st.isSymbolicLink()) {
+      const resolved = await fsp.realpath(symlinkPath);
+      return path.join(resolved, 'faiss.index');
+    }
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+  }
+  const legacy = path.join(dir, 'faiss.index', 'faiss.index');
+  try {
+    await fsp.access(legacy);
+    return legacy;
+  } catch {
+    return null;
+  }
 }
 
 export function modelNameFilePath(modelId: string): string {
@@ -105,6 +143,15 @@ export interface RegisteredModel {
   model_id: string;
   provider: string;
   model_name: string;
+  /**
+   * RFC 014 — true when this model has both the new versioned layout
+   * (`index → index.vN/`) AND the legacy `faiss.index/` directory present.
+   * Downgrading the npm package would silently ignore embeddings added
+   * since the upgrade. Surfaced by `kb models list` and the `list_models`
+   * MCP tool. Cleared automatically on next load when only one layout
+   * remains.
+   */
+  downgrade_hazard?: boolean;
 }
 
 export async function listRegisteredModels(): Promise<RegisteredModel[]> {
@@ -120,7 +167,19 @@ export async function listRegisteredModels(): Promise<RegisteredModel[]> {
     if (!(await isRegisteredModel(entry))) continue;
     const modelName = (await readStoredModelName(entry)) ?? entry;
     const { provider } = parseModelId(entry);
-    models.push({ model_id: entry, provider, model_name: modelName });
+    let downgradeHazard = false;
+    try {
+      await fsp.access(path.join(modelDir(entry), '.downgrade-hazard'));
+      downgradeHazard = true;
+    } catch {
+      // marker absent — no hazard
+    }
+    models.push({
+      model_id: entry,
+      provider,
+      model_name: modelName,
+      ...(downgradeHazard ? { downgrade_hazard: true } : {}),
+    });
   }
   return models.sort((a, b) => a.model_id.localeCompare(b.model_id));
 }

--- a/src/atomic-save.test.ts
+++ b/src/atomic-save.test.ts
@@ -1,0 +1,453 @@
+// RFC 014 — atomic FAISS save tests.
+//
+// These tests use a real on-disk layout (tmpdir) but mock `FaissStore` so we
+// can:
+//   1. Inject a controlled "version generation" into each save (saveCounter)
+//   2. Have load() assert that both files in the loaded directory carry the
+//      SAME generation — a docid mismatch would manifest as a thrown error.
+//   3. Run 1000 reader/writer iterations in <30s without a real embedder.
+//
+// The test that catches the F1 docid-mismatch race is "F1 invariant —
+// reader during concurrent writer". If that test ever fails, the design
+// is broken.
+
+import * as fsp from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import * as properLockfile from 'proper-lockfile';
+
+const DEFAULT_MODEL_ID = 'huggingface__BAAI-bge-small-en-v1.5';
+
+// ---------- shared mock state across tests ----------
+const saveMock = jest.fn();
+const loadMock = jest.fn();
+const fromTextsMock = jest.fn();
+const addDocumentsMock = jest.fn();
+const similaritySearchMock = jest.fn();
+
+// Per-save monotonic generation counter. Incremented every save; the value
+// at save-time is written into BOTH `faiss.index` and `docstore.json` so a
+// torn read (one file from save N, other from save N+1) is detectable.
+let nextGen = 0;
+
+function incrementGen(): number {
+  nextGen += 1;
+  return nextGen;
+}
+
+function resetMockState() {
+  saveMock.mockClear();
+  loadMock.mockClear();
+  fromTextsMock.mockClear();
+  addDocumentsMock.mockClear();
+  similaritySearchMock.mockClear();
+  nextGen = 0;
+}
+
+class MockFaissStore {
+  // Carries the gen this in-memory store is "valid for" — for asserting
+  // post-load consistency.
+  loadedGen: number | null = null;
+
+  async addDocuments(...args: unknown[]) {
+    return addDocumentsMock(...args);
+  }
+
+  async save(directory: string) {
+    saveMock(directory);
+    const gen = incrementGen();
+    await fsp.mkdir(directory, { recursive: true });
+    // Two files like real FaissStore.save. Both carry the same gen.
+    await fsp.writeFile(path.join(directory, 'faiss.index'), `gen=${gen}\n`, 'utf-8');
+    await fsp.writeFile(path.join(directory, 'docstore.json'), `gen=${gen}\n`, 'utf-8');
+  }
+
+  async similaritySearchWithScore(...args: unknown[]) {
+    return similaritySearchMock(...args);
+  }
+
+  static async fromTexts(...args: unknown[]) {
+    fromTextsMock(...args);
+    return new MockFaissStore();
+  }
+
+  // The crucial behavior: load reads BOTH files (like real FaissStore.load
+  // doing Promise.all of two opens) and asserts they have the same gen.
+  // Mismatched gen = the F1 docid-mismatch bug. The loaded path should be
+  // an absolute path (caller pre-resolved any symlink); we DO NOT resolve
+  // anything here — if the caller passes a symlink we'd get partial file
+  // resolution exactly like the real F1 bug.
+  static async load(directory: string, embeddings: unknown) {
+    loadMock(directory, embeddings);
+    const [a, b] = await Promise.all([
+      fsp.readFile(path.join(directory, 'faiss.index'), 'utf-8'),
+      fsp.readFile(path.join(directory, 'docstore.json'), 'utf-8'),
+    ]);
+    const genA = parseInt(/^gen=(\d+)/.exec(a)?.[1] ?? '', 10);
+    const genB = parseInt(/^gen=(\d+)/.exec(b)?.[1] ?? '', 10);
+    if (!Number.isFinite(genA) || !Number.isFinite(genB)) {
+      throw new Error(`MockFaissStore.load: missing gen marker in ${directory}`);
+    }
+    if (genA !== genB) {
+      throw new Error(
+        `MockFaissStore.load: TORN READ in ${directory} — faiss.index gen=${genA}, ` +
+          `docstore.json gen=${genB}. RFC 014 atomicity violated.`,
+      );
+    }
+    const store = new MockFaissStore();
+    store.loadedGen = genA;
+    return store;
+  }
+}
+
+jest.mock('@langchain/community/embeddings/hf', () => ({
+  __esModule: true,
+  HuggingFaceInferenceEmbeddings: class MockEmbedding {
+    constructor(public _config: unknown) {}
+  },
+}));
+
+jest.mock('@langchain/community/vectorstores/faiss', () => ({
+  __esModule: true,
+  FaissStore: MockFaissStore,
+}));
+
+// ---------- helpers ----------
+
+function modelDirIn(faissPath: string): string {
+  return path.join(faissPath, 'models', DEFAULT_MODEL_ID);
+}
+
+async function makeManager(faissPath: string) {
+  process.env.NODE_ENV = 'test';
+  process.env.FAISS_INDEX_PATH = faissPath;
+  // Pin to the huggingface default so DEFAULT_MODEL_ID resolves predictably,
+  // regardless of what's in the dev shell env (Ollama vs HF vs OpenAI).
+  process.env.EMBEDDING_PROVIDER = 'huggingface';
+  process.env.HUGGINGFACE_MODEL_NAME = 'BAAI/bge-small-en-v1.5';
+  process.env.HUGGINGFACE_API_KEY = 'test-stub';
+  // Re-import the module fresh so it re-reads env vars.
+  jest.resetModules();
+  const mod = await import('./FaissIndexManager.js');
+  return new mod.FaissIndexManager();
+}
+
+async function holdWriteLock<T>(modelDir: string, fn: () => Promise<T>): Promise<T> {
+  await fsp.mkdir(modelDir, { recursive: true });
+  const lockfilePath = path.join(modelDir, '.kb-write.lock');
+  const release = await properLockfile.lock(modelDir, {
+    lockfilePath,
+    update: 5000,
+    stale: 10_000,
+    retries: { retries: 5, factor: 1.5, minTimeout: 100, maxTimeout: 1000 },
+  });
+  try {
+    return await fn();
+  } finally {
+    await release();
+  }
+}
+
+// ---------- tests ----------
+
+describe('RFC 014 atomic save — file-private helpers', () => {
+  let nextVersionAfter: (s: string | null) => string;
+
+  beforeAll(async () => {
+    const mod = await import('./FaissIndexManager.js');
+    nextVersionAfter = mod.nextVersionAfter;
+  });
+
+  test('nextVersionAfter(null) returns index.v0', () => {
+    expect(nextVersionAfter(null)).toBe('index.v0');
+  });
+
+  test('nextVersionAfter increments numerically', () => {
+    expect(nextVersionAfter('index.v0')).toBe('index.v1');
+    expect(nextVersionAfter('index.v9')).toBe('index.v10');
+    expect(nextVersionAfter('index.v999')).toBe('index.v1000');
+  });
+
+  test('nextVersionAfter rejects malformed non-empty targets', () => {
+    expect(() => nextVersionAfter('faiss.index')).toThrow(/unrecognized symlink target/);
+    expect(() => nextVersionAfter('index.foo')).toThrow();
+  });
+
+  test('nextVersionAfter treats empty string as no current target', () => {
+    // Empty string is falsy and equivalent to null — both indicate no
+    // current versioned layout exists yet (fresh install).
+    expect(nextVersionAfter('')).toBe('index.v0');
+  });
+});
+
+describe('RFC 014 atomic save — atomicity smoke', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    resetMockState();
+    tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'rfc014-smoke-'));
+  });
+
+  afterEach(async () => {
+    await fsp.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  test('two saves advance the symlink and leave legacy untouched', async () => {
+    const mgr = await makeManager(tmpDir);
+    const modelDir = modelDirIn(tmpDir);
+    await fsp.mkdir(modelDir, { recursive: true });
+
+    // Pre-create a legacy faiss.index/ directory; assert it stays untouched.
+    // Use the gen=N format so any incidental load via the mock would succeed
+    // (avoids triggering the corruption-recovery branch in initialize, which
+    // would rmrf the legacy dir).
+    const legacyDir = path.join(modelDir, 'faiss.index');
+    await fsp.mkdir(legacyDir);
+    await fsp.writeFile(path.join(legacyDir, 'faiss.index'), 'gen=99\n');
+    await fsp.writeFile(path.join(legacyDir, 'docstore.json'), 'gen=99\n');
+    const legacyMtime = (await fsp.stat(legacyDir)).mtimeMs;
+
+    // Skip initialize() — the mock would load the legacy fixture but we're
+    // testing atomicSave specifically. Inject a faissIndex directly.
+    (mgr as any).faissIndex = new MockFaissStore();
+
+    await holdWriteLock(modelDir, () => (mgr as any).atomicSave());
+    expect(await fsp.readlink(path.join(modelDir, 'index'))).toBe('index.v0');
+
+    await holdWriteLock(modelDir, () => (mgr as any).atomicSave());
+    expect(await fsp.readlink(path.join(modelDir, 'index'))).toBe('index.v1');
+
+    // Legacy untouched.
+    expect((await fsp.stat(legacyDir)).mtimeMs).toBe(legacyMtime);
+    expect(await fsp.readFile(path.join(legacyDir, 'faiss.index'), 'utf-8')).toBe('gen=99\n');
+  });
+});
+
+describe('RFC 014 atomic save — F1 invariant (reader-during-writer)', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    resetMockState();
+    tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'rfc014-f1-'));
+  });
+
+  afterEach(async () => {
+    await fsp.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  test('1000 concurrent reads while writer races never observe a torn read', async () => {
+    const mgr = await makeManager(tmpDir);
+    const modelDir = modelDirIn(tmpDir);
+    await fsp.mkdir(modelDir, { recursive: true });
+    await mgr.initialize({ readOnly: true });
+    (mgr as any).faissIndex = new MockFaissStore();
+
+    // Seed: one initial save so loadAtomic has something to read.
+    await holdWriteLock(modelDir, () => (mgr as any).atomicSave());
+
+    let done = false;
+    let writerSaves = 0;
+    const writerErrors: Error[] = [];
+    const readerErrors: Error[] = [];
+
+    const writer = (async () => {
+      while (!done) {
+        try {
+          await holdWriteLock(modelDir, () => (mgr as any).atomicSave());
+          writerSaves += 1;
+        } catch (err) {
+          writerErrors.push(err as Error);
+          break;
+        }
+      }
+    })();
+
+    const ITERATIONS = 1000;
+    const READERS = 20;
+    const readers = Array.from({ length: READERS }, async () => {
+      for (let i = 0; i < ITERATIONS / READERS; i += 1) {
+        try {
+          // We need a fresh manager-like loader because faissIndex is mutated
+          // by the writer; instead just call the static load via the symlink.
+          // loadAtomic is the function under test — we can call it directly
+          // on a fresh manager that doesn't share state with the writer.
+          const reader = new (await import('./FaissIndexManager.js')).FaissIndexManager();
+          // Force the reader to resolve through OUR pre-resolved path code.
+          await reader.initialize({ readOnly: true });
+          // initialize calls loadAtomic; if a torn read happened, it would
+          // throw with the mock's "TORN READ" message. We don't need to do
+          // anything else here.
+        } catch (err) {
+          readerErrors.push(err as Error);
+        }
+      }
+    });
+
+    await Promise.all(readers);
+    done = true;
+    await writer;
+
+    // The writer must have made progress (else the test isn't actually exercising the race).
+    expect(writerSaves).toBeGreaterThan(5);
+    expect(writerErrors).toEqual([]);
+    expect(readerErrors).toEqual([]);
+  }, 30_000);
+});
+
+describe('RFC 014 atomic save — GC retention (N=3)', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    resetMockState();
+    tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'rfc014-gc-'));
+  });
+
+  afterEach(async () => {
+    await fsp.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  test('after 6 saves, only index.v3, v4, v5 remain', async () => {
+    const mgr = await makeManager(tmpDir);
+    const modelDir = modelDirIn(tmpDir);
+    await fsp.mkdir(modelDir, { recursive: true });
+    await mgr.initialize({ readOnly: true });
+    (mgr as any).faissIndex = new MockFaissStore();
+
+    for (let i = 0; i < 6; i += 1) {
+      await holdWriteLock(modelDir, () => (mgr as any).atomicSave());
+    }
+
+    const entries = await fsp.readdir(modelDir);
+    const versions = entries.filter((e) => /^index\.v\d+$/.test(e)).sort();
+    expect(versions).toEqual(['index.v3', 'index.v4', 'index.v5']);
+    expect(await fsp.readlink(path.join(modelDir, 'index'))).toBe('index.v5');
+  });
+});
+
+describe('RFC 014 atomic save — lstat-vs-pathExists regression', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    resetMockState();
+    tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'rfc014-lstat-'));
+  });
+
+  afterEach(async () => {
+    await fsp.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  test('dangling symlink (target rm-ed) throws loud error, not silent legacy fallthrough', async () => {
+    const modelDir = modelDirIn(tmpDir);
+    await fsp.mkdir(modelDir, { recursive: true });
+
+    // Set up a dangling symlink: index → index.v0 but index.v0/ does not exist.
+    await fsp.symlink('index.v0', path.join(modelDir, 'index'));
+    // Also create a legacy directory with content — if loadAtomic falls through
+    // silently (the bug), it would load THIS instead of throwing.
+    const legacyDir = path.join(modelDir, 'faiss.index');
+    await fsp.mkdir(legacyDir);
+    await fsp.writeFile(path.join(legacyDir, 'faiss.index'), 'gen=999\n');
+    await fsp.writeFile(path.join(legacyDir, 'docstore.json'), 'gen=999\n');
+
+    const mgr = await makeManager(tmpDir);
+    // initialize() catches and logs, but the corruption-recovery branch in
+    // FaissIndexManager will rm the symlink and then load null. We're
+    // testing that loadAtomic itself raises on the dangling case, so call
+    // it directly via the corruption-recovery contract.
+    let raised: Error | null = null;
+    try {
+      await (mgr as any).loadAtomic();
+    } catch (err) {
+      raised = err as Error;
+    }
+    expect(raised).not.toBeNull();
+    expect(raised!.message).toMatch(/N=3 retention contract violated/);
+  });
+});
+
+describe('RFC 014 atomic save — lazy migration (legacy load + first save creates versioned)', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    resetMockState();
+    tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'rfc014-lazy-'));
+  });
+
+  afterEach(async () => {
+    await fsp.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  test('initialize on a legacy-only model loads from faiss.index/, first save creates index.v0', async () => {
+    const modelDir = modelDirIn(tmpDir);
+    await fsp.mkdir(modelDir, { recursive: true });
+
+    // Build a "0.3.0" fixture: faiss.index/ directory with the two files.
+    const legacyDir = path.join(modelDir, 'faiss.index');
+    await fsp.mkdir(legacyDir);
+    await fsp.writeFile(path.join(legacyDir, 'faiss.index'), 'gen=42\n');
+    await fsp.writeFile(path.join(legacyDir, 'docstore.json'), 'gen=42\n');
+
+    const mgr = await makeManager(tmpDir);
+    await mgr.initialize({ readOnly: true });
+    // loadAtomic should have read from legacy.
+    expect(loadMock).toHaveBeenCalledWith(legacyDir, expect.anything());
+
+    // Now do a save — should create index.v0 and the symlink.
+    (mgr as any).faissIndex = new MockFaissStore();
+    await holdWriteLock(modelDir, () => (mgr as any).atomicSave());
+
+    expect(await fsp.readlink(path.join(modelDir, 'index'))).toBe('index.v0');
+    // Legacy untouched (no migration step).
+    expect(await fsp.readFile(path.join(legacyDir, 'faiss.index'), 'utf-8')).toBe('gen=42\n');
+  });
+});
+
+describe('RFC 014 atomic save — downgrade-hazard surfacing', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    resetMockState();
+    tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'rfc014-hazard-'));
+  });
+
+  afterEach(async () => {
+    await fsp.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  test('marker file is written when both versioned + legacy coexist, cleared when legacy removed', async () => {
+    const modelDir = modelDirIn(tmpDir);
+    await fsp.mkdir(modelDir, { recursive: true });
+
+    // Build both layouts.
+    const legacyDir = path.join(modelDir, 'faiss.index');
+    await fsp.mkdir(legacyDir);
+    await fsp.writeFile(path.join(legacyDir, 'faiss.index'), 'gen=99\n');
+    await fsp.writeFile(path.join(legacyDir, 'docstore.json'), 'gen=99\n');
+
+    const v0 = path.join(modelDir, 'index.v0');
+    await fsp.mkdir(v0);
+    await fsp.writeFile(path.join(v0, 'faiss.index'), 'gen=1\n');
+    await fsp.writeFile(path.join(v0, 'docstore.json'), 'gen=1\n');
+    await fsp.symlink('index.v0', path.join(modelDir, 'index'));
+
+    const mgr = await makeManager(tmpDir);
+    await (mgr as any).loadAtomic();
+
+    // Marker file written.
+    const marker = path.join(modelDir, '.downgrade-hazard');
+    expect(await fsp.access(marker).then(() => true)).toBe(true);
+
+    // Now remove legacy and re-load — marker should be cleared.
+    await fsp.rm(legacyDir, { recursive: true, force: true });
+    await (mgr as any).loadAtomic();
+
+    let stillThere = false;
+    try {
+      await fsp.access(marker);
+      stillThere = true;
+    } catch {
+      // expected — marker cleared
+    }
+    expect(stillThere).toBe(false);
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,6 +17,7 @@ import { FaissIndexManager } from './FaissIndexManager.js';
 import {
   ActiveModelResolutionError,
   faissIndexBinaryPath,
+  resolveFaissIndexBinaryPath,
   isRegisteredModel,
   listRegisteredModels,
   modelDir,
@@ -297,8 +298,17 @@ async function runModelsList(): Promise<number> {
   const idWidth = Math.max(8, ...models.map((m) => m.model_id.length));
   for (const m of models) {
     const marker = m.model_id === activeId ? '*' : ' ';
+    const hazard = m.downgrade_hazard ? '  [downgrade-hazard]' : '';
     process.stdout.write(
-      `${marker} ${m.model_id.padEnd(idWidth)}  ${m.provider.padEnd(11)}  ${m.model_name}\n`,
+      `${marker} ${m.model_id.padEnd(idWidth)}  ${m.provider.padEnd(11)}  ${m.model_name}${hazard}\n`,
+    );
+  }
+  if (models.some((m) => m.downgrade_hazard)) {
+    process.stdout.write(
+      `\n[downgrade-hazard] models have BOTH the RFC-014 versioned layout and the legacy\n` +
+        `faiss.index/ directory. Downgrading will silently ignore any embeddings added\n` +
+        `since the upgrade. Run \`rm -rf \${FAISS_INDEX_PATH}/models/<id>/faiss.index\` to\n` +
+        `reclaim disk and clear the hazard once you're confident in the new layout.\n`,
     );
   }
   return 0;
@@ -762,8 +772,12 @@ interface Staleness {
 
 async function computeStaleness(modelId: string): Promise<Staleness> {
   // Index mtime — target the inner binary file (NOT the directory; round-3
-  // mtime correction).
-  const binaryPath = faissIndexBinaryPath(modelId);
+  // mtime correction). RFC 014: prefer the versioned layout if present,
+  // fall back to the legacy faiss.index/.
+  const binaryPath = await resolveFaissIndexBinaryPath(modelId);
+  if (binaryPath === null) {
+    return { indexMtime: null, modifiedFiles: 0, newFiles: 0 };
+  }
   let indexStat;
   try {
     indexStat = await fsp.stat(binaryPath);
@@ -839,13 +853,21 @@ function formatFreshnessFooter(s: Staleness, refreshed: boolean): string {
   );
 }
 
-// ----- JSON-parse retry (RFC §7 N4 mitigation) -------------------------------
+// ----- JSON-parse retry (pre-RFC-014 defensive belt) -------------------------
 
 async function loadWithJsonRetry(manager: FaissIndexManager): Promise<void> {
-  // FaissStore.save is non-atomic (mkdir-p + parallel writes of faiss.index +
-  // docstore.json, no rename). A concurrent CLI read can land mid-write and
-  // see partial JSON. Retry once after 100 ms; if the second attempt also
-  // fails with a SyntaxError, surface the documented "index appears mid-write"
+  // Pre-RFC-014 defensive belt for the LEGACY `faiss.index/` load path only.
+  // The versioned `index → index.vN/` layout (RFC 014) pre-resolves the
+  // symlink before any file open, so torn JSON is structurally impossible
+  // there. Legacy reads still go through `FaissStore.load(legacyPath)`
+  // directly and CAN race with a concurrent legacy writer (extremely rare
+  // since v014 code never writes to the legacy path). Slated for removal
+  // in the same follow-up PR that drops the single-instance advisory,
+  // after the legacy-cleanup task confirms no remaining users on legacy
+  // layout.
+  //
+  // Retry once after 100 ms; if the second attempt also fails with a
+  // SyntaxError, surface the documented "index appears mid-write"
   // message so the operator knows to retry.
   const isJsonParseError = (err: unknown): boolean =>
     err instanceof SyntaxError ||


### PR DESCRIPTION
## Summary

Lifts [RFC 013 §11 N4](./docs/rfcs/013-multimodel-support.md#L117). New per-model layout `${FAISS_INDEX_PATH}/models/<id>/index → index.vN/` makes save+load directory-atomic via symlink-swap with reader-side pre-resolution. Eliminates the docid-mismatch race that previously required the single-MCP-instance advisory to compensate for. The advisory itself remains in this PR as a transitional safety belt — its removal is the immediate follow-up release.

Full design at [`docs/rfcs/014-atomic-faiss-save.md`](./docs/rfcs/014-atomic-faiss-save.md).

## Why

Today, only one MCP server can hold a `$FAISS_INDEX_PATH` at a time (`src/instance-lock.ts`). The constraint exists because `@langchain/community`'s `FaissStore.save()` is non-atomic (`mkdir -p + Promise.all([index.write, writeFile(docstore.json)])`, no rename). Two writers interleave; a reader mid-save sees torn JSON or — worse — an N-vector index paired with an N±k-doc docstore (silent retrieval bugs).

Per-model write locks (RFC 013) solve writer-vs-writer. The advisory closes the cross-process gap. With atomic save in place, both can be retired (the advisory in the next release; `loadWithJsonRetry` once the legacy load path is dropped).

## How

**Save algorithm.** `atomicSave` in `FaissIndexManager.ts` writes to a fresh `index.vN/`, atomically swaps the `index` symlink via `rename(2)` (POSIX-atomic for symlinks), runs synchronous N=3 GC inside the per-model write lock that callers already hold (verified at `KnowledgeBaseServer.ts:216,374` and `cli.ts:436,646`).

**Load algorithm — the F1 fix.** `loadAtomic` calls `realpath` ONCE on the symlink, then passes the absolute resolved path to `FaissStore.load`. langchain's internal `Promise.all([open(faiss.index), open(docstore.json)])` then opens both files via the absolute resolved path with no symlink in it — both opens hit the same pinned version even if a writer atomically swaps the symlink in between.

**No migration.** Additive layout. Old `faiss.index/` directory untouched on upgrade — preserved as rollback safety. First save under v014 creates `index.v0/` and the `index` symlink. `loadAtomic` falls back to legacy when no symlink is present. Old server versions reading after a downgrade still find their data (with any post-upgrade embeddings unreachable until re-saved under the older version).

**Per-branch corruption recovery.** If versioned layout fails to load → remove ONLY the symlink (preserves legacy as rollback safety). If legacy fails → remove ONLY the legacy dir.

**Downgrade-hazard surface.** When both layouts coexist, `.downgrade-hazard` marker file is written; surfaced in `kb models list` with `[downgrade-hazard]` flag and an explainer footer; `logger.warn` emitted at `initialize`. Marker is cleared automatically when only one layout remains.

## Verification

**3 rounds of iterative RFC review** before any code (each round caught real flaws):

- v1 → v2: handwaved `FaissStore.load` atomicity (false — fixed via reader-side `realpath`); 2-step migration crash window (fixed by going additive).
- v2 → v3: `pathExists` follows symlinks → silent stale-data fallthrough (fixed via `lstat`); F_FULLFSYNC vaporware (dropped — matches repo policy).
- v3 → v4: editorial precision (conditional doc text, hazard marker discoverability, runnable shell command in warning).

**1 round of implementation review** against the v4 spec — caught a blocking finding (corruption recovery destroying good legacy data when versioned layout failed) plus 3 worthwhile suggestions, all addressed.

**Test plan, all passing:**

- [x] **F1 invariant test** (the load-bearing one): 1000 reader iterations under a concurrent writer, asserts every load returns a consistent `(faiss.index, docstore.json)` pair (jest mocks with deterministic `gen=N` markers; mock load throws on mismatched gens). 1043ms wall-clock. If this test ever fails, the design is broken.
- [x] Atomicity smoke (two saves advance symlink; legacy untouched).
- [x] GC retention (N=3): 6 saves → exactly `index.v3, v4, v5` remain.
- [x] `lstat`-vs-`pathExists` regression (dangling symlink throws loud error, not silent legacy fallthrough).
- [x] Lazy migration (legacy load → first save creates versioned, legacy preserved).
- [x] Downgrade-hazard marker (written when both coexist; cleared when only one remains).
- [x] `nextVersionAfter` pure-function tests (null, increment, malformed, empty-string equivalence).
- [x] Full suite: 267/267 tests pass (was 257; +10 RFC 014 tests).

## Crash safety

No fsync. Matches the existing repo policy (per-file hash sidecars at `FaissIndexManager.ts:807-822` use `tmp+rename` without fsync). Atomicity comes from `rename(2)`; durability is best-effort across the codebase. A power-cut may lose the most recent save (symlink reverts, staging dir cleaned by next save's active rmrf-before-save). **No torn data ever.**

## Compatibility

- **Linux + macOS only** (matches existing CI matrix). Symlinks on Windows need admin/dev mode.
- **Disk usage temporarily ~2x per model** (legacy + new versioned dirs) until the legacy is removed. CHANGELOG provides the runnable cleanup command. A future `kb models migrate` CLI (planned) will wrap this.
- **Backup tools may double-count** until the legacy directory is removed.
- **Downgrade after v014** silently drops post-upgrade embeddings (now visible via the downgrade-hazard surface).

## Out of scope (separate follow-ups, in order)

1. Remove `src/instance-lock.ts` (one-line change after one release of stability).
2. Remove `loadWithJsonRetry` (same).
3. `kb models migrate` CLI for disk reclamation.
4. Remove legacy `faiss.index/` load path entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)