### PR TITLE
feat(cli): soften kb search 'Index may be stale' banner when 0 modified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased] — `kb search` freshness banner
+
+### Changed
+
+- **`kb search` no longer leads with "Index may be stale" when zero files have been modified.** When only new files have appeared since the last refresh (`modifiedFiles == 0 && newFiles > 0`), the banner now reads `_<N> new file(s) since <indexMtime>; run \`kb search --refresh\` to include them._` instead of `_Index may be stale: 0 modified, N new file(s)…_`. Existing indexed content hasn't shifted in that case, so leading with "may be stale" overstated the problem and trained agents to ignore the banner. The original "may be stale" wording is preserved unchanged when `modifiedFiles > 0`, since edited content can produce stale chunks. Closes #145.
+
 ## [Unreleased] — CLI `kb remember`
 
 ### Added

--- a/src/cli-search.test.ts
+++ b/src/cli-search.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from '@jest/globals';
+import { formatFreshnessFooter, Staleness } from './cli-search.js';
+
+const MTIME = '2026-05-03T15:33:56.964Z';
+
+describe('formatFreshnessFooter', () => {
+  it('reports "not yet built" when indexMtime is null', () => {
+    const s: Staleness = { indexMtime: null, modifiedFiles: 0, newFiles: 0 };
+    expect(formatFreshnessFooter(s, false)).toBe(
+      '> _Index not yet built. Run `kb search --refresh` to create it._',
+    );
+  });
+
+  it('reports a refresh confirmation when refreshed=true', () => {
+    const s: Staleness = { indexMtime: MTIME, modifiedFiles: 0, newFiles: 17 };
+    expect(formatFreshnessFooter(s, true)).toBe(`> _Index refreshed at ${MTIME}._`);
+  });
+
+  it('reports up-to-date when neither modified nor new files exist', () => {
+    const s: Staleness = { indexMtime: MTIME, modifiedFiles: 0, newFiles: 0 };
+    expect(formatFreshnessFooter(s, false)).toBe(`> _Index up-to-date as of ${MTIME}._`);
+  });
+
+  it('uses a gentle hint (no "may be stale") when only new files were added', () => {
+    const s: Staleness = { indexMtime: MTIME, modifiedFiles: 0, newFiles: 1857 };
+    const out = formatFreshnessFooter(s, false);
+    expect(out).toBe(
+      `> _1857 new file(s) since ${MTIME}; run \`kb search --refresh\` to include them._`,
+    );
+    expect(out).not.toMatch(/may be stale/);
+  });
+
+  it('still warns "may be stale" when at least one file was modified', () => {
+    const s: Staleness = { indexMtime: MTIME, modifiedFiles: 3, newFiles: 0 };
+    expect(formatFreshnessFooter(s, false)).toBe(
+      `> _Index may be stale: 3 modified, 0 new file(s) since ${MTIME}. Run \`kb search --refresh\` to update._`,
+    );
+  });
+
+  it('still warns "may be stale" when files were both modified and added', () => {
+    const s: Staleness = { indexMtime: MTIME, modifiedFiles: 2, newFiles: 5 };
+    expect(formatFreshnessFooter(s, false)).toBe(
+      `> _Index may be stale: 2 modified, 5 new file(s) since ${MTIME}. Run \`kb search --refresh\` to update._`,
+    );
+  });
+});

--- a/src/cli-search.ts
+++ b/src/cli-search.ts
@@ -28,7 +28,7 @@ interface SearchArgs {
   stdin: boolean;
 }
 
-interface Staleness {
+export interface Staleness {
   indexMtime: string | null;
   modifiedFiles: number;
   newFiles: number;
@@ -224,7 +224,7 @@ async function computeStaleness(modelId: string): Promise<Staleness> {
   return { indexMtime, modifiedFiles: modified, newFiles: added };
 }
 
-function formatFreshnessFooter(s: Staleness, refreshed: boolean): string {
+export function formatFreshnessFooter(s: Staleness, refreshed: boolean): string {
   if (s.indexMtime === null) {
     return `> _Index not yet built. Run \`kb search --refresh\` to create it._`;
   }
@@ -233,6 +233,12 @@ function formatFreshnessFooter(s: Staleness, refreshed: boolean): string {
   }
   if (s.modifiedFiles === 0 && s.newFiles === 0) {
     return `> _Index up-to-date as of ${s.indexMtime}._`;
+  }
+  if (s.modifiedFiles === 0) {
+    return (
+      `> _${s.newFiles} new file(s) since ${s.indexMtime}; ` +
+      `run \`kb search --refresh\` to include them._`
+    );
   }
   return (
     `> _Index may be stale: ${s.modifiedFiles} modified, ${s.newFiles} new ` +


### PR DESCRIPTION
## Summary

- When `kb search` finds zero modified files but only newly-added files since the last refresh (`modifiedFiles == 0 && newFiles > 0`), the banner no longer leads with "Index may be stale". It now reads `_<N> new file(s) since <indexMtime>; run \`kb search --refresh\` to include them._`
- The original "may be stale" wording is preserved unchanged when `modifiedFiles > 0`, since edited indexed content is the genuine staleness signal worth flagging loudly.
- `formatFreshnessFooter` and the `Staleness` interface are now exported so the message matrix is unit-testable; new `src/cli-search.test.ts` covers all five branches (null mtime, refreshed, up-to-date, new-only, modified-only, modified+new).

## Why

The previous message conflated two different signals:

| Modified | New | Signal | Old behavior |
|---|---|---|---|
| 0 | 0 | index fully fresh | no banner (kept) |
| 0 | many | new files exist but indexed content unchanged | "Index may be stale" (false alarm) |
| many | many | indexed content has shifted | "Index may be stale" (correct) |

The middle row was the noisy one — observed during a Kookr dogfooding session where every search printed `0 modified, 1857 new file(s)`. Across a session that trains agents to ignore the banner, masking the genuine drift case in the bottom row.

## Test plan

- [x] `npm test` — all 403 tests pass (20 suites)
- [x] 6 new unit tests in `src/cli-search.test.ts` cover every branch of `formatFreshnessFooter`
- [x] `npm run build` clean (TypeScript strict)
- [x] CHANGELOG entry added under `## [Unreleased]`

Closes #145.

🤖 Generated with [Claude Code](https://claude.com/claude-code)