### PR TITLE
feat(mcp): expose knowledge bases as MCP resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased] — MCP Resources for KB documents
+
+### Added
+
+- **Knowledge-base files are now exposed as MCP Resources.** Clients that browse resources can list documents as `kb://<kb-name>/<relative-path>` and read the selected file directly. Markdown, text, HTML, and unknown text-like files return text content; PDFs return base64 blobs with `application/pdf`. Resource listing uses the same recursive dot-prefix skip behavior as indexing, so `.faiss`, `.index`, `.reindex-trigger`, and other hidden paths stay off the wire. Path resolution is guarded against `../`, absolute paths, encoded separator payloads, and symlinks that leave the KB root. Closes #49.
+
 ## [Unreleased] — PDF and HTML loaders behind extension-based routing
 
 ### Added

--- a/src/KnowledgeBaseServer.test.ts
+++ b/src/KnowledgeBaseServer.test.ts
@@ -389,6 +389,155 @@ describe('KnowledgeBaseServer handlers', () => {
     expect(payload.error.message).toMatch(/ENOENT|no such file/i);
   });
 
+  // --- MCP Resources (#49) --------------------------------------------------
+
+  it('resources/list returns kb:// URIs across multiple KBs', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-server-resources-list-'));
+    await fsp.mkdir(path.join(tempDir, 'alpha', 'docs'), { recursive: true });
+    await fsp.mkdir(path.join(tempDir, 'beta'), { recursive: true });
+    await fsp.writeFile(path.join(tempDir, 'alpha', 'docs', 'guide.md'), '# Guide\n');
+    await fsp.writeFile(path.join(tempDir, 'alpha', 'notes.txt'), 'notes\n');
+    await fsp.writeFile(path.join(tempDir, 'beta', 'paper.pdf'), Buffer.from('%PDF-1.4\n'));
+    await fsp.writeFile(path.join(tempDir, 'beta', 'page.html'), '<h1>Page</h1>');
+
+    process.env.KNOWLEDGE_BASES_ROOT_DIR = tempDir;
+    process.env.FAISS_INDEX_PATH = path.join(tempDir, '.faiss');
+    process.env.EMBEDDING_PROVIDER = 'huggingface';
+    process.env.HUGGINGFACE_API_KEY = 'test-key';
+
+    const server = await freshServer();
+    const result = await server['handleListResources']();
+
+    expect(result.resources.map((resource: { uri: string }) => resource.uri).sort()).toEqual([
+      'kb://alpha/docs/guide.md',
+      'kb://alpha/notes.txt',
+      'kb://beta/page.html',
+      'kb://beta/paper.pdf',
+    ]);
+    expect(result.resources.find((resource: { uri: string }) => resource.uri === 'kb://alpha/docs/guide.md')).toMatchObject({
+      name: 'docs/guide.md',
+      mimeType: 'text/markdown',
+    });
+    expect(result.resources.find((resource: { uri: string }) => resource.uri === 'kb://beta/paper.pdf')).toMatchObject({
+      mimeType: 'application/pdf',
+    });
+    expect(result.resources.find((resource: { uri: string }) => resource.uri === 'kb://beta/page.html')).toMatchObject({
+      mimeType: 'text/html',
+    });
+  });
+
+  it('resources/read returns markdown text for an existing file', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-server-resources-read-'));
+    await fsp.mkdir(path.join(tempDir, 'alpha', 'docs'), { recursive: true });
+    await fsp.writeFile(path.join(tempDir, 'alpha', 'docs', 'onboarding.md'), '# Onboarding\n\nWelcome.\n');
+
+    process.env.KNOWLEDGE_BASES_ROOT_DIR = tempDir;
+    process.env.FAISS_INDEX_PATH = path.join(tempDir, '.faiss');
+    process.env.EMBEDDING_PROVIDER = 'huggingface';
+    process.env.HUGGINGFACE_API_KEY = 'test-key';
+
+    const server = await freshServer();
+    const result = await server['handleReadResource']('kb://alpha/docs/onboarding.md');
+
+    expect(result.contents).toEqual([
+      {
+        uri: 'kb://alpha/docs/onboarding.md',
+        mimeType: 'text/markdown',
+        text: '# Onboarding\n\nWelcome.\n',
+      },
+    ]);
+  });
+
+  it('resources/read returns PDF bytes as a base64 blob', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-server-resources-pdf-'));
+    const pdfBytes = Buffer.from([0x25, 0x50, 0x44, 0x46, 0x0a, 0xff]);
+    await fsp.mkdir(path.join(tempDir, 'alpha'), { recursive: true });
+    await fsp.writeFile(path.join(tempDir, 'alpha', 'paper.pdf'), pdfBytes);
+
+    process.env.KNOWLEDGE_BASES_ROOT_DIR = tempDir;
+    process.env.FAISS_INDEX_PATH = path.join(tempDir, '.faiss');
+    process.env.EMBEDDING_PROVIDER = 'huggingface';
+    process.env.HUGGINGFACE_API_KEY = 'test-key';
+
+    const server = await freshServer();
+    const result = await server['handleReadResource']('kb://alpha/paper.pdf');
+
+    expect(result.contents).toHaveLength(1);
+    const content = result.contents[0];
+    expect(content.uri).toBe('kb://alpha/paper.pdf');
+    expect(content.mimeType).toBe('application/pdf');
+    expect('blob' in content ? content.blob : undefined).toBe(pdfBytes.toString('base64'));
+    expect('text' in content ? content.text : undefined).toBeUndefined();
+  });
+
+  it('resources/read rejects a non-existent file with a clean error', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-server-resources-missing-'));
+    await fsp.mkdir(path.join(tempDir, 'alpha'), { recursive: true });
+
+    process.env.KNOWLEDGE_BASES_ROOT_DIR = tempDir;
+    process.env.FAISS_INDEX_PATH = path.join(tempDir, '.faiss');
+    process.env.EMBEDDING_PROVIDER = 'huggingface';
+    process.env.HUGGINGFACE_API_KEY = 'test-key';
+
+    const server = await freshServer();
+    await expect(server['handleReadResource']('kb://alpha/missing.md')).rejects.toThrow(
+      /path not found: "missing\.md"/,
+    );
+  });
+
+  it.each([
+    ['plain parent traversal', 'kb://alpha/../secret.md'],
+    ['absolute path payload', 'kb://alpha//etc/passwd'],
+    ['encoded parent traversal', 'kb://alpha/%2E%2E/secret.md'],
+    ['encoded slash traversal', 'kb://alpha/..%2Fsecret.md'],
+    ['encoded absolute path', 'kb://alpha/%2Fetc%2Fpasswd'],
+  ])('resources/read rejects %s', async (_label, uri) => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-server-resources-traversal-'));
+    await fsp.mkdir(path.join(tempDir, 'alpha'), { recursive: true });
+    await fsp.writeFile(path.join(tempDir, 'alpha', 'safe.md'), 'safe');
+
+    process.env.KNOWLEDGE_BASES_ROOT_DIR = tempDir;
+    process.env.FAISS_INDEX_PATH = path.join(tempDir, '.faiss');
+    process.env.EMBEDDING_PROVIDER = 'huggingface';
+    process.env.HUGGINGFACE_API_KEY = 'test-key';
+
+    const server = await freshServer();
+    await expect(server['handleReadResource'](uri)).rejects.toThrow(/path escapes KB root/);
+  });
+
+  it('resources/list excludes dot-prefixed files and directories', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-server-resources-dot-'));
+    await fsp.mkdir(path.join(tempDir, 'alpha', '.faiss'), { recursive: true });
+    await fsp.mkdir(path.join(tempDir, 'alpha', '.index'), { recursive: true });
+    await fsp.mkdir(path.join(tempDir, 'alpha', 'docs'), { recursive: true });
+    await fsp.mkdir(path.join(tempDir, '.hidden-root'), { recursive: true });
+    await fsp.writeFile(path.join(tempDir, 'alpha', 'visible.md'), 'visible');
+    await fsp.writeFile(path.join(tempDir, 'alpha', 'docs', 'guide.md'), 'guide');
+    await fsp.writeFile(path.join(tempDir, 'alpha', '.reindex-trigger'), '');
+    await fsp.writeFile(path.join(tempDir, 'alpha', '.faiss', 'hidden.md'), 'hidden');
+    await fsp.writeFile(path.join(tempDir, 'alpha', '.index', 'hidden.md'), 'hidden');
+    await fsp.writeFile(path.join(tempDir, 'alpha', '.hidden.md'), 'hidden');
+    await fsp.writeFile(path.join(tempDir, '.hidden-root', 'hidden.md'), 'hidden');
+
+    process.env.KNOWLEDGE_BASES_ROOT_DIR = tempDir;
+    process.env.FAISS_INDEX_PATH = path.join(tempDir, '.faiss');
+    process.env.EMBEDDING_PROVIDER = 'huggingface';
+    process.env.HUGGINGFACE_API_KEY = 'test-key';
+
+    const server = await freshServer();
+    const result = await server['handleListResources']();
+    const uris = result.resources.map((resource: { uri: string }) => resource.uri).sort();
+
+    expect(uris).toEqual([
+      'kb://alpha/docs/guide.md',
+      'kb://alpha/visible.md',
+    ]);
+    expect(uris.join('\n')).not.toContain('.faiss');
+    expect(uris.join('\n')).not.toContain('.index');
+    expect(uris.join('\n')).not.toContain('.reindex-trigger');
+    expect(uris.join('\n')).not.toContain('.hidden');
+  });
+
   // --- handleRetrieveKnowledge ----------------------------------------------
 
   it('handleRetrieveKnowledge formats multi-result responses with Result N, score, and source blocks', async () => {

--- a/src/KnowledgeBaseServer.ts
+++ b/src/KnowledgeBaseServer.ts
@@ -2,7 +2,16 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { z } from 'zod';
-import type { CallToolResult, TextContent } from '@modelcontextprotocol/sdk/types.js';
+import {
+  ListResourcesRequestSchema,
+  ListResourceTemplatesRequestSchema,
+  ReadResourceRequestSchema,
+  type CallToolResult,
+  type ListResourcesResult,
+  type ReadResourceResult,
+  type Resource,
+  type TextContent,
+} from '@modelcontextprotocol/sdk/types.js';
 import { FaissIndexManager } from './FaissIndexManager.js';
 import type { IndexUpdateProgress } from './FaissIndexManager.js';
 import {
@@ -31,10 +40,10 @@ import {
   type TransportConfig,
 } from './config.js';
 import { formatRetrievalAsMarkdown, sanitizeMetadataForWire } from './formatter.js';
-import { listKnowledgeBases } from './kb-fs.js';
+import { listKnowledgeBases, resolveKnowledgeBaseDocumentPath } from './kb-fs.js';
 import { withWriteLock } from './write-lock.js';
 import { logger } from './logger.js';
-import { filterIngestablePaths, getFilesRecursively, toError } from './utils.js';
+import { filterIngestablePaths, getFilesRecursively, isValidKbName, toError } from './utils.js';
 import * as fsp from 'fs/promises';
 import * as path from 'path';
 import { SseHost } from './transport/sse.js';
@@ -95,6 +104,83 @@ function mcpErrorContent(error: Error): TextContent {
       },
     }),
   };
