### PR TITLE
refactor(file-utils): promote pathExists; replace 8 inline copies (#160 step 1)

### DIFF
--- a/src/FaissIndexManager.ts
+++ b/src/FaissIndexManager.ts
@@ -15,7 +15,7 @@ import { FaissStore } from "@langchain/community/vectorstores/faiss";
 import { Document } from "@langchain/core/documents";
 import { MarkdownTextSplitter, RecursiveCharacterTextSplitter } from "langchain/text_splitter";
 import { handleFsOperationError, toError } from './error-utils.js';
-import { calculateSHA256 } from './file-utils.js';
+import { calculateSHA256, pathExists } from './file-utils.js';
 import { parseFrontmatter } from './frontmatter.js';
 import { detectSiblingPdfPath, liftFrontmatter } from './frontmatter-lift.js';
 import { loadFile } from './loaders.js';
@@ -50,7 +50,6 @@ import {
 import { makeOllamaOnFailedAttempt } from './ollama-error.js';
 import {
   loadFaissStoreAtomic,
-  pathExists,
   resolveActiveIndexFilePath as resolveActiveIndexFilePathFromLayout,
   saveFaissStoreAtomic,
 } from './faiss-store-layout.js';

--- a/src/active-model.ts
+++ b/src/active-model.ts
@@ -19,6 +19,7 @@ import {
   OLLAMA_MODEL,
   OPENAI_MODEL_NAME,
 } from './config.js';
+import { pathExists } from './file-utils.js';
 import { deriveModelId, EmbeddingProvider, isValidModelId, parseModelId } from './model-id.js';
 import { logger } from './logger.js';
 
@@ -78,12 +79,7 @@ export async function resolveFaissIndexBinaryPath(modelId: string): Promise<stri
     if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
   }
   const legacy = path.join(dir, 'faiss.index', 'faiss.index');
-  try {
-    await fsp.access(legacy);
-    return legacy;
-  } catch {
-    return null;
-  }
+  return (await pathExists(legacy)) ? legacy : null;
 }
 
 export function modelNameFilePath(modelId: string): string {
@@ -125,18 +121,9 @@ export async function isRegisteredModel(modelId: string): Promise<boolean> {
     return false;
   }
   // Has model_name.txt?
-  try {
-    await fsp.access(modelNameFilePath(modelId));
-  } catch {
-    return false;
-  }
-  // No .adding sentinel?
-  try {
-    await fsp.access(addingSentinelPath(modelId));
-    return false; // exists → mid-add → not registered
-  } catch {
-    return true;
-  }
+  if (!(await pathExists(modelNameFilePath(modelId)))) return false;
+  // No .adding sentinel? (exists → mid-add → not registered)
+  return !(await pathExists(addingSentinelPath(modelId)));
 }
 
 export interface RegisteredModel {
@@ -194,12 +181,7 @@ async function detectDowngradeHazard(dir: string): Promise<boolean> {
     // index symlink absent — versioned layout not present yet
   }
   if (!hasVersioned) return false;
-  try {
-    await fsp.access(path.join(dir, 'faiss.index'));
-    return true;
-  } catch {
-    return false;
-  }
+  return pathExists(path.join(dir, 'faiss.index'));
 }
 
 // ---------------------------------------------------------------------------
