### PR TITLE
feat: warm stale FAISS indexes on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased] — eager startup rebuild with MCP progress logs
+
+### Added
+
+- **Startup now begins rebuilding a missing or corrupt active FAISS index in the background.** The MCP transport is exposed first so `tools/list` and `list_knowledge_bases` can respond while the one-time embedding rebuild runs.
+- **Rebuild progress is emitted as MCP `notifications/message` logs.** The server reports embedded-file progress every 10 files and at completion so clients can surface activity during long startup rebuilds. In SSE mode, progress is fanned out across every connected session so each client gets the warm-up notifications; in stdio mode, progress is emitted on the single connected `McpServer`. Closes #87.
+
 ## [Unreleased] — invalidate hash sidecars when this model's FAISS store is missing
 
 ### Fixed
@@ -39,11 +46,12 @@ The trade-off, which the warning log calls out: when a second model is registere
 
 Before this fix, a KB rsync'd from an NTFS volume produced a zero-byte sibling `<file>:Zone.Identifier` for every markdown file. The ingest filter happened to drop them via the extension allowlist (`extname(...)` returned `.Identifier`, not `.md`), but that was coincidence — making the skip explicit means a future loader (#46 PDF/HTML) that widens the extension allowlist still drops these sidecars instead of attempting to embed zero-byte payloads on every retrieve call.
 
-## [Unreleased] — fail stdio startup before exposing poisoned indexes
+## [Unreleased] — active-index startup warm-up
 
 ### Fixed
 
-- **Stdio startup now warms the active FAISS manager before connecting MCP tools.** If index invalidation or corrupt-index cleanup fails, startup aborts before clients can call `tools/list` or `list_knowledge_bases` against a process that already knows its active index is unsafe. Closes #85.
+- **Stdio startup now starts active FAISS manager warm-up automatically** instead of leaving the first retrieval call to discover stale or corrupt indexes. Closes #85.
+- **Superseded by the eager startup rebuild entry above:** stdio now connects before background warm-up so safe tools stay available while the active index rebuilds. Warm-up failures are logged and retrieval calls still surface the underlying error.
 
 ## [Unreleased] — lazy-import unused embedding providers
 

