### PR TITLE
refactor(config): extract transport-config; trim grab-bag surface (#159)

### DIFF
--- a/src/KnowledgeBaseServer.ts
+++ b/src/KnowledgeBaseServer.ts
@@ -25,14 +25,16 @@ import {
   KNOWLEDGE_BASES_ROOT_DIR,
   LIST_KNOWLEDGE_BASES_DESCRIPTION,
   LIST_MODELS_DESCRIPTION,
-  loadTransportConfig,
   REINDEX_KNOWLEDGE_BASE_DESCRIPTION,
   REINDEX_TRIGGER_PATH,
   REINDEX_TRIGGER_POLL_MS,
   RETRIEVE_KNOWLEDGE_DESCRIPTION,
+} from './config.js';
+import {
+  loadTransportConfig,
   TransportConfigError,
   type TransportConfig,
-} from './config.js';
+} from './transport-config.js';
 import { formatRetrievalAsMarkdown } from './formatter.js';
 import {
   listKnowledgeBases,

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,5 @@
 import * as path from 'path';
 import * as os from 'os';
-import type { InferenceProviderOrPolicy } from '@huggingface/inference';
 
 export const KNOWLEDGE_BASES_ROOT_DIR = process.env.KNOWLEDGE_BASES_ROOT_DIR ||
   path.join(os.homedir(), 'knowledge_bases');
@@ -22,9 +21,11 @@ export const KB_ACTIVE_MODEL = process.env.KB_ACTIVE_MODEL || '';
 export const DEFAULT_HUGGINGFACE_MODEL_NAME = 'BAAI/bge-small-en-v1.5';
 export const HUGGINGFACE_MODEL_NAME = process.env.HUGGINGFACE_MODEL_NAME || DEFAULT_HUGGINGFACE_MODEL_NAME;
 export const DEFAULT_HUGGINGFACE_PROVIDER = 'hf-inference';
-export const HUGGINGFACE_PROVIDER = (
-  process.env.HUGGINGFACE_PROVIDER || DEFAULT_HUGGINGFACE_PROVIDER
-) as InferenceProviderOrPolicy;
+// Issue #159 — typed as plain `string` so consumers do not transitively
+// couple to `@huggingface/inference`'s `InferenceProviderOrPolicy`. The
+// SDK call site in `embedding-provider.ts` casts at the boundary.
+export const HUGGINGFACE_PROVIDER: string =
+  process.env.HUGGINGFACE_PROVIDER || DEFAULT_HUGGINGFACE_PROVIDER;
 const HUGGINGFACE_ENDPOINT_URL_OVERRIDE = process.env.HUGGINGFACE_ENDPOINT_URL?.trim();
 export const HUGGINGFACE_ENDPOINT_URL_OVERRIDDEN = Boolean(HUGGINGFACE_ENDPOINT_URL_OVERRIDE);
 
@@ -33,7 +34,7 @@ export const HUGGINGFACE_ENDPOINT_URL_OVERRIDDEN = Boolean(HUGGINGFACE_ENDPOINT_
 // Inference Providers router. Route feature-extraction calls through the
 // router by default; allow a full override via HUGGINGFACE_ENDPOINT_URL
 // for self-hosted or Inference Endpoints deployments.
-export function huggingFaceRouterUrl(model: string): string {
+function huggingFaceRouterUrl(model: string): string {
   return `https://router.huggingface.co/hf-inference/models/${model}/pipeline/feature-extraction`;
 }
 
@@ -124,6 +125,15 @@ const DEFAULT_REINDEX_TRIGGER_POLL_MS = 5000;
 const MIN_REINDEX_TRIGGER_POLL_MS = 1000;
 const MAX_REINDEX_TRIGGER_POLL_MS = 60000;
 
+/**
+ * @internal
+ *
+ * Exported only so `config.test.ts` can pin the parser semantics
+ * (default, sentinel, MIN/MAX clamp, scientific-notation acceptance)
+ * directly. Production code uses the resolved `REINDEX_TRIGGER_POLL_MS`
+ * constant below — no consumer outside the test file should import this
+ * function.
+ */
 export function parseReindexTriggerPollMs(raw: string | undefined): number {
   if (raw === undefined || raw.trim() === '') {
     return DEFAULT_REINDEX_TRIGGER_POLL_MS;
@@ -203,120 +213,7 @@ export const DELETE_DOCUMENT_DESCRIPTION =
 export const REINDEX_KNOWLEDGE_BASE_DESCRIPTION =
   'Forces the active model to fully rebuild its FAISS index from on-disk files, replacing the in-memory store and clearing orphan vectors left behind by prior delete_document calls. The rebuild always covers every KB because FAISS lacks per-vector deletion; passing knowledge_base_name is accepted (and recorded in the response) but does not narrow the rebuild scope.';
 
-// ---------------------------------------------------------------------------
-// Transport configuration (RFC 008: stdio + SSE + streamable HTTP).
-// ---------------------------------------------------------------------------
-
-export type McpTransport = 'stdio' | 'sse' | 'http';
-
-const VALID_TRANSPORTS: readonly McpTransport[] = ['stdio', 'sse', 'http'];
-
-export const DEFAULT_MCP_PORT = 8765;
-export const DEFAULT_MCP_BIND_ADDR = '127.0.0.1';
-
-export interface TransportConfig {
-  transport: McpTransport;
-  port: number;
-  bindAddr: string;
-  authToken?: string;
-  allowedOrigins: string[];
-}
-
-export class TransportConfigError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = 'TransportConfigError';
-  }
-}
-
-function parseTransport(raw: string | undefined): McpTransport {
-  if (raw === undefined || raw === '') {
-    return 'stdio';
-  }
-  if ((VALID_TRANSPORTS as readonly string[]).includes(raw)) {
-    return raw as McpTransport;
-  }
-  throw new TransportConfigError(
-    `Invalid MCP_TRANSPORT='${raw}'; expected one of ${VALID_TRANSPORTS.join('|')}`,
-  );
-}
-
-function parsePort(raw: string | undefined): number {
-  if (raw === undefined || raw === '') {
-    return DEFAULT_MCP_PORT;
-  }
-  const port = Number(raw);
-  if (!Number.isInteger(port) || port < 1 || port > 65535) {
-    throw new TransportConfigError(
-      `Invalid MCP_PORT='${raw}'; expected integer in [1, 65535]`,
-    );
-  }
-  return port;
-}
-
-/**
- * Normalize an origin string to the RFC 6454 form browsers actually send:
- * lowercased scheme + host, no path, no trailing slash. Non-default ports
- * are preserved (`:8080`); the WHATWG URL parser strips scheme-default ports
- * (`:443` on https, `:80` on http), matching browser behavior.
- * Accepts operator-friendly input like "HTTPS://App.EXAMPLE.com:8080/".
- *
- * Falls back to a plain `toLowerCase()` on strings the WHATWG URL parser
- * rejects (e.g. missing scheme). A malformed stored entry will then never
- * match a browser-sent Origin and silently behave as "deny" — which is the
- * safe direction for an allow-list. Tightening this into a hard reject is
- * tracked separately in #77's issue body.
- */
-export function normalizeOrigin(origin: string): string {
-  const trimmed = origin.endsWith('/') ? origin.slice(0, -1) : origin;
-  try {
-    const url = new URL(trimmed);
-    return `${url.protocol}//${url.host}`;
-  } catch {
-    return trimmed.toLowerCase();
-  }
-}
-
-function parseAllowedOrigins(raw: string | undefined): string[] {
-  if (raw === undefined || raw.trim() === '') {
-    return [];
-  }
-  if (raw.trim() === '*') {
-    throw new TransportConfigError(
-      "MCP_ALLOWED_ORIGINS='*' is rejected; list explicit origins (see RFC 008 §6.4 / §7.6)",
-    );
-  }
-  return raw
-    .split(',')
-    .map((entry) => entry.trim())
-    .filter((entry) => entry.length > 0)
-    .map((entry) => normalizeOrigin(entry));
-}
-
-export function loadTransportConfig(env: NodeJS.ProcessEnv = process.env): TransportConfig {
-  const transport = parseTransport(env.MCP_TRANSPORT);
-  const port = parsePort(env.MCP_PORT);
-  const bindAddr = env.MCP_BIND_ADDR && env.MCP_BIND_ADDR.length > 0
-    ? env.MCP_BIND_ADDR
-    : DEFAULT_MCP_BIND_ADDR;
-  const authToken = env.MCP_AUTH_TOKEN;
-  const allowedOrigins = parseAllowedOrigins(env.MCP_ALLOWED_ORIGINS);
-
-  if (transport === 'sse' || transport === 'http') {
-    if (!authToken || authToken.length === 0) {
-      throw new TransportConfigError(
-        `MCP_TRANSPORT=${transport} requires MCP_AUTH_TOKEN to be set (generate with: openssl rand -base64 32)`,
-      );
-    }
-    // RFC 008 §6.1 / §8.1 R3: tokens shorter than 32 chars are rejected at
-    // startup so operators cannot unintentionally deploy a brute-forceable
-    // secret even if generation tooling truncates.
-    if (authToken.length < 32) {
-      throw new TransportConfigError(
-        'MCP_AUTH_TOKEN must be at least 32 characters (generate with: openssl rand -base64 32)',
-      );
-    }
-  }
-
-  return { transport, port, bindAddr, authToken, allowedOrigins };
-}
+// Transport configuration (RFC 008) moved to `src/transport-config.ts`
+// in issue #159 — `KnowledgeBaseServer.run`, `transport/sse.ts`,
+// `transport/http.ts`, and `transport/base-http-host.ts` import it
+// directly.

--- a/src/embedding-provider.ts
+++ b/src/embedding-provider.ts
@@ -6,6 +6,7 @@
 // `import type` is erased by tsc, so the union type is preserved without any
 // runtime require/resolve of the unused provider's tree.
 import type { HuggingFaceInferenceEmbeddings } from '@langchain/community/embeddings/hf';
+import type { InferenceProviderOrPolicy } from '@huggingface/inference';
 import type { OllamaEmbeddings } from '@langchain/ollama';
 import type { OpenAIEmbeddings } from '@langchain/openai';
 import {
@@ -87,6 +88,12 @@ export async function createEmbeddingsClient(
     apiKey: huggingFaceApiKey,
     model: modelName,
     endpointUrl,
-    provider: HUGGINGFACE_ENDPOINT_URL_OVERRIDDEN ? undefined : HUGGINGFACE_PROVIDER,
+    // Issue #159 — HUGGINGFACE_PROVIDER is typed as plain `string` so
+    // `config.ts` doesn't leak `@huggingface/inference`'s
+    // `InferenceProviderOrPolicy` to other modules. Cast at this boundary
+    // — the SDK is the right home for its own type knowledge.
+    provider: HUGGINGFACE_ENDPOINT_URL_OVERRIDDEN
+      ? undefined
+      : (HUGGINGFACE_PROVIDER as InferenceProviderOrPolicy),
   });
 }

--- a/src/transport-config.ts
+++ b/src/transport-config.ts
@@ -1,0 +1,122 @@
+// src/transport-config.ts
+//
+// RFC 008 — MCP transport selection + per-transport config (stdio, SSE,
+// streamable HTTP). Extracted out of `src/config.ts` (issue #159) so the
+// transport types/loader form a coherent module instead of one face of a
+// 40-export grab-bag. `KnowledgeBaseServer.run`, `transport/sse.ts`, and
+// `transport/http.ts` import directly from here; nothing in `config.ts`
+// depends on this file.
+
+export type McpTransport = 'stdio' | 'sse' | 'http';
+
+const VALID_TRANSPORTS: readonly McpTransport[] = ['stdio', 'sse', 'http'];
+
+export const DEFAULT_MCP_PORT = 8765;
+export const DEFAULT_MCP_BIND_ADDR = '127.0.0.1';
+
+export interface TransportConfig {
+  transport: McpTransport;
+  port: number;
+  bindAddr: string;
+  authToken?: string;
+  allowedOrigins: string[];
+}
+
+export class TransportConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'TransportConfigError';
+  }
+}
+
+function parseTransport(raw: string | undefined): McpTransport {
+  if (raw === undefined || raw === '') {
+    return 'stdio';
+  }
+  if ((VALID_TRANSPORTS as readonly string[]).includes(raw)) {
+    return raw as McpTransport;
+  }
+  throw new TransportConfigError(
+    `Invalid MCP_TRANSPORT='${raw}'; expected one of ${VALID_TRANSPORTS.join('|')}`,
+  );
+}
+
+function parsePort(raw: string | undefined): number {
+  if (raw === undefined || raw === '') {
+    return DEFAULT_MCP_PORT;
+  }
+  const port = Number(raw);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new TransportConfigError(
+      `Invalid MCP_PORT='${raw}'; expected integer in [1, 65535]`,
+    );
+  }
+  return port;
+}
+
+/**
+ * Normalize an origin string to the RFC 6454 form browsers actually send:
+ * lowercased scheme + host, no path, no trailing slash. Non-default ports
+ * are preserved (`:8080`); the WHATWG URL parser strips scheme-default ports
+ * (`:443` on https, `:80` on http), matching browser behavior.
+ * Accepts operator-friendly input like "HTTPS://App.EXAMPLE.com:8080/".
+ *
+ * Falls back to a plain `toLowerCase()` on strings the WHATWG URL parser
+ * rejects (e.g. missing scheme). A malformed stored entry will then never
+ * match a browser-sent Origin and silently behave as "deny" — which is the
+ * safe direction for an allow-list. Tightening this into a hard reject is
+ * tracked separately in #77's issue body.
+ */
+export function normalizeOrigin(origin: string): string {
+  const trimmed = origin.endsWith('/') ? origin.slice(0, -1) : origin;
+  try {
+    const url = new URL(trimmed);
+    return `${url.protocol}//${url.host}`;
+  } catch {
+    return trimmed.toLowerCase();
+  }
+}
+
+function parseAllowedOrigins(raw: string | undefined): string[] {
+  if (raw === undefined || raw.trim() === '') {
+    return [];
+  }
+  if (raw.trim() === '*') {
+    throw new TransportConfigError(
+      "MCP_ALLOWED_ORIGINS='*' is rejected; list explicit origins (see RFC 008 §6.4 / §7.6)",
+    );
+  }
+  return raw
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0)
+    .map((entry) => normalizeOrigin(entry));
+}
+
+export function loadTransportConfig(env: NodeJS.ProcessEnv = process.env): TransportConfig {
+  const transport = parseTransport(env.MCP_TRANSPORT);
+  const port = parsePort(env.MCP_PORT);
+  const bindAddr = env.MCP_BIND_ADDR && env.MCP_BIND_ADDR.length > 0
+    ? env.MCP_BIND_ADDR
+    : DEFAULT_MCP_BIND_ADDR;
+  const authToken = env.MCP_AUTH_TOKEN;
+  const allowedOrigins = parseAllowedOrigins(env.MCP_ALLOWED_ORIGINS);
+
+  if (transport === 'sse' || transport === 'http') {
+    if (!authToken || authToken.length === 0) {
+      throw new TransportConfigError(
+        `MCP_TRANSPORT=${transport} requires MCP_AUTH_TOKEN to be set (generate with: openssl rand -base64 32)`,
+      );
+    }
+    // RFC 008 §6.1 / §8.1 R3: tokens shorter than 32 chars are rejected at
+    // startup so operators cannot unintentionally deploy a brute-forceable
+    // secret even if generation tooling truncates.
+    if (authToken.length < 32) {
+      throw new TransportConfigError(
+        'MCP_AUTH_TOKEN must be at least 32 characters (generate with: openssl rand -base64 32)',
+      );
+    }
+  }
+
+  return { transport, port, bindAddr, authToken, allowedOrigins };
+}

