### PR TITLE
test: cover scoped search staleness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- **`kb search --kb=<name>` now reports freshness for the selected KB separately from global index drift.** JSON output keeps the existing top-level `stale`, `modified_files`, and `new_files` fields as the effective search scope, and adds `global_*` plus `scope` fields so agents can distinguish "this scoped search is current" from "other KBs still have drift." Markdown output mirrors the distinction in the freshness footer.
+- **`kb search --kb=<name>` now reports freshness for the selected KB separately from global index drift.** JSON output keeps the existing top-level `stale`, `modified_files`, and `new_files` fields as the effective search scope, and adds `global_*` plus `scope` fields so agents can distinguish "this scoped search is current" from "other KBs still have drift." Markdown output mirrors the distinction in the freshness footer. Closes #192.
 - **Refresh-lock contention now has agent-friendly output.** When `kb search --refresh --format=json` cannot acquire the write lock, it emits a parseable `{error: {code: "REFRESH_LOCK_BUSY", ...}}` payload instead of only surfacing the raw lockfile message. Human-mode stderr includes retry guidance and the lock path. Closes #181.
 
 ## [Unreleased] — `kb search --group-by-source`

--- a/docs/requirements/INDEX.md
+++ b/docs/requirements/INDEX.md
@@ -1,0 +1,17 @@
+# Requirements
+
+## Search
+
+### FR-SEARCH-192: Scoped Search Staleness
+**Status:** Implemented
+**Priority:** High
+
+**Requirement:** The system shall report staleness for the selected knowledge base when `kb search --kb=<name>` scopes a query.
+
+**Acceptance Criteria:**
+- [x] Given a scoped search, when files in the selected knowledge base are stale, then the stale counts reflect that selected knowledge base.
+- [x] Given an unscoped search, when files across knowledge bases are stale, then the stale counts reflect global drift.
+- [x] Given JSON output for a scoped search, when scoped and global stale counts differ, then the payload distinguishes scoped fields from global fields.
+
+**Linked Tests:** TS-SEARCH-192
+**Dependencies:** RFC005

--- a/docs/testing/INDEX.md
+++ b/docs/testing/INDEX.md
@@ -1,0 +1,11 @@
+# Testing
+
+## Search
+
+### TS-SEARCH-192: Scoped Search Staleness
+**Requirement:** FR-SEARCH-192
+
+**Test Cases:**
+- `computeStaleness` shall count modified and new files in the selected KB separately from other KBs.
+- `computeStaleness` shall preserve global modified and new file counts for unscoped searches.
+- `formatFreshnessFooter` and JSON payload tests shall verify scoped fields remain distinct from global fields.

--- a/src/cli-search-staleness.test.ts
+++ b/src/cli-search-staleness.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
+import * as fsp from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+
+const ORIGINAL_ENV = {
+  KNOWLEDGE_BASES_ROOT_DIR: process.env.KNOWLEDGE_BASES_ROOT_DIR,
+  FAISS_INDEX_PATH: process.env.FAISS_INDEX_PATH,
+};
+
+afterEach(async () => {
+  if (ORIGINAL_ENV.KNOWLEDGE_BASES_ROOT_DIR === undefined) {
+    delete process.env.KNOWLEDGE_BASES_ROOT_DIR;
+  } else {
+    process.env.KNOWLEDGE_BASES_ROOT_DIR = ORIGINAL_ENV.KNOWLEDGE_BASES_ROOT_DIR;
+  }
+  if (ORIGINAL_ENV.FAISS_INDEX_PATH === undefined) {
+    delete process.env.FAISS_INDEX_PATH;
+  } else {
+    process.env.FAISS_INDEX_PATH = ORIGINAL_ENV.FAISS_INDEX_PATH;
+  }
+  jest.resetModules();
+});
+
+describe('computeStaleness', () => {
+  it('counts scoped stale files separately from other KBs and preserves global counts', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-search-stale-'));
+    try {
+      const kbRoot = path.join(tempDir, 'kbs');
+      const faissDir = path.join(tempDir, '.faiss');
+      const modelId = 'ollama__scoped-stale-test';
+      process.env.KNOWLEDGE_BASES_ROOT_DIR = kbRoot;
+      process.env.FAISS_INDEX_PATH = faissDir;
+
+      const indexBinaryPath = path.join(
+        faissDir,
+        'models',
+        modelId,
+        'faiss.index',
+        'faiss.index',
+      );
+      await fsp.mkdir(path.dirname(indexBinaryPath), { recursive: true });
+      await fsp.writeFile(indexBinaryPath, 'index', 'utf-8');
+
+      const alphaFresh = path.join(kbRoot, 'alpha', 'fresh.md');
+      const alphaModified = path.join(kbRoot, 'alpha', 'modified.md');
+      const betaModified = path.join(kbRoot, 'beta', 'modified.md');
+      await fsp.mkdir(path.dirname(alphaFresh), { recursive: true });
+      await fsp.mkdir(path.dirname(betaModified), { recursive: true });
+      await fsp.writeFile(alphaFresh, '# Alpha fresh\n', 'utf-8');
+      await fsp.writeFile(alphaModified, '# Alpha modified\n', 'utf-8');
+      await fsp.writeFile(betaModified, '# Beta modified\n', 'utf-8');
+
+      await fsp.mkdir(path.join(kbRoot, 'alpha', '.index'), { recursive: true });
+      await fsp.writeFile(path.join(kbRoot, 'alpha', '.index', 'fresh.hash'), 'hash', 'utf-8');
+
+      const beforeIndex = new Date('2026-05-03T15:00:00.000Z');
+      const indexTime = new Date('2026-05-03T15:30:00.000Z');
+      const afterIndex = new Date('2026-05-03T16:00:00.000Z');
+      await fsp.utimes(indexBinaryPath, indexTime, indexTime);
+      await fsp.utimes(alphaFresh, beforeIndex, beforeIndex);
+      await fsp.utimes(alphaModified, afterIndex, afterIndex);
+      await fsp.utimes(betaModified, afterIndex, afterIndex);
+
+      jest.resetModules();
+      const { computeStaleness } = await import('./cli-search.js');
+
+      await expect(computeStaleness(modelId, 'alpha')).resolves.toMatchObject({
+        modifiedFiles: 1,
+        newFiles: 1,
+        scope: { kb: 'alpha', modifiedFiles: 1, newFiles: 1 },
+        global: { modifiedFiles: 2, newFiles: 2 },
+      });
+
+      await expect(computeStaleness(modelId)).resolves.toMatchObject({
+        modifiedFiles: 2,
+        newFiles: 2,
+      });
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Add filesystem-level coverage for scoped `kb search --kb=<name>` stale counts versus global drift.
- Record the RFC005 requirement/test trace for issue #192.
- Mark the existing scoped freshness changelog entry as closing #192.

## Test plan
- [x] `npx jest src/cli-search-staleness.test.ts --runInBand`
- [x] `npm run build`
- [x] `npm test`

Closes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)