### PR TITLE
feat(retrieve): metadata filters (extensions, path_glob, tags) (closes #53)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [Unreleased] — retrieve_knowledge metadata filters
+
+### Added
+
+- **`retrieve_knowledge` accepts three optional metadata filters** that constrain which chunks are returned without changing the FAISS query: `extensions` (array of file extensions, e.g. `[".md", ".pdf"]`, case-insensitive, leading dot optional), `path_glob` (single minimatch pattern matched against the chunk's KB-internal relative path — the KB-name segment is stripped first so `"runbooks/**"` matches any KB's `runbooks/foo.md`; the full KB-prefixed form is also tried so explicit prefixes still work), and `tags` (array of strings, AND semantics — every tag must be present on the chunk's `metadata.tags`, which is populated from YAML frontmatter at ingest by `parseFrontmatter`). Filters are applied as POST-filters on `[doc, score]` tuples after `FaissStore.similaritySearchWithScore` returns; the FAISS index itself is never pre-filtered (langchain's `FaissStore` silently drops filter args). When any filter is active the search over-fetches up to `ntotal` so a small `k` doesn't starve once the post-filter drops top-ranked unfiltered hits. Closes #53.
+
+### Why
+
+For mixed-content KBs (code + docs + notes + future PDF/HTML loaders per #46), an unfiltered `retrieve_knowledge` query for "onboarding" returns hits from every KB regardless of intent. Competitor MCP servers expose this as a metadata filter (`chroma-mcp` `where`, `pinecone-mcp` `filter`); this lands the equivalent surface for the three filter axes most likely to be useful on a local KB without adding a new tool. Implementation reuses `minimatch` (already a dependency for `INGEST_EXCLUDE_PATHS`) and the existing `metadata.tags` field that ingest has been writing since RFC 010 M1 — no new dependency, no ingest schema change.
+
 ## [Unreleased] — eager startup rebuild with MCP progress logs
 
 ### Added

--- a/src/FaissIndexManager.test.ts
+++ b/src/FaissIndexManager.test.ts
@@ -2255,3 +2255,321 @@ describe('FaissIndexManager integration — frontmatter + pdf_path (RFC 011 M2)'
     }
   });
 });
