### PR TITLE
feat: improve kb search freshness lock output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased] — `kb search` scoped freshness and lock errors
+
+### Changed
+
+- **`kb search --kb=<name>` now reports freshness for the selected KB separately from global index drift.** JSON output keeps the existing top-level `stale`, `modified_files`, and `new_files` fields as the effective search scope, and adds `global_*` plus `scope` fields so agents can distinguish "this scoped search is current" from "other KBs still have drift." Markdown output mirrors the distinction in the freshness footer.
+- **Refresh-lock contention now has agent-friendly output.** When `kb search --refresh --format=json` cannot acquire the write lock, it emits a parseable `{error: {code: "REFRESH_LOCK_BUSY", ...}}` payload instead of only surfacing the raw lockfile message. Human-mode stderr includes retry guidance and the lock path. Closes #181.
+
 ## [Unreleased] — CLI `kb remember` semantic preflight (default ON)
 
 ### Added

--- a/src/cli-search.test.ts
+++ b/src/cli-search.test.ts
@@ -2,10 +2,13 @@ import { describe, expect, it } from '@jest/globals';
 import {
   AutoThresholdDecision,
   computeAutoThreshold,
+  formatLockContentionJson,
+  formatLockContentionStderr,
   formatAutoThresholdHeader,
   formatFreshnessFooter,
   Staleness,
 } from './cli-search.js';
+import { WriteLockContentionError } from './write-lock.js';
 
 const MTIME = '2026-05-03T15:33:56.964Z';
 
@@ -48,6 +51,77 @@ describe('formatFreshnessFooter', () => {
     expect(formatFreshnessFooter(s, false)).toBe(
       `> _Index may be stale: 2 modified, 5 new file(s) since ${MTIME}. Run \`kb search --refresh\` to update._`,
     );
+  });
+
+  it('reports scoped stale counts separately from global counts', () => {
+    const s: Staleness = {
+      indexMtime: MTIME,
+      modifiedFiles: 0,
+      newFiles: 0,
+      scope: { kb: 'agent-task-lessons', modifiedFiles: 0, newFiles: 0 },
+      global: { modifiedFiles: 2, newFiles: 2016 },
+    };
+    expect(formatFreshnessFooter(s, false)).toBe(
+      `> _Index up-to-date for KB "agent-task-lessons" as of ${MTIME}. Global index drift outside this scope: 2 modified, 2016 new file(s)._`,
+    );
+  });
+
+  it('keeps scoped stale guidance scoped to the selected KB', () => {
+    const s: Staleness = {
+      indexMtime: MTIME,
+      modifiedFiles: 1,
+      newFiles: 3,
+      scope: { kb: 'agent-task-lessons', modifiedFiles: 1, newFiles: 3 },
+      global: { modifiedFiles: 7, newFiles: 11 },
+    };
+    expect(formatFreshnessFooter(s, false)).toBe(
+      `> _Index may be stale for KB "agent-task-lessons": 1 modified, 3 new file(s) since ${MTIME}. Run \`kb search --kb=agent-task-lessons --refresh\` to update this scope. Global index drift: 7 modified, 11 new file(s)._`,
+    );
+  });
+
+  it('reports scoped refreshes without hiding global drift', () => {
+    const s: Staleness = {
+      indexMtime: MTIME,
+      modifiedFiles: 0,
+      newFiles: 0,
+      scope: { kb: 'agent-task-lessons', modifiedFiles: 0, newFiles: 0 },
+      global: { modifiedFiles: 0, newFiles: 2016 },
+    };
+    expect(formatFreshnessFooter(s, true)).toBe(
+      `> _Index refreshed for KB "agent-task-lessons" at ${MTIME}. Global index drift outside this scope: 0 modified, 2016 new file(s)._`,
+    );
+  });
+});
+
+describe('lock contention output', () => {
+  it('emits parseable JSON for --format=json callers', () => {
+    const err = new WriteLockContentionError({
+      resource: '/tmp/model',
+      lockPath: '/tmp/model/.kb-write.lock',
+      causeMessage: 'Lock file is already being held',
+    });
+    const parsed = JSON.parse(formatLockContentionJson(err));
+    expect(parsed).toEqual({
+      error: {
+        code: 'REFRESH_LOCK_BUSY',
+        message: 'Refresh lock is already held for this model. Retry after the current refresh finishes.',
+        lock_path: '/tmp/model/.kb-write.lock',
+        resource: '/tmp/model',
+        retry_hint: 'Retry in a few seconds; only one kb search --refresh writer may run per model at a time.',
+      },
+    });
+  });
+
+  it('prints retry guidance for human-mode stderr', () => {
+    const err = new WriteLockContentionError({
+      resource: '/tmp/model',
+      lockPath: '/tmp/model/.kb-write.lock',
+      causeMessage: 'Lock file is already being held',
+    });
+    const out = formatLockContentionStderr(err);
+    expect(out).toContain('refresh lock is busy');
+    expect(out).toContain('Retry in a few seconds');
+    expect(out).toContain('/tmp/model/.kb-write.lock');
   });
 });
 

