### PR TITLE
refactor: move fs error translation helpers

### DIFF
--- a/src/FaissIndexManager.ts
+++ b/src/FaissIndexManager.ts
@@ -15,7 +15,7 @@ import type { OpenAIEmbeddings } from "@langchain/openai";
 import { FaissStore } from "@langchain/community/vectorstores/faiss";
 import { Document } from "@langchain/core/documents";
 import { MarkdownTextSplitter, RecursiveCharacterTextSplitter } from "langchain/text_splitter";
-import { toError } from './error-utils.js';
+import { handleFsOperationError, toError } from './error-utils.js';
 import { calculateSHA256, getFilesRecursively } from './file-utils.js';
 import { parseFrontmatter } from './frontmatter.js';
 import { detectSiblingPdfPath, liftFrontmatter } from './frontmatter-lift.js';
@@ -86,46 +86,6 @@ async function writeModelNameAtomic(modelNameFile: string, modelName: string): P
 // independent open(2) calls — each would re-resolve a symlink given the
 // path, but an absolute resolved path has no symlink to re-resolve.
 // ---------------------------------------------------------------------------
-
-type FsError = NodeJS.ErrnoException & { code?: string };
-
-function isPermissionError(error: unknown): error is FsError {
-  if (!error || typeof error !== 'object') {
-    return false;
-  }
-  const code = (error as FsError).code;
-  return code === 'EACCES' || code === 'EPERM' || code === 'EROFS';
-}
-
-function handleFsOperationError(action: string, targetPath: string, error: unknown): never {
-  const pathDescription = path.resolve(targetPath);
-  const stack = (error as Error)?.stack;
-  if (isPermissionError(error)) {
-    const message = `Permission denied while attempting to ${action} ${pathDescription}. Grant write access and retry.`;
-    logger.error(message);
-    if (stack) {
-      logger.error(stack);
-    }
-    const loggedError = new KBError('PERMISSION_DENIED', message, error) as KBError & {
-      __alreadyLogged?: boolean;
-    };
-    loggedError.__alreadyLogged = true;
-    throw loggedError;
-  }
-  logger.error(`Failed to ${action} ${pathDescription}:`, error);
-  if (stack) {
-    logger.error(stack);
-  }
-  if (error instanceof Error) {
-    (error as Error & { __alreadyLogged?: boolean }).__alreadyLogged = true;
-    throw error;
-  }
-  const newError = new Error(`Failed to ${action} ${pathDescription}: ${String(error)}`) as Error & {
-    __alreadyLogged?: boolean;
-  };
-  newError.__alreadyLogged = true;
-  throw newError;
-}
 
 /**
  * RFC 013 §4.8 — module-level cache for `bootstrapLayout()`. Ensures migration

--- a/src/error-utils.ts
+++ b/src/error-utils.ts
@@ -1,3 +1,9 @@
+import * as path from 'path';
+import { KBError } from './errors.js';
+import { logger } from './logger.js';
+
+type FsError = NodeJS.ErrnoException & { code?: string };
+
 /**
  * Coerce an unknown thrown value into an `Error`.
  *
@@ -20,4 +26,53 @@ export function toError(x: unknown): Error {
   } catch {
     return new Error(String(x));
   }
+}
+
+export function isPermissionError(error: unknown): error is FsError {
+  if (!error || typeof error !== 'object') {
+    return false;
+  }
+  const code = (error as FsError).code;
+  return code === 'EACCES' || code === 'EPERM' || code === 'EROFS';
+}
+
+/**
+ * Translate filesystem operation failures into operator-facing errors.
+ *
+ * Permission-like failures become `KBError('PERMISSION_DENIED')`; all thrown
+ * errors are marked `__alreadyLogged` so outer catch blocks do not log the
+ * same failure twice.
+ */
+export function handleFsOperationError(
+  action: string,
+  targetPath: string,
+  error: unknown,
+): never {
+  const pathDescription = path.resolve(targetPath);
+  const stack = (error as Error)?.stack;
+  if (isPermissionError(error)) {
+    const message = `Permission denied while attempting to ${action} ${pathDescription}. Grant write access and retry.`;
+    logger.error(message);
+    if (stack) {
+      logger.error(stack);
+    }
+    const loggedError = new KBError('PERMISSION_DENIED', message, error) as KBError & {
+      __alreadyLogged?: boolean;
+    };
+    loggedError.__alreadyLogged = true;
+    throw loggedError;
+  }
+  logger.error(`Failed to ${action} ${pathDescription}:`, error);
+  if (stack) {
+    logger.error(stack);
+  }
+  if (error instanceof Error) {
+    (error as Error & { __alreadyLogged?: boolean }).__alreadyLogged = true;
+    throw error;
+  }
+  const newError = new Error(`Failed to ${action} ${pathDescription}: ${String(error)}`) as Error & {
+    __alreadyLogged?: boolean;
+  };
+  newError.__alreadyLogged = true;
+  throw newError;
 }

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -12,7 +12,8 @@ import {
   SKIPPED_FILENAME_PATTERNS,
 } from './ingest-filter.js';
 import { parseFrontmatter } from './frontmatter.js';
