### PR TITLE
feat: add grouped source search output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@
 - **`kb search --kb=<name>` now reports freshness for the selected KB separately from global index drift.** JSON output keeps the existing top-level `stale`, `modified_files`, and `new_files` fields as the effective search scope, and adds `global_*` plus `scope` fields so agents can distinguish "this scoped search is current" from "other KBs still have drift." Markdown output mirrors the distinction in the freshness footer.
 - **Refresh-lock contention now has agent-friendly output.** When `kb search --refresh --format=json` cannot acquire the write lock, it emits a parseable `{error: {code: "REFRESH_LOCK_BUSY", ...}}` payload instead of only surfacing the raw lockfile message. Human-mode stderr includes retry guidance and the lock path. Closes #181.
 
+## [Unreleased] — `kb search --group-by-source`
+
+### Added
+
+- **`kb search --group-by-source` groups repeated chunks from the same source file.** Markdown output now collapses matching chunks under one source heading, reports the best score for that source, and preserves each chunk's score and location for inspection. JSON output keeps the existing raw `results` array unchanged and adds `grouped_results` only when the flag is present. Closes #182.
+
 ## [Unreleased] — CLI `kb remember` semantic preflight (default ON)
 
 ### Added

--- a/src/cli-search.ts
+++ b/src/cli-search.ts
@@ -10,7 +10,12 @@ import {
   FRONTMATTER_EXTRAS_WIRE_VISIBLE,
   KNOWLEDGE_BASES_ROOT_DIR,
 } from './config.js';
-import { formatRetrievalAsJson, formatRetrievalAsMarkdown } from './formatter.js';
+import {
+  formatRetrievalAsJson,
+  formatRetrievalAsMarkdown,
+  formatRetrievalGroupedBySourceAsMarkdown,
+  groupRetrievalBySource,
+} from './formatter.js';
 import { enumerateIngestableKbFiles, listKnowledgeBases } from './kb-fs.js';
 import { withWriteLock, WriteLockContentionError } from './write-lock.js';
 import { loadManagerForModel, loadWithJsonRetry } from './cli-shared.js';
