### PR TITLE
refactor: extract sidecar lock helper

### DIFF
--- a/src/FaissIndexManager.ts
+++ b/src/FaissIndexManager.ts
@@ -2,7 +2,6 @@
 import * as fsp from 'fs/promises';
 import * as path from 'path';
 import { minimatch } from 'minimatch';
-import * as properLockfile from 'proper-lockfile';
 // Issue #59 — provider modules are loaded lazily inside initialize(). Each
 // `@langchain/*` provider drags its full dep graph (e.g. @huggingface/inference,
 // openai, ollama) at import time; eager-loading all three for a process that
@@ -23,7 +22,6 @@ import { loadFile } from './loaders.js';
 import {
   EMBEDDING_PROVIDER,
   KNOWLEDGE_BASES_ROOT_DIR,
-  FAISS_INDEX_PATH,
   HUGGINGFACE_MODEL_NAME,
   HUGGINGFACE_PROVIDER,
   HUGGINGFACE_ENDPOINT_URL,
@@ -55,6 +53,7 @@ import {
   resolveActiveIndexFilePath as resolveActiveIndexFilePathFromLayout,
   saveFaissStoreAtomic,
 } from './faiss-store-layout.js';
+import { withSidecarLock } from './write-lock.js';
 
 export { nextVersionAfter } from './faiss-store-layout.js';
 export { MigrationRefusedError } from './layout-bootstrap.js';
@@ -89,52 +88,6 @@ async function writeModelNameAtomic(modelNameFile: string, modelName: string): P
 // independent open(2) calls — each would re-resolve a symlink given the
 // path, but an absolute resolved path has no symlink to re-resolve.
 // ---------------------------------------------------------------------------
-
-// Issue #90 follow-up — cross-model serialization for per-KB hash sidecar
-// state at `<kb>/.index/`. Sidecars are SHARED across models (the on-disk
-// shape is per-KB, not per-model), but `updateIndex` historically protected
-// them with a PER-MODEL write lock. That left two concurrent windows racy:
-//   1. Two models updating different KBs simultaneously: harmless overwrite
-//      with the same hash bytes.
-//   2. One model's `purgeStaleSidecars` (init under missing store) firing
-//      while another model's `updateIndex` is mid-`Promise.all` of sidecar
-//      writes: the writer's `fsp.rename(tmp, target)` ENOENTs because the
-//      parent `.index/` dir was just rmrf'd by the purger.
-//
-// The shared lock at `${FAISS_INDEX_PATH}/.kb-sidecar.lock` serializes
-// every cross-model sidecar mutation: both the purge and the post-save
-// sidecar write batch acquire it briefly. The lock is held only across
-// filesystem syscalls (no embedding work), so cross-model contention adds
-// at most milliseconds per `updateIndex`.
-const SIDECAR_LOCK_PATH = path.join(FAISS_INDEX_PATH, '.kb-sidecar.lock');
-
-async function withSidecarLock<T>(action: () => Promise<T>): Promise<T> {
-  await fsp.mkdir(FAISS_INDEX_PATH, { recursive: true });
-  let release: (() => Promise<void>) | null = null;
-  try {
-    release = await properLockfile.lock(FAISS_INDEX_PATH, {
-      lockfilePath: SIDECAR_LOCK_PATH,
-      stale: 30_000,
-      retries: { retries: 10, factor: 1.5, minTimeout: 50, maxTimeout: 500 },
-    });
-  } catch (err) {
-    // Lock acquisition exhausted retries: a peer is holding it for an
-    // unusually long time, or we're on a filesystem where proper-lockfile
-    // can't operate. Either way, falling through is safer than aborting:
-    // the worst case (rename ENOENT from a concurrent rmrf) is recoverable
-    // on the next updateIndex pass, while a hard abort poisons the caller.
-    logger.warn(
-      `Issue #90 sidecar lock: could not acquire ${SIDECAR_LOCK_PATH}, proceeding without serialization: ${(err as Error).message}`,
-    );
-  }
-  try {
-    return await action();
-  } finally {
-    if (release) {
-      try { await release(); } catch { /* best-effort */ }
-    }
-  }
-}
 
 const DEFAULT_CHUNK_SIZE = 1000;
 const DEFAULT_CHUNK_OVERLAP = 200;

--- a/src/write-lock.test.ts
+++ b/src/write-lock.test.ts
@@ -105,3 +105,45 @@ describe('withWriteLock', () => {
     expect(bStart).toBeLessThan(aEnd);
   });
 });
