### PR TITLE
fix(strict): use `error: unknown` in catch blocks + add `toError` helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [Unreleased] — strict catch blocks (`error: unknown` + `toError` helper)
+
+### Changed
+
+- **`catch (error: any)` → `catch (error: unknown)`** at every site in `src/KnowledgeBaseServer.ts` and `src/FaissIndexManager.ts`. Strict-mode (`"strict": true` in `tsconfig.json`) treats `catch` variables as `unknown` semantically, but `: any` was bypassing that. With `: unknown` the type checker will now flag any future unchecked `error.message` / `error.stack` access. Closes #60.
+- **New helper: `toError(x: unknown): Error`** in `src/utils.ts`. Narrows a thrown value to an `Error` once at the catch boundary: returns the same reference when given an `Error` (preserves the `__alreadyLogged` marker pattern in `FaissIndexManager`), wraps strings into `new Error(x)`, and JSON-stringifies other shapes. Falls back to `String(x)` if `JSON.stringify` throws (cycles, BigInt) so the helper itself never throws inside a catch.
+
+### Why
+
+Pre-fix, a non-`Error` rejection (e.g. a thrown string from a third-party lib) silently produced `error.message === undefined` in user-facing tool responses. Post-fix, every catch coerces through `toError` so `error.message` and `error.stack` are always defined.
+
 ## [Unreleased] — derive downgrade-hazard flag from filesystem state
 
 ### Fixed

--- a/src/FaissIndexManager.ts
+++ b/src/FaissIndexManager.ts
@@ -14,6 +14,7 @@ import {
   filterIngestablePaths,
   getFilesRecursively,
   parseFrontmatter,
+  toError,
 } from './utils.js';
 import {
   EMBEDDING_PROVIDER,
@@ -635,14 +636,15 @@ export class FaissIndexManager {
           handleFsOperationError('persist embedding model metadata in', this.modelNameFile, error);
         }
       }
