### PR TITLE
feat(cli): add kb capture command for command-output snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased] — CLI `kb capture`
+
+### Added
+
+- **`kb capture` CLI command.** Runs a command via `child_process.spawn` (`shell: false`, argv after `--`) and appends its stdout to a KB note as a fenced, provenance-tagged code block. The block opens with an optional `### <note>` header (`--note=<text>`), records the literal command on a `$ <cmd>` line (POSIX-shell-quoted for round-trip safety), then a fenced code block with the captured stdout. The fence widens beyond three backticks when the output contains `` ``` `` runs, so embedded fences round-trip without breaking the host markdown. `--max-bytes=<N>` truncates oversize stdout (default 64 KiB) and appends `... (truncated, N bytes elided)` inside the fence. `--language=<hint>` overrides the fence language; otherwise it auto-detects `json`/`yaml` from a `.json` / `.yml` / `.yaml` argv tail. Captures refuse to write when stdout is empty or when the command exits non-zero (override with `--allow-fail`). `--refresh` re-indexes the affected KB after the write. The `--append=<path>` target uses the same KB-relative resolver as `kb remember --append` — traversal/absolute paths are rejected before the command spawns. Composes with `kb remember --append-section` (#139) once that lands; without it the captured block lands at EOF. Closes #143.
+
 ## [Unreleased] — `kb search --threshold=auto`
 
 ### Added

--- a/src/cli-capture.ts
+++ b/src/cli-capture.ts
@@ -1,0 +1,311 @@
+// `kb capture` — run a command and append its stdout to a KB note as a
+// fenced, provenance-tagged code block. See issue #143.
+//
+// Composes with `kb remember --append=<path>` for the write path. The
+// `--append-section` heading-aware variant is tracked separately under
+// issue #139; without it the captured block lands at EOF of the target
+// note.
+
+import { spawn } from 'child_process';
+import * as fsp from 'fs/promises';
+import * as path from 'path';
+import { ActiveModelResolutionError, resolveActiveModel } from './active-model.js';
+import { FaissIndexManager } from './FaissIndexManager.js';
+import { KNOWLEDGE_BASES_ROOT_DIR } from './config.js';
+import { resolveKbRelativePath, resolveKnowledgeBaseDir } from './kb-fs.js';
+import { withWriteLock } from './write-lock.js';
+import { loadManagerForModel } from './cli-shared.js';
+
+interface CaptureArgs {
+  kb?: string;
+  append?: string;
+  note?: string;
+  language?: string;
+  maxBytes: number;
+  allowFail: boolean;
+  refresh: boolean;
+  command: string[];
+}
+
+interface CommandResult {
+  stdout: string;
+  truncated: boolean;
+  bytesElided: number;
+  exitCode: number;
+}
+
+const DEFAULT_MAX_BYTES = 64 * 1024;
+
+const LANGUAGE_BY_EXT: Record<string, string> = {
+  json: 'json',
+  yml: 'yaml',
+  yaml: 'yaml',
+};
+
+export async function runCapture(rest: string[]): Promise<number> {
+  let parsed: CaptureArgs;
+  try {
+    parsed = parseCaptureArgs(rest);
+    validateCaptureArgs(parsed);
+  } catch (err) {
+    process.stderr.write(`kb capture: ${(err as Error).message}\n`);
+    return 2;
+  }
+
+  // Reject traversal/absolute --append paths before spawning the command —
+  // an obviously bogus target shouldn't have side effects.
+  try {
+    rejectAbsoluteOrTraversal(parsed.append!);
+  } catch (err) {
+    process.stderr.write(`kb capture: ${(err as Error).message}\n`);
+    return 1;
+  }
+
+  let result: CommandResult;
+  try {
+    result = await runCommand(parsed.command, parsed.maxBytes);
+  } catch (err) {
+    process.stderr.write(`kb capture: failed to spawn command: ${(err as Error).message}\n`);
+    return 1;
+  }
+
+  if (result.exitCode !== 0 && !parsed.allowFail) {
+    process.stderr.write(
+      `kb capture: command exited ${result.exitCode}; pass --allow-fail to capture anyway.\n`,
+    );
+    return 1;
+  }
+  if (result.stdout.length === 0) {
+    process.stderr.write('kb capture: command produced no stdout; refusing to write empty fence.\n');
+    return 1;
+  }
+
+  const language = parsed.language ?? detectLanguageFromCommand(parsed.command);
+  const block = buildMarkdownBlock({
+    note: parsed.note,
+    command: parsed.command,
+    stdout: result.stdout,
+    truncated: result.truncated,
+    bytesElided: result.bytesElided,
+    language,
+  });
+
+  let relativePath: string;
+  try {
+    relativePath = await appendToNote(parsed.kb!, parsed.append!, block);
+  } catch (err) {
+    process.stderr.write(`kb capture: ${(err as Error).message}\n`);
+    return 1;
+  }
+
+  if (parsed.refresh) {
+    try {
+      await refreshKnowledgeBase(parsed.kb!);
+    } catch (err) {
+      if (err instanceof ActiveModelResolutionError) {
+        process.stderr.write(`kb capture: ${err.message}\n`);
+        return 2;
+      }
+      process.stderr.write(`kb capture: refresh failed after write: ${(err as Error).message}\n`);
+      return 1;
+    }
+  }
+
+  process.stdout.write(`${JSON.stringify({
+    knowledge_base_name: parsed.kb,
+    path: relativePath,
+    action: 'capture',
+    truncated: result.truncated,
+    bytes_elided: result.bytesElided,
+    exit_code: result.exitCode,
+    refreshed: parsed.refresh,
+  }, null, 2)}\n`);
+  return 0;
+}
+
+function parseCaptureArgs(rest: string[]): CaptureArgs {
+  const out: CaptureArgs = {
+    maxBytes: DEFAULT_MAX_BYTES,
+    allowFail: false,
+    refresh: false,
+    command: [],
+  };
+  let sawSeparator = false;
+  for (let i = 0; i < rest.length; i++) {
+    const raw = rest[i];
+    if (sawSeparator) {
+      out.command.push(raw);
+      continue;
+    }
+    if (raw === '--') { sawSeparator = true; continue; }
+    if (raw === '--allow-fail') { out.allowFail = true; continue; }
+    if (raw === '--refresh') { out.refresh = true; continue; }
+    if (raw.startsWith('--kb=')) { out.kb = raw.slice('--kb='.length); continue; }
+    if (raw.startsWith('--append=')) { out.append = raw.slice('--append='.length); continue; }
+    if (raw.startsWith('--note=')) { out.note = raw.slice('--note='.length); continue; }
+    if (raw === '--note') {
+      const next = rest[i + 1];
+      if (next === undefined) throw new Error('--note requires a value');
+      out.note = next;
+      i++;
+      continue;
+    }
+    if (raw.startsWith('--language=')) { out.language = raw.slice('--language='.length); continue; }
+    if (raw.startsWith('--max-bytes=')) {
+      const valueStr = raw.slice('--max-bytes='.length);
+      const n = Number(valueStr);
+      if (!Number.isInteger(n) || n <= 0) {
+        throw new Error(`invalid --max-bytes: ${JSON.stringify(valueStr)}`);
+      }
+      out.maxBytes = n;
+      continue;
+    }
+    if (raw.startsWith('--')) throw new Error(`unknown flag: ${raw}`);
+    throw new Error(`unexpected argument before "--": ${JSON.stringify(raw)}`);
+  }
+  return out;
+}
+
+function validateCaptureArgs(args: CaptureArgs): void {
+  if (args.kb === undefined || args.kb.trim() === '') {
+    throw new Error('missing --kb=<name>');
+  }
+  if (args.append === undefined || args.append.trim() === '') {
+    throw new Error('missing --append=<path>');
+  }
+  if (args.command.length === 0) {
+    throw new Error('missing command after "--"');
+  }
+}
+
+async function runCommand(command: string[], maxBytes: number): Promise<CommandResult> {
+  return new Promise((resolve, reject) => {
+    const [cmd, ...args] = command;
+    const child = spawn(cmd, args, { shell: false, stdio: ['ignore', 'pipe', 'inherit'] });
+    const chunks: Buffer[] = [];
+    let captured = 0;
+    let totalBytes = 0;
+    let truncated = false;
+    child.stdout.on('data', (chunk: Buffer) => {
+      totalBytes += chunk.length;
+      if (truncated) return;
+      const remaining = maxBytes - captured;
+      if (chunk.length <= remaining) {
+        chunks.push(chunk);
+        captured += chunk.length;
+      } else {
+        if (remaining > 0) {
+          const slice = chunk.subarray(0, remaining);
+          chunks.push(slice);
+          captured += slice.length;
+        }
+        truncated = true;
+      }
+    });
+    child.on('error', reject);
+    child.on('close', (code) => {
+      const stdout = Buffer.concat(chunks).toString('utf-8');
+      resolve({
+        stdout,
+        truncated,
+        bytesElided: truncated ? Math.max(0, totalBytes - captured) : 0,
+        exitCode: code ?? 1,
+      });
+    });
+  });
+}
+
+interface BlockOptions {
+  note?: string;
+  command: string[];
+  stdout: string;
+  truncated: boolean;
+  bytesElided: number;
+  language: string | null;
+}
+
+function buildMarkdownBlock(opts: BlockOptions): string {
+  const fence = '`'.repeat(longestBacktickRun(opts.stdout) + 1);
+  const lines: string[] = [];
+  lines.push('');
+  if (opts.note !== undefined && opts.note.length > 0) {
+    lines.push(`### ${opts.note}`);
+    lines.push('');
+  }
+  lines.push(`$ ${quoteCommand(opts.command)}`);
+  lines.push(opts.language !== null ? `${fence}${opts.language}` : fence);
+  lines.push(stripTrailingNewline(opts.stdout));
+  if (opts.truncated) {
+    lines.push(`... (truncated, ${opts.bytesElided} bytes elided)`);
+  }
+  lines.push(fence);
+  lines.push('');
+  return lines.join('\n');
+}
+
+function stripTrailingNewline(text: string): string {
+  return text.endsWith('\n') ? text.slice(0, -1) : text;
+}
+
+function longestBacktickRun(text: string): number {
+  const matches = text.match(/`+/g);
+  if (matches === null) return 2;
+  let longest = 2;
+  for (const run of matches) {
+    if (run.length > longest) longest = run.length;
+  }
+  return longest;
+}
+
+function quoteCommand(argv: string[]): string {
+  return argv.map(shellQuote).join(' ');
+}
+
+function shellQuote(arg: string): string {
+  if (arg.length === 0) return "''";
+  if (/^[A-Za-z0-9_./:@%+=-]+$/.test(arg)) return arg;
+  return `'${arg.replace(/'/g, "'\\''")}'`;
+}
+
+function detectLanguageFromCommand(argv: string[]): string | null {
+  for (let i = argv.length - 1; i >= 0; i--) {
+    const match = argv[i].match(/\.([A-Za-z0-9]+)$/);
+    if (match === null) continue;
+    const ext = match[1].toLowerCase();
+    if (ext in LANGUAGE_BY_EXT) return LANGUAGE_BY_EXT[ext];
+  }
+  return null;
+}
+
+async function appendToNote(kbName: string, relativePath: string, content: string): Promise<string> {
+  rejectAbsoluteOrTraversal(relativePath);
+  const documentPath = await resolveKbRelativePath(KNOWLEDGE_BASES_ROOT_DIR, kbName, relativePath);
+  const stat = await fsp.stat(documentPath);
+  if (!stat.isFile()) {
+    throw new Error(`append target is not a file: ${JSON.stringify(relativePath)}`);
+  }
+  await fsp.appendFile(documentPath, content, 'utf-8');
+  const kbDir = await resolveKnowledgeBaseDir(KNOWLEDGE_BASES_ROOT_DIR, kbName);
+  return path.relative(kbDir, documentPath).split(path.sep).join('/');
+}
+
+function rejectAbsoluteOrTraversal(relativePath: string): void {
+  const normalized = relativePath.replace(/\\/g, '/');
+  if (
+    path.posix.isAbsolute(normalized) ||
+    path.win32.isAbsolute(relativePath) ||
+    normalized.split('/').some((segment) => segment === '..')
+  ) {
+    throw new Error(`append path escapes KB root: ${JSON.stringify(relativePath)}`);
+  }
+}
+
+async function refreshKnowledgeBase(kbName: string): Promise<void> {
+  await FaissIndexManager.bootstrapLayout();
+  const activeModelId = await resolveActiveModel();
+  const manager = await loadManagerForModel(activeModelId);
+  await withWriteLock(manager.modelDir, async () => {
+    await manager.initialize();
+    await manager.updateIndex(kbName);
+  });
+}

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -46,6 +46,7 @@ describe('kb CLI — argv parsing and dispatch', () => {
     expect(r.stdout).toContain('kb list');
     expect(r.stdout).toContain('kb search');
     expect(r.stdout).toContain('kb remember');
+    expect(r.stdout).toContain('kb capture');
   });
 
   it('no args exits 0 with usage text', () => {
@@ -262,6 +263,173 @@ describe('kb remember', () => {
     } finally {
       await fsp.rm(tempDir, { recursive: true, force: true });
     }
+  });
+});
+
+describe('kb capture', () => {
+  async function makeKb(prefix: string): Promise<{ tempDir: string; rootDir: string; faissDir: string; notePath: string }> {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), prefix));
+    const rootDir = path.join(tempDir, 'kbs');
+    const faissDir = path.join(tempDir, '.faiss');
+    const notePath = path.join(rootDir, 'project', 'snapshots.md');
+    await fsp.mkdir(path.dirname(notePath), { recursive: true });
+    await fsp.writeFile(notePath, '# Snapshots\n', 'utf-8');
+    return { tempDir, rootDir, faissDir, notePath };
+  }
+
+  it('appends a fenced block with $ command line and note header', async () => {
+    const { tempDir, rootDir, faissDir, notePath } = await makeKb('kb-cli-capture-basic-');
+    try {
+      const r = runCli(
+        ['capture', '--kb=project', '--append=snapshots.md', '--note=Snapshot 1', '--', 'echo', 'hello'],
+        { KNOWLEDGE_BASES_ROOT_DIR: rootDir, FAISS_INDEX_PATH: faissDir },
+      );
+
+      expect(r.code).toBe(0);
+      expect(r.stdout).toContain('"action": "capture"');
+      expect(r.stdout).toContain('"truncated": false');
+      expect(r.stdout).toContain('"path": "snapshots.md"');
+      const after = await fsp.readFile(notePath, 'utf-8');
+      expect(after).toBe(
+        '# Snapshots\n' +
+        '\n' +
+        '### Snapshot 1\n' +
+        '\n' +
+        '$ echo hello\n' +
+        '```\n' +
+        'hello\n' +
+        '```\n',
+      );
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('auto-detects json language hint from a .json positional arg', async () => {
+    const { tempDir, rootDir, faissDir, notePath } = await makeKb('kb-cli-capture-lang-');
+    try {
+      const dataPath = path.join(tempDir, 'data.json');
+      await fsp.writeFile(dataPath, '{"k":1}\n', 'utf-8');
+
+      const r = runCli(
+        ['capture', '--kb=project', '--append=snapshots.md', '--', 'cat', dataPath],
+        { KNOWLEDGE_BASES_ROOT_DIR: rootDir, FAISS_INDEX_PATH: faissDir },
+      );
+
+      expect(r.code).toBe(0);
+      const after = await fsp.readFile(notePath, 'utf-8');
+      expect(after).toContain('```json\n');
+      expect(after).toContain('{"k":1}');
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('escapes backticks in stdout by widening the fence', async () => {
+    const { tempDir, rootDir, faissDir, notePath } = await makeKb('kb-cli-capture-fence-');
+    try {
+      const r = runCli(
+        ['capture', '--kb=project', '--append=snapshots.md', '--', 'printf', '```inner```\n'],
+        { KNOWLEDGE_BASES_ROOT_DIR: rootDir, FAISS_INDEX_PATH: faissDir },
+      );
+
+      expect(r.code).toBe(0);
+      const after = await fsp.readFile(notePath, 'utf-8');
+      expect(after).toContain('\n````\n```inner```\n````\n');
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('truncates at --max-bytes and records the elision count', async () => {
+    const { tempDir, rootDir, faissDir, notePath } = await makeKb('kb-cli-capture-trunc-');
+    try {
+      const r = runCli(
+        [
+          'capture', '--kb=project', '--append=snapshots.md', '--max-bytes=4',
+          '--', 'printf', 'abcdefghij',
+        ],
+        { KNOWLEDGE_BASES_ROOT_DIR: rootDir, FAISS_INDEX_PATH: faissDir },
+      );
+
+      expect(r.code).toBe(0);
+      expect(r.stdout).toContain('"truncated": true');
+      expect(r.stdout).toContain('"bytes_elided": 6');
+      const after = await fsp.readFile(notePath, 'utf-8');
+      expect(after).toContain('abcd\n... (truncated, 6 bytes elided)\n');
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('refuses non-zero exit unless --allow-fail is passed', async () => {
+    const { tempDir, rootDir, faissDir, notePath } = await makeKb('kb-cli-capture-fail-');
+    try {
+      const before = await fsp.readFile(notePath, 'utf-8');
+      const fail = runCli(
+        ['capture', '--kb=project', '--append=snapshots.md', '--', 'sh', '-c', 'echo hi; exit 3'],
+        { KNOWLEDGE_BASES_ROOT_DIR: rootDir, FAISS_INDEX_PATH: faissDir },
+      );
+      expect(fail.code).toBe(1);
+      expect(fail.stderr).toContain('command exited 3');
+      await expect(fsp.readFile(notePath, 'utf-8')).resolves.toBe(before);
+
+      const allow = runCli(
+        ['capture', '--kb=project', '--append=snapshots.md', '--allow-fail', '--', 'sh', '-c', 'echo hi; exit 3'],
+        { KNOWLEDGE_BASES_ROOT_DIR: rootDir, FAISS_INDEX_PATH: faissDir },
+      );
+      expect(allow.code).toBe(0);
+      expect(allow.stdout).toContain('"exit_code": 3');
+      const after = await fsp.readFile(notePath, 'utf-8');
+      expect(after).toContain('hi');
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('refuses to write an empty fence when stdout is empty', async () => {
+    const { tempDir, rootDir, faissDir, notePath } = await makeKb('kb-cli-capture-empty-');
+    try {
+      const before = await fsp.readFile(notePath, 'utf-8');
+      const r = runCli(
+        ['capture', '--kb=project', '--append=snapshots.md', '--', 'true'],
+        { KNOWLEDGE_BASES_ROOT_DIR: rootDir, FAISS_INDEX_PATH: faissDir },
+      );
+      expect(r.code).toBe(1);
+      expect(r.stderr).toContain('produced no stdout');
+      await expect(fsp.readFile(notePath, 'utf-8')).resolves.toBe(before);
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects traversal in --append before spawning the command', async () => {
+    const { tempDir, rootDir, faissDir } = await makeKb('kb-cli-capture-path-');
+    try {
+      const r = runCli(
+        ['capture', '--kb=project', '--append=../outside.md', '--', 'printf', 'x'],
+        { KNOWLEDGE_BASES_ROOT_DIR: rootDir, FAISS_INDEX_PATH: faissDir },
+      );
+      expect(r.code).toBe(1);
+      expect(r.stderr).toContain('escapes KB root');
+      await expect(fsp.access(path.join(tempDir, 'outside.md'))).rejects.toMatchObject({ code: 'ENOENT' });
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects argv errors (missing --kb / missing command after --)', async () => {
+    const noKb = runCli(['capture', '--append=snapshots.md', '--', 'printf', 'x']);
+    expect(noKb.code).toBe(2);
+    expect(noKb.stderr).toContain('missing --kb');
+
+    const noCmd = runCli(['capture', '--kb=project', '--append=snapshots.md']);
+    expect(noCmd.code).toBe(2);
+    expect(noCmd.stderr).toContain('missing command after "--"');
+
+    const badMax = runCli(['capture', '--kb=project', '--append=snapshots.md', '--max-bytes=abc', '--', 'printf', 'x']);
+    expect(badMax.code).toBe(2);
+    expect(badMax.stderr).toContain('invalid --max-bytes');
   });
 });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,12 +1,14 @@
 #!/usr/bin/env node
 // RFC 012 — `kb` CLI alongside the MCP server.
 //
-// Two subcommands:
+// Subcommands:
 //   - `kb list`               → list ingested knowledge bases (one per line)
 //   - `kb search <query>`     → similarity search; default read-only
 //                               (skips updateIndex, no write lock)
 //   - `kb search --refresh`   → also runs updateIndex under the write lock
 //   - `kb remember ...`       → conservative CLI write/suggest surface
+//   - `kb capture -- <cmd>`   → run a command and append its stdout to a
+//                               KB note as a fenced, provenance-tagged block
 //
 // Both subcommands check `model_name.txt` against the configured embedding
 // model on every invocation and exit non-zero on mismatch (RFC §4.7) so a
@@ -16,6 +18,7 @@
 import { readFileSync, realpathSync } from 'fs';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
+import { runCapture } from './cli-capture.js';
 import { runCompare } from './cli-compare.js';
 import { runList } from './cli-list.js';
 import { runModels } from './cli-models.js';
@@ -37,6 +40,10 @@ Usage:
                                            Create a new markdown note.
   kb remember --kb=<name> --append=<path> --stdin --yes
                                            Append to an existing KB-relative note.
+  kb capture --kb=<name> --append=<path> [--note=<text>] [--language=<hint>]
+             [--max-bytes=<N>] [--allow-fail] [--refresh] -- <cmd> [args...]
+                                           Run a command and append its stdout
+                                           to a KB note as a fenced block.
   kb compare <query> <a> <b>              Side-by-side rank/score table.
   kb models list                          List registered embedding models.
   kb models add <provider> <model>        Register a new model + ingest.
@@ -62,6 +69,18 @@ Remember options:
   --stdin               Read note content from stdin.
   --yes                 Required for non-interactive writes.
   --refresh             Re-index the affected KB after a successful write.
+
+Capture options:
+  --kb=<name>           Target knowledge base.
+  --append=<path>       Existing KB-relative note path; rejects traversal.
+  --note=<text>         Optional "### <text>" header above the captured block.
+  --language=<hint>     Code-fence language hint; auto-detected from .json /
+                        .yml / .yaml args if absent.
+  --max-bytes=<N>       Truncate captured stdout at N bytes (default 65536).
+  --allow-fail          Capture even when the command exits non-zero.
+  --refresh             Re-index the affected KB after a successful write.
+  --                    End of options; remaining argv is the command + args
+                        passed verbatim to spawn(..., { shell: false }).
 
 Models add options:
   --yes                 Skip the cost-estimate confirmation prompt.
@@ -100,6 +119,9 @@ export async function main(argv: string[]): Promise<number> {
   }
   if (sub === 'remember') {
     return runRemember(rest);
+  }
+  if (sub === 'capture') {
+    return runCapture(rest);
   }
   if (sub === 'models') {
     return runModels(rest);


### PR DESCRIPTION
## Summary

- Adds `kb capture --kb=<name> --append=<path> [--note=<text>] [--language=<hint>] [--max-bytes=<N>] [--allow-fail] [--refresh] -- <cmd> [args...]` — runs a command via `child_process.spawn` (`shell: false`, argv after `--`) and appends its stdout to a KB note as a fenced, provenance-tagged code block.
- The block records the literal command on a `$ <cmd>` line (POSIX-shell-quoted for round-trip), then a fenced code block with the captured stdout. Fence widens beyond three backticks when stdout contains a `` ``` `` run, so embedded fences round-trip without breaking the host markdown.
- Safety: refuses to write when stdout is empty or exit code is non-zero (override with `--allow-fail`); rejects traversal/absolute `--append` paths before spawning; never reads stdin (use `kb remember --stdin` for piped content).
- Auto-detects `json`/`yaml` fence language from a `.json` / `.yml` / `.yaml` argv tail when `--language` is not supplied. `--max-bytes=<N>` truncates oversize stdout (default 64 KiB) and appends `... (truncated, N bytes elided)` inside the fence.

Composes with `kb remember --append-section` (#139) once that lands; without it the captured block lands at EOF of the target note, as the issue describes.

Closes #143.

## Test plan

- [x] `npm run build` clean.
- [x] `npm test` — 424/424 pass; 8 new `kb capture` tests cover: fenced block + note header, json language auto-detect from a `.json` argv tail, fence widening when stdout contains `` ``` ``, `--max-bytes` truncation + elision count, non-zero exit refusal vs `--allow-fail`, empty-stdout refusal, traversal `--append` rejection before spawn, and argv errors (missing `--kb`, missing command after `--`, invalid `--max-bytes`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)