--- a/src/transport/base-http-host.ts
+++ b/src/transport/base-http-host.ts
@@ -22,7 +22,7 @@ import { Buffer } from 'node:buffer';
 import { timingSafeEqual } from 'node:crypto';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
-import { normalizeOrigin, type TransportConfig } from '../config.js';
+import { normalizeOrigin, type TransportConfig } from '../transport-config.js';
 import { logger } from '../logger.js';
 
 const HEALTH_ENDPOINT = '/health';

--- a/src/transport/sse.test.ts
+++ b/src/transport/sse.test.ts
@@ -18,7 +18,7 @@ import {
   loadTransportConfig,
   TransportConfigError,
   DEFAULT_MCP_PORT,
-} from '../config.js';
+} from '../transport-config.js';
 import { SseHost } from './sse.js';
 
 const VALID_TOKEN = 'a-very-secret-token-for-test-use-only';


### PR DESCRIPTION
## Summary

Issue #159 — `src/config.ts` was a 322-line, 40-export grab-bag mixing five unrelated concerns AND leaking `@huggingface/inference`'s `InferenceProviderOrPolicy` type to every consumer of `HUGGINGFACE_PROVIDER`. Three independent changes land in one PR:

### Step 1 — extract `src/transport-config.ts`

Move the entire RFC 008 transport block out of `config.ts`:

