### PR TITLE
feat: add retrieval eval command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased] — `kb eval` retrieval fixtures
+
+### Added
+
+- **`kb eval <fixture.yml|json>` fixture-driven retrieval checks.** Fixtures can assert required sources, forbidden sources, expected metadata, duplicate-source budgets, and stale-policy expectations per query, with per-case gating so exploratory cases warn while CI gates fail the command. Closes #194.
+
 ## [Unreleased] — `kb search` scoped freshness and lock errors
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -43,12 +43,30 @@ kb search "query" --refresh   # also re-scan KB files (write path)
 kb remember --suggest --kb=work --title="Quarterly plan"
 printf '# Quarterly plan\n\n...' | kb remember --kb=work --title="Quarterly plan" --stdin --yes
 printf '\nFollow-up note.\n' | kb remember --kb=work --append=quarterly-plan.md --stdin --yes
+kb eval retrieval-eval.yml     # run fixture-driven retrieval checks
 kb --help
 ```
 
 The `kb` bin shares the same env vars as the MCP server (`KNOWLEDGE_BASES_ROOT_DIR`, `FAISS_INDEX_PATH`, `EMBEDDING_PROVIDER`, `OLLAMA_*`, `OPENAI_*`, `HUGGINGFACE_*`). `kb search` defaults to read-only — it loads the existing FAISS index but does not re-scan KB files. Pass `--refresh` to re-index. Output includes a freshness footer indicating whether the index is up-to-date relative to KB file mtimes.
 
 `kb remember` is a conservative CLI write path for agent shells. `--suggest` is read-only and lists likely existing targets from note filenames/headings. Creates and appends require both `--stdin` and `--yes`; create uses a slugified `.md` filename and refuses overwrites, while append accepts only existing KB-relative paths. Add `--refresh` to re-index the affected KB after a successful write.
+
+`kb eval <fixture.yml|json>` runs retrieval checks from fixtures. Each case can set `query`, optional `kb`, `required_sources`, `forbidden_sources`, `expected_metadata`, `max_duplicate_groups`, `stale_policy`, and `gate`. Failing ungated cases print warnings and exit 0; failing gated cases exit 1 for CI.
+
+```yaml
+gate: false
+cases:
+  - name: deployment runbook
+    query: rollback procedure
+    kb: work
+    gate: true
+    required_sources: [runbooks/deploy.md]
+    forbidden_sources: [archive/old-deploy.md]
+    expected_metadata:
+      frontmatter.status: approved
+    max_duplicate_groups: 1
+    stale_policy: fresh
+```
 
 The MCP server (`knowledge-base-mcp-server` bin) is unchanged and still works with all the configurations in [docs/clients.md](docs/clients.md). The CLI is additive.
 

--- a/docs/requirements/INDEX.md
+++ b/docs/requirements/INDEX.md
@@ -1,0 +1,3 @@
+# Requirements
+
+- [Retrieval eval command](retrieval-eval.md)

--- a/docs/requirements/retrieval-eval.md
+++ b/docs/requirements/retrieval-eval.md
@@ -1,0 +1,18 @@
+# Retrieval Eval Command
+
+### FR-RETRIEVAL-EVAL-001: Fixture-Driven Retrieval Evaluation
+
+**Status:** Implemented
+**Priority:** High
+
+**Requirement:** The system shall run retrieval evaluation fixtures that define a query, optional knowledge-base scope, required sources, forbidden sources, expected metadata, duplicate-source budget, stale-policy expectation, and gate behavior.
+
+**Acceptance Criteria:**
+
+- [ ] Given a fixture case with required sources, when `kb eval` runs the query, then the case fails if any required source is missing.
+- [ ] Given a fixture case with forbidden sources, when a forbidden source appears in the results, then the case fails.
+- [ ] Given a fixture case with a duplicate-source budget, when the number of repeated-source groups exceeds the budget, then the case fails.
+- [ ] Given a fixture case without gate behavior, when the case fails, then the command reports the failure as a warning and exits 0.
+- [ ] Given a fixture case with gate behavior, when the case fails, then the command exits nonzero.
+
+**Linked Tests:** TS-RETRIEVAL-EVAL-001

--- a/docs/testing/INDEX.md
+++ b/docs/testing/INDEX.md
@@ -1,0 +1,3 @@
+# Testing
+
+- [Retrieval eval command](retrieval-eval.md)

--- a/docs/testing/retrieval-eval.md
+++ b/docs/testing/retrieval-eval.md
@@ -1,0 +1,11 @@
+# Retrieval Eval Command Tests
+
+### TS-RETRIEVAL-EVAL-001: Fixture Evaluator Coverage
+
+The unit tests in `src/retrieval-eval.test.ts` cover:
+
+- Passing fixture cases with required sources, expected metadata, stale policy, and duplicate budget.
+- Missing required source failures.
+- Forbidden source failures.
+- Duplicate-source budget failures.
+- Exit-code behavior where ungated failures warn and gated failures fail CI.

--- a/src/cli-eval.ts
+++ b/src/cli-eval.ts
@@ -1,0 +1,182 @@
+import * as fsp from 'fs/promises';
+import yaml from 'js-yaml';
+import { FaissIndexManager } from './FaissIndexManager.js';
+import {
+  ActiveModelResolutionError,
+  resolveActiveModel,
+} from './active-model.js';
+import { computeStaleness } from './cli-search.js';
+import { loadManagerForModel, loadWithJsonRetry } from './cli-shared.js';
+import {
+  evaluateRetrievalCase,
+  formatRetrievalEvalMarkdown,
+  normalizeRetrievalEvalFixture,
+  retrievalEvalExitCode,
+  summarizeRetrievalEval,
+  type RetrievalEvalFixture,
+} from './retrieval-eval.js';
+
+interface EvalArgs {
+  fixturePath: string | null;
+  model?: string;
+  format: 'md' | 'json';
+  k: number;
+  threshold: number;
+}
+
+const DEFAULT_K = 10;
+const DEFAULT_THRESHOLD = 2;
+
+export async function runEval(rest: string[]): Promise<number> {
+  let parsed: EvalArgs;
+  try {
+    parsed = parseEvalArgs(rest);
+  } catch (err) {
+    process.stderr.write(`kb eval: ${(err as Error).message}\n`);
+    return 2;
+  }
+
+  if (parsed.fixturePath === null) {
+    process.stderr.write('kb eval: missing <fixture> or --fixture=<path>\n');
+    return 2;
+  }
+
+  let fixture: RetrievalEvalFixture;
+  try {
+    fixture = await loadEvalFixture(parsed.fixturePath);
+  } catch (err) {
+    process.stderr.write(`kb eval: ${(err as Error).message}\n`);
+    return 2;
+  }
+
+  try {
+    await FaissIndexManager.bootstrapLayout();
+  } catch (err) {
+    process.stderr.write(`kb eval: layout bootstrap failed: ${(err as Error).message}\n`);
+    return 1;
+  }
+
+  let activeModelId: string;
+  try {
+    activeModelId = await resolveActiveModel({ explicitOverride: parsed.model });
+  } catch (err) {
+    if (err instanceof ActiveModelResolutionError) {
+      process.stderr.write(`kb eval: ${err.message}\n`);
+      return 2;
+    }
+    process.stderr.write(`kb eval: ${(err as Error).message}\n`);
+    return 1;
+  }
+
+  let manager: FaissIndexManager;
+  try {
+    manager = await loadManagerForModel(activeModelId);
+    await loadWithJsonRetry(manager);
+  } catch (err) {
+    process.stderr.write(`kb eval: ${(err as Error).message}\n`);
+    return 1;
+  }
+
+  const results = [];
+  for (const fixtureCase of fixture.cases) {
+    try {
+      const caseResults = await manager.similaritySearch(
+        fixtureCase.query,
+        fixtureCase.k ?? parsed.k,
+        fixtureCase.threshold ?? parsed.threshold,
+        fixtureCase.kb,
+      );
+      const staleness = await computeStaleness(activeModelId, fixtureCase.kb);
+      results.push(evaluateRetrievalCase(fixtureCase, caseResults, staleness, fixture.gate));
+    } catch (err) {
+      process.stderr.write(`kb eval: ${fixtureCase.name}: ${(err as Error).message}\n`);
+      return 1;
+    }
+  }
+
+  const report = summarizeRetrievalEval(results);
+  if (parsed.format === 'json') {
+    process.stdout.write(`${JSON.stringify(toJsonReport(report), null, 2)}\n`);
+  } else {
+    process.stdout.write(formatRetrievalEvalMarkdown(report));
+  }
+  return retrievalEvalExitCode(report);
+}
+
+export function parseEvalArgs(rest: string[]): EvalArgs {
+  const out: EvalArgs = {
+    fixturePath: null,
+    format: 'md',
+    k: DEFAULT_K,
+    threshold: DEFAULT_THRESHOLD,
+  };
+
+  for (const raw of rest) {
+    if (raw === '--help' || raw === '-h') {
+      throw new Error(
+        'usage: kb eval <fixture.yml|json> [--model=<id>] [--k=<int>] [--threshold=<float>] [--format=md|json]',
+      );
+    }
+    if (raw.startsWith('--fixture=')) {
+      const value = raw.slice('--fixture='.length);
+      if (value.length === 0) throw new Error('--fixture=<path> requires a non-empty value');
+      out.fixturePath = value;
+      continue;
+    }
+    if (raw.startsWith('--model=')) {
+      out.model = raw.slice('--model='.length);
+      continue;
+    }
+    if (raw.startsWith('--format=')) {
+      const value = raw.slice('--format='.length);
+      if (value !== 'md' && value !== 'json') throw new Error(`invalid --format: ${raw}`);
+      out.format = value;
+      continue;
+    }
+    if (raw.startsWith('--k=')) {
+      const value = Number(raw.slice('--k='.length));
+      if (!Number.isInteger(value) || value <= 0) throw new Error(`invalid --k: ${raw}`);
+      out.k = value;
+      continue;
+    }
+    if (raw.startsWith('--threshold=')) {
+      const value = Number(raw.slice('--threshold='.length));
+      if (!Number.isFinite(value) || value <= 0) throw new Error(`invalid --threshold: ${raw}`);
+      out.threshold = value;
+      continue;
+    }
+    if (raw.startsWith('--')) throw new Error(`unknown flag: ${raw}`);
+    if (out.fixturePath !== null) throw new Error(`unexpected argument: ${JSON.stringify(raw)}`);
+    out.fixturePath = raw;
+  }
+
+  return out;
+}
+
+async function loadEvalFixture(fixturePath: string): Promise<RetrievalEvalFixture> {
+  const raw = await fsp.readFile(fixturePath, 'utf-8');
+  const parsed = fixturePath.endsWith('.json')
+    ? JSON.parse(raw) as unknown
+    : yaml.load(raw);
+  return normalizeRetrievalEvalFixture(parsed);
+}
+
+function toJsonReport(report: ReturnType<typeof summarizeRetrievalEval>): unknown {
+  return {
+    total: report.total,
+    passed: report.passed,
+    failed: report.failed,
+    gate_failed: report.gateFailed,
+    cases: report.cases.map((result) => ({
+      name: result.name,
+      query: result.query,
+      ...(result.kb !== undefined ? { kb: result.kb } : {}),
+      gate: result.gate,
+      passed: result.passed,
+      failures: result.failures,
+      warnings: result.warnings,
+      result_count: result.resultCount,
+      duplicate_groups: result.duplicateGroups,
+    })),
+  };
+}

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -48,6 +48,7 @@ describe('kb CLI — argv parsing and dispatch', () => {
     expect(r.stdout).toContain('kb remember');
     expect(r.stdout).toContain('kb capture');
     expect(r.stdout).toContain('kb doctor');
+    expect(r.stdout).toContain('kb eval');
     expect(r.stdout).toContain('kb stale-check');
   });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -21,6 +21,7 @@ import { fileURLToPath } from 'url';
 import { runCapture } from './cli-capture.js';
 import { runCompare } from './cli-compare.js';
 import { runDoctor } from './cli-doctor.js';
+import { runEval } from './cli-eval.js';
 import { runList } from './cli-list.js';
 import { runModels } from './cli-models.js';
 import { runRemember } from './cli-remember.js';
@@ -67,6 +68,8 @@ Usage:
                                            to a KB note as a fenced block.
   kb compare <query> <a> <b>              Side-by-side rank/score table.
   kb doctor [--format=md|json]            Aggregate model/index/backend health.
+  kb eval <fixture.yml|json> [--model=<id>] [--format=md|json]
+                                           Run fixture-driven retrieval checks.
   kb stale-check [--kb=<name>] [--no-cache] [--verbose]
                                            Scan markdown notes for path / URL
                                            references that no longer resolve.
@@ -189,6 +192,9 @@ export async function main(argv: string[]): Promise<number> {
   }
   if (sub === 'doctor') {
     return runDoctor(rest);
+  }
+  if (sub === 'eval') {
+    return runEval(rest);
   }
   if (sub === 'stale-check') {
     return runStaleCheck(rest);

--- a/src/retrieval-eval.test.ts
+++ b/src/retrieval-eval.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from '@jest/globals';
+import type { ScoredDocument } from './formatter.js';
+import type { Staleness } from './cli-search.js';
+import {
+  evaluateRetrievalCase,
+  normalizeRetrievalEvalFixture,
+  retrievalEvalExitCode,
+  summarizeRetrievalEval,
+  type RetrievalEvalCase,
+} from './retrieval-eval.js';
+
+const FRESH: Staleness = { indexMtime: '2026-05-09T08:00:00.000Z', modifiedFiles: 0, newFiles: 0 };
+
+function doc(source: string, score = 0.5, metadata: Record<string, unknown> = {}): ScoredDocument {
+  return {
+    pageContent: `content from ${source}`,
+    score,
+    metadata: {
+      source,
+      relativePath: source,
+      ...metadata,
+    },
+  };
+}
+
+function fixtureCase(overrides: Partial<RetrievalEvalCase> = {}): RetrievalEvalCase {
+  return {
+    name: 'case',
+    query: 'deployment notes',
+    requiredSources: [],
+    forbiddenSources: [],
+    expectedMetadata: [],
+    stalePolicy: 'fresh',
+    ...overrides,
+  };
+}
+
+describe('normalizeRetrievalEvalFixture', () => {
+  it('normalizes fixture cases with source, metadata, duplicate, gate, and stale policy fields', () => {
+    const fixture = normalizeRetrievalEvalFixture({
+      gate: true,
+      cases: [{
+        name: 'routing',
+        query: 'routing bug',
+        kb: 'ops',
+        k: 5,
+        threshold: 0.8,
+        gate: false,
+        required_sources: ['runbooks/routing.md'],
+        forbidden_sources: ['archive/old-routing.md'],
+        expected_metadata: { 'frontmatter.status': 'approved' },
+        max_duplicate_groups: 1,
+        stale_policy: { expect: 'fresh' },
+      }],
+    });
+
+    expect(fixture.gate).toBe(true);
+    expect(fixture.cases[0]).toMatchObject({
+      name: 'routing',
+      query: 'routing bug',
+      kb: 'ops',
+      k: 5,
+      threshold: 0.8,
+      gate: false,
+      requiredSources: ['runbooks/routing.md'],
+      forbiddenSources: ['archive/old-routing.md'],
+      maxDuplicateGroups: 1,
+      stalePolicy: 'fresh',
+    });
+    expect(fixture.cases[0].expectedMetadata).toEqual([
+      { path: 'frontmatter.status', equals: 'approved' },
+    ]);
+  });
+});
+
+describe('evaluateRetrievalCase', () => {
+  it('passes when required sources and metadata are present and duplicate budget is respected', () => {
+    const result = evaluateRetrievalCase(
+      fixtureCase({
+        requiredSources: ['runbooks/routing.md'],
+        forbiddenSources: ['archive/old-routing.md'],
+        expectedMetadata: [{ path: 'frontmatter.status', equals: 'approved' }],
+        maxDuplicateGroups: 1,
+      }),
+      [
+        doc('/tmp/kbs/ops/runbooks/routing.md', 0.2, {
+          frontmatter: { status: 'approved' },
+        }),
+        doc('notes/design.md'),
+        doc('notes/design.md'),
+      ],
+      FRESH,
+    );
+
+    expect(result.passed).toBe(true);
+    expect(result.duplicateGroups).toBe(1);
+    expect(result.failures).toEqual([]);
+  });
+
+  it('fails when a required source is missing', () => {
+    const result = evaluateRetrievalCase(
+      fixtureCase({ requiredSources: ['runbooks/incident.md'] }),
+      [doc('runbooks/routing.md')],
+      FRESH,
+    );
+
+    expect(result.passed).toBe(false);
+    expect(result.failures).toContain('missing required source: runbooks/incident.md');
+  });
+
+  it('fails when a forbidden source is present', () => {
+    const result = evaluateRetrievalCase(
+      fixtureCase({ forbiddenSources: ['archive/obsolete.md'] }),
+      [doc('archive/obsolete.md')],
+      FRESH,
+    );
+
+    expect(result.passed).toBe(false);
+    expect(result.failures).toContain('forbidden source present: archive/obsolete.md');
+  });
+
+  it('fails when duplicate source groups exceed the budget', () => {
+    const result = evaluateRetrievalCase(
+      fixtureCase({ maxDuplicateGroups: 1 }),
+      [
+        doc('notes/a.md'),
+        doc('notes/a.md'),
+        doc('notes/b.md'),
+        doc('notes/b.md'),
+        doc('notes/c.md'),
+      ],
+      FRESH,
+    );
+
+    expect(result.passed).toBe(false);
+    expect(result.duplicateGroups).toBe(2);
+    expect(result.failures).toContain('duplicate source groups 2 exceeds budget 1');
+  });
+
+  it('only produces a nonzero exit when a failing case is gated', () => {
+    const warning = evaluateRetrievalCase(
+      fixtureCase({ requiredSources: ['missing.md'] }),
+      [],
+      FRESH,
+      false,
+    );
+    const gated = evaluateRetrievalCase(
+      fixtureCase({ gate: true, requiredSources: ['missing.md'] }),
+      [],
+      FRESH,
+      false,
+    );
+
+    expect(retrievalEvalExitCode(summarizeRetrievalEval([warning]))).toBe(0);
+    expect(retrievalEvalExitCode(summarizeRetrievalEval([gated]))).toBe(1);
+  });
+});

--- a/src/retrieval-eval.ts
+++ b/src/retrieval-eval.ts
@@ -1,0 +1,358 @@
+import { minimatch } from 'minimatch';
+import type { ScoredDocument } from './formatter.js';
+import type { Staleness } from './cli-search.js';
+
+export type StalePolicy = 'allow_stale' | 'fresh' | 'stale';
+
+export interface ExpectedMetadataRule {
+  path: string;
+  equals: unknown;
+}
+
+export interface RetrievalEvalCase {
+  name: string;
+  query: string;
+  kb?: string;
+  k?: number;
+  threshold?: number;
+  gate?: boolean;
+  requiredSources: string[];
+  forbiddenSources: string[];
+  expectedMetadata: ExpectedMetadataRule[];
+  maxDuplicateGroups?: number;
+  stalePolicy: StalePolicy;
+}
+
+export interface RetrievalEvalCaseInput {
+  name?: string;
+  query: string;
+  kb?: string;
+  k?: number;
+  threshold?: number;
+  gate?: boolean;
+  required_sources?: string[];
+  forbidden_sources?: string[];
+  expected_metadata?: Record<string, unknown> | Array<Record<string, unknown>>;
+  max_duplicate_groups?: number;
+  stale_policy?: StalePolicy | { expect?: StalePolicy };
+}
+
+export interface RetrievalEvalFixture {
+  gate: boolean;
+  cases: RetrievalEvalCase[];
+}
+
+export interface RetrievalEvalCaseResult {
+  name: string;
+  query: string;
+  kb?: string;
+  gate: boolean;
+  passed: boolean;
+  failures: string[];
+  warnings: string[];
+  resultCount: number;
+  duplicateGroups: number;
+}
+
+export interface RetrievalEvalReport {
+  cases: RetrievalEvalCaseResult[];
+  total: number;
+  passed: number;
+  failed: number;
+  gateFailed: number;
+}
+
+export function normalizeRetrievalEvalFixture(input: unknown): RetrievalEvalFixture {
+  if (!isRecord(input)) {
+    throw new Error('fixture must be an object with a cases array');
+  }
+  const gate = readOptionalBoolean(input, 'gate') ?? false;
+  const rawCases = input.cases;
+  if (!Array.isArray(rawCases) || rawCases.length === 0) {
+    throw new Error('fixture cases must be a non-empty array');
+  }
+  return {
+    gate,
+    cases: rawCases.map((raw, idx) => normalizeCase(raw, idx + 1)),
+  };
+}
+
+export function evaluateRetrievalCase(
+  fixtureCase: RetrievalEvalCase,
+  results: readonly ScoredDocument[],
+  staleness: Staleness,
+  fixtureGate = false,
+): RetrievalEvalCaseResult {
+  const failures: string[] = [];
+  const warnings: string[] = [];
+
+  for (const required of fixtureCase.requiredSources) {
+    if (!results.some((doc) => documentMatchesSource(doc, required))) {
+      failures.push(`missing required source: ${required}`);
+    }
+  }
+
+  for (const forbidden of fixtureCase.forbiddenSources) {
+    if (results.some((doc) => documentMatchesSource(doc, forbidden))) {
+      failures.push(`forbidden source present: ${forbidden}`);
+    }
+  }
+
+  for (const expected of fixtureCase.expectedMetadata) {
+    if (!results.some((doc) => metadataMatchesRule(doc.metadata, expected))) {
+      failures.push(`expected metadata not found: ${expected.path} = ${JSON.stringify(expected.equals)}`);
+    }
+  }
+
+  const duplicateGroups = countDuplicateSourceGroups(results);
+  if (
+    fixtureCase.maxDuplicateGroups !== undefined &&
+    duplicateGroups > fixtureCase.maxDuplicateGroups
+  ) {
+    failures.push(
+      `duplicate source groups ${duplicateGroups} exceeds budget ${fixtureCase.maxDuplicateGroups}`,
+    );
+  }
+
+  const stale = isStale(staleness);
+  if (fixtureCase.stalePolicy === 'fresh' && stale) {
+    failures.push('stale policy expected fresh results, but the index has modified/new files');
+  } else if (fixtureCase.stalePolicy === 'stale' && !stale) {
+    failures.push('stale policy expected stale results, but the index is fresh');
+  } else if (fixtureCase.stalePolicy === 'allow_stale' && stale) {
+    warnings.push('index has modified/new files, but stale_policy allows stale results');
+  }
+
+  const gate = fixtureCase.gate ?? fixtureGate;
+  return {
+    name: fixtureCase.name,
+    query: fixtureCase.query,
+    ...(fixtureCase.kb !== undefined ? { kb: fixtureCase.kb } : {}),
+    gate,
+    passed: failures.length === 0,
+    failures,
+    warnings,
+    resultCount: results.length,
+    duplicateGroups,
+  };
+}
+
+export function summarizeRetrievalEval(results: RetrievalEvalCaseResult[]): RetrievalEvalReport {
+  const failed = results.filter((r) => !r.passed).length;
+  return {
+    cases: results,
+    total: results.length,
+    passed: results.length - failed,
+    failed,
+    gateFailed: results.filter((r) => r.gate && !r.passed).length,
+  };
+}
+
+export function retrievalEvalExitCode(report: RetrievalEvalReport): number {
+  return report.gateFailed > 0 ? 1 : 0;
+}
+
+export function formatRetrievalEvalMarkdown(report: RetrievalEvalReport): string {
+  const lines = ['# kb eval', ''];
+  for (const result of report.cases) {
+    const status = result.passed ? 'PASS' : result.gate ? 'FAIL' : 'WARN';
+    const scope = result.kb === undefined ? 'all KBs' : `kb=${result.kb}`;
+    lines.push(
+      `- ${status} ${result.name} (${scope}, ${result.resultCount} result(s), duplicate groups: ${result.duplicateGroups})`,
+    );
+    for (const failure of result.failures) {
+      lines.push(`  - ${failure}`);
+    }
+    for (const warning of result.warnings) {
+      lines.push(`  - ${warning}`);
+    }
+  }
+  lines.push('');
+  lines.push(
+    `Summary: ${report.passed}/${report.total} passed; ${report.failed} failed; ${report.gateFailed} gate failure(s).`,
+  );
+  return `${lines.join('\n')}\n`;
+}
+
+function normalizeCase(raw: unknown, caseNumber: number): RetrievalEvalCase {
+  if (!isRecord(raw)) {
+    throw new Error(`case ${caseNumber} must be an object`);
+  }
+  const query = readRequiredString(raw, 'query', `case ${caseNumber}`);
+  const kb = readOptionalString(raw, 'kb');
+  const k = readOptionalPositiveInteger(raw, 'k');
+  const threshold = readOptionalPositiveNumber(raw, 'threshold');
+  const gate = readOptionalBoolean(raw, 'gate');
+  const maxDuplicateGroups = readOptionalNonNegativeInteger(raw, 'max_duplicate_groups');
+  return {
+    name: readOptionalString(raw, 'name') ?? `case ${caseNumber}`,
+    query,
+    ...(kb !== undefined ? { kb } : {}),
+    ...(k !== undefined ? { k } : {}),
+    ...(threshold !== undefined ? { threshold } : {}),
+    ...(gate !== undefined ? { gate } : {}),
+    requiredSources: readOptionalStringArray(raw, 'required_sources') ?? [],
+    forbiddenSources: readOptionalStringArray(raw, 'forbidden_sources') ?? [],
+    expectedMetadata: normalizeExpectedMetadata(raw.expected_metadata, caseNumber),
+    ...(maxDuplicateGroups !== undefined ? { maxDuplicateGroups } : {}),
+    stalePolicy: normalizeStalePolicy(raw.stale_policy, caseNumber),
+  };
+}
+
+function normalizeExpectedMetadata(raw: unknown, caseNumber: number): ExpectedMetadataRule[] {
+  if (raw === undefined) return [];
+  if (isRecord(raw)) {
+    return Object.entries(raw).map(([path, equals]) => ({ path, equals }));
+  }
+  if (Array.isArray(raw)) {
+    const rules: ExpectedMetadataRule[] = [];
+    raw.forEach((entry, idx) => {
+      if (!isRecord(entry)) {
+        throw new Error(`case ${caseNumber} expected_metadata[${idx}] must be an object`);
+      }
+      for (const [path, equals] of Object.entries(entry)) {
+        rules.push({ path, equals });
+      }
+    });
+    return rules;
+  }
+  throw new Error(`case ${caseNumber} expected_metadata must be an object or array of objects`);
+}
+
+function normalizeStalePolicy(raw: unknown, caseNumber: number): StalePolicy {
+  if (raw === undefined) return 'allow_stale';
+  const candidate = isRecord(raw) ? raw.expect : raw;
+  if (candidate === 'allow_stale' || candidate === 'fresh' || candidate === 'stale') {
+    return candidate;
+  }
+  throw new Error(
+    `case ${caseNumber} stale_policy must be "allow_stale", "fresh", or "stale"`,
+  );
+}
+
+function documentMatchesSource(doc: ScoredDocument, pattern: string): boolean {
+  return sourceIdentities(doc).some((source) => sourceMatches(source, pattern));
+}
+
+function sourceIdentities(doc: ScoredDocument): string[] {
+  const metadata = doc.metadata as Record<string, unknown>;
+  const candidates = [metadata.source, metadata.relativePath];
+  return candidates.filter((candidate): candidate is string =>
+    typeof candidate === 'string' && candidate.trim() !== '');
+}
+
+function sourceMatches(source: string, pattern: string): boolean {
+  if (source === pattern) return true;
+  if (source.endsWith(`/${pattern}`)) return true;
+  return minimatch(source, pattern, { dot: true });
+}
+
+function countDuplicateSourceGroups(results: readonly ScoredDocument[]): number {
+  const counts = new Map<string, number>();
+  results.forEach((doc, idx) => {
+    const key = sourceIdentities(doc)[0] ?? `(unknown source ${idx + 1})`;
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  });
+  return Array.from(counts.values()).filter((count) => count > 1).length;
+}
+
+function metadataMatchesRule(metadata: unknown, rule: ExpectedMetadataRule): boolean {
+  return deepEqual(readPath(metadata, rule.path), rule.equals);
+}
+
+function readPath(input: unknown, dotPath: string): unknown {
+  let current = input;
+  for (const segment of dotPath.split('.')) {
+    if (!isRecord(current) || !(segment in current)) return undefined;
+    current = current[segment];
+  }
+  return current;
+}
+
+function deepEqual(a: unknown, b: unknown): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+function isStale(s: Staleness): boolean {
+  return s.modifiedFiles + s.newFiles > 0;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function readRequiredString(
+  input: Record<string, unknown>,
+  key: string,
+  context: string,
+): string {
+  const value = input[key];
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new Error(`${context} requires non-empty ${key}`);
+  }
+  return value;
+}
+
+function readOptionalString(input: Record<string, unknown>, key: string): string | undefined {
+  const value = input[key];
+  if (value === undefined) return undefined;
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new Error(`${key} must be a non-empty string`);
+  }
+  return value;
+}
+
+function readOptionalBoolean(input: Record<string, unknown>, key: string): boolean | undefined {
+  const value = input[key];
+  if (value === undefined) return undefined;
+  if (typeof value !== 'boolean') throw new Error(`${key} must be boolean`);
+  return value;
+}
+
+function readOptionalStringArray(
+  input: Record<string, unknown>,
+  key: string,
+): string[] | undefined {
+  const value = input[key];
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value) || value.some((entry) => typeof entry !== 'string' || entry.trim() === '')) {
+    throw new Error(`${key} must be an array of non-empty strings`);
+  }
+  return value;
+}
+
+function readOptionalPositiveInteger(
+  input: Record<string, unknown>,
+  key: string,
+): number | undefined {
+  const value = input[key];
+  if (value === undefined) return undefined;
+  if (typeof value !== 'number' || !Number.isInteger(value) || value <= 0) {
+    throw new Error(`${key} must be a positive integer`);
+  }
+  return value;
+}
+
+function readOptionalNonNegativeInteger(
+  input: Record<string, unknown>,
+  key: string,
+): number | undefined {
+  const value = input[key];
+  if (value === undefined) return undefined;
+  if (typeof value !== 'number' || !Number.isInteger(value) || value < 0) {
+    throw new Error(`${key} must be a non-negative integer`);
+  }
+  return value;
+}
+
+function readOptionalPositiveNumber(
+  input: Record<string, unknown>,
+  key: string,
+): number | undefined {
+  const value = input[key];
+  if (value === undefined) return undefined;
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+    throw new Error(`${key} must be a positive number`);
+  }
+  return value;
+}


### PR DESCRIPTION
## Summary
- add `kb eval` for YAML/JSON retrieval fixtures with required/forbidden source checks, expected metadata, duplicate-source budgets, stale-policy expectations, and per-case gating
- wire the command into CLI help and document the fixture format in README, requirements, and testing docs
- add evaluator coverage for passing cases, missing required sources, forbidden sources, duplicate budget failures, and gated exit behavior

## Test plan
- [x] `npx jest src/retrieval-eval.test.ts --runInBand`
- [x] `npx jest src/retrieval-eval.test.ts src/cli.test.ts --runInBand`
- [x] `npx tsc --noEmit`
- [x] `npm run build`
- [x] `npm test`

Closes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)