### PR TITLE
feat(errors): add structured MCP error codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased] — structured MCP error codes
+
+### Added
+
+- **Structured MCP error payloads.** Tool-handler failures now return `isError: true` with a JSON text payload shaped as `{ "error": { "code": "...", "message": "..." } }`, allowing clients to branch on stable error codes instead of substring matching. Closes #58.
+- **`KBError` taxonomy.** New `src/errors.ts` defines the MCP-facing error codes and `KBError` class; provider auth failures, permission failures, and uninitialized-index searches now throw classified errors.
+
 ## [Unreleased] — strict catch blocks (`error: unknown` + `toError` helper)
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -79,6 +79,31 @@ kb models remove huggingface__BAAI-bge-small-en-v1.5
 
 **MCP surface** — `retrieve_knowledge` gains an optional `model_name` argument; a new `list_models` tool returns the registered models. Tools that don't pass `model_name` keep working unchanged (wire format is byte-equal to 0.2.x).
 
+### MCP error codes
+
+Tool errors are returned with `isError: true` and a JSON text payload so MCP clients can branch without substring matching:
+
+```json
+{
+  "error": {
+    "code": "PROVIDER_AUTH",
+    "message": "OPENAI_API_KEY environment variable is required when using OpenAI provider"
+  }
+}
+```
+
+| Code | Meaning | Typical client action |
+| --- | --- | --- |
+| `INDEX_NOT_INITIALIZED` | A search ran before a FAISS index was available. | Retry after initialization or trigger a refresh. |
+| `PROVIDER_UNAVAILABLE` | The embedding provider is temporarily unavailable. | Retry with backoff. |
+| `PROVIDER_TIMEOUT` | The embedding provider timed out. | Retry with backoff. |
+| `PROVIDER_AUTH` | Provider credentials are missing or invalid. | Ask the user to configure a valid API key. |
+| `KB_NOT_FOUND` | The requested knowledge base does not exist. | Prompt for one of the listed knowledge bases. |
+| `PERMISSION_DENIED` | The server cannot read or write a required local path. | Surface to the operator/admin. |
+| `CORRUPT_INDEX` | The persisted FAISS index is corrupt or unreadable. | Rebuild or recover the index. |
+| `VALIDATION` | A caller-supplied argument failed validation. | Fix the request before retrying. |
+| `INTERNAL` | An unclassified server error occurred. | Surface the message and logs for investigation. |
+
 ### Install via Smithery
 
 To install Knowledge Base Server for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@jeanibarz/knowledge-base-mcp-server):

--- a/src/FaissIndexManager.test.ts
+++ b/src/FaissIndexManager.test.ts
@@ -196,10 +196,18 @@ describe('provider construction', () => {
     delete process.env.OPENAI_API_KEY;
 
     const { FaissIndexManager } = await import('./FaissIndexManager.js');
+    const { KBError } = await import('./errors.js');
 
     expect(() => new FaissIndexManager()).toThrow(
       'OPENAI_API_KEY environment variable is required when using OpenAI provider',
     );
+    try {
+      new FaissIndexManager();
+      throw new Error('expected constructor to throw');
+    } catch (error) {
+      expect(error).toBeInstanceOf(KBError);
+      expect(error).toMatchObject({ code: 'PROVIDER_AUTH' });
+    }
     expect(openAIEmbeddingConstructorMock).not.toHaveBeenCalled();
   });
 
@@ -223,10 +231,18 @@ describe('provider construction', () => {
     delete process.env.HUGGINGFACE_API_KEY;
 
     const { FaissIndexManager } = await import('./FaissIndexManager.js');
+    const { KBError } = await import('./errors.js');
 
     expect(() => new FaissIndexManager()).toThrow(
       'HUGGINGFACE_API_KEY environment variable is required when using HuggingFace provider',
     );
+    try {
+      new FaissIndexManager();
+      throw new Error('expected constructor to throw');
+    } catch (error) {
+      expect(error).toBeInstanceOf(KBError);
+      expect(error).toMatchObject({ code: 'PROVIDER_AUTH' });
+    }
     expect(embeddingConstructorMock).not.toHaveBeenCalled();
   });
 });
