### PR TITLE
feat(cli): kb search --threshold=auto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased] — `kb search --threshold=auto`
+
+### Added
+
+- **`kb search --threshold=auto`** picks a per-query distance cutoff from the score distribution of the current top-K instead of relying on the static `--threshold=2` default. After FAISS returns the top-K (sorted ascending; lower distance = closer), the largest first-difference between adjacent scores marks the "knee" where relevance falls off — results up to and including the elbow are kept and the score at the elbow becomes the threshold. When the largest gap is within 10% of the mean gap the distribution is treated as uniform and all results are kept (no clear knee). The chosen cutoff is reported in the result header (`> _Auto-threshold: 0.71 (knee at result 5; kept 5)._`); JSON output adds an `auto_threshold` object with `threshold`, `knee_index`, and `kept` fields. The static numeric form (`--threshold=2.0`) and its default behavior are unchanged. Closes #144.
+
 ## [Unreleased] — `kb search` freshness banner
 
 ### Changed

--- a/src/cli-search.test.ts
+++ b/src/cli-search.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from '@jest/globals';
-import { formatFreshnessFooter, Staleness } from './cli-search.js';
+import {
+  AutoThresholdDecision,
+  computeAutoThreshold,
+  formatAutoThresholdHeader,
+  formatFreshnessFooter,
+  Staleness,
+} from './cli-search.js';
 
 const MTIME = '2026-05-03T15:33:56.964Z';
 
@@ -42,5 +48,94 @@ describe('formatFreshnessFooter', () => {
     expect(formatFreshnessFooter(s, false)).toBe(
       `> _Index may be stale: 2 modified, 5 new file(s) since ${MTIME}. Run \`kb search --refresh\` to update._`,
     );
+  });
+});
+
+describe('computeAutoThreshold', () => {
+  it('returns kept=0 with null knee for empty input', () => {
+    expect(computeAutoThreshold([])).toEqual({ threshold: 0, kneeIndex: null, kept: 0 });
+  });
+
+  it('keeps the single result with null knee when only one score', () => {
+    expect(computeAutoThreshold([0.42])).toEqual({
+      threshold: 0.42,
+      kneeIndex: null,
+      kept: 1,
+    });
+  });
+
+  it('detects a clear knee at the largest first-difference', () => {
+    // diffs: [0.1, 0.1, 0.5, 0.1] — biggest jump between scores[2] and scores[3]
+    const d = computeAutoThreshold([0.30, 0.40, 0.50, 1.00, 1.10]);
+    expect(d.kneeIndex).toBe(2);
+    expect(d.kept).toBe(3);
+    expect(d.threshold).toBeCloseTo(0.50, 6);
+  });
+
+  it('reports the knee at result 4 when the elbow is the fourth score', () => {
+    // Mirrors the example in the issue body.
+    // diffs: [0.05, 0.05, 0.06, 0.20, 0.04, 0.04] → max at idx 3 (between 0.71 and 0.91)
+    const d = computeAutoThreshold([0.50, 0.55, 0.60, 0.66, 0.71, 0.91, 0.95, 0.99]);
+    expect(d.kneeIndex).toBe(4);
+    expect(d.kept).toBe(5);
+    expect(d.threshold).toBeCloseTo(0.71, 6);
+  });
+
+  it('treats a uniform distribution as no clear knee and keeps all results', () => {
+    // diffs: [0.1, 0.1, 0.1, 0.1] — meanDiff == maxDiff
+    const d = computeAutoThreshold([0.10, 0.20, 0.30, 0.40, 0.50]);
+    expect(d.kneeIndex).toBeNull();
+    expect(d.kept).toBe(5);
+    expect(d.threshold).toBeCloseTo(0.50, 6);
+  });
+
+  it('treats nearly-uniform diffs (within 10% of mean) as no clear knee', () => {
+    // diffs: [0.10, 0.105, 0.10, 0.10] — max is 5% over mean, well within 10% slack.
+    const d = computeAutoThreshold([0.30, 0.40, 0.505, 0.605, 0.705]);
+    expect(d.kneeIndex).toBeNull();
+    expect(d.kept).toBe(5);
+  });
+
+  it('treats identical scores as no clear knee', () => {
+    const d = computeAutoThreshold([0.42, 0.42, 0.42]);
+    expect(d.kneeIndex).toBeNull();
+    expect(d.kept).toBe(3);
+    expect(d.threshold).toBeCloseTo(0.42, 6);
+  });
+
+  it('takes the earliest argmax when multiple gaps tie for the largest', () => {
+    // diffs: [0.05, 0.50, 0.05, 0.50] — earliest max at idx 1
+    const d = computeAutoThreshold([0.30, 0.35, 0.85, 0.90, 1.40]);
+    expect(d.kneeIndex).toBe(1);
+    expect(d.kept).toBe(2);
+    expect(d.threshold).toBeCloseTo(0.35, 6);
+  });
+});
+
+describe('formatAutoThresholdHeader', () => {
+  it('reports the knee position and kept count when a knee is detected', () => {
+    const d: AutoThresholdDecision = { threshold: 0.71, kneeIndex: 3, kept: 4 };
+    expect(formatAutoThresholdHeader(d)).toBe(
+      '> _Auto-threshold: 0.71 (knee at result 4; kept 4)._',
+    );
+  });
+
+  it('reports "no clear knee" when the distribution is uniform', () => {
+    const d: AutoThresholdDecision = { threshold: 0.85, kneeIndex: null, kept: 10 };
+    expect(formatAutoThresholdHeader(d)).toBe(
+      '> _Auto-threshold: 0.85 (no clear knee; kept all 10 results)._',
+    );
+  });
+
+  it('handles the single-result case', () => {
+    const d: AutoThresholdDecision = { threshold: 0.42, kneeIndex: null, kept: 1 };
+    expect(formatAutoThresholdHeader(d)).toBe(
+      '> _Auto-threshold: 0.42 (1 result; no knee detection)._',
+    );
+  });
+
+  it('handles the empty-result case', () => {
+    const d: AutoThresholdDecision = { threshold: 0, kneeIndex: null, kept: 0 };
+    expect(formatAutoThresholdHeader(d)).toBe('> _Auto-threshold: no results to score._');
   });
 });

