### PR TITLE
fix(mcp): decode resource URI segments with decodeURIComponent

### DIFF
--- a/src/KnowledgeBaseServer.test.ts
+++ b/src/KnowledgeBaseServer.test.ts
@@ -470,6 +470,40 @@ describe('KnowledgeBaseServer handlers', () => {
     expect('text' in content ? content.text : undefined).toBeUndefined();
   });
 
+  it('resources/list and resources/read round-trip filenames with reserved URI characters', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-server-resources-reserved-'));
+    await fsp.mkdir(path.join(tempDir, 'alpha', 'issues'), { recursive: true });
+    // Filenames covering reserved chars `decodeURI` would leave literal:
+    //   `#` (%23), `?` (%3F), `&` (%26), `+` (%2B), `=` (%3D), space (%20)
+    const filename = 'bug#42 &v=2+rev?.md';
+    await fsp.writeFile(path.join(tempDir, 'alpha', 'issues', filename), '# Reserved\n');
+
+    process.env.KNOWLEDGE_BASES_ROOT_DIR = tempDir;
+    process.env.FAISS_INDEX_PATH = path.join(tempDir, '.faiss');
+    process.env.EMBEDDING_PROVIDER = 'huggingface';
+    process.env.HUGGINGFACE_API_KEY = 'test-key';
+
+    const server = await freshServer();
+    const listResult = await server['handleListResources']();
+    const entry = listResult.resources.find((resource: { uri: string }) =>
+      resource.uri.includes('issues/'),
+    );
+    expect(entry).toBeDefined();
+    // The list URI must be percent-encoded so MCP clients can use it as-is.
+    expect(entry!.uri).toBe(
+      `kb://alpha/issues/${encodeURIComponent(filename)}`,
+    );
+
+    const readResult = await server['handleReadResource'](entry!.uri);
+    expect(readResult.contents).toEqual([
+      {
+        uri: entry!.uri,
+        mimeType: 'text/markdown',
+        text: '# Reserved\n',
+      },
+    ]);
+  });
+
   it('resources/read rejects a non-existent file with a clean error', async () => {
     const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-server-resources-missing-'));
     await fsp.mkdir(path.join(tempDir, 'alpha'), { recursive: true });

--- a/src/KnowledgeBaseServer.ts
+++ b/src/KnowledgeBaseServer.ts
@@ -169,9 +169,20 @@ function parseKnowledgeBaseResourceUri(uri: string): { kbName: string; relativeP
     throw new Error(`path escapes KB root: ${JSON.stringify(rawRelativePath)}`);
   }
 
+  // Decode each path segment with `decodeURIComponent` to round-trip
+  // `resourceUri()`, which percent-encodes per-segment with the matching
+  // function. `decodeURI` leaves reserved characters (`#`, `?`, `&`, `+`,
+  // `=`, …) literal, so a filename like `bug#123.md` would round-trip to a
+  // literal `%23` and `resources/read` would fail with "path not found".
+  // The earlier `%2f|%5c` guard already rejects encoded path separators
+  // before this point, so per-segment decoding cannot reintroduce a `/` or
+  // `\` boundary.
   let relativePath: string;
   try {
-    relativePath = decodeURI(rawRelativePath);
+    relativePath = rawRelativePath
+      .split('/')
+      .map((segment) => decodeURIComponent(segment))
+      .join('/');
   } catch (error: unknown) {
     throw new Error(`invalid kb:// URI path encoding: ${toError(error).message}`);
   }


### PR DESCRIPTION
Round-trip fix for kb:// resource URIs surfaced during PR #128 review.

## Problem

`resourceUri()` percent-encodes each path segment with `encodeURIComponent`, but `parseKnowledgeBaseResourceUri()` decoded the whole path with `decodeURI`, which intentionally leaves reserved escapes (`%23`, `%3F`, `%26`, `%2B`, `%3D`, …) literal.

So a filename like `bug#42 &v=2+rev?.md`:

1. `resources/list` returns `kb://alpha/issues/bug%2342%20%26v%3D2%2Brev%3F.md`.
2. `resources/read` on that URI calls `decodeURI`, which leaves `%23`/`%3F`/`%26`/`%2B`/`%3D` untouched.
3. The KB filesystem has no file literally named `bug%2342…` — `resources/read` fails with `path not found`.

## Fix

Split the raw path on `/` and decode each segment with `decodeURIComponent`, matching the encoder. The pre-existing `%2f|%5c` guard still rejects encoded path separators *before* decode, so per-segment decoding cannot reintroduce a `/` or `\` boundary.

## Tests

Adds a round-trip test in `KnowledgeBaseServer.test.ts` that creates a file named `bug#42 &v=2+rev?.md`, calls `resources/list` to get its URI (verifying `encodeURIComponent` shape), then `resources/read` on that exact URI and asserts the file contents come back. Covers `#`, `?`, `&`, `+`, `=`, and space.

Suite: 18 / 18 suites, 371 / 371 tests green.

## Background

This fix was originally pushed to the #128 branch as commit `0a4c4cf` before the squash-merge, but the squash captured an earlier branch state and dropped it. Re-applying as its own PR.

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes (371 / 371)
- [x] Round-trip test exercises `#`, `?`, `&`, `+`, `=`, space