### PR TITLE
refactor(kb-fs): consolidate KB-path validators into resolveKbPath (#160 step 2)

### DIFF
--- a/src/KnowledgeBaseServer.ts
+++ b/src/KnowledgeBaseServer.ts
@@ -36,7 +36,7 @@ import {
 import { formatRetrievalAsMarkdown } from './formatter.js';
 import {
   listKnowledgeBases,
-  resolveKbRelativePath,
+  resolveKbPath,
   resolveKnowledgeBaseDir,
 } from './kb-fs.js';
 import { computeKbStats } from './kb-stats.js';
@@ -308,10 +308,11 @@ export class KnowledgeBaseServer {
       const manager = await this.getActiveManagerForMutation();
       let documentPath = '';
       await withWriteLock(manager.modelDir, async () => {
-        documentPath = await resolveKbRelativePath(
+        documentPath = await resolveKbPath(
           KNOWLEDGE_BASES_ROOT_DIR,
           args.knowledge_base_name,
           args.path,
+          { mustExist: false },
         );
         await fsp.mkdir(path.dirname(documentPath), { recursive: true });
         await fsp.writeFile(documentPath, args.content, 'utf-8');
@@ -355,10 +356,11 @@ export class KnowledgeBaseServer {
           KNOWLEDGE_BASES_ROOT_DIR,
           args.knowledge_base_name,
         );
-        documentPath = await resolveKbRelativePath(
+        documentPath = await resolveKbPath(
           KNOWLEDGE_BASES_ROOT_DIR,
           args.knowledge_base_name,
           args.path,
+          { mustExist: false },
         );
         const relativePath = path.relative(kbDir, documentPath);
         sidecarPath = path.join(

--- a/src/cli-capture.ts
+++ b/src/cli-capture.ts
@@ -12,7 +12,7 @@ import * as path from 'path';
 import { ActiveModelResolutionError, resolveActiveModel } from './active-model.js';
 import { FaissIndexManager } from './FaissIndexManager.js';
 import { KNOWLEDGE_BASES_ROOT_DIR } from './config.js';
-import { assertNoTraversal, resolveKbRelativePath, resolveKnowledgeBaseDir } from './kb-fs.js';
+import { assertNoTraversal, resolveKbPath, resolveKnowledgeBaseDir } from './kb-fs.js';
 import { withWriteLock } from './write-lock.js';
 import { loadManagerForModel } from './cli-shared.js';
 
@@ -279,7 +279,7 @@ function detectLanguageFromCommand(argv: string[]): string | null {
 
 async function appendToNote(kbName: string, relativePath: string, content: string): Promise<string> {
   assertNoTraversal(relativePath);
-  const documentPath = await resolveKbRelativePath(KNOWLEDGE_BASES_ROOT_DIR, kbName, relativePath);
+  const documentPath = await resolveKbPath(KNOWLEDGE_BASES_ROOT_DIR, kbName, relativePath, { mustExist: false });
   const stat = await fsp.stat(documentPath);
   if (!stat.isFile()) {
     throw new Error(`append target is not a file: ${JSON.stringify(relativePath)}`);

--- a/src/cli-remember.ts
+++ b/src/cli-remember.ts
@@ -5,7 +5,7 @@ import { FaissIndexManager } from './FaissIndexManager.js';
 import { KNOWLEDGE_BASES_ROOT_DIR } from './config.js';
 import { getFilesRecursively } from './file-utils.js';
 import { filterIngestablePaths } from './ingest-filter.js';
-import { assertNoTraversal, resolveKbRelativePath, resolveKnowledgeBaseDir } from './kb-fs.js';
+import { assertNoTraversal, resolveKbPath, resolveKnowledgeBaseDir } from './kb-fs.js';
 import { withWriteLock } from './write-lock.js';
 import { loadManagerForModel, loadWithJsonRetry } from './cli-shared.js';
 import { appendSectionInDocument, parseHeadingSpec } from './markdown-section.js';
@@ -450,7 +450,7 @@ function tokenize(value: string): Set<string> {
 
 async function createNewNote(kbName: string, title: string, content: string): Promise<string> {
   const relativePath = `${slugifyTitle(title)}.md`;
-  const documentPath = await resolveKbRelativePath(KNOWLEDGE_BASES_ROOT_DIR, kbName, relativePath);
+  const documentPath = await resolveKbPath(KNOWLEDGE_BASES_ROOT_DIR, kbName, relativePath, { mustExist: false });
   await fsp.mkdir(path.dirname(documentPath), { recursive: true });
   try {
     const handle = await fsp.open(documentPath, 'wx');
@@ -470,7 +470,7 @@ async function createNewNote(kbName: string, title: string, content: string): Pr
 
 async function appendExistingNote(kbName: string, relativePath: string, content: string): Promise<string> {
   assertNoTraversal(relativePath);
-  const documentPath = await resolveKbRelativePath(KNOWLEDGE_BASES_ROOT_DIR, kbName, relativePath);
+  const documentPath = await resolveKbPath(KNOWLEDGE_BASES_ROOT_DIR, kbName, relativePath, { mustExist: false });
   const stat = await fsp.stat(documentPath);
   if (!stat.isFile()) {
     throw new Error(`append target is not a file: ${JSON.stringify(relativePath)}`);
@@ -494,7 +494,7 @@ async function appendSectionInExistingNote(
     throw new Error('--append-section refuses to write empty content (stdin was empty or whitespace-only)');
   }
   assertNoTraversal(relativePath);
-  const documentPath = await resolveKbRelativePath(KNOWLEDGE_BASES_ROOT_DIR, kbName, relativePath);
+  const documentPath = await resolveKbPath(KNOWLEDGE_BASES_ROOT_DIR, kbName, relativePath, { mustExist: false });
   let stat;
   try {
     stat = await fsp.stat(documentPath);

--- a/src/kb-fs.ts
+++ b/src/kb-fs.ts
@@ -6,7 +6,6 @@
 
 import * as fsp from 'fs/promises';
 import * as path from 'path';
-import { assertValidKbName } from './kb-paths.js';
 import { KBError } from './errors.js';
 import { getFilesRecursively } from './file-utils.js';
 import { filterIngestablePaths } from './ingest-filter.js';
@@ -182,53 +181,104 @@ async function realpathIfExists(target: string): Promise<string | null> {
   }
 }
 
-/**
- * Resolves a KB-relative document path under `<rootDir>/<kbName>/` and
- * verifies the final filesystem target remains inside that KB directory.
- *
- * The guard is both lexical (before touching the candidate) and realpath
- * based (after following symlinks), so `../`, absolute-path payloads, and
- * symlinks that point outside the KB are refused.
- *
- * Used by the MCP `resources/read` handler (kb:// URIs). Requires the
- * resolved file to exist — throws "path not found" otherwise. For ingest
- * tools that may target a not-yet-created file, see `resolveKbRelativePath`.
- */
-export async function resolveKnowledgeBaseDocumentPath(
-  rootDir: string,
-  kbName: string,
-  relativePath: string,
-): Promise<string> {
-  assertValidKbName(kbName);
+export interface ResolveKbPathOptions {
+  /**
+   * When true (resources/read), the resolved file MUST exist on disk;
+   * a missing target throws `path not found: "<relativePath>"`. The
+   * returned path is realpath-resolved.
+   *
+   * When false (add_document, kb remember/capture writes), the lexical
+   * target may not exist yet, but every existing ancestor in the path
+   * prefix MUST resolve inside the KB root. The returned path is
+   * lexical (the user-requested location, not a symlink target).
+   */
+  mustExist: boolean;
+}
 
+/**
+ * Issue #160 step 2 — single home for "validate user-supplied
+ * KB-relative path and return its absolute fs path under the KB root".
+ *
+ * Replaces the prior pair of `resolveKnowledgeBaseDocumentPath` (must-exist)
+ * and `resolveKbRelativePath` (may-not-exist). The defence-in-depth chain
+ * is the same in both modes:
+ *   1. Lexical guards: empty / null-byte / traversal (`assertNoTraversal`).
+ *   2. KB-name + KB-dir validation (`resolveKnowledgeBaseDir`).
+ *   3. Lexical inside-or-equal check on `<kbDir>/<relativePath>`.
+ *   4. realpath check on the existing target (or its nearest existing
+ *      ancestor when `mustExist === false`).
+ *
+ * Failures throw `KBError('VALIDATION', ...)` for input/escape problems
+ * and propagate `KBError('KB_NOT_FOUND', ...)` from the KB-dir resolver.
+ * `path not found` is a plain `Error` to match the prior public wording
+ * of `resolves/read` test assertions; the message format is preserved.
+ */
+export async function resolveKbPath(
+  rootDir: string,
+  knowledgeBaseName: string,
+  relativePath: string,
+  options: ResolveKbPathOptions,
+): Promise<string> {
   if (relativePath.length === 0) {
-    throw new Error('kb:// URI requires a non-empty resource path');
+    throw new KBError('VALIDATION', 'path must not be empty');
   }
   if (relativePath.includes('\0')) {
-    throw new Error('path contains null byte');
+    throw new KBError('VALIDATION', 'path contains null byte');
   }
-  assertNoTraversal(relativePath);
+  try {
+    assertNoTraversal(relativePath);
+  } catch (err) {
+    // Promote the plain Error to a typed KBError so callers (add_document,
+    // delete_document) keep their `error.code === 'VALIDATION'` contract.
+    throw new KBError('VALIDATION', (err as Error).message);
+  }
 
+  const kbDir = await resolveKnowledgeBaseDir(rootDir, knowledgeBaseName);
+  const kbReal = await fsp.realpath(kbDir);
   const normalizedRelative = relativePath.replace(/\\/g, '/');
-  const kbRoot = path.resolve(rootDir, kbName);
-  const kbRootReal = await realpathIfExists(kbRoot);
-  if (kbRootReal === null) {
-    throw new Error(`knowledge base not found: ${JSON.stringify(kbName)}`);
-  }
-
-  const lexicalCandidate = path.resolve(kbRootReal, normalizedRelative);
-  if (!isInsideOrEqual(kbRootReal, lexicalCandidate)) {
-    throw new Error(`path escapes KB root: ${JSON.stringify(relativePath)}`);
+  const lexicalCandidate = path.resolve(kbDir, normalizedRelative);
+  const escapesError = (): KBError =>
+    new KBError(
+      'VALIDATION',
+      `path escapes KB root: ${JSON.stringify(relativePath)}`,
+    );
+  if (!isInsideOrEqual(path.resolve(kbDir), lexicalCandidate)) {
+    throw escapesError();
   }
 
   const realCandidate = await realpathIfExists(lexicalCandidate);
-  if (realCandidate === null) {
+  if (realCandidate !== null) {
+    if (!isInsideOrEqual(kbReal, realCandidate)) {
+      throw escapesError();
+    }
+    return options.mustExist ? realCandidate : lexicalCandidate;
+  }
+
+  if (options.mustExist) {
+    // Plain Error (not KBError) — `mcpErrorContent` would otherwise stamp
+    // this as `INTERNAL` for `resources/read`; the SDK serializes the
+    // raw `error.message` directly, and the existing test pin
+    // (KnowledgeBaseServer.test.ts:717) expects exactly this wording.
     throw new Error(`path not found: ${JSON.stringify(relativePath)}`);
   }
-  if (!isInsideOrEqual(kbRootReal, realCandidate)) {
-    throw new Error(`path escapes KB root: ${JSON.stringify(relativePath)}`);
+
+  // mustExist === false: walk up to the nearest existing ancestor and
+  // confirm it resolves inside the KB. This is what lets add_document
+  // create new files at not-yet-existing paths while still rejecting
+  // ones whose realpath chain points outside the KB.
+  let existingAncestor = path.dirname(lexicalCandidate);
+  while (!(await realpathIfExists(existingAncestor))) {
+    const parent = path.dirname(existingAncestor);
+    if (parent === existingAncestor) {
+      throw escapesError();
+    }
+    existingAncestor = parent;
   }
-  return realCandidate;
+  const ancestorReal = await fsp.realpath(existingAncestor);
+  if (!isInsideOrEqual(kbReal, ancestorReal)) {
+    throw escapesError();
+  }
+  return lexicalCandidate;
 }
 
 /**
@@ -292,84 +342,3 @@ export async function resolveKnowledgeBaseDir(
   return kbDir;
 }
 
-/**
- * Resolve a user-supplied KB-relative document path to an absolute path under
- * `<rootDir>/<knowledgeBaseName>`.
- *
- * The final path may not exist yet (needed by add_document), but any existing
- * ancestor, existing file, or existing symlink target must resolve under the
- * KB root. `..` components are rejected lexically, even if normalization
- * would bring the path back inside the KB.
- */
-export async function resolveKbRelativePath(
-  rootDir: string,
-  knowledgeBaseName: string,
-  relativePath: string,
-): Promise<string> {
-  if (relativePath.length === 0) {
-    throw new KBError('VALIDATION', 'Document path must not be empty.');
-  }
-  if (relativePath.includes('\0')) {
-    throw new KBError('VALIDATION', 'Document path contains a null byte.');
-  }
-
-  const normalizedRelative = relativePath.replace(/\\/g, '/');
-  if (path.posix.isAbsolute(normalizedRelative)) {
-    throw new KBError(
-      'VALIDATION',
-      `Document path escapes KB root: ${JSON.stringify(relativePath)}.`,
-    );
-  }
-
-  const rawSegments = normalizedRelative.split('/').filter((segment) => segment.length > 0);
-  if (rawSegments.length === 0 || rawSegments.some((segment) => segment === '..')) {
-    throw new KBError(
-      'VALIDATION',
-      `Document path escapes KB root: ${JSON.stringify(relativePath)}.`,
-    );
-  }
-
-  const kbDir = await resolveKnowledgeBaseDir(rootDir, knowledgeBaseName);
-  const kbReal = await fsp.realpath(kbDir);
-  const normalizedSegments = path.posix.normalize(rawSegments.join('/')).split('/');
-  const candidate = path.resolve(kbDir, ...normalizedSegments);
-  if (!isInsideOrEqual(path.resolve(kbDir), candidate)) {
-    throw new KBError(
-      'VALIDATION',
-      `Document path escapes KB root: ${JSON.stringify(relativePath)}.`,
-    );
-  }
-
-  const existingTarget = await realpathIfExists(candidate);
-  if (existingTarget !== null) {
-    if (!isInsideOrEqual(kbReal, existingTarget)) {
-      throw new KBError(
-        'VALIDATION',
-        `Document path escapes KB root: ${JSON.stringify(relativePath)}.`,
-      );
-    }
-    return candidate;
-  }
-
-  let existingAncestor = path.dirname(candidate);
-  while (!(await realpathIfExists(existingAncestor))) {
-    const parent = path.dirname(existingAncestor);
-    if (parent === existingAncestor) {
-      throw new KBError(
-        'VALIDATION',
-        `Document path escapes KB root: ${JSON.stringify(relativePath)}.`,
-      );
-    }
-    existingAncestor = parent;
-  }
-
-  const ancestorReal = await fsp.realpath(existingAncestor);
-  if (!isInsideOrEqual(kbReal, ancestorReal)) {
-    throw new KBError(
-      'VALIDATION',
-      `Document path escapes KB root: ${JSON.stringify(relativePath)}.`,
-    );
-  }
-
-  return candidate;
-}

--- a/src/mcp-resources.ts
+++ b/src/mcp-resources.ts
@@ -22,7 +22,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { KNOWLEDGE_BASES_ROOT_DIR } from './config.js';
 import { toError } from './error-utils.js';
 import { getFilesRecursively } from './file-utils.js';
-import { listKnowledgeBases, resolveKnowledgeBaseDocumentPath } from './kb-fs.js';
+import { listKnowledgeBases, resolveKbPath } from './kb-fs.js';
 import { isValidKbName } from './kb-paths.js';
 
 export function mimeTypeForResource(filePath: string): string {
@@ -158,10 +158,11 @@ export async function listResources(): Promise<ListResourcesResult> {
  */
 export async function readResource(uri: string): Promise<ReadResourceResult> {
   const { kbName, relativePath } = parseKnowledgeBaseResourceUri(uri);
-  const filePath = await resolveKnowledgeBaseDocumentPath(
+  const filePath = await resolveKbPath(
     KNOWLEDGE_BASES_ROOT_DIR,
     kbName,
     relativePath,
+    { mustExist: true },
   );
   const mimeType = mimeTypeForResource(filePath);
 


### PR DESCRIPTION
## Summary

Step 2 of #160 — final piece. Replace the pair of overlapping validators with one unified function.

**Before** (two near-duplicate implementations with subtly different semantics):
- `resolveKnowledgeBaseDocumentPath(rootDir, kbName, relPath)` — must-exist semantics, plain `Error`, only caller is `mcp-resources.readResource`.
- `resolveKbRelativePath(rootDir, kbName, relPath)` — may-not-exist + ancestor-walk, `KBError`, used by `add_document`, `delete_document`, `kb remember` writes, `kb capture` writes.

**After**:

```ts
resolveKbPath(rootDir, kbName, relPath, { mustExist: boolean }): Promise<string>
```

The defence-in-depth chain is the same in both modes:
1. Lexical guards (empty / null-byte / `assertNoTraversal`).
2. KB-name + KB-dir validation via `resolveKnowledgeBaseDir`.
3. Lexical inside-or-equal check on `<kbDir>/<relPath>`.
4. realpath check on the existing target, OR — when `mustExist=false` — a walk up to the nearest existing ancestor with the same inside-or-equal check.

Returns:
- `mustExist=true` → realpath-resolved path of an existing target.
- `mustExist=false` → lexical path (write callers `mkdir -p` and write to this; not a symlink target).

Errors:
- `KBError('VALIDATION', …)` for input / escape / null-byte / traversal.
- `KBError('KB_NOT_FOUND', …)` propagated from `resolveKnowledgeBaseDir`.
- Plain `Error` for `path not found: "<relPath>"` (mustExist=true) so the existing resources/read test pin keeps holding without the SDK stamping `INTERNAL` over the wire.

### Behaviour deltas worth flagging

- **resources/read** previously had a redundant `assertValidKbName` pre-check (kbName already passes `isValidKbName` in the URI parser). The unified function delegates KB-name validation to `resolveKnowledgeBaseDir` — strictly looser on naming, but adds a `stat`-is-directory check. Net: same logical outcomes, clearer "is the KB present?" failure point.
- **Add/delete document** previously got error message `Document path escapes KB root: "…"`. It now gets `path escapes KB root: "…"` (no `Document path` prefix, no trailing period). All existing tests assert against the `escapes KB root` substring; none rely on the dropped wording.
- **Add/delete document** previously had a separate "Document path must not be empty" check. Now it shares `path must not be empty` with resources/read. No test asserts on the dropped wording.

### Call sites updated

| File | Lines | mustExist |
|---|---|---|
| `mcp-resources.ts` | 161 | `true` |
| `cli-capture.ts` | 282 | `false` |
| `cli-remember.ts` | 453, 473, 497 | `false` |
| `KnowledgeBaseServer.ts` | 311, 358 | `false` |

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 530/530 tests pass (25 suites)
- [x] No new test file: the unified function is exercised by every traversal-rejection / not-found / escape / wire-error case across `KnowledgeBaseServer.test.ts`, `mcp-resources.test.ts`, `cli-remember.test.ts`, `cli-capture.test.ts`, `cli.test.ts`
- [ ] Manual `resources/read` against a missing file + a `..` payload — not done; the SDK-mediated tests cover the wire path

**Closes #160** — all four sub-steps shipped (#171 step 1 `pathExists`, #173 steps 3+4 `assertNoTraversal` + dead `resolveKbPath`, this PR step 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)