### PR TITLE
feat(stats): add kb_stats MCP tool for index observability (closes #54)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [Unreleased] — kb_stats observability tool
+
+### Added
+
+- **New `kb_stats` MCP tool surfaces index observability** — counts, last-index timestamp, and the active model — so agents and humans can introspect the KB instead of guessing. Per-KB it returns `file_count` (post-ingest-filter), `chunk_count` (per `metadata.knowledgeBase` in the loaded FAISS docstore), `total_bytes_indexed` (sum of stat sizes), and `last_updated_at` (max mtime under `<kb>/.index/`, ISO 8601, `null` if the KB has never been embedded). The envelope adds `embedding.{provider,model,dim}` (dim from `IndexFlatL2.getDimension()`, `null` pre-load), the absolute `index_path`, and `server.{version,uptime_ms}`. Pass the optional `knowledge_base_name` arg to scope to one KB; an unknown name returns a `KB_NOT_FOUND` MCP error. The tool is read-only — it does NOT acquire the write lock or trigger `updateIndex`. `KB_STATS_DESCRIPTION` overrides the model-facing description like the other tools. Closes #54.
+
+### Why
+
+Without an introspection surface, an agent has no way to ask "how many files/chunks are in this KB, when did the index last update, what model built it?" — so debugging "empty results" comes down to grepping logs. `pinecone-mcp`'s `describe-index-stats` is the precedent. Per-KB chunk counts are derived by walking the in-memory docstore at call time rather than tracked alongside ingest writes: the docstore is the single post-load source of truth, so counts can't drift after a fallback rebuild or restart, and the cost is O(n) for a tool that's expected to fire rarely. Per-KB `last_updated_at` from the sidecar tree (rather than the global `faiss.index` mtime) gives a tighter signal — the most recent embedding event for that KB specifically.
+
 ## [Unreleased] — retrieve_knowledge metadata filters
 
 ### Added

--- a/src/FaissIndexManager.ts
+++ b/src/FaissIndexManager.ts
@@ -1495,6 +1495,74 @@ export class FaissIndexManager {
       score,
     }));
   }