@@ -1122,6 +1138,25 @@ describe('FaissIndexManager similaritySearch threshold filter', () => {
     expect(results).toHaveLength(1);
     expect(results[0].pageContent).toBe('a');
     expect(results[0].score).toBe(0.5);
+  });
+
+  it('throws INDEX_NOT_INITIALIZED when similaritySearch runs before initialize/updateIndex', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-faiss-uninitialized-'));
+    process.env.KNOWLEDGE_BASES_ROOT_DIR = tempDir;
+    process.env.FAISS_INDEX_PATH = path.join(tempDir, '.faiss');
+    process.env.EMBEDDING_PROVIDER = 'huggingface';
+    process.env.HUGGINGFACE_API_KEY = 'test-key';
+
+    jest.resetModules();
+    const { FaissIndexManager } = await import('./FaissIndexManager.js');
+    const { KBError } = await import('./errors.js');
+    const manager = new FaissIndexManager();
+
+    await expect(manager.similaritySearch('query', 10)).rejects.toBeInstanceOf(KBError);
+    await expect(manager.similaritySearch('query', 10)).rejects.toMatchObject({
+      code: 'INDEX_NOT_INITIALIZED',
+      message: 'FAISS index is not initialized',
+    });
   });
 
   it('keeps results at or below the default threshold of 2 and drops the rest', async () => {

--- a/src/FaissIndexManager.ts
+++ b/src/FaissIndexManager.ts
@@ -39,6 +39,7 @@ import {
 } from './active-model.js';
 import { deriveModelId, EmbeddingProvider } from './model-id.js';
 import { logger } from './logger.js';
+import { KBError } from './errors.js';
 
 /**
  * RFC 013 §4.7 — atomic write for `model_name.txt`. Per-model file:
@@ -308,7 +309,7 @@ function handleFsOperationError(action: string, targetPath: string, error: unkno
     if (stack) {
       logger.error(stack);
     }
-    const loggedError = new Error(message, { cause: error instanceof Error ? error : undefined }) as Error & {
+    const loggedError = new KBError('PERMISSION_DENIED', message, error) as KBError & {
       __alreadyLogged?: boolean;
     };
     loggedError.__alreadyLogged = true;
@@ -510,7 +511,7 @@ export class FaissIndexManager {
       logger.info(`Initializing FaissIndexManager with OpenAI embeddings (model: ${this.modelName})`);
       const openaiApiKey = process.env.OPENAI_API_KEY;
       if (!openaiApiKey) {
-        throw new Error('OPENAI_API_KEY environment variable is required when using OpenAI provider');
+        throw new KBError('PROVIDER_AUTH', 'OPENAI_API_KEY environment variable is required when using OpenAI provider');
       }
 
       this.embeddings = new OpenAIEmbeddings({
@@ -521,7 +522,7 @@ export class FaissIndexManager {
       logger.info(`Initializing FaissIndexManager with HuggingFace embeddings (model: ${this.modelName})`);
       const huggingFaceApiKey = process.env.HUGGINGFACE_API_KEY;
       if (!huggingFaceApiKey) {
-        throw new Error('HUGGINGFACE_API_KEY environment variable is required when using HuggingFace provider');
+        throw new KBError('PROVIDER_AUTH', 'HUGGINGFACE_API_KEY environment variable is required when using HuggingFace provider');
       }
 
       // HuggingFace endpoint URL is computed from HUGGINGFACE_MODEL_NAME at
@@ -1097,7 +1098,7 @@ export class FaissIndexManager {
    */
   async similaritySearch(query: string, k: number, threshold: number = 2, knowledgeBaseName?: string) {
     if (!this.faissIndex) {
-      throw new Error('FAISS index is not initialized');
+      throw new KBError('INDEX_NOT_INITIALIZED', 'FAISS index is not initialized');
     }
 
     const scoped = typeof knowledgeBaseName === 'string' && knowledgeBaseName.length > 0;

--- a/src/KnowledgeBaseServer.test.ts
+++ b/src/KnowledgeBaseServer.test.ts
@@ -243,10 +243,11 @@ describe('KnowledgeBaseServer handlers', () => {
     expect(result.isError).toBe(true);
     expect(result.content).toHaveLength(1);
     expect(result.content[0].type).toBe('text');
-    expect(result.content[0].text).toMatch(/^Error listing knowledge bases:/);
+    const payload = JSON.parse(result.content[0].text);
+    expect(payload.error.code).toBe('INTERNAL');
     // readdir on a non-existent path emits ENOENT; the handler must surface
     // enough of the underlying failure to be actionable by the caller.
-    expect(result.content[0].text).toMatch(/ENOENT|no such file/i);
+    expect(payload.error.message).toMatch(/ENOENT|no such file/i);
   });
 
   // --- handleRetrieveKnowledge ----------------------------------------------
@@ -331,14 +332,43 @@ describe('KnowledgeBaseServer handlers', () => {
     expect(result.isError).toBe(true);
     expect(result.content).toHaveLength(1);
     expect(result.content[0].type).toBe('text');
-    expect(result.content[0].text).toMatch(/^Error retrieving knowledge:/);
-    expect(result.content[0].text).toContain('index boom');
+    expect(JSON.parse(result.content[0].text)).toEqual({
+      error: {
+        code: 'INTERNAL',
+        message: 'index boom',
+      },
+    });
     // If similaritySearch itself throws, the same error-path must apply.
     similaritySearchMock.mockRejectedValueOnce(new Error('search boom'));
     updateIndexMock.mockResolvedValueOnce(undefined);
     const result2 = await server['handleRetrieveKnowledge']({ query: 'q' });
     expect(result2.isError).toBe(true);
-    expect(result2.content[0].text).toContain('search boom');
+    expect(JSON.parse(result2.content[0].text)).toEqual({
+      error: {
+        code: 'INTERNAL',
+        message: 'search boom',
+      },
+    });
+  });
+
+  it('handleRetrieveKnowledge preserves KBError codes in the MCP error payload', async () => {
+    await setRetrieveEnv();
+
+    const server = await freshServer();
+    const { KBError } = await import('./errors.js');
+    updateIndexMock.mockRejectedValue(new KBError('PROVIDER_AUTH', 'provider credentials are invalid'));
+
+    const result = await server['handleRetrieveKnowledge']({ query: 'q' });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0].type).toBe('text');
+    expect(JSON.parse(result.content[0].text)).toEqual({
+      error: {
+        code: 'PROVIDER_AUTH',
+        message: 'provider credentials are invalid',
+      },
+    });
   });
 
   it('threshold argument flows through to similaritySearch(query, 10, threshold, kb)', async () => {

--- a/src/KnowledgeBaseServer.ts
+++ b/src/KnowledgeBaseServer.ts
@@ -32,9 +32,23 @@ import { logger } from './logger.js';
 import { toError } from './utils.js';
 import { SseHost } from './transport/sse.js';
 import { ReindexTriggerWatcher } from './triggerWatcher.js';
+import { KBError, type KBErrorCode } from './errors.js';
 
 const SERVER_NAME = 'knowledge-base-server';
 const SERVER_VERSION = '0.1.0';
+
+function mcpErrorContent(error: Error): TextContent {
+  const code: KBErrorCode = error instanceof KBError ? error.code : 'INTERNAL';
+  return {
+    type: 'text',
+    text: JSON.stringify({
+      error: {
+        code,
+        message: error.message,
+      },
+    }),
+  };
+}
 
 // Re-export for backward compatibility: existing tests import
 // `sanitizeMetadataForWire` from this module. The canonical home is now
@@ -152,11 +166,7 @@ export class KnowledgeBaseServer {
     } catch (error: unknown) {
       const err = toError(error);
       logger.error('Error listing models:', err);
-      const content: TextContent = {
-        type: 'text',
-        text: `Error listing models: ${err.message}`,
-      };
-      return { content: [content], isError: true };
+      return { content: [mcpErrorContent(err)], isError: true };
     }
   }
 
@@ -174,11 +184,7 @@ export class KnowledgeBaseServer {
       if (err.stack) {
         logger.error(err.stack);
       }
-      const content: TextContent = {
-        type: 'text',
-        text: `Error listing knowledge bases: ${err.message}`,
-      };
-      return { content: [content], isError: true };
+      return { content: [mcpErrorContent(err)], isError: true };
     }
   }
 
@@ -244,8 +250,7 @@ export class KnowledgeBaseServer {
       if (err.stack) {
         logger.error(err.stack);
       }
-      const content: TextContent = { type: 'text', text: `Error retrieving knowledge: ${err.message}` };
-      return { content: [content], isError: true };
+      return { content: [mcpErrorContent(err)], isError: true };
     }
   }
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,23 @@
+export type KBErrorCode =
+  | 'INDEX_NOT_INITIALIZED'
+  | 'PROVIDER_UNAVAILABLE'
+  | 'PROVIDER_TIMEOUT'
+  | 'PROVIDER_AUTH'
+  | 'KB_NOT_FOUND'
+  | 'PERMISSION_DENIED'
+  | 'CORRUPT_INDEX'
+  | 'VALIDATION'
+  | 'INTERNAL';
+
+export class KBError extends Error {
+  readonly code: KBErrorCode;
+  override readonly cause?: unknown;
+
+  constructor(code: KBErrorCode, message: string, cause?: unknown) {
+    super(message, { cause });
+    this.name = 'KBError';
+    this.code = code;
+    this.cause = cause;
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}


### PR DESCRIPTION
## Summary

- Closes #58.
- Add `KBError` / `KBErrorCode` in `src/errors.ts`.
- Classify provider API-key failures as `PROVIDER_AUTH`, permission failures as `PERMISSION_DENIED`, and uninitialized FAISS searches as `INDEX_NOT_INITIALIZED`.
- Serialize MCP handler failures as JSON text payloads shaped like `{ "error": { "code": "...", "message": "..." } }`.
- Document the MCP error-code taxonomy in the README.

## Verification

- `npm run build` — pass.
- `npm test -- --runTestsByPath src/FaissIndexManager.test.ts src/KnowledgeBaseServer.test.ts` — 80/80 tests pass.
- `npm test` — 275/275 tests pass across 16 suites.
- MCP stdio smoke with local Ollama and a temp KB:
  - `tools/list` returned `list_knowledge_bases`, `retrieve_knowledge`, and `list_models`.
  - `list_knowledge_bases` returned `alpha` and `beta`.
  - `retrieve_knowledge` returned a non-error result containing Alpha content.

## Follow-ups

- None.