@@ -226,12 +208,7 @@ export async function writeActiveModelAtomic(modelId: string): Promise<void> {
 }
 
 export async function activeFileExists(): Promise<boolean> {
-  try {
-    await fsp.access(ACTIVE_FILE);
-    return true;
-  } catch {
-    return false;
-  }
+  return pathExists(ACTIVE_FILE);
 }
 
 interface ActiveReadResult {

--- a/src/cli-models.ts
+++ b/src/cli-models.ts
@@ -15,6 +15,7 @@ import { KNOWLEDGE_BASES_ROOT_DIR } from './config.js';
 import { enumerateIngestableKbFiles, listKnowledgeBases } from './kb-fs.js';
 import { withWriteLock } from './write-lock.js';
 import { estimateCostUsd } from './cost-estimates.js';
+import { pathExists } from './file-utils.js';
 
 export async function runModels(rest: string[]): Promise<number> {
   const verb = rest[0];
@@ -108,8 +109,7 @@ async function runModelsAdd(rest: string[]): Promise<number> {
     );
     return 2;
   }
-  const sentinelExists = await fsp.access(addingSentinelPath(modelId)).then(() => true).catch(() => false);
-  if (sentinelExists) {
+  if (await pathExists(addingSentinelPath(modelId))) {
     process.stderr.write(
       `kb models add: previous \`kb models add ${modelId}\` was interrupted (.adding sentinel present). ` +
       `Run \`kb models remove ${modelId} --force-incomplete\` to clean up, then retry.\n`,
@@ -261,8 +261,7 @@ async function runModelsRemove(rest: string[]): Promise<number> {
   }
 
   const dir = modelDir(id);
-  const exists = await fsp.access(dir).then(() => true).catch(() => false);
-  if (!exists) {
+  if (!(await pathExists(dir))) {
     process.stderr.write(`kb models remove: "${id}" does not exist on disk.\n`);
     return 2;
   }
@@ -280,8 +279,7 @@ async function runModelsRemove(rest: string[]): Promise<number> {
     return 2;
   }
 
-  const sentinelExists = await fsp.access(addingSentinelPath(id)).then(() => true).catch(() => false);
-  if (sentinelExists && !forceIncomplete) {
+  if ((await pathExists(addingSentinelPath(id))) && !forceIncomplete) {
     process.stderr.write(
       'kb models remove: ".adding" sentinel present (interrupted add). Pass --force-incomplete to confirm.\n',
     );

--- a/src/faiss-store-layout.ts
+++ b/src/faiss-store-layout.ts
@@ -2,26 +2,12 @@ import * as fsp from 'fs/promises';
 import * as path from 'path';
 import type { EmbeddingsInterface } from '@langchain/core/embeddings';
 import { FaissStore } from '@langchain/community/vectorstores/faiss';
+import { pathExists } from './file-utils.js';
 import { logger } from './logger.js';
 
 const VERSION_DIR_PATTERN = /^index\.v(\d+)$/;
 const SYMLINK_NAME = 'index';
 const LEGACY_INDEX_NAME = 'faiss.index';
-
-type FsError = NodeJS.ErrnoException & { code?: string };
-
-export async function pathExists(target: string): Promise<boolean> {
-  try {
-    await fsp.stat(target);
-    return true;
-  } catch (error) {
-    const code = (error as FsError | undefined)?.code;
-    if (code === 'ENOENT' || code === 'ENOTDIR') {
-      return false;
-    }
-    throw error;
-  }
-}
 
 async function readSymlinkOrNull(p: string): Promise<string | null> {
   try {

--- a/src/file-utils.ts
+++ b/src/file-utils.ts
@@ -3,6 +3,33 @@ import * as fsp from 'fs/promises';
 import * as path from 'path';
 import { logger } from './logger.js';
 
+type FsError = NodeJS.ErrnoException & { code?: string };
+
+/**
+ * Issue #160 step 1 — single home for "does this path exist?".
+ *
+ * Returns `true` for a real entry, `false` for `ENOENT`/`ENOTDIR`, and
+ * RETHROWS every other filesystem error (`EACCES`, `ELOOP`, `EMFILE`,
+ * etc.). The deliberate non-swallow on permission/handle errors is the
+ * point: the inline `fsp.access(...).then(() => true).catch(() => false)`
+ * forms scattered around the repo silently masked them, so a bad
+ * permission setup or fd exhaustion would look exactly like a missing
+ * file. A real `pathExists` should report only existence — not "I gave
+ * up checking".
+ */
+export async function pathExists(target: string): Promise<boolean> {
+  try {
+    await fsp.stat(target);
+    return true;
+  } catch (error) {
+    const code = (error as FsError | undefined)?.code;
+    if (code === 'ENOENT' || code === 'ENOTDIR') {
+      return false;
+    }
+    throw error;
+  }
+}
+
 export async function calculateSHA256(filePath: string): Promise<string> {
   const fileBuffer = await fsp.readFile(filePath);
   const hashSum = crypto.createHash('sha256');

--- a/src/layout-bootstrap.ts
+++ b/src/layout-bootstrap.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import * as properLockfile from 'proper-lockfile';
 import { FAISS_INDEX_PATH } from './config.js';
 import { writeActiveModelAtomic } from './active-model.js';
-import { pathExists } from './faiss-store-layout.js';
+import { pathExists } from './file-utils.js';
 import { logger } from './logger.js';
 import { deriveModelId, type EmbeddingProvider } from './model-id.js';
 


### PR DESCRIPTION
## Summary

Step 1 of #160 — consolidate the "does this path exist?" predicate.

- Move `pathExists` from `src/faiss-store-layout.ts` → `src/file-utils.ts` (the home #160 nominated). Body unchanged: `fsp.stat`-based, returns `false` for `ENOENT`/`ENOTDIR`, **rethrows** every other filesystem error.
- Update consumers (`faiss-store-layout.ts`, `layout-bootstrap.ts`, `FaissIndexManager.ts`) to import from `./file-utils.js`.

Replace 8 inline existence-check copies with `pathExists`:

| File | Lines | Pattern |
|---|---|---|
| `cli-models.ts` | 111, 264, 283 | `fsp.access(p).then(() => true).catch(() => false)` (issue's cited sites) |
| `active-model.ts` | 82, 129, 135, 198, 230 | `try { fsp.access(p); … } catch { … }` (same predicate written longhand, including `activeFileExists()` which is now a 1-line delegate) |

### Behaviour change (deliberate)

The inline forms swallowed **all** filesystem errors (`EACCES`, `ELOOP`, `EMFILE`, …) and silently reported "does not exist". `pathExists` only swallows `ENOENT`/`ENOTDIR` and rethrows everything else. So a permission-denied or fd-exhaustion situation that previously looked exactly like a missing file will now surface as a real error to the caller.

The issue called these inline copies *"a future bug-fix-doesn't-propagate trap"*; this PR propagates the canonical behaviour. Worth flagging for review.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 535/535 tests pass (25 suites)
- [x] No new test file: the predicate is exercised transitively by 8 call sites in production code; the RFC 014 atomic-save suite already pins the canonical `lstat`/`stat` semantics
- [ ] Manual smoke against a real FAISS index path with read-restricted ancestor — not done; this is exactly the edge case the behaviour change targets, but the existing `pathExists` body (now relocated, not rewritten) has shipped that semantics for the FAISS layout path since RFC 014. The change here is making other call sites match.

Refs #160 — steps 2 (consolidate the three KB-path validators), 3 (extract `assertNoTraversal`), and 4 (delete dead `resolveKbPath`) remain as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)