### PR TITLE
feat(cli): add kb remember --append-section for heading-aware appends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased] — CLI `kb remember --append-section`
+
+### Added
+
+- **`kb remember --append=<path> --append-section="<#level> <text>" [--occurrence=<N>] --stdin --yes`.** Heading-aware append into an existing markdown note. The new content lands at the END of the named section — after every nested subsection — instead of at EOF, so logical document structure stays intact across repeated edits. The heading is located with a real markdown parser (`mdast-util-from-markdown`) so matches inside fenced code blocks, indented code blocks, HTML comments, and YAML frontmatter never trigger; the spec must include the level prefix (`## Foo` does NOT match `### Foo`). Failure modes are loud, never silent: missing heading errors with the list of available headings; duplicate matches error with line numbers and require `--occurrence=<N>` to disambiguate; missing target file errors and points the user at `--title` (create) instead of falling back to EOF; empty / whitespace-only stdin is refused (the foot-gun this feature exists to remove). Writes are atomic — the rewritten content lands in `<path>.kb-tmp.<pid>.<ts>` with `fsync()`, then `rename()` over the original — and adjacent blank lines around the insertion point are collapsed so repeated appends don't accumulate vertical whitespace. Frontmatter is preserved byte-identical above the body. JSON output reports `"action": "append-section"`. Closes #139.
+
 ## [Unreleased] — CLI `kb list --describe`
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "html-to-text": "^9.0.5",
         "js-yaml": "^4.1.1",
         "langchain": "^0.3.15",
+        "mdast-util-from-markdown": "^2.0.3",
         "minimatch": "^10.2.5",
         "pdf-parse": "^1.1.1",
         "pickleparser": "^0.2.1",
@@ -2630,6 +2631,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
     "node_modules/@types/ms": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
@@ -2702,6 +2712,12 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "license": "MIT"
     },
     "node_modules/@types/uuid": {
@@ -3401,6 +3417,16 @@
         "node": ">=10"
       }
     },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chokidar": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -3697,6 +3723,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/decompress-response": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
@@ -3764,6 +3803,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
@@ -3781,6 +3829,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/dfa": {
@@ -6954,6 +7015,43 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/media-typer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
@@ -6980,6 +7078,448 @@
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/micromatch": {
@@ -9094,6 +9634,19 @@
       "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/universalify": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "html-to-text": "^9.0.5",
     "js-yaml": "^4.1.1",
     "langchain": "^0.3.15",
+    "mdast-util-from-markdown": "^2.0.3",
     "minimatch": "^10.2.5",
     "pdf-parse": "^1.1.1",
     "pickleparser": "^0.2.1",

--- a/src/cli-remember.ts
+++ b/src/cli-remember.ts
@@ -8,11 +8,14 @@ import { filterIngestablePaths } from './ingest-filter.js';
 import { resolveKbRelativePath, resolveKnowledgeBaseDir } from './kb-fs.js';
 import { withWriteLock } from './write-lock.js';
 import { loadManagerForModel } from './cli-shared.js';
