### PR TITLE
refactor: extract ManagerRegistry + drop sanitizeMetadataForWire re-export (#157 steps 3+5)

### DIFF
--- a/src/KnowledgeBaseServer.test.ts
+++ b/src/KnowledgeBaseServer.test.ts
@@ -1293,14 +1293,14 @@ describe('KnowledgeBaseServer handlers', () => {
   });
 
   it('sanitizeMetadataForWire passes through metadata with no frontmatter unchanged', async () => {
-    const { sanitizeMetadataForWire } = await import('./KnowledgeBaseServer.js');
+    const { sanitizeMetadataForWire } = await import('./formatter.js');
     const md = { source: '/kb/a.md', relativePath: 'a.md', tags: ['x'] };
     expect(sanitizeMetadataForWire(md, false)).toBe(md);
     expect(sanitizeMetadataForWire(md, true)).toBe(md);
   });
 
   it('sanitizeMetadataForWire passes through metadata whose frontmatter has no extras', async () => {
-    const { sanitizeMetadataForWire } = await import('./KnowledgeBaseServer.js');
+    const { sanitizeMetadataForWire } = await import('./formatter.js');
     const md = {
       source: '/kb/a.md',
       frontmatter: { arxiv_id: '2604.1', title: 'X' },
@@ -1310,7 +1310,7 @@ describe('KnowledgeBaseServer handlers', () => {
   });
 
   it('sanitizeMetadataForWire does not mutate the input object', async () => {
-    const { sanitizeMetadataForWire } = await import('./KnowledgeBaseServer.js');
+    const { sanitizeMetadataForWire } = await import('./formatter.js');
     const md = {
       source: '/kb/a.md',
       frontmatter: {

--- a/src/KnowledgeBaseServer.ts
+++ b/src/KnowledgeBaseServer.ts
@@ -14,11 +14,9 @@ import {
   ActiveModelResolutionError,
   listRegisteredModels,
   modelDir,
-  parseModelId,
-  readStoredModelName,
   resolveActiveModel,
 } from './active-model.js';
-import type { EmbeddingProvider } from './model-id.js';
+import { ManagerRegistry } from './manager-registry.js';
 import {
   ADD_DOCUMENT_DESCRIPTION,
   DELETE_DOCUMENT_DESCRIPTION,
@@ -35,7 +33,7 @@ import {
   TransportConfigError,
   type TransportConfig,
 } from './config.js';
-import { formatRetrievalAsMarkdown, sanitizeMetadataForWire } from './formatter.js';
+import { formatRetrievalAsMarkdown } from './formatter.js';
 import {
   listKnowledgeBases,
   resolveKbRelativePath,
@@ -73,18 +71,13 @@ function mcpErrorContent(error: Error): TextContent {
   };
 }
 
-// Re-export for backward compatibility: existing tests import
-// `sanitizeMetadataForWire` from this module. The canonical home is now
-// `src/formatter.ts` (RFC 012 §4.9 boundary fix).
-export { sanitizeMetadataForWire };
-
 export class KnowledgeBaseServer {
   private mcp: McpServer;
-  // RFC 013 M1: per-model manager cache. Lazily populated on first use of
-  // each model_id. The active model is resolved per `handleRetrieveKnowledge`
-  // call (allows future M3 `model_name` arg without redesign).
-  private managerCache: Map<string, FaissIndexManager> = new Map();
-  private managerInitCache: Map<string, Promise<FaissIndexManager>> = new Map();
+  // RFC 013 M1 (#157 step 3): per-model FaissIndexManager cache. Lazily
+  // populates on first use of each model_id. The active model is resolved
+  // per call so a future M3 `model_name` override drops in without
+  // redesign.
+  private readonly managers = new ManagerRegistry();
   private activeWarmupPromise: Promise<void> | null = null;
   private httpHost?: StreamableHttpHost;
   private sseHost?: SseHost;
@@ -103,38 +96,6 @@ export class KnowledgeBaseServer {
       await this.shutdown();
       process.exit(0);
     });
-  }
-
-  /**
-   * Resolve a model_id to a (cached) FaissIndexManager instance.
-   * RFC 013 M1: takes the explicit model_id (resolved by the caller via
-   * `resolveActiveModel`); constructs the manager on first use, caches it.
-   */
-  private async getManagerFor(modelId: string): Promise<FaissIndexManager> {
-    const cached = this.managerCache.get(modelId);
-    if (cached) return cached;
-    const initializing = this.managerInitCache.get(modelId);
-    if (initializing) return initializing;
-    const initPromise = (async () => {
-      const { provider } = parseModelId(modelId);
-      const modelName = await readStoredModelName(modelId);
-      if (modelName === null) {
-        throw new Error(`model_name.txt missing for registered model "${modelId}"`);
-      }
-      const manager = new FaissIndexManager({
-        provider: provider as EmbeddingProvider,
-        modelName,
-      });
-      await manager.initialize();
-      this.managerCache.set(modelId, manager);
-      return manager;
-    })();
-    this.managerInitCache.set(modelId, initPromise);
-    try {
-      return await initPromise;
-    } finally {
-      this.managerInitCache.delete(modelId);
-    }
   }
 
   private buildMcpServer(): McpServer {
@@ -314,7 +275,7 @@ export class KnowledgeBaseServer {
         }
         throw err;
       }
-      const manager = await this.getManagerFor(activeModelId);
+      const manager = await this.managers.getOrCreate(activeModelId);
       const payload = await computeKbStats(manager, {
         knowledgeBaseName: args.knowledge_base_name,
         serverVersion: SERVER_VERSION,
@@ -335,7 +296,7 @@ export class KnowledgeBaseServer {
 
   private async getActiveManagerForMutation(): Promise<FaissIndexManager> {
     const activeModelId = await resolveActiveModel();
-    return this.getManagerFor(activeModelId);
+    return this.managers.getOrCreate(activeModelId);
   }
 
   private async handleAddDocument(args: {
@@ -509,7 +470,7 @@ export class KnowledgeBaseServer {
         }
         throw err;
       }
-      const manager = await this.getManagerFor(activeModelId);
+      const manager = await this.managers.getOrCreate(activeModelId);
 
       // RFC 013 §4.6 — write lock is per-model (resource = `models/<id>/`).
       // A `kb models add B` against another model never blocks retrievals on A.
@@ -656,7 +617,7 @@ export class KnowledgeBaseServer {
   private async warmActiveManager(): Promise<void> {
     try {
       const activeId = await resolveActiveModel();
-      const manager = await this.getManagerFor(activeId);
+      const manager = await this.managers.getOrCreate(activeId);
       if (manager.hasLoadedIndex) {
         logger.info(`Active FAISS index ${activeId} loaded; startup rebuild not needed`);
         return;
@@ -741,7 +702,7 @@ export class KnowledgeBaseServer {
       async () => {
         try {
           const activeId = await resolveActiveModel();
-          const manager = await this.getManagerFor(activeId);
+          const manager = await this.managers.getOrCreate(activeId);
           await withWriteLock(manager.modelDir, () => manager.updateIndex(undefined));
         } catch (err) {
           logger.warn(`Trigger watcher updateIndex failed: ${(err as Error).message}`);

--- a/src/manager-registry.ts
+++ b/src/manager-registry.ts
@@ -1,0 +1,54 @@
+// manager-registry.ts — RFC 013 M1 per-model FaissIndexManager cache.
+//
+// Issue #157 step 3 — extracted out of `KnowledgeBaseServer` so the cache
+// is its own object: swappable in tests, reusable from a future CLI that
+// wants the same warm-cache semantics, and free of accidental reach-ins
+// from elsewhere on the server class.
+//
+// Concurrency: a per-`modelId` init-promise coalesces simultaneous
+// `getOrCreate` calls so two readers cannot race-construct two managers
+// for the same model. The init-promise lives in a separate map from the
+// resolved cache so a hard failure on first init doesn't poison
+// subsequent retries (the entry is removed in the `finally`).
+
+import { parseModelId, readStoredModelName } from './active-model.js';
+import { FaissIndexManager } from './FaissIndexManager.js';
+import type { EmbeddingProvider } from './model-id.js';
+
+export class ManagerRegistry {
+  private readonly cache: Map<string, FaissIndexManager> = new Map();
+  private readonly initCache: Map<string, Promise<FaissIndexManager>> = new Map();
+
+  /**
+   * Resolve `modelId` to a `FaissIndexManager`, constructing on first
+   * use. Throws if `model_name.txt` is missing for the (otherwise
+   * registered) id — that means the model directory is half-built and
+   * the caller should not pretend to have a usable manager.
+   */
+  async getOrCreate(modelId: string): Promise<FaissIndexManager> {
+    const cached = this.cache.get(modelId);
+    if (cached) return cached;
+    const initializing = this.initCache.get(modelId);
+    if (initializing) return initializing;
+    const initPromise = (async () => {
+      const { provider } = parseModelId(modelId);
+      const modelName = await readStoredModelName(modelId);
+      if (modelName === null) {
+        throw new Error(`model_name.txt missing for registered model "${modelId}"`);
+      }
+      const manager = new FaissIndexManager({
+        provider: provider as EmbeddingProvider,
+        modelName,
+      });
+      await manager.initialize();
+      this.cache.set(modelId, manager);
+      return manager;
+    })();
+    this.initCache.set(modelId, initPromise);
+    try {
+      return await initPromise;
+    } finally {
+      this.initCache.delete(modelId);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Steps 3 and 5 of #157 (after #163, #165) — close out the smaller mechanical chunks of the `KnowledgeBaseServer` split.

**Step 3 — `src/manager-registry.ts` (new):** RFC 013 M1 per-model `FaissIndexManager` cache extracted into its own class. The two private maps and the init-promise dance that lived on `KnowledgeBaseServer` are now `ManagerRegistry.getOrCreate(modelId)`, with the same per-id init coalescing so concurrent lookups cannot race-construct two managers.

**`KnowledgeBaseServer.ts` changes:**
- Replace `managerCache` / `managerInitCache` fields with a single `private readonly managers = new ManagerRegistry()`.
- Delete the private `getManagerFor` method; rewrite ~10 internal call sites to `this.managers.getOrCreate(...)`. The wrapper had no transport-shape responsibilities — unlike `handleKbStats` / `handleListResources` which were kept as delegates for the existing private-method test surface — so inlining is cleaner.
- Drop `parseModelId`, `readStoredModelName`, `EmbeddingProvider` imports (used only inside the relocated cache).

**Step 5 — drop the `sanitizeMetadataForWire` re-export.** The shim at `export { sanitizeMetadataForWire }` was a backward-compat hack from the RFC 012 §4.9 boundary fix. Tests in `KnowledgeBaseServer.test.ts` that imported it via `await import('./KnowledgeBaseServer.js')` now pull from `./formatter.js` (its canonical home), removing the cross-module import bridge.

`KnowledgeBaseServer.ts`: 795 → 756 (-39). Cumulative across #157 steps 1–3 + 5 (#163 + #165 + this PR): 1052 → 756 (-296).

**Step 4 (warmup-fanout inversion)** is the only remaining piece of #157 and lands separately because it genuinely changes the host/server contract (`SseHost`/`StreamableHttpHost` would need a `notify(level, msg)` method instead of the server pulling `host.getConnectedMcpServers()`).

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 527/527 tests pass (25 suites)
- [x] No new test file: the cache is exercised transitively by every test that goes through `freshServer()`, and the explicit `modelName === null` error path is unchanged from the pre-extraction code (move + rename only)
- [x] 3 cases in `KnowledgeBaseServer.test.ts:1295-1322` migrated from the deleted re-export to `./formatter.js` directly

Refs #157.

🤖 Generated with [Claude Code](https://claude.com/claude-code)