+}
+
+function mimeTypeForResource(filePath: string): string {
+  const ext = path.extname(filePath).toLowerCase();
+  switch (ext) {
+    case '.md':
+    case '.markdown':
+      return 'text/markdown';
+    case '.pdf':
+      return 'application/pdf';
+    case '.html':
+    case '.htm':
+      return 'text/html';
+    case '.txt':
+    default:
+      return 'text/plain';
+  }
+}
+
+function resourceUri(kbName: string, relativePath: string): string {
+  const encodedPath = relativePath
+    .split('/')
+    .map((segment) => encodeURIComponent(segment))
+    .join('/');
+  return `kb://${kbName}/${encodedPath}`;
+}
+
+function parseKnowledgeBaseResourceUri(uri: string): { kbName: string; relativePath: string } {
+  const rawMatch = /^kb:\/\/([^/?#]*)([^?#]*)/i.exec(uri);
+  if (!rawMatch) {
+    throw new Error('resource URI must use the kb:// scheme');
+  }
+
+  let url: URL;
+  try {
+    url = new URL(uri);
+  } catch (error: unknown) {
+    throw new Error(`invalid kb:// URI: ${toError(error).message}`);
+  }
+
+  if (url.protocol !== 'kb:') {
+    throw new Error(`unsupported resource URI scheme: ${url.protocol}`);
+  }
+
+  const kbName = url.hostname;
+  if (kbName.length === 0) {
+    throw new Error('kb:// URI requires a non-empty KB authority');
+  }
+  if (!isValidKbName(kbName)) {
+    throw new Error('invalid KB name in kb:// URI');
+  }
+
+  const rawPath = rawMatch[2] ?? '';
+  if (!rawPath.startsWith('/')) {
+    throw new Error('kb:// URI requires a non-empty resource path');
+  }
+
+  const rawRelativePath = rawPath.slice(1);
+  if (rawRelativePath.length === 0) {
+    throw new Error('kb:// URI requires a non-empty resource path');
+  }
+  if (/%(?:2f|5c)/i.test(rawRelativePath)) {
+    throw new Error(`path escapes KB root: ${JSON.stringify(rawRelativePath)}`);
+  }
+
+  let relativePath: string;
+  try {
+    relativePath = decodeURI(rawRelativePath);
+  } catch (error: unknown) {
+    throw new Error(`invalid kb:// URI path encoding: ${toError(error).message}`);
+  }
+
+  if (relativePath.split('/').some((segment) => segment === '..')) {
+    throw new Error(`path escapes KB root: ${JSON.stringify(relativePath)}`);
+  }
+
+  return { kbName, relativePath };
 }
 
 // Re-export for backward compatibility: existing tests import
@@ -167,6 +253,7 @@ export class KnowledgeBaseServer {
     });
     mcp.server.onerror = (error) => logger.error('[MCP Error]', error);
     this.registerTools(mcp);
+    this.registerResources(mcp);
     return mcp;
   }
 