--- a/src/cli-search.ts
+++ b/src/cli-search.ts
@@ -12,7 +12,7 @@ import {
 } from './config.js';
 import { formatRetrievalAsJson, formatRetrievalAsMarkdown } from './formatter.js';
 import { enumerateIngestableKbFiles, listKnowledgeBases } from './kb-fs.js';
-import { withWriteLock } from './write-lock.js';
+import { withWriteLock, WriteLockContentionError } from './write-lock.js';
 import { loadManagerForModel, loadWithJsonRetry } from './cli-shared.js';
 
 interface SearchArgs {
@@ -31,6 +31,17 @@ export interface Staleness {
   indexMtime: string | null;
   modifiedFiles: number;
   newFiles: number;
+  scope?: StalenessScope;
+  global?: StalenessCounts;
+}
+
+export interface StalenessCounts {
+  modifiedFiles: number;
+  newFiles: number;
+}
+
+export interface StalenessScope extends StalenessCounts {
+  kb: string;
 }
 
 export interface AutoThresholdDecision {
@@ -96,6 +107,14 @@ export async function runSearch(rest: string[]): Promise<number> {
       await loadWithJsonRetry(manager);
     }
   } catch (err) {
+    if (err instanceof WriteLockContentionError) {
+      if (parsed.format === 'json') {
+        process.stdout.write(formatLockContentionJson(err));
+      } else {
+        process.stderr.write(formatLockContentionStderr(err));
+      }
+      return 1;
+    }
     process.stderr.write(`kb search: ${(err as Error).message}\n`);
     return 1;
   }
@@ -125,16 +144,45 @@ export async function runSearch(rest: string[]): Promise<number> {
     return 1;
   }
 
-  const staleness = await computeStaleness(activeModelId);
+  const staleness = await computeStaleness(activeModelId, parsed.kb);
 
   if (parsed.format === 'json') {
     const body = formatRetrievalAsJson(results, FRONTMATTER_EXTRAS_WIRE_VISIBLE);
+    const effectiveCounts = parsed.refresh
+      ? { modifiedFiles: 0, newFiles: 0 }
+      : { modifiedFiles: staleness.modifiedFiles, newFiles: staleness.newFiles };
+    const globalCounts = staleness.global ?? {
+      modifiedFiles: staleness.modifiedFiles,
+      newFiles: staleness.newFiles,
+    };
+    const scopedCounts = staleness.scope
+      ? {
+          modifiedFiles: parsed.refresh ? 0 : staleness.scope.modifiedFiles,
+          newFiles: parsed.refresh ? 0 : staleness.scope.newFiles,
+        }
+      : null;
+    const globalCountsForPayload = parsed.refresh && !parsed.kb
+      ? { modifiedFiles: 0, newFiles: 0 }
+      : globalCounts;
     const payload = {
       results: body,
       index_mtime: staleness.indexMtime,
-      stale: parsed.refresh ? false : staleness.modifiedFiles + staleness.newFiles > 0,
-      modified_files: parsed.refresh ? 0 : staleness.modifiedFiles,
-      new_files: parsed.refresh ? 0 : staleness.newFiles,
+      stale: hasStaleCounts(effectiveCounts),
+      modified_files: effectiveCounts.modifiedFiles,
+      new_files: effectiveCounts.newFiles,
+      global_stale: hasStaleCounts(globalCountsForPayload),
+      global_modified_files: globalCountsForPayload.modifiedFiles,
+      global_new_files: globalCountsForPayload.newFiles,
+      ...(staleness.scope && scopedCounts
+        ? {
+            scope: {
+              kb: staleness.scope.kb,
+              stale: hasStaleCounts(scopedCounts),
+              modified_files: scopedCounts.modifiedFiles,
+              new_files: scopedCounts.newFiles,
+            },
+          }
+        : {}),
       ...(autoDecision !== null
         ? {
             auto_threshold: {
@@ -199,60 +247,104 @@ function parseSearchArgs(rest: string[]): SearchArgs {
   return out;
 }
 
-async function computeStaleness(modelId: string): Promise<Staleness> {
+export async function computeStaleness(modelId: string, scopedKb?: string): Promise<Staleness> {
   const binaryPath = await resolveFaissIndexBinaryPath(modelId);
   if (binaryPath === null) {
-    return { indexMtime: null, modifiedFiles: 0, newFiles: 0 };
+    return emptyStaleness(null, scopedKb);
   }
   let indexStat;
   try {
     indexStat = await fsp.stat(binaryPath);
   } catch {
-    return { indexMtime: null, modifiedFiles: 0, newFiles: 0 };
+    return emptyStaleness(null, scopedKb);
   }
   const indexMtimeMs = indexStat.mtimeMs;
   const indexMtime = new Date(indexMtimeMs).toISOString();
 
-  let modified = 0;
-  let added = 0;
   let kbs: string[];
   try {
     kbs = await listKnowledgeBases(KNOWLEDGE_BASES_ROOT_DIR);
   } catch {
-    return { indexMtime, modifiedFiles: 0, newFiles: 0 };
+    return emptyStaleness(indexMtime, scopedKb);
   }
 
   const enumerations = await enumerateIngestableKbFiles(KNOWLEDGE_BASES_ROOT_DIR, kbs);
+  const global = await countStaleness(enumerations, indexMtimeMs);
+  if (!scopedKb) {
+    return { indexMtime, modifiedFiles: global.modifiedFiles, newFiles: global.newFiles };
+  }
 
+  const scopedEnumeration = enumerations.filter((entry) => entry.kbName === scopedKb);
+  const scopeCounts = await countStaleness(scopedEnumeration, indexMtimeMs);
+  return {
+    indexMtime,
+    modifiedFiles: scopeCounts.modifiedFiles,
+    newFiles: scopeCounts.newFiles,
+    scope: { kb: scopedKb, ...scopeCounts },
+    global,
+  };
+}
+
+async function countStaleness(
+  enumerations: Awaited<ReturnType<typeof enumerateIngestableKbFiles>>,
+  indexMtimeMs: number,
+): Promise<StalenessCounts> {
+  let modifiedFiles = 0;
+  let newFiles = 0;
   for (const { kbPath, filePaths } of enumerations) {
-    for (const f of filePaths) {
+    for (const filePath of filePaths) {
       try {
-        const st = await fsp.stat(f);
-        if (st.mtimeMs > indexMtimeMs) modified += 1;
+        const st = await fsp.stat(filePath);
+        if (st.mtimeMs > indexMtimeMs) modifiedFiles += 1;
       } catch {
         // file vanished between the walker and stat; ignore it
       }
     }
 
-    const sidecarDir = path.join(kbPath, '.index');
-    let sidecarCount = 0;
-    try {
-      const sidecars = await fsp.readdir(sidecarDir);
-      sidecarCount = sidecars.length;
-    } catch {
-      // .index missing; count difference below covers this case
-    }
+    const sidecarCount = await countSidecarFiles(path.join(kbPath, '.index'));
     if (filePaths.length > sidecarCount) {
-      added += filePaths.length - sidecarCount;
+      newFiles += filePaths.length - sidecarCount;
     }
   }
+  return { modifiedFiles, newFiles };
+}
 
-  return { indexMtime, modifiedFiles: modified, newFiles: added };
+async function countSidecarFiles(dir: string): Promise<number> {
+  let entries;
+  try {
+    entries = await fsp.readdir(dir, { withFileTypes: true });
+  } catch {
+    return 0;
+  }
+  let count = 0;
+  for (const entry of entries) {
+    const entryPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      count += await countSidecarFiles(entryPath);
+    } else if (entry.isFile()) {
+      count += 1;
+    }
+  }
+  return count;
+}
+
+function emptyStaleness(indexMtime: string | null, scopedKb?: string): Staleness {
+  if (!scopedKb) return { indexMtime, modifiedFiles: 0, newFiles: 0 };
+  return {
+    indexMtime,
+    modifiedFiles: 0,
+    newFiles: 0,
+    scope: { kb: scopedKb, modifiedFiles: 0, newFiles: 0 },
+    global: { modifiedFiles: 0, newFiles: 0 },
+  };
 }
 
 export function formatFreshnessFooter(s: Staleness, refreshed: boolean): string {
   if (s.indexMtime === null) {
     return `> _Index not yet built. Run \`kb search --refresh\` to create it._`;
+  }
+  if (s.scope) {
+    return formatScopedFreshnessFooter(s, refreshed);
   }
   if (refreshed) {
     return `> _Index refreshed at ${s.indexMtime}._`;
@@ -269,6 +361,53 @@ export function formatFreshnessFooter(s: Staleness, refreshed: boolean): string 
   return (
     `> _Index may be stale: ${s.modifiedFiles} modified, ${s.newFiles} new ` +
     `file(s) since ${s.indexMtime}. Run \`kb search --refresh\` to update._`
+  );
+}
+
+function formatScopedFreshnessFooter(s: Staleness, refreshed: boolean): string {
+  const scope = s.scope!;
+  const global = s.global ?? { modifiedFiles: s.modifiedFiles, newFiles: s.newFiles };
+  const globalText = `${global.modifiedFiles} modified, ${global.newFiles} new file(s)`;
+  if (refreshed) {
+    if (global.modifiedFiles === 0 && global.newFiles === 0) {
+      return `> _Index refreshed for KB "${scope.kb}" at ${s.indexMtime}; global index drift is also 0 modified, 0 new file(s)._`;
+    }
+    return `> _Index refreshed for KB "${scope.kb}" at ${s.indexMtime}. Global index drift outside this scope: ${globalText}._`;
+  }
+  if (scope.modifiedFiles === 0 && scope.newFiles === 0) {
+    if (global.modifiedFiles === 0 && global.newFiles === 0) {
+      return `> _Index up-to-date for KB "${scope.kb}" as of ${s.indexMtime}; global index drift is also 0 modified, 0 new file(s)._`;
+    }
+    return `> _Index up-to-date for KB "${scope.kb}" as of ${s.indexMtime}. Global index drift outside this scope: ${globalText}._`;
+  }
+  return (
+    `> _Index may be stale for KB "${scope.kb}": ${scope.modifiedFiles} modified, ${scope.newFiles} new ` +
+    `file(s) since ${s.indexMtime}. Run \`kb search --kb=${scope.kb} --refresh\` to update this scope. ` +
+    `Global index drift: ${globalText}._`
+  );
+}
+
+function hasStaleCounts(counts: StalenessCounts): boolean {
+  return counts.modifiedFiles + counts.newFiles > 0;
+}
+
+export function formatLockContentionJson(err: WriteLockContentionError): string {
+  return `${JSON.stringify({
+    error: {
+      code: err.code,
+      message: err.message,
+      lock_path: err.lockPath,
+      resource: err.resource,
+      retry_hint: 'Retry in a few seconds; only one kb search --refresh writer may run per model at a time.',
+    },
+  }, null, 2)}\n`;
+}
+
+export function formatLockContentionStderr(err: WriteLockContentionError): string {
+  return (
+    `kb search: refresh lock is busy for this model. Retry in a few seconds; ` +
+    `only one \`kb search --refresh\` writer may run per model at a time. ` +
+    `Lock: ${err.lockPath}\n`
   );
 }
 

--- a/src/write-lock.test.ts
+++ b/src/write-lock.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals
 import * as fsp from 'fs/promises';
 import * as os from 'os';
 import * as path from 'path';
+import * as properLockfile from 'proper-lockfile';
 
 // All env state is read at module load by config.ts → so each test resets
 // modules and re-imports write-lock.ts after setting env. Pattern matches
@@ -77,6 +78,25 @@ describe('withWriteLock', () => {
 
     // No stranded lock.
     await expect(fsp.stat(lockPath)).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('surfaces exhausted contention as a structured error', async () => {
+    jest.resetModules();
+    const { withWriteLock, WriteLockContentionError } = await import('./write-lock.js');
+
+    const release = await properLockfile.lock(tempDir, { lockfilePath: lockPath });
+    try {
+      await expect(withWriteLock(tempDir, async () => undefined))
+        .rejects.toMatchObject({
+          code: 'REFRESH_LOCK_BUSY',
+          lockPath,
+          resource: tempDir,
+        });
+      await expect(withWriteLock(tempDir, async () => undefined))
+        .rejects.toBeInstanceOf(WriteLockContentionError);
+    } finally {
+      await release();
+    }
   });
 
   it('isolates per-resource: two different resources do not contend (RFC 013 M1+M2 prep)', async () => {

--- a/src/write-lock.ts
+++ b/src/write-lock.ts
@@ -37,6 +37,31 @@ const SIDECAR_LOCK_OPTS_BASE: Omit<properLockfile.LockOptions, 'lockfilePath'> =
   retries: { retries: 10, factor: 1.5, minTimeout: 50, maxTimeout: 500 },
 };
 
+export class WriteLockContentionError extends Error {
+  readonly code = 'REFRESH_LOCK_BUSY';
+  readonly resource: string;
+  readonly lockPath: string;
+  readonly causeMessage: string;
+
+  constructor(opts: { resource: string; lockPath: string; causeMessage: string }) {
+    super('Refresh lock is already held for this model. Retry after the current refresh finishes.');
+    this.name = 'WriteLockContentionError';
+    this.resource = opts.resource;
+    this.lockPath = opts.lockPath;
+    this.causeMessage = opts.causeMessage;
+  }
+}
+
+function isLockContentionError(err: unknown): boolean {
+  const code = (err as { code?: unknown })?.code;
+  const message = (err as Error)?.message ?? '';
+  return (
+    code === 'ELOCKED' ||
+    /Lock file is already being held/i.test(message) ||
+    /exceeded.*lock/i.test(message)
+  );
+}
+
 /**
  * Acquire the write lock on `resource`, run `fn`, release the lock. The
  * lock is held for exactly the duration of `fn` — not longer.
@@ -53,10 +78,22 @@ export async function withWriteLock<T>(resource: string, fn: () => Promise<T>): 
   await fsp.mkdir(resource, { recursive: true });
 
   const lockfilePath = path.join(resource, '.kb-write.lock');
-  const release = await properLockfile.lock(resource, {
-    ...WRITE_LOCK_OPTS_BASE,
-    lockfilePath,
-  });
+  let release: () => Promise<void>;
+  try {
+    release = await properLockfile.lock(resource, {
+      ...WRITE_LOCK_OPTS_BASE,
+      lockfilePath,
+    });
+  } catch (err) {
+    if (isLockContentionError(err)) {
+      throw new WriteLockContentionError({
+        resource,
+        lockPath: lockfilePath,
+        causeMessage: (err as Error).message,
+      });
+    }
+    throw err;
+  }
   try {
     return await fn();
   } finally {


### PR DESCRIPTION
## Summary
- Report scoped `kb search --kb=<name>` freshness separately from global index drift in markdown and JSON output.
- Emit structured `REFRESH_LOCK_BUSY` JSON for `kb search --refresh --format=json` lock contention, with retry guidance for human stderr.
- Add regression coverage for scoped freshness footers, lock contention output, and typed write-lock contention errors.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx jest src/cli-search.test.ts src/write-lock.test.ts --runInBand`
- [x] `npm run build`
- [x] `npm test`

Closes #181