### PR TITLE
feat: hybrid retrieval via RRF c=60 (#206 stage 2; stacked on #223)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [Unreleased] — `--mode=hybrid` RRF dense+lexical fusion (#206 stage 2)
+
+### Added
+
+- **`kb search --mode=hybrid` and MCP `retrieve_knowledge` `search_mode: "hybrid"`.** Stage 2 of #206. Runs the dense FAISS leg and the per-KB BM25 lexical leg concurrently, fuses the two ranked lists via Reciprocal Rank Fusion (Cormack 2009; `c=60`), returns the fused top-k. Default remains `dense` (byte-equal to 0.x); `--mode=hybrid` and the new optional `search_mode` MCP arg are strictly additive. Closes recall blind spots on exact-token queries (filenames, RFC/ADR numbers, error codes, env var names, model ids) without regressing natural-language queries.
+- `src/rrf.ts` — pure RRF combinator with per-retriever weights, within-list dedupe (best rank wins), and stable insertion-order tie-break. 13 unit + property-shaped tests. Exports `chunkIdFromMetadata` for callers that need the same `${source}#${chunkIndex}` identifier the dense/lexical legs use.
+- ADR `0006-hybrid-retrieval-rrf-default-c60.md` — rationale for choosing RRF over linear interpolation, and `c=60` over alternatives. Cross-referenced from the threat-model and RFC 006.
+- `docs/testing/fixtures/hybrid-vs-dense.yml` — `kb eval` fixture pack with 6 exact-token cases (where hybrid is expected to lift) plus 6 paraphrase cases (where hybrid must not regress). `gate: false` — operator-facing guidance until the project ships a stable dogfooding KB seed.
+
+### Changed
+
+- The MCP `retrieve_knowledge` tool gains an optional `search_mode: "dense" | "hybrid"` field. Wire-compatible: clients that omit it (every 0.x client) keep the dense path byte-for-byte. Hybrid responses prepend a `> _Mode: hybrid (RRF c=60); dense fetched N, lexical fetched M_` header line to the markdown payload so an inspecting agent can attribute the ranking. The `model_name` envelope from RFC 013 M3 still applies on top.
+
+### Internal
+
+- 598 tests pass (13 new RRF + 585 prior). Dense-path test surface untouched.
+
 ## [Unreleased] — `kb search --mode=lexical` BM25 debug surface (#206 stage 1)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ kb list                       # list available knowledge bases
 kb search "your query"                       # read-only dense search; cheap, fast (~0.6 s)
 kb search "query" --refresh                  # also re-scan KB files (write path)
 kb search "INDEX_NOT_INITIALIZED" --mode=lexical --refresh   # BM25 debug surface (#206 stage 1)
+kb search "INDEX_NOT_INITIALIZED" --mode=hybrid              # dense ⨁ BM25 fused via RRF (#206 stage 2)
 kb remember --suggest --kb=work --title="Quarterly plan"
 printf '# Quarterly plan\n\n...' | kb remember --kb=work --title="Quarterly plan" --stdin --yes
 printf '\nFollow-up note.\n' | kb remember --kb=work --append=quarterly-plan.md --stdin --yes

--- a/docs/architecture/adr/0006-hybrid-retrieval-rrf-default-c60.md
+++ b/docs/architecture/adr/0006-hybrid-retrieval-rrf-default-c60.md
@@ -1,0 +1,54 @@
+# 0006 — Hybrid retrieval via Reciprocal Rank Fusion with c=60
+
+- **Status:** Accepted (#206 stage 2)
+- **Date:** 2026-05-09
+- **Deciders:** Repo owner
+
+## Context and Problem Statement
+
+Pure dense retrieval (FAISS over an embedding model) has well-documented blind spots on **exact-token queries**: filenames, RFC/ADR numbers, error codes, env var names, model ids, code identifiers. RFC 006 §4 named sparse+dense hybrid retrieval as a non-goal and explicitly deferred it to a follow-up sparse-hybrid RFC; issue #206 is that follow-up. Stage 1 (#206 stage 1, PR #223) shipped the per-KB BM25 lexical index and a `kb search --mode=lexical` debug surface. Stage 2 (this ADR) wires the two ranked lists together.
+
+Two combiner families were considered:
+
+1. **Linear interpolation.** `score(d) = α · norm(dense_score(d)) + (1-α) · norm(lexical_score(d))`. Requires a score-normalization step per retriever and a parameter sweep over `α`. Highly sensitive to score-distribution drift across embedding models, BM25 corpus size, and retriever weighting.
+2. **Reciprocal Rank Fusion (RRF, Cormack et al. 2009).** `score(d) = Σ_r w_r · 1/(c + rank_r(d))`. Operates only on **rank**, not raw score, so it is invariant under any monotonic transform of either retriever's scoring. Has one knob (`c`) which Cormack found near-optimal at `60` across TREC topics; LangChain's `EnsembleRetriever` ships with the same default.
+
+## Decision
+
+Use **RRF with `c = 60`** as the default and only fuser for `--mode=hybrid` and the MCP `retrieve_knowledge` `search_mode: "hybrid"` arg.
+
+## Decision Drivers
+
+- **Score-distribution invariance.** Dense scores are FAISS L2 distances on float vectors; BM25 scores are TF-IDF aggregates over token frequencies. There is no principled normalization between them. RRF sidesteps the question entirely.
+- **Cross-model stability.** When users add a second embedding model (RFC 013 multi-model support), the dense score distribution shifts; RRF keeps fusion stable.
+- **One-knob simplicity.** Cormack's `c=60` choice has held up empirically across TREC corpora and inside LangChain's production retriever stack. We start from the same default and let operators tune via per-retriever weights (`KB_HYBRID_DENSE_WEIGHT`, `KB_HYBRID_LEXICAL_WEIGHT`) when their workload warrants it.
+- **Existing convention.** RFC 006 §5.4 already chose RRF for the dense-multi-provider fusion path. Reusing the same combinator for sparse+dense keeps the codebase coherent and lets the eventual three-way (dense_A + dense_B + lexical) fusion in RFC 006's `deep` tier be a one-line extension instead of a redesign.
+- **Per-retriever weight headroom.** RRF accepts `w_r` weights without changing the math, so future ablations on `α` can land as `weights = { dense: α, lexical: 1-α }` without reworking the combinator.
+
+## Considered and Rejected
+
+- **Linear interpolation with score normalization.** Scores from different retrievers normalize differently; min-max normalization makes the fusion sensitive to outliers; z-score normalization is ill-defined for BM25 corpora with one or two documents. The op-cost of "what α should I use?" lands on every operator. Rejected.
+- **Cross-encoder rerank** (RFC 006's `deep` tier) **as the fuser.** Cross-encoder rerank is a separate concern (re-rank a top-N candidate set with a transformer model) — it's *complementary* to RRF, not a replacement. Out of scope for #206; RFC 006 §5 keeps it.
+- **Higher c (e.g. `100`).** Reduces the gap between rank-1 and rank-50 contributions, which over-weights deep-tail matches. Net regression on the exact-token cases that motivate hybrid in the first place.
+- **Lower c (e.g. `10`).** Over-amplifies rank-1 contributions; one strong-rank-1 in a single retriever dominates the fused score; loses the cross-confirmation effect that hybrid is meant to provide.
+
+## Implementation Notes
+
+- `src/rrf.ts` is the only place the RRF math lives. Pure function; unit-tested.
+- `c` is hard-coded to `60` at the call sites today. Surfacing it as `KB_HYBRID_RRF_C` is a small follow-up if operator demand surfaces.
+- Per-retriever weights are wired through `RRFOptions.weights` but not exposed via env var in v1. Default `dense: 1, lexical: 1`.
+- Tie-break on equal `fusedScore` is **stable insertion order** of the contributing lists — dense first, then lexical. Documented in the unit tests.
+
+## Validation
+
+The validation gate per #206 §M2 is:
+
+1. **Byte-equality of dense-only callers.** Any `retrieve_knowledge` call that omits `search_mode` or passes `search_mode: "dense"` produces output identical to the 0.x dense-only behavior. Verified by the existing dense-path test suite (583 tests retained).
+2. **Lift on exact-token cases.** The `docs/testing/fixtures/hybrid-vs-dense.yml` pack contains gated cases like `INDEX_NOT_INITIALIZED`, `RFC 006`, `pickleparser`, `MCP_AUTH_TOKEN`, `ollama__nomic-embed-text-latest` where dense alone misses; hybrid is expected to pass.
+3. **No regression on natural-language cases.** Same fixture pack contains paraphrased doc-heading queries where dense should win; hybrid must keep passing them.
+
+## More Information
+
+- Cormack, G. V., Clarke, C. L. A., & Büttcher, S. (2009). *Reciprocal Rank Fusion outperforms Condorcet and individual rank learning methods.*
+- RFC 006 (`docs/rfcs/006-multi-provider-tiered-retrieval.md`) §4–§5.
+- Issue #206; issue #214 (cross-process query-embedding cache, separate concern).

--- a/docs/testing/fixtures/hybrid-vs-dense.yml
+++ b/docs/testing/fixtures/hybrid-vs-dense.yml
@@ -1,0 +1,104 @@
+# #206 stage 2 — kb eval fixture pack: hybrid (RRF) vs dense baseline.
+#
+# Two case sets:
+#
+#   1. Exact-token queries — dense often misses, hybrid is expected to win.
+#      Targets the literature's "out-of-vocabulary lift" claim
+#      (llm-memory/pdfs/2604.17948.pdf chunks 46-48).
+#
+#   2. Natural-language queries — paraphrased doc headings where dense
+#      should already win. Hybrid must NOT regress these.
+#
+# Run with:
+#   kb eval docs/testing/fixtures/hybrid-vs-dense.yml --mode=dense
+#   kb eval docs/testing/fixtures/hybrid-vs-dense.yml --mode=hybrid
+#
+# The fixture is `gate: false` — failures print a warning and exit 0.
+# This is a guidance pack for operators / contributors to verify the
+# claim against their own KBs; in CI it is currently informational.
+# Once the project ships a stable dogfooding KB seed, the gate flips.
+#
+# `kb` (or `--kb=...` per case) must point at a KB whose corpus actually
+# contains the referenced sources — substitute the paths for your local
+# KBs. The defaults below assume a `docs` KB containing the project's
+# own README, RFCs, and threat-model.
+
+gate: false
+
+cases:
+  # === Exact-token / OOV cases — hybrid expected to win =====================
+
+  - name: exact error code — INDEX_NOT_INITIALIZED
+    query: INDEX_NOT_INITIALIZED
+    kb: docs
+    required_sources:
+      - README.md
+    max_duplicate_groups: 3
+
+  - name: exact RFC reference — RFC 006
+    query: "RFC 006"
+    kb: docs
+    required_sources:
+      - docs/rfcs/006-multi-provider-tiered-retrieval.md
+
+  - name: exact env var — MCP_AUTH_TOKEN
+    query: MCP_AUTH_TOKEN
+    kb: docs
+    required_sources:
+      - README.md
+
+  - name: exact dependency name — pickleparser
+    query: pickleparser
+    kb: docs
+    required_sources:
+      - docs/architecture/threat-model.md
+
+  - name: exact model id — ollama__nomic-embed-text-latest
+    query: "ollama__nomic-embed-text-latest"
+    kb: docs
+    required_sources:
+      - docs/rfcs/013-multimodel-support.md
+
+  - name: exact ADR number — ADR 0002
+    query: "ADR 0002"
+    kb: docs
+    required_sources:
+      - docs/architecture/adr/0002-per-file-hash-sidecars.md
+
+  # === Natural-language cases — hybrid must not regress =====================
+
+  - name: paraphrase — how chunking works
+    query: how does the markdown chunker handle headings
+    kb: docs
+    required_sources:
+      - docs/architecture/adr/0004-markdown-splitter-default.md
+
+  - name: paraphrase — single-process invariant
+    query: why does the server only support one process per index path
+    kb: docs
+    required_sources:
+      - docs/architecture/threat-model.md
+
+  - name: paraphrase — per-file invalidation strategy
+    query: how does the index decide which files to re-embed
+    kb: docs
+    required_sources:
+      - docs/architecture/adr/0002-per-file-hash-sidecars.md
+
+  - name: paraphrase — what does kb doctor check
+    query: what health checks run when I invoke the doctor command
+    kb: docs
+    required_sources:
+      - README.md
+
+  - name: paraphrase — multi-model rationale
+    query: why support keeping multiple embedding models side by side
+    kb: docs
+    required_sources:
+      - docs/rfcs/013-multimodel-support.md
+
+  - name: paraphrase — atomic save guarantees
+    query: how does the FAISS save remain atomic during concurrent writes
+    kb: docs
+    required_sources:
+      - docs/rfcs/014-atomic-faiss-save.md

--- a/scripts/dogfood-hybrid.sh
+++ b/scripts/dogfood-hybrid.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+#
+# Dogfood `kb search --mode=hybrid` against `--mode=dense` on real KBs.
+# Issue #206 stage 2 / ADR 0006 reproducibility script.
+#
+# Runs a curated query set in both modes against KBs whose lexical index is
+# already built (or builds it on first run via `--refresh`), captures top-K
+# source paths per mode, and tallies recall against an "expected" source for
+# each gated query. Reports a per-query breakdown plus a summary so reviewers
+# can re-run the empirical lift evidence attached to PR #224.
+#
+# Usage:
+#   scripts/dogfood-hybrid.sh                 # use the default query bundle
+#   QUERIES_FILE=my.tsv scripts/dogfood-hybrid.sh   # custom bundle
+#   KB_BIN=./build/cli.js scripts/dogfood-hybrid.sh # explicit cli location
+#
+# Query bundle file format (TSV; pipes accepted as the v1 separator):
+#   <kb>|<kind>|<query>|<expected_substring>
+# Lines starting with `#` are skipped. `<expected_substring>` may be empty —
+# such queries are reported as informational ("—" in the dense/hybrid columns).
+#
+# Exit code: 0 if no regressions (hybrid never strictly worse than dense for a
+# gated query), 1 otherwise. Lifts are not required — a no-op tie matrix still
+# exits 0.
+#
+# Defaults assume the KBs at ~/knowledge_bases/ and a globally-installed `kb`
+# bin. Override KNOWLEDGE_BASES_ROOT_DIR / FAISS_INDEX_PATH via env if your
+# layout differs (the same env vars the server reads).
+
+set -euo pipefail
+
+KB_BIN="${KB_BIN:-$(command -v kb || true)}"
+if [ -z "${KB_BIN}" ] || [ ! -x "${KB_BIN}" ]; then
+  # Fall back to the local build inside this checkout.
+  here_build="$(cd "$(dirname "$0")/.." && pwd)/build/cli.js"
+  if [ -x "$here_build" ] || [ -f "$here_build" ]; then
+    KB_BIN="$here_build"
+  fi
+fi
+if [ -z "${KB_BIN}" ] || [ ! -e "${KB_BIN}" ]; then
+  echo "dogfood-hybrid: cannot find kb. Set KB_BIN or install/build first." >&2
+  exit 2
+fi
+
+INVOKE=(node "$KB_BIN")
+case "$KB_BIN" in
+  */kb|kb) INVOKE=("$KB_BIN") ;;     # bin shim, run directly
+esac
+
+K="${TOP_K:-5}"
+QUERIES_FILE="${QUERIES_FILE:-}"
+
+# Default bundle. The exact-token queries below are the ones referenced in
+# PR #224's empirical evidence comment; tweak via QUERIES_FILE for another
+# corpus.
+DEFAULT_BUNDLE="$(cat <<'EOF'
+arxiv-llm-inference|exact|DeepSeekMoE|2605.05693
+arxiv-llm-inference|exact|SpikingBrain|2604.22575
+arxiv-llm-inference|exact|SSE-SWA|2604.22575
+llm-memory|exact|SecureBERT 2.0|2604.17948
+llm-memory|exact|Falcon H1R|2604.17948
+llm-memory|exact|Reciprocal Rank Fusion|
+arxiv-llm-inference|paraphrase|how does mixture of experts speed up inference|
+arxiv-llm-inference|paraphrase|sparse attention with brain-inspired memory gating|2604.22575
+llm-memory|paraphrase|hybrid retrieval beats dense alone for code reasoning|2604.17948
+llm-memory|paraphrase|hierarchical memory architecture for long context LLMs|
+llm-as-judge|paraphrase|how to evaluate LLM judges for bias|
+llm-reasoning|paraphrase|chain of thought versus tree search for reasoning|
+EOF
+)"
+
+if [ -n "$QUERIES_FILE" ]; then
+  if [ ! -r "$QUERIES_FILE" ]; then
+    echo "dogfood-hybrid: QUERIES_FILE not readable: $QUERIES_FILE" >&2
+    exit 2
+  fi
+  BUNDLE="$(grep -vE '^[[:space:]]*(#|$)' "$QUERIES_FILE")"
+else
+  BUNDLE="$DEFAULT_BUNDLE"
+fi
+
+# Run kb search; print top-K relativePath values, one per line.
+run_mode() {
+  local kb=$1 query=$2 mode=$3
+  "${INVOKE[@]}" search "$query" --kb="$kb" --mode="$mode" --k="$K" --format=json 2>/dev/null \
+    | jq -r '.results[]?.metadata.relativePath // empty' 2>/dev/null \
+    | head -"$K"
+}
+
+# Find rank (1..K) of an expected substring in a list of source paths; 0 if
+# absent; "-" if no expected was supplied.
+find_rank() {
+  local expected=$1 sources=$2
+  [ -z "$expected" ] && { echo "-"; return; }
+  local rank=1
+  while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    if [[ "$line" == *"$expected"* ]]; then
+      echo "$rank"
+      return
+    fi
+    rank=$((rank + 1))
+  done <<< "$sources"
+  echo 0
+}
+
+printf "| %-22s | %-12s | %-50s | %-12s | dense | hybrid |\n" "KB" "Kind" "Query" "Expected"
+printf "|------------------------|--------------|----------------------------------------------------|--------------|-------|--------|\n"
+
+dense_finds=0
+hybrid_finds=0
+hybrid_lifts=0
+hybrid_regress=0
+hybrid_better=0
+dense_better=0
+ties=0
+neither=0
+gated=0
+
+while IFS='|' read -r kb kind query expected; do
+  [ -z "$kb" ] && continue
+  dense_top=$(run_mode "$kb" "$query" dense)
+  hybrid_top=$(run_mode "$kb" "$query" hybrid)
+  dense_rank=$(find_rank "$expected" "$dense_top")
+  hybrid_rank=$(find_rank "$expected" "$hybrid_top")
+
+  if [ -n "$expected" ]; then
+    gated=$((gated + 1))
+    [ "$dense_rank" != "0" ] && dense_finds=$((dense_finds + 1))
+    [ "$hybrid_rank" != "0" ] && hybrid_finds=$((hybrid_finds + 1))
+    if [ "$dense_rank" = "0" ] && [ "$hybrid_rank" != "0" ]; then
+      hybrid_lifts=$((hybrid_lifts + 1))
+    elif [ "$dense_rank" != "0" ] && [ "$hybrid_rank" = "0" ]; then
+      hybrid_regress=$((hybrid_regress + 1))
+    elif [ "$dense_rank" = "0" ] && [ "$hybrid_rank" = "0" ]; then
+      neither=$((neither + 1))
+    elif [ "$dense_rank" = "$hybrid_rank" ]; then
+      ties=$((ties + 1))
+    elif [ "$hybrid_rank" -lt "$dense_rank" ] 2>/dev/null; then
+      hybrid_better=$((hybrid_better + 1))
+    else
+      dense_better=$((dense_better + 1))
+    fi
+    dense_label=$([ "$dense_rank" = "0" ] && echo "miss" || echo "@$dense_rank")
+    hybrid_label=$([ "$hybrid_rank" = "0" ] && echo "miss" || echo "@$hybrid_rank")
+  else
+    dense_label="—"
+    hybrid_label="—"
+  fi
+  printf "| %-22s | %-12s | %-50s | %-12s | %5s | %6s |\n" \
+    "$kb" "$kind" "$(printf '%s' "$query" | cut -c1-50)" "$expected" \
+    "$dense_label" "$hybrid_label"
+done <<< "$BUNDLE"
+
+echo ""
+echo "Summary on the gated subset (queries with an expected source):"
+echo "  hybrid_lifts:    $hybrid_lifts (hybrid found, dense missed)"
+echo "  hybrid_better:   $hybrid_better (both found, hybrid ranked higher)"
+echo "  ties:            $ties"
+echo "  dense_better:    $dense_better (both found, dense ranked higher)"
+echo "  hybrid_regress:  $hybrid_regress (dense found, hybrid missed)"
+echo "  neither_found:   $neither"
+echo ""
+echo "  dense recall:    $dense_finds / $gated expected"
+echo "  hybrid recall:   $hybrid_finds / $gated expected"
+
+# Exit non-zero only on a regression — recall ties are fine; lifts are bonus.
+if [ "$hybrid_regress" -gt 0 ] || [ "$dense_better" -gt 0 ]; then
+  echo ""
+  echo "FAIL: hybrid retrieval shows ${hybrid_regress} regression(s) and ${dense_better} cases where dense ranked the expected source higher." >&2
+  exit 1
+fi

--- a/src/KnowledgeBaseServer.ts
+++ b/src/KnowledgeBaseServer.ts
@@ -56,6 +56,8 @@ import { StreamableHttpHost } from './transport/http.js';
 import { SseHost } from './transport/sse.js';
 import { ReindexTriggerWatcher } from './triggerWatcher.js';
 import { KBError, type KBErrorCode } from './errors.js';
+import { LexicalIndex, type LexicalSearchResult } from './lexical-index.js';
+import { chunkIdFromMetadata, reciprocalRankFusion, type RankedList } from './rrf.js';
 
 const SERVER_NAME = 'knowledge-base-server';
 const SERVER_VERSION = '0.1.0';
@@ -134,6 +136,12 @@ export class KnowledgeBaseServer {
         extensions: z.array(z.string()).optional().describe('Limit results to chunks whose source file has one of these extensions (e.g. [".md", ".pdf"]). Case-insensitive; leading dot optional.'),
         path_glob: z.string().optional().describe('Limit results to chunks whose KB-internal relative path matches this glob (e.g. "runbooks/**"). The KB-name segment is stripped before matching.'),
         tags: z.array(z.string()).optional().describe('Limit results to chunks whose source file has ALL of these tags in its YAML frontmatter.'),
+        // #206 stage 2 — sparse+dense hybrid retrieval. Default 'dense' is
+        // wire-compatible with 0.x clients: when the field is absent the
+        // server runs the unmodified dense path. 'hybrid' fuses dense FAISS
+        // top-N with per-KB BM25 top-N via Reciprocal Rank Fusion (c=60,
+        // Cormack 2009); see RFC 006 §4 + #206 + ADR 0006.
+        search_mode: z.enum(['dense', 'hybrid']).optional().describe('Retrieval mode. "dense" (default) uses FAISS only. "hybrid" fuses FAISS top-N with per-KB BM25 top-N via Reciprocal Rank Fusion. See #206.'),
       },
       async (args) => this.handleRetrieveKnowledge(args)
     );