+
+describe('FaissIndexManager similaritySearch metadata filters (#53)', () => {
+  const originalEnv = {
+    KNOWLEDGE_BASES_ROOT_DIR: process.env.KNOWLEDGE_BASES_ROOT_DIR,
+    FAISS_INDEX_PATH: process.env.FAISS_INDEX_PATH,
+    EMBEDDING_PROVIDER: process.env.EMBEDDING_PROVIDER,
+    HUGGINGFACE_API_KEY: process.env.HUGGINGFACE_API_KEY,
+  };
+
+  beforeEach(() => {
+    saveMock.mockReset();
+    addDocumentsMock.mockReset();
+    fromTextsMock.mockReset();
+    loadMock.mockReset();
+    similaritySearchMock.mockReset();
+    embeddingConstructorMock.mockReset();
+  });
+
+  afterEach(() => {
+    const keys = Object.keys(originalEnv) as Array<keyof typeof originalEnv>;
+    for (const key of keys) {
+      const value = originalEnv[key];
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+    jest.restoreAllMocks();
+  });
+
+  // The mock FaissStore exposes ntotal() unconditionally — the real one is set
+  // up by FaissStore.fromTexts. Patch it on the instance after updateIndex.
+  async function setupReadyManager() {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-faiss-filters-'));
+    const kbDir = path.join(tempDir, 'kb');
+    const defaultKb = path.join(kbDir, 'default');
+    await fsp.mkdir(defaultKb, { recursive: true });
+    await fsp.writeFile(path.join(defaultKb, 'doc.md'), '# Title\n\nContent for filter tests.');
+
+    process.env.KNOWLEDGE_BASES_ROOT_DIR = kbDir;
+    process.env.FAISS_INDEX_PATH = path.join(tempDir, '.faiss');
+    process.env.EMBEDDING_PROVIDER = 'huggingface';
+    process.env.HUGGINGFACE_API_KEY = 'test-key';
+
+    jest.resetModules();
+    const { FaissIndexManager } = await import('./FaissIndexManager.js');
+    const manager = new FaissIndexManager();
+    await manager.initialize();
+    await manager.updateIndex();
+    // Provide ntotal() so the over-fetch branch (scoped or filtered) doesn't
+    // crash on undefined.index. The real FaissStore exposes this; the mock
+    // does not, so wire the minimum surface the implementation reads.
+    interface IndexHandle { index: { ntotal: () => number } }
+    (manager as unknown as IndexHandle).index = { ntotal: () => 100 };
+    const internal = manager as unknown as { faissIndex: { index: { ntotal: () => number } } };
+    internal.faissIndex.index = { ntotal: () => 100 };
+    return manager;
+  }
+
+  it('returns only chunks whose extension is in the extensions filter', async () => {
+    const manager = await setupReadyManager();
+    const md = { pageContent: 'm', metadata: { source: '/abs/a.md', extension: '.md', relativePath: 'kb/a.md' } };
+    const pdf = { pageContent: 'p', metadata: { source: '/abs/a.pdf', extension: '.pdf', relativePath: 'kb/a.pdf' } };
+    similaritySearchMock.mockResolvedValueOnce([
+      [md, 0.1],
+      [pdf, 0.2],
+    ]);
+
+    const results = await manager.similaritySearch('q', 10, undefined, undefined, {
+      extensions: ['.md'],
+    });
+
+    expect(results.map((r) => r.pageContent)).toEqual(['m']);
+  });
+
+  it('extensions filter is case-insensitive and tolerates missing leading dot', async () => {
+    const manager = await setupReadyManager();
+    const md = { pageContent: 'm', metadata: { extension: '.md', relativePath: 'kb/a.md' } };
+    const txt = { pageContent: 't', metadata: { extension: '.txt', relativePath: 'kb/a.txt' } };
+    similaritySearchMock.mockResolvedValueOnce([
+      [md, 0.1],
+      [txt, 0.2],
+    ]);
+
+    const results = await manager.similaritySearch('q', 10, undefined, undefined, {
+      extensions: ['MD'],
+    });
+
+    expect(results.map((r) => r.pageContent)).toEqual(['m']);
+  });
+
+  it('drops every result when no chunk matches the extensions filter', async () => {
+    const manager = await setupReadyManager();
+    const md = { pageContent: 'm', metadata: { extension: '.md', relativePath: 'kb/a.md' } };
+    similaritySearchMock.mockResolvedValueOnce([[md, 0.1]]);
+
+    const results = await manager.similaritySearch('q', 10, undefined, undefined, {
+      extensions: ['.pdf'],
+    });
+
+    expect(results).toEqual([]);
+  });
+
+  it('path_glob matches the in-KB relative path (KB-name segment stripped)', async () => {
+    const manager = await setupReadyManager();
+    const runbook = {
+      pageContent: 'on',
+      metadata: { extension: '.md', relativePath: 'ops/runbooks/oncall.md' },
+    };
+    const meeting = {
+      pageContent: 'mt',
+      metadata: { extension: '.md', relativePath: 'ops/meetings/standup.md' },
+    };
+    similaritySearchMock.mockResolvedValueOnce([
+      [runbook, 0.1],
+      [meeting, 0.2],
+    ]);
+
+    const results = await manager.similaritySearch('q', 10, undefined, undefined, {
+      pathGlob: 'runbooks/**',
+    });
+
+    expect(results.map((r) => r.pageContent)).toEqual(['on']);
+  });
+
+  it('path_glob also matches against the full KB-prefixed relativePath', async () => {
+    const manager = await setupReadyManager();
+    const a = { pageContent: 'a', metadata: { relativePath: 'alpha/notes/x.md', extension: '.md' } };
+    const b = { pageContent: 'b', metadata: { relativePath: 'beta/notes/y.md', extension: '.md' } };
+    similaritySearchMock.mockResolvedValueOnce([
+      [a, 0.1],
+      [b, 0.2],
+    ]);
+
+    const results = await manager.similaritySearch('q', 10, undefined, undefined, {
+      pathGlob: 'alpha/**',
+    });
+
+    expect(results.map((r) => r.pageContent)).toEqual(['a']);
+  });
+
+  it('tags filter requires every tag (AND semantics)', async () => {
+    const manager = await setupReadyManager();
+    const both = {
+      pageContent: 'both',
+      metadata: { tags: ['ops', 'oncall'], extension: '.md', relativePath: 'kb/a.md' },
+    };
+    const opsOnly = {
+      pageContent: 'opsOnly',
+      metadata: { tags: ['ops'], extension: '.md', relativePath: 'kb/b.md' },
+    };
+    const noTags = {
+      pageContent: 'noTags',
+      metadata: { tags: [], extension: '.md', relativePath: 'kb/c.md' },
+    };
+    similaritySearchMock.mockResolvedValueOnce([
+      [both, 0.1],
+      [opsOnly, 0.2],
+      [noTags, 0.3],
+    ]);
+
+    const results = await manager.similaritySearch('q', 10, undefined, undefined, {
+      tags: ['ops', 'oncall'],
+    });
+
+    expect(results.map((r) => r.pageContent)).toEqual(['both']);
+  });
+
+  it('tags filter rejects chunks with no tags array on metadata', async () => {
+    const manager = await setupReadyManager();
+    const noTagField = {
+      pageContent: 'x',
+      metadata: { extension: '.md', relativePath: 'kb/a.md' },
+    };
+    similaritySearchMock.mockResolvedValueOnce([[noTagField, 0.1]]);
+
+    const results = await manager.similaritySearch('q', 10, undefined, undefined, {
+      tags: ['ops'],
+    });
+
+    expect(results).toEqual([]);
+  });
+
+  it('combined filters AND together: extension + path_glob + tags', async () => {
+    const manager = await setupReadyManager();
+    const match = {
+      pageContent: 'match',
+      metadata: {
+        extension: '.md',
+        relativePath: 'kb/runbooks/oncall.md',
+        tags: ['ops', 'oncall'],
+      },
+    };
+    const wrongExt = {
+      pageContent: 'wrongExt',
+      metadata: {
+        extension: '.txt',
+        relativePath: 'kb/runbooks/oncall.txt',
+        tags: ['ops', 'oncall'],
+      },
+    };
+    const wrongPath = {
+      pageContent: 'wrongPath',
+      metadata: {
+        extension: '.md',
+        relativePath: 'kb/meetings/standup.md',
+        tags: ['ops', 'oncall'],
+      },
+    };
+    const missingTag = {
+      pageContent: 'missingTag',
+      metadata: {
+        extension: '.md',
+        relativePath: 'kb/runbooks/oncall.md',
+        tags: ['ops'],
+      },
+    };
+    similaritySearchMock.mockResolvedValueOnce([
+      [match, 0.1],
+      [wrongExt, 0.15],
+      [wrongPath, 0.2],
+      [missingTag, 0.25],
+    ]);
+
+    const results = await manager.similaritySearch('q', 10, undefined, undefined, {
+      extensions: ['.md'],
+      pathGlob: 'runbooks/**',
+      tags: ['ops', 'oncall'],
+    });
+
+    expect(results.map((r) => r.pageContent)).toEqual(['match']);
+  });
+
+  it('empty filter arrays are treated as absent and do not exclude every chunk', async () => {
+    const manager = await setupReadyManager();
+    const a = { pageContent: 'a', metadata: { extension: '.md', relativePath: 'kb/a.md', tags: [] } };
+    similaritySearchMock.mockResolvedValueOnce([[a, 0.1]]);
+
+    const results = await manager.similaritySearch('q', 10, undefined, undefined, {
+      extensions: [],
+      tags: [],
+    });
+
+    expect(results.map((r) => r.pageContent)).toEqual(['a']);
+  });
+
+  it('end-to-end: ingest reads YAML frontmatter tags, then tags filter selects chunks at search time', async () => {
+    // Real ingest path through buildChunkDocuments: frontmatter is parsed,
+    // tags land on every chunk's metadata, the post-filter then selects.
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-faiss-filters-e2e-'));
+    const kbDir = path.join(tempDir, 'kb');
+    const kb = path.join(kbDir, 'mixed');
+    await fsp.mkdir(kb, { recursive: true });
+    await fsp.writeFile(
+      path.join(kb, 'tagged.md'),
+      '---\ntags: [ops, oncall]\n---\n# Title\n\nOncall runbook content.\n',
+    );
+    await fsp.writeFile(
+      path.join(kb, 'untagged.md'),
+      '# Untagged\n\nGeneric notes without frontmatter.\n',
+    );
+
+    process.env.KNOWLEDGE_BASES_ROOT_DIR = kbDir;
+    process.env.FAISS_INDEX_PATH = path.join(tempDir, '.faiss');
+    process.env.EMBEDDING_PROVIDER = 'huggingface';
+    process.env.HUGGINGFACE_API_KEY = 'test-key';
+
+    jest.resetModules();
+    const { FaissIndexManager } = await import('./FaissIndexManager.js');
+    const manager = new FaissIndexManager();
+    await manager.initialize();
+    await manager.updateIndex();
+    const internal = manager as unknown as { faissIndex: { index: { ntotal: () => number } } };
+    internal.faissIndex.index = { ntotal: () => 100 };
+
+    // Capture the metadata that ingest stamped on the chunks for both files;
+    // feed those exact objects back via the FAISS mock so the post-filter
+    // sees the real shape produced by buildChunkDocuments.
+    const taggedChunks: Array<{ pageContent: string; metadata: Record<string, unknown> }> = [];
+    const untaggedChunks: Array<{ pageContent: string; metadata: Record<string, unknown> }> = [];
+    for (const call of fromTextsMock.mock.calls) {
+      const [texts, metadatas] = call as [string[], Record<string, unknown>[]];
+      for (let i = 0; i < texts.length; i += 1) {
+        const target = (metadatas[i].source as string).endsWith('/tagged.md') ? taggedChunks : untaggedChunks;
+        target.push({ pageContent: texts[i], metadata: metadatas[i] });
+      }
+    }
+    for (const call of addDocumentsMock.mock.calls) {
+      const [docs] = call as [Array<{ pageContent: string; metadata: Record<string, unknown> }>];
+      for (const d of docs) {
+        const target = (d.metadata.source as string).endsWith('/tagged.md') ? taggedChunks : untaggedChunks;
+        target.push(d);
+      }
+    }
+    expect(taggedChunks.length).toBeGreaterThan(0);
+    expect(untaggedChunks.length).toBeGreaterThan(0);
+    expect(taggedChunks[0].metadata.tags).toEqual(['ops', 'oncall']);
+    expect(untaggedChunks[0].metadata.tags).toEqual([]);
+
+    similaritySearchMock.mockResolvedValueOnce([
+      [taggedChunks[0], 0.1],
+      [untaggedChunks[0], 0.2],
+    ]);
+    const tagged = await manager.similaritySearch('q', 10, undefined, undefined, { tags: ['ops'] });
+    expect(tagged).toHaveLength(1);
+    expect((tagged[0].metadata as { source: string }).source).toMatch(/\/tagged\.md$/);
+
+    similaritySearchMock.mockResolvedValueOnce([
+      [taggedChunks[0], 0.1],
+      [untaggedChunks[0], 0.2],
+    ]);
+    const md = await manager.similaritySearch('q', 10, undefined, undefined, { extensions: ['.md'] });
+    expect(md.map((r) => (r.metadata as { source: string }).source).sort()).toEqual(
+      [taggedChunks[0].metadata.source, untaggedChunks[0].metadata.source].sort(),
+    );
+  });
+});

--- a/src/FaissIndexManager.ts
+++ b/src/FaissIndexManager.ts
@@ -2,6 +2,7 @@
 import * as fs from 'fs';
 import * as fsp from 'fs/promises';
 import * as path from 'path';
+import { minimatch } from 'minimatch';
 import * as properLockfile from 'proper-lockfile';
 // Issue #59 — provider modules are loaded lazily inside initialize(). Each
 // `@langchain/*` provider drags its full dep graph (e.g. @huggingface/inference,
@@ -1399,17 +1400,50 @@ export class FaissIndexManager {
    * Performs a similarity search and returns the results with their similarity scores.
    * When `knowledgeBaseName` is provided, results are scoped to documents whose `source`
    * metadata lives under that KB directory; otherwise all KBs are searched.
+   *
+   * Issue #53 — `filters` adds three optional metadata POST-filters on top of
+   * the score + KB filter that already runs here. Each filter is applied to
+   * `doc.metadata` after FAISS returns; the FAISS index itself is never
+   * pre-filtered (langchain's FaissStore silently drops filter args). When
+   * any filter is active we over-fetch up to `ntotal` so a small `k` doesn't
+   * starve once the post-filter drops the top-ranked unfiltered hits.
+   *
+   *   `extensions`  AND-with-existing — exact match on `metadata.extension`
+   *                 (already lowercased + dotted at ingest, so ".md" works
+   *                 directly; we lowercase the filter value and add a leading
+   *                 dot defensively).
+   *   `pathGlob`    AND-with-existing — minimatch against the KB-internal
+   *                 relative path (i.e. `metadata.relativePath` with the KB
+   *                 name segment stripped). This lets `"runbooks/**"` match
+   *                 `<any-kb>/runbooks/onboarding.md` without forcing the
+   *                 caller to know the KB name. `dot: true, nonegate: true`
+   *                 mirror the ingest filter's pattern semantics.
+   *   `tags`        AND semantics: every entry in the filter must be present
+   *                 on `metadata.tags`. Empty filter array short-circuits.
    */
-  async similaritySearch(query: string, k: number, threshold: number = 2, knowledgeBaseName?: string) {
+  async similaritySearch(
+    query: string,
+    k: number,
+    threshold: number = 2,
+    knowledgeBaseName?: string,
+    filters?: { extensions?: readonly string[]; pathGlob?: string; tags?: readonly string[] },
+  ) {
     if (!this.faissIndex) {
       throw new KBError('INDEX_NOT_INITIALIZED', 'FAISS index is not initialized');
     }
 
     const scoped = typeof knowledgeBaseName === 'string' && knowledgeBaseName.length > 0;
-    // When scoping to a KB, over-fetch up to the whole index so we can still
-    // surface up to `k` same-KB hits when other KBs dominate the top of the
-    // unfiltered ranking.
-    const fetchK = scoped
+
+    const normalizedExtensions = normalizeExtensionFilter(filters?.extensions);
+    const pathGlob = filters?.pathGlob && filters.pathGlob.length > 0 ? filters.pathGlob : undefined;
+    const requiredTags = filters?.tags?.filter((t): t is string => typeof t === 'string' && t.length > 0) ?? [];
+    const hasMetadataFilter =
+      normalizedExtensions !== undefined || pathGlob !== undefined || requiredTags.length > 0;
+
+    // Over-fetch when scoping or when any metadata post-filter is active so
+    // the post-filter doesn't starve `k` when other docs dominate the
+    // unfiltered top-K. The cost (linear in ntotal) is bounded by KB size.
+    const fetchK = scoped || hasMetadataFilter
       ? Math.max(k, this.faissIndex.index.ntotal())
       : k;
 
@@ -1426,9 +1460,32 @@ export class FaissIndexManager {
       if (score > threshold) {
         return false;
       }
+      const metadata = doc.metadata as Record<string, unknown> | undefined;
       if (kbPrefix) {
-        const source = (doc.metadata as { source?: unknown })?.source;
-        return typeof source === 'string' && source.startsWith(kbPrefix);
+        const source = metadata?.source;
+        if (typeof source !== 'string' || !source.startsWith(kbPrefix)) {
+          return false;
+        }
+      }
+      if (normalizedExtensions !== undefined) {
+        const ext = metadata?.extension;
+        if (typeof ext !== 'string' || !normalizedExtensions.has(ext.toLowerCase())) {
+          return false;
+        }
+      }
+      if (pathGlob !== undefined) {
+        const rel = metadata?.relativePath;
+        if (typeof rel !== 'string' || !matchesPathGlob(rel, pathGlob)) {
+          return false;
+        }
+      }
+      if (requiredTags.length > 0) {
+        const tags = metadata?.tags;
+        if (!Array.isArray(tags)) return false;
+        const tagSet = new Set(tags.filter((x): x is string => typeof x === 'string'));
+        for (const required of requiredTags) {
+          if (!tagSet.has(required)) return false;
+        }
       }
       return true;
     });
@@ -1438,4 +1495,43 @@ export class FaissIndexManager {
       score,
     }));
   }
+}
+
+/**
+ * Issue #53 — normalize the extensions filter into a lower-cased, dot-prefixed
+ * Set for O(1) lookup. Returns `undefined` when the filter is absent or empty
+ * (so the caller can skip the filter entirely instead of rejecting every doc).
+ * Empty/whitespace entries are dropped silently — a trailing `,` or stray
+ * empty string in the user's array shouldn't cause a no-results.
+ */
+function normalizeExtensionFilter(raw: readonly string[] | undefined): Set<string> | undefined {
+  if (!raw || raw.length === 0) return undefined;
+  const out = new Set<string>();
+  for (const entry of raw) {
+    if (typeof entry !== 'string') continue;
+    const trimmed = entry.trim().toLowerCase();
+    if (trimmed.length === 0) continue;
+    out.add(trimmed.startsWith('.') ? trimmed : `.${trimmed}`);
+  }
+  return out.size > 0 ? out : undefined;
+}
+
+/**
+ * Issue #53 — match `pathGlob` against the KB-internal relative path.
+ * `metadata.relativePath` is KNOWLEDGE_BASES_ROOT_DIR-relative (i.e.
+ * `<kb-name>/path/to/file.md`). The user's glob is meant to read against the
+ * in-KB path — `"runbooks/**"` should match any KB's `runbooks/foo.md` —
+ * so we strip the KB-name segment and match against the rest. The full
+ * KB-prefixed form is also tried as a fallback so an explicit prefix in the
+ * pattern (e.g. `"my-kb/notes/**"`) still works.
+ */
+function matchesPathGlob(relativePath: string, pattern: string): boolean {
+  const opts = { dot: true, nonegate: true } as const;
+  if (minimatch(relativePath, pattern, opts)) return true;
+  const firstSep = relativePath.indexOf('/');
+  if (firstSep > 0) {
+    const inKb = relativePath.slice(firstSep + 1);
+    if (minimatch(inKb, pattern, opts)) return true;
+  }
+  return false;
 }

