### PR TITLE
refactor(kb-stats): extract computeKbStats + shared per-KB walk helper (#157 step 1)

### DIFF
--- a/src/FaissIndexManager.ts
+++ b/src/FaissIndexManager.ts
@@ -16,10 +16,9 @@ import { FaissStore } from "@langchain/community/vectorstores/faiss";
 import { Document } from "@langchain/core/documents";
 import { MarkdownTextSplitter, RecursiveCharacterTextSplitter } from "langchain/text_splitter";
 import { handleFsOperationError, toError } from './error-utils.js';
-import { calculateSHA256, getFilesRecursively } from './file-utils.js';
+import { calculateSHA256 } from './file-utils.js';
 import { parseFrontmatter } from './frontmatter.js';
 import { detectSiblingPdfPath, liftFrontmatter } from './frontmatter-lift.js';
-import { filterIngestablePaths } from './ingest-filter.js';
 import { loadFile } from './loaders.js';
 import {
   EMBEDDING_PROVIDER,
@@ -45,7 +44,7 @@ import {
 import { deriveModelId, EmbeddingProvider } from './model-id.js';
 import { logger } from './logger.js';
 import { KBError } from './errors.js';
-import { listKnowledgeBases } from './kb-fs.js';
+import { enumerateIngestableKbFiles, listKnowledgeBases } from './kb-fs.js';
 import { makeOllamaOnFailedAttempt } from './ollama-error.js';
 import {
   loadFaissStoreAtomic,
@@ -838,30 +837,30 @@ export class FaissIndexManager {
       );
       const pendingHashWrites: { path: string; hash: string }[] = [];
 
-      const knowledgeBaseFiles: {
-        knowledgeBaseName: string;
-        knowledgeBasePath: string;
-        filePaths: string[];
-      }[] = [];
-
       // First enumerate every candidate path so progress notifications can
-      // report a stable denominator before embedding begins.
-      for (const knowledgeBaseName of knowledgeBases) {
+      // report a stable denominator before embedding begins. `knowledgeBases`
+      // can come from a raw `fsp.readdir` above and may include dot folders
+      // (`.faiss`, `.reindex-trigger`); filter them here since the shared
+      // helper does not.
+      const ingestableKbNames = knowledgeBases.filter((knowledgeBaseName) => {
         if (knowledgeBaseName.startsWith('.')) {
           logger.debug(`Skipping dot folder: ${knowledgeBaseName}`);
-          continue;
+          return false;
         }
-        const knowledgeBasePath = path.join(KNOWLEDGE_BASES_ROOT_DIR, knowledgeBaseName);
-        const filePaths = filterIngestablePaths(
-          await getFilesRecursively(knowledgeBasePath),
-          knowledgeBasePath,
-          {
-            extraExtensions: INGEST_EXTRA_EXTENSIONS,
-            excludePaths: INGEST_EXCLUDE_PATHS,
-          },
-        );
-        knowledgeBaseFiles.push({ knowledgeBaseName, knowledgeBasePath, filePaths });
-      }
+        return true;
+      });
+      const knowledgeBaseFiles = (await enumerateIngestableKbFiles(
+        KNOWLEDGE_BASES_ROOT_DIR,
+        ingestableKbNames,
+        {
+          extraExtensions: INGEST_EXTRA_EXTENSIONS,
+          excludePaths: INGEST_EXCLUDE_PATHS,
+        },
+      )).map((entry) => ({
+        knowledgeBaseName: entry.kbName,
+        knowledgeBasePath: entry.kbPath,
+        filePaths: entry.filePaths,
+      }));
 
       const totalFiles = totalFileCount(knowledgeBaseFiles);
       const reportProgress = async (currentFile: string): Promise<void> => {

--- a/src/KnowledgeBaseServer.ts
+++ b/src/KnowledgeBaseServer.ts
@@ -26,10 +26,7 @@ import type { EmbeddingProvider } from './model-id.js';
 import {
   ADD_DOCUMENT_DESCRIPTION,
   DELETE_DOCUMENT_DESCRIPTION,
-  FAISS_INDEX_PATH,
   FRONTMATTER_EXTRAS_WIRE_VISIBLE,
-  INGEST_EXCLUDE_PATHS,
-  INGEST_EXTRA_EXTENSIONS,
   KB_STATS_DESCRIPTION,
   KNOWLEDGE_BASES_ROOT_DIR,
   LIST_KNOWLEDGE_BASES_DESCRIPTION,
@@ -49,11 +46,11 @@ import {
   resolveKnowledgeBaseDir,
   resolveKnowledgeBaseDocumentPath,
 } from './kb-fs.js';
+import { computeKbStats } from './kb-stats.js';
 import { withWriteLock } from './write-lock.js';
 import { logger } from './logger.js';
 import { toError } from './error-utils.js';
 import { getFilesRecursively } from './file-utils.js';
-import { filterIngestablePaths } from './ingest-filter.js';
 import { isValidKbName } from './kb-paths.js';
 import * as fsp from 'fs/promises';
 import * as path from 'path';
@@ -64,46 +61,6 @@ import { KBError, type KBErrorCode } from './errors.js';
 
 const SERVER_NAME = 'knowledge-base-server';
 const SERVER_VERSION = '0.1.0';
-
-/**
- * Issue #54 — recursively walk `dir` for the latest mtime of any file under
- * it. Used by kb_stats to derive `last_updated_at` per KB from sidecar hash
- * files at `<kb>/.index/`: the most recent sidecar mtime is the last time
- * any file in this KB was (re)embedded by the active model. Returns an ISO
- * string with millisecond precision, or null when the directory is missing
- * (KB never indexed) or contains no files.
- */
-async function maxMtimeIso(dir: string): Promise<string | null> {
-  let latest = 0;
-  async function walk(target: string): Promise<void> {
-    let entries: Array<import('fs').Dirent>;
-    try {
-      entries = await fsp.readdir(target, { withFileTypes: true });
-    } catch (err) {
-      const code = (err as NodeJS.ErrnoException).code;
-      if (code === 'ENOENT' || code === 'ENOTDIR') return;
-      throw err;
-    }
-    for (const entry of entries) {
-      const child = path.join(target, entry.name);
-      if (entry.isDirectory()) {
-        await walk(child);
-        continue;
-      }
-      if (!entry.isFile()) continue;
-      try {
-        const st = await fsp.stat(child);
-        if (st.mtimeMs > latest) latest = st.mtimeMs;
-      } catch (err) {
-        const code = (err as NodeJS.ErrnoException).code;
-        if (code === 'ENOENT') continue;
-        throw err;
-      }
-    }
-  }
-  await walk(dir);
-  return latest === 0 ? null : new Date(latest).toISOString();
-}
 
 function mcpErrorContent(error: Error): TextContent {
   const code: KBErrorCode = error instanceof KBError ? error.code : 'INTERNAL';
@@ -480,9 +437,10 @@ export class KnowledgeBaseServer {
   }
 
   /**
-   * Issue #54 — kb_stats. Read-only observability surface; does NOT acquire
-   * the write lock and does NOT trigger an updateIndex. Counts reflect
-   * whatever is on disk + in the loaded FAISS docstore RIGHT NOW.
+   * Issue #54 — kb_stats MCP handler. Thin transport wrapper: resolves the
+   * active model, delegates to `computeKbStats` (#157), wraps the payload
+   * as a `CallToolResult`. Read-only — does NOT acquire the write lock and
+   * does NOT trigger an updateIndex.
    */
   private async handleKbStats(args: {
     knowledge_base_name?: string;
@@ -501,82 +459,11 @@ export class KnowledgeBaseServer {
         throw err;
       }
       const manager = await this.getManagerFor(activeModelId);
-
-      const allKbs = await listKnowledgeBases(KNOWLEDGE_BASES_ROOT_DIR);
-      let kbsToReport: string[];
-      if (args.knowledge_base_name !== undefined) {
-        if (!allKbs.includes(args.knowledge_base_name)) {
-          return {
-            content: [
-              mcpErrorContent(
-                new KBError(
-                  'KB_NOT_FOUND',
-                  `Knowledge base "${args.knowledge_base_name}" not found under ${KNOWLEDGE_BASES_ROOT_DIR}.`,
-                ),
-              ),
-            ],
-            isError: true,
-          };
-        }
-        kbsToReport = [args.knowledge_base_name];
-      } else {
-        kbsToReport = allKbs;
-      }
-
-      const indexStats = manager.getStats();
-
-      const knowledge_bases: Record<string, {
-        file_count: number;
-        chunk_count: number;
-        total_bytes_indexed: number;
-        last_updated_at: string | null;
-      }> = {};
-
-      for (const kb of kbsToReport) {
-        const kbPath = path.join(KNOWLEDGE_BASES_ROOT_DIR, kb);
-        // Apply the SAME ingest filter the indexer uses, so file_count and
-        // total_bytes_indexed reflect what would actually be embedded — not
-        // the raw file walk (which still includes excluded extensions and
-        // excluded subtrees).
-        const candidatePaths = await getFilesRecursively(kbPath);
-        const filePaths = filterIngestablePaths(candidatePaths, kbPath, {
-          extraExtensions: INGEST_EXTRA_EXTENSIONS,
-          excludePaths: INGEST_EXCLUDE_PATHS,
-        });
-        let totalBytes = 0;
-        for (const filePath of filePaths) {
-          try {
-            const st = await fsp.stat(filePath);
-            totalBytes += st.size;
-          } catch (err) {
-            // Best-effort: a TOCTOU between getFilesRecursively and stat
-            // (e.g. concurrent edit) shouldn't fail the whole stats call.
-            logger.debug(`kb_stats: could not stat ${filePath}: ${(err as Error).message}`);
-          }
-        }
-        const lastUpdatedAt = await maxMtimeIso(path.join(kbPath, '.index'));
-        knowledge_bases[kb] = {
-          file_count: filePaths.length,
-          chunk_count: indexStats.chunkCountsByKb[kb] ?? 0,
-          total_bytes_indexed: totalBytes,
-          last_updated_at: lastUpdatedAt,
-        };
-      }
-
-      const payload = {
-        knowledge_bases,
-        embedding: {
-          provider: manager.embeddingProvider,
-          model: manager.modelName,
-          dim: indexStats.dim,
-        },
-        index_path: FAISS_INDEX_PATH,
-        server: {
-          version: SERVER_VERSION,
-          uptime_ms: Date.now() - this.startedAt,
-        },
-      };
-
+      const payload = await computeKbStats(manager, {
+        knowledgeBaseName: args.knowledge_base_name,
+        serverVersion: SERVER_VERSION,
+        startedAt: this.startedAt,
+      });
       return {
         content: [{ type: 'text', text: JSON.stringify(payload, null, 2) }],
       };

--- a/src/cli-models.ts
+++ b/src/cli-models.ts
@@ -1,5 +1,4 @@
 import * as fsp from 'fs/promises';
-import * as path from 'path';
 import { FaissIndexManager } from './FaissIndexManager.js';
 import {
   ActiveModelResolutionError,
@@ -13,11 +12,9 @@ import {
 } from './active-model.js';
 import { deriveModelId, type EmbeddingProvider } from './model-id.js';
 import { KNOWLEDGE_BASES_ROOT_DIR } from './config.js';
-import { listKnowledgeBases } from './kb-fs.js';
+import { enumerateIngestableKbFiles, listKnowledgeBases } from './kb-fs.js';
 import { withWriteLock } from './write-lock.js';
 import { estimateCostUsd } from './cost-estimates.js';
-import { getFilesRecursively } from './file-utils.js';
-import { filterIngestablePaths } from './ingest-filter.js';
 
 export async function runModels(rest: string[]): Promise<number> {
   const verb = rest[0];
@@ -124,11 +121,9 @@ async function runModelsAdd(rest: string[]): Promise<number> {
   let fileCount = 0;
   try {
     const kbs = await listKnowledgeBases(KNOWLEDGE_BASES_ROOT_DIR);
-    for (const kbName of kbs) {
-      const kbDir = path.join(KNOWLEDGE_BASES_ROOT_DIR, kbName);
-      const all = await getFilesRecursively(kbDir);
-      const ingestable = await filterIngestablePaths(all, kbDir);
-      for (const f of ingestable) {
+    const enumerations = await enumerateIngestableKbFiles(KNOWLEDGE_BASES_ROOT_DIR, kbs);
+    for (const { filePaths } of enumerations) {
+      for (const f of filePaths) {
         try {
           const st = await fsp.stat(f);
           totalBytes += st.size;

--- a/src/cli-search.ts
+++ b/src/cli-search.ts
@@ -11,10 +11,8 @@ import {
   KNOWLEDGE_BASES_ROOT_DIR,
 } from './config.js';
 import { formatRetrievalAsJson, formatRetrievalAsMarkdown } from './formatter.js';
-import { listKnowledgeBases } from './kb-fs.js';
+import { enumerateIngestableKbFiles, listKnowledgeBases } from './kb-fs.js';
 import { withWriteLock } from './write-lock.js';
-import { getFilesRecursively } from './file-utils.js';
-import { filterIngestablePaths } from './ingest-filter.js';
 import { loadManagerForModel, loadWithJsonRetry } from './cli-shared.js';
 
 interface SearchArgs {
@@ -224,26 +222,19 @@ async function computeStaleness(modelId: string): Promise<Staleness> {
     return { indexMtime, modifiedFiles: 0, newFiles: 0 };
   }
 
-  for (const kbName of kbs) {
-    const kbDir = path.join(KNOWLEDGE_BASES_ROOT_DIR, kbName);
-    let allFiles: string[];
-    try {
-      allFiles = await getFilesRecursively(kbDir);
-    } catch {
-      continue;
-    }
-    const ingestable = await filterIngestablePaths(allFiles, kbDir);
+  const enumerations = await enumerateIngestableKbFiles(KNOWLEDGE_BASES_ROOT_DIR, kbs);
 
-    for (const f of ingestable) {
+  for (const { kbPath, filePaths } of enumerations) {
+    for (const f of filePaths) {
       try {
         const st = await fsp.stat(f);
         if (st.mtimeMs > indexMtimeMs) modified += 1;
       } catch {
-        // file vanished between getFilesRecursively and stat; ignore it
+        // file vanished between the walker and stat; ignore it
       }
     }
 
-    const sidecarDir = path.join(kbDir, '.index');
+    const sidecarDir = path.join(kbPath, '.index');
     let sidecarCount = 0;
     try {
       const sidecars = await fsp.readdir(sidecarDir);
@@ -251,8 +242,8 @@ async function computeStaleness(modelId: string): Promise<Staleness> {
     } catch {
       // .index missing; count difference below covers this case
     }
-    if (ingestable.length > sidecarCount) {
-      added += ingestable.length - sidecarCount;
+    if (filePaths.length > sidecarCount) {
+      added += filePaths.length - sidecarCount;
     }
   }
 

--- a/src/kb-fs.ts
+++ b/src/kb-fs.ts
@@ -8,6 +8,8 @@ import * as fsp from 'fs/promises';
 import * as path from 'path';
 import { assertValidKbName } from './kb-paths.js';
 import { KBError } from './errors.js';
+import { getFilesRecursively } from './file-utils.js';
+import { filterIngestablePaths } from './ingest-filter.js';
 
 /**
  * Returns the names of available knowledge bases under `rootDir` (one per
@@ -21,6 +23,48 @@ import { KBError } from './errors.js';
 export async function listKnowledgeBases(rootDir: string): Promise<string[]> {
   const entries = await fsp.readdir(rootDir);
   return entries.filter((entry) => !entry.startsWith('.'));
+}
+
+export interface KbFileEnumeration {
+  kbName: string;
+  kbPath: string;
+  filePaths: string[];
+}
+
+export interface EnumerateIngestableKbFilesOptions {
+  extraExtensions?: readonly string[];
+  excludePaths?: readonly string[];
+}
+
+/**
+ * Issue #157 — single home for the per-KB walk + ingest-filter shape that
+ * `kb_stats`, the indexer, `kb models add` cost preview, and `kb search`
+ * staleness preview all share.
+ *
+ * For each name in `kbNames`, walks `<rootDir>/<kbName>` with
+ * `getFilesRecursively` (which already skips dot-prefixed entries) and
+ * applies `filterIngestablePaths` (with caller-supplied extras/excludes).
+ * Result preserves input order so callers can stream progress against a
+ * stable denominator.
+ *
+ * Caller is responsible for filtering dot-prefixed names out of `kbNames`
+ * if its source admits them (e.g. raw `fsp.readdir`); `listKnowledgeBases`
+ * already does this.
+ */
+export async function enumerateIngestableKbFiles(
+  rootDir: string,
+  kbNames: readonly string[],
+  options?: EnumerateIngestableKbFilesOptions,
+): Promise<KbFileEnumeration[]> {
+  const filterOpts = options ?? {};
+  const result: KbFileEnumeration[] = [];
+  for (const kbName of kbNames) {
+    const kbPath = path.join(rootDir, kbName);
+    const candidates = await getFilesRecursively(kbPath);
+    const filePaths = filterIngestablePaths(candidates, kbPath, filterOpts);
+    result.push({ kbName, kbPath, filePaths });
+  }
+  return result;
 }
 
 const KB_DESCRIPTION_MAX_LEN = 80;

--- a/src/kb-stats.test.ts
+++ b/src/kb-stats.test.ts
@@ -1,0 +1,274 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import * as fsp from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+
+// Issue #157 — direct tests for the computeKbStats data layer extracted out
+// of KnowledgeBaseServer.handleKbStats (#54). The integration tests in
+// KnowledgeBaseServer.test.ts cover the MCP wire wrapping; these cover the
+// pure data contract that a future `kb stats` CLI will consume.
+
+interface FakeManager {
+  embeddingProvider: string;
+  modelName: string;
+  getStats(): {
+    totalChunks: number;
+    chunkCountsByKb: Record<string, number>;
+    dim: number | null;
+  };
+}
+
+function makeManager(opts: {
+  provider?: string;
+  modelName?: string;
+  chunkCountsByKb?: Record<string, number>;
+  dim?: number | null;
+}): FakeManager {
+  return {
+    embeddingProvider: opts.provider ?? 'huggingface',
+    modelName: opts.modelName ?? 'BAAI/bge-small-en-v1.5',
+    getStats: () => ({
+      totalChunks: Object.values(opts.chunkCountsByKb ?? {}).reduce((s, n) => s + n, 0),
+      chunkCountsByKb: opts.chunkCountsByKb ?? {},
+      dim: opts.dim ?? null,
+    }),
+  };
+}
+
+async function freshKbStats(env: Record<string, string>): Promise<typeof import('./kb-stats.js')> {
+  for (const [k, v] of Object.entries(env)) process.env[k] = v;
+  jest.resetModules();
+  return import('./kb-stats.js');
+}
+
+describe('computeKbStats', () => {
+  const originalEnv = {
+    KNOWLEDGE_BASES_ROOT_DIR: process.env.KNOWLEDGE_BASES_ROOT_DIR,
+    FAISS_INDEX_PATH: process.env.FAISS_INDEX_PATH,
+    INGEST_EXCLUDE_PATHS: process.env.INGEST_EXCLUDE_PATHS,
+    INGEST_EXTRA_EXTENSIONS: process.env.INGEST_EXTRA_EXTENSIONS,
+  };
+
+  afterEach(() => {
+    for (const [k, v] of Object.entries(originalEnv)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  });
+
+  it('returns one row per registered KB with file_count, total_bytes_indexed, chunk_count', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-stats-'));
+    await fsp.mkdir(path.join(tempDir, 'alpha'));
+    await fsp.mkdir(path.join(tempDir, 'beta'));
+    await fsp.writeFile(path.join(tempDir, 'alpha', 'one.md'), 'hello world'); // 11 bytes
+    await fsp.writeFile(path.join(tempDir, 'alpha', 'two.md'), '12345');       // 5
+    await fsp.writeFile(path.join(tempDir, 'beta', 'long.md'), 'x'.repeat(100));
+
+    const { computeKbStats } = await freshKbStats({
+      KNOWLEDGE_BASES_ROOT_DIR: tempDir,
+      FAISS_INDEX_PATH: path.join(tempDir, '.faiss'),
+    });
+
+    const manager = makeManager({
+      chunkCountsByKb: { alpha: 4, beta: 3 },
+      dim: 384,
+    });
+
+    const startedAt = Date.now() - 5;
+    const payload = await computeKbStats(manager as any, {
+      serverVersion: '9.9.9',
+      startedAt,
+    });
+
+    expect(Object.keys(payload.knowledge_bases).sort()).toEqual(['alpha', 'beta']);
+    expect(payload.knowledge_bases.alpha).toEqual({
+      file_count: 2,
+      chunk_count: 4,
+      total_bytes_indexed: 16,
+      last_updated_at: null,
+    });
+    expect(payload.knowledge_bases.beta).toMatchObject({
+      file_count: 1,
+      chunk_count: 3,
+      total_bytes_indexed: 100,
+    });
+    expect(payload.embedding).toEqual({
+      provider: 'huggingface',
+      model: 'BAAI/bge-small-en-v1.5',
+      dim: 384,
+    });
+    expect(payload.index_path).toBe(path.join(tempDir, '.faiss'));
+    expect(payload.server.version).toBe('9.9.9');
+    expect(payload.server.uptime_ms).toBeGreaterThanOrEqual(0);
+
+    await fsp.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('scopes to a single KB when knowledgeBaseName is set', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-stats-scope-'));
+    await fsp.mkdir(path.join(tempDir, 'alpha'));
+    await fsp.mkdir(path.join(tempDir, 'beta'));
+    await fsp.writeFile(path.join(tempDir, 'alpha', 'a.md'), 'aaa');
+    await fsp.writeFile(path.join(tempDir, 'beta', 'b.md'), 'bbbb');
+
+    const { computeKbStats } = await freshKbStats({
+      KNOWLEDGE_BASES_ROOT_DIR: tempDir,
+      FAISS_INDEX_PATH: path.join(tempDir, '.faiss'),
+    });
+
+    const manager = makeManager({
+      chunkCountsByKb: { alpha: 5, beta: 4 },
+      dim: 768,
+    });
+
+    const payload = await computeKbStats(manager as any, {
+      knowledgeBaseName: 'alpha',
+      serverVersion: '0.0.0',
+      startedAt: Date.now(),
+    });
+
+    expect(Object.keys(payload.knowledge_bases)).toEqual(['alpha']);
+    expect(payload.knowledge_bases.alpha.chunk_count).toBe(5);
+    expect(payload.embedding.dim).toBe(768);
+
+    await fsp.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("throws KBError('KB_NOT_FOUND') when knowledgeBaseName is unregistered (handler maps to wire shape)", async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-stats-missing-'));
+    await fsp.mkdir(path.join(tempDir, 'alpha'));
+
+    const { computeKbStats } = await freshKbStats({
+      KNOWLEDGE_BASES_ROOT_DIR: tempDir,
+      FAISS_INDEX_PATH: path.join(tempDir, '.faiss'),
+    });
+    const { KBError } = await import('./errors.js');
+
+    const manager = makeManager({});
+    await expect(
+      computeKbStats(manager as any, {
+        knowledgeBaseName: 'doesnotexist',
+        serverVersion: '0.0.0',
+        startedAt: Date.now(),
+      }),
+    ).rejects.toMatchObject({
+      // Throws the typed error rather than wrapping in MCP shape — the
+      // handler is responsible for transport conversion (#157 boundary).
+      code: 'KB_NOT_FOUND',
+    });
+    // Sanity: the thrown error is a real KBError instance, not a plain Error.
+    await expect(
+      computeKbStats(manager as any, {
+        knowledgeBaseName: 'doesnotexist',
+        serverVersion: '0.0.0',
+        startedAt: Date.now(),
+      }),
+    ).rejects.toBeInstanceOf(KBError);
+
+    await fsp.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('derives last_updated_at from the most recent mtime under <kb>/.index/', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-stats-mtime-'));
+    await fsp.mkdir(path.join(tempDir, 'alpha'));
+    const sidecarDir = path.join(tempDir, 'alpha', '.index');
+    await fsp.mkdir(sidecarDir, { recursive: true });
+    const sidecar = path.join(sidecarDir, 'a.md');
+    await fsp.writeFile(sidecar, 'hash');
+    const fixedMs = 1_700_000_000_000;
+    await fsp.utimes(sidecar, fixedMs / 1000, fixedMs / 1000);
+
+    const { computeKbStats } = await freshKbStats({
+      KNOWLEDGE_BASES_ROOT_DIR: tempDir,
+      FAISS_INDEX_PATH: path.join(tempDir, '.faiss'),
+    });
+
+    const manager = makeManager({});
+    const payload = await computeKbStats(manager as any, {
+      knowledgeBaseName: 'alpha',
+      serverVersion: '0.0.0',
+      startedAt: Date.now(),
+    });
+    expect(payload.knowledge_bases.alpha.last_updated_at).toBe(new Date(fixedMs).toISOString());
+
+    await fsp.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('respects INGEST_EXCLUDE_PATHS so excluded files do not contribute to file_count or bytes', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-stats-exclude-'));
+    await fsp.mkdir(path.join(tempDir, 'alpha'));
+    await fsp.mkdir(path.join(tempDir, 'alpha', 'pdfs'));
+    await fsp.writeFile(path.join(tempDir, 'alpha', 'note.md'), 'hello');         // 5
+    await fsp.writeFile(path.join(tempDir, 'alpha', 'pdfs', 'paper.md'), 'xxx');  // excluded by pattern
+
+    const { computeKbStats } = await freshKbStats({
+      KNOWLEDGE_BASES_ROOT_DIR: tempDir,
+      FAISS_INDEX_PATH: path.join(tempDir, '.faiss'),
+      INGEST_EXCLUDE_PATHS: 'pdfs/**',
+    });
+
+    const manager = makeManager({});
+    const payload = await computeKbStats(manager as any, {
+      serverVersion: '0.0.0',
+      startedAt: Date.now(),
+    });
+    expect(payload.knowledge_bases.alpha.file_count).toBe(1);
+    expect(payload.knowledge_bases.alpha.total_bytes_indexed).toBe(5);
+
+    await fsp.rm(tempDir, { recursive: true, force: true });
+  });
+});
+
+describe('enumerateIngestableKbFiles', () => {
+  it('returns one entry per requested KB, preserving input order', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-enum-'));
+    try {
+      await fsp.mkdir(path.join(tempDir, 'alpha'));
+      await fsp.mkdir(path.join(tempDir, 'beta'));
+      await fsp.writeFile(path.join(tempDir, 'alpha', 'a.md'), 'a');
+      await fsp.writeFile(path.join(tempDir, 'beta', 'b.md'), 'b');
+
+      const { enumerateIngestableKbFiles } = await import('./kb-fs.js');
+      const out = await enumerateIngestableKbFiles(tempDir, ['beta', 'alpha']);
+      expect(out.map((e) => e.kbName)).toEqual(['beta', 'alpha']);
+      expect(out[0].kbPath).toBe(path.join(tempDir, 'beta'));
+      expect(out[0].filePaths.map((p) => path.basename(p))).toEqual(['b.md']);
+      expect(out[1].filePaths.map((p) => path.basename(p))).toEqual(['a.md']);
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('applies extraExtensions and excludePaths from options', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-enum-opts-'));
+    try {
+      await fsp.mkdir(path.join(tempDir, 'kb'));
+      await fsp.mkdir(path.join(tempDir, 'kb', 'logs'));
+      await fsp.writeFile(path.join(tempDir, 'kb', 'note.md'), 'a');
+      await fsp.writeFile(path.join(tempDir, 'kb', 'data.csv'), 'a,b');
+      await fsp.writeFile(path.join(tempDir, 'kb', 'logs', 'r.md'), 'a');
+
+      const { enumerateIngestableKbFiles } = await import('./kb-fs.js');
+      const out = await enumerateIngestableKbFiles(tempDir, ['kb'], {
+        extraExtensions: ['.csv'],
+        excludePaths: ['logs/**'],
+      });
+      const names = out[0].filePaths.map((p) => path.basename(p)).sort();
+      expect(names).toEqual(['data.csv', 'note.md']);
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns an empty filePaths array for a missing KB directory', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-enum-missing-'));
+    try {
+      const { enumerateIngestableKbFiles } = await import('./kb-fs.js');
+      const out = await enumerateIngestableKbFiles(tempDir, ['ghost']);
+      // getFilesRecursively logs and returns [] on ENOENT — caller-stable.
+      expect(out).toEqual([{ kbName: 'ghost', kbPath: path.join(tempDir, 'ghost'), filePaths: [] }]);
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/kb-stats.ts
+++ b/src/kb-stats.ts
@@ -1,0 +1,167 @@
+// kb-stats.ts — read-only observability surface for the kb_stats MCP tool
+// (#54) and a future `kb stats` CLI (#157).
+//
+// Pure data computation: takes a `FaissIndexManager` and the on-disk KB
+// layout, returns a structured payload. Knows nothing about MCP wire
+// shape — the caller wraps the result. The MCP handler in
+// `KnowledgeBaseServer.handleKbStats` and a future CLI subcommand both
+// consume `computeKbStats`.
+
+import * as fsp from 'fs/promises';
+import * as path from 'path';
+import type { FaissIndexManager } from './FaissIndexManager.js';
+import {
+  FAISS_INDEX_PATH,
+  INGEST_EXCLUDE_PATHS,
+  INGEST_EXTRA_EXTENSIONS,
+  KNOWLEDGE_BASES_ROOT_DIR,
+} from './config.js';
+import { KBError } from './errors.js';
+import { enumerateIngestableKbFiles, listKnowledgeBases } from './kb-fs.js';
+import { logger } from './logger.js';
+
+export interface KbStatsRow {
+  file_count: number;
+  chunk_count: number;
+  total_bytes_indexed: number;
+  last_updated_at: string | null;
+}
+
+export interface KbStatsPayload {
+  knowledge_bases: Record<string, KbStatsRow>;
+  embedding: { provider: string; model: string; dim: number | null };
+  index_path: string;
+  server: { version: string; uptime_ms: number };
+}
+
+export interface ComputeKbStatsOptions {
+  /** Restrict to a single KB. Throws `KBError('KB_NOT_FOUND')` if unregistered. */
+  knowledgeBaseName?: string;
+  /** Server version string surfaced under `server.version`. */
+  serverVersion: string;
+  /** `Date.now()` baseline used to derive `server.uptime_ms`. */
+  startedAt: number;
+}
+
+/**
+ * Issue #54 + #157 — compute the kb_stats payload from a manager + the
+ * registered KB list on disk. Returns plain data; the MCP handler wraps
+ * it as `CallToolResult` and a future `kb stats` CLI prints it directly.
+ *
+ * Counts reflect whatever is on disk + in the loaded FAISS docstore RIGHT
+ * NOW. Read-only — does not acquire the write lock and does not trigger
+ * an `updateIndex`.
+ *
+ * Throws `KBError('KB_NOT_FOUND')` when `options.knowledgeBaseName` is
+ * set but the KB is not registered under `KNOWLEDGE_BASES_ROOT_DIR`.
+ */
+export async function computeKbStats(
+  manager: FaissIndexManager,
+  options: ComputeKbStatsOptions,
+): Promise<KbStatsPayload> {
+  const allKbs = await listKnowledgeBases(KNOWLEDGE_BASES_ROOT_DIR);
+  let kbsToReport: string[];
+  if (options.knowledgeBaseName !== undefined) {
+    if (!allKbs.includes(options.knowledgeBaseName)) {
+      throw new KBError(
+        'KB_NOT_FOUND',
+        `Knowledge base "${options.knowledgeBaseName}" not found under ${KNOWLEDGE_BASES_ROOT_DIR}.`,
+      );
+    }
+    kbsToReport = [options.knowledgeBaseName];
+  } else {
+    kbsToReport = allKbs;
+  }
+
+  const indexStats = manager.getStats();
+
+  // Apply the SAME ingest filter the indexer uses, so file_count and
+  // total_bytes_indexed reflect what would actually be embedded — not the
+  // raw file walk (which still includes excluded extensions and excluded
+  // subtrees).
+  const enumerations = await enumerateIngestableKbFiles(
+    KNOWLEDGE_BASES_ROOT_DIR,
+    kbsToReport,
+    {
+      extraExtensions: INGEST_EXTRA_EXTENSIONS,
+      excludePaths: INGEST_EXCLUDE_PATHS,
+    },
+  );
+
+  const knowledge_bases: Record<string, KbStatsRow> = {};
+  for (const { kbName, kbPath, filePaths } of enumerations) {
+    let totalBytes = 0;
+    for (const filePath of filePaths) {
+      try {
+        const st = await fsp.stat(filePath);
+        totalBytes += st.size;
+      } catch (err) {
+        // Best-effort: a TOCTOU between the walker and stat (e.g. concurrent
+        // edit) shouldn't fail the whole stats call.
+        logger.debug(`kb_stats: could not stat ${filePath}: ${(err as Error).message}`);
+      }
+    }
+    const lastUpdatedAt = await maxMtimeIso(path.join(kbPath, '.index'));
+    knowledge_bases[kbName] = {
+      file_count: filePaths.length,
+      chunk_count: indexStats.chunkCountsByKb[kbName] ?? 0,
+      total_bytes_indexed: totalBytes,
+      last_updated_at: lastUpdatedAt,
+    };
+  }
+
+  return {
+    knowledge_bases,
+    embedding: {
+      provider: manager.embeddingProvider,
+      model: manager.modelName,
+      dim: indexStats.dim,
+    },
+    index_path: FAISS_INDEX_PATH,
+    server: {
+      version: options.serverVersion,
+      uptime_ms: Date.now() - options.startedAt,
+    },
+  };
+}
+
+/**
+ * Issue #54 — recursively walk `dir` for the latest mtime of any file
+ * under it. Used by `computeKbStats` to derive `last_updated_at` per KB
+ * from sidecar hash files at `<kb>/.index/`: the most recent sidecar
+ * mtime is the last time any file in this KB was (re)embedded by the
+ * active model. Returns an ISO string with millisecond precision, or
+ * null when the directory is missing (KB never indexed) or contains no
+ * files.
+ */
+export async function maxMtimeIso(dir: string): Promise<string | null> {
+  let latest = 0;
+  async function walk(target: string): Promise<void> {
+    let entries: Array<import('fs').Dirent>;
+    try {
+      entries = await fsp.readdir(target, { withFileTypes: true });
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === 'ENOENT' || code === 'ENOTDIR') return;
+      throw err;
+    }
+    for (const entry of entries) {
+      const child = path.join(target, entry.name);
+      if (entry.isDirectory()) {
+        await walk(child);
+        continue;
+      }
+      if (!entry.isFile()) continue;
+      try {
+        const st = await fsp.stat(child);
+        if (st.mtimeMs > latest) latest = st.mtimeMs;
+      } catch (err) {
+        const code = (err as NodeJS.ErrnoException).code;
+        if (code === 'ENOENT') continue;
+        throw err;
+      }
+    }
+  }
+  await walk(dir);
+  return latest === 0 ? null : new Date(latest).toISOString();
+}


### PR DESCRIPTION
## Summary

Step 1 of #157 — split `src/KnowledgeBaseServer.ts` (1052 → 939 lines).

- **New `src/kb-stats.ts`** — `computeKbStats(manager, options)` returns the kb_stats payload as plain data; throws `KBError('KB_NOT_FOUND')` so the MCP handler is the single transport-shape boundary. `maxMtimeIso` moved here. The future `kb stats` CLI (#157 step 1's stated motivation) can consume the same function without going through `CallToolResult`.
- **New `enumerateIngestableKbFiles` in `src/kb-fs.ts`** — single home for the per-KB walk + ingest-filter shape that `kb_stats`, the indexer batch, `kb models add` cost preview, and `kb search` staleness preview all duplicated. Folds in the four occurrences cited in the issue (`KnowledgeBaseServer.ts:535-557`, `cli-models.ts:127-138`, `cli-search.ts:227-244`, `FaissIndexManager.ts:1041-1056`).
- **`KnowledgeBaseServer.handleKbStats`** is now a 30-line transport wrapper around `computeKbStats`; loses its inline aggregation, sidecar mtime walk, and KB_NOT_FOUND wire-shape branch.
- **`FaissIndexManager`, `cli-models`, `cli-search`** use the shared helper. The indexer keeps its dot-folder skip via a pre-pass since `indexBatch`'s input comes from a raw `fsp.readdir` (not `listKnowledgeBases`).
- The other steps in the issue's suggested approach (mcp-resources extraction, manager-registry extraction, warmup-fanout inversion, `sanitizeMetadataForWire` re-export deletion) are out of scope here — the issue says "each extraction above is a separate PR".

The existing `kb_stats` wire contract (file_count, total_bytes_indexed, last_updated_at, chunk_count, embedding, index_path, server) is preserved — covered by the existing `KnowledgeBaseServer.test.ts` cases plus a new `kb-stats.test.ts` (8 cases) that exercises the data layer directly so the API contract is documented for the future CLI consumer.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 503/503 tests pass (24 suites)
- [x] New `src/kb-stats.test.ts` (8 cases): payload shape, single-KB scoping, KBError throw on unknown KB, last_updated_at from `<kb>/.index/` mtime, INGEST_EXCLUDE_PATHS honored, enumerateIngestableKbFiles preserves input order + applies opts + handles missing dir
- [x] Existing `KnowledgeBaseServer.test.ts` `handleKbStats` cases (5) still pass — wire contract unchanged
- [ ] Manual MCP verification (a tools/call against `kb_stats`) — not done; the existing handler tests cover the wire payload and no behavior was intended to change

Closes #157 (step 1 of 5; the issue notes it partly depends on #156, but step 1's walk-and-stat consolidation does not require #156 to land first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)