### PR TITLE
refactor: move chunk config resolver

### DIFF
--- a/src/FaissIndexManager.test.ts
+++ b/src/FaissIndexManager.test.ts
@@ -91,59 +91,6 @@ function createPermissionError(message: string): NodeJS.ErrnoException {
   return error;
 }
 
-describe('resolveChunkSize (#107 follow-up — KB_CHUNK_SIZE / KB_CHUNK_OVERLAP env vars)', () => {
-  const savedSize = process.env.KB_CHUNK_SIZE;
-  const savedOverlap = process.env.KB_CHUNK_OVERLAP;
-  let resolveChunkSize: () => { chunkSize: number; chunkOverlap: number };
-
-  beforeAll(async () => {
-    // Late import to ensure env-driven module-state isn't captured at top-level.
-    const mod = await import('./FaissIndexManager.js');
-    resolveChunkSize = mod.resolveChunkSize;
-  });
-
-  afterEach(() => {
-    if (savedSize === undefined) delete process.env.KB_CHUNK_SIZE; else process.env.KB_CHUNK_SIZE = savedSize;
-    if (savedOverlap === undefined) delete process.env.KB_CHUNK_OVERLAP; else process.env.KB_CHUNK_OVERLAP = savedOverlap;
-  });
-
-  it('returns historical defaults (1000 / 200) when no env vars are set', () => {
-    delete process.env.KB_CHUNK_SIZE;
-    delete process.env.KB_CHUNK_OVERLAP;
-    expect(resolveChunkSize()).toEqual({ chunkSize: 1000, chunkOverlap: 200 });
-  });
-
-  it('honors KB_CHUNK_SIZE; overlap scales as floor(chunkSize/5)', () => {
-    process.env.KB_CHUNK_SIZE = '358';
-    delete process.env.KB_CHUNK_OVERLAP;
-    expect(resolveChunkSize()).toEqual({ chunkSize: 358, chunkOverlap: 71 });
-  });
-
-  it('honors an independent KB_CHUNK_OVERLAP', () => {
-    process.env.KB_CHUNK_SIZE = '500';
-    process.env.KB_CHUNK_OVERLAP = '50';
-    expect(resolveChunkSize()).toEqual({ chunkSize: 500, chunkOverlap: 50 });
-  });
-
-  it('falls back to default 200 overlap when KB_CHUNK_SIZE is the default 1000 and overlap unset', () => {
-    process.env.KB_CHUNK_SIZE = '1000';
-    delete process.env.KB_CHUNK_OVERLAP;
-    expect(resolveChunkSize()).toEqual({ chunkSize: 1000, chunkOverlap: 200 });
-  });
-
-  it('treats invalid / non-positive values as unset (preserves defaults)', () => {
-    process.env.KB_CHUNK_SIZE = 'not-a-number';
-    process.env.KB_CHUNK_OVERLAP = '-1';
-    expect(resolveChunkSize()).toEqual({ chunkSize: 1000, chunkOverlap: 200 });
-  });
-
-  it('accepts zero overlap explicitly', () => {
-    process.env.KB_CHUNK_SIZE = '500';
-    process.env.KB_CHUNK_OVERLAP = '0';
-    expect(resolveChunkSize()).toEqual({ chunkSize: 500, chunkOverlap: 0 });
-  });
-});
-
 describe('provider construction', () => {
   // Issue #59 — embeddings are now built lazily inside initialize() via
   // dynamic import of the active provider's @langchain module. The

--- a/src/FaissIndexManager.ts
+++ b/src/FaissIndexManager.ts
@@ -31,6 +31,7 @@ import {
   OLLAMA_BASE_URL,
   OLLAMA_MODEL,
   OPENAI_MODEL_NAME,
+  resolveChunkSize,
 } from './config.js';
 import {
   activeFileExists,
@@ -89,36 +90,12 @@ async function writeModelNameAtomic(modelNameFile: string, modelName: string): P
 // path, but an absolute resolved path has no symlink to re-resolve.
 // ---------------------------------------------------------------------------
 
-const DEFAULT_CHUNK_SIZE = 1000;
-const DEFAULT_CHUNK_OVERLAP = 200;
 export const DEFAULT_REBUILD_PROGRESS_INTERVAL_FILES = 10;
 
 function totalFileCount(
   entries: ReadonlyArray<{ filePaths: readonly string[] }>,
 ): number {
   return entries.reduce((sum, entry) => sum + entry.filePaths.length, 0);
-}
-
-/**
- * Resolve the splitter chunk size and overlap from env vars, with the
- * historical defaults preserved when nothing is set. `KB_CHUNK_SIZE` lets
- * operators tune the splitter for short-context embedding models without
- * editing source — when `bench:compare` (#107) auto-clamps for a short-ctx
- * leg, it sets this so the production code path emits chunks small enough
- * to fit. `KB_CHUNK_OVERLAP` is honored independently when set; otherwise
- * it scales as `floor(chunkSize / 5)` so the previous 1000/200 ratio
- * (chunkSize=1000 → overlap=200) holds at the default.
- */
-export function resolveChunkSize(): { chunkSize: number; chunkOverlap: number } {
-  const sizeRaw = process.env.KB_CHUNK_SIZE;
-  const overlapRaw = process.env.KB_CHUNK_OVERLAP;
-  const sizeParsed = sizeRaw ? Number(sizeRaw) : NaN;
-  const chunkSize = Number.isFinite(sizeParsed) && sizeParsed > 0 ? Math.floor(sizeParsed) : DEFAULT_CHUNK_SIZE;
-  const overlapParsed = overlapRaw ? Number(overlapRaw) : NaN;
-  const chunkOverlap = Number.isFinite(overlapParsed) && overlapParsed >= 0
-    ? Math.floor(overlapParsed)
-    : (chunkSize === DEFAULT_CHUNK_SIZE ? DEFAULT_CHUNK_OVERLAP : Math.floor(chunkSize / 5));
-  return { chunkSize, chunkOverlap };
 }
 
 /**

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,4 +1,50 @@
-import { parseReindexTriggerPollMs } from './config.js';
+import { parseReindexTriggerPollMs, resolveChunkSize } from './config.js';
+
+describe('resolveChunkSize (#107 follow-up — KB_CHUNK_SIZE / KB_CHUNK_OVERLAP env vars)', () => {
+  const savedSize = process.env.KB_CHUNK_SIZE;
+  const savedOverlap = process.env.KB_CHUNK_OVERLAP;
+
+  afterEach(() => {
+    if (savedSize === undefined) delete process.env.KB_CHUNK_SIZE; else process.env.KB_CHUNK_SIZE = savedSize;
+    if (savedOverlap === undefined) delete process.env.KB_CHUNK_OVERLAP; else process.env.KB_CHUNK_OVERLAP = savedOverlap;
+  });
+
+  it('returns historical defaults (1000 / 200) when no env vars are set', () => {
+    delete process.env.KB_CHUNK_SIZE;
+    delete process.env.KB_CHUNK_OVERLAP;
+    expect(resolveChunkSize()).toEqual({ chunkSize: 1000, chunkOverlap: 200 });
+  });
+
+  it('honors KB_CHUNK_SIZE; overlap scales as floor(chunkSize/5)', () => {
+    process.env.KB_CHUNK_SIZE = '358';
+    delete process.env.KB_CHUNK_OVERLAP;
+    expect(resolveChunkSize()).toEqual({ chunkSize: 358, chunkOverlap: 71 });
+  });
+
+  it('honors an independent KB_CHUNK_OVERLAP', () => {
+    process.env.KB_CHUNK_SIZE = '500';
+    process.env.KB_CHUNK_OVERLAP = '50';
+    expect(resolveChunkSize()).toEqual({ chunkSize: 500, chunkOverlap: 50 });
+  });
+
+  it('falls back to default 200 overlap when KB_CHUNK_SIZE is the default 1000 and overlap unset', () => {
+    process.env.KB_CHUNK_SIZE = '1000';
+    delete process.env.KB_CHUNK_OVERLAP;
+    expect(resolveChunkSize()).toEqual({ chunkSize: 1000, chunkOverlap: 200 });
+  });
+
+  it('treats invalid / non-positive values as unset (preserves defaults)', () => {
+    process.env.KB_CHUNK_SIZE = 'not-a-number';
+    process.env.KB_CHUNK_OVERLAP = '-1';
+    expect(resolveChunkSize()).toEqual({ chunkSize: 1000, chunkOverlap: 200 });
+  });
+
+  it('accepts zero overlap explicitly', () => {
+    process.env.KB_CHUNK_SIZE = '500';
+    process.env.KB_CHUNK_OVERLAP = '0';
+    expect(resolveChunkSize()).toEqual({ chunkSize: 500, chunkOverlap: 0 });
+  });
+});
 
 describe('parseReindexTriggerPollMs (RFC 011 §5.5)', () => {
   it('returns the default (5000) for undefined or empty input', () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -70,6 +70,37 @@ export const INGEST_EXCLUDE_PATHS: readonly string[] = parseCommaSeparatedList(
   process.env.INGEST_EXCLUDE_PATHS,
 );
 
+// ---------------------------------------------------------------------------
+// Chunking configuration (#107 follow-up).
+// ---------------------------------------------------------------------------
+
+const DEFAULT_CHUNK_SIZE = 1000;
+const DEFAULT_CHUNK_OVERLAP = 200;
+
+/**
+ * Resolve the splitter chunk size and overlap from env vars, with the
+ * historical defaults preserved when nothing is set. `KB_CHUNK_SIZE` lets
+ * operators tune the splitter for short-context embedding models without
+ * editing source — when `bench:compare` (#107) auto-clamps for a short-ctx
+ * leg, it sets this so the production code path emits chunks small enough
+ * to fit. `KB_CHUNK_OVERLAP` is honored independently when set; otherwise
+ * it scales as `floor(chunkSize / 5)` so the previous 1000/200 ratio
+ * (chunkSize=1000 → overlap=200) holds at the default.
+ */
+export function resolveChunkSize(): { chunkSize: number; chunkOverlap: number } {
+  const sizeRaw = process.env.KB_CHUNK_SIZE;
+  const overlapRaw = process.env.KB_CHUNK_OVERLAP;
+  const sizeParsed = sizeRaw ? Number(sizeRaw) : NaN;
+  const chunkSize = Number.isFinite(sizeParsed) && sizeParsed > 0
+    ? Math.floor(sizeParsed)
+    : DEFAULT_CHUNK_SIZE;
+  const overlapParsed = overlapRaw ? Number(overlapRaw) : NaN;
+  const chunkOverlap = Number.isFinite(overlapParsed) && overlapParsed >= 0
+    ? Math.floor(overlapParsed)
+    : (chunkSize === DEFAULT_CHUNK_SIZE ? DEFAULT_CHUNK_OVERLAP : Math.floor(chunkSize / 5));
+  return { chunkSize, chunkOverlap };
+}
+
 /**
  * When false (default), `frontmatter.extras` is stripped from every
  * `retrieve_knowledge` response before JSON serialization. Extras hold


### PR DESCRIPTION
## Summary
- Move the KB chunk-size resolver from `FaissIndexManager.ts` into `config.ts`
- Keep the manager focused on indexing flow by importing `resolveChunkSize`
- Move the existing chunk env-var coverage from the manager suite to `config.test.ts`

## Test plan
- [x] `npm run build`
- [x] `npm test -- --runTestsByPath src/config.test.ts src/FaissIndexManager.test.ts`
- [x] `npm test`

Refs #156