### PR TITLE
fix(ollama): translate context-overflow into actionable error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [Unreleased] — actionable Ollama context-overflow error
+
+### Fixed
+
+- **Ollama embedding requests no longer retry deterministic context-overflow errors 7 times.** When a configured `OLLAMA_MODEL` rejects an input as too long for its context window (e.g. `all-minilm:latest`'s 256-token ceiling against the default ~1000-character chunker), the server now short-circuits the `@langchain/core` `AsyncCaller` retry loop on the first attempt and surfaces a translated, actionable message that names the offending model and points at larger-context alternatives (`nomic-embed-text` 8192 ctx, `dengcao/Qwen3-Embedding-0.6B:Q8_0` 32K ctx). Closes #86.
+
+### Why
+
+`@langchain/core`'s default failed-attempt handler short-circuits HTTP 4xx via `error.status` / `error.response.status`, but `ollama`'s `ResponseError` exposes the status as `status_code` (snake_case), so the handler never sees it and the call retried 6 more times before bubbling up a raw stack trace. The new `src/ollama-error.ts` recognises the snake_case shape plus the well-known overflow phrasings and rethrows a `KBError('VALIDATION', ...)` from inside `onFailedAttempt`, which p-retry treats as terminal.
+
 ## [Unreleased] — skip filesystem-metadata sidecars in the ingest filter
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Use this path if you want to develop against the repo or pin an unreleased commi
         OLLAMA_MODEL=dengcao/Qwen3-Embedding-0.6B:Q8_0          # Default embedding model
         KNOWLEDGE_BASES_ROOT_DIR=$HOME/knowledge_bases
         ```
+    *   **Minimum context window:** the embedding model must accept at least ~500 tokens of input. The default chunker emits ~1000-character chunks which commonly tokenize past 256 tokens, so models like `all-minilm` (256 ctx) will reject every request. Use `nomic-embed-text` (8192 ctx), `dengcao/Qwen3-Embedding-0.6B:Q8_0` (32K ctx), or any model with ≥512 ctx instead.
 
     ### Option 2: OpenAI Configuration
 

--- a/src/FaissIndexManager.test.ts
+++ b/src/FaissIndexManager.test.ts
@@ -201,10 +201,16 @@ describe('provider construction', () => {
     expect(ollamaEmbeddingConstructorMock).not.toHaveBeenCalled();
     await manager.initialize();
 
-    expect(ollamaEmbeddingConstructorMock).toHaveBeenCalledWith({
-      baseUrl: 'http://127.0.0.1:11434',
-      model: 'mxbai-embed-large',
-    });
+    // Issue #86 — we now also pass an `onFailedAttempt` so deterministic
+    // Ollama 4xx errors (e.g. "input length exceeds the context length")
+    // short-circuit the AsyncCaller's 7-attempt retry loop.
+    expect(ollamaEmbeddingConstructorMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseUrl: 'http://127.0.0.1:11434',
+        model: 'mxbai-embed-large',
+        onFailedAttempt: expect.any(Function),
+      }),
+    );
   });
 
   it('throws when OPENAI_API_KEY is unset for the OpenAI provider', async () => {

--- a/src/FaissIndexManager.ts
+++ b/src/FaissIndexManager.ts
@@ -46,6 +46,7 @@ import {
 import { deriveModelId, EmbeddingProvider } from './model-id.js';
 import { logger } from './logger.js';
 import { KBError } from './errors.js';
+import { makeOllamaOnFailedAttempt } from './ollama-error.js';
 
 /**
  * RFC 013 §4.7 — atomic write for `model_name.txt`. Per-model file:
@@ -531,9 +532,15 @@ export class FaissIndexManager {
     if (this.embeddingProvider === 'ollama') {
       logger.info(`Initializing FaissIndexManager with Ollama embeddings (model: ${this.modelName})`);
       const { OllamaEmbeddings } = await import('@langchain/ollama');
+      // Issue #86 — Ollama's ResponseError uses snake_case `status_code`,
+      // which langchain's default failed-attempt handler doesn't recognise,
+      // so deterministic 400s (e.g. "input length exceeds the context length")
+      // burn 7 retries. We pass our own onFailedAttempt that short-circuits
+      // those errors and rethrows them as a translated KBError.
       return new OllamaEmbeddings({
         baseUrl: OLLAMA_BASE_URL,
         model: this.modelName,
+        onFailedAttempt: makeOllamaOnFailedAttempt(this.modelName),
       });
     }
     if (this.embeddingProvider === 'openai') {
@@ -1116,9 +1123,16 @@ export class FaissIndexManager {
     } catch (error: unknown) {
       const err = toError(error) as Error & { __alreadyLogged?: boolean };
       if (!err.__alreadyLogged) {
-        logger.error('Error updating FAISS index:', err);
-        if (err.stack) {
-          logger.error(err.stack);
+        // Issue #86 — for KBError we already crafted an operator-facing
+        // message; suppress the stack to keep the log readable. Unknown
+        // errors still get the full stack for debugging.
+        if (err instanceof KBError) {
+          logger.error(`Error updating FAISS index: ${err.message}`);
+        } else {
+          logger.error('Error updating FAISS index:', err);
+          if (err.stack) {
+            logger.error(err.stack);
+          }
         }
       }
       throw err;

--- a/src/ollama-error.test.ts
+++ b/src/ollama-error.test.ts
@@ -1,0 +1,170 @@
+import {
+  isOllamaContextLengthError,
+  isNonRetryableOllamaError,
+  translateOllamaEmbeddingError,
+  makeOllamaOnFailedAttempt,
+} from './ollama-error.js';
+import { KBError } from './errors.js';
+
+// Mirror the runtime shape produced by the `ollama` SDK's checkOk():
+//   throw new ResponseError(message, response.status);
+//   class ResponseError extends Error { status_code: number; name: 'ResponseError' }
+class FakeOllamaResponseError extends Error {
+  status_code: number;
+  override name = 'ResponseError';
+  constructor(message: string, statusCode: number) {
+    super(message);
+    this.status_code = statusCode;
+  }
+}
+
+describe('isOllamaContextLengthError', () => {
+  it('matches the verbatim Ollama 0.x message', () => {
+    const err = new FakeOllamaResponseError(
+      'the input length exceeds the context length',
+      400,
+    );
+    expect(isOllamaContextLengthError(err)).toBe(true);
+  });
+
+  it('matches a phrasing variant ("input is too long")', () => {
+    const err = new FakeOllamaResponseError('input is too long for model', 400);
+    expect(isOllamaContextLengthError(err)).toBe(true);
+  });
+
+  it('matches a future "context length exceeded" rephrasing', () => {
+    const err = new FakeOllamaResponseError('context length exceeded', 400);
+    expect(isOllamaContextLengthError(err)).toBe(true);
+  });
+
+  it('matches by status_code 400 + context+length keywords', () => {
+    const err = new FakeOllamaResponseError(
+      'request rejected: context length not enough for input',
+      400,
+    );
+    expect(isOllamaContextLengthError(err)).toBe(true);
+  });
+
+  it('does not match generic 5xx errors', () => {
+    const err = new FakeOllamaResponseError('internal server error', 500);
+    expect(isOllamaContextLengthError(err)).toBe(false);
+  });
+
+  it('does not match plain Error instances', () => {
+    expect(isOllamaContextLengthError(new Error('socket hang up'))).toBe(false);
+  });
+
+  it('returns false for non-objects', () => {
+    expect(isOllamaContextLengthError(undefined)).toBe(false);
+    expect(isOllamaContextLengthError(null)).toBe(false);
+    expect(isOllamaContextLengthError('boom')).toBe(false);
+  });
+});
+
+describe('isNonRetryableOllamaError', () => {
+  it.each([400, 401, 402, 403, 404, 405, 406, 407, 409])(
+    'flags ResponseError with status %i as non-retryable',
+    (status) => {
+      const err = new FakeOllamaResponseError('nope', status);
+      expect(isNonRetryableOllamaError(err)).toBe(true);
+    },
+  );
+
+  it.each([408, 425, 429, 500, 502, 503, 504])(
+    'leaves status %i as retryable',
+    (status) => {
+      const err = new FakeOllamaResponseError('transient', status);
+      expect(isNonRetryableOllamaError(err)).toBe(false);
+    },
+  );
+
+  it('does not flag generic Errors as non-retryable', () => {
+    expect(isNonRetryableOllamaError(new Error('ECONNRESET'))).toBe(false);
+  });
+
+  it('flags context-length errors even without ResponseError name', () => {
+    // Defensive: future SDK rewrap might lose the .name. Keep matching by
+    // message so we still short-circuit.
+    const err = Object.assign(new Error('the input length exceeds the context length'), {
+      status_code: 400,
+    });
+    expect(isNonRetryableOllamaError(err)).toBe(true);
+  });
+});
+
+describe('translateOllamaEmbeddingError', () => {
+  it('returns a KBError with VALIDATION code for context-length errors', () => {
+    const original = new FakeOllamaResponseError(
+      'the input length exceeds the context length',
+      400,
+    );
+    const translated = translateOllamaEmbeddingError(original, 'all-minilm:latest');
+    expect(translated).toBeInstanceOf(KBError);
+    expect(translated.code).toBe('VALIDATION');
+    expect(translated.cause).toBe(original);
+  });
+
+  it('names the offending model in the translated message', () => {
+    const err = new FakeOllamaResponseError(
+      'the input length exceeds the context length',
+      400,
+    );
+    const translated = translateOllamaEmbeddingError(err, 'all-minilm:latest');
+    expect(translated.message).toContain('all-minilm:latest');
+  });
+
+  it('points at larger-context alternatives', () => {
+    const err = new FakeOllamaResponseError(
+      'the input length exceeds the context length',
+      400,
+    );
+    const translated = translateOllamaEmbeddingError(err, 'all-minilm:latest');
+    expect(translated.message).toContain('nomic-embed-text');
+    expect(translated.message).toContain('Qwen3-Embedding-0.6B');
+  });
+
+  it('falls back to PROVIDER_UNAVAILABLE for non-context 4xx', () => {
+    const err = new FakeOllamaResponseError('not found', 404);
+    const translated = translateOllamaEmbeddingError(err, 'fake-model');
+    expect(translated).toBeInstanceOf(KBError);
+    expect(translated.code).toBe('PROVIDER_UNAVAILABLE');
+    expect(translated.message).toContain('fake-model');
+    expect(translated.message).toContain('not found');
+  });
+});
+
+describe('makeOllamaOnFailedAttempt', () => {
+  it('throws a translated KBError on context-length errors (aborts retry)', () => {
+    const handler = makeOllamaOnFailedAttempt('all-minilm:latest');
+    const err = new FakeOllamaResponseError(
+      'the input length exceeds the context length',
+      400,
+    );
+    expect(() => handler(err)).toThrow(KBError);
+    try {
+      handler(err);
+      fail('expected throw');
+    } catch (caught) {
+      expect(caught).toBeInstanceOf(KBError);
+      expect((caught as KBError).code).toBe('VALIDATION');
+      expect((caught as KBError).message).toContain('all-minilm:latest');
+    }
+  });
+
+  it('throws on any non-retryable 4xx', () => {
+    const handler = makeOllamaOnFailedAttempt('foo');
+    const err = new FakeOllamaResponseError('forbidden', 403);
+    expect(() => handler(err)).toThrow(KBError);
+  });
+
+  it('does NOT throw on retryable 5xx (lets AsyncCaller keep retrying)', () => {
+    const handler = makeOllamaOnFailedAttempt('foo');
+    const err = new FakeOllamaResponseError('upstream timeout', 504);
+    expect(() => handler(err)).not.toThrow();
+  });
+
+  it('does NOT throw on plain Error (network jitter etc.)', () => {
+    const handler = makeOllamaOnFailedAttempt('foo');
+    expect(() => handler(new Error('ECONNRESET'))).not.toThrow();
+  });
+});

--- a/src/ollama-error.ts
+++ b/src/ollama-error.ts
@@ -1,0 +1,108 @@
+// Ollama embedding error translation + retry short-circuit (issue #86).
+//
+// `@langchain/core`'s AsyncCaller retries failed embedding calls 7 times by
+// default. Its built-in defaultFailedAttemptHandler short-circuits HTTP 4xx
+// via `error.status` / `error.response.status`, but the `ollama` SDK's
+// ResponseError exposes the status as snake_case `status_code`, so the
+// handler never sees it and we burn 7 attempts on a deterministic 400.
+//
+// This module returns an `onFailedAttempt` handler that:
+//   1. Recognises the deterministic schema-violation classes we care about
+//      (context-length overflow, generic Ollama 4xx).
+//   2. Throws a KBError translated for the operator — model name + a pointer
+//      at safer alternatives — which aborts p-retry on the very first attempt.
+import { KBError } from './errors.js';
+
+const CONTEXT_OVERFLOW_PATTERNS = [
+  /input length exceeds the context length/i,
+  /context length exceeded/i,
+  /input is too long/i,
+];
+
+interface OllamaResponseErrorShape {
+  status_code?: number;
+  status?: number;
+  response?: { status?: number };
+  message?: string;
+  name?: string;
+}
+
+function readStatus(err: OllamaResponseErrorShape): number | undefined {
+  return err.status_code ?? err.status ?? err.response?.status;
+}
+
+export function isOllamaContextLengthError(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false;
+  const e = err as OllamaResponseErrorShape;
+  const msg = typeof e.message === 'string' ? e.message : '';
+  if (CONTEXT_OVERFLOW_PATTERNS.some((p) => p.test(msg))) return true;
+  // Some Ollama builds report context overflow with status 400 + a slightly
+  // different phrasing; treat 400 with "context" + "length" in the message
+  // as the same bucket.
+  if (readStatus(e) === 400 && /context/i.test(msg) && /length/i.test(msg)) {
+    return true;
+  }
+  return false;
+}
+
+export function isNonRetryableOllamaError(err: unknown): boolean {
+  if (isOllamaContextLengthError(err)) return true;
+  if (!err || typeof err !== 'object') return false;
+  const e = err as OllamaResponseErrorShape;
+  if (e.name !== 'ResponseError') return false;
+  const status = readStatus(e);
+  // Treat the langchain STATUS_NO_RETRY set (4xx schema violations,
+  // not-found, auth, payment) as terminal. 408/429 stay retryable.
+  if (status === undefined) return false;
+  return [400, 401, 402, 403, 404, 405, 406, 407, 409].includes(status);
+}
+
+const KNOWN_LARGE_CONTEXT_OLLAMA_MODELS: { name: string; ctx: string }[] = [
+  { name: 'nomic-embed-text', ctx: '8192 tokens' },
+  { name: 'dengcao/Qwen3-Embedding-0.6B:Q8_0', ctx: '32K tokens' },
+  { name: 'mxbai-embed-large', ctx: '512 tokens' },
+];
+
+export function translateOllamaEmbeddingError(err: unknown, model: string): KBError {
+  if (isOllamaContextLengthError(err)) {
+    const suggestions = KNOWN_LARGE_CONTEXT_OLLAMA_MODELS
+      .map((m) => `\`${m.name}\` (${m.ctx})`)
+      .join(', ');
+    const message =
+      `Ollama embedding model \`${model}\` rejected an input chunk as too long for ` +
+      `its context window. The default chunker emits ~1000-character chunks, which ` +
+      `commonly tokenize past 256 tokens — too large for small models like ` +
+      `all-minilm. Switch OLLAMA_MODEL to a larger-context embedding model ` +
+      `(e.g. ${suggestions}) and retry. See README → Ollama Configuration.`;
+    return new KBError('VALIDATION', message, err);
+  }
+  // Generic non-retryable Ollama 4xx — keep the original message but tag it
+  // so callers know we already decided not to retry.
+  const original =
+    err && typeof err === 'object' && 'message' in err
+      ? String((err as { message?: unknown }).message ?? '')
+      : String(err);
+  return new KBError(
+    'PROVIDER_UNAVAILABLE',
+    `Ollama embedding request for model \`${model}\` failed with a non-retryable error: ${original}`,
+    err,
+  );
+}
+
+/**
+ * Returns an `onFailedAttempt` handler suitable for `OllamaEmbeddings`'s
+ * AsyncCaller. Throwing from this handler aborts the p-retry loop on the
+ * first failed attempt, so deterministic schema violations fail fast with
+ * an actionable message instead of running through 7 retries.
+ */
+export function makeOllamaOnFailedAttempt(
+  model: string,
+): (err: unknown) => void {
+  return (err: unknown) => {
+    if (isNonRetryableOllamaError(err)) {
+      throw translateOllamaEmbeddingError(err, model);
+    }
+    // Other errors stay retryable — fall through (no throw) so AsyncCaller
+    // continues with its exponential-backoff retry loop.
+  };
+}


