### PR TITLE
feat(mcp): add ingest tools (add_document, delete_document, reindex_knowledge_base)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
-## [Unreleased] — MCP Resources for KB documents
+## [Unreleased] — MCP ingest tools
 
 ### Added
 
-- **Knowledge-base files are now exposed as MCP Resources.** Clients that browse resources can list documents as `kb://<kb-name>/<relative-path>` and read the selected file directly. Markdown, text, HTML, and unknown text-like files return text content; PDFs return base64 blobs with `application/pdf`. Resource listing uses the same recursive dot-prefix skip behavior as indexing, so `.faiss`, `.index`, `.reindex-trigger`, and other hidden paths stay off the wire. Path resolution is guarded against `../`, absolute paths, encoded separator payloads, and symlinks that leave the KB root. Closes #49.
+- **New MCP ingest tools:** `add_document`, `delete_document`, and `reindex_knowledge_base`. Agents can now write UTF-8 content into a KB, delete KB files plus their hash sidecars, and force re-indexing through the MCP surface without shell access. All writes resolve KB-relative paths defensively, reject traversal, and run under the active model's write lock. `add_document` updates the index synchronously so newly written content is queryable immediately. `delete_document` documents the FAISS limitation: orphan vectors can remain until a full rebuild, so run `reindex_knowledge_base` after deletes when vector hygiene matters. `reindex_knowledge_base` always rebuilds the FAISS store globally — passing `knowledge_base_name` is accepted (and echoed in the response) but does not narrow the rebuild scope, because FAISS lacks per-vector deletion in this server; the response advertises `scope: "global"` so callers know what happened. Closes #51.
 
 ## [Unreleased] — PDF and HTML loaders behind extension-based routing
 

--- a/src/FaissIndexManager.test.ts
+++ b/src/FaissIndexManager.test.ts
@@ -423,6 +423,59 @@ describe('FaissIndexManager permission handling', () => {
     expect(logContents).toContain('Permission denied while attempting to save FAISS index for model');
   });
 