@@ -25,6 +30,7 @@ interface SearchArgs {
   format: 'md' | 'json';
   refresh: boolean;
   stdin: boolean;
+  groupBySource: boolean;
 }
 
 export interface Staleness {
@@ -166,6 +172,9 @@ export async function runSearch(rest: string[]): Promise<number> {
       : globalCounts;
     const payload = {
       results: body,
+      ...(parsed.groupBySource
+        ? { grouped_results: groupRetrievalBySource(results, FRONTMATTER_EXTRAS_WIRE_VISIBLE) }
+        : {}),
       index_mtime: staleness.indexMtime,
       stale: hasStaleCounts(effectiveCounts),
       modified_files: effectiveCounts.modifiedFiles,
@@ -199,7 +208,9 @@ export async function runSearch(rest: string[]): Promise<number> {
       process.stdout.write(formatAutoThresholdHeader(autoDecision));
       process.stdout.write('\n\n');
     }
-    const md = formatRetrievalAsMarkdown(results, FRONTMATTER_EXTRAS_WIRE_VISIBLE);
+    const md = parsed.groupBySource
+      ? formatRetrievalGroupedBySourceAsMarkdown(results, FRONTMATTER_EXTRAS_WIRE_VISIBLE)
+      : formatRetrievalAsMarkdown(results, FRONTMATTER_EXTRAS_WIRE_VISIBLE);
     process.stdout.write(md);
     process.stdout.write('\n\n');
     process.stdout.write(formatFreshnessFooter(staleness, parsed.refresh));
@@ -217,10 +228,12 @@ function parseSearchArgs(rest: string[]): SearchArgs {
     refresh: false,
     stdin: false,
     thresholdAuto: false,
+    groupBySource: false,
   };
   for (const raw of rest) {
     if (raw === '--refresh') { out.refresh = true; continue; }
     if (raw === '--stdin')   { out.stdin = true; continue; }
+    if (raw === '--group-by-source') { out.groupBySource = true; continue; }
     if (raw.startsWith('--kb=')) { out.kb = raw.slice('--kb='.length); continue; }
     if (raw.startsWith('--model=')) { out.model = raw.slice('--model='.length); continue; }
     if (raw.startsWith('--threshold=')) {

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -112,6 +112,11 @@ describe('kb CLI — argv parsing and dispatch', () => {
     const r = runCli(['search', 'q', '--threshold=auto']);
     expect(r.stderr).not.toContain('invalid --threshold');
   });
+
+  it('search with --group-by-source is accepted by the parser', () => {
+    const r = runCli(['search', 'q', '--group-by-source']);
+    expect(r.stderr).not.toContain('unknown flag');
+  });
 });
 
 describe('kb remember', () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -86,6 +86,9 @@ Search options:
   --threshold=<float>   Max similarity score (default 2).
   --k=<int>             Top-K results (default 10).
   --format=md|json      Output format (default md).
+  --group-by-source     Collapse repeated chunks from the same source file in
+                        markdown output. With --format=json, keeps raw
+                        results and adds grouped_results.
   --refresh             Re-scan KB files; acquires per-model write lock.
   --stdin               Read query from stdin (multi-line safe).
 

--- a/src/formatter.test.ts
+++ b/src/formatter.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from '@jest/globals';
 import {
   formatRetrievalAsJson,
+  formatRetrievalGroupedBySourceAsMarkdown,
   formatRetrievalAsMarkdown,
+  groupRetrievalBySource,
   sanitizeMetadataForWire,
   ScoredDocument,
 } from './formatter.js';
@@ -124,5 +126,95 @@ describe('formatRetrievalAsJson', () => {
     } as unknown as ScoredDocument;
     const out = formatRetrievalAsJson([doc], false);
     expect(out[0].metadata).toEqual({ frontmatter: { title: 'T' } });
+  });
+});
+
+describe('groupRetrievalBySource', () => {
+  it('collapses repeated chunks from the same source and keeps best score plus locations', () => {
+    const docs: ScoredDocument[] = [
+      {
+        pageContent: 'first chunk',
+        metadata: {
+          source: 'kb/repeated.md',
+          loc: { lines: { from: 1, to: 5 } },
+        },
+        score: 0.7,
+      } as unknown as ScoredDocument,
+      {
+        pageContent: 'second chunk',
+        metadata: {
+          source: 'kb/repeated.md',
+          loc: { lines: { from: 20, to: 25 } },
+        },
+        score: 0.3,
+      } as unknown as ScoredDocument,
+      {
+        pageContent: 'other file',
+        metadata: {
+          source: 'kb/other.md',
+          loc: { lines: { from: 3, to: 8 } },
+        },
+        score: 0.5,
+      } as unknown as ScoredDocument,
+    ];
+
+    const grouped = groupRetrievalBySource(docs, false);
+
+    expect(grouped).toHaveLength(2);
+    expect(grouped[0].source).toBe('kb/repeated.md');
+    expect(grouped[0].best_score).toBe(0.3);
+    expect(grouped[0].chunks).toHaveLength(2);
+    expect(grouped[0].locations).toEqual([
+      { score: 0.7, location: { lines: { from: 1, to: 5 } } },
+      { score: 0.3, location: { lines: { from: 20, to: 25 } } },
+    ]);
+    expect(grouped[1].source).toBe('kb/other.md');
+  });
+
+  it('keeps raw chunk metadata sanitized in grouped JSON-ready output', () => {
+    const docs: ScoredDocument[] = [
+      {
+        pageContent: 'frontmatter',
+        metadata: {
+          source: 'kb/doc.md',
+          frontmatter: { title: 'Visible', extras: { hidden: true } },
+        },
+        score: 0.2,
+      } as unknown as ScoredDocument,
+    ];
+
+    const grouped = groupRetrievalBySource(docs, false);
+
+    expect(grouped[0].chunks[0].metadata).toEqual({
+      source: 'kb/doc.md',
+      frontmatter: { title: 'Visible' },
+    });
+  });
+});
+
+describe('formatRetrievalGroupedBySourceAsMarkdown', () => {
+  it('renders one source section for repeated chunks with chunk locations', () => {
+    const docs: ScoredDocument[] = [
+      {
+        pageContent: 'first chunk',
+        metadata: { source: 'kb/repeated.md', loc: { lines: { from: 1, to: 5 } } },
+        score: 0.7,
+      } as unknown as ScoredDocument,
+      {
+        pageContent: 'second chunk',
+        metadata: { source: 'kb/repeated.md', loc: { lines: { from: 20, to: 25 } } },
+        score: 0.3,
+      } as unknown as ScoredDocument,
+    ];
+
+    const out = formatRetrievalGroupedBySourceAsMarkdown(docs, false);
+
+    expect(out).toContain('**Source 1:** `kb/repeated.md`');
+    expect(out).not.toContain('**Source 2:**');
+    expect(out).toContain('**Best score:** 0.30');
+    expect(out).toContain('"from":1');
+    expect(out).toContain('"from":20');
+    expect(out).toContain('first chunk');
+    expect(out).toContain('second chunk');
   });
 });

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -13,6 +13,23 @@ export interface ScoredDocument extends Document {
   score?: number;
 }
 
+export interface RetrievalJsonResult {
+  score: number | null;
+  content: string;
+  metadata: Record<string, unknown>;
+}
+
+export interface GroupedRetrievalChunk extends RetrievalJsonResult {
+  location: unknown | null;
+}
+
+export interface GroupedRetrievalSource {
+  source: string;
+  best_score: number | null;
+  locations: Array<{ score: number | null; location: unknown | null }>;
+  chunks: GroupedRetrievalChunk[];
+}
+
 /**
  * Strips `frontmatter.extras` from a chunk's metadata before wire
  * serialization unless the operator has opted back in via
@@ -71,6 +88,36 @@ export function formatRetrievalAsMarkdown(
   return `## Semantic Search Results\n\n${formattedResults}${disclaimer}`;
 }
 
+export function formatRetrievalGroupedBySourceAsMarkdown(
+  results: ScoredDocument[] | null | undefined,
+  extrasVisible: boolean,
+): string {
+  const grouped = groupRetrievalBySource(results, extrasVisible);
+  let formattedResults = '';
+  if (grouped.length > 0) {
+    formattedResults = grouped
+      .map((group, idx) => {
+        const chunks = group.chunks
+          .map((chunk, chunkIdx) => {
+            const scoreText = formatScore(chunk.score);
+            const locationText = formatLocation(chunk.location);
+            return `${chunkIdx + 1}. **Score:** ${scoreText}\n   **Location:** ${locationText}\n\n   ${indentChunkContent(chunk.content.trim())}`;
+          })
+          .join('\n\n');
+        return (
+          `**Source ${idx + 1}:** \`${group.source}\`\n\n` +
+          `**Best score:** ${formatScore(group.best_score)}\n\n` +
+          `**Matching chunks:**\n\n${chunks}`
+        );
+      })
+      .join('\n\n---\n\n');
+  } else {
+    formattedResults = '_No similar results found._';
+  }
+  const disclaimer = '\n\n> **Disclaimer:** The provided results might not all be relevant. Please cross-check the relevance of the information.';
+  return `## Semantic Search Results\n\n${formattedResults}${disclaimer}`;
+}
+
 /**
  * Produces the JSON shape the CLI emits with `--format=json`. Includes the
  * sanitized metadata and the score as a top-level field so callers don't
@@ -79,7 +126,7 @@ export function formatRetrievalAsMarkdown(
 export function formatRetrievalAsJson(
   results: ScoredDocument[] | null | undefined,
   extrasVisible: boolean,
-): Array<{ score: number | null; content: string; metadata: Record<string, unknown> }> {
+): RetrievalJsonResult[] {
   if (!results || results.length === 0) return [];
   return results.map((doc) => ({
     score: doc.score ?? null,
@@ -89,4 +136,80 @@ export function formatRetrievalAsJson(
       extrasVisible,
     ),
   }));
+}
+
+export function groupRetrievalBySource(
+  results: ScoredDocument[] | null | undefined,
+  extrasVisible: boolean,
+): GroupedRetrievalSource[] {
+  if (!results || results.length === 0) return [];
+
+  const groups: GroupedRetrievalSource[] = [];
+  const bySource = new Map<string, GroupedRetrievalSource>();
+
+  results.forEach((doc, idx) => {
+    const sanitizedMetadata = sanitizeMetadataForWire(
+      doc.metadata as Record<string, unknown>,
+      extrasVisible,
+    );
+    const source = getSourcePath(sanitizedMetadata, idx);
+    let group = bySource.get(source);
+    if (group === undefined) {
+      group = { source, best_score: null, locations: [], chunks: [] };
+      bySource.set(source, group);
+      groups.push(group);
+    }
+
+    const score = doc.score ?? null;
+    const location = getChunkLocation(sanitizedMetadata);
+    group.best_score = bestScore(group.best_score, score);
+    group.locations.push({ score, location });
+    group.chunks.push({
+      score,
+      content: doc.pageContent,
+      metadata: sanitizedMetadata,
+      location,
+    });
+  });
+
+  return groups;
+}
+
+function getSourcePath(metadata: Record<string, unknown>, idx: number): string {
+  const source = metadata.source;
+  if (typeof source === 'string' && source.trim() !== '') {
+    return source;
+  }
+  const relativePath = metadata.relativePath;
+  if (typeof relativePath === 'string' && relativePath.trim() !== '') {
+    return relativePath;
+  }
+  return `(unknown source ${idx + 1})`;
+}
+
+function getChunkLocation(metadata: Record<string, unknown>): unknown | null {
+  if ('loc' in metadata) return metadata.loc;
+  if ('chunkIndex' in metadata) return { chunkIndex: metadata.chunkIndex };
+  if ('chunk_index' in metadata) return { chunk_index: metadata.chunk_index };
+  return null;
+}
+
+function bestScore(current: number | null, candidate: number | null): number | null {
+  if (candidate === null) return current;
+  if (current === null) return candidate;
+  return Math.min(current, candidate);
+}
+
+function formatScore(score: number | null): string {
+  return score === null ? 'n/a' : score.toFixed(2);
+}
+
+function formatLocation(location: unknown | null): string {
+  if (location === null || location === undefined) return 'not recorded';
+  return `\`${JSON.stringify(location)}\``;
+}
+
+function indentChunkContent(content: string): string {
+  if (content === '') return '';
+  return content.replace(/\n/g, '\n   ');
 }


### PR DESCRIPTION
## Summary
- Add `kb search --group-by-source` to collapse repeated chunks under each source in markdown output.
- Keep JSON `results` raw by default, adding `grouped_results` only when grouping is requested.
- Preserve source path, best score, per-chunk scores, and chunk locations in grouped output.

## Test plan
- [x] `npm run build`
- [x] `npx tsc --noEmit`
- [x] `npx jest --runInBand src/formatter.test.ts src/cli.test.ts`
- [x] `npm test`

Closes #182

Generated with Claude Code