+import { appendSectionInDocument, parseHeadingSpec } from './markdown-section.js';
 
 interface RememberArgs {
   kb?: string;
   title?: string;
   append?: string;
+  appendSection?: string;
+  occurrence?: number;
   suggest: boolean;
   stdin: boolean;
   yes: boolean;
@@ -53,11 +56,23 @@ export async function runRemember(rest: string[]): Promise<number> {
   }
 
   let relativePath: string;
+  let action: 'create' | 'append' | 'append-section';
   try {
-    if (parsed.append !== undefined) {
+    if (parsed.appendSection !== undefined) {
+      relativePath = await appendSectionInExistingNote(
+        parsed.kb!,
+        parsed.append!,
+        parsed.appendSection,
+        content,
+        parsed.occurrence,
+      );
+      action = 'append-section';
+    } else if (parsed.append !== undefined) {
       relativePath = await appendExistingNote(parsed.kb!, parsed.append, content);
+      action = 'append';
     } else {
       relativePath = await createNewNote(parsed.kb!, parsed.title!, content);
+      action = 'create';
     }
   } catch (err) {
     process.stderr.write(`kb remember: ${(err as Error).message}\n`);
@@ -80,7 +95,7 @@ export async function runRemember(rest: string[]): Promise<number> {
   process.stdout.write(`${JSON.stringify({
     knowledge_base_name: parsed.kb,
     path: relativePath,
-    action: parsed.append !== undefined ? 'append' : 'create',
+    action,
     refreshed: parsed.refresh,
   }, null, 2)}\n`);
   return 0;
@@ -101,6 +116,19 @@ function parseRememberArgs(rest: string[]): RememberArgs {
     if (raw.startsWith('--kb=')) { out.kb = raw.slice('--kb='.length); continue; }
     if (raw.startsWith('--title=')) { out.title = raw.slice('--title='.length); continue; }
     if (raw.startsWith('--append=')) { out.append = raw.slice('--append='.length); continue; }
+    if (raw.startsWith('--append-section=')) {
+      out.appendSection = raw.slice('--append-section='.length);
+      continue;
+    }
+    if (raw.startsWith('--occurrence=')) {
+      const value = raw.slice('--occurrence='.length);
+      const parsedNum = Number(value);
+      if (!Number.isInteger(parsedNum) || parsedNum < 1) {
+        throw new Error(`--occurrence must be a positive integer; got ${JSON.stringify(value)}`);
+      }
+      out.occurrence = parsedNum;
+      continue;
+    }
     if (raw.startsWith('--')) throw new Error(`unknown flag: ${raw}`);
     throw new Error(`unexpected argument: ${raw}`);
   }
@@ -135,6 +163,24 @@ function validateRememberArgs(args: RememberArgs): void {
   }
   if (!args.yes) {
     throw new Error('writes require --yes');
+  }
+  if (args.appendSection !== undefined) {
+    if (args.appendSection.trim() === '') {
+      throw new Error('--append-section must not be empty');
+    }
+    if (args.append === undefined) {
+      throw new Error('--append-section requires --append=<path>');
+    }
+    if (args.title !== undefined) {
+      throw new Error('--append-section cannot be combined with --title');
+    }
+    if (args.append.trim() === '') {
+      throw new Error('--append must not be empty');
+    }
+    return;
+  }
+  if (args.occurrence !== undefined) {
+    throw new Error('--occurrence requires --append-section');
   }
   if (args.append !== undefined) {
     if (args.append.trim() === '') {
@@ -253,6 +299,62 @@ async function appendExistingNote(kbName: string, relativePath: string, content:
   return path.relative(await resolveKnowledgeBaseDir(KNOWLEDGE_BASES_ROOT_DIR, kbName), documentPath)
     .split(path.sep)
     .join('/');
+}
+
+async function appendSectionInExistingNote(
+  kbName: string,
+  relativePath: string,
+  headingSpec: string,
+  content: string,
+  occurrence: number | undefined,
+): Promise<string> {
+  if (content.trim() === '') {
+    // The point of --append-section is to prevent foot-guns; silently writing
+    // empty content is the original error mode this feature exists to remove.
+    throw new Error('--append-section refuses to write empty content (stdin was empty or whitespace-only)');
+  }
+  rejectAbsoluteOrTraversal(relativePath);
+  const documentPath = await resolveKbRelativePath(KNOWLEDGE_BASES_ROOT_DIR, kbName, relativePath);
+  let stat;
+  try {
+    stat = await fsp.stat(documentPath);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      throw new Error(
+        `--append-section target does not exist: ${JSON.stringify(relativePath)} (use --title to create a new note)`,
+      );
+    }
+    throw err;
+  }
+  if (!stat.isFile()) {
+    throw new Error(`append target is not a file: ${JSON.stringify(relativePath)}`);
+  }
+
+  const spec = parseHeadingSpec(headingSpec);
+  const original = await fsp.readFile(documentPath, 'utf-8');
+  const { content: rewritten } = appendSectionInDocument(original, spec, content, { occurrence });
+  await atomicWriteFile(documentPath, rewritten);
+
+  return path.relative(await resolveKnowledgeBaseDir(KNOWLEDGE_BASES_ROOT_DIR, kbName), documentPath)
+    .split(path.sep)
+    .join('/');
+}
+
+async function atomicWriteFile(targetPath: string, data: string): Promise<void> {
+  const tmpPath = `${targetPath}.kb-tmp.${process.pid}.${Date.now()}`;
+  const handle = await fsp.open(tmpPath, 'w');
+  try {
+    await handle.writeFile(data, 'utf-8');
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+  try {
+    await fsp.rename(tmpPath, targetPath);
+  } catch (err) {
+    await fsp.unlink(tmpPath).catch(() => {});
+    throw err;
+  }
 }
 
 function rejectAbsoluteOrTraversal(relativePath: string): void {

--- a/src/cli-remember.ts
+++ b/src/cli-remember.ts
@@ -333,17 +333,21 @@ async function appendSectionInExistingNote(
   const spec = parseHeadingSpec(headingSpec);
   const original = await fsp.readFile(documentPath, 'utf-8');
   const { content: rewritten } = appendSectionInDocument(original, spec, content, { occurrence });
-  await atomicWriteFile(documentPath, rewritten);
+  await atomicWriteFile(documentPath, rewritten, stat.mode);
 
   return path.relative(await resolveKnowledgeBaseDir(KNOWLEDGE_BASES_ROOT_DIR, kbName), documentPath)
     .split(path.sep)
     .join('/');
 }
 
-async function atomicWriteFile(targetPath: string, data: string): Promise<void> {
+async function atomicWriteFile(targetPath: string, data: string, mode?: number): Promise<void> {
   const tmpPath = `${targetPath}.kb-tmp.${process.pid}.${Date.now()}`;
-  const handle = await fsp.open(tmpPath, 'w');
+  const permissions = mode === undefined ? undefined : mode & 0o7777;
+  const handle = await fsp.open(tmpPath, 'w', permissions);
   try {
+    if (permissions !== undefined) {
+      await handle.chmod(permissions);
+    }
     await handle.writeFile(data, 'utf-8');
     await handle.sync();
   } finally {

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -238,6 +238,228 @@ describe('kb remember', () => {
     }
   });
 
+  it('appends at the end of a named section, not at EOF', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-cli-remember-section-'));
+    try {
+      const rootDir = path.join(tempDir, 'kbs');
+      const faissDir = path.join(tempDir, '.faiss');
+      const notePath = path.join(rootDir, 'project', 'notes', 'flows.md');
+      await fsp.mkdir(path.dirname(notePath), { recursive: true });
+      await fsp.writeFile(
+        notePath,
+        '# Top\n\n## OSS gate flow\n\nFirst note.\n\n### Sub\n\nSub note.\n\n## Cross-references\n\nLinks.\n',
+        'utf-8',
+      );
+
+      const r = runCli(
+        [
+          'remember',
+          '--kb=project',
+          '--append=notes/flows.md',
+          '--append-section=## OSS gate flow',
+          '--stdin',
+          '--yes',
+        ],
+        { KNOWLEDGE_BASES_ROOT_DIR: rootDir, FAISS_INDEX_PATH: faissDir },
+        'Newer note.\n',
+      );
+
+      expect(r.code).toBe(0);
+      expect(r.stdout).toContain('"action": "append-section"');
+      const after = await fsp.readFile(notePath, 'utf-8');
+      expect(after).toBe(
+        '# Top\n\n## OSS gate flow\n\nFirst note.\n\n### Sub\n\nSub note.\n\nNewer note.\n\n## Cross-references\n\nLinks.\n',
+      );
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('errors when the named heading is missing without falling back to EOF', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-cli-remember-section-missing-'));
+    try {
+      const rootDir = path.join(tempDir, 'kbs');
+      const faissDir = path.join(tempDir, '.faiss');
+      const notePath = path.join(rootDir, 'project', 'notes.md');
+      await fsp.mkdir(path.dirname(notePath), { recursive: true });
+      const original = '# Top\n\nbody\n';
+      await fsp.writeFile(notePath, original, 'utf-8');
+
+      const r = runCli(
+        [
+          'remember',
+          '--kb=project',
+          '--append=notes.md',
+          '--append-section=## Nope',
+          '--stdin',
+          '--yes',
+        ],
+        { KNOWLEDGE_BASES_ROOT_DIR: rootDir, FAISS_INDEX_PATH: faissDir },
+        'should not land\n',
+      );
+
+      expect(r.code).toBe(1);
+      expect(r.stderr).toContain('heading not found');
+      expect(r.stderr).toContain('Available headings');
+      // The file must be byte-identical when the heading is missing.
+      await expect(fsp.readFile(notePath, 'utf-8')).resolves.toBe(original);
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not match a heading hidden inside a fenced code block', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-cli-remember-section-fence-'));
+    try {
+      const rootDir = path.join(tempDir, 'kbs');
+      const faissDir = path.join(tempDir, '.faiss');
+      const notePath = path.join(rootDir, 'project', 'fenced.md');
+      await fsp.mkdir(path.dirname(notePath), { recursive: true });
+      const original = '# Real\n\n```\n## Trick\n```\n';
+      await fsp.writeFile(notePath, original, 'utf-8');
+
+      const r = runCli(
+        ['remember', '--kb=project', '--append=fenced.md', '--append-section=## Trick', '--stdin', '--yes'],
+        { KNOWLEDGE_BASES_ROOT_DIR: rootDir, FAISS_INDEX_PATH: faissDir },
+        'X',
+      );
+      expect(r.code).toBe(1);
+      expect(r.stderr).toContain('heading not found');
+      await expect(fsp.readFile(notePath, 'utf-8')).resolves.toBe(original);
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not accumulate blank lines on repeated --append-section writes', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-cli-remember-section-rep-'));
+    try {
+      const rootDir = path.join(tempDir, 'kbs');
+      const faissDir = path.join(tempDir, '.faiss');
+      const notePath = path.join(rootDir, 'project', 'rep.md');
+      await fsp.mkdir(path.dirname(notePath), { recursive: true });
+      await fsp.writeFile(notePath, '## Foo\n\nbody\n\n## Bar\n\nbar\n', 'utf-8');
+
+      for (const text of ['first', 'second', 'third']) {
+        const r = runCli(
+          ['remember', '--kb=project', '--append=rep.md', '--append-section=## Foo', '--stdin', '--yes'],
+          { KNOWLEDGE_BASES_ROOT_DIR: rootDir, FAISS_INDEX_PATH: faissDir },
+          text,
+        );
+        expect(r.code).toBe(0);
+      }
+      const after = await fsp.readFile(notePath, 'utf-8');
+      // Single blank line separates each appended block — never two.
+      expect(after).toBe(
+        '## Foo\n\nbody\n\nfirst\n\nsecond\n\nthird\n\n## Bar\n\nbar\n',
+      );
+      expect(/\n\n\n/.test(after)).toBe(false);
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects --append-section without --append', async () => {
+    const r = runCli(
+      ['remember', '--kb=project', '--append-section=## Foo', '--stdin', '--yes'],
+      {},
+      'x',
+    );
+    expect(r.code).toBe(2);
+    expect(r.stderr).toContain('--append-section requires --append');
+  });
+
+  it('errors on duplicate headings without --occurrence and disambiguates with it', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-cli-remember-section-dup-'));
+    try {
+      const rootDir = path.join(tempDir, 'kbs');
+      const faissDir = path.join(tempDir, '.faiss');
+      const notePath = path.join(rootDir, 'project', 'dup.md');
+      await fsp.mkdir(path.dirname(notePath), { recursive: true });
+      await fsp.writeFile(
+        notePath,
+        '## Foo\n\nfirst\n\n## Foo\n\nsecond\n',
+        'utf-8',
+      );
+
+      const ambiguous = runCli(
+        ['remember', '--kb=project', '--append=dup.md', '--append-section=## Foo', '--stdin', '--yes'],
+        { KNOWLEDGE_BASES_ROOT_DIR: rootDir, FAISS_INDEX_PATH: faissDir },
+        'X',
+      );
+      expect(ambiguous.code).toBe(1);
+      expect(ambiguous.stderr).toContain('appears 2 times');
+
+      const second = runCli(
+        [
+          'remember',
+          '--kb=project',
+          '--append=dup.md',
+          '--append-section=## Foo',
+          '--occurrence=2',
+          '--stdin',
+          '--yes',
+        ],
+        { KNOWLEDGE_BASES_ROOT_DIR: rootDir, FAISS_INDEX_PATH: faissDir },
+        'Picked.\n',
+      );
+      expect(second.code).toBe(0);
+      const after = await fsp.readFile(notePath, 'utf-8');
+      expect(after).toBe('## Foo\n\nfirst\n\n## Foo\n\nsecond\n\nPicked.\n');
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('refuses empty stdin under --append-section', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-cli-remember-section-empty-'));
+    try {
+      const rootDir = path.join(tempDir, 'kbs');
+      const faissDir = path.join(tempDir, '.faiss');
+      const notePath = path.join(rootDir, 'project', 'a.md');
+      await fsp.mkdir(path.dirname(notePath), { recursive: true });
+      const original = '## Foo\n\nbody\n';
+      await fsp.writeFile(notePath, original, 'utf-8');
+
+      const r = runCli(
+        ['remember', '--kb=project', '--append=a.md', '--append-section=## Foo', '--stdin', '--yes'],
+        { KNOWLEDGE_BASES_ROOT_DIR: rootDir, FAISS_INDEX_PATH: faissDir },
+        '   \n',
+      );
+      expect(r.code).toBe(1);
+      expect(r.stderr).toContain('empty content');
+      await expect(fsp.readFile(notePath, 'utf-8')).resolves.toBe(original);
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves frontmatter byte-identical when appending into a section', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-cli-remember-section-fm-'));
+    try {
+      const rootDir = path.join(tempDir, 'kbs');
+      const faissDir = path.join(tempDir, '.faiss');
+      const notePath = path.join(rootDir, 'project', 'fm.md');
+      await fsp.mkdir(path.dirname(notePath), { recursive: true });
+      await fsp.writeFile(
+        notePath,
+        '---\ntitle: Notes\ntags: [a, b]\n---\n## Foo\n\nbody\n',
+        'utf-8',
+      );
+
+      const r = runCli(
+        ['remember', '--kb=project', '--append=fm.md', '--append-section=## Foo', '--stdin', '--yes'],
+        { KNOWLEDGE_BASES_ROOT_DIR: rootDir, FAISS_INDEX_PATH: faissDir },
+        'Added.',
+      );
+      expect(r.code).toBe(0);
+      const after = await fsp.readFile(notePath, 'utf-8');
+      expect(after).toBe('---\ntitle: Notes\ntags: [a, b]\n---\n## Foo\n\nbody\n\nAdded.\n');
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it('rejects write argv errors without touching stdin content', async () => {
     const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-cli-remember-argv-'));
     try {

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -460,6 +460,31 @@ describe('kb remember', () => {
     }
   });
 
+  it('preserves target file permissions when appending into a section', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-cli-remember-section-mode-'));
+    try {
+      const rootDir = path.join(tempDir, 'kbs');
+      const faissDir = path.join(tempDir, '.faiss');
+      const notePath = path.join(rootDir, 'project', 'private.md');
+      await fsp.mkdir(path.dirname(notePath), { recursive: true });
+      await fsp.writeFile(notePath, '## Private\n\nbody\n', 'utf-8');
+      await fsp.chmod(notePath, 0o600);
+
+      const r = runCli(
+        ['remember', '--kb=project', '--append=private.md', '--append-section=## Private', '--stdin', '--yes'],
+        { KNOWLEDGE_BASES_ROOT_DIR: rootDir, FAISS_INDEX_PATH: faissDir },
+        'Added.',
+      );
+
+      expect(r.code).toBe(0);
+      expect((await fsp.stat(notePath)).mode & 0o777).toBe(0o600);
+      await expect(fsp.readFile(notePath, 'utf-8')).resolves.toBe('## Private\n\nbody\n\nAdded.\n');
+    } finally {
+      await fsp.chmod(path.join(tempDir, 'kbs', 'project', 'private.md'), 0o600).catch(() => {});
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it('rejects write argv errors without touching stdin content', async () => {
     const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-cli-remember-argv-'));
     try {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -46,6 +46,12 @@ Usage:
                                            Create a new markdown note.
   kb remember --kb=<name> --append=<path> --stdin --yes
                                            Append to an existing KB-relative note.
+  kb remember --kb=<name> --append=<path> --append-section="<#level> <text>"
+             [--occurrence=<N>] --stdin --yes
+                                           Append at the END of a named heading
+                                           section (after all subsections), not
+                                           at EOF. Heading spec must include the
+                                           level prefix (e.g. "## OSS gate flow").
   kb capture --kb=<name> --append=<path> [--note=<text>] [--language=<hint>]
              [--max-bytes=<N>] [--allow-fail] [--refresh] -- <cmd> [args...]
                                            Run a command and append its stdout
@@ -79,6 +85,14 @@ Remember options:
   --kb=<name>           Target knowledge base.
   --title=<title>       Note title; create uses a slugified .md filename.
   --append=<path>       Existing KB-relative note path; rejects traversal.
+  --append-section=<spec>
+                        Heading-aware append target. Spec is "<#level> <text>"
+                        (e.g. "## OSS gate flow"). Requires --append=<path>.
+                        Inserts at the end of the named section (after every
+                        subsection), atomically rewrites the file, and refuses
+                        to fall back to EOF if the heading is missing.
+  --occurrence=<N>      1-indexed disambiguation when the heading appears
+                        multiple times. Requires --append-section.
   --suggest             Read-only suggestions; does not read stdin.
   --stdin               Read note content from stdin.
   --yes                 Required for non-interactive writes.

--- a/src/markdown-section.ts
+++ b/src/markdown-section.ts
@@ -1,0 +1,255 @@
+// Heading-aware section splicing for `kb remember --append-section` (#139).
+//
+// Goal: locate a named heading in a markdown document and append new content
+// at the END of that section (after every subsection), then return the new
+// document. Headings inside fenced code blocks, HTML comments, and YAML
+// frontmatter must NEVER match — that's the whole reason we parse rather
+// than regex-walk.
+
+import { fromMarkdown } from 'mdast-util-from-markdown';
+import type { Heading, Root, Text } from 'mdast';
+import { parseFrontmatter } from './frontmatter.js';
+
+export interface HeadingSpec {
+  level: number;
+  text: string;
+}
+
+export interface FoundHeading {
+  level: number;
+  text: string;
+  /** 1-indexed line of the heading in the body (frontmatter excluded). */
+  line: number;
+}
+
+export interface SpliceResult {
+  content: string;
+}
+
+/**
+ * Parse `--append-section` argument into a {level, text} pair.
+ *
+ * Input must be `<#{1..6}> <text>` exactly — leading hashes set the level,
+ * a single space separator, then the rendered heading text. We require the
+ * level prefix so `## Foo` cannot accidentally match `### Foo`.
+ */
+export function parseHeadingSpec(spec: string): HeadingSpec {
+  const match = spec.match(/^(#{1,6})\s+(\S.*?)\s*$/);
+  if (!match) {
+    throw new Error(
+      `--append-section must be of the form "<#..######> <heading text>" (e.g. "## OSS gate"); got ${JSON.stringify(spec)}`,
+    );
+  }
+  return { level: match[1].length, text: match[2] };
+}
+
+/**
+ * Extract every heading from `body` with its rendered text and 1-indexed
+ * line position. mdast handles fenced code blocks, HTML comments, and
+ * indented blocks correctly — a `## Foo` inside ``` ... ``` is NOT a heading
+ * and never appears in the returned list.
+ */
+export function listHeadings(body: string): FoundHeading[] {
+  const tree: Root = fromMarkdown(body);
+  const out: FoundHeading[] = [];
+  for (const node of tree.children) {
+    if (node.type !== 'heading') continue;
+    const heading = node as Heading;
+    if (!heading.position) continue;
+    out.push({
+      level: heading.depth,
+      text: renderHeadingText(heading),
+      line: heading.position.start.line,
+    });
+  }
+  return out;
+}
+
+function renderHeadingText(heading: Heading): string {
+  let text = '';
+  for (const child of heading.children) {
+    if (child.type === 'text' || child.type === 'inlineCode') {
+      text += (child as Text).value;
+    } else if ('children' in child && Array.isArray(child.children)) {
+      // Recursively render emphasis/strong/link children — match what a
+      // human would read when scanning the heading.
+      for (const nested of child.children) {
+        if (nested.type === 'text' || nested.type === 'inlineCode') {
+          text += (nested as Text).value;
+        }
+      }
+    }
+  }
+  return text.trim();
+}
+
+/**
+ * Result of locating the named section in `body`.
+ *
+ * `splitLineIndex` is the 0-indexed line of `body.split('\n')` where the
+ * next sibling-or-shallower heading begins, or `lines.length` if the section
+ * extends to EOF.
+ */
+export interface LocatedSection {
+  /** 1-indexed line of the matched heading in body. */
+  headingLine: number;
+  /** 0-indexed split point used by spliceAppend. */
+  splitLineIndex: number;
+}
+
+export interface LocateOptions {
+  /** 1-indexed occurrence to pick when multiple headings match. Default: must be unique. */
+  occurrence?: number;
+}
+
+export class HeadingNotFoundError extends Error {
+  readonly available: FoundHeading[];
+  constructor(spec: HeadingSpec, available: FoundHeading[]) {
+    super(buildNotFoundMessage(spec, available));
+    this.name = 'HeadingNotFoundError';
+    this.available = available;
+  }
+}
+
+function buildNotFoundMessage(spec: HeadingSpec, available: FoundHeading[]): string {
+  const want = `${'#'.repeat(spec.level)} ${spec.text}`;
+  if (available.length === 0) {
+    return `--append-section: heading not found: ${JSON.stringify(want)} (file has no headings)`;
+  }
+  const lines = available.map((h) => `  ${'#'.repeat(h.level)} ${h.text}  (line ${h.line})`);
+  return `--append-section: heading not found: ${JSON.stringify(want)}\nAvailable headings:\n${lines.join('\n')}`;
+}
+
+export class AmbiguousHeadingError extends Error {
+  readonly matches: FoundHeading[];
+  constructor(spec: HeadingSpec, matches: FoundHeading[]) {
+    const want = `${'#'.repeat(spec.level)} ${spec.text}`;
+    const lineList = matches.map((h) => `  line ${h.line}`).join('\n');
+    super(
+      `--append-section: heading appears ${matches.length} times: ${JSON.stringify(want)}\n${lineList}\nDisambiguate with --occurrence=<N> (1-indexed).`,
+    );
+    this.name = 'AmbiguousHeadingError';
+    this.matches = matches;
+  }
+}
+
+export class OccurrenceOutOfRangeError extends Error {
+  constructor(spec: HeadingSpec, requested: number, available: number) {
+    const want = `${'#'.repeat(spec.level)} ${spec.text}`;
+    super(
+      `--append-section: --occurrence=${requested} out of range for ${JSON.stringify(want)} (file has ${available} match${available === 1 ? '' : 'es'})`,
+    );
+    this.name = 'OccurrenceOutOfRangeError';
+  }
+}
+
+/**
+ * Locate the named heading in `body` and compute the line-array split point
+ * that marks the end of its section.
+ */
+export function locateSection(body: string, spec: HeadingSpec, opts: LocateOptions = {}): LocatedSection {
+  const headings = listHeadings(body);
+  const matches = headings.filter((h) => h.level === spec.level && h.text === spec.text);
+
+  if (matches.length === 0) {
+    throw new HeadingNotFoundError(spec, headings);
+  }
+
+  let chosen: FoundHeading;
+  if (opts.occurrence !== undefined) {
+    if (opts.occurrence < 1 || opts.occurrence > matches.length) {
+      throw new OccurrenceOutOfRangeError(spec, opts.occurrence, matches.length);
+    }
+    chosen = matches[opts.occurrence - 1];
+  } else {
+    if (matches.length > 1) {
+      throw new AmbiguousHeadingError(spec, matches);
+    }
+    chosen = matches[0];
+  }
+
+  // Find the next heading at the same OR shallower level after `chosen`.
+  // That's where this section ends.
+  const lineCount = body.split('\n').length;
+  let splitLineIndex = lineCount;
+  for (const h of headings) {
+    if (h.line <= chosen.line) continue;
+    if (h.level <= chosen.level) {
+      // mdast lines are 1-indexed; split-point is 0-indexed, so we use
+      // `h.line - 1` to land the split point on the heading line.
+      splitLineIndex = h.line - 1;
+      break;
+    }
+  }
+  return { headingLine: chosen.line, splitLineIndex };
+}
+
+/**
+ * Splice `newContent` into `body` at `splitLineIndex` with exactly one
+ * blank line above and one blank line below. Adjacent blank lines on either
+ * side of the insertion point are collapsed so repeated appends do not
+ * accumulate vertical whitespace.
+ *
+ * The returned body always ends with a newline — even if the input did not.
+ */
+export function spliceAppend(body: string, splitLineIndex: number, newContent: string): string {
+  const lines = body.split('\n');
+
+  let lastContent = splitLineIndex - 1;
+  while (lastContent >= 0 && lines[lastContent].trim() === '') {
+    lastContent--;
+  }
+
+  let firstAfter = splitLineIndex;
+  while (firstAfter < lines.length && lines[firstAfter].trim() === '') {
+    firstAfter++;
+  }
+
+  const newLines = newContent.split('\n');
+  let nlStart = 0;
+  let nlEnd = newLines.length - 1;
+  while (nlStart <= nlEnd && newLines[nlStart].trim() === '') nlStart++;
+  while (nlEnd >= nlStart && newLines[nlEnd].trim() === '') nlEnd--;
+  const trimmedNew = newLines.slice(nlStart, nlEnd + 1);
+
+  if (trimmedNew.length === 0) {
+    // Shouldn't happen — caller validates non-empty content. Defensive return.
+    return body;
+  }
+
+  const beforePart = lastContent >= 0 ? lines.slice(0, lastContent + 1) : [];
+  const afterPart = firstAfter < lines.length ? lines.slice(firstAfter) : [];
+
+  const result: string[] = [];
+  if (beforePart.length > 0) {
+    result.push(...beforePart);
+    result.push('');
+  }
+  result.push(...trimmedNew);
+  if (afterPart.length > 0) {
+    result.push('');
+    result.push(...afterPart);
+  } else {
+    result.push('');
+  }
+
+  return result.join('\n');
+}
+
+/**
+ * High-level entry point: take the raw file content, the heading spec, and
+ * the new content; return the rewritten file. Frontmatter is preserved
+ * byte-identical — headings inside frontmatter delimiters never match.
+ */
+export function appendSectionInDocument(
+  fileContent: string,
+  spec: HeadingSpec,
+  newContent: string,
+  opts: LocateOptions = {},
+): SpliceResult {
+  const { body } = parseFrontmatter(fileContent);
+  const frontmatterPrefix = fileContent.slice(0, fileContent.length - body.length);
+  const located = locateSection(body, spec, opts);
+  const newBody = spliceAppend(body, located.splitLineIndex, newContent);
+  return { content: frontmatterPrefix + newBody };
+}


### PR DESCRIPTION
## Summary

- Add `kb remember --append=<path> --append-section="<#level> <text>" [--occurrence=<N>]` for heading-aware appends into existing notes. Inserts at the END of the named section (after every nested subsection) instead of at EOF, so logical document structure stays intact across repeated edits.
- Heading is located with `mdast-util-from-markdown` (a real markdown parser, not regex) so matches inside fenced/indented code blocks, HTML comments, and YAML frontmatter never trigger. The spec must include the level prefix (`## Foo` does NOT match `### Foo`).
- Failure modes are loud: missing heading errors with the list of available headings; duplicate matches require `--occurrence=<N>`; missing target file points at `--title` (create); empty/whitespace-only stdin is refused (the foot-gun this feature exists to remove).
- Writes are atomic (`<path>.kb-tmp.<pid>.<ts>` -> `fsync` -> `rename`) and now preserve the original target file mode when rewriting restrictive notes. Adjacent blank lines at the insertion point are collapsed so repeated appends don't accumulate vertical whitespace. Frontmatter is preserved byte-identical above the body.

## Test plan

- [x] `npm run build` clean
- [x] `npx jest src/cli.test.ts --runInBand` clean
- [x] `npm test` - all 483 tests pass (22 suites; +8 new integration tests in `cli.test.ts`)
- New integration tests cover: heading-aware append (lands after subsections, before next sibling), missing-heading error (file untouched), missing `--append` rejection, duplicate-heading + `--occurrence`, empty-stdin rejection, frontmatter preservation, fenced-code-block exclusion, repeated-append blank-line collapse, and preserving restrictive file permissions during atomic section rewrites.

Closes #139.

Generated with AI assistance.