+
+describe('withSidecarLock', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-sidecar-lock-'));
+    process.env.FAISS_INDEX_PATH = tempDir;
+  });
+
+  it('acquires the shared sidecar lock, runs fn, releases', async () => {
+    jest.resetModules();
+    const { sidecarLockPathFor, withSidecarLock } = await import('./write-lock.js');
+    const lockPath = sidecarLockPathFor();
+
+    let lockedDuringFn = false;
+    const result = await withSidecarLock(async () => {
+      lockedDuringFn = await fsp
+        .stat(lockPath)
+        .then(() => true)
+        .catch(() => false);
+      return 'value';
+    });
+
+    expect(result).toBe('value');
+    expect(lockedDuringFn).toBe(true);
+    await expect(fsp.stat(lockPath)).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('releases the shared sidecar lock even if fn throws', async () => {
+    jest.resetModules();
+    const { sidecarLockPathFor, withSidecarLock } = await import('./write-lock.js');
+    const lockPath = sidecarLockPathFor();
+
+    await expect(
+      withSidecarLock(async () => {
+        throw new Error('boom');
+      }),
+    ).rejects.toThrow('boom');
+
+    await expect(fsp.stat(lockPath)).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+});

--- a/src/write-lock.ts
+++ b/src/write-lock.ts
@@ -14,6 +14,7 @@
 import * as fsp from 'fs/promises';
 import * as path from 'path';
 import * as properLockfile from 'proper-lockfile';
+import { FAISS_INDEX_PATH } from './config.js';
 import { logger } from './logger.js';
 
 const WRITE_LOCK_OPTS_BASE: Omit<properLockfile.LockOptions, 'lockfilePath'> = {
@@ -29,6 +30,11 @@ const WRITE_LOCK_OPTS_BASE: Omit<properLockfile.LockOptions, 'lockfilePath'> = {
   // exhaust this and error with a clear message — that's the documented
   // RFC 012 §4.8.3 slow-path behavior.
   retries: { retries: 5, factor: 1.5, minTimeout: 100, maxTimeout: 1000 },
+};
+
+const SIDECAR_LOCK_OPTS_BASE: Omit<properLockfile.LockOptions, 'lockfilePath'> = {
+  stale: 30_000,
+  retries: { retries: 10, factor: 1.5, minTimeout: 50, maxTimeout: 500 },
 };
 
 /**
@@ -69,4 +75,58 @@ export async function withWriteLock<T>(resource: string, fn: () => Promise<T>): 
  */
 export function writeLockPathFor(resource: string): string {
   return path.join(resource, '.kb-write.lock');
+}
+
+/**
+ * Issue #90 follow-up — cross-model serialization for per-KB hash sidecar
+ * state at `<kb>/.index/`. Sidecars are SHARED across models (the on-disk
+ * shape is per-KB, not per-model), but `updateIndex` historically protected
+ * them with a PER-MODEL write lock. That left two concurrent windows racy:
+ *   1. Two models updating different KBs simultaneously: harmless overwrite
+ *      with the same hash bytes.
+ *   2. One model's `purgeStaleSidecars` (init under missing store) firing
+ *      while another model's `updateIndex` is mid-`Promise.all` of sidecar
+ *      writes: the writer's `fsp.rename(tmp, target)` ENOENTs because the
+ *      parent `.index/` dir was just rmrf'd by the purger.
+ *
+ * The shared lock at `${FAISS_INDEX_PATH}/.kb-sidecar.lock` serializes
+ * every cross-model sidecar mutation: both the purge and the post-save
+ * sidecar write batch acquire it briefly. The lock is held only across
+ * filesystem syscalls (no embedding work), so cross-model contention adds
+ * at most milliseconds per `updateIndex`.
+ */
+export async function withSidecarLock<T>(action: () => Promise<T>): Promise<T> {
+  await fsp.mkdir(FAISS_INDEX_PATH, { recursive: true });
+  const lockfilePath = sidecarLockPathFor();
+  let release: (() => Promise<void>) | null = null;
+  try {
+    release = await properLockfile.lock(FAISS_INDEX_PATH, {
+      ...SIDECAR_LOCK_OPTS_BASE,
+      lockfilePath,
+    });
+  } catch (err) {
+    // Lock acquisition exhausted retries: a peer is holding it for an
+    // unusually long time, or we're on a filesystem where proper-lockfile
+    // can't operate. Either way, falling through is safer than aborting:
+    // the worst case (rename ENOENT from a concurrent rmrf) is recoverable
+    // on the next updateIndex pass, while a hard abort poisons the caller.
+    logger.warn(
+      `Issue #90 sidecar lock: could not acquire ${lockfilePath}, proceeding without serialization: ${(err as Error).message}`,
+    );
+  }
+  try {
+    return await action();
+  } finally {
+    if (release) {
+      try {
+        await release();
+      } catch {
+        // best-effort
+      }
+    }
+  }
+}
+
+export function sidecarLockPathFor(): string {
+  return path.join(FAISS_INDEX_PATH, '.kb-sidecar.lock');
 }


### PR DESCRIPTION
## Summary
- Move the shared sidecar lock primitive out of `FaissIndexManager.ts` into `write-lock.ts`
- Export a sidecar lock path helper and cover acquire/release behavior in `write-lock.test.ts`
- Keep `FaissIndexManager` focused on indexing flow by importing the lock helper

## Test plan
- [x] `npm run build`
- [x] `npm test -- --runTestsByPath src/write-lock.test.ts src/FaissIndexManager.test.ts`
- [x] `npm test`

Refs #156