-import { toError } from './error-utils.js';
+import { handleFsOperationError, isPermissionError, toError } from './error-utils.js';
+import { KBError } from './errors.js';
 import { logger } from './logger.js';
 import * as fsp from 'fs/promises';
 import * as fs from 'fs'; // Import fs for PathLike and Dirent
@@ -644,5 +645,69 @@ describe('toError', () => {
     expect(result).toBeInstanceOf(Error);
     expect(typeof result.message).toBe('string');
     expect(result.message.length).toBeGreaterThan(0);
+  });
+});
+
+describe('isPermissionError', () => {
+  it('recognizes filesystem permission-style error codes', () => {
+    expect(isPermissionError(Object.assign(new Error('denied'), { code: 'EACCES' }))).toBe(true);
+    expect(isPermissionError(Object.assign(new Error('denied'), { code: 'EPERM' }))).toBe(true);
+    expect(isPermissionError(Object.assign(new Error('readonly'), { code: 'EROFS' }))).toBe(true);
+  });
+
+  it('rejects non-permission errors and non-objects', () => {
+    expect(isPermissionError(Object.assign(new Error('missing'), { code: 'ENOENT' }))).toBe(false);
+    expect(isPermissionError(null)).toBe(false);
+    expect(isPermissionError('EACCES')).toBe(false);
+  });
+});
+
+describe('handleFsOperationError', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('translates permission errors into already-logged KBError instances', () => {
+    const loggerModule = jest.requireActual('./logger.js') as typeof import('./logger.js');
+    const errorSpy = jest.spyOn(loggerModule.logger, 'error').mockImplementation(() => {});
+    const cause = Object.assign(new Error('cannot write'), { code: 'EACCES' });
+
+    expect.assertions(5);
+    try {
+      handleFsOperationError('write file', '/tmp/example', cause);
+    } catch (error) {
+      expect(error).toBeInstanceOf(KBError);
+      expect((error as KBError).code).toBe('PERMISSION_DENIED');
+      expect((error as Error & { __alreadyLogged?: boolean }).__alreadyLogged).toBe(true);
+      expect((error as Error).message).toContain('Permission denied while attempting to write file');
+    }
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Permission denied'));
+  });
+
+  it('marks non-permission Error instances as already logged and rethrows by reference', () => {
+    const loggerModule = jest.requireActual('./logger.js') as typeof import('./logger.js');
+    jest.spyOn(loggerModule.logger, 'error').mockImplementation(() => {});
+    const original = new Error('boom') as Error & { __alreadyLogged?: boolean };
+
+    try {
+      handleFsOperationError('read file', '/tmp/example', original);
+    } catch (error) {
+      expect(error).toBe(original);
+      expect(original.__alreadyLogged).toBe(true);
+    }
+  });
+
+  it('wraps non-Error values and marks the wrapper as already logged', () => {
+    const loggerModule = jest.requireActual('./logger.js') as typeof import('./logger.js');
+    jest.spyOn(loggerModule.logger, 'error').mockImplementation(() => {});
+
+    try {
+      handleFsOperationError('read file', '/tmp/example', 'boom');
+    } catch (error) {
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toContain('Failed to read file');
+      expect((error as Error).message).toContain('boom');
+      expect((error as Error & { __alreadyLogged?: boolean }).__alreadyLogged).toBe(true);
+    }
   });
 });


### PR DESCRIPTION
## Summary
- Moved filesystem permission detection and operation-error translation from `FaissIndexManager` into `error-utils.ts`.
- Kept `FaissIndexManager` call sites behavior-equivalent by importing the shared helper.
- Added focused tests for permission detection, translated `KBError` output, already-logged markers, and non-Error wrapping.

## Test plan
- [x] `npm run build`
- [x] `npm test -- --runTestsByPath src/utils.test.ts src/FaissIndexManager.test.ts`
- [x] `npm test -- --runTestsByPath src/utils.test.ts`
- [x] `npm test`

Refs #156

Generated with Codex.