### PR TITLE
feat(cli): add kb where --topic for one-shot KB+file recommendation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased] — CLI `kb where`
+
+### Added
+
+- **`kb where --topic=<query>` CLI command.** One-shot recommendation for "which KB and which file should I update?" — runs a similarity search across every KB (no `--kb=` filter), groups hits by `metadata.knowledgeBase`, picks the KB whose top hit has the lowest FAISS distance, then picks the lowest-scoring file within that KB as the suggested append target. When the best in-KB file score is below `--threshold` (default `1.0`, lower distance = closer match) the output recommends an `--append=<existing-file>` invocation; otherwise it suggests `--title=<title>` to create a new note. `--format=md` (default) prints a four-line block (`Recommended KB`, `Existing target`, `Confidence`, `Suggested invocation`); `--format=json` emits `{recommended_kb, existing_target, confidence, suggested_invocation}`. Strictly read-only — same posture as `kb search` without `--refresh`. Closes #141.
+
 ## [Unreleased] — CLI `kb stale-check`
 
 ### Added

--- a/src/cli-where.test.ts
+++ b/src/cli-where.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+  decideWhere,
+  formatWhereMarkdown,
+  parseWhereArgs,
+} from './cli-where.js';
+import type { ScoredDocument } from './formatter.js';
+
+function doc(kb: string | null, rel: string | null, score: number): ScoredDocument {
+  const metadata: Record<string, unknown> = {};
+  if (kb !== null) metadata.knowledgeBase = kb;
+  if (rel !== null) metadata.relativePath = rel;
+  return { pageContent: 'x', metadata, score };
+}
+
+describe('parseWhereArgs', () => {
+  it('parses --topic and applies defaults', () => {
+    const a = parseWhereArgs(['--topic=kookr state-file schema']);
+    expect(a.topic).toBe('kookr state-file schema');
+    expect(a.threshold).toBe(1.0);
+    expect(a.k).toBe(20);
+    expect(a.format).toBe('md');
+  });
+
+  it('parses --threshold, --k, --format, --model', () => {
+    const a = parseWhereArgs([
+      '--topic=t',
+      '--threshold=0.7',
+      '--k=5',
+      '--format=json',
+      '--model=hf/some-model',
+    ]);
+    expect(a.threshold).toBeCloseTo(0.7, 6);
+    expect(a.k).toBe(5);
+    expect(a.format).toBe('json');
+    expect(a.model).toBe('hf/some-model');
+  });
+
+  it('rejects empty --topic', () => {
+    expect(() => parseWhereArgs(['--topic='])).toThrow(/--topic.*non-empty/);
+  });
+
+  it('rejects unknown flags and positional arguments', () => {
+    expect(() => parseWhereArgs(['--topic=t', '--bogus'])).toThrow(/unknown flag/);
+    expect(() => parseWhereArgs(['--topic=t', 'positional'])).toThrow(/unexpected argument/);
+  });
+
+  it('rejects invalid --threshold and --k', () => {
+    expect(() => parseWhereArgs(['--threshold=abc'])).toThrow(/invalid --threshold/);
+    expect(() => parseWhereArgs(['--threshold=0'])).toThrow(/invalid --threshold/);
+    expect(() => parseWhereArgs(['--k=0'])).toThrow(/invalid --k/);
+    expect(() => parseWhereArgs(['--k=2.5'])).toThrow(/invalid --k/);
+  });
+
+  it('rejects invalid --format', () => {
+    expect(() => parseWhereArgs(['--format=yaml'])).toThrow(/invalid --format/);
+  });
+});
+
+describe('decideWhere', () => {
+  it('returns null on empty results', () => {
+    expect(decideWhere([])).toBeNull();
+  });
+
+  it('picks the KB whose top hit has the lowest score', () => {
+    const results = [
+      doc('alpha', 'a/file-a.md', 0.85),
+      doc('beta', 'b/file-b.md', 0.40),
+      doc('alpha', 'a/file-c.md', 0.92),
+    ];
+    const d = decideWhere(results);
+    expect(d).not.toBeNull();
+    expect(d!.recommendedKb).toBe('beta');
+    expect(d!.existingTarget).toBe('b/file-b.md');
+    expect(d!.confidence).toBeCloseTo(0.40, 6);
+    expect(d!.suggestedInvocation).toContain('--kb=beta');
+    expect(d!.suggestedInvocation).toContain('--append=b/file-b.md');
+  });
+
+  it('within the chosen KB, picks the lowest-score file', () => {
+    const results = [
+      doc('alpha', 'a/older.md', 0.30),
+      doc('alpha', 'a/closer.md', 0.20),
+      doc('alpha', 'a/farther.md', 0.55),
+    ];
+    const d = decideWhere(results);
+    expect(d!.recommendedKb).toBe('alpha');
+    expect(d!.existingTarget).toBe('a/closer.md');
+  });
+
+  it('suggests creating a new note when best score is above the threshold', () => {
+    const results = [
+      doc('alpha', 'a/loose.md', 1.40),
+      doc('beta', 'b/loose.md', 1.55),
+    ];
+    const d = decideWhere(results, 1.0);
+    expect(d!.recommendedKb).toBe('alpha');
+    expect(d!.existingTarget).toBeNull();
+    expect(d!.suggestedInvocation).toContain('--title=<title>');
+    expect(d!.suggestedInvocation).not.toContain('--append=');
+  });
+
+  it('honours a custom confidence threshold', () => {
+    const results = [doc('alpha', 'a/x.md', 0.80)];
+    expect(decideWhere(results, 0.5)!.existingTarget).toBeNull();
+    expect(decideWhere(results, 1.0)!.existingTarget).toBe('a/x.md');
+  });
+
+  it('skips results with no knowledgeBase metadata when picking the KB', () => {
+    const results = [
+      doc(null, null, 0.10),
+      doc('beta', 'b/note.md', 0.50),
+    ];
+    const d = decideWhere(results);
+    expect(d!.recommendedKb).toBe('beta');
+  });
+
+  it('falls back to create-new when the chosen KB has no relativePath hits', () => {
+    // Simulates a KB whose only hit has knowledgeBase set but relativePath
+    // missing (e.g., a chunk created by an older indexing run).
+    const results = [doc('alpha', null, 0.20)];
+    const d = decideWhere(results);
+    expect(d!.recommendedKb).toBe('alpha');
+    expect(d!.existingTarget).toBeNull();
+    expect(d!.suggestedInvocation).toContain('--title=<title>');
+  });
+});
+
+describe('formatWhereMarkdown', () => {
+  it('renders an existing-target recommendation', () => {
+    const out = formatWhereMarkdown({
+      recommendedKb: 'beta',
+      existingTarget: 'b/file-b.md',
+      confidence: 0.71,
+      suggestedInvocation: 'kb remember --kb=beta --append=b/file-b.md --stdin --yes',
+    });
+    expect(out).toContain('Recommended KB:        beta');
+    expect(out).toContain('Existing target:       b/file-b.md');
+    expect(out).toContain('Confidence:            0.71');
+    expect(out).toContain('high; lower distance = closer match');
+  });
+
+  it('renders a create-new recommendation when no existing target', () => {
+    const out = formatWhereMarkdown({
+      recommendedKb: 'alpha',
+      existingTarget: null,
+      confidence: 1.42,
+      suggestedInvocation: 'kb remember --kb=alpha --title=<title> --stdin --yes',
+    });
+    expect(out).toContain('Existing target:       _(none');
+    expect(out).toContain('low; lower distance = closer match');
+    expect(out).toContain('--title=<title>');
+  });
+});