+  it('upgrades a scoped force-reindex to a global rebuild so deletions are honored without duplicates (#51 P1)', async () => {
+    // Setup: two KBs (alpha, beta), each with one file. Initial updateIndex
+    // builds the global FAISS index; both files land in the store.
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-faiss-scoped-force-'));
+    const kbDir = path.join(tempDir, 'kb');
+    const alphaDir = path.join(kbDir, 'alpha');
+    const betaDir = path.join(kbDir, 'beta');
+    await fsp.mkdir(alphaDir, { recursive: true });
+    await fsp.mkdir(betaDir, { recursive: true });
+    await fsp.writeFile(path.join(alphaDir, 'a.md'), '# alpha doc\n\nAlpha content.');
+    await fsp.writeFile(path.join(betaDir, 'b.md'), '# beta doc\n\nBeta content.');
+
+    process.env.KNOWLEDGE_BASES_ROOT_DIR = kbDir;
+    process.env.FAISS_INDEX_PATH = path.join(tempDir, '.faiss');
+    process.env.EMBEDDING_PROVIDER = 'huggingface';
+    process.env.HUGGINGFACE_API_KEY = 'test-key';
+
+    jest.resetModules();
+    const { FaissIndexManager } = await import('./FaissIndexManager.js');
+    const manager = new FaissIndexManager();
+    await manager.initialize();
+    await manager.updateIndex();
+
+    // Initial build: one fromTexts() seeds the store with alpha's file,
+    // beta's file goes through addDocuments(). Total ingested = 2 files.
+    expect(fromTextsMock).toHaveBeenCalledTimes(1);
+    const initialAdds = addDocumentsMock.mock.calls.length;
+    fromTextsMock.mockClear();
+    addDocumentsMock.mockClear();
+
+    // Action: caller scopes a forced reindex to "alpha". The bug we are
+    // fixing: this would keep the existing store and only re-embed alpha,
+    // appending duplicates while leaving any orphaned vectors alive. The
+    // fix nulls the in-memory store and walks ALL KBs.
+    await manager.updateIndex('alpha', { force: true });
+
+    // After fix: the in-memory store was nulled, so the rebuild starts
+    // with fromTexts() again, and BOTH KBs' files are re-ingested.
+    expect(fromTextsMock).toHaveBeenCalledTimes(1);
+    // Both alpha (1 file) and beta (1 file) re-embedded — minus the seed
+    // file that fromTexts consumes. So addDocuments runs once for the
+    // remaining file.
+    const rebuildAdds = addDocumentsMock.mock.calls.length;
+    expect(rebuildAdds).toBe(initialAdds);
+
+    // The KB hash sidecars must reflect the rebuild — both files have
+    // up-to-date sidecars now.
+    const alphaSidecar = path.join(alphaDir, '.index', 'a.md');
+    const betaSidecar = path.join(betaDir, '.index', 'b.md');
+    await expect(fsp.readFile(alphaSidecar, 'utf-8')).resolves.toMatch(/^[0-9a-f]{64}$/);
+    await expect(fsp.readFile(betaSidecar, 'utf-8')).resolves.toMatch(/^[0-9a-f]{64}$/);
+  });
+
   it('saves the FAISS index exactly once per updateIndex call when multiple files change', async () => {
     const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-faiss-save-once-'));
     const kbDir = path.join(tempDir, 'kb');

--- a/src/FaissIndexManager.ts
+++ b/src/FaissIndexManager.ts
@@ -540,6 +540,7 @@ export interface IndexUpdateProgress {
 export interface UpdateIndexOptions {
   onProgress?: (progress: IndexUpdateProgress) => void | Promise<void>;
   progressIntervalFiles?: number;
+  force?: boolean;
 }
 
 export class FaissIndexManager {
@@ -1171,6 +1172,13 @@ export class FaissIndexManager {
   ): Promise<void> {
     logger.debug('Updating FAISS index...');
     try {
+      const forceReindex = opts.force === true;
+      if (forceReindex && specificKnowledgeBase === undefined) {
+        // A global forced reindex is the only shape that can clean orphaned
+        // vectors from deleted files in the single global FAISS store.
+        this.faissIndex = null;
+      }
+
       let knowledgeBases: string[] = [];
       if (specificKnowledgeBase) {
         knowledgeBases.push(specificKnowledgeBase);
@@ -1264,10 +1272,12 @@ export class FaissIndexManager {
           // process it. The missing-index case must ignore matching sidecars:
           // otherwise a rebuild can silently omit files whose hashes were
           // already current.
-          if (rebuildFromEmptyIndex || fileHash !== storedHash) {
+          if (rebuildFromEmptyIndex || forceReindex || fileHash !== storedHash) {
             logger.info(
               rebuildFromEmptyIndex
                 ? `FAISS index is empty. Rebuilding from ${filePath}...`
+                : forceReindex
+                  ? `Force re-indexing ${filePath}...`
                 : `File ${filePath} has changed. Updating index...`,
             );
             // Issue #46 — extension-routed loader. `.pdf` runs through

--- a/src/FaissIndexManager.ts
+++ b/src/FaissIndexManager.ts
@@ -1173,15 +1173,33 @@ export class FaissIndexManager {
     logger.debug('Updating FAISS index...');
     try {
       const forceReindex = opts.force === true;
-      if (forceReindex && specificKnowledgeBase === undefined) {
-        // A global forced reindex is the only shape that can clean orphaned
-        // vectors from deleted files in the single global FAISS store.
+      // FAISS has no per-vector delete API and we keep one global store
+      // across all KBs. So a forced rebuild MUST null the in-memory index
+      // AND walk every KB. A scoped force ("rebuild just KB alpha") would
+      // either:
+      //   (a) keep the existing store and append fresh embeddings, leaving
+      //       orphaned vectors from deleted files alive AND duplicating
+      //       every still-present file, or
+      //   (b) build a fresh store containing only the scoped KB's vectors,
+      //       silently dropping every other KB.
+      // Both are wrong. Treat scope as advisory under force: log the
+      // upgrade and rebuild globally.
+      let scopedKnowledgeBase = specificKnowledgeBase;
+      if (forceReindex) {
         this.faissIndex = null;
+        if (scopedKnowledgeBase !== undefined) {
+          logger.info(
+            `Forced reindex of "${scopedKnowledgeBase}" upgraded to a global rebuild ` +
+              `(FAISS deletion is unsupported; scoped rebuild would either duplicate ` +
+              `vectors or drop other KBs).`,
+          );
+          scopedKnowledgeBase = undefined;
+        }
       }
 
       let knowledgeBases: string[] = [];
-      if (specificKnowledgeBase) {
-        knowledgeBases.push(specificKnowledgeBase);
+      if (scopedKnowledgeBase) {
+        knowledgeBases.push(scopedKnowledgeBase);
       } else {
         knowledgeBases = await fsp.readdir(KNOWLEDGE_BASES_ROOT_DIR);
       }

--- a/src/KnowledgeBaseServer.test.ts
+++ b/src/KnowledgeBaseServer.test.ts
@@ -521,7 +521,10 @@ describe('KnowledgeBaseServer handlers', () => {
     expect(result.isError).toBeUndefined();
     expect(updateIndexMock).toHaveBeenCalledWith('alpha', { force: true });
     const payload = JSON.parse(result.content[0].text);
-    expect(payload).toEqual({ knowledge_base_name: 'alpha', reindexed: true });
+    // The rebuild always covers every KB (FAISS has no per-vector delete),
+    // so the response advertises scope: 'global' even when a KB name was
+    // passed. The KB name is preserved as a caller-provided echo.
+    expect(payload).toEqual({ knowledge_base_name: 'alpha', reindexed: true, scope: 'global' });
   });
 
   it('handleReindexKnowledgeBase forces a global update when no KB is named', async () => {
@@ -534,7 +537,7 @@ describe('KnowledgeBaseServer handlers', () => {
     expect(result.isError).toBeUndefined();
     expect(updateIndexMock).toHaveBeenCalledWith(undefined, { force: true });
     const payload = JSON.parse(result.content[0].text);
-    expect(payload).toEqual({ knowledge_base_name: null, reindexed: true });
+    expect(payload).toEqual({ knowledge_base_name: null, reindexed: true, scope: 'global' });
   });
 
   it('handleReindexKnowledgeBase rejects path-like KB names', async () => {

--- a/src/KnowledgeBaseServer.test.ts
+++ b/src/KnowledgeBaseServer.test.ts
@@ -109,6 +109,19 @@ describe('KnowledgeBaseServer handlers', () => {
     return new KnowledgeBaseServer();
   }
 
+  async function exists(target: string): Promise<boolean> {
+    try {
+      await fsp.stat(target);
+      return true;
+    } catch (error: unknown) {
+      const code = (error as NodeJS.ErrnoException | undefined)?.code;
+      if (code === 'ENOENT' || code === 'ENOTDIR') {
+        return false;
+      }
+      throw error;
+    }
+  }
+
   // --- handleListKnowledgeBases ---------------------------------------------
 
   it('handleListKnowledgeBases returns filtered (dot-free) entries', async () => {
@@ -367,6 +380,189 @@ describe('KnowledgeBaseServer handlers', () => {
     expect(payload.knowledge_bases.alpha.last_updated_at).toBe(
       new Date(fixedMs).toISOString(),
     );
+  });
+
+  // --- ingest tools (#51) ---------------------------------------------------
+
+  it('handleAddDocument writes content and updates that KB immediately', async () => {
+    const tempDir = await setRetrieveEnv();
+    await fsp.mkdir(path.join(tempDir, 'alpha'));
+    updateIndexMock.mockResolvedValue(undefined);
+
+    const server = await freshServer();
+    const result = await server['handleAddDocument']({
+      knowledge_base_name: 'alpha',
+      path: 'notes/new.md',
+      content: '# New note\n\nHello ingest.',
+    });
+
+    expect(result.isError).toBeUndefined();
+    const documentPath = path.join(tempDir, 'alpha', 'notes', 'new.md');
+    await expect(fsp.readFile(documentPath, 'utf-8')).resolves.toBe('# New note\n\nHello ingest.');
+    expect(updateIndexMock).toHaveBeenCalledWith('alpha');
+    const payload = JSON.parse(result.content[0].text);
+    expect(payload).toMatchObject({
+      knowledge_base_name: 'alpha',
+      path: 'notes/new.md',
+      absolute_path: documentPath,
+      indexed: true,
+    });
+  });
+
+  it('handleAddDocument rejects path traversal and does not update the index', async () => {
+    const tempDir = await setRetrieveEnv();
+    await fsp.mkdir(path.join(tempDir, 'alpha'));
+
+    const server = await freshServer();
+    const result = await server['handleAddDocument']({
+      knowledge_base_name: 'alpha',
+      path: '../escape.md',
+      content: 'nope',
+    });
+
+    expect(result.isError).toBe(true);
+    const payload = JSON.parse(result.content[0].text);
+    expect(payload.error.code).toBe('VALIDATION');
+    expect(payload.error.message).toContain('escapes KB root');
+    await expect(exists(path.join(tempDir, 'escape.md'))).resolves.toBe(false);
+    expect(updateIndexMock).not.toHaveBeenCalled();
+  });
+
+  it('handleAddDocument returns KB_NOT_FOUND for a missing KB', async () => {
+    await setRetrieveEnv();
+
+    const server = await freshServer();
+    const result = await server['handleAddDocument']({
+      knowledge_base_name: 'missing',
+      path: 'doc.md',
+      content: 'nope',
+    });
+
+    expect(result.isError).toBe(true);
+    const payload = JSON.parse(result.content[0].text);
+    expect(payload.error.code).toBe('KB_NOT_FOUND');
+    expect(updateIndexMock).not.toHaveBeenCalled();
+  });
+
+  it('handleDeleteDocument removes the file and hash sidecar without re-indexing', async () => {
+    const tempDir = await setRetrieveEnv();
+    const documentPath = path.join(tempDir, 'alpha', 'notes', 'old.md');
+    const sidecarPath = path.join(tempDir, 'alpha', '.index', 'notes', 'old.md');
+    await fsp.mkdir(path.dirname(documentPath), { recursive: true });
+    await fsp.mkdir(path.dirname(sidecarPath), { recursive: true });
+    await fsp.writeFile(documentPath, 'old');
+    await fsp.writeFile(sidecarPath, 'hash');
+
+    const server = await freshServer();
+    const result = await server['handleDeleteDocument']({
+      knowledge_base_name: 'alpha',
+      path: 'notes/old.md',
+    });
+
+    expect(result.isError).toBeUndefined();
+    await expect(exists(documentPath)).resolves.toBe(false);
+    await expect(exists(sidecarPath)).resolves.toBe(false);
+    expect(updateIndexMock).not.toHaveBeenCalled();
+    const payload = JSON.parse(result.content[0].text);
+    expect(payload).toMatchObject({
+      knowledge_base_name: 'alpha',
+      path: 'notes/old.md',
+      absolute_path: documentPath,
+      sidecar_path: sidecarPath,
+      deleted: true,
+    });
+  });
+
+  it('handleDeleteDocument rejects path traversal and leaves files intact', async () => {
+    const tempDir = await setRetrieveEnv();
+    await fsp.mkdir(path.join(tempDir, 'alpha'));
+    const siblingPath = path.join(tempDir, 'escape.md');
+    await fsp.writeFile(siblingPath, 'keep');
+
+    const server = await freshServer();
+    const result = await server['handleDeleteDocument']({
+      knowledge_base_name: 'alpha',
+      path: '../escape.md',
+    });
+
+    expect(result.isError).toBe(true);
+    const payload = JSON.parse(result.content[0].text);
+    expect(payload.error.code).toBe('VALIDATION');
+    expect(payload.error.message).toContain('escapes KB root');
+    await expect(fsp.readFile(siblingPath, 'utf-8')).resolves.toBe('keep');
+    expect(updateIndexMock).not.toHaveBeenCalled();
+  });
+
+  it('handleDeleteDocument returns KB_NOT_FOUND for a missing KB', async () => {
+    await setRetrieveEnv();
+
+    const server = await freshServer();
+    const result = await server['handleDeleteDocument']({
+      knowledge_base_name: 'missing',
+      path: 'doc.md',
+    });
+
+    expect(result.isError).toBe(true);
+    const payload = JSON.parse(result.content[0].text);
+    expect(payload.error.code).toBe('KB_NOT_FOUND');
+    expect(updateIndexMock).not.toHaveBeenCalled();
+  });
+
+  it('handleReindexKnowledgeBase forces a scoped KB update', async () => {
+    const tempDir = await setRetrieveEnv();
+    await fsp.mkdir(path.join(tempDir, 'alpha'));
+    updateIndexMock.mockResolvedValue(undefined);
+
+    const server = await freshServer();
+    const result = await server['handleReindexKnowledgeBase']({
+      knowledge_base_name: 'alpha',
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(updateIndexMock).toHaveBeenCalledWith('alpha', { force: true });
+    const payload = JSON.parse(result.content[0].text);
+    expect(payload).toEqual({ knowledge_base_name: 'alpha', reindexed: true });
+  });
+
+  it('handleReindexKnowledgeBase forces a global update when no KB is named', async () => {
+    await setRetrieveEnv();
+    updateIndexMock.mockResolvedValue(undefined);
+
+    const server = await freshServer();
+    const result = await server['handleReindexKnowledgeBase']({});
+
+    expect(result.isError).toBeUndefined();
+    expect(updateIndexMock).toHaveBeenCalledWith(undefined, { force: true });
+    const payload = JSON.parse(result.content[0].text);
+    expect(payload).toEqual({ knowledge_base_name: null, reindexed: true });
+  });
+
+  it('handleReindexKnowledgeBase rejects path-like KB names', async () => {
+    await setRetrieveEnv();
+
+    const server = await freshServer();
+    const result = await server['handleReindexKnowledgeBase']({
+      knowledge_base_name: '../alpha',
+    });
+
+    expect(result.isError).toBe(true);
+    const payload = JSON.parse(result.content[0].text);
+    expect(payload.error.code).toBe('KB_NOT_FOUND');
+    expect(updateIndexMock).not.toHaveBeenCalled();
+  });
+
+  it('handleReindexKnowledgeBase returns KB_NOT_FOUND for a missing KB', async () => {
+    await setRetrieveEnv();
+
+    const server = await freshServer();
+    const result = await server['handleReindexKnowledgeBase']({
+      knowledge_base_name: 'missing',
+    });
+
+    expect(result.isError).toBe(true);
+    const payload = JSON.parse(result.content[0].text);
+    expect(payload.error.code).toBe('KB_NOT_FOUND');
+    expect(updateIndexMock).not.toHaveBeenCalled();
   });
 
   it('handleListKnowledgeBases surfaces readdir errors as { isError: true } naming the failure', async () => {
@@ -954,6 +1150,8 @@ describe('KnowledgeBaseServer handlers', () => {
     expect(describeOf(server, 'retrieve_knowledge')).toBe(
       'Retrieves similar chunks from the knowledge base based on a query. Optionally, if a knowledge base is specified, only that one is searched; otherwise, all available knowledge bases are considered. By default, at most 10 documents are returned with a score below a threshold of 2. A different threshold can optionally be provided.'
     );
+    expect(describeOf(server, 'delete_document')).toContain('FAISS does not support vector deletion');
+    expect(describeOf(server, 'delete_document')).toContain('orphan vectors');
   });
 
   it('RETRIEVE_KNOWLEDGE_DESCRIPTION overrides only the retrieve_knowledge description', async () => {

--- a/src/KnowledgeBaseServer.ts
+++ b/src/KnowledgeBaseServer.ts
@@ -24,6 +24,8 @@ import {
 } from './active-model.js';
 import type { EmbeddingProvider } from './model-id.js';
 import {
+  ADD_DOCUMENT_DESCRIPTION,
+  DELETE_DOCUMENT_DESCRIPTION,
   FAISS_INDEX_PATH,
   FRONTMATTER_EXTRAS_WIRE_VISIBLE,
   INGEST_EXCLUDE_PATHS,
@@ -33,6 +35,7 @@ import {
   LIST_KNOWLEDGE_BASES_DESCRIPTION,
   LIST_MODELS_DESCRIPTION,
   loadTransportConfig,
+  REINDEX_KNOWLEDGE_BASE_DESCRIPTION,
   REINDEX_TRIGGER_PATH,
   REINDEX_TRIGGER_POLL_MS,
   RETRIEVE_KNOWLEDGE_DESCRIPTION,
@@ -40,7 +43,12 @@ import {
   type TransportConfig,
 } from './config.js';
 import { formatRetrievalAsMarkdown, sanitizeMetadataForWire } from './formatter.js';
-import { listKnowledgeBases, resolveKnowledgeBaseDocumentPath } from './kb-fs.js';
+import {
+  listKnowledgeBases,
+  resolveKbRelativePath,
+  resolveKnowledgeBaseDir,
+  resolveKnowledgeBaseDocumentPath,
+} from './kb-fs.js';
 import { withWriteLock } from './write-lock.js';
 import { logger } from './logger.js';
 import { filterIngestablePaths, getFilesRecursively, isValidKbName, toError } from './utils.js';
@@ -305,6 +313,39 @@ export class KnowledgeBaseServer {
       },
       async (args) => this.handleKbStats(args)
     );
+
+    mcp.tool(
+      'add_document',
+      ADD_DOCUMENT_DESCRIPTION,
+      {
+        knowledge_base_name: z.string().describe('The name of the knowledge base to write into.'),
+        path: z.string().describe('KB-relative document path to create or overwrite. Parent directories are created as needed.'),
+        content: z.string().describe('UTF-8 text content to write.'),
+      },
+      async (args) => this.handleAddDocument(args)
+    );
+
+    mcp.tool(
+      'delete_document',
+      DELETE_DOCUMENT_DESCRIPTION,
+      {
+        knowledge_base_name: z.string().describe('The name of the knowledge base to delete from.'),
+        path: z.string().describe('KB-relative document path to delete.'),
+      },
+      async (args) => this.handleDeleteDocument(args)
+    );
+
+    mcp.tool(
+      'reindex_knowledge_base',
+      REINDEX_KNOWLEDGE_BASE_DESCRIPTION,
+      {
+        knowledge_base_name: z
+          .string()
+          .optional()
+          .describe('Name of a single KB to force re-index. If omitted, every registered KB is re-indexed.'),
+      },
+      async (args) => this.handleReindexKnowledgeBase(args)
+    );
   }
 
   private registerResources(mcp: McpServer): void {
@@ -526,6 +567,143 @@ export class KnowledgeBaseServer {
     } catch (error: unknown) {
       const err = toError(error);
       logger.error('Error computing kb_stats:', err);
+      if (err.stack) {
+        logger.error(err.stack);
+      }
+      return { content: [mcpErrorContent(err)], isError: true };
+    }
+  }
+
+  private async getActiveManagerForMutation(): Promise<FaissIndexManager> {
+    const activeModelId = await resolveActiveModel();
+    return this.getManagerFor(activeModelId);
+  }
+
+  private async handleAddDocument(args: {
+    knowledge_base_name: string;
+    path: string;
+    content: string;
+  }): Promise<CallToolResult> {
+    try {
+      const manager = await this.getActiveManagerForMutation();
+      let documentPath = '';
+      await withWriteLock(manager.modelDir, async () => {
+        documentPath = await resolveKbRelativePath(
+          KNOWLEDGE_BASES_ROOT_DIR,
+          args.knowledge_base_name,
+          args.path,
+        );
+        await fsp.mkdir(path.dirname(documentPath), { recursive: true });
+        await fsp.writeFile(documentPath, args.content, 'utf-8');
+        await manager.updateIndex(args.knowledge_base_name);
+      });
+
+      return {
+        content: [{
+          type: 'text',
+          text: JSON.stringify({
+            knowledge_base_name: args.knowledge_base_name,
+            path: args.path,
+            absolute_path: documentPath,
+            indexed: true,
+          }, null, 2),
+        }],
+      };
+    } catch (error: unknown) {
+      if (error instanceof ActiveModelResolutionError) {
+        return { content: [{ type: 'text', text: error.message }], isError: true };
+      }
+      const err = toError(error);
+      logger.error('Error adding document:', err);
+      if (err.stack) {
+        logger.error(err.stack);
+      }
+      return { content: [mcpErrorContent(err)], isError: true };
+    }
+  }
+
+  private async handleDeleteDocument(args: {
+    knowledge_base_name: string;
+    path: string;
+  }): Promise<CallToolResult> {
+    try {
+      const manager = await this.getActiveManagerForMutation();
+      let documentPath = '';
+      let sidecarPath = '';
+      await withWriteLock(manager.modelDir, async () => {
+        const kbDir = await resolveKnowledgeBaseDir(
+          KNOWLEDGE_BASES_ROOT_DIR,
+          args.knowledge_base_name,
+        );
+        documentPath = await resolveKbRelativePath(
+          KNOWLEDGE_BASES_ROOT_DIR,
+          args.knowledge_base_name,
+          args.path,
+        );
+        const relativePath = path.relative(kbDir, documentPath);
+        sidecarPath = path.join(
+          kbDir,
+          '.index',
+          path.dirname(relativePath),
+          path.basename(relativePath),
+        );
+        await fsp.rm(documentPath);
+        await fsp.rm(sidecarPath, { force: true });
+      });
+
+      return {
+        content: [{
+          type: 'text',
+          text: JSON.stringify({
+            knowledge_base_name: args.knowledge_base_name,
+            path: args.path,
+            absolute_path: documentPath,
+            sidecar_path: sidecarPath,
+            deleted: true,
+            faiss_orphan_vectors: 'Orphan vectors may persist until a full reindex_knowledge_base rebuild.',
+          }, null, 2),
+        }],
+      };
+    } catch (error: unknown) {
+      if (error instanceof ActiveModelResolutionError) {
+        return { content: [{ type: 'text', text: error.message }], isError: true };
+      }
+      const err = toError(error);
+      logger.error('Error deleting document:', err);
+      if (err.stack) {
+        logger.error(err.stack);
+      }
+      return { content: [mcpErrorContent(err)], isError: true };
+    }
+  }
+
+  private async handleReindexKnowledgeBase(args: {
+    knowledge_base_name?: string;
+  }): Promise<CallToolResult> {
+    try {
+      const manager = await this.getActiveManagerForMutation();
+      await withWriteLock(manager.modelDir, async () => {
+        if (args.knowledge_base_name !== undefined) {
+          await resolveKnowledgeBaseDir(KNOWLEDGE_BASES_ROOT_DIR, args.knowledge_base_name);
+        }
+        await manager.updateIndex(args.knowledge_base_name, { force: true });
+      });
+
+      return {
+        content: [{
+          type: 'text',
+          text: JSON.stringify({
+            knowledge_base_name: args.knowledge_base_name ?? null,
+            reindexed: true,
+          }, null, 2),
+        }],
+      };
+    } catch (error: unknown) {
+      if (error instanceof ActiveModelResolutionError) {
+        return { content: [{ type: 'text', text: error.message }], isError: true };
+      }
+      const err = toError(error);
+      logger.error('Error re-indexing knowledge base:', err);
       if (err.stack) {
         logger.error(err.stack);
       }

--- a/src/KnowledgeBaseServer.ts
+++ b/src/KnowledgeBaseServer.ts
@@ -695,6 +695,9 @@ export class KnowledgeBaseServer {
           text: JSON.stringify({
             knowledge_base_name: args.knowledge_base_name ?? null,
             reindexed: true,
+            // FAISS has no per-vector deletion in this server, so every
+            // forced rebuild covers all KBs (see FaissIndexManager.updateIndex).
+            scope: 'global',
           }, null, 2),
         }],
       };

--- a/src/config.ts
+++ b/src/config.ts
@@ -162,6 +162,16 @@ export const KB_STATS_DESCRIPTION =
     ? process.env.KB_STATS_DESCRIPTION
     : DEFAULT_KB_STATS_DESCRIPTION;
 
+// Issue #51 — MCP ingest tools.
+export const ADD_DOCUMENT_DESCRIPTION =
+  'Adds or overwrites a UTF-8 document in a knowledge base, creating parent directories as needed, then updates the active model index so the new content is queryable immediately.';
+
+export const DELETE_DOCUMENT_DESCRIPTION =
+  'DESTRUCTIVE: Deletes a document from a knowledge base and removes its hash sidecar. FAISS does not support vector deletion in this server, so orphan vectors for the removed file persist until a full rebuild; run reindex_knowledge_base after deletes if vector hygiene matters.';
+
+export const REINDEX_KNOWLEDGE_BASE_DESCRIPTION =
+  'Forces the active model to re-index a knowledge base. Pass knowledge_base_name to reindex one KB, or omit it to reindex all KBs.';
+
 // ---------------------------------------------------------------------------
 // Transport configuration (RFC 008 stage 1: stdio + SSE).
 // ---------------------------------------------------------------------------

--- a/src/config.ts
+++ b/src/config.ts
@@ -170,7 +170,7 @@ export const DELETE_DOCUMENT_DESCRIPTION =
   'DESTRUCTIVE: Deletes a document from a knowledge base and removes its hash sidecar. FAISS does not support vector deletion in this server, so orphan vectors for the removed file persist until a full rebuild; run reindex_knowledge_base after deletes if vector hygiene matters.';
 
 export const REINDEX_KNOWLEDGE_BASE_DESCRIPTION =
-  'Forces the active model to re-index a knowledge base. Pass knowledge_base_name to reindex one KB, or omit it to reindex all KBs.';
+  'Forces the active model to fully rebuild its FAISS index from on-disk files, replacing the in-memory store and clearing orphan vectors left behind by prior delete_document calls. The rebuild always covers every KB because FAISS lacks per-vector deletion; passing knowledge_base_name is accepted (and recorded in the response) but does not narrow the rebuild scope.';
 
 // ---------------------------------------------------------------------------
 // Transport configuration (RFC 008 stage 1: stdio + SSE).

--- a/src/kb-fs.ts
+++ b/src/kb-fs.ts
@@ -7,6 +7,7 @@
 import * as fsp from 'fs/promises';
 import * as path from 'path';
 import { assertValidKbName } from './utils.js';
+import { KBError } from './errors.js';
 
 /**
  * Returns the names of available knowledge bases under `rootDir` (one per
@@ -22,10 +23,24 @@ export async function listKnowledgeBases(rootDir: string): Promise<string[]> {
   return entries.filter((entry) => !entry.startsWith('.'));
 }
 
-function assertPathInsideKb(kbRoot: string, resolvedPath: string, originalPath: string): void {
-  const relative = path.relative(kbRoot, resolvedPath);
-  if (relative === '' || relative.startsWith('..') || path.isAbsolute(relative)) {
-    throw new Error(`path escapes KB root: ${JSON.stringify(originalPath)}`);
+function hasPathSeparator(value: string): boolean {
+  return value.includes('/') || value.includes('\\');
+}
+
+function isInsideOrEqual(root: string, candidate: string): boolean {
+  const prefix = root.endsWith(path.sep) ? root : `${root}${path.sep}`;
+  return candidate === root || candidate.startsWith(prefix);
+}
+
+async function realpathIfExists(target: string): Promise<string | null> {
+  try {
+    return await fsp.realpath(target);
+  } catch (error: unknown) {
+    const code = (error as NodeJS.ErrnoException | undefined)?.code;
+    if (code === 'ENOENT' || code === 'ENOTDIR') {
+      return null;
+    }
+    throw error;
   }
 }
 
@@ -36,6 +51,10 @@ function assertPathInsideKb(kbRoot: string, resolvedPath: string, originalPath: 
  * The guard is both lexical (before touching the candidate) and realpath
  * based (after following symlinks), so `../`, absolute-path payloads, and
  * symlinks that point outside the KB are refused.
+ *
+ * Used by the MCP `resources/read` handler (kb:// URIs). Requires the
+ * resolved file to exist — throws "path not found" otherwise. For ingest
+ * tools that may target a not-yet-created file, see `resolveKbRelativePath`.
  */
 export async function resolveKnowledgeBaseDocumentPath(
   rootDir: string,
@@ -62,29 +81,165 @@ export async function resolveKnowledgeBaseDocumentPath(
   }
 
   const kbRoot = path.resolve(rootDir, kbName);
-  let kbRootReal: string;
-  try {
-    kbRootReal = await fsp.realpath(kbRoot);
-  } catch (error: unknown) {
-    const code = (error as NodeJS.ErrnoException | undefined)?.code;
-    if (code === 'ENOENT' || code === 'ENOTDIR') {
-      throw new Error(`knowledge base not found: ${JSON.stringify(kbName)}`);
-    }
-    throw error;
+  const kbRootReal = await realpathIfExists(kbRoot);
+  if (kbRootReal === null) {
+    throw new Error(`knowledge base not found: ${JSON.stringify(kbName)}`);
   }
 
   const lexicalCandidate = path.resolve(kbRootReal, normalizedRelative);
-  assertPathInsideKb(kbRootReal, lexicalCandidate, relativePath);
+  if (!isInsideOrEqual(kbRootReal, lexicalCandidate)) {
+    throw new Error(`path escapes KB root: ${JSON.stringify(relativePath)}`);
+  }
 
+  const realCandidate = await realpathIfExists(lexicalCandidate);
+  if (realCandidate === null) {
+    throw new Error(`path not found: ${JSON.stringify(relativePath)}`);
+  }
+  if (!isInsideOrEqual(kbRootReal, realCandidate)) {
+    throw new Error(`path escapes KB root: ${JSON.stringify(relativePath)}`);
+  }
+  return realCandidate;
+}
+
+/**
+ * Resolve an existing, addressable KB directory below `rootDir`.
+ *
+ * The ingest tools deliberately treat dot-prefixed entries and path-like KB
+ * names as not addressable. That keeps the write surface aligned with
+ * `listKnowledgeBases` and prevents a KB name from participating in path
+ * traversal before the document path helper runs.
+ */
+export async function resolveKnowledgeBaseDir(
+  rootDir: string,
+  knowledgeBaseName: string,
+): Promise<string> {
+  if (
+    knowledgeBaseName.length === 0 ||
+    knowledgeBaseName.startsWith('.') ||
+    knowledgeBaseName.includes('\0') ||
+    path.isAbsolute(knowledgeBaseName) ||
+    hasPathSeparator(knowledgeBaseName)
+  ) {
+    throw new KBError(
+      'KB_NOT_FOUND',
+      `Knowledge base "${knowledgeBaseName}" not found under ${rootDir}.`,
+    );
+  }
+
+  const rootReal = await realpathIfExists(rootDir);
+  if (rootReal === null) {
+    throw new KBError('KB_NOT_FOUND', `Knowledge base root ${rootDir} does not exist.`);
+  }
+
+  const kbDir = path.join(rootDir, knowledgeBaseName);
+  let stat;
   try {
-    const realCandidate = await fsp.realpath(lexicalCandidate);
-    assertPathInsideKb(kbRootReal, realCandidate, relativePath);
-    return realCandidate;
+    stat = await fsp.stat(kbDir);
   } catch (error: unknown) {
     const code = (error as NodeJS.ErrnoException | undefined)?.code;
     if (code === 'ENOENT' || code === 'ENOTDIR') {
-      throw new Error(`path not found: ${JSON.stringify(relativePath)}`);
+      throw new KBError(
+        'KB_NOT_FOUND',
+        `Knowledge base "${knowledgeBaseName}" not found under ${rootDir}.`,
+      );
     }
     throw error;
   }
+  if (!stat.isDirectory()) {
+    throw new KBError(
+      'KB_NOT_FOUND',
+      `Knowledge base "${knowledgeBaseName}" not found under ${rootDir}.`,
+    );
+  }
+
+  const kbReal = await fsp.realpath(kbDir);
+  if (!isInsideOrEqual(rootReal, kbReal)) {
+    throw new KBError(
+      'VALIDATION',
+      `Knowledge base "${knowledgeBaseName}" resolves outside ${rootDir}.`,
+    );
+  }
+  return kbDir;
+}
+
+/**
+ * Resolve a user-supplied KB-relative document path to an absolute path under
+ * `<rootDir>/<knowledgeBaseName>`.
+ *
+ * The final path may not exist yet (needed by add_document), but any existing
+ * ancestor, existing file, or existing symlink target must resolve under the
+ * KB root. `..` components are rejected lexically, even if normalization
+ * would bring the path back inside the KB.
+ */
+export async function resolveKbRelativePath(
+  rootDir: string,
+  knowledgeBaseName: string,
+  relativePath: string,
+): Promise<string> {
+  if (relativePath.length === 0) {
+    throw new KBError('VALIDATION', 'Document path must not be empty.');
+  }
+  if (relativePath.includes('\0')) {
+    throw new KBError('VALIDATION', 'Document path contains a null byte.');
+  }
+
+  const normalizedRelative = relativePath.replace(/\\/g, '/');
+  if (path.posix.isAbsolute(normalizedRelative)) {
+    throw new KBError(
+      'VALIDATION',
+      `Document path escapes KB root: ${JSON.stringify(relativePath)}.`,
+    );
+  }
+
+  const rawSegments = normalizedRelative.split('/').filter((segment) => segment.length > 0);
+  if (rawSegments.length === 0 || rawSegments.some((segment) => segment === '..')) {
+    throw new KBError(
+      'VALIDATION',
+      `Document path escapes KB root: ${JSON.stringify(relativePath)}.`,
+    );
+  }
+
+  const kbDir = await resolveKnowledgeBaseDir(rootDir, knowledgeBaseName);
+  const kbReal = await fsp.realpath(kbDir);
+  const normalizedSegments = path.posix.normalize(rawSegments.join('/')).split('/');
+  const candidate = path.resolve(kbDir, ...normalizedSegments);
+  if (!isInsideOrEqual(path.resolve(kbDir), candidate)) {
+    throw new KBError(
+      'VALIDATION',
+      `Document path escapes KB root: ${JSON.stringify(relativePath)}.`,
+    );
+  }
+
+  const existingTarget = await realpathIfExists(candidate);
+  if (existingTarget !== null) {
+    if (!isInsideOrEqual(kbReal, existingTarget)) {
+      throw new KBError(
+        'VALIDATION',
+        `Document path escapes KB root: ${JSON.stringify(relativePath)}.`,
+      );
+    }
+    return candidate;
+  }
+
+  let existingAncestor = path.dirname(candidate);
+  while (!(await realpathIfExists(existingAncestor))) {
+    const parent = path.dirname(existingAncestor);
+    if (parent === existingAncestor) {
+      throw new KBError(
+        'VALIDATION',
+        `Document path escapes KB root: ${JSON.stringify(relativePath)}.`,
+      );
+    }
+    existingAncestor = parent;
+  }
+
+  const ancestorReal = await fsp.realpath(existingAncestor);
+  if (!isInsideOrEqual(kbReal, ancestorReal)) {
+    throw new KBError(
+      'VALIDATION',
+      `Document path escapes KB root: ${JSON.stringify(relativePath)}.`,
+    );
+  }
+
+  return candidate;
 }


### PR DESCRIPTION
Closes #51.

## Summary
- Add `add_document`, `delete_document`, and `reindex_knowledge_base` MCP tools.
- Add shared KB/path resolution helpers that reject traversal and require addressable, non-dot KB directories.
- Add forced `FaissIndexManager.updateIndex(..., { force: true })` support plus handler coverage for happy paths, traversal rejection, and missing KBs.

## FAISS deletion caveat
`delete_document` removes the file and hash sidecar only. The tool description explicitly warns that orphan vectors can remain in FAISS until a full rebuild; operators should run `reindex_knowledge_base` after deletes when vector hygiene matters.

## Test plan
- `npm run build`
- `npm test`

## Pre-PR checklist
- Build: passed
- Tests: passed
- Diff review: done
- Reviewer specialists: skipped because this Codex session is not authorized to spawn subagents unless explicitly requested.
- Gate file: created
