### PR TITLE
perf: lazy-import unused embedding providers to cut cold start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [Unreleased] — lazy-import unused embedding providers
+
+### Changed
+
+- **`FaissIndexManager` now constructs the active provider's embedding client inside `initialize()`, not in the constructor.** The three `@langchain/*` provider modules (`@langchain/community/embeddings/hf`, `@langchain/ollama`, `@langchain/openai`) and their transitive SDKs (`@huggingface/inference`, `ollama`, `openai`) are loaded via dynamic `await import()` so a process running with `EMBEDDING_PROVIDER=ollama` no longer pays the import cost of HuggingFace + OpenAI (and vice versa). Closes #59.
+- API-key validation moves with the instantiation: `OPENAI_API_KEY` / `HUGGINGFACE_API_KEY` are now checked when `initialize()` runs (still synchronous-feeling — the throw fires before any disk work). The thrown `KBError` and its `PROVIDER_AUTH` code (added in the structured-errors entry below) are unchanged.
+
+### Why
+
+RFC 007 §5.1 measured the constructor at ~170 ms / 81 MB peak RSS, dominated by `@langchain/*` module loading. Cold start matters for serverless / ephemeral MCP deployments and for the SSE/HTTP transport (RFC 008) where reconnects cold-start frequently. Verified empirically with `node scripts/verify-lazy-imports.mjs` — for each provider, the trace contains the active module subtree (HF: 301 URLs, Ollama: 17, OpenAI: 333) and zero URLs from the other two providers' subtrees.
+
 ## [Unreleased] — structured MCP error codes
 
 ### Added

--- a/scripts/lazy-imports-trace-loader.mjs
+++ b/scripts/lazy-imports-trace-loader.mjs
@@ -1,0 +1,21 @@
+// Issue #59 — ESM loader hook used only by `verify-lazy-imports.mjs`.
+//
+// Records every module URL the loader resolves into the file pointed at by
+// $LAZY_IMPORTS_TRACE_FILE. Per-process, single shot — the file is opened
+// in append mode and closed by the OS on process exit.
+//
+// Loader hooks run in their own scope, so we can't share state with the
+// probe; the file path crosses the boundary via env. We use writeFileSync
+// per resolve (cheap; the probe only loads ~1k modules total) instead of
+// buffering, so a probe that crashes mid-init still produces a useful trace.
+import { appendFileSync } from 'node:fs';
+
+const TRACE_FILE = process.env.LAZY_IMPORTS_TRACE_FILE;
+
+export async function resolve(specifier, context, nextResolve) {
+  const result = await nextResolve(specifier, context);
+  if (TRACE_FILE) {
+    appendFileSync(TRACE_FILE, `${result.url}\n`);
+  }
+  return result;
+}