-    } catch (error: any) {
-      if (!error?.__alreadyLogged) {
-        logger.error('Error initializing FAISS index:', error);
-        if (error?.stack) {
-          logger.error(error.stack);
+    } catch (error: unknown) {
+      const err = toError(error) as Error & { __alreadyLogged?: boolean };
+      if (!err.__alreadyLogged) {
+        logger.error('Error initializing FAISS index:', err);
+        if (err.stack) {
+          logger.error(err.stack);
         }
       }
-      throw error;
+      throw err;
     }
   }
 
@@ -959,8 +961,8 @@ export class FaissIndexManager {
             let content = '';
             try {
               content = await fsp.readFile(filePath, 'utf-8');
-            } catch (error: any) {
-              logger.error(`Error reading file ${filePath}:`, error);
+            } catch (error: unknown) {
+              logger.error(`Error reading file ${filePath}:`, toError(error));
               continue;
             }
 
@@ -1045,7 +1047,7 @@ export class FaissIndexManager {
         // versioned layout.
         try {
           await this.atomicSave();
-        } catch (saveError: any) {
+        } catch (saveError: unknown) {
           handleFsOperationError(
             'save FAISS index for model',
             this.modelId,
@@ -1076,14 +1078,15 @@ export class FaissIndexManager {
         );
       }
       logger.debug('FAISS index update process completed.');
-    } catch (error: any) {
-      if (!error?.__alreadyLogged) {
-        logger.error('Error updating FAISS index:', error);
-        if (error?.stack) {
-          logger.error(error.stack);
+    } catch (error: unknown) {
+      const err = toError(error) as Error & { __alreadyLogged?: boolean };
+      if (!err.__alreadyLogged) {
+        logger.error('Error updating FAISS index:', err);
+        if (err.stack) {
+          logger.error(err.stack);
         }
       }
-      throw error;
+      throw err;
     }
   }
 

--- a/src/KnowledgeBaseServer.ts
+++ b/src/KnowledgeBaseServer.ts
@@ -29,6 +29,7 @@ import { formatRetrievalAsMarkdown, sanitizeMetadataForWire } from './formatter.
 import { listKnowledgeBases } from './kb-fs.js';
 import { withWriteLock } from './write-lock.js';
 import { logger } from './logger.js';
+import { toError } from './utils.js';
 import { SseHost } from './transport/sse.js';
 import { ReindexTriggerWatcher } from './triggerWatcher.js';
 
@@ -148,11 +149,12 @@ export class KnowledgeBaseServer {
       return {
         content: [{ type: 'text', text: JSON.stringify(enriched, null, 2) }],
       };
-    } catch (error: any) {
-      logger.error('Error listing models:', error);
+    } catch (error: unknown) {
+      const err = toError(error);
+      logger.error('Error listing models:', err);
       const content: TextContent = {
         type: 'text',
-        text: `Error listing models: ${error.message}`,
+        text: `Error listing models: ${err.message}`,
       };
       return { content: [content], isError: true };
     }
@@ -166,14 +168,15 @@ export class KnowledgeBaseServer {
         text: JSON.stringify(knowledgeBases, null, 2),
       };
       return { content: [content] };
-    } catch (error: any) {
-      logger.error('Error listing knowledge bases:', error);
-      if (error?.stack) {
-        logger.error(error.stack);
+    } catch (error: unknown) {
+      const err = toError(error);
+      logger.error('Error listing knowledge bases:', err);
+      if (err.stack) {
+        logger.error(err.stack);
       }
       const content: TextContent = {
         type: 'text',
-        text: `Error listing knowledge bases: ${error.message}`,
+        text: `Error listing knowledge bases: ${err.message}`,
       };
       return { content: [content], isError: true };
     }
@@ -235,12 +238,13 @@ export class KnowledgeBaseServer {
 
       const content: TextContent = { type: 'text', text: responseText };
       return { content: [content] };
-    } catch (error: any) {
-      logger.error('Error retrieving knowledge:', error);
-      if (error?.stack) {
-        logger.error(error.stack);
+    } catch (error: unknown) {
+      const err = toError(error);
+      logger.error('Error retrieving knowledge:', err);
+      if (err.stack) {
+        logger.error(err.stack);
       }
-      const content: TextContent = { type: 'text', text: `Error retrieving knowledge: ${error.message}` };
+      const content: TextContent = { type: 'text', text: `Error retrieving knowledge: ${err.message}` };
       return { content: [content], isError: true };
     }
   }
@@ -280,10 +284,11 @@ export class KnowledgeBaseServer {
         return;
       }
       await this.runSse(transportConfig);
-    } catch (error: any) {
-      logger.error('Error during server startup:', error);
-      if (error?.stack) {
-        logger.error(error.stack);
+    } catch (error: unknown) {
+      const err = toError(error);
+      logger.error('Error during server startup:', err);
+      if (err.stack) {
+        logger.error(err.stack);
       }
       process.exitCode = 1;
     }

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -5,6 +5,7 @@ import {
   isValidKbName,
   parseFrontmatter,
   resolveKbPath,
+  toError,
 } from './utils.js';
 import * as fsp from 'fs/promises';
 import * as fs from 'fs'; // Import fs for PathLike and Dirent
@@ -473,5 +474,49 @@ describe('parseFrontmatter (RFC 011 M2 frontmatter lift)', () => {
       arxiv_id: '2604.1',
       custom_field: 'value',
     });
+  });
+});
+
+describe('toError', () => {
+  it('returns the same Error reference when given an Error', () => {
+    // Identity matters: callers in FaissIndexManager attach an
+    // `__alreadyLogged` marker to the thrown Error, and the migration helper
+    // must not break that pattern by wrapping the Error in a new instance.
+    const original = new Error('boom') as Error & { __alreadyLogged?: boolean };
+    original.__alreadyLogged = true;
+    const result = toError(original);
+    expect(result).toBe(original);
+    expect((result as Error & { __alreadyLogged?: boolean }).__alreadyLogged).toBe(true);
+  });
+
+  it('preserves Error subclass instances by reference (TypeError, custom)', () => {
+    const typeErr = new TypeError('bad type');
+    expect(toError(typeErr)).toBe(typeErr);
+
+    class CustomError extends Error {}
+    const custom = new CustomError('custom');
+    expect(toError(custom)).toBe(custom);
+  });
+
+  it('wraps a string into a new Error whose message is the string', () => {
+    const result = toError('something failed');
+    expect(result).toBeInstanceOf(Error);
+    expect(result.message).toBe('something failed');
+  });
+
+  it('JSON-stringifies plain objects into the Error message', () => {
+    const result = toError({ code: 'EACCES', path: '/tmp/x' });
+    expect(result).toBeInstanceOf(Error);
+    expect(result.message).toBe('{"code":"EACCES","path":"/tmp/x"}');
+  });
+
+  it('handles values JSON.stringify cannot serialize (cycles) without throwing', () => {
+    type Cyclic = { self?: Cyclic };
+    const cyclic: Cyclic = {};
+    cyclic.self = cyclic;
+    const result = toError(cyclic);
+    expect(result).toBeInstanceOf(Error);
+    expect(typeof result.message).toBe('string');
+    expect(result.message.length).toBeGreaterThan(0);
   });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,6 +5,30 @@ import yaml from 'js-yaml';
 import { minimatch } from 'minimatch';
 import { logger } from './logger.js';
 
+/**
+ * Coerce an unknown thrown value into an `Error`.
+ *
+ * Strict mode (`tsconfig.json` `useUnknownInCatchVariables`) types `catch`
+ * variables as `unknown`; this helper narrows once at the catch boundary so
+ * callers can rely on `err.message` / `err.stack` without re-checking.
+ *
+ * - `Error` in → returned by reference (preserves prototype, `cause`, and any
+ *   ad-hoc properties like `__alreadyLogged` set by callers further up).
+ * - `string` in → `new Error(x)`.
+ * - anything else → `new Error(JSON.stringify(x))`. JSON-encoding is best-effort:
+ *   if it throws (cycle, BigInt) we fall back to `String(x)` so the helper
+ *   itself never throws inside a catch.
+ */
+export function toError(x: unknown): Error {
+  if (x instanceof Error) return x;
+  if (typeof x === 'string') return new Error(x);
+  try {
+    return new Error(JSON.stringify(x));
+  } catch {
+    return new Error(String(x));
+  }
+}
+
 export async function calculateSHA256(filePath: string): Promise<string> {
   const fileBuffer = await fsp.readFile(filePath);
   const hashSum = crypto.createHash('sha256');


### PR DESCRIPTION
## Summary

Closes #60. Replaces `catch (error: any)` with `catch (error: unknown)` at every site in `src/KnowledgeBaseServer.ts` and `src/FaissIndexManager.ts`, and introduces a `toError(x: unknown): Error` helper in `src/utils.ts` so error narrowing happens once at the catch boundary rather than via unchecked property access.

## Motivation

`catch (error: any)` bypassed `tsconfig.json`'s `"strict": true`. A non-`Error` rejection (e.g. a thrown string from a third-party lib) silently produced `error.message === undefined` in the user-facing MCP tool response. With `: unknown` the type checker now flags any future unchecked `error.message` / `error.stack` access, and `toError` guarantees those properties are always defined.

## Changes

- `src/utils.ts` — new exported `toError(x: unknown): Error`. Returns the same `Error` reference when given one (preserves the `__alreadyLogged` marker pattern in `FaissIndexManager.ts`), wraps strings into `new Error(x)`, and JSON-stringifies other shapes. `JSON.stringify` failure (cycles, BigInt) falls back to `String(x)` so the helper itself never throws inside a catch.
- `src/KnowledgeBaseServer.ts` — 4 catch sites migrated (`handleListModels`, `handleListKnowledgeBases`, `handleRetrieveKnowledge`, `run` startup).
- `src/FaissIndexManager.ts` — 4 catch sites migrated (`initialize`, `updateIndex` outer, `updateIndex` inner read-error continue, `atomicSave` wrapper). The two outer catches that read `error?.__alreadyLogged` keep that semantic by narrowing via `toError` (returns the same Error reference) and casting to `Error & { __alreadyLogged?: boolean }`.
- `src/utils.test.ts` — 5 new tests for `toError` (Error by reference, Error-subclass by reference, string coercion, plain-object JSON-stringify, cycle fallback).
- `CHANGELOG.md` — entry under `[Unreleased]`.

## Verification

- `npm test` — all **269 tests pass** (16 suites, includes the 5 new `toError` cases).
- `grep -rn 'catch (error: any)' src/` returns 0 occurrences post-fix.
- Pre-existing tsc deprecation (`moduleResolution=node10`, `tsconfig.json:6`) is present on `main` too and is **not introduced** by this PR.

## Test plan

- [x] `npm test` green
- [x] No remaining `catch (error: any)` in `src/`
- [x] `__alreadyLogged` propagation preserved (Error by-reference test)
- [ ] Reviewer: confirm the helper signature is acceptable; happy to inline / rename

🤖 Generated with [Claude Code](https://claude.com/claude-code)