--- a/src/FaissIndexManager.ts
+++ b/src/FaissIndexManager.ts
@@ -396,6 +396,13 @@ async function withSidecarLock<T>(action: () => Promise<T>): Promise<T> {
 
 const DEFAULT_CHUNK_SIZE = 1000;
 const DEFAULT_CHUNK_OVERLAP = 200;
+export const DEFAULT_REBUILD_PROGRESS_INTERVAL_FILES = 10;
+
+function totalFileCount(
+  entries: ReadonlyArray<{ filePaths: readonly string[] }>,
+): number {
+  return entries.reduce((sum, entry) => sum + entry.filePaths.length, 0);
+}
 
 /**
  * Resolve the splitter chunk size and overlap from env vars, with the
@@ -521,6 +528,18 @@ export interface FaissIndexManagerOptions {
   modelName: string;
 }
 
+export interface IndexUpdateProgress {
+  processedFiles: number;
+  totalFiles: number;
+  currentFile: string;
+  modelId: string;
+}
+
+export interface UpdateIndexOptions {
+  onProgress?: (progress: IndexUpdateProgress) => void | Promise<void>;
+  progressIntervalFiles?: number;
+}
+
 export class FaissIndexManager {
   private faissIndex: FaissStore | null = null;
   // Issue #59 — populated by initialize() via dynamic import of the active
@@ -565,6 +584,10 @@ export class FaissIndexManager {
     // moves with them; the throw still fires before any disk work.
 
     logger.info(`FaissIndexManager bound to ${this.modelDir} (provider=${this.embeddingProvider}, model=${this.modelName}, id=${this.modelId})`);
+  }
+
+  get hasLoadedIndex(): boolean {
+    return this.faissIndex !== null;
   }
 
   /**
@@ -1116,13 +1139,34 @@ export class FaissIndexManager {
     return documents;
   }
 
+  private async addDocumentsToIndex(documentsToAdd: Document[]): Promise<boolean> {
+    if (documentsToAdd.length === 0) {
+      return false;
+    }
+
+    if (this.faissIndex === null) {
+      logger.info('Creating new FAISS index from texts...');
+      this.faissIndex = await FaissStore.fromTexts(
+        documentsToAdd.map((doc) => doc.pageContent),
+        documentsToAdd.map((doc) => doc.metadata),
+        this.embeddings
+      );
+    } else {
+      await this.faissIndex.addDocuments(documentsToAdd);
+    }
+    return true;
+  }
+
   /**
    * Updates the FAISS index.
    * If `specificKnowledgeBase` is provided, only files from that knowledge base will be checked and updated.
    * If no update occurs (and the FAISS index remains uninitialized) but there are documents,
    * then the index is built from all available files.
    */
-  async updateIndex(specificKnowledgeBase?: string): Promise<void> {
+  async updateIndex(
+    specificKnowledgeBase?: string,
+    opts: UpdateIndexOptions = {},
+  ): Promise<void> {
     logger.debug('Updating FAISS index...');
     try {
       let knowledgeBases: string[] = [];
@@ -1134,9 +1178,23 @@ export class FaissIndexManager {
 
       let anyFileProcessed = false;
       let indexMutated = false;
+      let processedFiles = 0;
+      let lastProgressFileCount = 0;
+      const rebuildFromEmptyIndex = this.faissIndex === null;
+      const progressIntervalFiles = Math.max(
+        1,
+        Math.floor(opts.progressIntervalFiles ?? DEFAULT_REBUILD_PROGRESS_INTERVAL_FILES),
+      );
       const pendingHashWrites: { path: string; hash: string }[] = [];
 
-      // Process each knowledge base directory.
+      const knowledgeBaseFiles: {
+        knowledgeBaseName: string;
+        knowledgeBasePath: string;
+        filePaths: string[];
+      }[] = [];
+
+      // First enumerate every candidate path so progress notifications can
+      // report a stable denominator before embedding begins.
       for (const knowledgeBaseName of knowledgeBases) {
         if (knowledgeBaseName.startsWith('.')) {
           logger.debug(`Skipping dot folder: ${knowledgeBaseName}`);
@@ -1151,7 +1209,31 @@ export class FaissIndexManager {
             excludePaths: INGEST_EXCLUDE_PATHS,
           },
         );
+        knowledgeBaseFiles.push({ knowledgeBaseName, knowledgeBasePath, filePaths });
+      }
 
+      const totalFiles = totalFileCount(knowledgeBaseFiles);
+      const reportProgress = async (currentFile: string): Promise<void> => {
+        if (!opts.onProgress || processedFiles === lastProgressFileCount) {
+          return;
+        }
+        if (
+          processedFiles % progressIntervalFiles !== 0 &&
+          processedFiles !== totalFiles
+        ) {
+          return;
+        }
+        lastProgressFileCount = processedFiles;
+        await opts.onProgress({
+          processedFiles,
+          totalFiles,
+          currentFile,
+          modelId: this.modelId,
+        });
+      };
+
+      // Process each knowledge base directory.
+      for (const { knowledgeBaseName, knowledgeBasePath, filePaths } of knowledgeBaseFiles) {
         for (const filePath of filePaths) {
           anyFileProcessed = true;
 
@@ -1176,9 +1258,16 @@ export class FaissIndexManager {
             // The hash file may not exist yet; that's fine.
           }
 
-          // If the file is new or has changed, process it.
-          if (fileHash !== storedHash) {
-            logger.info(`File ${filePath} has changed. Updating index...`);
+          // If the file is new/changed, or the index itself is absent,
+          // process it. The missing-index case must ignore matching sidecars:
+          // otherwise a rebuild can silently omit files whose hashes were
+          // already current.
+          if (rebuildFromEmptyIndex || fileHash !== storedHash) {
+            logger.info(
+              rebuildFromEmptyIndex
+                ? `FAISS index is empty. Rebuilding from ${filePath}...`
+                : `File ${filePath} has changed. Updating index...`,
+            );
             let content = '';
             try {
               content = await fsp.readFile(filePath, 'utf-8');
@@ -1193,20 +1282,12 @@ export class FaissIndexManager {
               knowledgeBaseName
             );
 
-            if (documentsToAdd.length > 0) {
-              if (this.faissIndex === null) {
-                logger.info('Creating new FAISS index from texts...');
-                this.faissIndex = await FaissStore.fromTexts(
-                  documentsToAdd.map((doc) => doc.pageContent),
-                  documentsToAdd.map((doc) => doc.metadata),
-                  this.embeddings
-                );
-              } else {
-                await this.faissIndex.addDocuments(documentsToAdd);
-              }
+            if (await this.addDocumentsToIndex(documentsToAdd)) {
               indexMutated = true;
               pendingHashWrites.push({ path: indexFilePath, hash: fileHash });
               logger.debug(`Index updated in-memory for ${filePath}.`);
+              processedFiles += 1;
+              await reportProgress(filePath);
             } else {
               logger.debug(`No documents generated from ${filePath}. Skipping index update.`);
             }
@@ -1220,18 +1301,7 @@ export class FaissIndexManager {
       // then attempt to build the FAISS index from all available documents.
       if (this.faissIndex === null && anyFileProcessed) {
         logger.info('No updates detected but FAISS index is not initialized. Building index from all available documents...');
-        let allDocuments: Document[] = [];
-        for (const knowledgeBaseName of knowledgeBases) {
-          if (knowledgeBaseName.startsWith('.')) continue;
-          const knowledgeBasePath = path.join(KNOWLEDGE_BASES_ROOT_DIR, knowledgeBaseName);
-          const filePaths = filterIngestablePaths(
-            await getFilesRecursively(knowledgeBasePath),
-            knowledgeBasePath,
-            {
-              extraExtensions: INGEST_EXTRA_EXTENSIONS,
-              excludePaths: INGEST_EXCLUDE_PATHS,
-            },
-          );
+        for (const { knowledgeBaseName, filePaths } of knowledgeBaseFiles) {
           for (const filePath of filePaths) {
             let content = '';
             try {
@@ -1245,18 +1315,12 @@ export class FaissIndexManager {
               content,
               knowledgeBaseName
             );
-            if (documents.length > 0) {
-              allDocuments.push(...documents);
+            if (await this.addDocumentsToIndex(documents)) {
+              indexMutated = true;
+              processedFiles += 1;
+              await reportProgress(filePath);
             }
           }
-        }
-        if (allDocuments.length > 0) {
-          this.faissIndex = await FaissStore.fromTexts(
-            allDocuments.map((doc) => doc.pageContent),
-            allDocuments.map((doc) => doc.metadata),
-            this.embeddings
-          );
-          indexMutated = true;
         }
       }
 

--- a/src/KnowledgeBaseServer.test.ts
+++ b/src/KnowledgeBaseServer.test.ts
@@ -5,6 +5,7 @@ import * as path from 'path';
 const initializeMock = jest.fn();
 const updateIndexMock = jest.fn();
 const similaritySearchMock = jest.fn();
+const hasLoadedIndexMock = jest.fn(() => true);
 
 const FaissIndexManagerMock: any = jest.fn().mockImplementation((opts?: { provider?: string; modelName?: string }) => {
   // RFC 013 M1+M2: the manager exposes modelDir / modelId / modelName for
@@ -23,6 +24,9 @@ const FaissIndexManagerMock: any = jest.fn().mockImplementation((opts?: { provid
     modelId,
     modelName,
     embeddingProvider: provider,
+    get hasLoadedIndex() {
+      return hasLoadedIndexMock();
+    },
   };
 });
 // bootstrapLayout is a static method; the mock returns a no-op promise.
@@ -52,6 +56,8 @@ describe('KnowledgeBaseServer handlers', () => {
     initializeMock.mockReset();
     updateIndexMock.mockReset();
     similaritySearchMock.mockReset();
+    hasLoadedIndexMock.mockReset();
+    hasLoadedIndexMock.mockReturnValue(true);
   });
 
   afterEach(() => {
@@ -440,16 +446,100 @@ describe('KnowledgeBaseServer handlers', () => {
     expect(text).not.toContain(`"source": ${JSON.stringify(betaSource)}`);
   });
 
-  it('runStdio aborts before MCP connect when active model initialization fails (#85)', async () => {
+  it('runStdio connects before active model warm-up completes so list tools are available (#87)', async () => {
     await setRetrieveEnv();
-    initializeMock.mockRejectedValueOnce(new Error('stale FAISS cleanup failed'));
+    let resolveUpdate!: () => void;
+    const updateStarted = new Promise<void>((resolve) => {
+      updateIndexMock.mockImplementationOnce(async () => {
+        resolve();
+        await new Promise<void>((finish) => {
+          resolveUpdate = finish;
+        });
+      });
+    });
+    hasLoadedIndexMock.mockReturnValue(false);
 
     const server = await freshServer();
     const connectMock = jest.fn().mockResolvedValue(undefined);
     server['mcp'].connect = connectMock;
 
-    await expect(server['runStdio']()).rejects.toThrow('stale FAISS cleanup failed');
-    expect(connectMock).not.toHaveBeenCalled();
+    await expect(server['runStdio']()).resolves.toBeUndefined();
+    expect(connectMock).toHaveBeenCalledTimes(1);
+
+    await updateStarted;
+    expect(updateIndexMock).toHaveBeenCalledTimes(1);
+    resolveUpdate();
+    await server['activeWarmupPromise'];
+  });
+
+  it('startup warm-up rebuilds the active model when initialize finds no loaded index (#87)', async () => {
+    await setRetrieveEnv();
+    hasLoadedIndexMock.mockReturnValue(false);
+    updateIndexMock.mockResolvedValue(undefined);
+
+    const server = await freshServer();
+    server['mcp'].connect = jest.fn().mockResolvedValue(undefined);
+    server['mcp'].sendLoggingMessage = jest.fn().mockResolvedValue(undefined);
+
+    await server['runStdio']();
+    await server['activeWarmupPromise'];
+
+    expect(updateIndexMock).toHaveBeenCalledTimes(1);
+    expect(updateIndexMock.mock.calls[0][0]).toBeUndefined();
+    expect(updateIndexMock.mock.calls[0][1]).toEqual({
+      onProgress: expect.any(Function),
+    });
+  });
+
+  it('startup warm-up does not rebuild when initialize loads a fresh index (#87)', async () => {
+    await setRetrieveEnv();
+    hasLoadedIndexMock.mockReturnValue(true);
+
+    const server = await freshServer();
+    server['mcp'].connect = jest.fn().mockResolvedValue(undefined);
+
+    await server['runStdio']();
+    await server['activeWarmupPromise'];
+
+    expect(initializeMock).toHaveBeenCalledTimes(1);
+    expect(updateIndexMock).not.toHaveBeenCalled();
+  });
+
+  it('startup warm-up emits MCP logging messages for rebuild progress (#87)', async () => {
+    await setRetrieveEnv();
+    hasLoadedIndexMock.mockReturnValue(false);
+    updateIndexMock.mockImplementationOnce(async (
+      _kb: string | undefined,
+      opts: {
+        onProgress: (progress: {
+          processedFiles: number;
+          totalFiles: number;
+          currentFile: string;
+          modelId: string;
+        }) => Promise<void>;
+      },
+    ) => {
+      await opts.onProgress({
+        processedFiles: 10,
+        totalFiles: 25,
+        currentFile: '/tmp/kb/doc-10.md',
+        modelId: 'huggingface__BAAI-bge-small-en-v1.5',
+      });
+    });
+
+    const server = await freshServer();
+    const sendLoggingMessageMock = jest.fn().mockResolvedValue(undefined);
+    server['mcp'].connect = jest.fn().mockResolvedValue(undefined);
+    server['mcp'].sendLoggingMessage = sendLoggingMessageMock;
+
+    await server['runStdio']();
+    await server['activeWarmupPromise'];
+
+    expect(sendLoggingMessageMock).toHaveBeenCalledWith({
+      level: 'info',
+      logger: 'knowledge-base-server',
+      data: 'Embedded 10/25 files for huggingface__BAAI-bge-small-en-v1.5',
+    });
   });
 
   // --- tool description overrides (#52, RFC 010 M2) -------------------------

--- a/src/KnowledgeBaseServer.test.ts
+++ b/src/KnowledgeBaseServer.test.ts
@@ -542,6 +542,75 @@ describe('KnowledgeBaseServer handlers', () => {
     });
   });
 
+  // Codex review on PR #121 caught that in SSE mode the root `this.mcp` is
+  // never connected — every SSE session has its own `McpServer` (built via
+  // `createMcpServer`). Calling `sendLoggingMessage` on the unconnected root
+  // would silently drop the warm-up notifications. The fan-out across live
+  // session servers is the user-visible fix.
+  it('SSE warm-up logging fans out to every connected session McpServer (#87 / Codex review)', async () => {
+    await setRetrieveEnv();
+    hasLoadedIndexMock.mockReturnValue(false);
+    updateIndexMock.mockImplementationOnce(async (
+      _kb: string | undefined,
+      opts: {
+        onProgress: (progress: {
+          processedFiles: number;
+          totalFiles: number;
+          currentFile: string;
+          modelId: string;
+        }) => Promise<void>;
+      },
+    ) => {
+      await opts.onProgress({
+        processedFiles: 10,
+        totalFiles: 25,
+        currentFile: '/tmp/kb/doc-10.md',
+        modelId: 'huggingface__BAAI-bge-small-en-v1.5',
+      });
+    });
+
+    const server = await freshServer();
+    server['transportMode'] = 'sse';
+    const rootSendLoggingMessageMock = jest.fn().mockResolvedValue(undefined);
+    server['mcp'].sendLoggingMessage = rootSendLoggingMessageMock;
+
+    const sessionA = { sendLoggingMessage: jest.fn().mockResolvedValue(undefined) };
+    const sessionB = { sendLoggingMessage: jest.fn().mockResolvedValue(undefined) };
+    server['sseHost'] = {
+      getConnectedMcpServers: () => [sessionA, sessionB],
+    };
+
+    await server['warmActiveManager']();
+
+    expect(rootSendLoggingMessageMock).not.toHaveBeenCalled();
+    const expectedProgressArgs = {
+      level: 'info',
+      logger: 'knowledge-base-server',
+      data: 'Embedded 10/25 files for huggingface__BAAI-bge-small-en-v1.5',
+    };
+    expect(sessionA.sendLoggingMessage).toHaveBeenCalledWith(expectedProgressArgs);
+    expect(sessionB.sendLoggingMessage).toHaveBeenCalledWith(expectedProgressArgs);
+  });
+
+  it('SSE warm-up logging skips the broadcast when no clients are connected (#87 / Codex review)', async () => {
+    await setRetrieveEnv();
+    hasLoadedIndexMock.mockReturnValue(false);
+    updateIndexMock.mockResolvedValue(undefined);
+
+    const server = await freshServer();
+    server['transportMode'] = 'sse';
+    const rootSendLoggingMessageMock = jest.fn().mockResolvedValue(undefined);
+    server['mcp'].sendLoggingMessage = rootSendLoggingMessageMock;
+    server['sseHost'] = {
+      getConnectedMcpServers: () => [],
+    };
+
+    await expect(server['warmActiveManager']()).resolves.toBeUndefined();
+    // The unconnected root must not be used as a fallback target; the bug
+    // we're guarding against is exactly that silent drop.
+    expect(rootSendLoggingMessageMock).not.toHaveBeenCalled();
+  });
+
   // --- tool description overrides (#52, RFC 010 M2) -------------------------
   //
   // These tests assert behaviour visible at the MCP wire surface: the

--- a/src/KnowledgeBaseServer.ts
+++ b/src/KnowledgeBaseServer.ts
@@ -4,6 +4,7 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { z } from 'zod';
 import type { CallToolResult, TextContent } from '@modelcontextprotocol/sdk/types.js';
 import { FaissIndexManager } from './FaissIndexManager.js';
+import type { IndexUpdateProgress } from './FaissIndexManager.js';
 import {
   ActiveModelResolutionError,
   listRegisteredModels,
@@ -61,6 +62,8 @@ export class KnowledgeBaseServer {
   // each model_id. The active model is resolved per `handleRetrieveKnowledge`
   // call (allows future M3 `model_name` arg without redesign).
   private managerCache: Map<string, FaissIndexManager> = new Map();
+  private managerInitCache: Map<string, Promise<FaissIndexManager>> = new Map();
+  private activeWarmupPromise: Promise<void> | null = null;
   private sseHost?: SseHost;
   private triggerWatcher?: ReindexTriggerWatcher;
   private shutdownInstalled = false;
@@ -84,18 +87,28 @@ export class KnowledgeBaseServer {
   private async getManagerFor(modelId: string): Promise<FaissIndexManager> {
     const cached = this.managerCache.get(modelId);
     if (cached) return cached;
-    const { provider } = parseModelId(modelId);
-    const modelName = await readStoredModelName(modelId);
-    if (modelName === null) {
-      throw new Error(`model_name.txt missing for registered model "${modelId}"`);
+    const initializing = this.managerInitCache.get(modelId);
+    if (initializing) return initializing;
+    const initPromise = (async () => {
+      const { provider } = parseModelId(modelId);
+      const modelName = await readStoredModelName(modelId);
+      if (modelName === null) {
+        throw new Error(`model_name.txt missing for registered model "${modelId}"`);
+      }
+      const manager = new FaissIndexManager({
+        provider: provider as EmbeddingProvider,
+        modelName,
+      });
+      await manager.initialize();
+      this.managerCache.set(modelId, manager);
+      return manager;
+    })();
+    this.managerInitCache.set(modelId, initPromise);
+    try {
+      return await initPromise;
+    } finally {
+      this.managerInitCache.delete(modelId);
     }
-    const manager = new FaissIndexManager({
-      provider: provider as EmbeddingProvider,
-      modelName,
-    });
-    await manager.initialize();
-    this.managerCache.set(modelId, manager);
-    return manager;
   }
 
   private buildMcpServer(): McpServer {
@@ -300,21 +313,14 @@ export class KnowledgeBaseServer {
   }
 
   private async runStdio(): Promise<void> {
-    // Fail before exposing tools over stdio. If FAISS initialization knows the
-    // active index is bad but cannot clean it up, serving even "safe" tools
-    // leaves clients attached to a poisoned process (#85).
-    await this.warmActiveManager();
     const transport = new StdioServerTransport();
     await this.mcp.connect(transport);
     logger.info('Knowledge Base MCP server running on stdio');
+    this.startActiveManagerWarmup();
     this.startTriggerWatcher();
   }
 
   private async runSse(config: TransportConfig): Promise<void> {
-    // Block HTTP bind on a ready index so a fast first client cannot race
-    // updateIndex (RFC 008 §6.2: "client races init" footgun under HTTP).
-    await this.warmActiveManager();
-
     const host = new SseHost({
       config,
       createMcpServer: () => this.buildMcpServer(),
@@ -324,6 +330,7 @@ export class KnowledgeBaseServer {
     // Start watcher only after the HTTP bind succeeds; a throw from
     // host.start() unwinds without leaving a dangling polling timer.
     await host.start();
+    this.startActiveManagerWarmup();
     this.startTriggerWatcher();
   }
 
@@ -333,16 +340,61 @@ export class KnowledgeBaseServer {
    * `handleRetrieveKnowledge` call surfaces the error to the agent via
    * `isError: true` instead of dying at startup).
    */
+  private startActiveManagerWarmup(): void {
+    if (this.activeWarmupPromise) return;
+    this.activeWarmupPromise = this.warmActiveManager();
+  }
+
   private async warmActiveManager(): Promise<void> {
     try {
       const activeId = await resolveActiveModel();
-      await this.getManagerFor(activeId);
+      const manager = await this.getManagerFor(activeId);
+      if (manager.hasLoadedIndex) {
+        logger.info(`Active FAISS index ${activeId} loaded; startup rebuild not needed`);
+        return;
+      }
+
+      await this.sendWarmupLoggingMessage(
+        'info',
+        `Rebuilding FAISS index for active model ${activeId}`,
+      );
+      await withWriteLock(manager.modelDir, () =>
+        manager.updateIndex(undefined, {
+          onProgress: (progress) => this.sendRebuildProgress(progress),
+        }),
+      );
+      await this.sendWarmupLoggingMessage(
+        'info',
+        `Finished rebuilding FAISS index for active model ${activeId}`,
+      );
     } catch (err) {
       if (err instanceof ActiveModelResolutionError) {
         logger.warn(`No active model on startup: ${err.message}`);
         return;
       }
-      throw err;
+      const error = toError(err);
+      logger.error(`Startup FAISS warm-up failed: ${error.message}`);
+      if (error.stack) {
+        logger.error(error.stack);
+      }
+    }
+  }
+
+  private async sendRebuildProgress(progress: IndexUpdateProgress): Promise<void> {
+    await this.sendWarmupLoggingMessage(
+      'info',
+      `Embedded ${progress.processedFiles}/${progress.totalFiles} files for ${progress.modelId}`,
+    );
+  }
+
+  private async sendWarmupLoggingMessage(
+    level: 'info' | 'warning' | 'error',
+    data: string,
+  ): Promise<void> {
+    try {
+      await this.mcp.sendLoggingMessage({ level, logger: SERVER_NAME, data });
+    } catch (err) {
+      logger.debug(`Unable to emit MCP warm-up log: ${toError(err).message}`);
     }
   }
 

--- a/src/KnowledgeBaseServer.ts
+++ b/src/KnowledgeBaseServer.ts
@@ -65,6 +65,7 @@ export class KnowledgeBaseServer {
   private managerInitCache: Map<string, Promise<FaissIndexManager>> = new Map();
   private activeWarmupPromise: Promise<void> | null = null;
   private sseHost?: SseHost;
+  private transportMode: 'stdio' | 'sse' | null = null;
   private triggerWatcher?: ReindexTriggerWatcher;
   private shutdownInstalled = false;
 
@@ -315,6 +316,7 @@ export class KnowledgeBaseServer {
   private async runStdio(): Promise<void> {
     const transport = new StdioServerTransport();
     await this.mcp.connect(transport);
+    this.transportMode = 'stdio';
     logger.info('Knowledge Base MCP server running on stdio');
     this.startActiveManagerWarmup();
     this.startTriggerWatcher();
@@ -330,6 +332,7 @@ export class KnowledgeBaseServer {
     // Start watcher only after the HTTP bind succeeds; a throw from
     // host.start() unwinds without leaving a dangling polling timer.
     await host.start();
+    this.transportMode = 'sse';
     this.startActiveManagerWarmup();
     this.startTriggerWatcher();
   }
@@ -391,11 +394,30 @@ export class KnowledgeBaseServer {
     level: 'info' | 'warning' | 'error',
     data: string,
   ): Promise<void> {
-    try {
-      await this.mcp.sendLoggingMessage({ level, logger: SERVER_NAME, data });
-    } catch (err) {
-      logger.debug(`Unable to emit MCP warm-up log: ${toError(err).message}`);
+    // In stdio mode, `this.mcp` is the connected server. In SSE mode, every
+    // session has its own connected `McpServer` (built via `createMcpServer`)
+    // and `this.mcp` is unconnected — calling `sendLoggingMessage` on it
+    // would silently drop the notification. Fan out across the live sessions
+    // so each connected client sees the warm-up progress.
+    const targets =
+      this.transportMode === 'sse'
+        ? (this.sseHost?.getConnectedMcpServers() ?? [])
+        : [this.mcp];
+    if (targets.length === 0) {
+      logger.debug(
+        `MCP warm-up log skipped (no connected ${this.transportMode ?? 'transport'} clients): ${data}`,
+      );
+      return;
     }
+    await Promise.all(
+      targets.map(async (target) => {
+        try {
+          await target.sendLoggingMessage({ level, logger: SERVER_NAME, data });
+        } catch (err) {
+          logger.debug(`Unable to emit MCP warm-up log: ${toError(err).message}`);
+        }
+      }),
+    );
   }
 
   private startTriggerWatcher(): void {

--- a/src/transport/sse.ts
+++ b/src/transport/sse.ts
@@ -71,6 +71,19 @@ export class SseHost {
     this.authTokenBuf = Buffer.from(token, 'latin1');
   }
 
+  /**
+   * Snapshot of `McpServer` instances that are currently connected to an SSE
+   * session. Returns an array (not the live map values) so callers can iterate
+   * without seeing concurrent mutations from `transport.onclose` or
+   * `handleSseOpen`. Used by `KnowledgeBaseServer` to fan warm-up logging
+   * notifications across every live SSE client (the root `this.mcp` is never
+   * connected in SSE mode, so calling `sendLoggingMessage` on it would drop
+   * the notification).
+   */
+  getConnectedMcpServers(): McpServer[] {
+    return [...this.sessions.values()].map((entry) => entry.mcp);
+  }
+
   async start(): Promise<http.Server> {
     if (this.server) {
       throw new Error('SseHost already started');


### PR DESCRIPTION
## Summary

- start active FAISS warm-up after transport connection so safe tools remain available while stale indexes rebuild
- rebuild missing/corrupt indexes incrementally and emit MCP logging-message progress every 10 embedded files
- cover startup rebuild/fresh-index behavior and progress notification cadence in tests

Closes #87

## Verification

- `npm run build`
- `npm test -- --runTestsByPath src/FaissIndexManager.test.ts src/KnowledgeBaseServer.test.ts`
- `npm test`
- `git diff --check`
- simple diff secret-pattern scan with `rg`

## Pre-PR gate

- npm project detected
- build: passed
- tests: passed
- diff review: done
- reviewer specialists: skipped because the Codex CLI harness exposes no automatic specialist runner and subagent spawning is restricted unless explicitly requested
- gate file: created at `/dev/shm/.pr-gate-knowledge-base-mcp-server-feat-issue-87-eager-warm-pre-done`