--- a/scripts/verify-lazy-imports-probe.mjs
+++ b/scripts/verify-lazy-imports-probe.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+// Single-provider probe — invoked by verify-lazy-imports.mjs with
+// --experimental-loader=./scripts/lazy-imports-trace-loader.mjs.
+//
+// Initializes FaissIndexManager with the env's EMBEDDING_PROVIDER, then
+// reads the loader's trace file and asserts no INACTIVE provider's module
+// URLs appear in it.
+import { mkdtemp, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+// Module-URL substrings that mark a provider as loaded. Each provider is
+// shipped as a top-level package + drags in its SDK; either is sufficient.
+const FINGERPRINTS = {
+  huggingface: ['/@langchain/community/embeddings/hf', '/@huggingface/inference/'],
+  ollama: ['/@langchain/ollama/', '/ollama/'],
+  openai: ['/@langchain/openai/', '/openai/'],
+};
+
+const active = process.env.EMBEDDING_PROVIDER ?? '(unset)';
+const traceFile = process.env.LAZY_IMPORTS_TRACE_FILE;
+if (!traceFile) {
+  console.error('LAZY_IMPORTS_TRACE_FILE is not set — driver should set it.');
+  process.exit(2);
+}
+
+const tempDir = await mkdtemp(path.join(tmpdir(), `kb-lazy-${active}-`));
+process.env.KNOWLEDGE_BASES_ROOT_DIR = tempDir;
+process.env.FAISS_INDEX_PATH = path.join(tempDir, '.faiss');
+
+const modulePath = path.join(repoRoot, 'build', 'FaissIndexManager.js');
+const { FaissIndexManager } = await import(modulePath);
+
+const manager = new FaissIndexManager();
+await manager.initialize();
+
+const trace = (await readFile(traceFile, 'utf-8')).split('\n').filter(Boolean);
+const matchUrls = (fps) =>
+  fps.flatMap((fp) => trace.filter((u) => u.includes(fp)).map((u) => `${fp} → ${path.basename(new URL(u).pathname)}`));
+
+const inactive = Object.keys(FINGERPRINTS).filter((p) => p !== active);
+const activeHits = matchUrls(FINGERPRINTS[active] ?? []);
+const leaks = Object.fromEntries(inactive.map((p) => [p, matchUrls(FINGERPRINTS[p])]));
+
+console.log(`\n=== EMBEDDING_PROVIDER=${active} ===`);
+console.log(`trace size: ${trace.length} resolved module URLs`);
+console.log(`active provider: ${activeHits.length} matching URLs`);
+const seen = new Set();
+for (const h of activeHits) {
+  if (seen.has(h)) continue;
+  seen.add(h);
+  console.log(`  ✓ ${h}`);
+}
+let leaked = false;
+for (const [other, hits] of Object.entries(leaks)) {
+  if (hits.length === 0) {
+    console.log(`  ✓ ${other}: 0 URLs resolved (lazy)`);
+  } else {
+    leaked = true;
+    console.log(`  ✗ ${other}: ${hits.length} URLs unexpectedly resolved:`);
+    const dedupSeen = new Set();
+    for (const h of hits) {
+      if (dedupSeen.has(h)) continue;
+      dedupSeen.add(h);
+      console.log(`      ${h}`);
+    }
+  }
+}
+
+if (activeHits.length === 0) {
+  console.error(
+    `\nFAIL: the active provider (${active}) was not loaded — fingerprint pattern likely needs updating.`,
+  );
+  process.exit(1);
+}
+if (leaked) {
+  console.error(`\nFAIL: inactive provider modules were loaded for EMBEDDING_PROVIDER=${active}`);
+  process.exit(1);
+}
+process.exit(0);

--- a/scripts/verify-lazy-imports.mjs
+++ b/scripts/verify-lazy-imports.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+// Issue #59 — empirical verification that switching EMBEDDING_PROVIDER only
+// loads the active provider's @langchain module, not all three.
+//
+// Strategy:
+//   1. Spawn one Node subprocess per provider. Each child gets a fresh
+//      module graph (config.ts pins env values at module-load, so reusing a
+//      single process would cache stale config).
+//   2. Each child runs with --experimental-loader=./lazy-imports-trace-loader.mjs.
+//      That loader appends every resolved module URL to a per-child trace
+//      file. The probe reads the trace after `manager.initialize()` and
+//      checks the inactive providers' URLs are absent.
+//
+// Run after `npm run build`:
+//   node scripts/verify-lazy-imports.mjs
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '..');
+
+const cases = [
+  { provider: 'huggingface', extraEnv: { HUGGINGFACE_API_KEY: 'verify-fixture' } },
+  {
+    provider: 'ollama',
+    extraEnv: { OLLAMA_BASE_URL: 'http://127.0.0.1:11434', OLLAMA_MODEL: 'mxbai-embed-large' },
+  },
+  {
+    provider: 'openai',
+    extraEnv: { OPENAI_API_KEY: 'verify-fixture', OPENAI_MODEL_NAME: 'text-embedding-3-small' },
+  },
+];
+
+const PROBE = path.join(__dirname, 'verify-lazy-imports-probe.mjs');
+const LOADER = path.join(__dirname, 'lazy-imports-trace-loader.mjs');
+
+const traceDir = mkdtempSync(path.join(tmpdir(), 'kb-lazy-trace-'));
+
+let anyFailure = false;
+try {
+  for (const c of cases) {
+    const traceFile = path.join(traceDir, `${c.provider}.trace`);
+    const env = {
+      ...process.env,
+      EMBEDDING_PROVIDER: c.provider,
+      LAZY_IMPORTS_TRACE_FILE: traceFile,
+      ...c.extraEnv,
+    };
+    for (const otherKey of ['HUGGINGFACE_API_KEY', 'OPENAI_API_KEY']) {
+      if (!Object.prototype.hasOwnProperty.call(c.extraEnv, otherKey)) delete env[otherKey];
+    }
+    const res = spawnSync(
+      process.execPath,
+      ['--experimental-loader', LOADER, '--no-warnings=ExperimentalWarning', PROBE],
+      { cwd: repoRoot, env, encoding: 'utf-8' },
+    );
+    process.stdout.write(res.stdout);
+    process.stderr.write(res.stderr);
+    if (res.status !== 0) {
+      anyFailure = true;
+      console.error(`probe for ${c.provider} exited with status ${res.status}`);
+    }
+  }
+} finally {
+  rmSync(traceDir, { recursive: true, force: true });
+}
+
+if (anyFailure) {
+  console.error('\nFAIL — at least one provider probe did not pass.');
+  process.exit(1);
+}
+console.log('\nPASS — only the active provider was loaded for each EMBEDDING_PROVIDER value.');

