### PR TITLE
refactor: centralize legacy env model fallback

### DIFF
--- a/src/FaissIndexManager.test.ts
+++ b/src/FaissIndexManager.test.ts
@@ -207,6 +207,19 @@ describe('provider construction', () => {
     });
   });
 
+  it('keeps exact slash-containing HuggingFace model names in no-arg construction', async () => {
+    await seedTempEnv();
+    process.env.EMBEDDING_PROVIDER = 'huggingface';
+    process.env.HUGGINGFACE_MODEL_NAME = 'BAAI/bge-base-en-v1.5';
+
+    const { FaissIndexManager } = await import('./FaissIndexManager.js');
+    const manager = new FaissIndexManager();
+
+    expect(manager.embeddingProvider).toBe('huggingface');
+    expect(manager.modelName).toBe('BAAI/bge-base-en-v1.5');
+    expect(manager.modelId).toBe('huggingface__BAAI-bge-base-en-v1.5');
+  });
+
   it('throws when HUGGINGFACE_API_KEY is unset for the HuggingFace provider', async () => {
     await seedTempEnv();
     process.env.EMBEDDING_PROVIDER = 'huggingface';

--- a/src/FaissIndexManager.ts
+++ b/src/FaissIndexManager.ts
@@ -20,22 +20,18 @@ import { parseFrontmatter } from './frontmatter.js';
 import { detectSiblingPdfPath, liftFrontmatter } from './frontmatter-lift.js';
 import { loadFile } from './loaders.js';
 import {
-  EMBEDDING_PROVIDER,
   KNOWLEDGE_BASES_ROOT_DIR,
-  HUGGINGFACE_MODEL_NAME,
   HUGGINGFACE_PROVIDER,
   HUGGINGFACE_ENDPOINT_URL,
   HUGGINGFACE_ENDPOINT_URL_OVERRIDDEN,
   INGEST_EXCLUDE_PATHS,
   INGEST_EXTRA_EXTENSIONS,
   OLLAMA_BASE_URL,
-  OLLAMA_MODEL,
-  OPENAI_MODEL_NAME,
   resolveChunkSize,
 } from './config.js';
 import {
   activeFileExists,
-  computeLegacyEnvDerivedId,
+  computeLegacyEnvModelSpec,
   modelDir,
   modelNameFilePath,
 } from './active-model.js';
@@ -98,29 +94,6 @@ function totalFileCount(
   return entries.reduce((sum, entry) => sum + entry.filePaths.length, 0);
 }
 
-/**
- * Legacy constructor fallback — derive (provider, modelName) from env when no
- * args passed. Preserves 0.2.x tests + 0.2.x single-model callers that don't
- * yet thread an explicit model through. Multi-model code paths (`kb models *`,
- * `kb search --model=<id>`, MCP per-call selection) MUST use the explicit form.
- */
-function resolveLegacyConstructorArgs(): FaissIndexManagerOptions {
-  const provider = (EMBEDDING_PROVIDER || 'huggingface') as EmbeddingProvider;
-  let modelName: string;
-  switch (provider) {
-    case 'ollama':
-      modelName = OLLAMA_MODEL;
-      break;
-    case 'openai':
-      modelName = OPENAI_MODEL_NAME;
-      break;
-    default:
-      modelName = HUGGINGFACE_MODEL_NAME;
-      break;
-  }
-  return { provider, modelName };
-}
-
 export interface FaissIndexManagerOptions {
   provider: EmbeddingProvider;
   modelName: string;
@@ -171,10 +144,16 @@ export class FaissIndexManager {
    * model selection) use the explicit form.
    */
   constructor(opts?: FaissIndexManagerOptions) {
-    const resolved = opts ?? resolveLegacyConstructorArgs();
+    const resolved = opts !== undefined
+      ? {
+          provider: opts.provider,
+          modelName: opts.modelName,
+          modelId: deriveModelId(opts.provider, opts.modelName),
+        }
+      : computeLegacyEnvModelSpec();
     this.embeddingProvider = resolved.provider;
     this.modelName = resolved.modelName;
-    this.modelId = deriveModelId(resolved.provider, resolved.modelName);
+    this.modelId = resolved.modelId;
     this.modelDir = modelDir(this.modelId);
     this.modelNameFile = modelNameFilePath(this.modelId);
 

--- a/src/active-model.test.ts
+++ b/src/active-model.test.ts
@@ -7,6 +7,8 @@ const originalEnv = {
   FAISS_INDEX_PATH: process.env.FAISS_INDEX_PATH,
   EMBEDDING_PROVIDER: process.env.EMBEDDING_PROVIDER,
   HUGGINGFACE_MODEL_NAME: process.env.HUGGINGFACE_MODEL_NAME,
+  OLLAMA_MODEL: process.env.OLLAMA_MODEL,
+  OPENAI_MODEL_NAME: process.env.OPENAI_MODEL_NAME,
   KB_ACTIVE_MODEL: process.env.KB_ACTIVE_MODEL,
 };
 
@@ -25,6 +27,37 @@ async function seedRegistered(faissDir: string, modelId = REGISTERED_ID, modelNa
   await fsp.mkdir(dir, { recursive: true });
   await fsp.writeFile(path.join(dir, 'model_name.txt'), modelName);
 }
+
+describe('active-model: legacy env-derived model spec', () => {
+  it('keeps the exact configured model name while deriving the safe id', async () => {
+    jest.resetModules();
+    process.env.EMBEDDING_PROVIDER = 'huggingface';
+    process.env.HUGGINGFACE_MODEL_NAME = 'BAAI/bge-base-en-v1.5';
+
+    const { computeLegacyEnvDerivedId, computeLegacyEnvModelSpec } = await import('./active-model.js');
+
+    expect(computeLegacyEnvModelSpec()).toEqual({
+      provider: 'huggingface',
+      modelName: 'BAAI/bge-base-en-v1.5',
+      modelId: 'huggingface__BAAI-bge-base-en-v1.5',
+    });
+    expect(computeLegacyEnvDerivedId()).toBe('huggingface__BAAI-bge-base-en-v1.5');
+  });
+
+  it('preserves slash and tag characters in the Ollama model name', async () => {
+    jest.resetModules();
+    process.env.EMBEDDING_PROVIDER = 'ollama';
+    process.env.OLLAMA_MODEL = 'dengcao/Qwen3-Embedding-0.6B:Q8_0';
+
+    const { computeLegacyEnvModelSpec } = await import('./active-model.js');
+
+    expect(computeLegacyEnvModelSpec()).toEqual({
+      provider: 'ollama',
+      modelName: 'dengcao/Qwen3-Embedding-0.6B:Q8_0',
+      modelId: 'ollama__dengcao-Qwen3-Embedding-0.6B-Q8_0',
+    });
+  });
+});
 
 describe('active-model: writeActiveModelAtomic / robust reader', () => {
   let faissDir: string;

--- a/src/active-model.ts
+++ b/src/active-model.ts
@@ -359,8 +359,20 @@ export async function resolveActiveModel(opts: ResolveOptions = {}): Promise<str
   return envId;
 }
 
-/** Resolve the env-var-derived candidate id without registration check. */
-export function computeLegacyEnvDerivedId(): string {
+export interface LegacyEnvModelSpec {
+  provider: EmbeddingProvider;
+  modelName: string;
+  modelId: string;
+}
+
+/**
+ * Resolve the env-var-derived legacy model without registration check.
+ *
+ * This is the sole owner for the legacy env fallback mapping. Keep it here so
+ * `computeLegacyEnvDerivedId()` and backwards-compatible no-arg manager
+ * construction cannot drift.
+ */
+export function computeLegacyEnvModelSpec(): LegacyEnvModelSpec {
   const provider = (EMBEDDING_PROVIDER as EmbeddingProvider) ?? 'huggingface';
   let modelName: string;
   switch (provider) {
@@ -374,7 +386,18 @@ export function computeLegacyEnvDerivedId(): string {
       modelName = HUGGINGFACE_MODEL_NAME;
       break;
   }
-  return deriveModelId(provider, modelName);
+  const modelId = deriveModelId(provider, modelName);
+  const parsed = parseModelId(modelId);
+  return {
+    provider: parsed.provider as EmbeddingProvider,
+    modelName,
+    modelId,
+  };
+}
+
+/** Resolve the env-var-derived candidate id without registration check. */
+export function computeLegacyEnvDerivedId(): string {
+  return computeLegacyEnvModelSpec().modelId;
 }
 
 // Re-export for callers that need it from one place.


### PR DESCRIPTION
## Summary
- Move no-arg manager legacy env model resolution into active-model.ts
- Delete the duplicated resolveLegacyConstructorArgs switch from FaissIndexManager.ts
- Add regression tests that preserve exact configured model names while deriving safe model ids

## Test plan
- [x] npm run build
- [x] npm test -- --runTestsByPath src/active-model.test.ts src/FaissIndexManager.test.ts
- [x] npm test

Refs #156