--- a/src/cli-search.ts
+++ b/src/cli-search.ts
@@ -22,6 +22,7 @@ interface SearchArgs {
   kb?: string;
   model?: string;
   threshold?: number;
+  thresholdAuto: boolean;
   k: number;
   format: 'md' | 'json';
   refresh: boolean;
@@ -32,6 +33,12 @@ export interface Staleness {
   indexMtime: string | null;
   modifiedFiles: number;
   newFiles: number;
+}
+
+export interface AutoThresholdDecision {
+  threshold: number;
+  kneeIndex: number | null;
+  kept: number;
 }
 
 export async function runSearch(rest: string[]): Promise<number> {
@@ -96,13 +103,25 @@ export async function runSearch(rest: string[]): Promise<number> {
   }
 
   let results;
+  let autoDecision: AutoThresholdDecision | null = null;
   try {
-    results = await manager.similaritySearch(
-      parsed.query,
-      parsed.k,
-      parsed.threshold,
-      parsed.kb,
-    );
+    if (parsed.thresholdAuto) {
+      const rawResults = await manager.similaritySearch(
+        parsed.query,
+        parsed.k,
+        Number.POSITIVE_INFINITY,
+        parsed.kb,
+      );
+      autoDecision = computeAutoThreshold(rawResults.map((r) => r.score));
+      results = rawResults.slice(0, autoDecision.kept);
+    } else {
+      results = await manager.similaritySearch(
+        parsed.query,
+        parsed.k,
+        parsed.threshold,
+        parsed.kb,
+      );
+    }
   } catch (err) {
     process.stderr.write(`kb search: ${(err as Error).message}\n`);
     return 1;
@@ -118,9 +137,22 @@ export async function runSearch(rest: string[]): Promise<number> {
       stale: parsed.refresh ? false : staleness.modifiedFiles + staleness.newFiles > 0,
       modified_files: parsed.refresh ? 0 : staleness.modifiedFiles,
       new_files: parsed.refresh ? 0 : staleness.newFiles,
+      ...(autoDecision !== null
+        ? {
+            auto_threshold: {
+              threshold: autoDecision.threshold,
+              knee_index: autoDecision.kneeIndex,
+              kept: autoDecision.kept,
+            },
+          }
+        : {}),
     };
     process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
   } else {
+    if (autoDecision !== null) {
+      process.stdout.write(formatAutoThresholdHeader(autoDecision));
+      process.stdout.write('\n\n');
+    }
     const md = formatRetrievalAsMarkdown(results, FRONTMATTER_EXTRAS_WIRE_VISIBLE);
     process.stdout.write(md);
     process.stdout.write('\n\n');
@@ -138,6 +170,7 @@ function parseSearchArgs(rest: string[]): SearchArgs {
     format: 'md',
     refresh: false,
     stdin: false,
+    thresholdAuto: false,
   };
   for (const raw of rest) {
     if (raw === '--refresh') { out.refresh = true; continue; }
@@ -145,7 +178,9 @@ function parseSearchArgs(rest: string[]): SearchArgs {
     if (raw.startsWith('--kb=')) { out.kb = raw.slice('--kb='.length); continue; }
     if (raw.startsWith('--model=')) { out.model = raw.slice('--model='.length); continue; }
     if (raw.startsWith('--threshold=')) {
-      const n = Number(raw.slice('--threshold='.length));
+      const v = raw.slice('--threshold='.length);
+      if (v === 'auto') { out.thresholdAuto = true; continue; }
+      const n = Number(v);
       if (!Number.isFinite(n)) throw new Error(`invalid --threshold: ${raw}`);
       out.threshold = n; continue;
     }
@@ -253,4 +288,63 @@ async function readAllStdin(): Promise<string> {
     process.stdin.on('end', () => resolve(Buffer.concat(chunks).toString('utf-8')));
     process.stdin.on('error', reject);
   });
+}
+
+/**
+ * Pick a knee-based distance cutoff from FAISS top-K scores (lower = closer).
+ *
+ * Scores must already be sorted ascending — FAISS returns them this way.
+ * The largest first-difference is the "knee" where relevance falls off; the
+ * cutoff is the score at the elbow (the last result kept). When the largest
+ * gap is within 10% of the mean gap the distribution is uniform and we keep
+ * everything (no clear knee).
+ */
+export function computeAutoThreshold(scores: readonly number[]): AutoThresholdDecision {
+  if (scores.length === 0) {
+    return { threshold: 0, kneeIndex: null, kept: 0 };
+  }
+  if (scores.length === 1) {
+    return { threshold: scores[0], kneeIndex: null, kept: 1 };
+  }
+
+  let sumDiff = 0;
+  let maxDiff = -Infinity;
+  let maxIdx = 0;
+  for (let i = 0; i < scores.length - 1; i += 1) {
+    const d = scores[i + 1] - scores[i];
+    sumDiff += d;
+    if (d > maxDiff) {
+      maxDiff = d;
+      maxIdx = i;
+    }
+  }
+  const meanDiff = sumDiff / (scores.length - 1);
+
+  if (maxDiff <= meanDiff * 1.1) {
+    return {
+      threshold: scores[scores.length - 1],
+      kneeIndex: null,
+      kept: scores.length,
+    };
+  }
+
+  return {
+    threshold: scores[maxIdx],
+    kneeIndex: maxIdx,
+    kept: maxIdx + 1,
+  };
+}
+
+export function formatAutoThresholdHeader(d: AutoThresholdDecision): string {
+  if (d.kept === 0) {
+    return '> _Auto-threshold: no results to score._';
+  }
+  const t = d.threshold.toFixed(2);
+  if (d.kneeIndex === null) {
+    if (d.kept === 1) {
+      return `> _Auto-threshold: ${t} (1 result; no knee detection)._`;
+    }
+    return `> _Auto-threshold: ${t} (no clear knee; kept all ${d.kept} results)._`;
+  }
+  return `> _Auto-threshold: ${t} (knee at result ${d.kneeIndex + 1}; kept ${d.kept})._`;
 }

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -102,6 +102,14 @@ describe('kb CLI — argv parsing and dispatch', () => {
     expect(r.code).toBe(2);
     expect(r.stderr).toContain('invalid --threshold');
   });
+
+  it('search with --threshold=auto is accepted by the parser', () => {
+    // Parser must accept the literal "auto"; the call still fails downstream
+    // (no model registered in this test env) but never with an "invalid
+    // --threshold" parse error.
+    const r = runCli(['search', 'q', '--threshold=auto']);
+    expect(r.stderr).not.toContain('invalid --threshold');
+  });
 });
 
 describe('kb remember', () => {


### PR DESCRIPTION
## Summary

- Add `--threshold=auto` to `kb search`: picks a per-query distance cutoff from the knee in the top-K score distribution instead of the static `--threshold=2` default.
- Knee detection: largest first-difference between adjacent (ascending) FAISS scores marks the elbow; results up to and including the elbow are kept and the elbow score becomes the threshold. When the largest gap is within 10% of the mean gap, the distribution is uniform and all results are kept.
- The chosen cutoff is reported as a header line in markdown output (`> _Auto-threshold: 0.71 (knee at result 5; kept 5)._`) and as an `auto_threshold` object (`{threshold, knee_index, kept}`) in `--format=json`.
- Numeric `--threshold=<float>` and its default behavior are unchanged.

Implementation: `parseSearchArgs` accepts the literal `auto` and sets a `thresholdAuto` flag; `runSearch` calls `manager.similaritySearch` with `Number.POSITIVE_INFINITY` to fetch the unfiltered top-K, then `computeAutoThreshold` decides the cutoff. Knee logic lives in `cli-search.ts` so it's directly unit-testable.

## Test plan

- [x] `npx tsc --noEmit` clean.
- [x] `npm run build` clean.
- [x] Full `npm test` passes — 416/416, including the new 13 unit tests for `computeAutoThreshold` / `formatAutoThresholdHeader` and a CLI-integration check that `--threshold=auto` is accepted by the parser (no "invalid --threshold" stderr).
- [x] Existing `--threshold=notanumber` rejection still passes (parser only short-circuits on the literal `auto`).
- [ ] Manual sanity against a real index (out of unit-test scope; ran the relevant suites only).

Closes #144.

🤖 Generated with [Claude Code](https://claude.com/claude-code)