### PR TITLE
refactor(mcp-resources): extract kb:// URI surface + handlers (#157 step 2)

### DIFF
--- a/src/KnowledgeBaseServer.ts
+++ b/src/KnowledgeBaseServer.ts
@@ -3,13 +3,9 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { z } from 'zod';
 import {
-  ListResourcesRequestSchema,
-  ListResourceTemplatesRequestSchema,
-  ReadResourceRequestSchema,
   type CallToolResult,
   type ListResourcesResult,
   type ReadResourceResult,
-  type Resource,
   type TextContent,
 } from '@modelcontextprotocol/sdk/types.js';
 import { FaissIndexManager } from './FaissIndexManager.js';
@@ -44,14 +40,16 @@ import {
   listKnowledgeBases,
   resolveKbRelativePath,
   resolveKnowledgeBaseDir,
-  resolveKnowledgeBaseDocumentPath,
 } from './kb-fs.js';
 import { computeKbStats } from './kb-stats.js';
+import {
+  listResources,
+  readResource,
+  registerResources,
+} from './mcp-resources.js';
 import { withWriteLock } from './write-lock.js';
 import { logger } from './logger.js';
 import { toError } from './error-utils.js';
-import { getFilesRecursively } from './file-utils.js';
-import { isValidKbName } from './kb-paths.js';
 import * as fsp from 'fs/promises';
 import * as path from 'path';
 import { StreamableHttpHost } from './transport/http.js';
@@ -73,94 +71,6 @@ function mcpErrorContent(error: Error): TextContent {
       },
     }),
   };
-}
-
-function mimeTypeForResource(filePath: string): string {
-  const ext = path.extname(filePath).toLowerCase();
-  switch (ext) {
-    case '.md':
-    case '.markdown':
-      return 'text/markdown';
-    case '.pdf':
-      return 'application/pdf';
-    case '.html':
-    case '.htm':
-      return 'text/html';
-    case '.txt':
-    default:
-      return 'text/plain';
-  }
-}
-
-function resourceUri(kbName: string, relativePath: string): string {
-  const encodedPath = relativePath
-    .split('/')
-    .map((segment) => encodeURIComponent(segment))
-    .join('/');
-  return `kb://${kbName}/${encodedPath}`;
-}
-
-function parseKnowledgeBaseResourceUri(uri: string): { kbName: string; relativePath: string } {
-  const rawMatch = /^kb:\/\/([^/?#]*)([^?#]*)/i.exec(uri);
-  if (!rawMatch) {
-    throw new Error('resource URI must use the kb:// scheme');
-  }
-
-  let url: URL;
-  try {
-    url = new URL(uri);
-  } catch (error: unknown) {
-    throw new Error(`invalid kb:// URI: ${toError(error).message}`);
-  }
-
-  if (url.protocol !== 'kb:') {
-    throw new Error(`unsupported resource URI scheme: ${url.protocol}`);
-  }
-
-  const kbName = url.hostname;
-  if (kbName.length === 0) {
-    throw new Error('kb:// URI requires a non-empty KB authority');
-  }
-  if (!isValidKbName(kbName)) {
-    throw new Error('invalid KB name in kb:// URI');
-  }
-
-  const rawPath = rawMatch[2] ?? '';
-  if (!rawPath.startsWith('/')) {
-    throw new Error('kb:// URI requires a non-empty resource path');
-  }
-
-  const rawRelativePath = rawPath.slice(1);
-  if (rawRelativePath.length === 0) {
-    throw new Error('kb:// URI requires a non-empty resource path');
-  }
-  if (/%(?:2f|5c)/i.test(rawRelativePath)) {
-    throw new Error(`path escapes KB root: ${JSON.stringify(rawRelativePath)}`);
-  }
-
-  // Decode each path segment with `decodeURIComponent` to round-trip
-  // `resourceUri()`, which percent-encodes per-segment with the matching
-  // function. `decodeURI` leaves reserved characters (`#`, `?`, `&`, `+`,
-  // `=`, …) literal, so a filename like `bug#123.md` would round-trip to a
-  // literal `%23` and `resources/read` would fail with "path not found".
-  // The earlier `%2f|%5c` guard already rejects encoded path separators
-  // before this point, so per-segment decoding cannot reintroduce a `/` or
-  // `\` boundary.
-  let relativePath: string;
-  try {
-    relativePath = rawRelativePath
-      .split('/')
-      .map((segment) => decodeURIComponent(segment))
-      .join('/');
-  } catch (error: unknown) {
-    throw new Error(`invalid kb:// URI path encoding: ${toError(error).message}`);
-  }
-
-  if (relativePath.split('/').some((segment) => segment === '..')) {
-    throw new Error(`path escapes KB root: ${JSON.stringify(relativePath)}`);
-  }
-
-  return { kbName, relativePath };
 }
 
 // Re-export for backward compatibility: existing tests import
@@ -234,7 +144,7 @@ export class KnowledgeBaseServer {
     });
     mcp.server.onerror = (error) => logger.error('[MCP Error]', error);
     this.registerTools(mcp);
-    this.registerResources(mcp);
+    registerResources(mcp);
     return mcp;
   }
 
