### PR TITLE
feat(cli): add kb list --describe for one-line README descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased] — CLI `kb list --describe`
+
+### Added
+
+- **`kb list --describe` (alias `-v`).** Prints a one-line description per knowledge base alongside its name, sourced from each KB's own `README.md`. The first `#`-style heading wins (any level, leading hashes stripped); when no heading exists the first non-blank line is used, truncated at 80 characters so a stray long paragraph cannot break column alignment. Missing or unreadable READMEs surface as the empty string and the bare KB name is printed without trailing whitespace, so a partial filesystem cannot turn a listing into an error. Default md output is two-column padded (longest KB name + three spaces + description); `--format=json` emits `[{name, description}]` (or `[{name}]` without `--describe`). The bare `kb list` still prints one name per line so existing scripts that grep the listing keep working. Closes #140.
+
 ## [Unreleased] — CLI `kb where`
 
 ### Added

--- a/src/cli-list.ts
+++ b/src/cli-list.ts
@@ -1,11 +1,75 @@
 import { KNOWLEDGE_BASES_ROOT_DIR } from './config.js';
-import { listKnowledgeBases } from './kb-fs.js';
+import { describeKnowledgeBase, listKnowledgeBases } from './kb-fs.js';
 
-export async function runList(): Promise<number> {
+interface ListArgs {
+  describe: boolean;
+  format: 'md' | 'json';
+}
+
+function parseListArgs(rest: string[]): ListArgs {
+  let describe = false;
+  let format: 'md' | 'json' = 'md';
+  for (const arg of rest) {
+    if (arg === '--describe' || arg === '-v') {
+      describe = true;
+      continue;
+    }
+    if (arg.startsWith('--format=')) {
+      const value = arg.slice('--format='.length);
+      if (value !== 'md' && value !== 'json') {
+        throw new Error(`invalid --format value '${value}' (expected md or json)`);
+      }
+      format = value;
+      continue;
+    }
+    throw new Error(`unknown option '${arg}'`);
+  }
+  return { describe, format };
+}
+
+export async function runList(rest: string[] = []): Promise<number> {
+  let parsed: ListArgs;
+  try {
+    parsed = parseListArgs(rest);
+  } catch (err) {
+    process.stderr.write(`kb list: ${(err as Error).message}\n`);
+    return 2;
+  }
+
   try {
     const kbs = await listKnowledgeBases(KNOWLEDGE_BASES_ROOT_DIR);
-    for (const name of kbs) {
-      process.stdout.write(`${name}\n`);
+
+    if (parsed.format === 'json') {
+      const items = parsed.describe
+        ? await Promise.all(
+            kbs.map(async (name) => ({
+              name,
+              description: await describeKnowledgeBase(KNOWLEDGE_BASES_ROOT_DIR, name),
+            })),
+          )
+        : kbs.map((name) => ({ name }));
+      process.stdout.write(`${JSON.stringify(items, null, 2)}\n`);
+      return 0;
+    }
+
+    if (!parsed.describe) {
+      for (const name of kbs) {
+        process.stdout.write(`${name}\n`);
+      }
+      return 0;
+    }
+
+    const descriptions = await Promise.all(
+      kbs.map((name) => describeKnowledgeBase(KNOWLEDGE_BASES_ROOT_DIR, name)),
+    );
+    const longest = kbs.reduce((max, n) => Math.max(max, n.length), 0);
+    for (let i = 0; i < kbs.length; i++) {
+      const desc = descriptions[i];
+      if (desc.length === 0) {
+        process.stdout.write(`${kbs[i]}\n`);
+      } else {
+        process.stdout.write(`${kbs[i].padEnd(longest)}   ${desc}\n`);
+      }
     }
     return 0;
   } catch (err) {

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -463,6 +463,135 @@ describe('kb list', () => {
   });
 });
 
+describe('kb list --describe (#140)', () => {
+  it('prints two-column name + heading description from README.md', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-cli-list-describe-'));
+    try {
+      const eng = path.join(tempDir, 'engineering');
+      const personal = path.join(tempDir, 'personal');
+      await fsp.mkdir(eng);
+      await fsp.mkdir(personal);
+      await fsp.writeFile(
+        path.join(eng, 'README.md'),
+        '# Engineering notes\n\nlonger details below\n',
+      );
+      // personal: no README — should print the bare name with no trailing space.
+
+      const r = runCli(['list', '--describe'], {
+        KNOWLEDGE_BASES_ROOT_DIR: tempDir,
+        FAISS_INDEX_PATH: path.join(tempDir, '.faiss'),
+      });
+
+      expect(r.code).toBe(0);
+      const lines = r.stdout.trimEnd().split('\n').sort();
+      expect(lines).toHaveLength(2);
+      const engLine = lines.find((l) => l.startsWith('engineering'));
+      const personalLine = lines.find((l) => l.startsWith('personal'));
+      expect(engLine).toMatch(/^engineering\s{3,}Engineering notes$/);
+      expect(personalLine).toBe('personal');
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('-v is an alias for --describe', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-cli-list-v-'));
+    try {
+      const kb = path.join(tempDir, 'k');
+      await fsp.mkdir(kb);
+      await fsp.writeFile(path.join(kb, 'README.md'), '# only-kb\n');
+
+      const r = runCli(['list', '-v'], {
+        KNOWLEDGE_BASES_ROOT_DIR: tempDir,
+        FAISS_INDEX_PATH: path.join(tempDir, '.faiss'),
+      });
+
+      expect(r.code).toBe(0);
+      expect(r.stdout).toContain('only-kb');
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('--format=json --describe emits an array of {name, description}', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-cli-list-json-'));
+    try {
+      const eng = path.join(tempDir, 'engineering');
+      const personal = path.join(tempDir, 'personal');
+      await fsp.mkdir(eng);
+      await fsp.mkdir(personal);
+      await fsp.writeFile(path.join(eng, 'README.md'), '# Engineering notes\n');
+
+      const r = runCli(['list', '--describe', '--format=json'], {
+        KNOWLEDGE_BASES_ROOT_DIR: tempDir,
+        FAISS_INDEX_PATH: path.join(tempDir, '.faiss'),
+      });
+
+      expect(r.code).toBe(0);
+      const parsed = JSON.parse(r.stdout) as Array<{ name: string; description: string }>;
+      const byName = new Map(parsed.map((item) => [item.name, item.description]));
+      expect(byName.get('engineering')).toBe('Engineering notes');
+      expect(byName.get('personal')).toBe('');
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('--format=json without --describe emits {name}-only objects', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-cli-list-json-namesonly-'));
+    try {
+      await fsp.mkdir(path.join(tempDir, 'a'));
+
+      const r = runCli(['list', '--format=json'], {
+        KNOWLEDGE_BASES_ROOT_DIR: tempDir,
+        FAISS_INDEX_PATH: path.join(tempDir, '.faiss'),
+      });
+
+      expect(r.code).toBe(0);
+      const parsed = JSON.parse(r.stdout) as Array<Record<string, unknown>>;
+      expect(parsed).toHaveLength(1);
+      expect(parsed[0]).toEqual({ name: 'a' });
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects unknown options with exit code 2', () => {
+    const r = runCli(['list', '--bogus'], {
+      KNOWLEDGE_BASES_ROOT_DIR: '/tmp',
+    });
+    expect(r.code).toBe(2);
+    expect(r.stderr).toContain("unknown option '--bogus'");
+  });
+
+  it('rejects invalid --format values with exit code 2', () => {
+    const r = runCli(['list', '--format=xml'], {
+      KNOWLEDGE_BASES_ROOT_DIR: '/tmp',
+    });
+    expect(r.code).toBe(2);
+    expect(r.stderr).toContain('invalid --format');
+  });
+
+  it('plain `kb list` is unchanged (one bare name per line, no description)', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-cli-list-plain-'));
+    try {
+      const eng = path.join(tempDir, 'engineering');
+      await fsp.mkdir(eng);
+      await fsp.writeFile(path.join(eng, 'README.md'), '# would-be-description\n');
+
+      const r = runCli(['list'], {
+        KNOWLEDGE_BASES_ROOT_DIR: tempDir,
+        FAISS_INDEX_PATH: path.join(tempDir, '.faiss'),
+      });
+
+      expect(r.code).toBe(0);
+      expect(r.stdout.trimEnd().split('\n')).toEqual(['engineering']);
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+});
+
 describe('kb search — active-model resolution (RFC 013 §4.7)', () => {
   // RFC 013 supersedes the RFC-012 §4.7 model-mismatch check: each model lives
   // in its own ${PATH}/models/<id>/ subdir, so env-vs-active divergence no

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -32,7 +32,11 @@ import { runWhere } from './cli-where.js';
 const HELP = `kb — knowledge-base CLI (RFC 012 + RFC 013)
 
 Usage:
-  kb list                                 List available knowledge bases.
+  kb list [--describe|-v] [--format=md|json]
+                                           List available knowledge bases. With
+                                           --describe (alias -v) include a
+                                           one-line description sourced from
+                                           each KB's README.md.
   kb search <query> [opts]                Semantic search (read-only).
   kb search <query> --refresh             Also re-scan KB files (write path).
   kb search --stdin                       Read query from stdin.
@@ -122,7 +126,7 @@ export async function main(argv: string[]): Promise<number> {
   const rest = args.slice(1);
 
   if (sub === 'list') {
-    return runList();
+    return runList(rest);
   }
   if (sub === 'search') {
     return runSearch(rest);

--- a/src/kb-fs.test.ts
+++ b/src/kb-fs.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from '@jest/globals';
 import * as fsp from 'fs/promises';
 import * as os from 'os';
 import * as path from 'path';
-import { listKnowledgeBases } from './kb-fs.js';
+import { describeKnowledgeBase, extractKbDescription, listKnowledgeBases } from './kb-fs.js';
 
 describe('listKnowledgeBases', () => {
   it('returns names of subdirectories, filtering dot-prefixed entries', async () => {
@@ -35,5 +35,80 @@ describe('listKnowledgeBases', () => {
     await expect(
       listKnowledgeBases('/nonexistent/path/that/should/not/exist'),
     ).rejects.toThrow();
+  });
+});
+
+describe('extractKbDescription', () => {
+  it('returns the first heading title with leading hashes stripped', () => {
+    expect(extractKbDescription('# Engineering KB\n\nrest of body')).toBe('Engineering KB');
+  });
+
+  it('uses any-level heading and trims trailing whitespace', () => {
+    expect(extractKbDescription('\n### Deep heading wins   \n\nbody')).toBe('Deep heading wins');
+  });
+
+  it('skips blank lines before reaching a paragraph fallback', () => {
+    expect(extractKbDescription('\n\n\nplain prose with no heading\n')).toBe(
+      'plain prose with no heading',
+    );
+  });
+
+  it('truncates long paragraphs to 80 characters', () => {
+    const long = 'a'.repeat(200);
+    const out = extractKbDescription(`${long}\n`);
+    expect(out.length).toBe(80);
+    expect(out).toBe('a'.repeat(80));
+  });
+
+  it('returns empty string for empty content', () => {
+    expect(extractKbDescription('')).toBe('');
+  });
+
+  it('returns empty string when content is only whitespace', () => {
+    expect(extractKbDescription('\n   \n\t\n')).toBe('');
+  });
+
+  it('prefers heading over earlier paragraph text', () => {
+    // The pure-text "first non-empty paragraph" branch is a fallback only —
+    // a heading anywhere wins so READMEs that lead with a banner image or
+    // shields don't lose their title to the banner alt-text.
+    const body = '![banner](b.png)\n\n# Real Title\n\nbody';
+    expect(extractKbDescription(body)).toBe('Real Title');
+  });
+});
+
+describe('describeKnowledgeBase', () => {
+  it('reads README.md and returns the heading title', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-fs-describe-'));
+    try {
+      const kbDir = path.join(tempDir, 'engineering');
+      await fsp.mkdir(kbDir);
+      await fsp.writeFile(path.join(kbDir, 'README.md'), '# Engineering notes\n\nbody\n');
+
+      expect(await describeKnowledgeBase(tempDir, 'engineering')).toBe('Engineering notes');
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns empty string when README.md is absent', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-fs-describe-noreadme-'));
+    try {
+      await fsp.mkdir(path.join(tempDir, 'personal'));
+      expect(await describeKnowledgeBase(tempDir, 'personal')).toBe('');
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns empty string for dot-prefixed or path-like names without throwing', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-fs-describe-bad-'));
+    try {
+      expect(await describeKnowledgeBase(tempDir, '.faiss')).toBe('');
+      expect(await describeKnowledgeBase(tempDir, '../escape')).toBe('');
+      expect(await describeKnowledgeBase(tempDir, '')).toBe('');
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/kb-fs.ts
+++ b/src/kb-fs.ts
@@ -23,6 +23,70 @@ export async function listKnowledgeBases(rootDir: string): Promise<string[]> {
   return entries.filter((entry) => !entry.startsWith('.'));
 }
 
+const KB_DESCRIPTION_MAX_LEN = 80;
+
+/**
+ * Extract a one-line description from a `README.md` body.
+ *
+ * Used by `kb list --describe` (#140) so the listing is self-documenting:
+ * each KB's own README — not a hand-edited side table — is the source of
+ * truth. The first `#`-style heading wins (any level, leading hashes
+ * stripped); if none exists, the first non-blank line is returned,
+ * truncated at 80 characters so a stray long paragraph cannot break
+ * column alignment.
+ *
+ * Returns the empty string for an empty file or content with no
+ * non-blank lines, so callers can treat "no description" uniformly.
+ */
+export function extractKbDescription(content: string): string {
+  const lines = content.split(/\r?\n/);
+  for (const line of lines) {
+    const heading = /^\s*#+\s+(.+?)\s*$/.exec(line);
+    if (heading) {
+      return heading[1].trim();
+    }
+  }
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed.length > 0) {
+      return trimmed.length > KB_DESCRIPTION_MAX_LEN
+        ? trimmed.slice(0, KB_DESCRIPTION_MAX_LEN)
+        : trimmed;
+    }
+  }
+  return '';
+}
+
+/**
+ * Read `<rootDir>/<name>/README.md` and return a one-line description
+ * (`extractKbDescription`). Missing or unreadable READMEs surface as the
+ * empty string — `kb list --describe` is a read-only listing surface and
+ * a partial filesystem must not turn it into an error.
+ *
+ * Hidden / dot-prefixed names are rejected on the same grounds as
+ * `listKnowledgeBases` to keep the addressable surface aligned.
+ */
+export async function describeKnowledgeBase(
+  rootDir: string,
+  name: string,
+): Promise<string> {
+  if (name.length === 0 || name.startsWith('.') || hasPathSeparator(name)) {
+    return '';
+  }
+  const readmePath = path.join(rootDir, name, 'README.md');
+  let content: string;
+  try {
+    content = await fsp.readFile(readmePath, 'utf-8');
+  } catch (error: unknown) {
+    const code = (error as NodeJS.ErrnoException | undefined)?.code;
+    if (code === 'ENOENT' || code === 'ENOTDIR' || code === 'EISDIR') {
+      return '';
+    }
+    throw error;
+  }
+  return extractKbDescription(content);
+}
+
 function hasPathSeparator(value: string): boolean {
   return value.includes('/') || value.includes('\\');
 }


### PR DESCRIPTION
## Summary

- `kb list --describe` (alias `-v`) prints a one-line description per KB alongside its name, sourced from each KB's own `README.md` so the listing is self-documenting and drift-resistant.
- First `#`-style heading wins (any level, leading hashes stripped); falls back to the first non-blank line truncated at 80 characters; missing/unreadable READMEs surface as empty string with the bare KB name printed (no trailing whitespace).
- `--format=md` (default) is two-column padded; `--format=json` emits `[{name, description}]` with `--describe` or `[{name}]` without it. Plain `kb list` is unchanged so existing grep-the-listing scripts keep working.

## Implementation notes

- New pure helper `extractKbDescription(content)` in `src/kb-fs.ts` and a thin filesystem wrapper `describeKnowledgeBase(rootDir, name)`. The pure form is unit-tested (heading wins, paragraph fallback, 80-char cap, whitespace-only content, banner-image followed by heading).
- `src/cli-list.ts` parses `--describe`/`-v` and `--format=md|json`. Unknown options or invalid `--format` values exit `2` with a `kb list:` stderr line, matching the rest of the CLI's argv-error contract.
- `src/cli.ts` dispatches `rest` to `runList` and updates the `kb --help` block.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 474 tests pass (22 suites), including:
  - 7 new `kb list --describe` integration tests in `src/cli.test.ts` (md two-column output, `-v` alias, `--format=json` with and without `--describe`, unknown-option rejection, invalid `--format` rejection, plain `kb list` regression check)
  - 9 new unit tests in `src/kb-fs.test.ts` for `extractKbDescription` and `describeKnowledgeBase` (heading priority, paragraph fallback, truncation, empty/whitespace-only, missing README, dot-prefixed/path-like names)
- [x] Manual smoke test against the issue's example fixture set — output matches the spec verbatim, dot-prefixed entries filtered, underscore-prefixed (`_wisdom`) preserved.

Closes #140.

🤖 Generated with [Claude Code](https://claude.com/claude-code)