### PR TITLE
fix(faiss): abort stdio startup on stale index cleanup failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased] — fail stdio startup before exposing poisoned indexes
+
+### Fixed
+
+- **Stdio startup now warms the active FAISS manager before connecting MCP tools.** If index invalidation or corrupt-index cleanup fails, startup aborts before clients can call `tools/list` or `list_knowledge_bases` against a process that already knows its active index is unsafe. Closes #85.
+
 ## [Unreleased] — lazy-import unused embedding providers
 
 ### Changed

--- a/src/KnowledgeBaseServer.test.ts
+++ b/src/KnowledgeBaseServer.test.ts
@@ -440,6 +440,18 @@ describe('KnowledgeBaseServer handlers', () => {
     expect(text).not.toContain(`"source": ${JSON.stringify(betaSource)}`);
   });
 
+  it('runStdio aborts before MCP connect when active model initialization fails (#85)', async () => {
+    await setRetrieveEnv();
+    initializeMock.mockRejectedValueOnce(new Error('stale FAISS cleanup failed'));
+
+    const server = await freshServer();
+    const connectMock = jest.fn().mockResolvedValue(undefined);
+    server['mcp'].connect = connectMock;
+
+    await expect(server['runStdio']()).rejects.toThrow('stale FAISS cleanup failed');
+    expect(connectMock).not.toHaveBeenCalled();
+  });
+
   // --- tool description overrides (#52, RFC 010 M2) -------------------------
   //
   // These tests assert behaviour visible at the MCP wire surface: the

--- a/src/KnowledgeBaseServer.ts
+++ b/src/KnowledgeBaseServer.ts
@@ -300,12 +300,13 @@ export class KnowledgeBaseServer {
   }
 
   private async runStdio(): Promise<void> {
+    // Fail before exposing tools over stdio. If FAISS initialization knows the
+    // active index is bad but cannot clean it up, serving even "safe" tools
+    // leaves clients attached to a poisoned process (#85).
+    await this.warmActiveManager();
     const transport = new StdioServerTransport();
     await this.mcp.connect(transport);
     logger.info('Knowledge Base MCP server running on stdio');
-    // RFC 013: warm up the active model's manager so the first agent call
-    // doesn't pay construction cost.
-    await this.warmActiveManager();
     this.startTriggerWatcher();
   }
 


### PR DESCRIPTION
## Summary

- Warm the active FAISS manager before connecting the stdio MCP transport.
- This means failed stale-index invalidation or corrupt-index cleanup aborts startup before clients can call `tools/list` / `list_knowledge_bases` against a known-bad process.
- Add a regression test that forces active model initialization to fail and asserts stdio never connects.

## Repro steps

Root EISDIR primitive reproduced locally with the LangChain directory-shaped store:

```bash
mkdir -p /tmp/kb-issue85/.faiss/faiss.index
printf old > /tmp/kb-issue85/.faiss/faiss.index/faiss.index
printf '{}' > /tmp/kb-issue85/.faiss/faiss.index/docstore.json
node -e "require('fs/promises').unlink('/tmp/kb-issue85/.faiss/faiss.index').catch(e => console.log(e.code))"
# EISDIR
```

The recursive cleanup path already present on `main` removes that directory shape cleanly with `fs.rm(path, { recursive: true, force: true })`.

## Before / after

Before: stdio startup connected MCP first, then warmed the FAISS manager. If initialization failed after detecting a bad/stale index, `run()` logged and set `exitCode = 1`, but clients could already be attached to an MCP server that exposed safe-looking tools while the active index remained unsafe.

After: stdio startup warms the active manager before `mcp.connect(...)`. Initialization failures reject before any tools are exposed. SSE already had this safer ordering before binding HTTP, so stdio now matches it.

## Verification

- `npm test` — 16 suites / 276 tests passing
- `npm run build` — passing

Closes #85.
