### PR TITLE
docs(cli): clarify --kb= is optional, default searches all KBs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased] — `kb search` help clarifies cross-KB default
+
+### Changed
+
+- **`kb --help` now states that `--kb=<name>` is optional and defaults to searching every KB.** The previous text (`--kb=<name>           Scope to one knowledge base.`) read like the flag was required, leading agents to either skip `kb search` entirely (when they couldn't decide which KB to scope to) or burn an extra `kb list` call before searching. The new text — `Scope to one knowledge base. Omit to search ALL KBs (default).` — surfaces the affordance that already existed in `cli-search.ts` (omitting `--kb=` passes `undefined` to `similaritySearch`, which routes to the unscoped path).
+
 ## [Unreleased] — CLI `kb list --describe`
 
 ### Added

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -67,7 +67,7 @@ Usage:
   kb --help
 
 Search options:
-  --kb=<name>           Scope to one knowledge base.
+  --kb=<name>           Scope to one knowledge base. Omit to search ALL KBs (default).
   --model=<id>          Override active model for this call (RFC 013).
   --threshold=<float>   Max similarity score (default 2).
   --k=<int>             Top-K results (default 10).


### PR DESCRIPTION
## Summary

One-line help-text fix. The previous wording for the `--kb=<name>` flag in `kb --help` read like the flag was required:

```
Search options:
  --kb=<name>           Scope to one knowledge base.
```

That framing led agents to either skip \`kb search\` entirely when they couldn't decide which KB to scope to, or pay an extra \`kb list\` call before searching. The behavior — \`omitting \`--kb=\` searches every KB\` — already exists in \`cli-search.ts\` (the optional flag passes \`undefined\` to \`similaritySearch\`, which routes to the unscoped path). This PR just makes the help text say so.

After:

\`\`\`
Search options:
  --kb=<name>           Scope to one knowledge base. Omit to search ALL KBs (default).
\`\`\`

## Testing

- [x] No tests pin the previous help text (\`grep -rn "Scope to one knowledge base" src/ test/\` shows only the source line itself).
- [x] CHANGELOG updated under \`## [Unreleased]\` per PR template.

## Follow-ups

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)