+
+  /**
+   * Issue #54 — observability snapshot for the kb_stats MCP tool.
+   *
+   * Returns a lightweight, read-only view of the loaded FAISS store: total
+   * chunk count (= `index.ntotal()`), vector dimension (= `index.getDimension()`),
+   * and per-KB chunk counts grouped by `metadata.knowledgeBase`.
+   *
+   * Per-KB counts are derived from the in-memory docstore at call time rather
+   * than tracked as the index mutates. Reasons: the docstore is the single
+   * source of truth post-load, so counts can't drift after a fallback rebuild
+   * or a restart; the cost is O(n) over the docstore and `kb_stats` is rare.
+   *
+   * Pre-load (faissIndex === null): returns zeros and dim=null. The caller
+   * still has useful data via per-KB file walks + sidecar mtimes.
+   */
+  getStats(): {
+    totalChunks: number;
+    chunkCountsByKb: Record<string, number>;
+    dim: number | null;
+  } {
+    if (!this.faissIndex) {
+      return { totalChunks: 0, chunkCountsByKb: {}, dim: null };
+    }
+    const totalChunks = this.faissIndex.index.ntotal();
+    const dim = this.faissIndex.index.getDimension();
+    const chunkCountsByKb: Record<string, number> = {};
+    // SynchronousInMemoryDocstore exposes `_docs: Map<string, Document>`
+    // (langchain 0.3 internal — verified against the bundled
+    // node_modules/langchain/dist/stores/doc/in_memory.js). The cast
+    // surfaces only the fields we touch.
+    const docs = (
+      this.faissIndex.docstore as unknown as {
+        _docs: Map<string, { metadata?: { knowledgeBase?: unknown } }>;
+      }
+    )._docs;
+    for (const doc of docs.values()) {
+      const kb = doc.metadata?.knowledgeBase;
+      if (typeof kb === 'string') {
+        chunkCountsByKb[kb] = (chunkCountsByKb[kb] ?? 0) + 1;
+      }
+    }
+    return { totalChunks, chunkCountsByKb, dim };
+  }
+
+  /**
+   * Issue #54 — resolve the path of the active `faiss.index` file used for
+   * `last_updated_at`. Handles both the RFC 014 versioned layout
+   * (`${modelDir}/index.vN/faiss.index` via the `index` symlink) and the
+   * legacy directory (`${modelDir}/faiss.index/faiss.index`). Returns null
+   * if no index has been persisted yet for this model.
+   */
+  async resolveActiveIndexFilePath(): Promise<string | null> {
+    const symlinkPath = path.join(this.modelDir, SYMLINK_NAME);
+    try {
+      const symStat = await fsp.lstat(symlinkPath);
+      if (symStat.isSymbolicLink()) {
+        const resolved = await fsp.realpath(symlinkPath);
+        const candidate = path.join(resolved, LEGACY_INDEX_NAME);
+        if (await pathExists(candidate)) return candidate;
+      }
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+    }
+    const legacyFile = path.join(this.modelDir, LEGACY_INDEX_NAME, LEGACY_INDEX_NAME);
+    if (await pathExists(legacyFile)) return legacyFile;
+    return null;
+  }
 }
 
 /**

--- a/src/KnowledgeBaseServer.test.ts
+++ b/src/KnowledgeBaseServer.test.ts
@@ -6,6 +6,13 @@ const initializeMock = jest.fn();
 const updateIndexMock = jest.fn();
 const similaritySearchMock = jest.fn();
 const hasLoadedIndexMock = jest.fn(() => true);
+// Issue #54 — kb_stats reads chunk_count + dim from the manager. Default to
+// an empty store so tests that don't care about stats still see a sane shape.
+const getStatsMock = jest.fn(() => ({
+  totalChunks: 0,
+  chunkCountsByKb: {} as Record<string, number>,
+  dim: null as number | null,
+}));
 
 const FaissIndexManagerMock: any = jest.fn().mockImplementation((opts?: { provider?: string; modelName?: string }) => {
   // RFC 013 M1+M2: the manager exposes modelDir / modelId / modelName for
@@ -20,6 +27,7 @@ const FaissIndexManagerMock: any = jest.fn().mockImplementation((opts?: { provid
     initialize: initializeMock,
     updateIndex: updateIndexMock,
     similaritySearch: similaritySearchMock,
+    getStats: getStatsMock,
     modelDir,
     modelId,
     modelName,
@@ -58,6 +66,8 @@ describe('KnowledgeBaseServer handlers', () => {
     similaritySearchMock.mockReset();
     hasLoadedIndexMock.mockReset();
     hasLoadedIndexMock.mockReturnValue(true);
+    getStatsMock.mockReset();
+    getStatsMock.mockReturnValue({ totalChunks: 0, chunkCountsByKb: {}, dim: null });
   });
 
   afterEach(() => {
@@ -234,6 +244,129 @@ describe('KnowledgeBaseServer handlers', () => {
     const server = await freshServer();
     const result = await server['handleRetrieveKnowledge']({ query: 'q' });
     expect(result.content[0].text).not.toContain('Model:');
+  });
+
+  // --- handleKbStats (#54) -------------------------------------------------
+
+  it('handleKbStats with no args returns one entry per registered KB', async () => {
+    const tempDir = await setRetrieveEnv();
+    await fsp.mkdir(path.join(tempDir, 'alpha'));
+    await fsp.mkdir(path.join(tempDir, 'beta'));
+    await fsp.writeFile(path.join(tempDir, 'alpha', 'one.md'), 'hello world');
+    await fsp.writeFile(path.join(tempDir, 'alpha', 'two.md'), '12345');
+    await fsp.writeFile(path.join(tempDir, 'beta', 'long.md'), 'x'.repeat(100));
+
+    getStatsMock.mockReturnValue({
+      totalChunks: 7,
+      chunkCountsByKb: { alpha: 4, beta: 3 },
+      dim: 384,
+    });
+
+    const server = await freshServer();
+    const result = await server['handleKbStats']({});
+
+    expect(result.isError).toBeUndefined();
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0].type).toBe('text');
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(Object.keys(payload.knowledge_bases).sort()).toEqual(['alpha', 'beta']);
+    expect(payload.knowledge_bases.alpha.file_count).toBe(2);
+    expect(payload.knowledge_bases.alpha.total_bytes_indexed).toBe(11 + 5);
+    expect(payload.knowledge_bases.alpha.chunk_count).toBe(4);
+    expect(payload.knowledge_bases.beta.file_count).toBe(1);
+    expect(payload.knowledge_bases.beta.total_bytes_indexed).toBe(100);
+    expect(payload.knowledge_bases.beta.chunk_count).toBe(3);
+
+    expect(payload.embedding).toEqual({
+      provider: 'huggingface',
+      model: 'BAAI/bge-small-en-v1.5',
+      dim: 384,
+    });
+    expect(payload.index_path).toBe(process.env.FAISS_INDEX_PATH);
+    expect(typeof payload.server.version).toBe('string');
+    expect(payload.server.version.length).toBeGreaterThan(0);
+    expect(typeof payload.server.uptime_ms).toBe('number');
+    expect(payload.server.uptime_ms).toBeGreaterThanOrEqual(0);
+  });
+
+  it('handleKbStats with knowledge_base_name returns only that KB and asserts chunk_count', async () => {
+    const tempDir = await setRetrieveEnv();
+    await fsp.mkdir(path.join(tempDir, 'alpha'));
+    await fsp.mkdir(path.join(tempDir, 'beta'));
+    await fsp.writeFile(path.join(tempDir, 'alpha', 'a.md'), 'aaa');
+    await fsp.writeFile(path.join(tempDir, 'beta', 'b.md'), 'bbbb');
+
+    getStatsMock.mockReturnValue({
+      totalChunks: 9,
+      // chunk_count for `alpha` must come straight from this map even though
+      // there is also a `beta` entry — kb_stats with a name MUST scope.
+      chunkCountsByKb: { alpha: 5, beta: 4 },
+      dim: 768,
+    });
+
+    const server = await freshServer();
+    const result = await server['handleKbStats']({ knowledge_base_name: 'alpha' });
+
+    expect(result.isError).toBeUndefined();
+    const payload = JSON.parse(result.content[0].text);
+    expect(Object.keys(payload.knowledge_bases)).toEqual(['alpha']);
+    expect(payload.knowledge_bases.alpha.chunk_count).toBe(5);
+    expect(payload.knowledge_bases.alpha.file_count).toBe(1);
+    expect(payload.knowledge_bases.alpha.total_bytes_indexed).toBe(3);
+    expect(payload.embedding.dim).toBe(768);
+  });
+
+  it('handleKbStats returns 0 chunk_count for a KB with no docs in the index', async () => {
+    const tempDir = await setRetrieveEnv();
+    await fsp.mkdir(path.join(tempDir, 'newkb'));
+    await fsp.writeFile(path.join(tempDir, 'newkb', 'untouched.md'), 'data');
+
+    getStatsMock.mockReturnValue({
+      totalChunks: 0,
+      chunkCountsByKb: {},
+      dim: null,
+    });
+
+    const server = await freshServer();
+    const result = await server['handleKbStats']({});
+    const payload = JSON.parse(result.content[0].text);
+    expect(payload.knowledge_bases.newkb.chunk_count).toBe(0);
+    expect(payload.knowledge_bases.newkb.last_updated_at).toBeNull();
+    expect(payload.embedding.dim).toBeNull();
+  });
+
+  it('handleKbStats with unknown knowledge_base_name returns KB_NOT_FOUND error', async () => {
+    const tempDir = await setRetrieveEnv();
+    await fsp.mkdir(path.join(tempDir, 'alpha'));
+
+    const server = await freshServer();
+    const result = await server['handleKbStats']({ knowledge_base_name: 'doesnotexist' });
+
+    expect(result.isError).toBe(true);
+    const payload = JSON.parse(result.content[0].text);
+    expect(payload.error.code).toBe('KB_NOT_FOUND');
+    expect(payload.error.message).toContain('doesnotexist');
+  });
+
+  it('handleKbStats derives last_updated_at from the most recent file mtime under <kb>/.index/', async () => {
+    const tempDir = await setRetrieveEnv();
+    await fsp.mkdir(path.join(tempDir, 'alpha'));
+    await fsp.writeFile(path.join(tempDir, 'alpha', 'a.md'), 'x');
+    const sidecarDir = path.join(tempDir, 'alpha', '.index');
+    await fsp.mkdir(sidecarDir, { recursive: true });
+    const sidecar = path.join(sidecarDir, 'a.md');
+    await fsp.writeFile(sidecar, 'somehash');
+    // Pin a known mtime so the assertion is exact.
+    const fixedMs = 1_700_000_000_000;
+    await fsp.utimes(sidecar, fixedMs / 1000, fixedMs / 1000);
+
+    const server = await freshServer();
+    const result = await server['handleKbStats']({ knowledge_base_name: 'alpha' });
+    const payload = JSON.parse(result.content[0].text);
+    expect(payload.knowledge_bases.alpha.last_updated_at).toBe(
+      new Date(fixedMs).toISOString(),
+    );
   });
 
   it('handleListKnowledgeBases surfaces readdir errors as { isError: true } naming the failure', async () => {

--- a/src/KnowledgeBaseServer.ts
+++ b/src/KnowledgeBaseServer.ts
@@ -15,7 +15,11 @@ import {
 } from './active-model.js';
 import type { EmbeddingProvider } from './model-id.js';
 import {
+  FAISS_INDEX_PATH,
   FRONTMATTER_EXTRAS_WIRE_VISIBLE,
+  INGEST_EXCLUDE_PATHS,
+  INGEST_EXTRA_EXTENSIONS,
+  KB_STATS_DESCRIPTION,
   KNOWLEDGE_BASES_ROOT_DIR,
   LIST_KNOWLEDGE_BASES_DESCRIPTION,
   LIST_MODELS_DESCRIPTION,
@@ -30,13 +34,55 @@ import { formatRetrievalAsMarkdown, sanitizeMetadataForWire } from './formatter.
 import { listKnowledgeBases } from './kb-fs.js';
 import { withWriteLock } from './write-lock.js';
 import { logger } from './logger.js';
-import { toError } from './utils.js';
+import { filterIngestablePaths, getFilesRecursively, toError } from './utils.js';
+import * as fsp from 'fs/promises';
+import * as path from 'path';
 import { SseHost } from './transport/sse.js';
 import { ReindexTriggerWatcher } from './triggerWatcher.js';
 import { KBError, type KBErrorCode } from './errors.js';
 
 const SERVER_NAME = 'knowledge-base-server';
 const SERVER_VERSION = '0.1.0';
+
+/**
+ * Issue #54 — recursively walk `dir` for the latest mtime of any file under
+ * it. Used by kb_stats to derive `last_updated_at` per KB from sidecar hash
+ * files at `<kb>/.index/`: the most recent sidecar mtime is the last time
+ * any file in this KB was (re)embedded by the active model. Returns an ISO
+ * string with millisecond precision, or null when the directory is missing
+ * (KB never indexed) or contains no files.
+ */
+async function maxMtimeIso(dir: string): Promise<string | null> {
+  let latest = 0;
+  async function walk(target: string): Promise<void> {
+    let entries: Array<import('fs').Dirent>;
+    try {
+      entries = await fsp.readdir(target, { withFileTypes: true });
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === 'ENOENT' || code === 'ENOTDIR') return;
+      throw err;
+    }
+    for (const entry of entries) {
+      const child = path.join(target, entry.name);
+      if (entry.isDirectory()) {
+        await walk(child);
+        continue;
+      }
+      if (!entry.isFile()) continue;
+      try {
+        const st = await fsp.stat(child);
+        if (st.mtimeMs > latest) latest = st.mtimeMs;
+      } catch (err) {
+        const code = (err as NodeJS.ErrnoException).code;
+        if (code === 'ENOENT') continue;
+        throw err;
+      }
+    }
+  }
+  await walk(dir);
+  return latest === 0 ? null : new Date(latest).toISOString();
+}
 
 function mcpErrorContent(error: Error): TextContent {
   const code: KBErrorCode = error instanceof KBError ? error.code : 'INTERNAL';
@@ -68,6 +114,8 @@ export class KnowledgeBaseServer {
   private transportMode: 'stdio' | 'sse' | null = null;
   private triggerWatcher?: ReindexTriggerWatcher;
   private shutdownInstalled = false;
+  // Issue #54 — uptime baseline for kb_stats.server.uptime_ms.
+  private readonly startedAt: number = Date.now();
 
   constructor() {
     logger.info('Initializing KnowledgeBaseServer');
@@ -156,6 +204,20 @@ export class KnowledgeBaseServer {
       LIST_MODELS_DESCRIPTION,
       async () => this.handleListModels()
     );
+
+    // Issue #54 — kb_stats observability surface (counts, last-index timestamp,
+    // active model). Read-only; does not acquire the write lock.
+    mcp.tool(
+      'kb_stats',
+      KB_STATS_DESCRIPTION,
+      {
+        knowledge_base_name: z
+          .string()
+          .optional()
+          .describe('Name of a single KB to scope to. If omitted, every registered KB is reported.'),
+      },
+      async (args) => this.handleKbStats(args)
+    );
   }
 
   /**
@@ -200,6 +262,117 @@ export class KnowledgeBaseServer {
     } catch (error: unknown) {
       const err = toError(error);
       logger.error('Error listing knowledge bases:', err);
+      if (err.stack) {
+        logger.error(err.stack);
+      }
+      return { content: [mcpErrorContent(err)], isError: true };
+    }
+  }
+
+  /**
+   * Issue #54 — kb_stats. Read-only observability surface; does NOT acquire
+   * the write lock and does NOT trigger an updateIndex. Counts reflect
+   * whatever is on disk + in the loaded FAISS docstore RIGHT NOW.
+   */
+  private async handleKbStats(args: {
+    knowledge_base_name?: string;
+  }): Promise<CallToolResult> {
+    try {
+      let activeModelId: string;
+      try {
+        activeModelId = await resolveActiveModel();
+      } catch (err) {
+        if (err instanceof ActiveModelResolutionError) {
+          return {
+            content: [{ type: 'text', text: err.message }],
+            isError: true,
+          };
+        }
+        throw err;
+      }
+      const manager = await this.getManagerFor(activeModelId);
+
+      const allKbs = await listKnowledgeBases(KNOWLEDGE_BASES_ROOT_DIR);
+      let kbsToReport: string[];
+      if (args.knowledge_base_name !== undefined) {
+        if (!allKbs.includes(args.knowledge_base_name)) {
+          return {
+            content: [
+              mcpErrorContent(
+                new KBError(
+                  'KB_NOT_FOUND',
+                  `Knowledge base "${args.knowledge_base_name}" not found under ${KNOWLEDGE_BASES_ROOT_DIR}.`,
+                ),
+              ),
+            ],
+            isError: true,
+          };
+        }
+        kbsToReport = [args.knowledge_base_name];
+      } else {
+        kbsToReport = allKbs;
+      }
+
+      const indexStats = manager.getStats();
+
+      const knowledge_bases: Record<string, {
+        file_count: number;
+        chunk_count: number;
+        total_bytes_indexed: number;
+        last_updated_at: string | null;
+      }> = {};
+
+      for (const kb of kbsToReport) {
+        const kbPath = path.join(KNOWLEDGE_BASES_ROOT_DIR, kb);
+        // Apply the SAME ingest filter the indexer uses, so file_count and
+        // total_bytes_indexed reflect what would actually be embedded — not
+        // the raw file walk (which still includes excluded extensions and
+        // excluded subtrees).
+        const candidatePaths = await getFilesRecursively(kbPath);
+        const filePaths = filterIngestablePaths(candidatePaths, kbPath, {
+          extraExtensions: INGEST_EXTRA_EXTENSIONS,
+          excludePaths: INGEST_EXCLUDE_PATHS,
+        });
+        let totalBytes = 0;
+        for (const filePath of filePaths) {
+          try {
+            const st = await fsp.stat(filePath);
+            totalBytes += st.size;
+          } catch (err) {
+            // Best-effort: a TOCTOU between getFilesRecursively and stat
+            // (e.g. concurrent edit) shouldn't fail the whole stats call.
+            logger.debug(`kb_stats: could not stat ${filePath}: ${(err as Error).message}`);
+          }
+        }
+        const lastUpdatedAt = await maxMtimeIso(path.join(kbPath, '.index'));
+        knowledge_bases[kb] = {
+          file_count: filePaths.length,
+          chunk_count: indexStats.chunkCountsByKb[kb] ?? 0,
+          total_bytes_indexed: totalBytes,
+          last_updated_at: lastUpdatedAt,
+        };
+      }
+
+      const payload = {
+        knowledge_bases,
+        embedding: {
+          provider: manager.embeddingProvider,
+          model: manager.modelName,
+          dim: indexStats.dim,
+        },
+        index_path: FAISS_INDEX_PATH,
+        server: {
+          version: SERVER_VERSION,
+          uptime_ms: Date.now() - this.startedAt,
+        },
+      };
+
+      return {
+        content: [{ type: 'text', text: JSON.stringify(payload, null, 2) }],
+      };
+    } catch (error: unknown) {
+      const err = toError(error);
+      logger.error('Error computing kb_stats:', err);
       if (err.stack) {
         logger.error(err.stack);
       }

--- a/src/config.ts
+++ b/src/config.ts
@@ -154,6 +154,14 @@ export const LIST_MODELS_DESCRIPTION =
     ? process.env.LIST_MODELS_DESCRIPTION
     : DEFAULT_LIST_MODELS_DESCRIPTION;
 
+// Issue #54 — kb_stats tool description.
+export const DEFAULT_KB_STATS_DESCRIPTION =
+  'Reports observability stats for the knowledge base index: per-KB file_count, chunk_count, total_bytes_indexed and last_updated_at; the active embedding provider/model/dim; the on-disk index_path; and server version/uptime. Pass `knowledge_base_name` to scope to a single KB; omit it to get an entry per registered KB.';
+export const KB_STATS_DESCRIPTION =
+  process.env.KB_STATS_DESCRIPTION && process.env.KB_STATS_DESCRIPTION.length > 0
+    ? process.env.KB_STATS_DESCRIPTION
+    : DEFAULT_KB_STATS_DESCRIPTION;
+
 // ---------------------------------------------------------------------------
 // Transport configuration (RFC 008 stage 1: stdio + SSE).
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds a new read-only MCP tool `kb_stats(knowledge_base_name?)` so agents and humans can introspect the FAISS index from the wire surface instead of guessing. Closes #54.

Per-KB the tool returns:
- `file_count` — post-ingest-filter file count under the KB dir
- `chunk_count` — chunks attributed to the KB in the loaded FAISS docstore
- `total_bytes_indexed` — sum of stat sizes for the included files
- `last_updated_at` — max mtime under `<kb>/.index/`, ISO 8601, `null` if the KB has never been embedded

Envelope:
- `embedding.{provider,model,dim}` — dim from `IndexFlatL2.getDimension()`, `null` pre-load
- `index_path` — absolute on-disk path
- `server.{version,uptime_ms}`

## Design notes

- `chunk_count` is derived from the in-memory FAISS docstore at call time (`SynchronousInMemoryDocstore._docs.values()`, grouped by `metadata.knowledgeBase`) rather than tracked alongside ingest writes. The docstore is the single post-load source of truth, so counts can't drift after a fallback rebuild or restart, and the cost is O(n) for a tool that's expected to fire rarely.
- `last_updated_at` is per-KB rather than global — taken from the most recent file mtime under `<kb>/.index/`. That's a tighter signal than the global `faiss.index` mtime: it tells you the last time *this* KB was (re)embedded, not "any KB was touched".
- The tool is read-only — does NOT acquire the per-model write lock and does NOT trigger `updateIndex`. Counts reflect whatever is on disk and in the loaded FAISS docstore right now.
- Unknown KB names return a `KB_NOT_FOUND` MCP error.
- `KB_STATS_DESCRIPTION` env var overrides the model-facing description like the other tools.

## Test plan

- [x] `npm test` — 343 tests pass (5 new for `handleKbStats`)
- [x] `npm run build` — clean tsc
- [x] no-arg call returns one entry per registered KB with correct file/byte/chunk counts
- [x] named-KB call scopes to that KB and asserts `chunk_count` flows from the manager mock
- [x] unknown KB returns `KB_NOT_FOUND`
- [x] empty index returns `chunk_count: 0` and `dim: null`
- [x] `last_updated_at` derives from sidecar mtime under `<kb>/.index/`

## Out of scope

- MCP Resources (issue body suggests a "stats slice" of the architecture work; this PR is just the tool)
- Tracking retrieval latency in `kb_stats` (deferred — the issue body lists it under "could ask" but the suggested response shape doesn't include it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)