### PR TITLE
feat(cli): add kb remember command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased] — CLI `kb remember`
+
+### Added
+
+- **`kb remember` CLI command.** `--suggest --kb=<name> --title=<title>` is read-only and lists likely existing targets from note filenames/headings. Writes require `--stdin --yes`: create mode writes a slugified `.md` file and refuses overwrites, while append mode accepts only existing KB-relative paths and rejects traversal/absolute paths. `--refresh` re-indexes the affected KB after a successful write. Closes #137.
+
 ## [Unreleased] — MCP ingest tools
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -39,10 +39,15 @@ npm install -g @jeanibarz/knowledge-base-mcp-server@latest
 kb list                       # list available knowledge bases
 kb search "your query"        # read-only search; cheap, fast (~0.6 s)
 kb search "query" --refresh   # also re-scan KB files (write path)
+kb remember --suggest --kb=work --title="Quarterly plan"
+printf '# Quarterly plan\n\n...' | kb remember --kb=work --title="Quarterly plan" --stdin --yes
+printf '\nFollow-up note.\n' | kb remember --kb=work --append=quarterly-plan.md --stdin --yes
 kb --help
 ```
 
 The `kb` bin shares the same env vars as the MCP server (`KNOWLEDGE_BASES_ROOT_DIR`, `FAISS_INDEX_PATH`, `EMBEDDING_PROVIDER`, `OLLAMA_*`, `OPENAI_*`, `HUGGINGFACE_*`). `kb search` defaults to read-only — it loads the existing FAISS index but does not re-scan KB files. Pass `--refresh` to re-index. Output includes a freshness footer indicating whether the index is up-to-date relative to KB file mtimes.
+
+`kb remember` is a conservative CLI write path for agent shells. `--suggest` is read-only and lists likely existing targets from note filenames/headings. Creates and appends require both `--stdin` and `--yes`; create uses a slugified `.md` filename and refuses overwrites, while append accepts only existing KB-relative paths. Add `--refresh` to re-index the affected KB after a successful write.
 
 The MCP server (`knowledge-base-mcp-server` bin) is unchanged and still works with all the configurations in [docs/clients.md](docs/clients.md). The CLI is additive.
 

--- a/src/cli-remember.ts
+++ b/src/cli-remember.ts
@@ -1,0 +1,297 @@
+import * as fsp from 'fs/promises';
+import * as path from 'path';
+import { ActiveModelResolutionError, resolveActiveModel } from './active-model.js';
+import { FaissIndexManager } from './FaissIndexManager.js';
+import { KNOWLEDGE_BASES_ROOT_DIR } from './config.js';
+import { getFilesRecursively } from './file-utils.js';
+import { filterIngestablePaths } from './ingest-filter.js';
+import { resolveKbRelativePath, resolveKnowledgeBaseDir } from './kb-fs.js';
+import { withWriteLock } from './write-lock.js';
+import { loadManagerForModel } from './cli-shared.js';
+
+interface RememberArgs {
+  kb?: string;
+  title?: string;
+  append?: string;
+  suggest: boolean;
+  stdin: boolean;
+  yes: boolean;
+  refresh: boolean;
+}
+
+interface Suggestion {
+  relativePath: string;
+  score: number;
+  label: string;
+}
+
+export async function runRemember(rest: string[]): Promise<number> {
+  let parsed: RememberArgs;
+  try {
+    parsed = parseRememberArgs(rest);
+    validateRememberArgs(parsed);
+  } catch (err) {
+    process.stderr.write(`kb remember: ${(err as Error).message}\n`);
+    return 2;
+  }
+
+  if (parsed.suggest) {
+    try {
+      return await runSuggest(parsed.kb!, parsed.title!);
+    } catch (err) {
+      process.stderr.write(`kb remember: ${(err as Error).message}\n`);
+      return 1;
+    }
+  }
+
+  let content: string;
+  try {
+    content = await readAllStdin();
+  } catch (err) {
+    process.stderr.write(`kb remember: failed to read stdin: ${(err as Error).message}\n`);
+    return 1;
+  }
+
+  let relativePath: string;
+  try {
+    if (parsed.append !== undefined) {
+      relativePath = await appendExistingNote(parsed.kb!, parsed.append, content);
+    } else {
+      relativePath = await createNewNote(parsed.kb!, parsed.title!, content);
+    }
+  } catch (err) {
+    process.stderr.write(`kb remember: ${(err as Error).message}\n`);
+    return 1;
+  }
+
+  if (parsed.refresh) {
+    try {
+      await refreshKnowledgeBase(parsed.kb!);
+    } catch (err) {
+      if (err instanceof ActiveModelResolutionError) {
+        process.stderr.write(`kb remember: ${err.message}\n`);
+        return 2;
+      }
+      process.stderr.write(`kb remember: refresh failed after write: ${(err as Error).message}\n`);
+      return 1;
+    }
+  }
+
+  process.stdout.write(`${JSON.stringify({
+    knowledge_base_name: parsed.kb,
+    path: relativePath,
+    action: parsed.append !== undefined ? 'append' : 'create',
+    refreshed: parsed.refresh,
+  }, null, 2)}\n`);
+  return 0;
+}
+
+function parseRememberArgs(rest: string[]): RememberArgs {
+  const out: RememberArgs = {
+    suggest: false,
+    stdin: false,
+    yes: false,
+    refresh: false,
+  };
+  for (const raw of rest) {
+    if (raw === '--suggest') { out.suggest = true; continue; }
+    if (raw === '--stdin') { out.stdin = true; continue; }
+    if (raw === '--yes') { out.yes = true; continue; }
+    if (raw === '--refresh') { out.refresh = true; continue; }
+    if (raw.startsWith('--kb=')) { out.kb = raw.slice('--kb='.length); continue; }
+    if (raw.startsWith('--title=')) { out.title = raw.slice('--title='.length); continue; }
+    if (raw.startsWith('--append=')) { out.append = raw.slice('--append='.length); continue; }
+    if (raw.startsWith('--')) throw new Error(`unknown flag: ${raw}`);
+    throw new Error(`unexpected argument: ${raw}`);
+  }
+  return out;
+}
+
+function validateRememberArgs(args: RememberArgs): void {
+  if (args.kb === undefined || args.kb.trim() === '') {
+    throw new Error('missing --kb=<name>');
+  }
+  if (args.suggest) {
+    if (args.title === undefined || args.title.trim() === '') {
+      throw new Error('missing --title=<title>');
+    }
+    if (args.append !== undefined) {
+      throw new Error('--suggest cannot be combined with --append');
+    }
+    if (args.stdin) {
+      throw new Error('--suggest does not read stdin');
+    }
+    if (args.yes) {
+      throw new Error('--suggest cannot be combined with --yes');
+    }
+    if (args.refresh) {
+      throw new Error('--suggest cannot be combined with --refresh');
+    }
+    return;
+  }
+
+  if (!args.stdin) {
+    throw new Error('writes require --stdin');
+  }
+  if (!args.yes) {
+    throw new Error('writes require --yes');
+  }
+  if (args.append !== undefined) {
+    if (args.append.trim() === '') {
+      throw new Error('--append must not be empty');
+    }
+    if (args.title !== undefined) {
+      throw new Error('--append cannot be combined with --title');
+    }
+    return;
+  }
+  if (args.title === undefined || args.title.trim() === '') {
+    throw new Error('missing --title=<title>');
+  }
+}
+
+async function runSuggest(kbName: string, title: string): Promise<number> {
+  const kbDir = await resolveKnowledgeBaseDir(KNOWLEDGE_BASES_ROOT_DIR, kbName);
+  const allFiles = await getFilesRecursively(kbDir);
+  const ingestable = filterIngestablePaths(allFiles, kbDir);
+  const suggestions = (await Promise.all(
+    ingestable.map(async (filePath) => scoreCandidate(kbDir, filePath, title)),
+  ))
+    .filter((s): s is Suggestion => s !== null)
+    .sort((a, b) => b.score - a.score || a.relativePath.localeCompare(b.relativePath))
+    .slice(0, 10);
+
+  if (suggestions.length === 0) {
+    process.stdout.write(`No likely existing targets for "${title}" in ${kbName}.\n`);
+    return 0;
+  }
+
+  process.stdout.write(`Likely existing targets for "${title}" in ${kbName}:\n`);
+  for (const s of suggestions) {
+    process.stdout.write(`- ${s.relativePath} (${s.label})\n`);
+  }
+  return 0;
+}
+
+async function scoreCandidate(kbDir: string, filePath: string, title: string): Promise<Suggestion | null> {
+  const relativePath = path.relative(kbDir, filePath).split(path.sep).join('/');
+  const titleTokens = tokenize(title);
+  const pathText = relativePath.replace(/\.[^.]+$/, '').replace(/[/_-]+/g, ' ');
+  const pathScore = overlapScore(titleTokens, tokenize(pathText));
+
+  let headingScore = 0;
+  let heading = '';
+  try {
+    const content = await fsp.readFile(filePath, 'utf-8');
+    const firstHeading = content.split(/\r?\n/, 30).find((line) => /^#{1,6}\s+\S/.test(line));
+    if (firstHeading !== undefined) {
+      heading = firstHeading.replace(/^#{1,6}\s+/, '').trim();
+      headingScore = overlapScore(titleTokens, tokenize(heading));
+    }
+  } catch {
+    // A candidate that vanished or is unreadable between walk and score is
+    // simply not useful as a suggestion.
+    return null;
+  }
+
+  const score = Math.max(pathScore, headingScore);
+  if (score <= 0) return null;
+  return {
+    relativePath,
+    score,
+    label: headingScore >= pathScore && heading !== '' ? `heading: ${heading}` : 'filename match',
+  };
+}
+
+function overlapScore(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0 || b.size === 0) return 0;
+  let matches = 0;
+  for (const token of a) {
+    if (b.has(token)) matches += 1;
+  }
+  return matches / a.size;
+}
+
+function tokenize(value: string): Set<string> {
+  return new Set(
+    value
+      .toLowerCase()
+      .split(/[^a-z0-9]+/)
+      .map((token) => token.trim())
+      .filter((token) => token.length >= 3),
+  );
+}
+
+async function createNewNote(kbName: string, title: string, content: string): Promise<string> {
+  const relativePath = `${slugifyTitle(title)}.md`;
+  const documentPath = await resolveKbRelativePath(KNOWLEDGE_BASES_ROOT_DIR, kbName, relativePath);
+  await fsp.mkdir(path.dirname(documentPath), { recursive: true });
+  try {
+    const handle = await fsp.open(documentPath, 'wx');
+    try {
+      await handle.writeFile(content, 'utf-8');
+    } finally {
+      await handle.close();
+    }
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'EEXIST') {
+      throw new Error(`refusing to overwrite existing note: ${relativePath}`);
+    }
+    throw err;
+  }
+  return relativePath;
+}
+
+async function appendExistingNote(kbName: string, relativePath: string, content: string): Promise<string> {
+  rejectAbsoluteOrTraversal(relativePath);
+  const documentPath = await resolveKbRelativePath(KNOWLEDGE_BASES_ROOT_DIR, kbName, relativePath);
+  const stat = await fsp.stat(documentPath);
+  if (!stat.isFile()) {
+    throw new Error(`append target is not a file: ${JSON.stringify(relativePath)}`);
+  }
+  await fsp.appendFile(documentPath, content, 'utf-8');
+  return path.relative(await resolveKnowledgeBaseDir(KNOWLEDGE_BASES_ROOT_DIR, kbName), documentPath)
+    .split(path.sep)
+    .join('/');
+}
+
+function rejectAbsoluteOrTraversal(relativePath: string): void {
+  const normalized = relativePath.replace(/\\/g, '/');
+  if (
+    path.posix.isAbsolute(normalized) ||
+    path.win32.isAbsolute(relativePath) ||
+    normalized.split('/').some((segment) => segment === '..')
+  ) {
+    throw new Error(`append path escapes KB root: ${JSON.stringify(relativePath)}`);
+  }
+}
+
+function slugifyTitle(title: string): string {
+  const slug = title
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .replace(/-{2,}/g, '-');
+  return slug.length > 0 ? slug.slice(0, 80).replace(/-+$/g, '') : 'note';
+}
+
+async function refreshKnowledgeBase(kbName: string): Promise<void> {
+  await FaissIndexManager.bootstrapLayout();
+  const activeModelId = await resolveActiveModel();
+  const manager = await loadManagerForModel(activeModelId);
+  await withWriteLock(manager.modelDir, async () => {
+    await manager.initialize();
+    await manager.updateIndex(kbName);
+  });
+}
+
+async function readAllStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  return new Promise((resolve, reject) => {
+    process.stdin.on('data', (chunk) => chunks.push(Buffer.from(chunk)));
+    process.stdin.on('end', () => resolve(Buffer.concat(chunks).toString('utf-8')));
+    process.stdin.on('error', reject);
+  });
+}

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -24,10 +24,11 @@ interface RunResult {
   stderr: string;
 }
 
-function runCli(args: string[], env: Record<string, string> = {}): RunResult {
+function runCli(args: string[], env: Record<string, string> = {}, input?: string): RunResult {
   const result = spawnSync('node', [cliPath, ...args], {
     env: { PATH: process.env.PATH ?? '', ...env },
     encoding: 'utf-8',
+    input,
   });
   if (result.error) throw result.error;
   return {
@@ -44,6 +45,7 @@ describe('kb CLI — argv parsing and dispatch', () => {
     expect(r.stdout).toContain('kb — knowledge-base CLI');
     expect(r.stdout).toContain('kb list');
     expect(r.stdout).toContain('kb search');
+    expect(r.stdout).toContain('kb remember');
   });
 
   it('no args exits 0 with usage text', () => {
@@ -99,6 +101,159 @@ describe('kb CLI — argv parsing and dispatch', () => {
     const r = runCli(['search', 'q', '--threshold=notanumber']);
     expect(r.code).toBe(2);
     expect(r.stderr).toContain('invalid --threshold');
+  });
+});
+
+describe('kb remember', () => {
+  it('creates a new markdown note from stdin with a slugified title', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-cli-remember-create-'));
+    try {
+      const rootDir = path.join(tempDir, 'kbs');
+      const faissDir = path.join(tempDir, '.faiss');
+      await fsp.mkdir(path.join(rootDir, 'project'), { recursive: true });
+
+      const r = runCli(
+        ['remember', '--kb=project', '--title=Daily Meeting Notes', '--stdin', '--yes'],
+        { KNOWLEDGE_BASES_ROOT_DIR: rootDir, FAISS_INDEX_PATH: faissDir },
+        '# Daily Meeting Notes\n\nDecision log.\n',
+      );
+
+      expect(r.code).toBe(0);
+      expect(r.stdout).toContain('"action": "create"');
+      expect(r.stdout).toContain('"path": "daily-meeting-notes.md"');
+      await expect(fsp.readFile(path.join(rootDir, 'project', 'daily-meeting-notes.md'), 'utf-8'))
+        .resolves.toBe('# Daily Meeting Notes\n\nDecision log.\n');
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('refuses to overwrite an existing slug on create', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-cli-remember-overwrite-'));
+    try {
+      const rootDir = path.join(tempDir, 'kbs');
+      const faissDir = path.join(tempDir, '.faiss');
+      await fsp.mkdir(path.join(rootDir, 'project'), { recursive: true });
+      const notePath = path.join(rootDir, 'project', 'daily-meeting-notes.md');
+      await fsp.writeFile(notePath, 'original', 'utf-8');
+
+      const r = runCli(
+        ['remember', '--kb=project', '--title=Daily Meeting Notes', '--stdin', '--yes'],
+        { KNOWLEDGE_BASES_ROOT_DIR: rootDir, FAISS_INDEX_PATH: faissDir },
+        'replacement',
+      );
+
+      expect(r.code).toBe(1);
+      expect(r.stderr).toContain('refusing to overwrite');
+      await expect(fsp.readFile(notePath, 'utf-8')).resolves.toBe('original');
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('appends stdin to an existing KB-relative note', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-cli-remember-append-'));
+    try {
+      const rootDir = path.join(tempDir, 'kbs');
+      const faissDir = path.join(tempDir, '.faiss');
+      const notePath = path.join(rootDir, 'project', 'notes', 'status.md');
+      await fsp.mkdir(path.dirname(notePath), { recursive: true });
+      await fsp.writeFile(notePath, '# Status\n\nExisting.\n', 'utf-8');
+
+      const r = runCli(
+        ['remember', '--kb=project', '--append=notes/status.md', '--stdin', '--yes'],
+        { KNOWLEDGE_BASES_ROOT_DIR: rootDir, FAISS_INDEX_PATH: faissDir },
+        '\nAppended.\n',
+      );
+
+      expect(r.code).toBe(0);
+      expect(r.stdout).toContain('"action": "append"');
+      await expect(fsp.readFile(notePath, 'utf-8')).resolves.toBe('# Status\n\nExisting.\n\nAppended.\n');
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('suggests likely targets without reading stdin or writing files', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-cli-remember-suggest-'));
+    try {
+      const rootDir = path.join(tempDir, 'kbs');
+      const faissDir = path.join(tempDir, '.faiss');
+      const kbDir = path.join(rootDir, 'project');
+      await fsp.mkdir(kbDir, { recursive: true });
+      await fsp.writeFile(path.join(kbDir, 'research-plan.md'), '# Research Plan\n\nExisting note.\n', 'utf-8');
+
+      const r = runCli(
+        ['remember', '--suggest', '--kb=project', '--title=Research Plan'],
+        { KNOWLEDGE_BASES_ROOT_DIR: rootDir, FAISS_INDEX_PATH: faissDir },
+      );
+
+      expect(r.code).toBe(0);
+      expect(r.stdout).toContain('Likely existing targets');
+      expect(r.stdout).toContain('research-plan.md');
+      await expect(fsp.access(path.join(kbDir, 'research-plan.md.md'))).rejects.toMatchObject({ code: 'ENOENT' });
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects traversal and absolute append paths before writing', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-cli-remember-path-'));
+    try {
+      const rootDir = path.join(tempDir, 'kbs');
+      const faissDir = path.join(tempDir, '.faiss');
+      const notePath = path.join(rootDir, 'project', 'safe.md');
+      await fsp.mkdir(path.dirname(notePath), { recursive: true });
+      await fsp.writeFile(notePath, 'safe', 'utf-8');
+
+      const traversal = runCli(
+        ['remember', '--kb=project', '--append=../outside.md', '--stdin', '--yes'],
+        { KNOWLEDGE_BASES_ROOT_DIR: rootDir, FAISS_INDEX_PATH: faissDir },
+        'bad',
+      );
+      expect(traversal.code).toBe(1);
+      expect(traversal.stderr).toContain('escapes KB root');
+
+      const absolute = runCli(
+        ['remember', '--kb=project', `--append=${path.join(tempDir, 'outside.md')}`, '--stdin', '--yes'],
+        { KNOWLEDGE_BASES_ROOT_DIR: rootDir, FAISS_INDEX_PATH: faissDir },
+        'bad',
+      );
+      expect(absolute.code).toBe(1);
+      expect(absolute.stderr).toContain('escapes KB root');
+      await expect(fsp.readFile(notePath, 'utf-8')).resolves.toBe('safe');
+      await expect(fsp.access(path.join(tempDir, 'outside.md'))).rejects.toMatchObject({ code: 'ENOENT' });
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects write argv errors without touching stdin content', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-cli-remember-argv-'));
+    try {
+      const rootDir = path.join(tempDir, 'kbs');
+      const faissDir = path.join(tempDir, '.faiss');
+      await fsp.mkdir(path.join(rootDir, 'project'), { recursive: true });
+
+      const noYes = runCli(
+        ['remember', '--kb=project', '--title=Draft', '--stdin'],
+        { KNOWLEDGE_BASES_ROOT_DIR: rootDir, FAISS_INDEX_PATH: faissDir },
+        'draft',
+      );
+      expect(noYes.code).toBe(2);
+      expect(noYes.stderr).toContain('writes require --yes');
+
+      const unknown = runCli(
+        ['remember', '--kb=project', '--title=Draft', '--stdin', '--yes', '--bogus'],
+        { KNOWLEDGE_BASES_ROOT_DIR: rootDir, FAISS_INDEX_PATH: faissDir },
+        'draft',
+      );
+      expect(unknown.code).toBe(2);
+      expect(unknown.stderr).toContain('unknown flag');
+      await expect(fsp.access(path.join(rootDir, 'project', 'draft.md'))).rejects.toMatchObject({ code: 'ENOENT' });
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,6 +6,7 @@
 //   - `kb search <query>`     → similarity search; default read-only
 //                               (skips updateIndex, no write lock)
 //   - `kb search --refresh`   → also runs updateIndex under the write lock
+//   - `kb remember ...`       → conservative CLI write/suggest surface
 //
 // Both subcommands check `model_name.txt` against the configured embedding
 // model on every invocation and exit non-zero on mismatch (RFC §4.7) so a
@@ -18,6 +19,7 @@ import { fileURLToPath } from 'url';
 import { runCompare } from './cli-compare.js';
 import { runList } from './cli-list.js';
 import { runModels } from './cli-models.js';
+import { runRemember } from './cli-remember.js';
 import { runSearch } from './cli-search.js';
 
 // ----- Entry point -----------------------------------------------------------
@@ -29,6 +31,12 @@ Usage:
   kb search <query> [opts]                Semantic search (read-only).
   kb search <query> --refresh             Also re-scan KB files (write path).
   kb search --stdin                       Read query from stdin.
+  kb remember --suggest --kb=<name> --title=<title>
+                                           Suggest likely existing note targets.
+  kb remember --kb=<name> --title=<title> --stdin --yes
+                                           Create a new markdown note.
+  kb remember --kb=<name> --append=<path> --stdin --yes
+                                           Append to an existing KB-relative note.
   kb compare <query> <a> <b>              Side-by-side rank/score table.
   kb models list                          List registered embedding models.
   kb models add <provider> <model>        Register a new model + ingest.
@@ -45,6 +53,15 @@ Search options:
   --format=md|json      Output format (default md).
   --refresh             Re-scan KB files; acquires per-model write lock.
   --stdin               Read query from stdin (multi-line safe).
+
+Remember options:
+  --kb=<name>           Target knowledge base.
+  --title=<title>       Note title; create uses a slugified .md filename.
+  --append=<path>       Existing KB-relative note path; rejects traversal.
+  --suggest             Read-only suggestions; does not read stdin.
+  --stdin               Read note content from stdin.
+  --yes                 Required for non-interactive writes.
+  --refresh             Re-index the affected KB after a successful write.
 
 Models add options:
   --yes                 Skip the cost-estimate confirmation prompt.
@@ -80,6 +97,9 @@ export async function main(argv: string[]): Promise<number> {
   }
   if (sub === 'search') {
     return runSearch(rest);
+  }
+  if (sub === 'remember') {
+    return runRemember(rest);
   }
   if (sub === 'models') {
     return runModels(rest);


### PR DESCRIPTION
## Summary
- add `kb remember` with read-only suggestions and explicit stdin/yes write modes
- support safe create/append paths plus optional `--refresh`
- document usage and cover CLI behavior in tests

## Verification
- `npm run build`
- `npm test -- --runTestsByPath src/cli.test.ts`
- `npm test`
- manual temp-KB smoke test for suggest/create/append

Closes #137