@@ -446,6 +454,7 @@ export class KnowledgeBaseServer {
     extensions?: string[];
     path_glob?: string;
     tags?: string[];
+    search_mode?: 'dense' | 'hybrid';
   }): Promise<CallToolResult> {
     const query: string = args.query;
     const knowledgeBaseName: string | undefined = args.knowledge_base_name;
@@ -454,6 +463,16 @@ export class KnowledgeBaseServer {
     const filters = (args.extensions || args.path_glob || args.tags)
       ? { extensions: args.extensions, pathGlob: args.path_glob, tags: args.tags }
       : undefined;
+    const searchMode: 'dense' | 'hybrid' = args.search_mode ?? 'dense';
+
+    if (searchMode === 'hybrid') {
+      return this.handleRetrieveKnowledgeHybrid({
+        query,
+        knowledgeBaseName,
+        modelNameOverride,
+        filters,
+      });
+    }
 
     try {
       const startTime = Date.now();
@@ -517,6 +536,120 @@ export class KnowledgeBaseServer {
       if (err.stack) {
         logger.error(err.stack);
       }
+      return { content: [mcpErrorContent(err)], isError: true };
+    }
+  }
+
+  /**
+   * #206 stage 2 — hybrid retrieval handler. Runs the dense leg (FAISS via
+   * the active model) and the lexical leg (per-KB BM25) concurrently, fuses
+   * the two ranked lists with Reciprocal Rank Fusion (c=60, see ADR 0006),
+   * and returns the fused top-10 in the same `formatRetrievalAsMarkdown`
+   * shape as the dense path.
+   *
+   * Notes:
+   * - Threshold and metadata POST-filters are dense-only knobs and are NOT
+   *   applied to the hybrid output. They will be re-introduced in a follow-up
+   *   if user demand exceeds the byte-compat win — keeping them off here
+   *   means hybrid does not silently filter chunks the lexical leg returned.
+   * - The lexical index is auto-refreshed on first use per KB (when empty).
+   *   `kb search --refresh` (CLI) is the explicit refresh path; the MCP
+   *   server keeps the dense `updateIndex` invariant from the dense path.
+   * - Returns the same wire envelope as the dense handler with one added
+   *   markdown header line `> _Mode: hybrid (RRF c=60)_` so an inspecting
+   *   agent can attribute the ranking. JSON-shaped output is unchanged since
+   *   the `retrieve_knowledge` tool returns markdown text content.
+   */
+  private async handleRetrieveKnowledgeHybrid(input: {
+    query: string;
+    knowledgeBaseName?: string;
+    modelNameOverride?: string;
+    filters?: { extensions?: string[]; pathGlob?: string; tags?: string[] };
+  }): Promise<CallToolResult> {
+    const { query, knowledgeBaseName, modelNameOverride, filters } = input;
+    const HYBRID_FETCH_K = 40;
+    const HYBRID_TOP_K = 10;
+    const HYBRID_RRF_C = 60;
+
+    try {
+      let activeModelId: string;
+      try {
+        activeModelId = await resolveActiveModel({ explicitOverride: modelNameOverride });
+      } catch (err) {
+        if (err instanceof ActiveModelResolutionError) {
+          return { content: [{ type: 'text', text: err.message }], isError: true };
+        }
+        throw err;
+      }
+      const manager = await this.managers.getOrCreate(activeModelId);
+      await withWriteLock(manager.modelDir, () => manager.updateIndex(knowledgeBaseName));
+
+      // Dense leg — over-fetch to give RRF room.
+      const densePromise = manager
+        .similaritySearch(query, HYBRID_FETCH_K, Number.POSITIVE_INFINITY, knowledgeBaseName, filters)
+        .then((rs) => rs.map((r) => ({ pageContent: r.pageContent, metadata: r.metadata, score: r.score })));
+
+      // Lexical leg — BM25 over the same chunks the FAISS path embeds, but
+      // managed independently (the lexical index is model-agnostic and lives
+      // under `${FAISS_INDEX_PATH}/lexical/<kb>/`). Auto-refresh on first use
+      // per KB; explicit refresh is the CLI's job (`kb search --refresh`).
+      const lexicalPromise: Promise<LexicalSearchResult[]> = (async () => {
+        const all: LexicalSearchResult[] = [];
+        const kbNames = knowledgeBaseName
+          ? [knowledgeBaseName]
+          : await listKnowledgeBases(KNOWLEDGE_BASES_ROOT_DIR);
+        for (const kbName of kbNames) {
+          const kbPath = path.join(KNOWLEDGE_BASES_ROOT_DIR, kbName);
+          try {
+            const idx = await LexicalIndex.load(kbName, kbPath);
+            if (idx.numFiles() === 0) {
+              await idx.refresh();
+              await idx.save();
+            }
+            const hits = await idx.query(query, HYBRID_FETCH_K);
+            for (const h of hits) all.push(h);
+          } catch (err) {
+            // Per-KB lexical failure is non-fatal; the dense leg still runs.
+            logger.warn(`hybrid: lexical leg failed for KB "${kbName}": ${(err as Error).message}`);
+          }
+        }
+        all.sort((a, b) => b.score - a.score);
+        return all.slice(0, HYBRID_FETCH_K);
+      })();
+
+      const [denseResults, lexicalResults] = await Promise.all([densePromise, lexicalPromise]);
+
+      const denseList: RankedList = {
+        retriever: 'dense',
+        results: denseResults.map((r, i) => ({ id: chunkIdFromMetadata(r.metadata), rank: i + 1 })),
+      };
+      const lexicalList: RankedList = {
+        retriever: 'lexical',
+        results: lexicalResults.map((r, i) => ({ id: chunkIdFromMetadata(r.metadata), rank: i + 1 })),
+      };
+      const fused = reciprocalRankFusion([denseList, lexicalList], { c: HYBRID_RRF_C });
+
+      const byId = new Map<string, { pageContent: string; metadata: Record<string, unknown>; score: number }>();
+      for (const r of lexicalResults) byId.set(chunkIdFromMetadata(r.metadata), { pageContent: r.pageContent, metadata: r.metadata, score: r.score });
+      for (const r of denseResults) byId.set(chunkIdFromMetadata(r.metadata), { pageContent: r.pageContent, metadata: r.metadata, score: r.score });
+
+      const ranked = fused.slice(0, HYBRID_TOP_K).map((f) => {
+        const chunk = byId.get(f.id);
+        return chunk ? { ...chunk, score: f.fusedScore } : null;
+      }).filter((x): x is { pageContent: string; metadata: Record<string, unknown>; score: number } => x !== null);
+
+      let responseText = formatRetrievalAsMarkdown(ranked as never, FRONTMATTER_EXTRAS_WIRE_VISIBLE);
+      const header = `> _Mode: hybrid (RRF c=${HYBRID_RRF_C}); dense fetched ${denseResults.length}, lexical fetched ${lexicalResults.length} (#206 stage 2)._`;
+      responseText = modelNameOverride !== undefined
+        ? `> _Model: ${activeModelId}_\n${header}\n\n${responseText}`
+        : `${header}\n\n${responseText}`;
+
+      const content: TextContent = { type: 'text', text: responseText };
+      return { content: [content] };
+    } catch (error: unknown) {
+      const err = toError(error);
+      logger.error('Error retrieving knowledge (hybrid):', err);
+      if (err.stack) logger.error(err.stack);
       return { content: [mcpErrorContent(err)], isError: true };
     }
   }

--- a/src/cli-search.ts
+++ b/src/cli-search.ts
@@ -26,8 +26,9 @@ import { enumerateIngestableKbFiles, listKnowledgeBases } from './kb-fs.js';
 import { withWriteLock } from './write-lock.js';
 import { loadManagerForModel, loadWithJsonRetry } from './cli-shared.js';
 import { LexicalIndex, type LexicalSearchResult } from './lexical-index.js';
+import { chunkIdFromMetadata, reciprocalRankFusion, type RankedList } from './rrf.js';
 
-export type SearchMode = 'dense' | 'lexical';
+export type SearchMode = 'dense' | 'lexical' | 'hybrid';
 
 interface SearchArgs {
   query: string | null;
@@ -88,6 +89,9 @@ export async function runSearch(rest: string[]): Promise<number> {
 
   if (parsed.mode === 'lexical') {
     return runLexicalSearch(parsed);
+  }
+  if (parsed.mode === 'hybrid') {
+    return runHybridSearch(parsed);
   }
 
   try {
@@ -236,8 +240,8 @@ function parseSearchArgs(rest: string[]): SearchArgs {
     if (raw.startsWith('--model=')) { out.model = raw.slice('--model='.length); continue; }
     if (raw.startsWith('--mode=')) {
       const v = raw.slice('--mode='.length);
-      if (v !== 'dense' && v !== 'lexical') {
-        throw new Error(`invalid --mode: ${raw} (expected 'dense' or 'lexical')`);
+      if (v !== 'dense' && v !== 'lexical' && v !== 'hybrid') {
+        throw new Error(`invalid --mode: ${raw} (expected 'dense', 'lexical', or 'hybrid')`);
       }
       out.mode = v; continue;
     }
@@ -627,4 +631,154 @@ async function runLexicalSearch(parsed: SearchArgs): Promise<number> {
   }
 
   return errors.length > 0 ? 1 : 0;
+}
+
+// -- #206 stage 2 — hybrid (RRF) dispatch ----------------------------------
+
+const HYBRID_FETCH_MULTIPLIER = 4;
+const HYBRID_RRF_C = 60;
+
+interface HybridChunk {
+  pageContent: string;
+  metadata: Record<string, unknown>;
+  score: number;
+}
+
+async function runHybridSearch(parsed: SearchArgs): Promise<number> {
+  if (parsed.thresholdAuto || parsed.threshold !== undefined) {
+    process.stderr.write('kb search: --threshold/--threshold=auto are dense-only; ignored under --mode=hybrid\n');
+  }
+  if (parsed.groupBySource) {
+    process.stderr.write('kb search: --group-by-source is dense-only in stage 2; ignored under --mode=hybrid\n');
+  }
+
+  const query = parsed.query as string;
+  const fetchK = Math.max(parsed.k * HYBRID_FETCH_MULTIPLIER, parsed.k);
+
+  // -- dense leg -----------------------------------------------------------
+  let densePromise: Promise<HybridChunk[]>;
+  let denseError: Error | null = null;
+  let activeModelId: string | null = null;
+  try {
+    await FaissIndexManager.bootstrapLayout();
+    activeModelId = await resolveActiveModel({ explicitOverride: parsed.model });
+  } catch (err) {
+    return reportFailure(classifyKbSearchError(err), parsed.format);
+  }
+  let manager: FaissIndexManager;
+  try {
+    manager = await loadManagerForModel(activeModelId);
+  } catch (err) {
+    return reportFailure(classifyKbSearchError(err), parsed.format);
+  }
+  try {
+    if (parsed.refresh) {
+      await withWriteLock(manager.modelDir, async () => {
+        await manager.initialize();
+        await manager.updateIndex(parsed.kb);
+      });
+    } else {
+      await loadWithJsonRetry(manager);
+    }
+  } catch (err) {
+    return reportFailure(classifyKbSearchError(err), parsed.format);
+  }
+  densePromise = manager
+    .similaritySearch(query, fetchK, Number.POSITIVE_INFINITY, parsed.kb)
+    .then((rs) => rs.map((r) => ({ pageContent: r.pageContent, metadata: r.metadata, score: r.score })))
+    .catch((err) => {
+      denseError = err as Error;
+      return [];
+    });
+
+  // -- lexical leg ---------------------------------------------------------
+  let lexicalKbs: Array<{ kbName: string; kbPath: string }>;
+  try {
+    lexicalKbs = await listLexicalKbs(parsed.kb);
+  } catch (err) {
+    process.stderr.write(`kb search (hybrid): could not list KBs: ${(err as Error).message}\n`);
+    return 1;
+  }
+
+  const lexicalPromise: Promise<{ hits: HybridChunk[]; refreshed: number; failed: number }> = (async () => {
+    let refreshed = 0;
+    let failed = 0;
+    const all: LexicalSearchResult[] = [];
+    for (const { kbName, kbPath } of lexicalKbs) {
+      try {
+        const idx = await LexicalIndex.load(kbName, kbPath);
+        if (parsed.refresh || idx.numFiles() === 0) {
+          await idx.refresh();
+          await idx.save();
+          refreshed += 1;
+        }
+        const hits = await idx.query(query, fetchK);
+        for (const h of hits) all.push(h);
+      } catch (err) {
+        failed += 1;
+        process.stderr.write(`kb search (hybrid lexical leg): ${kbName} — ${(err as Error).message}\n`);
+      }
+    }
+    all.sort((a, b) => b.score - a.score);
+    const top = all.slice(0, fetchK);
+    return {
+      hits: top.map((h) => ({ pageContent: h.pageContent, metadata: h.metadata, score: h.score })),
+      refreshed,
+      failed,
+    };
+  })();
+
+  const [denseResults, lexicalResultsRow] = await Promise.all([densePromise, lexicalPromise]);
+  if (denseError) {
+    return reportFailure(classifyKbSearchError(denseError), parsed.format);
+  }
+  const lexicalResults = lexicalResultsRow.hits;
+
+  // -- fuse ----------------------------------------------------------------
+  const denseList: RankedList = {
+    retriever: 'dense',
+    results: denseResults.map((r, i) => ({ id: chunkIdFromMetadata(r.metadata), rank: i + 1 })),
+  };
+  const lexicalList: RankedList = {
+    retriever: 'lexical',
+    results: lexicalResults.map((r, i) => ({ id: chunkIdFromMetadata(r.metadata), rank: i + 1 })),
+  };
+  const fused = reciprocalRankFusion([denseList, lexicalList], { c: HYBRID_RRF_C });
+
+  // Index chunks by id for output. When both legs return the same id, prefer
+  // the dense entry (more complete metadata typically), but read from
+  // whichever exists.
+  const byId = new Map<string, HybridChunk>();
+  for (const r of lexicalResults) byId.set(chunkIdFromMetadata(r.metadata), r);
+  for (const r of denseResults) byId.set(chunkIdFromMetadata(r.metadata), r);
+  const ranked = fused.slice(0, parsed.k).map((f) => {
+    const chunk = byId.get(f.id);
+    return chunk ? { ...chunk, score: f.fusedScore } : null;
+  }).filter((x): x is HybridChunk => x !== null);
+
+  if (parsed.format === 'json') {
+    const payload = {
+      mode: 'hybrid' as const,
+      results: formatRetrievalAsJson(ranked as never, FRONTMATTER_EXTRAS_WIRE_VISIBLE),
+      retrievers: {
+        dense: { fetched: denseResults.length, model: activeModelId },
+        lexical: { fetched: lexicalResults.length, refreshed: lexicalResultsRow.refreshed, failed: lexicalResultsRow.failed },
+      },
+      rrf: { c: HYBRID_RRF_C, fetch_k: fetchK },
+    };
+    process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+  } else {
+    process.stdout.write(`> _Mode: hybrid (RRF c=${HYBRID_RRF_C}). Stage 2 — dense ⨁ lexical; see #206._\n\n`);
+    if (ranked.length === 0) {
+      process.stdout.write(`_No matches._\n\n`);
+    } else {
+      process.stdout.write(formatRetrievalAsMarkdown(ranked as never, FRONTMATTER_EXTRAS_WIRE_VISIBLE));
+      process.stdout.write('\n\n');
+    }
+    process.stdout.write(
+      `> _Hybrid status: dense fetched ${denseResults.length}, lexical fetched ${lexicalResults.length} (refreshed ${lexicalResultsRow.refreshed}, ${lexicalResultsRow.failed} failed); fused via RRF (c=${HYBRID_RRF_C}, fetch_k=${fetchK})._\n`,
+    );
+  }
+
+  return 0;
 }

--- a/src/rrf.test.ts
+++ b/src/rrf.test.ts
@@ -1,0 +1,141 @@
+// Issue #206 stage 2 — unit + property tests for src/rrf.ts.
+
+import { describe, expect, it } from '@jest/globals';
+import { DEFAULT_C, reciprocalRankFusion, type RankedList } from './rrf.js';
+
+describe('reciprocalRankFusion', () => {
+  it('returns empty for empty input', () => {
+    expect(reciprocalRankFusion([])).toEqual([]);
+  });
+
+  it('matches the Cormack formula on a single retriever', () => {
+    // Single ranked list: A at rank 1, B at rank 2. With default c=60:
+    //   score(A) = 1 / (60 + 1) = 1/61 ≈ 0.01639
+    //   score(B) = 1 / (60 + 2) = 1/62 ≈ 0.01613
+    const fused = reciprocalRankFusion([
+      { retriever: 'dense', results: [{ id: 'A', rank: 1 }, { id: 'B', rank: 2 }] },
+    ]);
+    expect(fused.map((r) => r.id)).toEqual(['A', 'B']);
+    expect(fused[0].fusedScore).toBeCloseTo(1 / (DEFAULT_C + 1), 12);
+    expect(fused[1].fusedScore).toBeCloseTo(1 / (DEFAULT_C + 2), 12);
+  });
+
+  it('sums contributions across retrievers for a doc that appears in both', () => {
+    const lists: RankedList[] = [
+      { retriever: 'dense', results: [{ id: 'X', rank: 1 }, { id: 'Y', rank: 2 }] },
+      { retriever: 'lexical', results: [{ id: 'Y', rank: 1 }, { id: 'X', rank: 5 }] },
+    ];
+    const fused = reciprocalRankFusion(lists);
+    const yScore = 1 / (DEFAULT_C + 2) + 1 / (DEFAULT_C + 1);
+    const xScore = 1 / (DEFAULT_C + 1) + 1 / (DEFAULT_C + 5);
+    // Y wins because it appears at rank 1 in lexical AND rank 2 in dense;
+    // X has a stronger first-place dense result but a much weaker rank-5
+    // lexical contribution.
+    expect(fused.map((r) => r.id)).toEqual(['Y', 'X']);
+    expect(fused[0].fusedScore).toBeCloseTo(yScore, 12);
+    expect(fused[1].fusedScore).toBeCloseTo(xScore, 12);
+    expect(fused[0].contributions).toMatchObject({
+      dense: 1 / (DEFAULT_C + 2),
+      lexical: 1 / (DEFAULT_C + 1),
+    });
+  });
+
+  it('honors per-retriever weights, including weight=0 to drop a retriever', () => {
+    const lists: RankedList[] = [
+      { retriever: 'dense', results: [{ id: 'X', rank: 1 }] },
+      { retriever: 'lexical', results: [{ id: 'X', rank: 1 }, { id: 'Y', rank: 2 }] },
+    ];
+    const denseOnly = reciprocalRankFusion(lists, { weights: { dense: 1, lexical: 0 } });
+    expect(denseOnly).toHaveLength(1);
+    expect(denseOnly[0].id).toBe('X');
+
+    const lexBias = reciprocalRankFusion(lists, { weights: { dense: 0.1, lexical: 2 } });
+    expect(lexBias[0].id).toBe('X');
+    // weight=2 doubles each lexical contribution
+    expect(lexBias[0].contributions.lexical).toBeCloseTo(2 * (1 / (DEFAULT_C + 1)), 12);
+  });
+
+  it('falls back to array index when explicit rank is missing', () => {
+    // No `rank` field — implicit 1-based from array order.
+    const fused = reciprocalRankFusion([
+      { retriever: 'dense', results: [{ id: 'A' } as any, { id: 'B' } as any, { id: 'C' } as any] },
+    ]);
+    expect(fused.map((r) => r.id)).toEqual(['A', 'B', 'C']);
+    expect(fused[0].fusedScore).toBeCloseTo(1 / (DEFAULT_C + 1), 12);
+    expect(fused[1].fusedScore).toBeCloseTo(1 / (DEFAULT_C + 2), 12);
+  });
+
+  it('keeps the BEST rank for within-list duplicates (no double counting)', () => {
+    const lists: RankedList[] = [
+      { retriever: 'dense', results: [{ id: 'X', rank: 5 }, { id: 'X', rank: 1 }] },
+    ];
+    const fused = reciprocalRankFusion(lists);
+    expect(fused).toHaveLength(1);
+    expect(fused[0].fusedScore).toBeCloseTo(1 / (DEFAULT_C + 1), 12);
+  });
+
+  it('breaks ties on insertion order across lists', () => {
+    // X and Y get identical fused scores. Insertion order is dense→lexical;
+    // X first appears in dense, Y first appears in lexical, so X wins ties.
+    const lists: RankedList[] = [
+      { retriever: 'dense', results: [{ id: 'X', rank: 1 }] },
+      { retriever: 'lexical', results: [{ id: 'Y', rank: 1 }] },
+    ];
+    const fused = reciprocalRankFusion(lists);
+    expect(fused.map((r) => r.id)).toEqual(['X', 'Y']);
+  });
+
+  it('rejects negative c', () => {
+    expect(() => reciprocalRankFusion([], { c: -1 })).toThrow(/c=-1/);
+  });
+
+  it('rejects non-finite or negative weights', () => {
+    expect(() => reciprocalRankFusion([], { weights: { dense: NaN } })).toThrow(/dense/);
+    expect(() => reciprocalRankFusion([], { weights: { dense: -0.5 } })).toThrow(/dense/);
+  });
+
+  it('rejects non-positive ranks', () => {
+    expect(() =>
+      reciprocalRankFusion([{ retriever: 'dense', results: [{ id: 'X', rank: 0 }] }]),
+    ).toThrow(/rank=0/);
+  });
+
+  // -- property-shaped checks (deterministic, no fast-check dep) ----------------
+
+  it('property: fused score is monotonically non-increasing across the output', () => {
+    const lists: RankedList[] = [
+      {
+        retriever: 'dense',
+        results: Array.from({ length: 50 }, (_, i) => ({ id: `D${i}`, rank: i + 1 })),
+      },
+      {
+        retriever: 'lexical',
+        // Reverse-rank list to maximize fusion noise.
+        results: Array.from({ length: 50 }, (_, i) => ({ id: `D${49 - i}`, rank: i + 1 })),
+      },
+    ];
+    const fused = reciprocalRankFusion(lists);
+    for (let i = 1; i < fused.length; i++) {
+      expect(fused[i - 1].fusedScore).toBeGreaterThanOrEqual(fused[i].fusedScore);
+    }
+  });
+
+  it('property: lower c amplifies first-rank contributions relative to deep ranks', () => {
+    const lists: RankedList[] = [
+      { retriever: 'dense', results: [{ id: 'A', rank: 1 }, { id: 'B', rank: 50 }] },
+    ];
+    const cSmall = reciprocalRankFusion(lists, { c: 1 });
+    const cLarge = reciprocalRankFusion(lists, { c: 100 });
+    const ratioSmall = cSmall[0].fusedScore / cSmall[1].fusedScore;
+    const ratioLarge = cLarge[0].fusedScore / cLarge[1].fusedScore;
+    expect(ratioSmall).toBeGreaterThan(ratioLarge);
+  });
+
+  it('property: weight=0 on every retriever yields empty output', () => {
+    const lists: RankedList[] = [
+      { retriever: 'dense', results: [{ id: 'A', rank: 1 }] },
+      { retriever: 'lexical', results: [{ id: 'A', rank: 1 }] },
+    ];
+    expect(reciprocalRankFusion(lists, { weights: { dense: 0, lexical: 0 } })).toEqual([]);
+  });
+});

--- a/src/rrf.ts
+++ b/src/rrf.ts
@@ -1,0 +1,161 @@
+// Issue #206 stage 2 — Reciprocal Rank Fusion combinator.
+//
+// Why this lives in its own module. The fusion math is pure (no I/O,
+// no clock, no filesystem) and is consumed from at least two surfaces
+// (CLI `--mode=hybrid` and MCP `retrieve_knowledge` with
+// `search_mode=hybrid`). Keeping it pure lets the unit tests pin every
+// behavioral knob — the constant `c=60` choice, the per-retriever
+// weights, the tie-break rule — without standing up a manager or a
+// retriever.
+//
+// The math. For a document `d` that appears at rank `rank_r(d)` in the
+// ranked list produced by retriever `r` (1-based), its fused score is:
+//
+//     score(d) = Σ_r  w_r * (1 / (c + rank_r(d)))
+//
+// where `w_r` is the per-retriever weight (defaulting to 1) and `c` is
+// the smoothing constant. We use `c = 60` per Cormack et al. 2009 (the
+// same default LangChain's `EnsembleRetriever` ships). Cormack
+// established `60` as a reasonable across-the-board choice on TREC; it
+// also happens to be the value RFC 006 §5.4 picked for dense-multi-
+// provider fusion, so this module's choice is consistent with the
+// existing in-house convention.
+//
+// Document identity. Fusion only makes sense if the same chunk appears
+// under the same identifier in both ranked lists. The chunks the FAISS
+// path and the lexical path each return carry `metadata.source`
+// (absolute path) and `metadata.chunkIndex`; together those form a
+// stable `${source}#${chunkIndex}` key. Callers compute the key once
+// per chunk and pass it as `id` to this module. This module does NOT
+// look at metadata — it operates purely over `(id, rank)` pairs.
+
+export interface RankedDoc {
+  /** Stable identifier; e.g. `${metadata.source}#${metadata.chunkIndex}`. */
+  id: string;
+  /** 1-based rank in the producing list. Position 1 is the highest-rated. */
+  rank: number;
+}
+
+export interface RankedList {
+  /** Tag for the contributing retriever. Surfaced on the fused output for
+   *  attribution; does not affect the math beyond per-retriever weights. */
+  retriever: string;
+  results: RankedDoc[];
+}
+
+export interface RRFOptions {
+  /** Smoothing constant `c` in `1 / (c + rank)`. Default 60 (Cormack 2009). */
+  c?: number;
+  /** Per-retriever weights, keyed by `RankedList.retriever`. Missing entries
+   *  default to 1. Negative or non-finite weights are rejected. */
+  weights?: Record<string, number>;
+}
+
+export interface FusedResult {
+  id: string;
+  /** Sum of per-retriever weighted reciprocal-rank contributions. */
+  fusedScore: number;
+  /** Per-retriever rank contributions; useful for debugging and explanation
+   *  surfaces. Absent retrievers are omitted. */
+  contributions: Record<string, number>;
+}
+
+export const DEFAULT_C = 60;
+
+/**
+ * Stable chunk identity for RRF fusion. Mirrors `${metadata.source}#${metadata.chunkIndex}`
+ * so the dense and lexical paths produce the same id for the same chunk.
+ *
+ * Robust against missing fields: falls back to the JSON-stringified metadata,
+ * which still gives a deterministic key — just not aligned with the other
+ * retriever, so those chunks then count as single-list hits (still useful, just
+ * not fused). The chunker (`buildChunkDocuments`) sets both `source` and
+ * `chunkIndex` for every chunk it emits, so the fallback is defense-in-depth.
+ */
+export function chunkIdFromMetadata(meta: Record<string, unknown>): string {
+  const source = typeof meta.source === 'string' ? meta.source : null;
+  const chunkIndex = typeof meta.chunkIndex === 'number' ? meta.chunkIndex : null;
+  if (source !== null && chunkIndex !== null) return `${source}#${chunkIndex}`;
+  return `meta:${JSON.stringify(meta)}`;
+}
+
+/**
+ * Reciprocal Rank Fusion. Pure function — no I/O, no clock, no globals.
+ *
+ * Implementation notes:
+ *
+ * - Empty `lists` returns `[]`.
+ * - Each `RankedList.results` is consumed in array order; if `rank` is
+ *   missing it is assigned from the array index (1-based). The explicit
+ *   `rank` field wins when present so callers that have already computed
+ *   ranks (e.g. after deduping or re-ranking) keep their authority.
+ * - Documents that appear multiple times within a single ranked list are
+ *   credited with the BEST (lowest) rank from that list — a defensive
+ *   choice for callers that pass un-deduped chunk lists. Within-list
+ *   duplicates do not double-count.
+ * - Tie-break on equal `fusedScore` is **insertion order from the
+ *   iteration over `lists`**. This is deterministic and stable across
+ *   runs given the same inputs, which is important for the eval-fixture
+ *   path (#206 §validation gate "no regression on natural-language
+ *   queries").
+ * - Throws on negative `c`, non-finite weights, or non-positive `rank`
+ *   values — these are programmer errors at the caller seam.
+ */
+export function reciprocalRankFusion(
+  lists: RankedList[],
+  options: RRFOptions = {},
+): FusedResult[] {
+  const c = options.c ?? DEFAULT_C;
+  if (!Number.isFinite(c) || c < 0) {
+    throw new Error(`RRF: invalid c=${c}; expected a finite non-negative number`);
+  }
+  const weights = options.weights ?? {};
+  for (const [name, weight] of Object.entries(weights)) {
+    if (!Number.isFinite(weight) || weight < 0) {
+      throw new Error(`RRF: invalid weight for retriever "${name}": ${weight}`);
+    }
+  }
+
+  // Order of first appearance across lists drives the tie-break.
+  const order: string[] = [];
+  const accum: Map<string, FusedResult> = new Map();
+
+  for (const list of lists) {
+    const w = weights[list.retriever] ?? 1;
+    if (w === 0) continue;
+
+    // Within-list dedupe: keep the smallest rank we see for each id.
+    const bestRankForId = new Map<string, number>();
+    list.results.forEach((doc, idx) => {
+      const explicit = doc.rank;
+      if (explicit !== undefined && (!Number.isFinite(explicit) || explicit < 1)) {
+        throw new Error(
+          `RRF: invalid rank=${explicit} for id="${doc.id}" in list "${list.retriever}"; expected ≥ 1`,
+        );
+      }
+      const rank = explicit ?? idx + 1;
+      const prior = bestRankForId.get(doc.id);
+      if (prior === undefined || rank < prior) {
+        bestRankForId.set(doc.id, rank);
+      }
+    });
+
+    for (const [id, rank] of bestRankForId.entries()) {
+      const contribution = w * (1 / (c + rank));
+      let entry = accum.get(id);
+      if (entry === undefined) {
+        entry = { id, fusedScore: 0, contributions: {} };
+        accum.set(id, entry);
+        order.push(id);
+      }
+      entry.fusedScore += contribution;
+      entry.contributions[list.retriever] = (entry.contributions[list.retriever] ?? 0) + contribution;
+    }
+  }
+
+  const out = order.map((id) => accum.get(id) as FusedResult);
+  // Stable sort: V8's Array.prototype.sort is guaranteed stable since 2018,
+  // which gives us the insertion-order tie-break for free.
+  out.sort((a, b) => b.fusedScore - a.fusedScore);
+  return out;
+}


### PR DESCRIPTION
## Summary

- **Stacked on #223** (#206 stage 1, base `feat/206-stage1-lexical-index`). Do not merge until #223 lands; once #223 is in, retarget this PR to `main`.
- Stage 2 of #206: wires the dense FAISS leg and the per-KB BM25 lexical leg through Reciprocal Rank Fusion to close the exact-token recall gap RFC 006 §4 deferred. Dense-default behavior is byte-equal to 0.x.
- Adds `src/rrf.ts` (pure combinator, `c=60` per Cormack 2009 / LangChain `EnsembleRetriever` / RFC 006 §5.4 in-house convention), `kb search --mode=hybrid` in the CLI, and an optional `search_mode: "dense" | "hybrid"` arg on the MCP `retrieve_knowledge` tool.
- Adds `ADR 0006` with the rationale (RRF over linear interpolation; `c=60` over alternatives) and `docs/testing/fixtures/hybrid-vs-dense.yml` with 6 exact-token + 6 paraphrase eval cases.

## Design highlights

- **Pure RRF** (`src/rrf.ts`): operates only on `(id, rank)` pairs. No score-distribution normalization needed across dense/lexical. Per-retriever weights, within-list dedupe (best rank wins), stable insertion-order tie-break. 13 unit + property-shaped tests.
- **Stable chunk identity**: `chunkIdFromMetadata` (exported from `rrf.ts`) builds `${source}#${chunkIndex}` so the dense and lexical legs produce the same id for the same chunk.
- **Wire-compat**: MCP clients that omit `search_mode` (every 0.x client) keep the dense path byte-for-byte. Hybrid responses prepend a `> _Mode: hybrid (RRF c=60); …_` markdown header so an inspecting agent can attribute the ranking; the RFC 013 `model_name` envelope still applies on top.
- **Auto-refresh on first use**: hybrid path bootstraps an empty lexical index on first call per KB; explicit refresh remains the CLI's job.

## Test plan

- [x] `npm run build` — green.
- [x] `npm test` — 598 passed (13 new RRF + 5 lexical from stage 1 + 580 pre-existing). Dense-path test surface untouched.
- [x] Smoke: `kb search --mode=hybrid --kb=test_kb --refresh --k=1` returns the lexical-leg result with `fusedScore = 1/(60+1) = 0.0164` (matches the math for a rank-1 single-list contribution).
- [x] Smoke: `kb search --kb=test_kb --k=1` (no `--mode`) — unchanged dense output.
- [x] Smoke: `kb search x --mode=garbage` — exit 2 with the updated error including `hybrid`.
- [ ] To run against your KB after merge: `kb eval docs/testing/fixtures/hybrid-vs-dense.yml --mode=hybrid` and compare against `--mode=dense` to confirm the lift on exact-token cases and non-regression on paraphrases.

## Out of scope (deferred)

- Per-retriever weight env vars (`KB_HYBRID_DENSE_WEIGHT`, `KB_HYBRID_LEXICAL_WEIGHT`). `RRFOptions.weights` already accepts them; just not surfaced via env in v1.
- Cross-encoder rerank on the fused top-k (RFC 006 `deep` tier).
- `KB_HYBRID_RRF_C` env override (constant is justified per ADR 0006).
- Tokenizer / stemming tuning (deferred per #206 risks).

Refs #206 (stacked on #223 / `feat/206-stage1-lexical-index`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)