@@ -321,70 +231,16 @@ export class KnowledgeBaseServer {
     );
   }
 
-  private registerResources(mcp: McpServer): void {
-    mcp.server.registerCapabilities({
-      resources: {
-        listChanged: true,
-      },
-    });
-
-    mcp.server.setRequestHandler(ListResourcesRequestSchema, async () =>
-      this.handleListResources()
-    );
-    mcp.server.setRequestHandler(ListResourceTemplatesRequestSchema, async () => ({
-      resourceTemplates: [],
-    }));
-    mcp.server.setRequestHandler(ReadResourceRequestSchema, async (request) =>
-      this.handleReadResource(request.params.uri)
-    );
-  }
-
+  // Issue #157 step 2 — `mcp-resources.ts` owns the wire surface and pure
+  // handler bodies. These remain on the class as thin delegates so the
+  // existing private-method test surface (KnowledgeBaseServer.test.ts) keeps
+  // working without re-plumbing.
   private async handleListResources(): Promise<ListResourcesResult> {
-    const resources: Resource[] = [];
-    const knowledgeBases = (await listKnowledgeBases(KNOWLEDGE_BASES_ROOT_DIR)).sort();
-
-    for (const kbName of knowledgeBases) {
-      if (!isValidKbName(kbName)) continue;
-      const kbPath = path.join(KNOWLEDGE_BASES_ROOT_DIR, kbName);
-      const filePaths = (await getFilesRecursively(kbPath)).sort();
-      for (const filePath of filePaths) {
-        const relativePath = path
-          .relative(kbPath, filePath)
-          .split(path.sep)
-          .join('/');
-
-        resources.push({
-          uri: resourceUri(kbName, relativePath),
-          name: relativePath,
-          description: `Document in knowledge base "${kbName}"`,
-          mimeType: mimeTypeForResource(filePath),
-        });
-      }
-    }
-
-    return { resources };
+    return listResources();
   }
 
   private async handleReadResource(uri: string): Promise<ReadResourceResult> {
-    const { kbName, relativePath } = parseKnowledgeBaseResourceUri(uri);
-    const filePath = await resolveKnowledgeBaseDocumentPath(
-      KNOWLEDGE_BASES_ROOT_DIR,
-      kbName,
-      relativePath,
-    );
-    const mimeType = mimeTypeForResource(filePath);
-
-    if (mimeType === 'application/pdf') {
-      const blob = (await fsp.readFile(filePath)).toString('base64');
-      return {
-        contents: [{ uri, mimeType, blob }],
-      };
-    }
-
-    const text = await fsp.readFile(filePath, 'utf-8');
-    return {
-      contents: [{ uri, mimeType, text }],
-    };
+    return readResource(uri);
   }
 
   /**

--- a/src/mcp-resources.test.ts
+++ b/src/mcp-resources.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+  buildResourceUri,
+  mimeTypeForResource,
+  parseKnowledgeBaseResourceUri,
+} from './mcp-resources.js';
+
+// Issue #157 step 2 — direct tests for the pure URI/MIME helpers extracted
+// out of KnowledgeBaseServer.handleReadResource (#49). The integration
+// tests in KnowledgeBaseServer.test.ts cover handleListResources /
+// handleReadResource end-to-end against a real tempdir; these cover the
+// pure-function contract that round-trip and traversal-rejection rest on.
+
+describe('mimeTypeForResource', () => {
+  it.each<[string, string]>([
+    ['notes.md', 'text/markdown'],
+    ['notes.markdown', 'text/markdown'],
+    ['paper.pdf', 'application/pdf'],
+    ['page.html', 'text/html'],
+    ['page.HTM', 'text/html'],
+    ['readme.txt', 'text/plain'],
+    ['no-extension', 'text/plain'],
+    ['weird.unknown', 'text/plain'],
+  ])('maps %s to %s', (filePath, expected) => {
+    expect(mimeTypeForResource(filePath)).toBe(expected);
+  });
+});
+
+describe('buildResourceUri', () => {
+  it('emits kb:// with percent-encoded segments for reserved characters', () => {
+    expect(buildResourceUri('alpha', 'docs/guide.md')).toBe('kb://alpha/docs/guide.md');
+    expect(buildResourceUri('alpha', 'issues/bug#42 &v=2.md')).toBe(
+      `kb://alpha/issues/${encodeURIComponent('bug#42 &v=2.md')}`,
+    );
+  });
+
+  it("does not encode the segment separator '/'", () => {
+    const out = buildResourceUri('alpha', 'a/b/c.md');
+    expect(out).toBe('kb://alpha/a/b/c.md');
+  });
+
+  it('round-trips with parseKnowledgeBaseResourceUri', () => {
+    const filename = 'bug#123 ?q=1+rev.md';
+    const uri = buildResourceUri('alpha', `issues/${filename}`);
+    const parsed = parseKnowledgeBaseResourceUri(uri);
+    expect(parsed).toEqual({ kbName: 'alpha', relativePath: `issues/${filename}` });
+  });
+});
+
+describe('parseKnowledgeBaseResourceUri', () => {
+  it('parses a plain kb:// URI', () => {
+    expect(parseKnowledgeBaseResourceUri('kb://alpha/docs/guide.md')).toEqual({
+      kbName: 'alpha',
+      relativePath: 'docs/guide.md',
+    });
+  });
+
+  it('rejects non-kb:// schemes', () => {
+    expect(() => parseKnowledgeBaseResourceUri('http://alpha/docs/guide.md')).toThrow(
+      /unsupported resource URI scheme|kb:\/\//,
+    );
+    expect(() => parseKnowledgeBaseResourceUri('not-a-uri')).toThrow(
+      /resource URI must use the kb:\/\/ scheme/,
+    );
+  });
+
+  it('rejects an empty KB authority', () => {
+    expect(() => parseKnowledgeBaseResourceUri('kb:///docs/guide.md')).toThrow(
+      /non-empty KB authority/,
+    );
+  });
+
+  it('rejects an invalid KB name', () => {
+    expect(() => parseKnowledgeBaseResourceUri('kb://..hidden/x.md')).toThrow(
+      /invalid KB name/,
+    );
+  });
+
+  it('rejects an empty resource path', () => {
+    expect(() => parseKnowledgeBaseResourceUri('kb://alpha')).toThrow(
+      /non-empty resource path/,
+    );
+    expect(() => parseKnowledgeBaseResourceUri('kb://alpha/')).toThrow(
+      /non-empty resource path/,
+    );
+  });
+
+  it('rejects encoded path separators (%2f, %5c) before decoding', () => {
+    expect(() => parseKnowledgeBaseResourceUri('kb://alpha/..%2Fsecret.md')).toThrow(
+      /path escapes KB root/,
+    );
+    expect(() => parseKnowledgeBaseResourceUri('kb://alpha/foo%5Cbar.md')).toThrow(
+      /path escapes KB root/,
+    );
+  });
+
+  it('rejects parent traversal segments after decoding', () => {
+    expect(() => parseKnowledgeBaseResourceUri('kb://alpha/%2E%2E/secret.md')).toThrow(
+      /path escapes KB root/,
+    );
+    expect(() => parseKnowledgeBaseResourceUri('kb://alpha/../secret.md')).toThrow(
+      /path escapes KB root/,
+    );
+  });
+
+  it('decodes per-segment so reserved chars (#, &, +, =, space) survive the round trip', () => {
+    // Filenames with these chars would survive `decodeURI` only as literal
+    // %xx — `resources/read` would then fail with "path not found". The
+    // module's per-segment `decodeURIComponent` is what makes this work.
+    const filename = 'bug#42 &v=2+rev?.md';
+    const uri = buildResourceUri('alpha', `issues/${filename}`);
+    const parsed = parseKnowledgeBaseResourceUri(uri);
+    expect(parsed.relativePath).toBe(`issues/${filename}`);
+  });
+});

--- a/src/mcp-resources.ts
+++ b/src/mcp-resources.ts
@@ -1,0 +1,202 @@
+// mcp-resources.ts — MCP resources surface (#49) for the knowledge-base
+// server. Owns the `kb://` URI scheme: parsing, building, MIME mapping,
+// and the `resources/list` + `resources/read` handlers.
+//
+// Issue #157 step 2 — extracted out of `KnowledgeBaseServer.ts` to give
+// the resources surface its own seam. The server's `buildMcpServer()`
+// calls `registerResources(mcp)`; the per-method handler bodies are pure
+// functions of `KNOWLEDGE_BASES_ROOT_DIR` + the URI/file-tree, with no
+// dependency on the server class.
+
+import * as fsp from 'fs/promises';
+import * as path from 'path';
+import {
+  ListResourcesRequestSchema,
+  ListResourceTemplatesRequestSchema,
+  ReadResourceRequestSchema,
+  type ListResourcesResult,
+  type ReadResourceResult,
+  type Resource,
+} from '@modelcontextprotocol/sdk/types.js';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { KNOWLEDGE_BASES_ROOT_DIR } from './config.js';
+import { toError } from './error-utils.js';
+import { getFilesRecursively } from './file-utils.js';
+import { listKnowledgeBases, resolveKnowledgeBaseDocumentPath } from './kb-fs.js';
+import { isValidKbName } from './kb-paths.js';
+
+export function mimeTypeForResource(filePath: string): string {
+  const ext = path.extname(filePath).toLowerCase();
+  switch (ext) {
+    case '.md':
+    case '.markdown':
+      return 'text/markdown';
+    case '.pdf':
+      return 'application/pdf';
+    case '.html':
+    case '.htm':
+      return 'text/html';
+    case '.txt':
+    default:
+      return 'text/plain';
+  }
+}
+
+/**
+ * Build a `kb://<kbName>/<encoded-relative-path>` URI. Each path segment
+ * is percent-encoded with `encodeURIComponent` so reserved characters
+ * (`#`, `?`, `&`, `+`, `=`, space) round-trip cleanly through MCP
+ * clients; `parseKnowledgeBaseResourceUri` decodes per-segment to match.
+ */
+export function buildResourceUri(kbName: string, relativePath: string): string {
+  const encodedPath = relativePath
+    .split('/')
+    .map((segment) => encodeURIComponent(segment))
+    .join('/');
+  return `kb://${kbName}/${encodedPath}`;
+}
+
+export function parseKnowledgeBaseResourceUri(uri: string): { kbName: string; relativePath: string } {
+  const rawMatch = /^kb:\/\/([^/?#]*)([^?#]*)/i.exec(uri);
+  if (!rawMatch) {
+    throw new Error('resource URI must use the kb:// scheme');
+  }
+
+  let url: URL;
+  try {
+    url = new URL(uri);
+  } catch (error: unknown) {
+    throw new Error(`invalid kb:// URI: ${toError(error).message}`);
+  }
+
+  if (url.protocol !== 'kb:') {
+    throw new Error(`unsupported resource URI scheme: ${url.protocol}`);
+  }
+
+  const kbName = url.hostname;
+  if (kbName.length === 0) {
+    throw new Error('kb:// URI requires a non-empty KB authority');
+  }
+  if (!isValidKbName(kbName)) {
+    throw new Error('invalid KB name in kb:// URI');
+  }
+
+  const rawPath = rawMatch[2] ?? '';
+  if (!rawPath.startsWith('/')) {
+    throw new Error('kb:// URI requires a non-empty resource path');
+  }
+
+  const rawRelativePath = rawPath.slice(1);
+  if (rawRelativePath.length === 0) {
+    throw new Error('kb:// URI requires a non-empty resource path');
+  }
+  if (/%(?:2f|5c)/i.test(rawRelativePath)) {
+    throw new Error(`path escapes KB root: ${JSON.stringify(rawRelativePath)}`);
+  }
+
+  // Decode each path segment with `decodeURIComponent` to round-trip
+  // `buildResourceUri()`, which percent-encodes per-segment with the
+  // matching function. `decodeURI` leaves reserved characters (`#`, `?`,
+  // `&`, `+`, `=`, …) literal, so a filename like `bug#123.md` would
+  // round-trip to a literal `%23` and `resources/read` would fail with
+  // "path not found". The earlier `%2f|%5c` guard already rejects
+  // encoded path separators before this point, so per-segment decoding
+  // cannot reintroduce a `/` or `\` boundary.
+  let relativePath: string;
+  try {
+    relativePath = rawRelativePath
+      .split('/')
+      .map((segment) => decodeURIComponent(segment))
+      .join('/');
+  } catch (error: unknown) {
+    throw new Error(`invalid kb:// URI path encoding: ${toError(error).message}`);
+  }
+
+  if (relativePath.split('/').some((segment) => segment === '..')) {
+    throw new Error(`path escapes KB root: ${JSON.stringify(relativePath)}`);
+  }
+
+  return { kbName, relativePath };
+}
+
+/**
+ * `resources/list` body. Walks every registered KB under
+ * `KNOWLEDGE_BASES_ROOT_DIR` and emits one `Resource` per file with a
+ * percent-encoded `kb://` URI and a content-type-by-extension mime hint.
+ */
+export async function listResources(): Promise<ListResourcesResult> {
+  const resources: Resource[] = [];
+  const knowledgeBases = (await listKnowledgeBases(KNOWLEDGE_BASES_ROOT_DIR)).sort();
+
+  for (const kbName of knowledgeBases) {
+    if (!isValidKbName(kbName)) continue;
+    const kbPath = path.join(KNOWLEDGE_BASES_ROOT_DIR, kbName);
+    const filePaths = (await getFilesRecursively(kbPath)).sort();
+    for (const filePath of filePaths) {
+      const relativePath = path
+        .relative(kbPath, filePath)
+        .split(path.sep)
+        .join('/');
+
+      resources.push({
+        uri: buildResourceUri(kbName, relativePath),
+        name: relativePath,
+        description: `Document in knowledge base "${kbName}"`,
+        mimeType: mimeTypeForResource(filePath),
+      });
+    }
+  }
+
+  return { resources };
+}
+
+/**
+ * `resources/read` body. Parses the `kb://` URI, resolves the document
+ * under `KNOWLEDGE_BASES_ROOT_DIR` (which rejects traversal escapes),
+ * and returns either a base64 blob (PDF) or UTF-8 text (markdown,
+ * HTML, plain text).
+ */
+export async function readResource(uri: string): Promise<ReadResourceResult> {
+  const { kbName, relativePath } = parseKnowledgeBaseResourceUri(uri);
+  const filePath = await resolveKnowledgeBaseDocumentPath(
+    KNOWLEDGE_BASES_ROOT_DIR,
+    kbName,
+    relativePath,
+  );
+  const mimeType = mimeTypeForResource(filePath);
+
+  if (mimeType === 'application/pdf') {
+    const blob = (await fsp.readFile(filePath)).toString('base64');
+    return {
+      contents: [{ uri, mimeType, blob }],
+    };
+  }
+
+  const text = await fsp.readFile(filePath, 'utf-8');
+  return {
+    contents: [{ uri, mimeType, text }],
+  };
+}
+
+/**
+ * Wire the resources surface onto an `McpServer`. Registers
+ * `resources/list`, `resources/read`, and an empty
+ * `resources/templates/list` (the server has no templates; clients that
+ * probe for them must get an empty response, not a method-not-found
+ * error). Called once from `KnowledgeBaseServer.buildMcpServer`.
+ */
+export function registerResources(mcp: McpServer): void {
+  mcp.server.registerCapabilities({
+    resources: {
+      listChanged: true,
+    },
+  });
+
+  mcp.server.setRequestHandler(ListResourcesRequestSchema, async () => listResources());
+  mcp.server.setRequestHandler(ListResourceTemplatesRequestSchema, async () => ({
+    resourceTemplates: [],
+  }));
+  mcp.server.setRequestHandler(ReadResourceRequestSchema, async (request) =>
+    readResource(request.params.uri),
+  );
+}


### PR DESCRIPTION
## Summary

Step 2 of #157 (after #163) — extract the MCP resources surface from `src/KnowledgeBaseServer.ts` so the `kb://` scheme + list/read handlers have their own seam.

- **New `src/mcp-resources.ts`** — `mimeTypeForResource`, `buildResourceUri` (renamed from local `resourceUri` for module-API clarity), `parseKnowledgeBaseResourceUri`, plus `listResources()` / `readResource(uri)` (pure handler bodies, read `KNOWLEDGE_BASES_ROOT_DIR` from config like `kb-stats.ts` does), plus `registerResources(mcp)` which wires `resources/list` + `resources/read` + the empty `resources/templates/list` onto an `McpServer`.
- **`KnowledgeBaseServer.buildMcpServer`** now calls `registerResources(mcp)` from the new module instead of a private method.
- **`handleListResources` / `handleReadResource`** remain on the class as 1-line delegates so the existing private-method test surface (`KnowledgeBaseServer.test.ts`) keeps working without retooling. Same precedent as `handleKbStats` in #163.
- The local `mimeTypeForResource` / `resourceUri` / `parseKnowledgeBaseResourceUri` / private `registerResources` are gone.

`KnowledgeBaseServer.ts`: 939 → 795 (-144). Cumulative across step 1 (#163) + step 2: 1052 → 795.

The `sanitizeMetadataForWire` re-export (issue's bullet 5), `manager-registry.ts` extraction (bullet 3), and warmup-fanout inversion (bullet 4) remain out of scope — separate PRs per the issue's "each extraction above is a separate PR" guidance.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 527/527 tests pass (25 suites)
- [x] New `src/mcp-resources.test.ts` (19 cases): MIME extension table, `buildResourceUri` percent-encoding + round-trip with `parseKnowledgeBaseResourceUri`, scheme/KB-name/path-segment validation, traversal rejection both pre-decode (`%2f`/`%5c`) and post-decode (`..`)
- [x] Existing 7 `handleListResources` / `handleReadResource` cases in `KnowledgeBaseServer.test.ts` still pass — wire shape preserved through the delegates
- [ ] Manual MCP `resources/list` + `resources/read` against a tempdir — not done; the existing fs-grounded handler tests (which include reserved-character round-trip, dot-prefix exclusion, and 5 traversal-attack URIs) cover the wire payloads end-to-end

Refs #157 (issue auto-closed by #163's `Closes #` footer; remaining steps tracked here in PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)