### PR TITLE
fix: derive downgrade-hazard flag from filesystem state, drop marker file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Changelog
 
-## [Unreleased] — drop single-instance MCP advisory
+## [Unreleased] — derive downgrade-hazard flag from filesystem state
+
+### Fixed
+
+- **`kb models list` now reflects the real downgrade-hazard state.** Pre-fix it read a `.downgrade-hazard` marker file written by `loadAtomic`. The marker only updated when the FaissIndexManager was instantiated; `kb models list` doesn't instantiate one (it only reads the directory listing). So an operator who removed the legacy `faiss.index/` directory still saw `[downgrade-hazard]` in `kb models list` until the next time `kb search` (or the MCP server) ran. Now the listing derives the flag directly from filesystem state via `lstat(symlink) && pathExists(legacy)` on every call — operator interventions are reflected immediately.
+
+### Removed
+
+- **`.downgrade-hazard` marker file.** No code writes or reads it post-fix. The runtime `logger.warn` in `loadAtomic` is preserved (still useful when the manager runs live), but the *signal* surfaced to operators (`kb models list`'s `[downgrade-hazard]` flag) is now derived purely from on-disk layout. The filesystem is the single source of truth — no derived state to drift.
+- Any leftover `${FAISS_INDEX_PATH}/models/<id>/.downgrade-hazard` files from prior installs are orphans (no code reads them). Safe to `rm -f`.
+
+## [Unreleased — earlier] — drop single-instance MCP advisory
 
 ### Removed
 

--- a/src/FaissIndexManager.ts
+++ b/src/FaissIndexManager.ts
@@ -73,7 +73,6 @@ async function writeModelNameAtomic(modelNameFile: string, modelName: string): P
 const VERSION_DIR_PATTERN = /^index\.v(\d+)$/;
 const SYMLINK_NAME = 'index';
 const LEGACY_INDEX_NAME = 'faiss.index';
-const DOWNGRADE_HAZARD_MARKER = '.downgrade-hazard';
 
 /** Read the symlink target if `p` is a symlink; otherwise null. */
 async function readSymlinkOrNull(p: string): Promise<string | null> {
@@ -660,14 +659,15 @@ export class FaissIndexManager {
    * against an absolute path with no symlink in it — both opens hit the same
    * pinned version even if a writer atomically swaps the symlink in between.
    *
-   * Side effect: writes / clears `${modelDir}/.downgrade-hazard` based on
-   * coexistence of versioned + legacy layouts, and emits a one-time warn
-   * when the hazard is present.
+   * Side effect: emits a one-time `logger.warn` when both versioned and
+   * legacy layouts coexist (the downgrade hazard). The hazard signal is
+   * derived directly from on-disk state by `kb models list` and
+   * `list_models` (active-model.ts:detectDowngradeHazard), so no marker
+   * file is required — the filesystem is the single source of truth.
    */
   private async loadAtomic(): Promise<FaissStore | null> {
     const symlinkPath = path.join(this.modelDir, SYMLINK_NAME);
     const legacyPath = path.join(this.modelDir, LEGACY_INDEX_NAME);
-    const hazardMarker = path.join(this.modelDir, DOWNGRADE_HAZARD_MARKER);
 
     // lstat (NOT stat) — detects symlink presence without following it.
     const symStat = await fsp.lstat(symlinkPath).catch((err) => {
@@ -717,21 +717,13 @@ export class FaissIndexManager {
         } catch (unlinkErr) {
           handleFsOperationError('delete corrupt index symlink', symlinkPath, unlinkErr);
         }
-        // Best-effort clear marker — versioned layout is gone, hazard no
-        // longer applies in its prior form.
-        await fsp.rm(hazardMarker, { force: true }).catch(() => undefined);
         return null;
       }
 
-      // Hazard surface: both layouts coexist → write marker + warn once.
+      // Hazard signal: both layouts coexist → warn the operator once.
+      // `kb models list` independently re-derives this from filesystem
+      // state, so live `kb` invocations always reflect the truth.
       if (await pathExists(legacyPath)) {
-        await fsp
-          .writeFile(
-            hazardMarker,
-            `${new Date().toISOString()}\nlegacy faiss.index/ coexists with versioned ${path.basename(resolved)}\n`,
-            'utf-8',
-          )
-          .catch(() => undefined);
         logger.warn(
           `model ${this.modelId} has both versioned (${path.basename(resolved)}) and legacy ` +
             `(faiss.index/) layouts present. Downgrading the npm package will silently ignore ` +
@@ -739,18 +731,11 @@ export class FaissIndexManager {
             `layout. To reclaim disk and remove the hazard once you're confident in the new ` +
             `layout: \`rm -rf "${legacyPath}"\`.`,
         );
-      } else {
-        // Hazard cleared (legacy was removed by operator). Best-effort clean.
-        await fsp.rm(hazardMarker, { force: true }).catch(() => undefined);
       }
 
       return store;
     }
 
-    // No versioned layout — clear any stale hazard marker before any
-    // legacy fallback or null return. The marker only makes sense when
-    // both layouts coexist, which requires the symlink branch above.
-    await fsp.rm(hazardMarker, { force: true }).catch(() => undefined);
 
     // Legacy path — pre-RFC-014 layout. Read directly. The torn-read hazard
     // described in the threat model still applies HERE until the first

--- a/src/active-model.ts
+++ b/src/active-model.ts
@@ -148,8 +148,9 @@ export interface RegisteredModel {
    * (`index → index.vN/`) AND the legacy `faiss.index/` directory present.
    * Downgrading the npm package would silently ignore embeddings added
    * since the upgrade. Surfaced by `kb models list` and the `list_models`
-   * MCP tool. Cleared automatically on next load when only one layout
-   * remains.
+   * MCP tool. Derived directly from filesystem state on every call (no
+   * marker file): operator interventions like `rm -rf faiss.index/` are
+   * reflected immediately on the next `kb models list`.
    */
   downgrade_hazard?: boolean;
 }
@@ -167,13 +168,7 @@ export async function listRegisteredModels(): Promise<RegisteredModel[]> {
     if (!(await isRegisteredModel(entry))) continue;
     const modelName = (await readStoredModelName(entry)) ?? entry;
     const { provider } = parseModelId(entry);
-    let downgradeHazard = false;
-    try {
-      await fsp.access(path.join(modelDir(entry), '.downgrade-hazard'));
-      downgradeHazard = true;
-    } catch {
-      // marker absent — no hazard
-    }
+    const downgradeHazard = await detectDowngradeHazard(modelDir(entry));
     models.push({
       model_id: entry,
       provider,
@@ -182,6 +177,29 @@ export async function listRegisteredModels(): Promise<RegisteredModel[]> {
     });
   }
   return models.sort((a, b) => a.model_id.localeCompare(b.model_id));
+}
+
+/**
+ * RFC 014 — derive the downgrade-hazard signal directly from on-disk
+ * layout: hazard exists iff the model has BOTH the versioned `index`
+ * symlink AND the legacy `faiss.index/` directory. No marker file: the
+ * filesystem is the single source of truth, and stale state can't drift.
+ */
+async function detectDowngradeHazard(dir: string): Promise<boolean> {
+  let hasVersioned = false;
+  try {
+    const st = await fsp.lstat(path.join(dir, 'index'));
+    hasVersioned = st.isSymbolicLink();
+  } catch {
+    // index symlink absent — versioned layout not present yet
+  }
+  if (!hasVersioned) return false;
+  try {
+    await fsp.access(path.join(dir, 'faiss.index'));
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/atomic-save.test.ts
+++ b/src/atomic-save.test.ts
@@ -402,7 +402,7 @@ describe('RFC 014 atomic save — lazy migration (legacy load + first save creat
   });
 });
 
-describe('RFC 014 atomic save — downgrade-hazard surfacing', () => {
+describe('RFC 014 atomic save — downgrade-hazard surfacing (filesystem-derived)', () => {
   let tmpDir: string;
 
   beforeEach(async () => {
@@ -414,40 +414,70 @@ describe('RFC 014 atomic save — downgrade-hazard surfacing', () => {
     await fsp.rm(tmpDir, { recursive: true, force: true });
   });
 
-  test('marker file is written when both versioned + legacy coexist, cleared when legacy removed', async () => {
+  test('listRegisteredModels reports downgrade_hazard iff both versioned and legacy layouts coexist', async () => {
     const modelDir = modelDirIn(tmpDir);
     await fsp.mkdir(modelDir, { recursive: true });
+    // model_name.txt is required for isRegisteredModel to return true.
+    await fsp.writeFile(path.join(modelDir, 'model_name.txt'), 'BAAI/bge-small-en-v1.5');
 
-    // Build both layouts.
-    const legacyDir = path.join(modelDir, 'faiss.index');
-    await fsp.mkdir(legacyDir);
-    await fsp.writeFile(path.join(legacyDir, 'faiss.index'), 'gen=99\n');
-    await fsp.writeFile(path.join(legacyDir, 'docstore.json'), 'gen=99\n');
+    process.env.NODE_ENV = 'test';
+    process.env.FAISS_INDEX_PATH = tmpDir;
+    process.env.EMBEDDING_PROVIDER = 'huggingface';
+    process.env.HUGGINGFACE_MODEL_NAME = 'BAAI/bge-small-en-v1.5';
+    process.env.HUGGINGFACE_API_KEY = 'test-stub';
+    jest.resetModules();
+    const { listRegisteredModels } = await import('./active-model.js');
 
+    // 1. Versioned-only — no hazard.
     const v0 = path.join(modelDir, 'index.v0');
     await fsp.mkdir(v0);
     await fsp.writeFile(path.join(v0, 'faiss.index'), 'gen=1\n');
     await fsp.writeFile(path.join(v0, 'docstore.json'), 'gen=1\n');
     await fsp.symlink('index.v0', path.join(modelDir, 'index'));
 
-    const mgr = await makeManager(tmpDir);
-    await (mgr as any).loadAtomic();
+    let models = await listRegisteredModels();
+    expect(models).toHaveLength(1);
+    expect(models[0].downgrade_hazard).toBeUndefined();
 
-    // Marker file written.
-    const marker = path.join(modelDir, '.downgrade-hazard');
-    expect(await fsp.access(marker).then(() => true)).toBe(true);
+    // 2. Add legacy → hazard appears immediately, no marker file required.
+    const legacyDir = path.join(modelDir, 'faiss.index');
+    await fsp.mkdir(legacyDir);
+    await fsp.writeFile(path.join(legacyDir, 'faiss.index'), 'gen=99\n');
+    await fsp.writeFile(path.join(legacyDir, 'docstore.json'), 'gen=99\n');
 
-    // Now remove legacy and re-load — marker should be cleared.
+    models = await listRegisteredModels();
+    expect(models[0].downgrade_hazard).toBe(true);
+
+    // 3. Remove legacy → hazard clears immediately on next call.
     await fsp.rm(legacyDir, { recursive: true, force: true });
-    await (mgr as any).loadAtomic();
+    models = await listRegisteredModels();
+    expect(models[0].downgrade_hazard).toBeUndefined();
 
-    let stillThere = false;
-    try {
-      await fsp.access(marker);
-      stillThere = true;
-    } catch {
-      // expected — marker cleared
-    }
-    expect(stillThere).toBe(false);
+    // 4. No marker file is created at any step — fs is the only source of truth.
+    await expect(
+      fsp.access(path.join(modelDir, '.downgrade-hazard')),
+    ).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  test('legacy-only layout is NOT a hazard (no versioned layout means no hidden data)', async () => {
+    const modelDir = modelDirIn(tmpDir);
+    await fsp.mkdir(modelDir, { recursive: true });
+    await fsp.writeFile(path.join(modelDir, 'model_name.txt'), 'BAAI/bge-small-en-v1.5');
+    const legacyDir = path.join(modelDir, 'faiss.index');
+    await fsp.mkdir(legacyDir);
+    await fsp.writeFile(path.join(legacyDir, 'faiss.index'), 'gen=42\n');
+    await fsp.writeFile(path.join(legacyDir, 'docstore.json'), 'gen=42\n');
+
+    process.env.NODE_ENV = 'test';
+    process.env.FAISS_INDEX_PATH = tmpDir;
+    process.env.EMBEDDING_PROVIDER = 'huggingface';
+    process.env.HUGGINGFACE_MODEL_NAME = 'BAAI/bge-small-en-v1.5';
+    process.env.HUGGINGFACE_API_KEY = 'test-stub';
+    jest.resetModules();
+    const { listRegisteredModels } = await import('./active-model.js');
+
+    const models = await listRegisteredModels();
+    expect(models).toHaveLength(1);
+    expect(models[0].downgrade_hazard).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

Fixes a stale-flag bug surfaced while cleaning up legacy data after [#112](https://github.com/jeanibarz/knowledge-base-mcp-server/pull/112).

`kb models list` previously read a `.downgrade-hazard` marker file written by `loadAtomic`. The marker only updated when a `FaissIndexManager` was instantiated (`kb search`, MCP server start). `kb models list` doesn't instantiate one — it just reads the directory listing. So an operator who removed the legacy `faiss.index/` directory still saw `[downgrade-hazard]` in `kb models list` until the next time `kb search` ran.

This PR drops the marker file. The flag is now derived directly from on-disk state on every `listRegisteredModels` call — the filesystem is the single source of truth.

## What changed

- **`src/active-model.ts`** — new file-private `detectDowngradeHazard(dir)`: `lstat(symlink).isSymbolicLink() && pathExists(legacyDir)`. `listRegisteredModels` calls it instead of `fsp.access(.downgrade-hazard)`.
- **`src/FaissIndexManager.ts`** — `loadAtomic` no longer writes or clears the marker. Three `rm(hazardMarker)` calls + one `writeFile` + the `DOWNGRADE_HAZARD_MARKER` constant removed (~17 lines net). The runtime `logger.warn` in the symlink-success branch is preserved (still useful when a live MCP server detects the hazard at startup); only the *consumer-facing signal* moved.
- **`src/atomic-save.test.ts`** — replaced the marker-write/clear test with two filesystem-derived tests:
  1. `listRegisteredModels` reports `downgrade_hazard` iff both layouts coexist, reflects operator cleanup immediately, and creates **no** marker file.
  2. Legacy-only layout is not a hazard (no versioned data means no hidden post-upgrade embeddings).
- **`CHANGELOG.md`** — documents the fix + notes leftover `.downgrade-hazard` files from prior installs are orphans (no code reads them).

## Verification

- [x] Type-check clean.
- [x] Tests: 264/264 pass (was 263; +1 from the new "legacy-only is not a hazard" test).
- [x] Reproduced the original bug locally before the fix (`mv legacy/ /tmp; kb models list` → still showed `[downgrade-hazard]` until `kb search` ran). Post-fix, removing legacy clears the flag on the very next `kb models list`.
- [x] Diff stat: 4 files, 101 insertions, 57 deletions.

## Migration / cleanup

- Any leftover `${FAISS_INDEX_PATH}/models/<id>/.downgrade-hazard` files from prior installs are orphans — no code reads them. Safe to `rm -f`. (Will also be silently ignored if old code ever runs against the same path.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)