### PR DESCRIPTION
## Summary

- Short-circuits the langchain `AsyncCaller` retry loop on deterministic Ollama 4xx errors (e.g. `the input length exceeds the context length`) — they used to burn 7 attempts before bubbling a raw stack trace.
- Translates the error into an operator-facing `KBError('VALIDATION', ...)` that names the offending model and points at larger-context alternatives (`nomic-embed-text` 8192 ctx, `dengcao/Qwen3-Embedding-0.6B:Q8_0` 32K ctx).
- Adds a one-line minimum-context note to README → Ollama Configuration.

Closes #86.

## Why

`@langchain/core`'s `AsyncCaller` short-circuits HTTP 4xx via `error.status` / `error.response.status`, but `ollama`'s `ResponseError` exposes the status as `status_code` (snake_case). The default handler never sees it, so even purely deterministic schema violations like context overflow ran through 6 retries with exponential backoff before failing.

The new `src/ollama-error.ts`:

- `isOllamaContextLengthError(err)` — recognises the verbatim Ollama 0.x message plus a couple of phrasing variants, plus a defensive "status 400 + context+length keywords" rule for future SDK rephrasings.
- `isNonRetryableOllamaError(err)` — flags the langchain `STATUS_NO_RETRY` set (400/401/402/403/404/405/406/407/409) when present in `status_code`. Leaves 408/429 and 5xx retryable so transient upstream failures still recover.
- `translateOllamaEmbeddingError(err, model)` — returns a `KBError('VALIDATION', ...)` for context overflow, `KBError('PROVIDER_UNAVAILABLE', ...)` for the rest of the non-retryable bucket.
- `makeOllamaOnFailedAttempt(model)` — the handler installed on `OllamaEmbeddings`. Throwing inside aborts p-retry on the first failed attempt.

