### PR TITLE
docs(readme): add npm version badge (#40)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Knowledge Base MCP Server
 
 [![Tests](https://github.com/jeanibarz/knowledge-base-mcp-server/actions/workflows/test.yml/badge.svg)](https://github.com/jeanibarz/knowledge-base-mcp-server/actions/workflows/test.yml)
+[![npm](https://img.shields.io/npm/v/@jeanibarz/knowledge-base-mcp-server.svg)](https://www.npmjs.com/package/@jeanibarz/knowledge-base-mcp-server)
 [![License](https://img.shields.io/github/license/jeanibarz/knowledge-base-mcp-server)](./UNLICENSE)
 [![Node.js >= 20](https://img.shields.io/badge/node-%3E%3D20-brightgreen)](./package.json)
 


### PR DESCRIPTION
## Summary

Issue #40 listed five badges for the README header. Four of the five already shipped (Tests workflow, License, Node ≥20, Smithery, Glama). The **npm-version badge** — the last item on the list — was missing.

The package is published as `@jeanibarz/knowledge-base-mcp-server` (verified: registry returns 200), so shields.io's npm endpoint resolves cleanly. Added the badge between the Tests + License rows so the version a visitor would `npm install` sits on the same line as the build status.

```
[![Tests](...)](...)
[![npm](https://img.shields.io/npm/v/@jeanibarz/knowledge-base-mcp-server.svg)](https://www.npmjs.com/package/@jeanibarz/knowledge-base-mcp-server)
[![License](...)](./UNLICENSE)
[![Node.js >= 20](...)](./package.json)
```

### Notes on the rest of #40

- The **demo gif / video** bullet (15-second Claude Desktop screen capture driving `retrieve_knowledge`) is a human deliverable. The README already has a `Live demo recording coming soon ([tracking #40](...))` placeholder pointing back at this issue, so the user-facing breadcrumb is in place.
- All four other badges from the issue's list are already in place; this PR only fills the one gap.

## Test plan

- [x] `git diff README.md` — single-line addition, no other changes.
- [x] `curl -I https://img.shields.io/npm/v/@jeanibarz/knowledge-base-mcp-server.svg` returns 200 — badge will render.
- [ ] Visual check on rendered GitHub README — once merged, GitHub's render will pull the live SVG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)