### PR TITLE
refactor: tag bootstrap reset helper internal

### DIFF
--- a/src/FaissIndexManager.ts
+++ b/src/FaissIndexManager.ts
@@ -229,6 +229,7 @@ export class FaissIndexManager {
     await bootstrapIndexLayout();
   }
 
+  /* @internal */
   /** Test-only: reset the bootstrap cache between tests. */
   static __resetBootstrapForTests(): void {
     resetBootstrapLayoutForTests();

--- a/src/layout-bootstrap.ts
+++ b/src/layout-bootstrap.ts
@@ -142,6 +142,7 @@ export async function bootstrapLayout(): Promise<void> {
   return bootstrapPromise;
 }
 
+/* @internal */
 /** Test-only: reset the bootstrap cache between tests. */
 export function __resetBootstrapForTests(): void {
   bootstrapPromise = null;


### PR DESCRIPTION
## Summary
- Tag the test-only bootstrap reset helper with `/* @internal */`
- Apply the same marker to the FaissIndexManager reset wrapper

## Test plan
- [x] npm run build
- [x] npm test -- --runTestsByPath src/FaissIndexManager.test.ts src/atomic-save.test.ts
- [x] npm test

Refs #156