--- a/src/FaissIndexManager.test.ts
+++ b/src/FaissIndexManager.test.ts
@@ -145,7 +145,14 @@ describe('resolveChunkSize (#107 follow-up — KB_CHUNK_SIZE / KB_CHUNK_OVERLAP 
 });
 
 describe('provider construction', () => {
+  // Issue #59 — embeddings are now built lazily inside initialize() via
+  // dynamic import of the active provider's @langchain module. The
+  // assertions below moved from `new FaissIndexManager()` to
+  // `manager.initialize()`; the API-key-throw shape and the constructor-arg
+  // shape are unchanged.
   const originalEnv = {
+    KNOWLEDGE_BASES_ROOT_DIR: process.env.KNOWLEDGE_BASES_ROOT_DIR,
+    FAISS_INDEX_PATH: process.env.FAISS_INDEX_PATH,
     EMBEDDING_PROVIDER: process.env.EMBEDDING_PROVIDER,
     OLLAMA_BASE_URL: process.env.OLLAMA_BASE_URL,
     OLLAMA_MODEL: process.env.OLLAMA_MODEL,
@@ -156,6 +163,13 @@ describe('provider construction', () => {
     HUGGINGFACE_PROVIDER: process.env.HUGGINGFACE_PROVIDER,
     HUGGINGFACE_ENDPOINT_URL: process.env.HUGGINGFACE_ENDPOINT_URL,
   };
+
+  async function seedTempEnv(): Promise<string> {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-provider-ctor-'));
+    process.env.KNOWLEDGE_BASES_ROOT_DIR = tempDir;
+    process.env.FAISS_INDEX_PATH = path.join(tempDir, '.faiss');
+    return tempDir;
+  }
 
   beforeEach(() => {
     jest.resetModules();
@@ -176,13 +190,16 @@ describe('provider construction', () => {
     }
   });
 
-  it('constructs Ollama embeddings with the configured base URL and model', async () => {
+  it('constructs Ollama embeddings with the configured base URL and model on initialize()', async () => {
+    await seedTempEnv();
     process.env.EMBEDDING_PROVIDER = 'ollama';
     process.env.OLLAMA_BASE_URL = 'http://127.0.0.1:11434';
     process.env.OLLAMA_MODEL = 'mxbai-embed-large';
 
     const { FaissIndexManager } = await import('./FaissIndexManager.js');
-    new FaissIndexManager();
+    const manager = new FaissIndexManager();
+    expect(ollamaEmbeddingConstructorMock).not.toHaveBeenCalled();
+    await manager.initialize();
 
     expect(ollamaEmbeddingConstructorMock).toHaveBeenCalledWith({
       baseUrl: 'http://127.0.0.1:11434',
@@ -191,33 +208,45 @@ describe('provider construction', () => {
   });
 
   it('throws when OPENAI_API_KEY is unset for the OpenAI provider', async () => {
+    await seedTempEnv();
     process.env.EMBEDDING_PROVIDER = 'openai';
     process.env.OPENAI_MODEL_NAME = 'text-embedding-3-large';
     delete process.env.OPENAI_API_KEY;
 
     const { FaissIndexManager } = await import('./FaissIndexManager.js');
     const { KBError } = await import('./errors.js');
+    const manager = new FaissIndexManager();
 
-    expect(() => new FaissIndexManager()).toThrow(
-      'OPENAI_API_KEY environment variable is required when using OpenAI provider',
-    );
+    // Issue #59 — embeddings are constructed lazily inside initialize(), so
+    // the API-key check fires there (not in the ctor). #116 — the throw is a
+    // typed KBError with code PROVIDER_AUTH so MCP clients can branch on the
+    // code rather than substring-matching the message.
+    let caught: unknown;
     try {
-      new FaissIndexManager();
-      throw new Error('expected constructor to throw');
-    } catch (error) {
-      expect(error).toBeInstanceOf(KBError);
-      expect(error).toMatchObject({ code: 'PROVIDER_AUTH' });
+      await manager.initialize();
+    } catch (err) {
+      caught = err;
     }
+    expect(caught).toBeInstanceOf(KBError);
+    expect(caught).toMatchObject({
+      code: 'PROVIDER_AUTH',
+      message: expect.stringContaining(
+        'OPENAI_API_KEY environment variable is required when using OpenAI provider',
+      ),
+    });
     expect(openAIEmbeddingConstructorMock).not.toHaveBeenCalled();
   });
 
-  it('constructs OpenAI embeddings with the configured model name', async () => {
+  it('constructs OpenAI embeddings with the configured model name on initialize()', async () => {
+    await seedTempEnv();
     process.env.EMBEDDING_PROVIDER = 'openai';
     process.env.OPENAI_API_KEY = 'test-openai-key';
     process.env.OPENAI_MODEL_NAME = 'text-embedding-3-large';
 
     const { FaissIndexManager } = await import('./FaissIndexManager.js');
-    new FaissIndexManager();
+    const manager = new FaissIndexManager();
+    expect(openAIEmbeddingConstructorMock).not.toHaveBeenCalled();
+    await manager.initialize();
 
     expect(openAIEmbeddingConstructorMock).toHaveBeenCalledWith({
       apiKey: 'test-openai-key',
@@ -226,23 +255,30 @@ describe('provider construction', () => {
   });
 
   it('throws when HUGGINGFACE_API_KEY is unset for the HuggingFace provider', async () => {
+    await seedTempEnv();
     process.env.EMBEDDING_PROVIDER = 'huggingface';
     process.env.HUGGINGFACE_MODEL_NAME = 'BAAI/bge-base-en-v1.5';
     delete process.env.HUGGINGFACE_API_KEY;
 
     const { FaissIndexManager } = await import('./FaissIndexManager.js');
     const { KBError } = await import('./errors.js');
+    const manager = new FaissIndexManager();
 
-    expect(() => new FaissIndexManager()).toThrow(
-      'HUGGINGFACE_API_KEY environment variable is required when using HuggingFace provider',
-    );
+    // Issue #59 — embeddings are constructed lazily inside initialize().
+    // #116 — the throw is a typed KBError with code PROVIDER_AUTH.
+    let caught: unknown;
     try {
-      new FaissIndexManager();
-      throw new Error('expected constructor to throw');
-    } catch (error) {
-      expect(error).toBeInstanceOf(KBError);
-      expect(error).toMatchObject({ code: 'PROVIDER_AUTH' });
+      await manager.initialize();
+    } catch (err) {
+      caught = err;
     }
+    expect(caught).toBeInstanceOf(KBError);
+    expect(caught).toMatchObject({
+      code: 'PROVIDER_AUTH',
+      message: expect.stringContaining(
+        'HUGGINGFACE_API_KEY environment variable is required when using HuggingFace provider',
+      ),
+    });
     expect(embeddingConstructorMock).not.toHaveBeenCalled();
   });
 });
@@ -316,7 +352,9 @@ describe('FaissIndexManager permission handling', () => {
 
     jest.resetModules();
     const { FaissIndexManager } = await import('./FaissIndexManager.js');
-    new FaissIndexManager();
+    const manager = new FaissIndexManager();
+    // Issue #59 — embeddings are constructed lazily inside initialize().
+    await manager.initialize();
 
     expect(embeddingConstructorMock).toHaveBeenCalledWith(expect.objectContaining({
       apiKey: 'test-key',
@@ -336,7 +374,9 @@ describe('FaissIndexManager permission handling', () => {
 
     jest.resetModules();
     const { FaissIndexManager } = await import('./FaissIndexManager.js');
-    new FaissIndexManager();
+    const manager = new FaissIndexManager();
+    // Issue #59 — embeddings are constructed lazily inside initialize().
+    await manager.initialize();
 
     expect(embeddingConstructorMock).toHaveBeenCalledWith(expect.objectContaining({
       apiKey: 'test-key',

--- a/src/FaissIndexManager.ts
+++ b/src/FaissIndexManager.ts
@@ -3,9 +3,15 @@ import * as fs from 'fs';
 import * as fsp from 'fs/promises';
 import * as path from 'path';
 import * as properLockfile from 'proper-lockfile';
-import { HuggingFaceInferenceEmbeddings } from "@langchain/community/embeddings/hf";
-import { OllamaEmbeddings } from "@langchain/ollama";
-import { OpenAIEmbeddings } from "@langchain/openai";
+// Issue #59 — provider modules are loaded lazily inside initialize(). Each
+// `@langchain/*` provider drags its full dep graph (e.g. @huggingface/inference,
+// openai, ollama) at import time; eager-loading all three for a process that
+// only ever uses one was ~170 ms / 81 MB peak RSS in RFC 007 §5.1.
+// `import type` is erased by tsc, so the union type is preserved without any
+// runtime require/resolve of the unused provider's tree.
+import type { HuggingFaceInferenceEmbeddings } from "@langchain/community/embeddings/hf";
+import type { OllamaEmbeddings } from "@langchain/ollama";
+import type { OpenAIEmbeddings } from "@langchain/openai";
 import { FaissStore } from "@langchain/community/vectorstores/faiss";
 import { Document } from "@langchain/core/documents";
 import { MarkdownTextSplitter, RecursiveCharacterTextSplitter } from "langchain/text_splitter";
@@ -469,7 +475,12 @@ export interface FaissIndexManagerOptions {
 
 export class FaissIndexManager {
   private faissIndex: FaissStore | null = null;
-  private embeddings: HuggingFaceInferenceEmbeddings | OllamaEmbeddings | OpenAIEmbeddings;
+  // Issue #59 — populated by initialize() via dynamic import of the active
+  // provider's @langchain module. Definite-assignment-asserted because the
+  // class invariant is "every method that touches embeddings runs after
+  // initialize()", which holds for every call site (KnowledgeBaseServer,
+  // cli.ts, every test that exercises retrieval).
+  private embeddings!: HuggingFaceInferenceEmbeddings | OllamaEmbeddings | OpenAIEmbeddings;
   // RFC 014 — monotonic counter for unique tmp-symlink names within this
   // process. Incremented on every atomicSave; combined with PID it guarantees
   // no collision between concurrent saves on the same modelDir (which the
@@ -501,47 +512,63 @@ export class FaissIndexManager {
     this.modelDir = modelDir(this.modelId);
     this.modelNameFile = modelNameFilePath(this.modelId);
 
+    // Issue #59 — embeddings are constructed lazily inside initialize() so
+    // the unused providers' @langchain modules never load. API-key validation
+    // moves with them; the throw still fires before any disk work.
+
+    logger.info(`FaissIndexManager bound to ${this.modelDir} (provider=${this.embeddingProvider}, model=${this.modelName}, id=${this.modelId})`);
+  }
+
+  /**
+   * Issue #59 — dynamically imports the active provider's `@langchain/*`
+   * module so cold start only pays for one provider's dep graph. Validates
+   * the relevant API key first; the throw shape and message match the
+   * pre-#59 constructor exactly so caller error handling is unchanged.
+   */
+  private async createEmbeddings(): Promise<
+    HuggingFaceInferenceEmbeddings | OllamaEmbeddings | OpenAIEmbeddings
+  > {
     if (this.embeddingProvider === 'ollama') {
       logger.info(`Initializing FaissIndexManager with Ollama embeddings (model: ${this.modelName})`);
-      this.embeddings = new OllamaEmbeddings({
+      const { OllamaEmbeddings } = await import('@langchain/ollama');
+      return new OllamaEmbeddings({
         baseUrl: OLLAMA_BASE_URL,
         model: this.modelName,
       });
-    } else if (this.embeddingProvider === 'openai') {
+    }
+    if (this.embeddingProvider === 'openai') {
       logger.info(`Initializing FaissIndexManager with OpenAI embeddings (model: ${this.modelName})`);
       const openaiApiKey = process.env.OPENAI_API_KEY;
       if (!openaiApiKey) {
         throw new KBError('PROVIDER_AUTH', 'OPENAI_API_KEY environment variable is required when using OpenAI provider');
       }
-
-      this.embeddings = new OpenAIEmbeddings({
+      const { OpenAIEmbeddings } = await import('@langchain/openai');
+      return new OpenAIEmbeddings({
         apiKey: openaiApiKey,
         model: this.modelName,
       });
-    } else {
-      logger.info(`Initializing FaissIndexManager with HuggingFace embeddings (model: ${this.modelName})`);
-      const huggingFaceApiKey = process.env.HUGGINGFACE_API_KEY;
-      if (!huggingFaceApiKey) {
-        throw new KBError('PROVIDER_AUTH', 'HUGGINGFACE_API_KEY environment variable is required when using HuggingFace provider');
-      }
-
-      // HuggingFace endpoint URL is computed from HUGGINGFACE_MODEL_NAME at
-      // module load (config.ts). In the multi-model world the endpoint is
-      // per-(provider+model), so for non-default models we recompute the URL
-      // here. The router URL pattern is `router.huggingface.co/hf-inference/models/<model>/pipeline/feature-extraction`.
-      const endpointUrl = HUGGINGFACE_ENDPOINT_URL_OVERRIDDEN
-        ? HUGGINGFACE_ENDPOINT_URL
-        : `https://router.huggingface.co/hf-inference/models/${this.modelName}/pipeline/feature-extraction`;
-
-      this.embeddings = new HuggingFaceInferenceEmbeddings({
-        apiKey: huggingFaceApiKey,
-        model: this.modelName,
-        endpointUrl,
-        provider: HUGGINGFACE_ENDPOINT_URL_OVERRIDDEN ? undefined : HUGGINGFACE_PROVIDER,
-      });
     }
+    logger.info(`Initializing FaissIndexManager with HuggingFace embeddings (model: ${this.modelName})`);
+    const huggingFaceApiKey = process.env.HUGGINGFACE_API_KEY;
+    if (!huggingFaceApiKey) {
+      throw new KBError('PROVIDER_AUTH', 'HUGGINGFACE_API_KEY environment variable is required when using HuggingFace provider');
+    }
+    const { HuggingFaceInferenceEmbeddings } = await import('@langchain/community/embeddings/hf');
 
-    logger.info(`FaissIndexManager bound to ${this.modelDir} (provider=${this.embeddingProvider}, model=${this.modelName}, id=${this.modelId})`);
+    // HuggingFace endpoint URL is computed from HUGGINGFACE_MODEL_NAME at
+    // module load (config.ts). In the multi-model world the endpoint is
+    // per-(provider+model), so for non-default models we recompute the URL
+    // here. The router URL pattern is `router.huggingface.co/hf-inference/models/<model>/pipeline/feature-extraction`.
+    const endpointUrl = HUGGINGFACE_ENDPOINT_URL_OVERRIDDEN
+      ? HUGGINGFACE_ENDPOINT_URL
+      : `https://router.huggingface.co/hf-inference/models/${this.modelName}/pipeline/feature-extraction`;
+
+    return new HuggingFaceInferenceEmbeddings({
+      apiKey: huggingFaceApiKey,
+      model: this.modelName,
+      endpointUrl,
+      provider: HUGGINGFACE_ENDPOINT_URL_OVERRIDDEN ? undefined : HUGGINGFACE_PROVIDER,
+    });
   }
 
   /**
@@ -610,6 +637,13 @@ export class FaissIndexManager {
    */
   async initialize(opts: { readOnly?: boolean } = {}): Promise<void> {
     try {
+      // Issue #59 — lazy provider import. Idempotent: a second initialize()
+      // (e.g. tests that re-call after corrupt-recovery) reuses the existing
+      // embeddings client. Throws here on missing API keys, matching the
+      // pre-#59 constructor's error shape.
+      if (!this.embeddings) {
+        this.embeddings = await this.createEmbeddings();
+      }
       // Ensure this model's directory exists. mkdir-p is cheap; first-run
       // for a fresh install creates `${PATH}/models/<id>/`.
       if (!(await pathExists(this.modelDir))) {


### PR DESCRIPTION
Closes #59.

## Summary

`FaissIndexManager` now constructs the active provider's embedding client via dynamic `await import()` inside `initialize()`. Top-level `import` statements for the three `@langchain/*` provider wrappers are demoted to `import type` (erased at compile time), so a process running with `EMBEDDING_PROVIDER=ollama` no longer pays the import cost of HuggingFace + OpenAI (and vice versa).

API-key validation moves with the instantiation: `OPENAI_API_KEY` / `HUGGINGFACE_API_KEY` are now checked when `initialize()` runs, before any disk work. Error messages are unchanged.

## Why

RFC 007 §5.1 measured `module import + new KnowledgeBaseServer()` at ~170 ms / 81 MB peak RSS, dominated by `@langchain/*` module loading. Cold start matters for serverless / ephemeral MCP deployments and the SSE/HTTP transport (RFC 008) where reconnects cold-start frequently. Issue body proposed lazy-loading directly (without waiting for the RFC 006 factory) — this is that PR.

## Empirical verification

`scripts/verify-lazy-imports.mjs` spawns one subprocess per provider with a small ESM loader (`scripts/lazy-imports-trace-loader.mjs`) that logs every resolved module URL. The probe script then reads the trace and asserts the **inactive** providers' subtrees are absent.

```
=== EMBEDDING_PROVIDER=huggingface ===
trace size: 862 resolved module URLs
active provider: 301 matching URLs   (@langchain/community/embeddings/hf, @huggingface/inference)
  ✓ ollama: 0 URLs resolved (lazy)
  ✓ openai: 0 URLs resolved (lazy)

=== EMBEDDING_PROVIDER=ollama ===
trace size: 621 resolved module URLs
active provider: 17 matching URLs    (@langchain/ollama, ollama)
  ✓ huggingface: 0 URLs resolved (lazy)
  ✓ openai: 0 URLs resolved (lazy)

=== EMBEDDING_PROVIDER=openai ===
trace size: 982 resolved module URLs
active provider: 333 matching URLs   (@langchain/openai, openai)
  ✓ huggingface: 0 URLs resolved (lazy)
  ✓ ollama: 0 URLs resolved (lazy)

PASS — only the active provider was loaded for each EMBEDDING_PROVIDER value.
```

## Tests

- All existing tests still green: `npm test` → 273 / 273 across 16 suites.
- `provider construction` tests rewritten to assert on `manager.initialize()` instead of `new FaissIndexManager()` (the only behavior change visible to callers — embedding constructor now fires lazily). Each test uses a tempdir so `initialize()` doesn't touch real paths. Throw messages and `expect(*).not.toHaveBeenCalled()` assertions are preserved.
- The two HF-provider-shape tests in `FaissIndexManager permission handling` add `await manager.initialize()` before asserting on the embedding constructor mock.

## Out of scope

- RFC 006 §5.2 provider factory — issue #59 explicitly says lazy-loading can be done eagerly without waiting for that RFC.
- Other `FaissIndexManager` cleanup (constructor still has the legacy/explicit-args branching).

🤖 Generated with [Claude Code](https://claude.com/claude-code)