### PR TITLE
test: tighten weak assertions exposed by quality audit

### DIFF
--- a/src/FaissIndexManager.test.ts
+++ b/src/FaissIndexManager.test.ts
@@ -834,8 +834,12 @@ describe('FaissIndexManager permission handling', () => {
     const migratedId = 'huggingface__sentence-transformers-all-MiniLM-L6-v2';
     const migratedIndexDir = path.join(faissDir, 'models', migratedId, 'faiss.index');
     await expect(fsp.stat(oldIndexDir)).rejects.toMatchObject({ code: 'ENOENT' });
-    await expect(fsp.stat(migratedIndexDir)).resolves.toBeDefined();
+    // The migrated path must be a directory (not a regular file or a
+    // symlink — the migration is supposed to move the layout, not turn
+    // it into a sentinel) AND its inner content must round-trip verbatim.
+    expect((await fsp.stat(migratedIndexDir)).isDirectory()).toBe(true);
     expect(await fsp.readFile(path.join(migratedIndexDir, 'faiss.index'), 'utf-8')).toBe('old-model-bytes');
+    expect(await fsp.readFile(path.join(migratedIndexDir, 'docstore.json'), 'utf-8')).toBe('{"old":"docstore"}');
 
     // model_name.txt moved into models/<id>/.
     expect(await fsp.readFile(path.join(faissDir, 'models', migratedId, 'model_name.txt'), 'utf-8'))
@@ -864,8 +868,14 @@ describe('FaissIndexManager permission handling', () => {
       FaissIndexManager.bootstrapLayout()
     ).rejects.toBeInstanceOf(MigrationRefusedError);
 
-    // Old layout untouched.
-    await expect(fsp.stat(path.join(faissDir, 'faiss.index'))).resolves.toBeDefined();
+    // Old layout untouched — assert byte-for-byte content preservation,
+    // not just path existence. A regression that truncated the index
+    // before throwing MigrationRefusedError would pass under the
+    // resolves.toBeDefined() bar.
+    expect((await fsp.stat(path.join(faissDir, 'faiss.index'))).isDirectory()).toBe(true);
+    expect(
+      await fsp.readFile(path.join(faissDir, 'faiss.index', 'faiss.index'), 'utf-8'),
+    ).toBe('mystery-bytes');
     await expect(fsp.stat(path.join(faissDir, 'models'))).rejects.toMatchObject({ code: 'ENOENT' });
   });
 
@@ -2010,9 +2020,13 @@ describe('FaissIndexManager ingest — PDF + HTML loaders (issue #46)', () => {
     const pdfMetadata = metadatas.find(
       (m) => String(m.source).endsWith('.pdf'),
     );
-    expect(pdfMetadata).toBeDefined();
-    expect(pdfMetadata?.extension).toBe('.pdf');
-    expect(String(pdfMetadata?.knowledgeBase)).toBe('docs');
+    // toMatchObject fails clearly when pdfMetadata is undefined AND when
+    // any subfield mismatches — strictly stronger than the prior
+    // toBeDefined()-then-?.-access pattern.
+    expect(pdfMetadata).toMatchObject({
+      extension: '.pdf',
+      knowledgeBase: 'docs',
+    });
   });
 
   it('ingests a `.html` file via the HTML loader (tags stripped before embedding)', async () => {
@@ -2042,8 +2056,7 @@ describe('FaissIndexManager ingest — PDF + HTML loaders (issue #46)', () => {
     const htmlMetadata = metadatas.find(
       (m) => String(m.source).endsWith('.html'),
     );
-    expect(htmlMetadata).toBeDefined();
-    expect(htmlMetadata?.extension).toBe('.html');
+    expect(htmlMetadata).toMatchObject({ extension: '.html' });
 
     // html-to-text uppercases <h1> by default; assert case-insensitively.
     const htmlTexts = texts.filter((t) =>

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1154,8 +1154,13 @@ describe('kb search — active-model resolution (RFC 013 §4.7)', () => {
       });
       expect(r.code).toBe(2);
       expect(r.stderr).toContain('refusing to remove the active model');
-      // Directory still on disk.
-      await expect(fsp.stat(path.join(faissDir, 'models', id))).resolves.toBeDefined();
+      // Directory still on disk AND its model_name.txt is byte-identical —
+      // a regression that "refused" but partially wiped state would pass
+      // the bare existence check; insist on full preservation.
+      expect((await fsp.stat(path.join(faissDir, 'models', id))).isDirectory()).toBe(true);
+      expect(
+        await fsp.readFile(path.join(faissDir, 'models', id, 'model_name.txt'), 'utf-8'),
+      ).toBe('BAAI/bge-small-en-v1.5');
     } finally {
       await fsp.rm(tempDir, { recursive: true, force: true });
     }
@@ -1276,9 +1281,14 @@ describe('kb search — active-model resolution (RFC 013 §4.7)', () => {
       });
       expect(r.code).toBe(0);
 
-      // Old layout migrated.
+      // Old layout migrated. The migrated `faiss.index` must be a directory
+      // (the modern langchain layout — turning it into a regular file would
+      // break load on the next start, but pass a bare existence check).
       const migratedId = 'huggingface__BAAI-bge-small-en-v1.5';
-      await expect(fsp.stat(path.join(faissDir, 'models', migratedId, 'faiss.index'))).resolves.toBeDefined();
+      const migratedIndexDir = path.join(faissDir, 'models', migratedId, 'faiss.index');
+      expect((await fsp.stat(migratedIndexDir)).isDirectory()).toBe(true);
+      expect(await fsp.readFile(path.join(migratedIndexDir, 'faiss.index'), 'utf-8')).toBe('old-bytes');
+      expect(await fsp.readFile(path.join(migratedIndexDir, 'docstore.json'), 'utf-8')).toBe('{"doc":"old"}');
       expect((await fsp.readFile(path.join(faissDir, 'active.txt'), 'utf-8')).trim()).toBe(migratedId);
       // model_name.txt moved into models/<id>/.
       expect(await fsp.readFile(path.join(faissDir, 'models', migratedId, 'model_name.txt'), 'utf-8'))

--- a/src/logger.test.ts
+++ b/src/logger.test.ts
@@ -36,7 +36,7 @@ describe('logger', () => {
       await new Promise((resolve) => setImmediate(resolve));
     });
 
-    await expect(fsp.stat(path.dirname(logFile))).resolves.toBeTruthy();
+    expect((await fsp.stat(path.dirname(logFile))).isDirectory()).toBe(true);
     const fileContents = await fsp.readFile(logFile, 'utf-8');
     expect(fileContents).toContain('File target message');
     expect(fileContents).toContain('[DEBUG] debug content');

--- a/src/triggerWatcher.test.ts
+++ b/src/triggerWatcher.test.ts
@@ -214,6 +214,10 @@ describe('ReindexTriggerWatcher (RFC 011 §5.5)', () => {
     await new Promise((r) => setTimeout(r, 200));
 
     await watcher.stop();
-    expect(onTrigger).toHaveBeenCalled();
+    // Coalescing contract: one mtime advance means exactly one fire, no
+    // matter how many polls observe it. Asserting "called at least once"
+    // (the previous bar) would let a regression that re-fired on every
+    // tick after the bump pass silently.
+    expect(onTrigger).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary

Test-quality pass on the full Jest suite (23 files, 495 tests). The audit found no implementation bugs and no critical tautologies — but six places where the assertion bar was weaker than the contract being tested. This PR tightens them so a regression that the prior bar would silently accept now fails loudly.

- **`Stats`-always-truthy fixes** (`logger.test.ts:39`, `FaissIndexManager.test.ts:837/872`, `cli.test.ts:1158/1281`): `await expect(fsp.stat(...)).resolves.toBeDefined()` resolves to a `Stats` object that is always truthy. A regression that turned a layout *directory* into a regular file would pass. Replaced with `.isDirectory()` plus byte-content round-trips on the inner files (`faiss.index`, `docstore.json`, `model_name.txt`).
- **Trigger-watcher coalescing pinned** (`triggerWatcher.test.ts:217`): `expect(onTrigger).toHaveBeenCalled()` only verified ≥1 fire. A bug that re-fired on every poll after the bump would still pass. Now asserts exactly one fire per mtime advance — the actual coalescing contract.
- **Folded guard-then-access** (`FaissIndexManager.test.ts:2013/2045`): `expect(meta).toBeDefined(); expect(meta?.extension).toBe('.pdf')` collapsed into a single `toMatchObject` for clearer failure output and stricter coverage.

Full audit report (summary counts, missing-coverage notes, flake risks, clean-files list) lives at `/tmp/kookr-test-quality-report.md` for the audit run.

## Test plan

- [x] `npm test` from the worktree → 23 suites, 495 passed, 0 failed (~86 s)
- [x] No production source changes; only `*.test.ts` files touched
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)