### PR TITLE
refactor: drop layout helper re-export

### DIFF
--- a/src/FaissIndexManager.ts
+++ b/src/FaissIndexManager.ts
@@ -51,7 +51,6 @@ import {
 } from './faiss-store-layout.js';
 import { withSidecarLock } from './write-lock.js';
 
-export { nextVersionAfter } from './faiss-store-layout.js';
 export { MigrationRefusedError } from './layout-bootstrap.js';
 
 /**

--- a/src/atomic-save.test.ts
+++ b/src/atomic-save.test.ts
@@ -150,11 +150,11 @@ async function holdWriteLock<T>(modelDir: string, fn: () => Promise<T>): Promise
 
 // ---------- tests ----------
 
-describe('RFC 014 atomic save — file-private helpers', () => {
+describe('RFC 014 atomic save — layout helpers', () => {
   let nextVersionAfter: (s: string | null) => string;
 
   beforeAll(async () => {
-    const mod = await import('./FaissIndexManager.js');
+    const mod = await import('./faiss-store-layout.js');
     nextVersionAfter = mod.nextVersionAfter;
   });
 


### PR DESCRIPTION
## Summary
- Remove the `nextVersionAfter` re-export from `FaissIndexManager.ts`
- Update atomic-save tests to import the helper from `faiss-store-layout.ts` directly
- Rename the helper test group to match the layout-module ownership

## Test plan
- [x] npm run build
- [x] npm test -- --runTestsByPath src/atomic-save.test.ts
- [x] npm test

Refs #156