--- a/src/KnowledgeBaseServer.test.ts
+++ b/src/KnowledgeBaseServer.test.ts
@@ -377,7 +377,7 @@ describe('KnowledgeBaseServer handlers', () => {
     });
   });
 
-  it('threshold argument flows through to similaritySearch(query, 10, threshold, kb)', async () => {
+  it('threshold argument flows through to similaritySearch(query, 10, threshold, kb, filters)', async () => {
     await setRetrieveEnv();
     updateIndexMock.mockResolvedValue(undefined);
     similaritySearchMock.mockResolvedValue([]);
@@ -385,10 +385,10 @@ describe('KnowledgeBaseServer handlers', () => {
     const server = await freshServer();
 
     await server['handleRetrieveKnowledge']({ query: 'q', threshold: 0.5 });
-    expect(similaritySearchMock).toHaveBeenLastCalledWith('q', 10, 0.5, undefined);
+    expect(similaritySearchMock).toHaveBeenLastCalledWith('q', 10, 0.5, undefined, undefined);
 
     await server['handleRetrieveKnowledge']({ query: 'q' });
-    expect(similaritySearchMock).toHaveBeenLastCalledWith('q', 10, undefined, undefined);
+    expect(similaritySearchMock).toHaveBeenLastCalledWith('q', 10, undefined, undefined, undefined);
 
     expect(similaritySearchMock).toHaveBeenCalledTimes(2);
   });
@@ -401,14 +401,45 @@ describe('KnowledgeBaseServer handlers', () => {
     const server = await freshServer();
 
     await server['handleRetrieveKnowledge']({ query: 'q', knowledge_base_name: 'alpha' });
-    expect(similaritySearchMock).toHaveBeenLastCalledWith('q', 10, undefined, 'alpha');
+    expect(similaritySearchMock).toHaveBeenLastCalledWith('q', 10, undefined, 'alpha', undefined);
 
     await server['handleRetrieveKnowledge']({
       query: 'q',
       knowledge_base_name: 'alpha',
       threshold: 0.25,
     });
-    expect(similaritySearchMock).toHaveBeenLastCalledWith('q', 10, 0.25, 'alpha');
+    expect(similaritySearchMock).toHaveBeenLastCalledWith('q', 10, 0.25, 'alpha', undefined);
+  });
+
+  it('handleRetrieveKnowledge forwards extensions / path_glob / tags filters (#53)', async () => {
+    await setRetrieveEnv();
+    updateIndexMock.mockResolvedValue(undefined);
+    similaritySearchMock.mockResolvedValue([]);
+
+    const server = await freshServer();
+
+    await server['handleRetrieveKnowledge']({
+      query: 'q',
+      extensions: ['.md'],
+      path_glob: 'runbooks/**',
+      tags: ['ops', 'oncall'],
+    });
+    expect(similaritySearchMock).toHaveBeenLastCalledWith(
+      'q',
+      10,
+      undefined,
+      undefined,
+      { extensions: ['.md'], pathGlob: 'runbooks/**', tags: ['ops', 'oncall'] },
+    );
+
+    await server['handleRetrieveKnowledge']({ query: 'q', extensions: ['.pdf'] });
+    expect(similaritySearchMock).toHaveBeenLastCalledWith(
+      'q',
+      10,
+      undefined,
+      undefined,
+      { extensions: ['.pdf'], pathGlob: undefined, tags: undefined },
+    );
   });
 
   it('handleRetrieveKnowledge scopes returned sources to knowledge_base_name (#71)', async () => {

--- a/src/KnowledgeBaseServer.ts
+++ b/src/KnowledgeBaseServer.ts
@@ -140,6 +140,11 @@ export class KnowledgeBaseServer {
         // When omitted, the server uses the model recorded in active.txt.
         // When passed, must be a registered model_id (see list_models).
         model_name: z.string().optional().describe('The model_id of an alternate embedding model to query (e.g. "openai__text-embedding-3-small"). If omitted, the active model is used. Run list_models for available ids.'),
+        // Issue #53 — metadata POST-filters. Applied after FAISS returns,
+        // ANDed with each other and with knowledge_base_name + threshold.
+        extensions: z.array(z.string()).optional().describe('Limit results to chunks whose source file has one of these extensions (e.g. [".md", ".pdf"]). Case-insensitive; leading dot optional.'),
+        path_glob: z.string().optional().describe('Limit results to chunks whose KB-internal relative path matches this glob (e.g. "runbooks/**"). The KB-name segment is stripped before matching.'),
+        tags: z.array(z.string()).optional().describe('Limit results to chunks whose source file has ALL of these tags in its YAML frontmatter.'),
       },
       async (args) => this.handleRetrieveKnowledge(args)
     );
@@ -202,11 +207,22 @@ export class KnowledgeBaseServer {
     }
   }
 
-  private async handleRetrieveKnowledge(args: { query: string; knowledge_base_name?: string; threshold?: number; model_name?: string; }): Promise<CallToolResult> {
+  private async handleRetrieveKnowledge(args: {
+    query: string;
+    knowledge_base_name?: string;
+    threshold?: number;
+    model_name?: string;
+    extensions?: string[];
+    path_glob?: string;
+    tags?: string[];
+  }): Promise<CallToolResult> {
     const query: string = args.query;
     const knowledgeBaseName: string | undefined = args.knowledge_base_name;
     const threshold: number | undefined = args.threshold;
     const modelNameOverride: string | undefined = args.model_name;
+    const filters = (args.extensions || args.path_glob || args.tags)
+      ? { extensions: args.extensions, pathGlob: args.path_glob, tags: args.tags }
+      : undefined;
 
     try {
       const startTime = Date.now();
@@ -235,7 +251,13 @@ export class KnowledgeBaseServer {
       logger.debug(`[${Date.now()}] FAISS index update completed`);
 
       // Perform similarity search using the provided query.
-      const similaritySearchResults = await manager.similaritySearch(query, 10, threshold, knowledgeBaseName);
+      const similaritySearchResults = await manager.similaritySearch(
+        query,
+        10,
+        threshold,
+        knowledgeBaseName,
+        filters,
+      );
       logger.debug(`[${Date.now()}] Similarity search completed`);
 
       // Build a nicely formatted markdown response including the similarity score.


### PR DESCRIPTION
## Summary

Adds three optional POST-filters to `retrieve_knowledge`:

- `extensions: string[]` — exact match on `metadata.extension` (case-insensitive, leading dot optional).
- `path_glob: string` — minimatch pattern. Matched against the KB-internal relative path (the KB-name segment is stripped from `metadata.relativePath`) so `"runbooks/**"` matches any KB's `runbooks/foo.md`. The full KB-prefixed path is also tried as a fallback, so explicit prefixes like `"my-kb/notes/**"` still work.
- `tags: string[]` — AND semantics against `metadata.tags`. Tags are already populated from YAML frontmatter at ingest (RFC 010 M1, via `parseFrontmatter` in `src/utils.ts`), so no ingest change is required.

All three are ANDed with each other and with the existing `knowledge_base_name` + `threshold` filters. When any filter is active, `similaritySearch` over-fetches up to `ntotal` so a small `k` doesn't starve once the post-filter drops top-ranked unfiltered hits — the same trick the existing KB-scoped path already used.

## Why minimatch and not a hand-rolled glob?

`minimatch` is already a dependency (used by `INGEST_EXCLUDE_PATHS` and the ingest filter at `src/utils.ts`). The post-filter passes the same options (`{ dot: true, nonegate: true }`) so a user's mental model of glob semantics carries over from `INGEST_EXCLUDE_PATHS` to `path_glob`.

## Implementation notes

- **No FAISS pre-filter.** `FaissStore.similaritySearchVectorWithScore` silently drops filter args; per the issue, filters are applied as a post-filter on `[doc, score]` tuples after FAISS returns. This is consistent with how the existing `knowledge_base_name` and `threshold` filters already work.
- **Ingest side was already done.** `buildChunkDocuments` (`src/FaissIndexManager.ts`) already stamps `relativePath`, `extension`, and `tags` (from `parseFrontmatter`) on every chunk's metadata. The PR reads those existing fields rather than introducing a new ingest schema.
- **Schema additions** are wired into `src/KnowledgeBaseServer.ts` via the existing zod schema on the `retrieve_knowledge` tool.

## Tests

- 10 new tests under `FaissIndexManager similaritySearch metadata filters (#53)` covering hit, miss, case-insensitivity, KB-prefixed-vs-stripped path matching, AND tag semantics, missing-tags-array rejection, combined filters, empty-array no-op, and an end-to-end test that writes real markdown with YAML frontmatter, runs the full ingest path through `buildChunkDocuments`, then asserts the tags filter selects the right chunk.
- 1 new test in `KnowledgeBaseServer.test.ts` that asserts the schema args (`extensions`, `path_glob`, `tags`) are forwarded to `manager.similaritySearch` as the 5th positional arg.
- 2 existing `KnowledgeBaseServer.test.ts` tests updated to match the new 5-arg signature (`undefined` filter when no filter is passed).
- Full suite: 338 passed, 0 failed (was 327 on main).

## Verification

- `npm run build` — green.
- `npm test` — 17 suites, 338 tests, all passing.

## Test plan

- [x] `npm test` green
- [x] `npm run build` green
- [x] Issue example payloads (`extensions: [".md", ".pdf"]`, `path_glob: "runbooks/**"`, `tags: [...]`) all unit-tested
- [x] Combined-filter AND semantics covered
- [x] End-to-end test exercises real frontmatter parsing through the ingest path

## Follow-ups

None spotted in scope. The CLI's `kb search` (`src/cli.ts`) doesn't expose these filters yet — surfacing them there is straightforward but a separate UX call (the issue body only specifies the MCP schema), so I left it for a follow-up.

Closes #53.

🤖 Generated with [Claude Code](https://claude.com/claude-code)