The `updateIndex` catch block now logs `KBError` as a single message line instead of dumping its stack, so the operator-facing translation is the first (and only) thing visible in stderr.

## Out of scope

- Fix (4) from #86 (`CHUNK_SIZE` / `CHUNK_OVERLAP` env vars) — that's a separate feature ticket.
- HuggingFace and OpenAI providers — they don't share Ollama's snake_case status field; their existing langchain default handler already classifies their 4xx correctly.

## Verification

- `npm test` — 316/316 passing locally (33 new tests in `src/ollama-error.test.ts` covering the snake_case detection, the retryable/non-retryable split, the translated message content, and the abort-on-throw contract of `makeOllamaOnFailedAttempt`). The new tests construct a `FakeOllamaResponseError` matching the exact wire shape from the issue stack trace (`status_code: 400`, message verbatim).
- `npm run build` — clean.
- One existing assertion in `src/FaissIndexManager.test.ts` was relaxed from a literal-object match to `expect.objectContaining({...})` so the new `onFailedAttempt` field doesn't break it. Comment in the test points back at this issue.

## Test plan

- [x] Unit tests for the new error-translation + short-circuit logic pass.
- [x] Existing test suite stays green.
- [x] `tsc -p tsconfig.json --noEmit` clean.
- [x] CHANGELOG entry under `[Unreleased]`.
- [x] README minimum-context note added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)