@@ -218,6 +305,72 @@ export class KnowledgeBaseServer {
       },
       async (args) => this.handleKbStats(args)
     );
+  }
+
+  private registerResources(mcp: McpServer): void {
+    mcp.server.registerCapabilities({
+      resources: {
+        listChanged: true,
+      },
+    });
+
+    mcp.server.setRequestHandler(ListResourcesRequestSchema, async () =>
+      this.handleListResources()
+    );
+    mcp.server.setRequestHandler(ListResourceTemplatesRequestSchema, async () => ({
+      resourceTemplates: [],
+    }));
+    mcp.server.setRequestHandler(ReadResourceRequestSchema, async (request) =>
+      this.handleReadResource(request.params.uri)
+    );
+  }
+
+  private async handleListResources(): Promise<ListResourcesResult> {
+    const resources: Resource[] = [];
+    const knowledgeBases = (await listKnowledgeBases(KNOWLEDGE_BASES_ROOT_DIR)).sort();
+
+    for (const kbName of knowledgeBases) {
+      if (!isValidKbName(kbName)) continue;
+      const kbPath = path.join(KNOWLEDGE_BASES_ROOT_DIR, kbName);
+      const filePaths = (await getFilesRecursively(kbPath)).sort();
+      for (const filePath of filePaths) {
+        const relativePath = path
+          .relative(kbPath, filePath)
+          .split(path.sep)
+          .join('/');
+
+        resources.push({
+          uri: resourceUri(kbName, relativePath),
+          name: relativePath,
+          description: `Document in knowledge base "${kbName}"`,
+          mimeType: mimeTypeForResource(filePath),
+        });
+      }
+    }
+
+    return { resources };
+  }
+
+  private async handleReadResource(uri: string): Promise<ReadResourceResult> {
+    const { kbName, relativePath } = parseKnowledgeBaseResourceUri(uri);
+    const filePath = await resolveKnowledgeBaseDocumentPath(
+      KNOWLEDGE_BASES_ROOT_DIR,
+      kbName,
+      relativePath,
+    );
+    const mimeType = mimeTypeForResource(filePath);
+
+    if (mimeType === 'application/pdf') {
+      const blob = (await fsp.readFile(filePath)).toString('base64');
+      return {
+        contents: [{ uri, mimeType, blob }],
+      };
+    }
+
+    const text = await fsp.readFile(filePath, 'utf-8');
+    return {
+      contents: [{ uri, mimeType, text }],
+    };
   }
 
   /**

--- a/src/kb-fs.ts
+++ b/src/kb-fs.ts
@@ -5,6 +5,8 @@
 // envelope.
 
 import * as fsp from 'fs/promises';
+import * as path from 'path';
+import { assertValidKbName } from './utils.js';
 
 /**
  * Returns the names of available knowledge bases under `rootDir` (one per
@@ -18,4 +20,71 @@ import * as fsp from 'fs/promises';
 export async function listKnowledgeBases(rootDir: string): Promise<string[]> {
   const entries = await fsp.readdir(rootDir);
   return entries.filter((entry) => !entry.startsWith('.'));
+}
+
+function assertPathInsideKb(kbRoot: string, resolvedPath: string, originalPath: string): void {
+  const relative = path.relative(kbRoot, resolvedPath);
+  if (relative === '' || relative.startsWith('..') || path.isAbsolute(relative)) {
+    throw new Error(`path escapes KB root: ${JSON.stringify(originalPath)}`);
+  }
+}
+
+/**
+ * Resolves a KB-relative document path under `<rootDir>/<kbName>/` and
+ * verifies the final filesystem target remains inside that KB directory.
+ *
+ * The guard is both lexical (before touching the candidate) and realpath
+ * based (after following symlinks), so `../`, absolute-path payloads, and
+ * symlinks that point outside the KB are refused.
+ */
+export async function resolveKnowledgeBaseDocumentPath(
+  rootDir: string,
+  kbName: string,
+  relativePath: string,
+): Promise<string> {
+  assertValidKbName(kbName);
+
+  if (relativePath.length === 0) {
+    throw new Error('kb:// URI requires a non-empty resource path');
+  }
+  if (relativePath.includes('\0')) {
+    throw new Error('path contains null byte');
+  }
+
+  const normalizedRelative = relativePath.replace(/\\/g, '/');
+  if (path.posix.isAbsolute(normalizedRelative)) {
+    throw new Error(`path escapes KB root: ${JSON.stringify(relativePath)}`);
+  }
+
+  const posixNormalized = path.posix.normalize(normalizedRelative);
+  if (posixNormalized.split('/').some((segment) => segment === '..')) {
+    throw new Error(`path escapes KB root: ${JSON.stringify(relativePath)}`);
+  }
+
+  const kbRoot = path.resolve(rootDir, kbName);
+  let kbRootReal: string;
+  try {
+    kbRootReal = await fsp.realpath(kbRoot);
+  } catch (error: unknown) {
+    const code = (error as NodeJS.ErrnoException | undefined)?.code;
+    if (code === 'ENOENT' || code === 'ENOTDIR') {
+      throw new Error(`knowledge base not found: ${JSON.stringify(kbName)}`);
+    }
+    throw error;
+  }
+
+  const lexicalCandidate = path.resolve(kbRootReal, normalizedRelative);
+  assertPathInsideKb(kbRootReal, lexicalCandidate, relativePath);
+
+  try {
+    const realCandidate = await fsp.realpath(lexicalCandidate);
+    assertPathInsideKb(kbRootReal, realCandidate, relativePath);
+    return realCandidate;
+  } catch (error: unknown) {
+    const code = (error as NodeJS.ErrnoException | undefined)?.code;
+    if (code === 'ENOENT' || code === 'ENOTDIR') {
+      throw new Error(`path not found: ${JSON.stringify(relativePath)}`);
+    }
+    throw error;
+  }
 }


### PR DESCRIPTION
Closes #49.

## Summary
- Adds MCP `resources/list` and `resources/read` handlers for `kb://<kb-name>/<relative-path>` document URIs.
- Lists files across KBs with dot-prefixed paths excluded and MIME types for markdown, text, PDF, and HTML.
- Reads text resources as `text` and PDFs as base64 `blob` content.
- Adds `resolveKnowledgeBaseDocumentPath` in `src/kb-fs.ts` with lexical and realpath traversal protection.
- Adds Jest coverage for listing, markdown reads, PDF blobs, missing files, traversal payloads, and dot-prefix exclusions.

## Design notes
- I used explicit MCP request handlers instead of the SDK `ResourceTemplate` helper because the helper normalizes `new URL(request.params.uri)` before invoking callbacks. Explicit handlers preserve the raw URI long enough to reject `../` and encoded traversal attempts clearly.

## Test plan
- [x] `npm run build`
- [x] `npm test`
- [x] Confirmed staged files were limited to `CHANGELOG.md`, `src/KnowledgeBaseServer.ts`, `src/KnowledgeBaseServer.test.ts`, and `src/kb-fs.ts`.