### PR TITLE
feat: add grouped source chunk counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Added
 
 - **`kb search --group-by-source` groups repeated chunks from the same source file.** Markdown output now collapses matching chunks under one source heading, reports the best score for that source, and preserves each chunk's score and location for inspection. JSON output keeps the existing raw `results` array unchanged and adds `grouped_results` only when the flag is present. Closes #182.
+- **Grouped source output now reports `chunk_count` per source.** Both JSON grouped results and markdown grouped output expose the explicit number of matched chunks per source while preserving the raw chunk list. Closes #193.
 
 ## [Unreleased] — CLI `kb remember` semantic preflight (default ON)
 

--- a/src/formatter.test.ts
+++ b/src/formatter.test.ts
@@ -211,6 +211,7 @@ describe('groupRetrievalBySource', () => {
 
     expect(grouped).toHaveLength(2);
     expect(grouped[0].source).toBe('kb/repeated.md');
+    expect(grouped[0].chunk_count).toBe(2);
     expect(grouped[0].best_score).toBe(0.3);
     expect(grouped[0].chunks).toHaveLength(2);
     expect(grouped[0].locations).toEqual([
@@ -218,6 +219,7 @@ describe('groupRetrievalBySource', () => {
       { score: 0.3, location: { lines: { from: 20, to: 25 } } },
     ]);
     expect(grouped[1].source).toBe('kb/other.md');
+    expect(grouped[1].chunk_count).toBe(1);
   });
 
   it('keeps raw chunk metadata sanitized in grouped JSON-ready output', () => {
@@ -261,6 +263,7 @@ describe('formatRetrievalGroupedBySourceAsMarkdown', () => {
     expect(out).toContain('**Source 1:** `kb/repeated.md`');
     expect(out).not.toContain('**Source 2:**');
     expect(out).toContain('**Best score:** 0.30');
+    expect(out).toContain('**Chunk count:** 2');
     expect(out).toContain('"from":1');
     expect(out).toContain('"from":20');
     expect(out).toContain('first chunk');

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -25,6 +25,7 @@ export interface GroupedRetrievalChunk extends RetrievalJsonResult {
 
 export interface GroupedRetrievalSource {
   source: string;
+  chunk_count: number;
   best_score: number | null;
   locations: Array<{ score: number | null; location: unknown | null }>;
   chunks: GroupedRetrievalChunk[];
@@ -107,6 +108,7 @@ export function formatRetrievalGroupedBySourceAsMarkdown(
         return (
           `**Source ${idx + 1}:** \`${group.source}\`\n\n` +
           `**Best score:** ${formatScore(group.best_score)}\n\n` +
+          `**Chunk count:** ${group.chunk_count}\n\n` +
           `**Matching chunks:**\n\n${chunks}`
         );
       })
@@ -155,13 +157,14 @@ export function groupRetrievalBySource(
     const source = getSourcePath(sanitizedMetadata, idx);
     let group = bySource.get(source);
     if (group === undefined) {
-      group = { source, best_score: null, locations: [], chunks: [] };
+      group = { source, chunk_count: 0, best_score: null, locations: [], chunks: [] };
       bySource.set(source, group);
       groups.push(group);
     }
 
     const score = doc.score ?? null;
     const location = getChunkLocation(sanitizedMetadata);
+    group.chunk_count += 1;
     group.best_score = bestScore(group.best_score, score);
     group.locations.push({ score, location });
     group.chunks.push({


### PR DESCRIPTION
## Summary
- Add `chunk_count` to each grouped source result emitted by `kb search --group-by-source --format=json`.
- Show the same chunk count in grouped markdown output while leaving default raw search output unchanged.
- Cover grouped results for repeated chunks and multiple source files.

## Test plan
- [x] npm test -- --runTestsByPath src/formatter.test.ts
- [x] npm run build
- [x] npm test

Closes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)