### PR TITLE
refactor: extract frontmatter lift helpers

### DIFF
--- a/src/FaissIndexManager.test.ts
+++ b/src/FaissIndexManager.test.ts
@@ -2123,7 +2123,7 @@ describe('FaissIndexManager ingest — PDF + HTML loaders (issue #46)', () => {
 
 describe('liftFrontmatter (RFC 011 §5.4.2)', () => {
   it('lifts whitelisted keys verbatim and coerces relevance_score via parseInt', async () => {
-    const { liftFrontmatter } = await import('./FaissIndexManager.js');
+    const { liftFrontmatter } = await import('./frontmatter-lift.js');
     const result = liftFrontmatter(
       {
         arxiv_id: '2604.21221',
@@ -2146,7 +2146,7 @@ describe('liftFrontmatter (RFC 011 §5.4.2)', () => {
   });
 
   it('lifts the llm-as-judge whitelist keys', async () => {
-    const { liftFrontmatter } = await import('./FaissIndexManager.js');
+    const { liftFrontmatter } = await import('./frontmatter-lift.js');
     const result = liftFrontmatter(
       {
         judge_method: 'single-LLM ref-free',
@@ -2163,7 +2163,7 @@ describe('liftFrontmatter (RFC 011 §5.4.2)', () => {
   });
 
   it('routes non-whitelisted string keys into extras', async () => {
-    const { liftFrontmatter } = await import('./FaissIndexManager.js');
+    const { liftFrontmatter } = await import('./frontmatter-lift.js');
     const result = liftFrontmatter(
       {
         arxiv_id: '2604.1',
@@ -2179,7 +2179,7 @@ describe('liftFrontmatter (RFC 011 §5.4.2)', () => {
   });
 
   it('drops relevance_score when non-numeric and logs at debug level', async () => {
-    const { liftFrontmatter } = await import('./FaissIndexManager.js');
+    const { liftFrontmatter } = await import('./frontmatter-lift.js');
     const loggerModule = await import('./logger.js');
     const debugSpy = jest.spyOn(loggerModule.logger, 'debug').mockImplementation(() => {});
 
@@ -2197,7 +2197,7 @@ describe('liftFrontmatter (RFC 011 §5.4.2)', () => {
   });
 
   it('drops non-string values and logs at debug level (YAML arrays, nested maps)', async () => {
-    const { liftFrontmatter } = await import('./FaissIndexManager.js');
+    const { liftFrontmatter } = await import('./frontmatter-lift.js');
     const loggerModule = await import('./logger.js');
     const debugSpy = jest.spyOn(loggerModule.logger, 'debug').mockImplementation(() => {});
 
@@ -2217,7 +2217,7 @@ describe('liftFrontmatter (RFC 011 §5.4.2)', () => {
   });
 
   it('ignores `tags` — it is handled by the sibling metadata.tags field', async () => {
-    const { liftFrontmatter } = await import('./FaissIndexManager.js');
+    const { liftFrontmatter } = await import('./frontmatter-lift.js');
     const result = liftFrontmatter(
       { arxiv_id: '2604.1', tags: ['kv-cache'] },
       '/kb/notes/paper.md',
@@ -2228,7 +2228,7 @@ describe('liftFrontmatter (RFC 011 §5.4.2)', () => {
   });
 
   it('returns undefined when the parsed frontmatter contains no liftable fields', async () => {
-    const { liftFrontmatter } = await import('./FaissIndexManager.js');
+    const { liftFrontmatter } = await import('./frontmatter-lift.js');
     expect(liftFrontmatter({}, '/kb/notes/paper.md')).toBeUndefined();
     // Non-string-only input: everything dropped → undefined.
     expect(liftFrontmatter({ some_array: ['a'] }, '/kb/notes/paper.md')).toBeUndefined();
@@ -2259,7 +2259,7 @@ describe('detectSiblingPdfPath (RFC 011 §5.3.4)', () => {
 
     process.env.KNOWLEDGE_BASES_ROOT_DIR = tempDir;
     jest.resetModules();
-    const { detectSiblingPdfPath } = await import('./FaissIndexManager.js');
+    const { detectSiblingPdfPath } = await import('./frontmatter-lift.js');
     const result = detectSiblingPdfPath(
       path.join(kbRoot, 'notes', '2604.21221.md'),
       kbName,
@@ -2277,7 +2277,7 @@ describe('detectSiblingPdfPath (RFC 011 §5.3.4)', () => {
 
     process.env.KNOWLEDGE_BASES_ROOT_DIR = tempDir;
     jest.resetModules();
-    const { detectSiblingPdfPath } = await import('./FaissIndexManager.js');
+    const { detectSiblingPdfPath } = await import('./frontmatter-lift.js');
     const result = detectSiblingPdfPath(path.join(kbRoot, 'paper.md'), kbName);
     expect(result).toBe('paper.pdf');
   });
@@ -2291,7 +2291,7 @@ describe('detectSiblingPdfPath (RFC 011 §5.3.4)', () => {
 
     process.env.KNOWLEDGE_BASES_ROOT_DIR = tempDir;
     jest.resetModules();
-    const { detectSiblingPdfPath } = await import('./FaissIndexManager.js');
+    const { detectSiblingPdfPath } = await import('./frontmatter-lift.js');
     const result = detectSiblingPdfPath(
       path.join(kbRoot, 'notes', 'paper.md'),
       kbName,
@@ -2318,7 +2318,7 @@ describe('detectSiblingPdfPath (RFC 011 §5.3.4)', () => {
 
     process.env.KNOWLEDGE_BASES_ROOT_DIR = tempDir;
     jest.resetModules();
-    const { detectSiblingPdfPath } = await import('./FaissIndexManager.js');
+    const { detectSiblingPdfPath } = await import('./frontmatter-lift.js');
     const result = detectSiblingPdfPath(
       path.join(kbRoot, 'notes', 'paper.md'),
       kbName,
@@ -2347,7 +2347,7 @@ describe('detectSiblingPdfPath (RFC 011 §5.3.4)', () => {
 
     process.env.KNOWLEDGE_BASES_ROOT_DIR = tempDir;
     jest.resetModules();
-    const { detectSiblingPdfPath } = await import('./FaissIndexManager.js');
+    const { detectSiblingPdfPath } = await import('./frontmatter-lift.js');
     const result = detectSiblingPdfPath(
       path.join(kbRoot, 'paper.md'),
       kbName,

--- a/src/FaissIndexManager.ts
+++ b/src/FaissIndexManager.ts
@@ -1,5 +1,4 @@
 // FaissIndexManager.ts — RFC 013 M1+M2 (multi-model layout).
-import * as fs from 'fs';
 import * as fsp from 'fs/promises';
 import * as path from 'path';
 import { minimatch } from 'minimatch';
@@ -19,6 +18,7 @@ import { MarkdownTextSplitter, RecursiveCharacterTextSplitter } from "langchain/
 import { toError } from './error-utils.js';
 import { calculateSHA256, getFilesRecursively } from './file-utils.js';
 import { parseFrontmatter } from './frontmatter.js';
+import { detectSiblingPdfPath, liftFrontmatter } from './frontmatter-lift.js';
 import { filterIngestablePaths } from './ingest-filter.js';
 import { loadFile } from './loaders.js';
 import {
@@ -86,158 +86,6 @@ async function writeModelNameAtomic(modelNameFile: string, modelName: string): P
 // independent open(2) calls — each would re-resolve a symlink given the
 // path, but an absolute resolved path has no symlink to re-resolve.
 // ---------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-// RFC 011 §5.4 — whitelisted frontmatter lift + sibling PDF detection.
-//
-// `parseFrontmatter` returns the entire parsed YAML object; the server lifts
-// a whitelist of known keys into a typed shape on every chunk's metadata.
-// Unknown string-valued keys are collected into `frontmatter.extras` so a
-// workflow author who adds a new field doesn't silently lose it — but the
-// MCP-boundary sanitizer strips `extras` by default (RFC 011 §7.1 R1, wired
-// in `src/KnowledgeBaseServer.ts`). Non-string-valued keys (YAML arrays or
-// nested maps — FAILSAFE doesn't coerce numbers or booleans) are dropped:
-// there's no safe scalar target for them here.
-// -----------------------------------------------------------------------------
-
-/** Whitelisted frontmatter keys lifted into `ChunkMetadata.frontmatter`. */
-const FRONTMATTER_WHITELIST: readonly string[] = [
-  'arxiv_id',
-  'title',
-  'authors',
-  'published',
-  'relevance_score',
-  'ingested_at',
-  'judge_method',
-  'metrics_used',
-  'bias_handling',
-] as const;
-
-export interface LiftedFrontmatter {
-  arxiv_id?: string;
-  title?: string;
-  authors?: string;
-  published?: string;
-  relevance_score?: number;
-  ingested_at?: string;
-  judge_method?: string;
-  metrics_used?: string;
-  bias_handling?: string;
-  /** Other string-valued frontmatter keys (e.g. workflow-specific additions). */
-  extras?: Record<string, string>;
-}
-
-/**
- * Applies the RFC 011 §5.4.2 whitelist to `parseFrontmatter`'s raw object.
- * Returns `undefined` when the input yields no fields — absent metadata is
- * preferable to an empty object at the wire boundary.
- */
-export function liftFrontmatter(
-  frontmatter: Record<string, unknown>,
-  filePath: string,
-): LiftedFrontmatter | undefined {
-  const lifted: LiftedFrontmatter = {};
-  const extras: Record<string, string> = {};
-  let hasAny = false;
-
-  for (const [key, value] of Object.entries(frontmatter)) {
-    // `tags` is already lifted into the sibling `tags` metadata field;
-    // don't duplicate it into the frontmatter block.
-    if (key === 'tags') continue;
-
-    // FAILSAFE parses scalars as strings and lists/maps as arrays/objects.
-    // Only strings survive the lift; arrays and objects are dropped with a
-    // debug log so a workflow author who wrote `metrics: [a, b, c]` sees
-    // why their field disappeared.
-    if (typeof value !== 'string') {
-      logger.debug(`Dropping non-string frontmatter key "${key}" from ${filePath}`);
-      continue;
-    }
-
-    if (key === 'relevance_score') {
-      // RFC 011 §5.4.3: parseInt + isFinite; non-numeric → omit and log.
-      // Log the *length* of the rejected value, never the value itself —
-      // frontmatter authored by the workflow is otherwise-untrusted input,
-      // and the RFC §5.4.2 leak rule for non-string keys ("key name, not
-      // value") applies equally here.
-      const parsed = parseInt(value, 10);
-      if (Number.isFinite(parsed)) {
-        lifted.relevance_score = parsed;
-        hasAny = true;
-      } else {
-        logger.debug(
-          `Dropping non-numeric relevance_score (length=${value.length}) from ${filePath}`,
-        );
-      }
-      continue;
-    }
-
-    if ((FRONTMATTER_WHITELIST as readonly string[]).includes(key)) {
-      (lifted as Record<string, unknown>)[key] = value;
-      hasAny = true;
-    } else {
-      extras[key] = value;
-    }
-  }
-
-  if (Object.keys(extras).length > 0) {
-    lifted.extras = extras;
-    hasAny = true;
-  }
-
-  return hasAny ? lifted : undefined;
-}
-
-/**
- * Looks for a PDF whose basename (without extension) matches the `.md` file
- * at `filePath`. Checks (in order) the arxiv `<kb>/pdfs/<stem>.pdf` layout,
- * then the same-directory `<stem>.pdf` fallback. Returns the KB-directory-
- * relative forward-slash path, or `undefined` when no sibling exists.
- *
- * Uses sync `existsSync` deliberately: called once per file inside an
- * already-`await`-heavy ingest loop; an extra async boundary is not worth
- * the 1-stat-per-file cost.
- */
-export function detectSiblingPdfPath(
-  filePath: string,
-  knowledgeBaseName: string,
-): string | undefined {
-  const ext = path.extname(filePath);
-  const stem = path.basename(filePath, ext);
-  const dir = path.dirname(filePath);
-  const kbRoot = path.join(KNOWLEDGE_BASES_ROOT_DIR, knowledgeBaseName);
-
-  // Returns a KB-directory-scoped forward-slash path, or undefined if
-  // `candidate` escapes the KB root (e.g. the arxiv layout's `../pdfs/`
-  // probe for a `.md` at the KB root resolves outside the KB — `pdf_path`
-  // on a chunk must not reference a sibling KB's files).
-  const toKbRelative = (candidate: string): string | undefined => {
-    const rel = path.relative(kbRoot, candidate).split(path.sep).join('/');
-    if (rel.length === 0 || rel.startsWith('../') || rel === '..' || path.posix.isAbsolute(rel)) {
-      return undefined;
-    }
-    return rel;
-  };
-
-  // arxiv layout: notes/<stem>.md next to pdfs/<stem>.pdf
-  const arxivCandidate = path.join(dir, '..', 'pdfs', `${stem}.pdf`);
-  if (fs.existsSync(arxivCandidate)) {
-    const rel = toKbRelative(arxivCandidate);
-    if (rel !== undefined) return rel;
-    // `arxivCandidate` escapes the KB (e.g. the .md lives at the KB root,
-    // so `dir/../pdfs/` points at KNOWLEDGE_BASES_ROOT_DIR/pdfs — a sibling
-    // directory, not a subdir of this KB). Fall through to same-dir check.
-  }
-
-  // Fallback: same-directory colocation (KBs that don't split notes/ and pdfs/)
-  const sameDirCandidate = path.join(dir, `${stem}.pdf`);
-  if (fs.existsSync(sameDirCandidate)) {
-    const rel = toKbRelative(sameDirCandidate);
-    if (rel !== undefined) return rel;
-  }
-
-  return undefined;
-}
 
 type FsError = NodeJS.ErrnoException & { code?: string };
 

--- a/src/frontmatter-lift.ts
+++ b/src/frontmatter-lift.ts
@@ -1,0 +1,156 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { KNOWLEDGE_BASES_ROOT_DIR } from './config.js';
+import { logger } from './logger.js';
+
+// -----------------------------------------------------------------------------
+// RFC 011 §5.4 — whitelisted frontmatter lift + sibling PDF detection.
+//
+// `parseFrontmatter` returns the entire parsed YAML object; the server lifts
+// a whitelist of known keys into a typed shape on every chunk's metadata.
+// Unknown string-valued keys are collected into `frontmatter.extras` so a
+// workflow author who adds a new field doesn't silently lose it — but the
+// MCP-boundary sanitizer strips `extras` by default (RFC 011 §7.1 R1, wired
+// in `src/KnowledgeBaseServer.ts`). Non-string-valued keys (YAML arrays or
+// nested maps — FAILSAFE doesn't coerce numbers or booleans) are dropped:
+// there's no safe scalar target for them here.
+// -----------------------------------------------------------------------------
+
+/** Whitelisted frontmatter keys lifted into `ChunkMetadata.frontmatter`. */
+const FRONTMATTER_WHITELIST: readonly string[] = [
+  'arxiv_id',
+  'title',
+  'authors',
+  'published',
+  'relevance_score',
+  'ingested_at',
+  'judge_method',
+  'metrics_used',
+  'bias_handling',
+] as const;
+
+export interface LiftedFrontmatter {
+  arxiv_id?: string;
+  title?: string;
+  authors?: string;
+  published?: string;
+  relevance_score?: number;
+  ingested_at?: string;
+  judge_method?: string;
+  metrics_used?: string;
+  bias_handling?: string;
+  /** Other string-valued frontmatter keys (e.g. workflow-specific additions). */
+  extras?: Record<string, string>;
+}
+
+/**
+ * Applies the RFC 011 §5.4.2 whitelist to `parseFrontmatter`'s raw object.
+ * Returns `undefined` when the input yields no fields — absent metadata is
+ * preferable to an empty object at the wire boundary.
+ */
+export function liftFrontmatter(
+  frontmatter: Record<string, unknown>,
+  filePath: string,
+): LiftedFrontmatter | undefined {
+  const lifted: LiftedFrontmatter = {};
+  const extras: Record<string, string> = {};
+  let hasAny = false;
+
+  for (const [key, value] of Object.entries(frontmatter)) {
+    // `tags` is already lifted into the sibling `tags` metadata field;
+    // don't duplicate it into the frontmatter block.
+    if (key === 'tags') continue;
+
+    // FAILSAFE parses scalars as strings and lists/maps as arrays/objects.
+    // Only strings survive the lift; arrays and objects are dropped with a
+    // debug log so a workflow author who wrote `metrics: [a, b, c]` sees
+    // why their field disappeared.
+    if (typeof value !== 'string') {
+      logger.debug(`Dropping non-string frontmatter key "${key}" from ${filePath}`);
+      continue;
+    }
+
+    if (key === 'relevance_score') {
+      // RFC 011 §5.4.3: parseInt + isFinite; non-numeric → omit and log.
+      // Log the *length* of the rejected value, never the value itself —
+      // frontmatter authored by the workflow is otherwise-untrusted input,
+      // and the RFC §5.4.2 leak rule for non-string keys ("key name, not
+      // value") applies equally here.
+      const parsed = parseInt(value, 10);
+      if (Number.isFinite(parsed)) {
+        lifted.relevance_score = parsed;
+        hasAny = true;
+      } else {
+        logger.debug(
+          `Dropping non-numeric relevance_score (length=${value.length}) from ${filePath}`,
+        );
+      }
+      continue;
+    }
+
+    if ((FRONTMATTER_WHITELIST as readonly string[]).includes(key)) {
+      (lifted as Record<string, unknown>)[key] = value;
+      hasAny = true;
+    } else {
+      extras[key] = value;
+    }
+  }
+
+  if (Object.keys(extras).length > 0) {
+    lifted.extras = extras;
+    hasAny = true;
+  }
+
+  return hasAny ? lifted : undefined;
+}
+
+/**
+ * Looks for a PDF whose basename (without extension) matches the `.md` file
+ * at `filePath`. Checks (in order) the arxiv `<kb>/pdfs/<stem>.pdf` layout,
+ * then the same-directory `<stem>.pdf` fallback. Returns the KB-directory-
+ * relative forward-slash path, or `undefined` when no sibling exists.
+ *
+ * Uses sync `existsSync` deliberately: called once per file inside an
+ * already-`await`-heavy ingest loop; an extra async boundary is not worth
+ * the 1-stat-per-file cost.
+ */
+export function detectSiblingPdfPath(
+  filePath: string,
+  knowledgeBaseName: string,
+): string | undefined {
+  const ext = path.extname(filePath);
+  const stem = path.basename(filePath, ext);
+  const dir = path.dirname(filePath);
+  const kbRoot = path.join(KNOWLEDGE_BASES_ROOT_DIR, knowledgeBaseName);
+
+  // Returns a KB-directory-scoped forward-slash path, or undefined if
+  // `candidate` escapes the KB root (e.g. the arxiv layout's `../pdfs/`
+  // probe for a `.md` at the KB root resolves outside the KB — `pdf_path`
+  // on a chunk must not reference a sibling KB's files).
+  const toKbRelative = (candidate: string): string | undefined => {
+    const rel = path.relative(kbRoot, candidate).split(path.sep).join('/');
+    if (rel.length === 0 || rel.startsWith('../') || rel === '..' || path.posix.isAbsolute(rel)) {
+      return undefined;
+    }
+    return rel;
+  };
+
+  // arxiv layout: notes/<stem>.md next to pdfs/<stem>.pdf
+  const arxivCandidate = path.join(dir, '..', 'pdfs', `${stem}.pdf`);
+  if (fs.existsSync(arxivCandidate)) {
+    const rel = toKbRelative(arxivCandidate);
+    if (rel !== undefined) return rel;
+    // `arxivCandidate` escapes the KB (e.g. the .md lives at the KB root,
+    // so `dir/../pdfs/` points at KNOWLEDGE_BASES_ROOT_DIR/pdfs — a sibling
+    // directory, not a subdir of this KB). Fall through to same-dir check.
+  }
+
+  // Fallback: same-directory colocation (KBs that don't split notes/ and pdfs/)
+  const sameDirCandidate = path.join(dir, `${stem}.pdf`);
+  if (fs.existsSync(sameDirCandidate)) {
+    const rel = toKbRelative(sameDirCandidate);
+    if (rel !== undefined) return rel;
+  }
+
+  return undefined;
+}


### PR DESCRIPTION
## Summary
- Extracted RFC 011 frontmatter lift policy and sibling PDF detection from `FaissIndexManager` into `frontmatter-lift.ts`.
- Updated the manager to import the focused helper module, reducing the exported surface of `FaissIndexManager.ts`.
- Pointed the existing helper coverage at the new module while preserving integration coverage through `FaissIndexManager`.

## Test plan
- [x] `npm run build`
- [x] `npm test -- --runTestsByPath src/FaissIndexManager.test.ts`
- [x] `npm test`

Refs #156

Generated with Codex.