--- a/src/cli-where.ts
+++ b/src/cli-where.ts
@@ -1,0 +1,271 @@
+// `kb where --topic=<query>` — one-shot "which KB and which file should I
+// update?" recommendation (issue #141).
+//
+// Strategy (from the issue body, "cheap path"):
+//   1. Run a similarity search across all KBs (no `--kb=` filter).
+//   2. Group hits by `metadata.knowledgeBase`. The KB with the highest-scoring
+//      top hit is the recommended KB.
+//   3. The single file with the highest score within that KB is the
+//      recommended existing target.
+//   4. Apply a confidence threshold: lower FAISS distance = closer match;
+//      a top score below `--threshold` (default 1.0) is "high confidence
+//      existing target", otherwise suggest `kb remember --title=...` to
+//      create a new note.
+//   5. Print the recommendation + a copy-pasteable `kb remember` invocation.
+//
+// Strictly read-only — same posture as `kb search` without `--refresh`.
+//
+// Composes with #139 (`--append-section`) and #140 (`kb list --describe`)
+// once those land; today the suggestion sticks to flags the CLI accepts.
+
+import { FaissIndexManager } from './FaissIndexManager.js';
+import {
+  ActiveModelResolutionError,
+  resolveActiveModel,
+} from './active-model.js';
+import { loadManagerForModel, loadWithJsonRetry } from './cli-shared.js';
+import type { ScoredDocument } from './formatter.js';
+
+export interface WhereArgs {
+  topic: string | null;
+  model?: string;
+  threshold: number;
+  k: number;
+  format: 'md' | 'json';
+}
+
+export interface WhereDecision {
+  recommendedKb: string;
+  existingTarget: string | null;
+  confidence: number;
+  suggestedInvocation: string;
+}
+
+const DEFAULT_CONFIDENCE_THRESHOLD = 1.0;
+const DEFAULT_K = 20;
+
+export async function runWhere(rest: string[]): Promise<number> {
+  let parsed: WhereArgs;
+  try {
+    parsed = parseWhereArgs(rest);
+  } catch (err) {
+    process.stderr.write(`kb where: ${(err as Error).message}\n`);
+    return 2;
+  }
+
+  if (parsed.topic === null) {
+    process.stderr.write('kb where: missing --topic=<query>\n');
+    return 2;
+  }
+
+  try {
+    await FaissIndexManager.bootstrapLayout();
+  } catch (err) {
+    process.stderr.write(`kb where: layout bootstrap failed: ${(err as Error).message}\n`);
+    return 1;
+  }
+
+  let activeModelId: string;
+  try {
+    activeModelId = await resolveActiveModel({ explicitOverride: parsed.model });
+  } catch (err) {
+    if (err instanceof ActiveModelResolutionError) {
+      process.stderr.write(`kb where: ${err.message}\n`);
+      return 2;
+    }
+    process.stderr.write(`kb where: ${(err as Error).message}\n`);
+    return 1;
+  }
+
+  let manager: FaissIndexManager;
+  try {
+    manager = await loadManagerForModel(activeModelId);
+  } catch (err) {
+    process.stderr.write(`kb where: ${(err as Error).message}\n`);
+    return 2;
+  }
+
+  try {
+    await loadWithJsonRetry(manager);
+  } catch (err) {
+    process.stderr.write(`kb where: ${(err as Error).message}\n`);
+    return 1;
+  }
+
+  let results: ScoredDocument[];
+  try {
+    // No `--kb=` filter — we want the cross-KB ranking.
+    results = await manager.similaritySearch(
+      parsed.topic,
+      parsed.k,
+      Number.POSITIVE_INFINITY,
+    );
+  } catch (err) {
+    process.stderr.write(`kb where: ${(err as Error).message}\n`);
+    return 1;
+  }
+
+  const decision = decideWhere(results, parsed.threshold);
+  if (decision === null) {
+    if (parsed.format === 'json') {
+      process.stdout.write(`${JSON.stringify({ recommended_kb: null, results: [] }, null, 2)}\n`);
+    } else {
+      process.stdout.write(
+        '_No similar notes found. Run `kb search --refresh` if the index is empty or stale._\n',
+      );
+    }
+    return 0;
+  }
+
+  if (parsed.format === 'json') {
+    process.stdout.write(`${JSON.stringify(toJsonShape(decision), null, 2)}\n`);
+  } else {
+    process.stdout.write(formatWhereMarkdown(decision));
+    process.stdout.write('\n');
+  }
+  return 0;
+}
+
+export function parseWhereArgs(rest: string[]): WhereArgs {
+  const out: WhereArgs = {
+    topic: null,
+    threshold: DEFAULT_CONFIDENCE_THRESHOLD,
+    k: DEFAULT_K,
+    format: 'md',
+  };
+  for (const raw of rest) {
+    if (raw === '--help' || raw === '-h') {
+      throw new Error(
+        'usage: kb where --topic=<query> [--threshold=<float>] [--k=<int>] [--format=md|json] [--model=<id>]',
+      );
+    }
+    if (raw.startsWith('--topic=')) {
+      const v = raw.slice('--topic='.length);
+      if (v.length === 0) throw new Error('--topic=<query> requires a non-empty value');
+      out.topic = v;
+      continue;
+    }
+    if (raw.startsWith('--model=')) {
+      out.model = raw.slice('--model='.length);
+      continue;
+    }
+    if (raw.startsWith('--threshold=')) {
+      const n = Number(raw.slice('--threshold='.length));
+      if (!Number.isFinite(n) || n <= 0) throw new Error(`invalid --threshold: ${raw}`);
+      out.threshold = n;
+      continue;
+    }
+    if (raw.startsWith('--k=')) {
+      const n = Number(raw.slice('--k='.length));
+      if (!Number.isInteger(n) || n <= 0) throw new Error(`invalid --k: ${raw}`);
+      out.k = n;
+      continue;
+    }
+    if (raw.startsWith('--format=')) {
+      const v = raw.slice('--format='.length);
+      if (v !== 'md' && v !== 'json') throw new Error(`invalid --format: ${raw}`);
+      out.format = v;
+      continue;
+    }
+    if (raw.startsWith('--')) throw new Error(`unknown flag: ${raw}`);
+    throw new Error(`unexpected argument: ${JSON.stringify(raw)}`);
+  }
+  return out;
+}
+
+/**
+ * Reduces a flat list of cross-KB search results to a single recommendation.
+ *
+ * Returns `null` when `results` is empty or no result has a usable
+ * `metadata.knowledgeBase` field (defensive — should not happen in practice
+ * since FaissIndexManager always stamps it).
+ *
+ * Lower score = closer match (FAISS L2 distance). The "best" hit is the one
+ * with the lowest score; the "best file" within that KB is the lowest-scoring
+ * result whose `relativePath` is set.
+ */
+export function decideWhere(
+  results: readonly ScoredDocument[],
+  confidenceThreshold: number = DEFAULT_CONFIDENCE_THRESHOLD,
+): WhereDecision | null {
+  if (results.length === 0) return null;
+
+  let bestKb: string | null = null;
+  let bestKbScore = Number.POSITIVE_INFINITY;
+  for (const r of results) {
+    const kb = readKb(r);
+    if (kb === null) continue;
+    const score = r.score ?? Number.POSITIVE_INFINITY;
+    if (score < bestKbScore) {
+      bestKbScore = score;
+      bestKb = kb;
+    }
+  }
+  if (bestKb === null) return null;
+
+  let bestFile: string | null = null;
+  let bestFileScore = Number.POSITIVE_INFINITY;
+  for (const r of results) {
+    if (readKb(r) !== bestKb) continue;
+    const rel = readRelativePath(r);
+    if (rel === null) continue;
+    const score = r.score ?? Number.POSITIVE_INFINITY;
+    if (score < bestFileScore) {
+      bestFileScore = score;
+      bestFile = rel;
+    }
+  }
+
+  const confident = bestFile !== null && bestFileScore < confidenceThreshold;
+  return {
+    recommendedKb: bestKb,
+    existingTarget: confident ? bestFile : null,
+    confidence: confident ? bestFileScore : bestKbScore,
+    suggestedInvocation: confident
+      ? buildAppendInvocation(bestKb, bestFile as string)
+      : buildCreateInvocation(bestKb),
+  };
+}
+
+function readKb(r: ScoredDocument): string | null {
+  const v = (r.metadata as Record<string, unknown> | undefined)?.knowledgeBase;
+  return typeof v === 'string' && v.length > 0 ? v : null;
+}
+
+function readRelativePath(r: ScoredDocument): string | null {
+  const v = (r.metadata as Record<string, unknown> | undefined)?.relativePath;
+  return typeof v === 'string' && v.length > 0 ? v : null;
+}
+
+function buildAppendInvocation(kb: string, relPath: string): string {
+  return (
+    `kb remember --kb=${kb} \\\n` +
+    `             --append=${relPath} \\\n` +
+    `             --stdin --yes`
+  );
+}
+
+function buildCreateInvocation(kb: string): string {
+  return `kb remember --kb=${kb} --title=<title> --stdin --yes`;
+}
+
+export function formatWhereMarkdown(d: WhereDecision): string {
+  const target = d.existingTarget ?? '_(none — suggest creating a new note)_';
+  const conf = d.confidence.toFixed(2);
+  const confLabel = d.existingTarget !== null ? 'high' : 'low';
+  return (
+    `Recommended KB:        ${d.recommendedKb}\n` +
+    `Existing target:       ${target}\n` +
+    `Confidence:            ${conf} (${confLabel}; lower distance = closer match)\n` +
+    `Suggested invocation:  ${d.suggestedInvocation}`
+  );
+}
+
+function toJsonShape(d: WhereDecision): Record<string, unknown> {
+  return {
+    recommended_kb: d.recommendedKb,
+    existing_target: d.existingTarget,
+    confidence: d.confidence,
+    suggested_invocation: d.suggestedInvocation,
+  };
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -25,6 +25,7 @@ import { runModels } from './cli-models.js';
 import { runRemember } from './cli-remember.js';
 import { runSearch } from './cli-search.js';
 import { runStaleCheck } from './cli-stale-check.js';
+import { runWhere } from './cli-where.js';
 
 // ----- Entry point -----------------------------------------------------------
 
@@ -50,6 +51,10 @@ Usage:
                                            Scan markdown notes for path / URL
                                            references that no longer resolve.
                                            Strictly read-only.
+  kb where --topic=<query> [--threshold=<float>] [--k=<int>] [--format=md|json]
+                                           One-shot recommendation: which KB
+                                           and which file should I update for
+                                           the given topic? Strictly read-only.
   kb models list                          List registered embedding models.
   kb models add <provider> <model>        Register a new model + ingest.
   kb models set-active <id>               Change the default model.
@@ -136,6 +141,9 @@ export async function main(argv: string[]): Promise<number> {
   }
   if (sub === 'stale-check') {
     return runStaleCheck(rest);
+  }
+  if (sub === 'where') {
+    return runWhere(rest);
   }
 
   process.stderr.write(`kb: unknown subcommand '${sub}'\n${HELP}`);


### PR DESCRIPTION
## Summary
- Adds a new top-level `kb where --topic="..."` CLI command that returns the recommended KB, the recommended existing target file (when confidence is high), and a ready-to-paste `kb remember` invocation.
- Internally composes existing `kb search` results across all KBs, groups hits by KB, picks the KB whose top hit has the lowest score, then picks the lowest-score file inside that KB.
- Applies a confidence threshold (default 1.0) — above threshold suggests creating a new note instead of appending.
- Supports `--format=md|json`, `--threshold`, `--k`, and `--model` flags.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm test` — all 457 tests pass (15 new in `src/cli-where.test.ts`)
- [x] `npm run build` clean
- [x] Smoke test: `kb where` prints usage; `kb where --topic=...` produces a recommendation

Closes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)