### PR TITLE
refactor(transport): extract BaseHttpHost — close the sse↔http duplication (#158)

### DIFF
--- a/src/transport/base-http-host.ts
+++ b/src/transport/base-http-host.ts
@@ -1,0 +1,441 @@
+// src/transport/base-http-host.ts
+//
+// Issue #158 — shared HTTP host for `SseHost` and `StreamableHttpHost`.
+// Both transports own a `node:http` server with the same shape:
+//
+//   1. CORS preflight short-circuits before auth.
+//   2. /health is unauthenticated and origin-unchecked.
+//   3. Origin allow-list (optional, present-only enforcement).
+//   4. Bearer-token auth (constant-time compare).
+//   5. Shutdown gate.
+//   6. CORS response headers for accepted cross-origin calls.
+//   7. Subclass-specific path routing (the actually-different bit).
+//
+// Plus identical lifecycle (start / stop with drain), session bookkeeping
+// (`sessionCount`, `notify` fanout), and observability (per-request access
+// log line). The pre-extraction `sse.ts` and `http.ts` were ~70%
+// byte-identical — every divergence now sits in a small set of subclass
+// hooks rather than two parallel copies that drift.
+
+import * as http from 'node:http';
+import { Buffer } from 'node:buffer';
+import { timingSafeEqual } from 'node:crypto';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+import { normalizeOrigin, type TransportConfig } from '../config.js';
+import { logger } from '../logger.js';
+
+const HEALTH_ENDPOINT = '/health';
+const SHUTDOWN_DRAIN_DEADLINE_MS = 10_000;
+const SHUTDOWN_POLL_INTERVAL_MS = 50;
+
+export interface BaseHttpHostOptions {
+  config: TransportConfig;
+  createMcpServer: () => McpServer;
+}
+
+export interface BaseSessionEntry<TTransport> {
+  transport: TTransport;
+  mcp: McpServer;
+}
+
+interface AccessLog {
+  ts: string;
+  method: string;
+  path: string;
+  status: number;
+  duration_ms: number;
+  origin: string | null;
+  auth_present: boolean;
+}
+
+export abstract class BaseHttpHost<TTransport extends { close(): Promise<void> }> {
+  protected readonly options: BaseHttpHostOptions;
+  protected readonly sessions = new Map<string, BaseSessionEntry<TTransport>>();
+  protected readonly originAllowList: ReadonlySet<string>;
+  private readonly authTokenBuf: Buffer;
+  protected server?: http.Server;
+  protected inFlight = 0;
+  protected shuttingDown = false;
+
+  constructor(options: BaseHttpHostOptions) {
+    this.options = options;
+    this.originAllowList = new Set(options.config.allowedOrigins);
+    // RFC 008 §6.3: compare as latin1 (1 byte == 1 codeunit) so an
+    // attacker-supplied `Authorization` header is not silently re-encoded
+    // via UTF-8 substitution (U+FFFD is 3 bytes and mutates length) before
+    // the constant-time compare. The presence of a token under
+    // `MCP_TRANSPORT=sse|http` is enforced at config load time; the
+    // empty-string fallback here is defence-in-depth for refactor accidents.
+    const token = options.config.authToken ?? '';
+    this.authTokenBuf = Buffer.from(token, 'latin1');
+  }
+
+  // ---------------------------------------------------------------------------
+  // Subclass hooks — the pieces that differ between SSE and streamable HTTP.
+  // ---------------------------------------------------------------------------
+
+  /** Short tag used in log lines (`sse`, `http`). */
+  protected abstract get logPrefix(): string;
+
+  /** Human-readable transport label used in the start banner. */
+  protected abstract get bannerLabel(): string;
+
+  /** Comma-separated value for the preflight `Access-Control-Allow-Methods` header. */
+  protected abstract corsAllowedMethods(): string;
+
+  /** Comma-separated value for the preflight `Access-Control-Allow-Headers` header. */
+  protected abstract corsAllowedHeaders(): string;
+
+  /**
+   * Subclass-extension point for non-default CORS response headers. The
+   * common `Access-Control-Allow-Origin` + `Vary: Origin` pair is set by
+   * the base class; HTTP additionally exposes `Mcp-Session-Id` so the
+   * client can read it.
+   */
+  protected setExtraCorsResponseHeaders(_res: http.ServerResponse): void {
+    // Default: no extras.
+  }
+
+  /**
+   * Path-routing for authenticated, origin-allowed, not-shutting-down
+   * requests. The `handlePreflight` / `handleHealth` short-circuits ran
+   * first; this method owns everything from `inFlight` accounting through
+   * the per-route handler. Returns the HTTP status used for the access log.
+   *
+   * Long-lived routes (SSE GET /sse) MUST NOT increment `inFlight` —
+   * doing so would block `stop()`'s drain indefinitely. Each subclass
+   * decides per-route.
+   */
+  protected abstract handleAuthenticatedRequest(
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+    url: URL,
+  ): Promise<number>;
+
+  // ---------------------------------------------------------------------------
+  // Public surface — shared lifecycle, observability, fanout.
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Number of live sessions. Read-only — narrower than a session-list
+   * export so callers cannot reach in to fan notifications out by hand.
+   * Use `notify(...)` for that.
+   */
+  get sessionCount(): number {
+    return this.sessions.size;
+  }
+
+  /**
+   * Issue #157 step 4 — fan a logging notification out across every live
+   * session. The host owns the iteration so callers never see the session
+   * list. Per-session errors are swallowed at debug level so a single
+   * misbehaving client cannot poison the broadcast for the rest. Operates
+   * against a snapshot of the values map to defend against
+   * `transport.onclose` deletes mid-iteration.
+   */
+  async notify(
+    level: 'info' | 'warning' | 'error',
+    logger_: string,
+    data: string,
+  ): Promise<void> {
+    const targets = [...this.sessions.values()].map((entry) => entry.mcp);
+    if (targets.length === 0) return;
+    await Promise.all(
+      targets.map(async (target) => {
+        try {
+          await target.sendLoggingMessage({ level, logger: logger_, data });
+        } catch (err) {
+          logger.debug(`[${this.logPrefix}] notify error: ${(err as Error).message}`);
+        }
+      }),
+    );
+  }
+
+  async start(): Promise<http.Server> {
+    if (this.server) {
+      throw new Error(`${this.constructor.name} already started`);
+    }
+    const server = http.createServer((req, res) => {
+      void this.dispatch(req, res);
+    });
+    server.on('clientError', (err, socket) => {
+      try {
+        socket.end('HTTP/1.1 400 Bad Request\r\n\r\n');
+      } catch {
+        // best-effort
+      }
+      logger.warn(`[${this.logPrefix}] clientError: ${err.message}`);
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      const onError = (err: Error) => {
+        server.removeListener('listening', onListening);
+        reject(err);
+      };
+      const onListening = () => {
+        server.removeListener('error', onError);
+        resolve();
+      };
+      server.once('error', onError);
+      server.once('listening', onListening);
+      server.listen(this.options.config.port, this.options.config.bindAddr);
+    });
+
+    this.server = server;
+    logger.info(
+      `Knowledge Base MCP server running on ${this.bannerLabel} at http://${this.options.config.bindAddr}:${this.options.config.port} ` +
+        `(allowed_origins=${this.options.config.allowedOrigins.length})`,
+    );
+    return server;
+  }
+
+  /**
+   * Graceful shutdown:
+   *   1. stop accepting new connections (server.close)
+   *   2. poll-wait in-flight non-long-lived requests for up to
+   *      SHUTDOWN_DRAIN_DEADLINE_MS
+   *   3. close all active sessions (transport.close + mcp.close)
+   *
+   * Closing snapshots the entries map first to defend against concurrent
+   * `transport.onclose` mutations. transport.close() chains into
+   * Protocol._onclose, which nulls the protocol's _transport reference —
+   * so the subsequent mcp.close() call routes through Protocol.close →
+   * undefined?.close() = no-op. That keeps us safe from the recursion
+   * pitfall while still giving the SDK a chance to run any future cleanup
+   * that lives on McpServer rather than Protocol.
+   */
+  async stop(): Promise<void> {
+    if (!this.server) return;
+    this.shuttingDown = true;
+
+    const server = this.server;
+    const closePromise = new Promise<void>((resolve) => {
+      server.close(() => resolve());
+    });
+
+    const deadline = Date.now() + SHUTDOWN_DRAIN_DEADLINE_MS;
+    while (this.inFlight > 0 && Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, SHUTDOWN_POLL_INTERVAL_MS));
+    }
+    if (this.inFlight > 0) {
+      logger.warn(
+        `[${this.logPrefix}] shutdown drain exceeded ${SHUTDOWN_DRAIN_DEADLINE_MS}ms with ${this.inFlight} in-flight; forcing close`,
+      );
+    }
+
+    const live = [...this.sessions.entries()];
+    for (const [sessionId, entry] of live) {
+      await this.closeEntry(sessionId, entry);
+    }
+    this.sessions.clear();
+    await closePromise;
+    this.server = undefined;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Dispatch pipeline — pre-auth gates, then delegates to the subclass.
+  // ---------------------------------------------------------------------------
+
+  private async dispatch(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+    const startedAt = Date.now();
+    const method = req.method ?? 'GET';
+    const url = new URL(req.url ?? '/', 'http://placeholder');
+    const path = url.pathname;
+    const originHeader = headerValue(req.headers.origin);
+    // Allow-list is normalized at config-parse time (parseAllowedOrigins);
+    // normalize the incoming Origin too so operator-friendly input like a
+    // trailing slash or mixed-case scheme matches the browser-sent form.
+    // The raw header is kept for the access log and the CORS echo because
+    // browsers compare Access-Control-Allow-Origin against their sent
+    // Origin byte-exactly.
+    const normalizedOrigin =
+      originHeader !== null ? normalizeOrigin(originHeader) : null;
+    const authPresent = Boolean(req.headers.authorization);
+
+    const finalize = (status: number) => {
+      this.writeAccessLog({
+        ts: new Date(startedAt).toISOString(),
+        method,
+        path,
+        status,
+        duration_ms: Date.now() - startedAt,
+        origin: originHeader,
+        auth_present: authPresent,
+      });
+    };
+
+    // 1. CORS preflight short-circuits before auth.
+    if (method === 'OPTIONS') {
+      finalize(this.handlePreflight(res, originHeader, normalizedOrigin));
+      return;
+    }
+
+    // 2. /health is unauthenticated and origin-unchecked.
+    if (path === HEALTH_ENDPOINT) {
+      finalize(this.handleHealth(method, res));
+      return;
+    }
+
+    // 3. Origin allow-list. Missing Origin is treated as a non-browser
+    //    caller and accepted; if Origin is present it must be in the
+    //    allow-list (after normalization).
+    if (normalizedOrigin !== null && !this.originAllowList.has(normalizedOrigin)) {
+      respond(res, 403, 'Origin not allowed');
+      finalize(403);
+      return;
+    }
+
+    // 4. Bearer-token auth.
+    if (!this.verifyBearer(req.headers.authorization)) {
+      res.setHeader('WWW-Authenticate', 'Bearer realm="knowledge-base-mcp"');
+      respond(res, 401, 'Unauthorized');
+      finalize(401);
+      return;
+    }
+
+    // 5. Shutdown gate — refuse new dispatch once stop() was called.
+    if (this.shuttingDown) {
+      res.setHeader('Retry-After', '0');
+      respond(res, 503, 'Shutting down');
+      finalize(503);
+      return;
+    }
+
+    // 6. Apply CORS response headers for accepted cross-origin calls.
+    if (originHeader !== null) {
+      this.setCorsResponseHeaders(res, originHeader);
+    }
+
+    // 7. Subclass routing.
+    const status = await this.handleAuthenticatedRequest(req, res, url);
+    finalize(status);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Pre-auth gate handlers — shared shape; CORS bits parameterized by hooks.
+  // ---------------------------------------------------------------------------
+
+  private handlePreflight(
+    res: http.ServerResponse,
+    originHeader: string | null,
+    normalizedOrigin: string | null,
+  ): number {
+    // originHeader and normalizedOrigin are null together (see dispatch);
+    // this guard short-circuits both cases — including a preflight with no
+    // Origin header, which gets a 403.
+    if (originHeader === null || normalizedOrigin === null ||
+        !this.originAllowList.has(normalizedOrigin)) {
+      respond(res, 403, 'Origin not allowed');
+      return 403;
+    }
+    this.setCorsResponseHeaders(res, originHeader);
+    res.setHeader('Access-Control-Allow-Methods', this.corsAllowedMethods());
+    res.setHeader('Access-Control-Allow-Headers', this.corsAllowedHeaders());
+    res.setHeader('Access-Control-Max-Age', '600');
+    res.writeHead(204).end();
+    return 204;
+  }
+
+  private handleHealth(method: string, res: http.ServerResponse): number {
+    if (method !== 'GET' && method !== 'HEAD') {
+      res.setHeader('Allow', 'GET, HEAD');
+      respond(res, 405, 'Method Not Allowed');
+      return 405;
+    }
+    // RFC 008 §6.8: /health is unauthenticated and origin-unchecked; it
+    // therefore must not leak any fingerprintable operator state (version,
+    // uptime, or file-system paths). Detailed status is available through
+    // the authenticated MCP channel.
+    const body = JSON.stringify({ status: 'ok' });
+    const buf = Buffer.from(body, 'utf8');
+    res.setHeader('Content-Type', 'application/json; charset=utf-8');
+    res.setHeader('Content-Length', String(buf.length));
+    res.setHeader('Cache-Control', 'no-store');
+    res.writeHead(200);
+    if (method === 'GET') {
+      res.end(buf);
+    } else {
+      res.end();
+    }
+    return 200;
+  }
+
+  protected setCorsResponseHeaders(res: http.ServerResponse, origin: string): void {
+    res.setHeader('Access-Control-Allow-Origin', origin);
+    res.setHeader('Vary', 'Origin');
+    this.setExtraCorsResponseHeaders(res);
+  }
+
+  /**
+   * Constant-time bearer comparison. Length-mismatched tokens
+   * short-circuit (the Node crypto API throws on unequal-length inputs);
+   * the wrapper try/catch is belt-and-braces against a future refactor
+   * losing the length check.
+   */
+  private verifyBearer(authHeader: string | undefined): boolean {
+    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+      return false;
+    }
+    if (this.authTokenBuf.length === 0) {
+      return false;
+    }
+    const provided = Buffer.from(authHeader.slice('Bearer '.length), 'latin1');
+    if (provided.length !== this.authTokenBuf.length) {
+      return false;
+    }
+    try {
+      return timingSafeEqual(provided, this.authTokenBuf);
+    } catch {
+      return false;
+    }
+  }
+
+  private writeAccessLog(entry: AccessLog): void {
+    // JSON.stringify escapes control characters in any user-controllable
+    // field (origin, path), so an adversarial header cannot break out of
+    // the log envelope.
+    const payload = JSON.stringify({ event: 'http_access', ...entry });
+    logger.info(payload);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Session cleanup — shared shape, used by stop() and subclass code paths.
+  // ---------------------------------------------------------------------------
+
+  protected async closeEntry(sessionId: string, entry: BaseSessionEntry<TTransport>): Promise<void> {
+    this.sessions.delete(sessionId);
+    try {
+      await entry.transport.close();
+    } catch (err) {
+      logger.warn(`[${this.logPrefix}] error closing transport: ${(err as Error).message}`);
+    }
+    try {
+      await entry.mcp.close();
+    } catch (err) {
+      logger.warn(`[${this.logPrefix}] error closing mcp: ${(err as Error).message}`);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers shared by both transports.
+// ---------------------------------------------------------------------------
+
+export function headerValue(value: string | string[] | undefined): string | null {
+  if (Array.isArray(value)) return value[0] ?? null;
+  return value ?? null;
+}
+
+export function respond(res: http.ServerResponse, status: number, message: string): void {
+  if (res.headersSent) {
+    try {
+      res.end();
+    } catch {
+      // ignore
+    }
+    return;
+  }
+  res.writeHead(status, { 'Content-Type': 'text/plain; charset=utf-8' });
+  res.end(message);
+}

--- a/src/transport/http.ts
+++ b/src/transport/http.ts
@@ -5,291 +5,92 @@
 // only loaded when MCP_TRANSPORT=http.
 //
 // Surface:
-//   GET  /health            unauthenticated JSON liveness probe
-//   POST /mcp               initialize or per-session JSON-RPC POST
-//   GET  /mcp               optional per-session SSE stream
-//   DELETE /mcp             terminate a session
-//   OPTIONS *               CORS preflight against MCP_ALLOWED_ORIGINS
+//   GET    /health     unauthenticated JSON liveness probe
+//   POST   /mcp        initialize or per-session JSON-RPC POST
+//   GET    /mcp        optional per-session SSE stream
+//   DELETE /mcp        terminate a session
+//   OPTIONS *          CORS preflight against MCP_ALLOWED_ORIGINS
+//
+// Issue #158 — most of the host (lifecycle, dispatch gates, auth, CORS,
+// notify fanout, access log) lives in `BaseHttpHost`; this file owns the
+// per-method routing on `/mcp`, the streamable-HTTP session bookkeeping
+// (Mcp-Session-Id header), and the JSON-RPC error envelope.
 
 import * as http from 'node:http';
 import { Buffer } from 'node:buffer';
-import { randomUUID, timingSafeEqual } from 'node:crypto';
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { randomUUID } from 'node:crypto';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
 
-import { normalizeOrigin, type TransportConfig } from '../config.js';
 import { logger } from '../logger.js';
+import {
+  BaseHttpHost,
+  type BaseHttpHostOptions,
+  respond,
+} from './base-http-host.js';
 
 const MCP_ENDPOINT = '/mcp';
-const HEALTH_ENDPOINT = '/health';
-
 const MAXIMUM_MESSAGE_SIZE_BYTES = 4 * 1024 * 1024;
-const SHUTDOWN_DRAIN_DEADLINE_MS = 10_000;
-const SHUTDOWN_POLL_INTERVAL_MS = 50;
 const UUID_SHAPE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
 
-export interface StreamableHttpHostOptions {
-  config: TransportConfig;
-  createMcpServer: () => McpServer;
-}
+export type StreamableHttpHostOptions = BaseHttpHostOptions;
 
-interface SessionEntry {
-  transport: StreamableHTTPServerTransport;
-  mcp: McpServer;
-}
-
-type AccessLog = {
-  ts: string;
-  method: string;
-  path: string;
-  status: number;
-  duration_ms: number;
-  origin: string | null;
-  auth_present: boolean;
-};
-
-export class StreamableHttpHost {
-  private readonly options: StreamableHttpHostOptions;
-  private readonly sessions = new Map<string, SessionEntry>();
-  private readonly originAllowList: ReadonlySet<string>;
-  private readonly authTokenBuf: Buffer;
-  private server?: http.Server;
-  private inFlight = 0;
-  private shuttingDown = false;
-
-  constructor(options: StreamableHttpHostOptions) {
-    this.options = options;
-    this.originAllowList = new Set(options.config.allowedOrigins);
-    const token = options.config.authToken ?? '';
-    this.authTokenBuf = Buffer.from(token, 'latin1');
+export class StreamableHttpHost extends BaseHttpHost<StreamableHTTPServerTransport> {
+  protected get logPrefix(): string {
+    return 'http';
   }
 
-  /**
-   * Number of live HTTP sessions. Read-only — narrower than a full
-   * session-list export so callers cannot reach in to fan notifications
-   * out by hand. Use `notify(...)` for that.
-   */
-  get sessionCount(): number {
-    return this.sessions.size;
+  protected get bannerLabel(): string {
+    return 'streamable HTTP';
   }
 
-  /**
-   * Issue #157 step 4 — fan a warm-up logging notification out across every
-   * live session. Same shape and semantics as `SseHost.notify`: the host
-   * owns the fanout, swallows per-session errors at debug level, and
-   * iterates a snapshot to defend against concurrent `onclose` deletes.
-   */
-  async notify(
-    level: 'info' | 'warning' | 'error',
-    logger_: string,
-    data: string,
-  ): Promise<void> {
-    const targets = [...this.sessions.values()].map((entry) => entry.mcp);
-    if (targets.length === 0) return;
-    await Promise.all(
-      targets.map(async (target) => {
-        try {
-          await target.sendLoggingMessage({ level, logger: logger_, data });
-        } catch (err) {
-          logger.debug(`[http] notify error: ${(err as Error).message}`);
-        }
-      }),
-    );
+  protected corsAllowedMethods(): string {
+    return 'GET, POST, DELETE, OPTIONS';
   }
 
-  async start(): Promise<http.Server> {
-    if (this.server) {
-      throw new Error('StreamableHttpHost already started');
-    }
-    const server = http.createServer((req, res) => {
-      void this.dispatch(req, res);
-    });
-    server.on('clientError', (err, socket) => {
-      try {
-        socket.end('HTTP/1.1 400 Bad Request\r\n\r\n');
-      } catch {
-        // best-effort
-      }
-      logger.warn(`[http] clientError: ${err.message}`);
-    });
-
-    await new Promise<void>((resolve, reject) => {
-      const onError = (err: Error) => {
-        server.removeListener('listening', onListening);
-        reject(err);
-      };
-      const onListening = () => {
-        server.removeListener('error', onError);
-        resolve();
-      };
-      server.once('error', onError);
-      server.once('listening', onListening);
-      server.listen(this.options.config.port, this.options.config.bindAddr);
-    });
-
-    this.server = server;
-    logger.info(
-      `Knowledge Base MCP server running on streamable HTTP at http://${this.options.config.bindAddr}:${this.options.config.port} ` +
-        `(allowed_origins=${this.options.config.allowedOrigins.length})`,
-    );
-    return server;
+  protected corsAllowedHeaders(): string {
+    return 'Authorization, Content-Type, Mcp-Session-Id, Mcp-Protocol-Version, Last-Event-ID';
   }
 
-  async stop(): Promise<void> {
-    if (!this.server) return;
-    this.shuttingDown = true;
-
-    const server = this.server;
-    const closePromise = new Promise<void>((resolve) => {
-      server.close(() => resolve());
-    });
-
-    const deadline = Date.now() + SHUTDOWN_DRAIN_DEADLINE_MS;
-    while (this.inFlight > 0 && Date.now() < deadline) {
-      await new Promise((r) => setTimeout(r, SHUTDOWN_POLL_INTERVAL_MS));
-    }
-    if (this.inFlight > 0) {
-      logger.warn(
-        `[http] shutdown drain exceeded ${SHUTDOWN_DRAIN_DEADLINE_MS}ms with ${this.inFlight} in-flight; forcing close`,
-      );
-    }
-
-    const live = [...this.sessions.entries()];
-    for (const [sessionId, entry] of live) {
-      await this.closeEntry(sessionId, entry);
-    }
-    await closePromise;
-    this.server = undefined;
+  protected setExtraCorsResponseHeaders(res: http.ServerResponse): void {
+    res.setHeader('Access-Control-Expose-Headers', 'Mcp-Session-Id');
   }
 
-  private async dispatch(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
-    const startedAt = Date.now();
+  protected async handleAuthenticatedRequest(
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+    url: URL,
+  ): Promise<number> {
     const method = req.method ?? 'GET';
-    const url = new URL(req.url ?? '/', 'http://placeholder');
-    const path = url.pathname;
-    const originHeader = headerValue(req.headers.origin);
-    const normalizedOrigin =
-      originHeader !== null ? normalizeOrigin(originHeader) : null;
-    const authPresent = Boolean(req.headers.authorization);
 
-    const finalize = (status: number) => {
-      this.writeAccessLog({
-        ts: new Date(startedAt).toISOString(),
-        method,
-        path,
-        status,
-        duration_ms: Date.now() - startedAt,
-        origin: originHeader,
-        auth_present: authPresent,
-      });
-    };
-
-    if (method === 'OPTIONS') {
-      const status = this.handlePreflight(req, res, originHeader, normalizedOrigin);
-      finalize(status);
-      return;
-    }
-
-    if (path === HEALTH_ENDPOINT) {
-      const status = this.handleHealth(method, res);
-      finalize(status);
-      return;
-    }
-
-    if (normalizedOrigin !== null && !this.originAllowList.has(normalizedOrigin)) {
-      respond(res, 403, 'Origin not allowed');
-      finalize(403);
-      return;
-    }
-
-    if (!this.verifyBearer(req.headers.authorization)) {
-      res.setHeader('WWW-Authenticate', 'Bearer realm="knowledge-base-mcp"');
-      respond(res, 401, 'Unauthorized');
-      finalize(401);
-      return;
-    }
-
-    if (this.shuttingDown) {
-      res.setHeader('Retry-After', '0');
-      respond(res, 503, 'Shutting down');
-      finalize(503);
-      return;
-    }
-
-    if (originHeader !== null) {
-      this.setCorsResponseHeaders(res, originHeader);
-    }
-
-    if (path !== MCP_ENDPOINT) {
+    if (url.pathname !== MCP_ENDPOINT) {
+      // Only /mcp is routed past the auth gate; everything else 404s as
+      // plain text (matches pre-#158 behaviour). The /health gate ran
+      // earlier in BaseHttpHost.dispatch.
       respond(res, 404, 'Not Found');
-      finalize(404);
-      return;
+      return 404;
     }
 
     this.inFlight += 1;
     try {
-      const status = await this.handleMcpRequest(req, res);
-      finalize(status);
+      return await this.handleMcpRequest(req, res, method);
     } catch (err) {
       logger.error(`[http] error handling ${method} /mcp: ${(err as Error).message}`);
       if (!res.headersSent) {
         respondJsonRpcError(res, 500, -32603, 'Internal Server Error');
       }
-      finalize(res.statusCode || 500);
+      return res.statusCode || 500;
     } finally {
       this.inFlight -= 1;
     }
   }
 
-  private handlePreflight(
-    req: http.IncomingMessage,
-    res: http.ServerResponse,
-    originHeader: string | null,
-    normalizedOrigin: string | null,
-  ): number {
-    if (originHeader === null || normalizedOrigin === null ||
-        !this.originAllowList.has(normalizedOrigin)) {
-      respond(res, 403, 'Origin not allowed');
-      return 403;
-    }
-    this.setCorsResponseHeaders(res, originHeader);
-    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS');
-    res.setHeader(
-      'Access-Control-Allow-Headers',
-      'Authorization, Content-Type, Mcp-Session-Id, Mcp-Protocol-Version, Last-Event-ID',
-    );
-    res.setHeader('Access-Control-Max-Age', '600');
-    res.writeHead(204).end();
-    return 204;
-  }
-
-  private handleHealth(method: string, res: http.ServerResponse): number {
-    if (method !== 'GET' && method !== 'HEAD') {
-      res.setHeader('Allow', 'GET, HEAD');
-      respond(res, 405, 'Method Not Allowed');
-      return 405;
-    }
-    const body = JSON.stringify({ status: 'ok' });
-    const buf = Buffer.from(body, 'utf8');
-    res.setHeader('Content-Type', 'application/json; charset=utf-8');
-    res.setHeader('Content-Length', String(buf.length));
-    res.setHeader('Cache-Control', 'no-store');
-    res.writeHead(200);
-    if (method === 'GET') {
-      res.end(buf);
-    } else {
-      res.end();
-    }
-    return 200;
-  }
-
   private async handleMcpRequest(
     req: http.IncomingMessage,
     res: http.ServerResponse,
+    method: string,
   ): Promise<number> {
-    const method = req.method ?? 'GET';
     if (method !== 'POST' && method !== 'GET' && method !== 'DELETE') {
       res.setHeader('Allow', 'GET, POST, DELETE');
       respondJsonRpcError(res, 405, -32000, 'Method not allowed.');
@@ -416,50 +217,12 @@ export class StreamableHttpHost {
     if (!entry) return;
     await this.closeEntry(sessionId, entry);
   }
-
-  private async closeEntry(sessionId: string, entry: SessionEntry): Promise<void> {
-    this.sessions.delete(sessionId);
-    try {
-      await entry.transport.close();
-    } catch (err) {
-      logger.warn(`[http] error closing transport: ${(err as Error).message}`);
-    }
-    try {
-      await entry.mcp.close();
-    } catch (err) {
-      logger.warn(`[http] error closing mcp: ${(err as Error).message}`);
-    }
-  }
-
-  private setCorsResponseHeaders(res: http.ServerResponse, origin: string): void {
-    res.setHeader('Access-Control-Allow-Origin', origin);
-    res.setHeader('Access-Control-Expose-Headers', 'Mcp-Session-Id');
-    res.setHeader('Vary', 'Origin');
-  }
-
-  private verifyBearer(authHeader: string | undefined): boolean {
-    if (!authHeader || !authHeader.startsWith('Bearer ')) {
-      return false;
-    }
-    if (this.authTokenBuf.length === 0) {
-      return false;
-    }
-    const provided = Buffer.from(authHeader.slice('Bearer '.length), 'latin1');
-    if (provided.length !== this.authTokenBuf.length) {
-      return false;
-    }
-    try {
-      return timingSafeEqual(provided, this.authTokenBuf);
-    } catch {
-      return false;
-    }
-  }
-
-  private writeAccessLog(entry: AccessLog): void {
-    const payload = JSON.stringify({ event: 'http_access', ...entry });
-    logger.info(payload);
-  }
 }
+
+// ---------------------------------------------------------------------------
+// HTTP-only helpers — JSON-RPC error envelope, session-id header parsing,
+// JSON body reader.
+// ---------------------------------------------------------------------------
 
 type SessionIdResult =
   | { kind: 'ok'; sessionId: string | null }
@@ -495,24 +258,6 @@ async function readJsonBody(req: http.IncomingMessage): Promise<unknown> {
     throw new Error('request body is empty');
   }
   return JSON.parse(raw);
-}
-
-function headerValue(value: string | string[] | undefined): string | null {
-  if (Array.isArray(value)) return value[0] ?? null;
-  return value ?? null;
-}
-
-function respond(res: http.ServerResponse, status: number, message: string): void {
-  if (res.headersSent) {
-    try {
-      res.end();
-    } catch {
-      // ignore
-    }
-    return;
-  }
-  res.writeHead(status, { 'Content-Type': 'text/plain; charset=utf-8' });
-  res.end(message);
 }
 
 function respondJsonRpcError(

--- a/src/transport/sse.ts
+++ b/src/transport/sse.ts
@@ -10,375 +10,102 @@
 //   POST /messages          per-session JSON-RPC POST (sessionId in query)
 //   OPTIONS *               CORS preflight against MCP_ALLOWED_ORIGINS
 //
-// Logging stays on the existing stderr-only logger to preserve the invariant
-// at src/logger.ts:16 (HTTP access lines never touch stdout).
+// Logging stays on the existing stderr-only logger to preserve the
+// invariant at src/logger.ts:16 (HTTP access lines never touch stdout).
+//
+// Issue #158 — most of the host (lifecycle, dispatch gates, auth, CORS,
+// notify fanout, access log) lives in `BaseHttpHost`; this file owns the
+// SSE-specific routing and the long-lived `GET /sse` handling that must
+// not increment `inFlight`.
 
 import * as http from 'node:http';
-import { Buffer } from 'node:buffer';
-import { timingSafeEqual } from 'node:crypto';
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
 
 import { logger } from '../logger.js';
-import { normalizeOrigin, type TransportConfig } from '../config.js';
+import {
+  BaseHttpHost,
+  type BaseHttpHostOptions,
+  respond,
+} from './base-http-host.js';
 
 const SSE_ENDPOINT = '/sse';
 const MESSAGES_ENDPOINT = '/messages';
-const HEALTH_ENDPOINT = '/health';
 
-const SHUTDOWN_DRAIN_DEADLINE_MS = 10_000;
-const SHUTDOWN_POLL_INTERVAL_MS = 50;
+export type SseHostOptions = BaseHttpHostOptions;
 
-export interface SseHostOptions {
-  config: TransportConfig;
-  createMcpServer: () => McpServer;
-}
-
-interface SessionEntry {
-  transport: SSEServerTransport;
-  mcp: McpServer;
-}
-
-type AccessLog = {
-  ts: string;
-  method: string;
-  path: string;
-  status: number;
-  duration_ms: number;
-  origin: string | null;
-  auth_present: boolean;
-};
-
-export class SseHost {
-  private readonly options: SseHostOptions;
-  private readonly sessions = new Map<string, SessionEntry>();
-  private readonly originAllowList: ReadonlySet<string>;
-  private readonly authTokenBuf: Buffer;
-  private server?: http.Server;
-  private inFlight = 0;
-  private shuttingDown = false;
-
-  constructor(options: SseHostOptions) {
-    this.options = options;
-    this.originAllowList = new Set(options.config.allowedOrigins);
-    // The auth token presence is enforced at config load time when transport
-    // is sse, so this branch should not fire — defensive fallback only.
-    // RFC 008 §6.3: compare as latin1 (1 byte == 1 codeunit) so an
-    // attacker-supplied `Authorization` header is not silently re-encoded via
-    // UTF-8 substitution (U+FFFD is 3 bytes and mutates length) before the
-    // constant-time compare.
-    const token = options.config.authToken ?? '';
-    this.authTokenBuf = Buffer.from(token, 'latin1');
+export class SseHost extends BaseHttpHost<SSEServerTransport> {
+  protected get logPrefix(): string {
+    return 'sse';
   }
 
-  /**
-   * Number of live SSE sessions. Read-only — the snapshot is intentionally
-   * narrower than a session-list export so callers cannot reach in to fan
-   * notifications out by hand. Use `notify(...)` for that.
-   */
-  get sessionCount(): number {
-    return this.sessions.size;
+  protected get bannerLabel(): string {
+    return 'SSE';
   }
 
-  /**
-   * Issue #157 step 4 — fan a warm-up logging notification out across every
-   * live session. The root `this.mcp` on `KnowledgeBaseServer` is never
-   * connected in SSE mode (every session has its own `McpServer` built via
-   * `createMcpServer`), so calling `sendLoggingMessage` on the root would
-   * silently drop the notification. The host owns the fanout: callers say
-   * "tell every session" and never see the session list.
-   *
-   * Per-session errors are swallowed at debug level so a single misbehaving
-   * client cannot poison the broadcast for the rest. Operating against a
-   * snapshot of the values map defends against `transport.onclose` deletes
-   * mid-iteration.
-   */
-  async notify(
-    level: 'info' | 'warning' | 'error',
-    logger_: string,
-    data: string,
-  ): Promise<void> {
-    const targets = [...this.sessions.values()].map((entry) => entry.mcp);
-    if (targets.length === 0) return;
-    await Promise.all(
-      targets.map(async (target) => {
-        try {
-          await target.sendLoggingMessage({ level, logger: logger_, data });
-        } catch (err) {
-          logger.debug(`[sse] notify error: ${(err as Error).message}`);
-        }
-      }),
-    );
+  protected corsAllowedMethods(): string {
+    return 'GET, POST, OPTIONS';
   }
 
-  async start(): Promise<http.Server> {
-    if (this.server) {
-      throw new Error('SseHost already started');
-    }
-    const server = http.createServer((req, res) => {
-      void this.dispatch(req, res);
-    });
-    server.on('clientError', (err, socket) => {
-      try {
-        socket.end('HTTP/1.1 400 Bad Request\r\n\r\n');
-      } catch {
-        // best-effort
-      }
-      logger.warn(`[sse] clientError: ${err.message}`);
-    });
-
-    await new Promise<void>((resolve, reject) => {
-      const onError = (err: Error) => {
-        server.removeListener('listening', onListening);
-        reject(err);
-      };
-      const onListening = () => {
-        server.removeListener('error', onError);
-        resolve();
-      };
-      server.once('error', onError);
-      server.once('listening', onListening);
-      server.listen(this.options.config.port, this.options.config.bindAddr);
-    });
-
-    this.server = server;
-    logger.info(
-      `Knowledge Base MCP server running on SSE at http://${this.options.config.bindAddr}:${this.options.config.port} ` +
-        `(allowed_origins=${this.options.config.allowedOrigins.length})`,
-    );
-    return server;
+  protected corsAllowedHeaders(): string {
+    return 'Authorization, Content-Type, Last-Event-ID';
   }
 
-  /**
-   * Graceful shutdown:
-   *   1. stop accepting new connections (server.close)
-   *   2. poll-wait in-flight POSTs for up to SHUTDOWN_DRAIN_DEADLINE_MS
-   *   3. close all active SSE sessions (transport.close + mcp.close)
-   */
-  async stop(): Promise<void> {
-    if (!this.server) return;
-    this.shuttingDown = true;
-
-    const server = this.server;
-    const closePromise = new Promise<void>((resolve) => {
-      server.close(() => resolve());
-    });
-
-    const deadline = Date.now() + SHUTDOWN_DRAIN_DEADLINE_MS;
-    while (this.inFlight > 0 && Date.now() < deadline) {
-      await new Promise((r) => setTimeout(r, SHUTDOWN_POLL_INTERVAL_MS));
-    }
-    if (this.inFlight > 0) {
-      logger.warn(
-        `[sse] shutdown drain exceeded ${SHUTDOWN_DRAIN_DEADLINE_MS}ms with ${this.inFlight} in-flight; forcing close`,
-      );
-    }
-
-    // Snapshot to defend against concurrent mutation via onclose deletes.
-    // transport.close() chains into Protocol._onclose, which nulls the
-    // protocol's _transport reference — so the subsequent mcp.close() call
-    // routes through Protocol.close → undefined?.close() = no-op. That keeps
-    // us safe from the recursion pitfall while still giving the SDK a chance
-    // to run any future cleanup that lives on McpServer rather than Protocol.
-    const live = [...this.sessions.values()];
-    for (const entry of live) {
-      try {
-        await entry.transport.close();
-      } catch (err) {
-        logger.warn(`[sse] error closing transport: ${(err as Error).message}`);
-      }
-      try {
-        await entry.mcp.close();
-      } catch (err) {
-        logger.warn(`[sse] error closing mcp: ${(err as Error).message}`);
-      }
-    }
-    this.sessions.clear();
-    await closePromise;
-    this.server = undefined;
-  }
-
-  // -------------------------------------------------------------------------
-  // Request dispatch
-  // -------------------------------------------------------------------------
-
-  private async dispatch(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
-    const startedAt = Date.now();
+  protected async handleAuthenticatedRequest(
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+    url: URL,
+  ): Promise<number> {
     const method = req.method ?? 'GET';
-    const url = new URL(req.url ?? '/', 'http://placeholder');
     const path = url.pathname;
-    const originHeader = headerValue(req.headers.origin);
-    // The stored allow-list is already normalized at config-parse time (see
-    // parseAllowedOrigins). Apply the same normalization to the incoming
-    // Origin before lookup so operator-friendly input like a trailing slash
-    // or mixed-case scheme still matches the browser-sent form. The raw
-    // header is kept for the access log and the CORS echo, because browsers
-    // compare Access-Control-Allow-Origin against their sent Origin byte-
-    // exactly.
-    const normalizedOrigin =
-      originHeader !== null ? normalizeOrigin(originHeader) : null;
-    const authPresent = Boolean(req.headers.authorization);
 
-    const finalize = (status: number) => {
-      this.writeAccessLog({
-        ts: new Date(startedAt).toISOString(),
-        method,
-        path,
-        status,
-        duration_ms: Date.now() - startedAt,
-        origin: originHeader,
-        auth_present: authPresent,
-      });
-    };
-
-    // 1. CORS preflight short-circuits before auth.
-    if (method === 'OPTIONS') {
-      const status = this.handlePreflight(req, res, originHeader, normalizedOrigin);
-      finalize(status);
-      return;
-    }
-
-    // 2. /health is unauthenticated and origin-unchecked.
-    if (path === HEALTH_ENDPOINT) {
-      const status = this.handleHealth(method, res);
-      finalize(status);
-      return;
-    }
-
-    // 3. Origin allow-list. Missing Origin is treated as a non-browser caller
-    //    and accepted; if Origin is present it must be in the allow-list
-    //    (after normalization).
-    if (normalizedOrigin !== null && !this.originAllowList.has(normalizedOrigin)) {
-      respond(res, 403, 'Origin not allowed');
-      finalize(403);
-      return;
-    }
-
-    // 4. Bearer-token auth.
-    if (!this.verifyBearer(req.headers.authorization)) {
-      res.setHeader('WWW-Authenticate', 'Bearer realm="knowledge-base-mcp"');
-      respond(res, 401, 'Unauthorized');
-      finalize(401);
-      return;
-    }
-
-    // 5. Shutdown gate — refuse new dispatch once stop() was called.
-    if (this.shuttingDown) {
-      res.setHeader('Retry-After', '0');
-      respond(res, 503, 'Shutting down');
-      finalize(503);
-      return;
-    }
-
-    // 6. Apply CORS response headers for accepted cross-origin calls.
-    if (originHeader !== null) {
-      this.setCorsResponseHeaders(res, originHeader);
-    }
-
-    // 7. Route by path.
     if (method === 'GET' && path === SSE_ENDPOINT) {
-      // SSE GET is long-lived; we do not increment inFlight (would block drain).
-      // Status logged immediately as 200; the SDK has already written headers
-      // by the time start() resolves.
+      // SSE GET is long-lived; we do NOT increment inFlight (would block
+      // drain). Status logged immediately as 200; the SDK has already
+      // written headers by the time start() resolves.
       try {
         await this.handleSseOpen(req, res);
-        finalize(200);
+        return 200;
       } catch (err) {
         logger.error(`[sse] error opening stream: ${(err as Error).message}`);
         if (!res.headersSent) {
           respond(res, 500, 'Error establishing SSE stream');
         }
-        finalize(500);
+        return 500;
       }
-      return;
     }
 
     if (method === 'POST' && path === MESSAGES_ENDPOINT) {
       this.inFlight += 1;
       try {
-        const status = await this.handleMessagePost(req, res, url);
-        finalize(status);
+        return await this.handleMessagePost(req, res, url);
       } catch (err) {
         logger.error(`[sse] error handling POST /messages: ${(err as Error).message}`);
         if (!res.headersSent) {
           respond(res, 500, 'Internal Server Error');
         }
-        finalize(res.statusCode || 500);
+        return res.statusCode || 500;
       } finally {
         this.inFlight -= 1;
       }
-      return;
     }
 
     respond(res, 404, 'Not Found');
-    finalize(404);
-  }
-
-  // -------------------------------------------------------------------------
-  // Endpoint handlers
-  // -------------------------------------------------------------------------
-
-  private handlePreflight(
-    req: http.IncomingMessage,
-    res: http.ServerResponse,
-    originHeader: string | null,
-    normalizedOrigin: string | null,
-  ): number {
-    // originHeader and normalizedOrigin are null together (see dispatch); this
-    // guard short-circuits both cases — including a preflight with no Origin
-    // header, which gets a 403.
-    if (originHeader === null || normalizedOrigin === null ||
-        !this.originAllowList.has(normalizedOrigin)) {
-      respond(res, 403, 'Origin not allowed');
-      return 403;
-    }
-    this.setCorsResponseHeaders(res, originHeader);
-    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
-    res.setHeader(
-      'Access-Control-Allow-Headers',
-      'Authorization, Content-Type, Last-Event-ID',
-    );
-    res.setHeader('Access-Control-Max-Age', '600');
-    res.writeHead(204).end();
-    return 204;
-  }
-
-  private handleHealth(method: string, res: http.ServerResponse): number {
-    if (method !== 'GET' && method !== 'HEAD') {
-      res.setHeader('Allow', 'GET, HEAD');
-      respond(res, 405, 'Method Not Allowed');
-      return 405;
-    }
-    // RFC 008 §6.8: /health is unauthenticated and origin-unchecked; it
-    // therefore must not leak any fingerprintable operator state (version,
-    // uptime, or file-system paths). Detailed status is available through
-    // the authenticated MCP channel.
-    const body = JSON.stringify({ status: 'ok' });
-    const buf = Buffer.from(body, 'utf8');
-    res.setHeader('Content-Type', 'application/json; charset=utf-8');
-    res.setHeader('Content-Length', String(buf.length));
-    res.setHeader('Cache-Control', 'no-store');
-    res.writeHead(200);
-    if (method === 'GET') {
-      res.end(buf);
-    } else {
-      res.end();
-    }
-    return 200;
+    return 404;
   }
 
   private async handleSseOpen(
-    req: http.IncomingMessage,
+    _req: http.IncomingMessage,
     res: http.ServerResponse,
   ): Promise<void> {
     const transport = new SSEServerTransport(MESSAGES_ENDPOINT, res);
     const mcp = this.options.createMcpServer();
     const sessionId = transport.sessionId;
-    // The SDK's Protocol.connect() chains additional handlers behind whatever
-    // we set here, so registering this *before* connect() preserves it. The
-    // handler must NOT call mcp.close(): Protocol.close() routes through
-    // transport.close() which re-fires onclose → infinite recursion. Map
-    // delete is idempotent, so multiple onclose firings are harmless.
+    // The SDK's Protocol.connect() chains additional handlers behind
+    // whatever we set here, so registering this *before* connect()
+    // preserves it. The handler must NOT call mcp.close(): Protocol.close()
+    // routes through transport.close() which re-fires onclose → infinite
+    // recursion. Map delete is idempotent, so multiple onclose firings are
+    // harmless.
     transport.onclose = () => {
       this.sessions.delete(sessionId);
     };
@@ -409,64 +136,4 @@ export class SseHost {
     await entry.transport.handlePostMessage(req, res);
     return res.statusCode || 202;
   }
-
-  // -------------------------------------------------------------------------
-  // Helpers
-  // -------------------------------------------------------------------------
-
-  private setCorsResponseHeaders(res: http.ServerResponse, origin: string): void {
-    res.setHeader('Access-Control-Allow-Origin', origin);
-    res.setHeader('Vary', 'Origin');
-  }
-
-  /**
-   * Constant-time bearer comparison. Length-mismatched tokens short-circuit
-   * (the Node crypto API throws on unequal-length inputs); the wrapper
-   * try/catch is belt-and-braces against a future refactor losing the
-   * length check.
-   */
-  private verifyBearer(authHeader: string | undefined): boolean {
-    if (!authHeader || !authHeader.startsWith('Bearer ')) {
-      return false;
-    }
-    if (this.authTokenBuf.length === 0) {
-      return false;
-    }
-    const provided = Buffer.from(authHeader.slice('Bearer '.length), 'latin1');
-    if (provided.length !== this.authTokenBuf.length) {
-      return false;
-    }
-    try {
-      return timingSafeEqual(provided, this.authTokenBuf);
-    } catch {
-      return false;
-    }
-  }
-
-  private writeAccessLog(entry: AccessLog): void {
-    // JSON.stringify escapes control characters in any user-controllable
-    // field (origin, path), so an adversarial header cannot break out of
-    // the log envelope.
-    const payload = JSON.stringify({ event: 'http_access', ...entry });
-    logger.info(payload);
-  }
 }
-
-function headerValue(value: string | string[] | undefined): string | null {
-  if (Array.isArray(value)) return value[0] ?? null;
-  return value ?? null;
-}
-
-function respond(res: http.ServerResponse, status: number, message: string): void {
-  if (res.headersSent) {
-    try {
-      res.end();
-    } catch {
-      // ignore
-    }
-    return;
-  }
-  res.writeHead(status, { 'Content-Type': 'text/plain; charset=utf-8' });
-  res.end(message);
-}
-


### PR DESCRIPTION
## Summary

Issue #158 — `src/transport/sse.ts` and `src/transport/http.ts` were ~70% byte-identical: same constructor, lifecycle (start/stop with drain), CORS preflight, /health, origin allow-list, bearer-token auth, shutdown gate, access logging, `sessionCount` + `notify` (added in #157 step 4), and per-session close. The two files diverged only at the path-routing step.

### New layout

- **`src/transport/base-http-host.ts`** (new) — `BaseHttpHost<TTransport>`:
  - Constructor + auth-token `Buffer` prep.
  - `start()` / `stop()` with drain + per-session close.
  - `dispatch()` pipeline up through the auth/shutdown gates.
  - `handlePreflight` + `handleHealth` (CORS bits parameterized by hooks).
  - `verifyBearer`, `writeAccessLog`.
  - `notify()`, `sessionCount`.
  - `closeEntry()` shared by both stop() loops.
  - Subclass hooks: `logPrefix`, `bannerLabel`, `corsAllowedMethods`, `corsAllowedHeaders`, `setExtraCorsResponseHeaders`, `handleAuthenticatedRequest`.
- **`src/transport/sse.ts`** (rewritten) — `SseHost extends BaseHttpHost<SSEServerTransport>`. Owns the `GET /sse` + `POST /messages` routing (long-lived `GET /sse` intentionally does NOT increment `inFlight`, which would block drain).
- **`src/transport/http.ts`** (rewritten) — `StreamableHttpHost extends BaseHttpHost<StreamableHTTPServerTransport>`. Owns `POST/GET/DELETE /mcp` routing, `Mcp-Session-Id` parsing, JSON body reading, and the JSON-RPC error envelope (HTTP-only).

### Sizes

| | before | after |
|---|---|---|
| `sse.ts` | 472 | 139 |
| `http.ts` | 538 | 283 |
| `base-http-host.ts` | — | 441 |
| **total** | **1010** | **863** |

Net **−147 lines (−15%)** AND no more parallel copies that drift.

### Behaviour preserved verbatim

- Same gate ordering (preflight → health → origin → bearer → shutdown → CORS-response → routing).
- Same response shapes for every gate (`403 Origin not allowed`, `401 WWW-Authenticate`, `503 + Retry-After`, plain-text `404` for unknown paths in both transports, JSON-RPC envelope only for `/mcp` routes).
- Same long-lived semantics (SSE `GET /sse` not counted in `inFlight`).
- Same access-log format and content.
- Same close-on-stop semantics + the snapshot-then-iterate defence against `transport.onclose` deletes mid-iteration.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 530/530 tests pass (25 suites)
- [x] Existing endpoint tests in `transport/sse.test.ts` (live HTTP roundtrips: health, auth, CORS, origin) and `transport/http.test.ts` (real MCP `Client` roundtrips: initialize, multi-session, disconnect cleanup) cover the full wire surface end-to-end
- [x] `sessionCount` + `notify` fanout tests (added in #157 step 4) still hold for both hosts
- [ ] Manual SSE + HTTP smoke against a real client — not done; the SDK-mediated tests already cover the wire path

Closes #158.

🤖 Generated with [Claude Code](https://claude.com/claude-code)