| Symbol | Was | Now |
|---|---|---|
| `McpTransport`, `DEFAULT_MCP_PORT`, `DEFAULT_MCP_BIND_ADDR`, `TransportConfig`, `TransportConfigError`, `loadTransportConfig`, `normalizeOrigin` | `./config.js` | `./transport-config.js` |
| `parseTransport`, `parsePort`, `parseAllowedOrigins` (private helpers) | `./config.js` | `./transport-config.js` |

Consumers updated: `KnowledgeBaseServer.ts` (splits its config imports across the two modules), `transport/base-http-host.ts`, `transport/sse.test.ts`.

### Step 2 — trim the public surface

- **`huggingFaceRouterUrl`** — unexported (`function` not `export function`). Zero external consumers; only used internally by `HUGGINGFACE_ENDPOINT_URL`'s default.
- **`parseReindexTriggerPollMs`** — kept exported but marked `@internal` via JSDoc. It's exported only so `config.test.ts` can pin parser semantics (default, sentinel, MIN/MAX clamp, scientific-notation accept). Every production caller uses the resolved `REINDEX_TRIGGER_POLL_MS` constant.

### Step 3 — stop the SDK type leak

- Re-type **`HUGGINGFACE_PROVIDER`** from `InferenceProviderOrPolicy` → plain `string`. Drop the `@huggingface/inference` type import from `config.ts` entirely.
- Cast at the boundary in `embedding-provider.ts` (the only call site that needs the SDK shape) — `HUGGINGFACE_PROVIDER as InferenceProviderOrPolicy`. The matching `import type` moves there too, which is its legitimate home.

### Sizes

| | before | after |
|---|---|---|
| `src/config.ts` | 322 | **219** (−103) |
| `src/transport-config.ts` | — | 122 (new) |

### Behaviour preserved

- Every transport-config error wording is unchanged.
- The pre-#159 `HUGGINGFACE_PROVIDER`-typed call site behaves identically; only the module-boundary type tightens.
- `parseReindexTriggerPollMs` stays exported (the JSDoc tag is advisory; tests still import it directly).

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 530/530 tests pass (25 suites)
- [x] `transport/sse.test.ts` continues to exercise the full `loadTransportConfig` validation matrix (missing token under `MCP_TRANSPORT=sse`, short-token reject, port range, `MCP_ALLOWED_ORIGINS=*` reject) through its new import path
- [ ] Manual `kb` startup with `MCP_TRANSPORT=sse` + `MCP_AUTH_TOKEN` set — not done; the validation cases above already cover the env wiring

Closes #159.

🤖 Generated with [Claude Code](https://claude.com/claude-code)