### PR TITLE
feat: batch changed-file embeddings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased] — Batched changed-file embeddings during updateIndex (#236)
+
+### Changed
+
+- **`FaissIndexManager.updateIndex` now embeds changed-file chunks in bounded document batches.** `INDEXING_BATCH_SIZE` controls the batch size, with conservative provider defaults. Empty indexes are seeded with one `fromTexts` batch and remaining chunks append through `addDocuments` batches, while preserving the existing single FAISS save and post-save sidecar hash writes. Closes #236.
+
 ## [Unreleased] — KB-authoring cookbook (#205)
 
 ### Added

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -58,11 +58,11 @@ Every run writes a single JSON object with stable top-level keys:
     },
     "cold_index": {
       "files": 100,
-      "chunks": 500,
-      "ms": 10761,
-      "save_calls": 100,
+      "chunks": 600,
+      "ms": 12238,
+      "save_calls": 1,
       "from_texts_calls": 1,
-      "add_documents_calls": 99
+      "add_documents_calls": 9
     },
     "warm_query": {
       "repetitions": 30,

--- a/docs/architecture/qa-budgets.md
+++ b/docs/architecture/qa-budgets.md
@@ -34,11 +34,11 @@ Today's embedding call pattern, per `updateIndex` call:
 | Scenario                           | `embedDocuments` calls | Batched? |
 | ---------------------------------- | ---------------------: | -------- |
 | Warm no-op                         | 0                       | N/A      |
-| 1 changed file                     | 1                       | Yes (one call per file, carrying that file's chunks) |
-| N changed files                    | N                       | **No** — each file goes through `addDocuments`/`fromTexts` serially at `src/FaissIndexManager.ts:278-287`. RFC 007 §6.2 batches this. |
-| Fallback rebuild                   | 1                       | Yes — one call with every chunk at `:338-343` |
+| 1 changed file                     | 1                       | Yes — its chunks fit in one bounded batch by default. |
+| N changed files                    | `ceil(total_chunks / INDEXING_BATCH_SIZE)` | Yes — changed-file chunks are queued and embedded in bounded FAISS batches. |
+| Fallback rebuild                   | `ceil(total_chunks / INDEXING_BATCH_SIZE)` | Yes — fallback rebuild uses the same bounded batching path. |
 
-**Provider-rate implication.** A user with 100 modified files on HuggingFace (~100 ms/call) pays 10 s minimum regardless of chunk count per file — because the calls are sequential. The fallback-rebuild path is faster per chunk than the changed-file path because it packs everything into one call.
+**Provider-rate implication.** A user with 100 modified files now pays for batches of chunks rather than one provider round trip per file. The default HuggingFace/OpenAI batch size is 64 chunks; the Ollama default is 16 chunks to keep local-provider payloads conservative.
 
 ## Supported scale
 
@@ -54,7 +54,7 @@ Current ceiling (informal, from code + §5 measurements, **not** a tested guaran
 ## Known cliffs
 
 - **Per-query scan** (`src/KnowledgeBaseServer.ts:84` → `src/FaissIndexManager.ts:202-389`). Every `retrieve_knowledge` pays the ~85 ms scan floor even when nothing changed. RFC 007 §6.3 (scan-on-signal) and §7.5 (mtime+size short-circuit) are the two candidate fixes.
-- **Per-file embedding round-trip** (`src/FaissIndexManager.ts:278-287`). Changed-file calls are serial, not batched. RFC 007 §6.2 tracks the batch refactor.
+- **Embedding provider payload limits.** `INDEXING_BATCH_SIZE` bounds changed-file and fallback rebuild batches. Raise it cautiously for high-throughput remote providers; lower it when a provider rejects large payloads.
 - **Global FAISS store memory** (`src/FaissIndexManager.ts:81`). Querying one KB still loads vectors from every KB into RAM. RFC 007 §6.4 tracks the per-KB split.
 - **No concurrency guard** across processes. One process per `$FAISS_INDEX_PATH` is a documented constraint, not an enforced one — see [`threat-model.md`](./threat-model.md) and issue #44.
 

--- a/docs/requirements/INDEX.md
+++ b/docs/requirements/INDEX.md
@@ -2,6 +2,24 @@
 
 - [Retrieval eval command](retrieval-eval.md)
 
+## Indexing
+
+### NFR-INDEX-236: Batched Changed-File Embeddings
+**Status:** Implemented
+**Priority:** High
+
+**Requirement:** The system shall embed changed-file chunks during `updateIndex` in bounded document batches before saving the FAISS index.
+**Rationale:** Batching amortizes embedding-provider round trips for refreshes and cold rebuilds while preserving the existing save-once durability boundary.
+
+**Acceptance Criteria:**
+- [x] Given multiple changed files, when their chunks fit within `INDEXING_BATCH_SIZE`, then `updateIndex` shall seed an empty FAISS store with one `fromTexts` call and shall not call `addDocuments` per file.
+- [x] Given changed-file chunks exceeding `INDEXING_BATCH_SIZE`, then `updateIndex` shall append the remaining chunks with one `addDocuments` call per bounded batch.
+- [x] Given a successful batched update, then `updateIndex` shall persist the FAISS store once and shall write hash sidecars only after that save succeeds.
+- [x] Given an invalid or unset `INDEXING_BATCH_SIZE`, then the system shall use conservative provider defaults.
+
+**Linked Tests:** TS-INDEX-236
+**Dependencies:** RFC007
+
 ## Search
 
 ### FR-SEARCH-192: Scoped Search Staleness

--- a/docs/testing/INDEX.md
+++ b/docs/testing/INDEX.md
@@ -2,6 +2,17 @@
 
 - [Retrieval eval command](retrieval-eval.md)
 
+## Indexing
+
+### TS-INDEX-236: Batched Changed-File Embeddings
+**Requirement:** NFR-INDEX-236
+
+**Test Cases:**
+- `resolveIndexingBatchSize` shall use provider defaults and validate `INDEXING_BATCH_SIZE`.
+- `FaissIndexManager.updateIndex` shall batch multiple changed files into a single seed call when they fit the configured batch size.
+- `FaissIndexManager.updateIndex` shall split changed-file documents into bounded append batches when the configured batch size is exceeded.
+- `FaissIndexManager.updateIndex` shall keep the one-save-at-end invariant and write sidecar hashes only after a successful save.
+
 ## Search
 
 ### TS-SEARCH-192: Scoped Search Staleness

--- a/src/FaissIndexManager.test.ts
+++ b/src/FaissIndexManager.test.ts
@@ -257,6 +257,7 @@ describe('FaissIndexManager permission handling', () => {
     HUGGINGFACE_API_KEY: process.env.HUGGINGFACE_API_KEY,
     HUGGINGFACE_ENDPOINT_URL: process.env.HUGGINGFACE_ENDPOINT_URL,
     HUGGINGFACE_PROVIDER: process.env.HUGGINGFACE_PROVIDER,
+    INDEXING_BATCH_SIZE: process.env.INDEXING_BATCH_SIZE,
     LOG_FILE: process.env.LOG_FILE,
   };
 
@@ -422,9 +423,9 @@ describe('FaissIndexManager permission handling', () => {
     // After fix: the in-memory store was nulled, so the rebuild starts
     // with fromTexts() again, and BOTH KBs' files are re-ingested.
     expect(fromTextsMock).toHaveBeenCalledTimes(1);
-    // Both alpha (1 file) and beta (1 file) re-embedded — minus the seed
-    // file that fromTexts consumes. So addDocuments runs once for the
-    // remaining file.
+    // Both alpha (1 file) and beta (1 file) re-embedded. With the default
+    // batch size they fit in the fromTexts seed batch, so addDocuments has
+    // the same call count as the initial build.
     const rebuildAdds = addDocumentsMock.mock.calls.length;
     expect(rebuildAdds).toBe(initialAdds);
 
@@ -464,7 +465,7 @@ describe('FaissIndexManager permission handling', () => {
     // RFC 014 — first save under v014 writes to index.v0/ via atomicSave.
     expect(saveMock).toHaveBeenCalledWith(versionedIndexPathIn(process.env.FAISS_INDEX_PATH!));
     expect(fromTextsMock).toHaveBeenCalledTimes(1);
-    expect(addDocumentsMock).toHaveBeenCalledTimes(fileCount - 1);
+    expect(addDocumentsMock).not.toHaveBeenCalled();
 
     for (const docPath of docPaths) {
       const relativePath = path.relative(defaultKb, docPath);
@@ -472,6 +473,57 @@ describe('FaissIndexManager permission handling', () => {
       const sidecarContent = await fsp.readFile(sidecarPath, 'utf-8');
       expect(sidecarContent).toMatch(/^[0-9a-f]{64}$/);
       await expect(fsp.stat(`${sidecarPath}.tmp`)).rejects.toMatchObject({ code: 'ENOENT' });
+    }
+  });
+
+  it('batches changed-file embeddings according to INDEXING_BATCH_SIZE', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-faiss-batch-embeddings-'));
+    const kbDir = path.join(tempDir, 'kb');
+    const defaultKb = path.join(kbDir, 'default');
+    await fsp.mkdir(defaultKb, { recursive: true });
+    const fileCount = 5;
+    const docPaths: string[] = [];
+    for (let i = 0; i < fileCount; i += 1) {
+      const docPath = path.join(defaultKb, `doc-${i}.md`);
+      await fsp.writeFile(docPath, `# Doc ${i}\n\nBatching content for document ${i}.`);
+      docPaths.push(docPath);
+    }
+
+    process.env.KNOWLEDGE_BASES_ROOT_DIR = kbDir;
+    process.env.FAISS_INDEX_PATH = path.join(tempDir, '.faiss');
+    process.env.EMBEDDING_PROVIDER = 'huggingface';
+    process.env.HUGGINGFACE_API_KEY = 'test-key';
+    process.env.INDEXING_BATCH_SIZE = '2';
+
+    jest.resetModules();
+    const { FaissIndexManager } = await import('./FaissIndexManager.js');
+    const manager = new FaissIndexManager();
+    await manager.initialize();
+    await manager.updateIndex();
+
+    expect(saveMock).toHaveBeenCalledTimes(1);
+    expect(fromTextsMock).toHaveBeenCalledTimes(1);
+    expect(addDocumentsMock).toHaveBeenCalledTimes(2);
+
+    const [seedTexts, seedMetadatas] = fromTextsMock.mock.calls[0] as [
+      string[],
+      Array<{ source: string }>,
+    ];
+    expect(seedTexts).toHaveLength(2);
+    expect(seedMetadatas.map((metadata) => metadata.source)).toEqual(docPaths.slice(0, 2));
+
+    const appendedSources = addDocumentsMock.mock.calls.map((call) => {
+      const [docs] = call as [Array<{ metadata: { source: string } }>];
+      return docs.map((doc) => doc.metadata.source);
+    });
+    expect(appendedSources).toEqual([
+      docPaths.slice(2, 4),
+      docPaths.slice(4, 5),
+    ]);
+
+    for (const docPath of docPaths) {
+      const sidecarPath = path.join(defaultKb, '.index', path.basename(docPath));
+      await expect(fsp.readFile(sidecarPath, 'utf-8')).resolves.toMatch(/^[0-9a-f]{64}$/);
     }
   });
 
@@ -522,8 +574,8 @@ describe('FaissIndexManager permission handling', () => {
     // survive (operator nuked $FAISS_INDEX_PATH, partial restore, crash
     // mid-rebuild), initialize() purges the now-untrustworthy sidecars
     // and updateIndex re-embeds every file from scratch through the
-    // per-file path: first file → fromTexts (creating the new store),
-    // each subsequent file → addDocuments. The fallback rebuild branch
+    // changed-file queue. The first batch creates the new store via
+    // fromTexts; later batches append via addDocuments. The fallback branch
     // is preserved as defence-in-depth (partial purge failure) but no
     // longer fires in this scenario.
     const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-faiss-fallback-'));
@@ -601,11 +653,11 @@ describe('FaissIndexManager permission handling', () => {
 
     await secondManager.updateIndex();
 
-    // Per-file recovery path: first file lands in fromTexts (creating the
-    // new store), each subsequent file is appended via addDocuments.
+    // Recovery path: the changed files fit in the default seed batch, which
+    // creates the new store via fromTexts without additional addDocuments.
     // One save call closes the updateIndex.
     expect(fromTextsMock).toHaveBeenCalledTimes(1);
-    expect(addDocumentsMock).toHaveBeenCalledTimes(fileCount - 1);
+    expect(addDocumentsMock).not.toHaveBeenCalled();
     expect(saveMock).toHaveBeenCalledTimes(1);
     // RFC 014 — first save under v014 writes to index.v0/ via atomicSave.
     expect(saveMock).toHaveBeenCalledWith(versionedIndexPathIn(process.env.FAISS_INDEX_PATH!));
@@ -1038,12 +1090,11 @@ describe('FaissIndexManager #90 — sidecar invalidation when FAISS store is mis
 
     // updateIndex must now re-embed every file from scratch (no sidecars to
     // mask the empty store). With faissIndex starting at null and no
-    // sidecars present, every file's `fileHash !== storedHash` triggers
-    // re-embed via the per-file path: the first file lands in fromTexts,
-    // the rest in addDocuments. One save call, sidecars rewritten.
+    // sidecars present, every file's `fileHash !== storedHash` queues the
+    // file for the default seed batch. One save call, sidecars rewritten.
     await manager.updateIndex();
     expect(fromTextsMock).toHaveBeenCalledTimes(1);
-    expect(addDocumentsMock).toHaveBeenCalledTimes(2);
+    expect(addDocumentsMock).not.toHaveBeenCalled();
     expect(saveMock).toHaveBeenCalledTimes(1);
 
     for (const file of [fileA1, fileA2, fileB1]) {

--- a/src/FaissIndexManager.ts
+++ b/src/FaissIndexManager.ts
@@ -12,6 +12,7 @@ import {
   KNOWLEDGE_BASES_ROOT_DIR,
   INGEST_EXCLUDE_PATHS,
   INGEST_EXTRA_EXTENSIONS,
+  INDEXING_BATCH_SIZE,
 } from './config.js';
 import {
   activeFileExists,
@@ -414,15 +415,18 @@ export class FaissIndexManager {
       return false;
     }
 
-    if (this.faissIndex === null) {
-      logger.info('Creating new FAISS index from texts...');
-      this.faissIndex = await FaissStore.fromTexts(
-        documentsToAdd.map((doc) => doc.pageContent),
-        documentsToAdd.map((doc) => doc.metadata),
-        this.embeddings
-      );
-    } else {
-      await this.faissIndex.addDocuments(documentsToAdd);
+    for (let offset = 0; offset < documentsToAdd.length; offset += INDEXING_BATCH_SIZE) {
+      const batch = documentsToAdd.slice(offset, offset + INDEXING_BATCH_SIZE);
+      if (this.faissIndex === null) {
+        logger.info(`Creating new FAISS index from ${batch.length} text(s)...`);
+        this.faissIndex = await FaissStore.fromTexts(
+          batch.map((doc) => doc.pageContent),
+          batch.map((doc) => doc.metadata),
+          this.embeddings
+        );
+      } else {
+        await this.faissIndex.addDocuments(batch);
+      }
     }
     return true;
   }
@@ -528,6 +532,12 @@ export class FaissIndexManager {
       };
 
       // Process each knowledge base directory.
+      const changedFileDocuments: Array<{
+        filePath: string;
+        indexFilePath: string;
+        fileHash: string;
+        documents: Document[];
+      }> = [];
       for (const { knowledgeBaseName, knowledgeBasePath, filePaths } of knowledgeBaseFiles) {
         for (const filePath of filePaths) {
           anyFileProcessed = true;
@@ -583,12 +593,13 @@ export class FaissIndexManager {
               knowledgeBaseName,
             );
 
-            if (await this.addDocumentsToIndex(documentsToAdd)) {
-              indexMutated = true;
-              pendingHashWrites.push({ path: indexFilePath, hash: fileHash });
-              logger.debug(`Index updated in-memory for ${filePath}.`);
-              processedFiles += 1;
-              await reportProgress(filePath);
+            if (documentsToAdd.length > 0) {
+              changedFileDocuments.push({
+                filePath,
+                indexFilePath,
+                fileHash,
+                documents: documentsToAdd,
+              });
             } else {
               logger.debug(`No documents generated from ${filePath}. Skipping index update.`);
             }
@@ -597,11 +608,22 @@ export class FaissIndexManager {
           }
         }
       }
+      const documentsToAdd = changedFileDocuments.flatMap((entry) => entry.documents);
+      if (await this.addDocumentsToIndex(documentsToAdd)) {
+        indexMutated = true;
+        for (const entry of changedFileDocuments) {
+          pendingHashWrites.push({ path: entry.indexFilePath, hash: entry.fileHash });
+          logger.debug(`Index updated in-memory for ${entry.filePath}.`);
+          processedFiles += 1;
+          await reportProgress(entry.filePath);
+        }
+      }
 
       // If at least one file was processed but no changes triggered index creation,
       // then attempt to build the FAISS index from all available documents.
       if (this.faissIndex === null && anyFileProcessed) {
         logger.info('No updates detected but FAISS index is not initialized. Building index from all available documents...');
+        const fallbackDocuments: Array<{ filePath: string; documents: Document[] }> = [];
         for (const { knowledgeBaseName, filePaths } of knowledgeBaseFiles) {
           for (const filePath of filePaths) {
             // Issue #46 — same extension-routed loader as the per-file path.
@@ -617,11 +639,16 @@ export class FaissIndexManager {
               content,
               knowledgeBaseName,
             );
-            if (await this.addDocumentsToIndex(documents)) {
-              indexMutated = true;
-              processedFiles += 1;
-              await reportProgress(filePath);
+            if (documents.length > 0) {
+              fallbackDocuments.push({ filePath, documents });
             }
+          }
+        }
+        if (await this.addDocumentsToIndex(fallbackDocuments.flatMap((entry) => entry.documents))) {
+          indexMutated = true;
+          for (const entry of fallbackDocuments) {
+            processedFiles += 1;
+            await reportProgress(entry.filePath);
           }
         }
       }

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,4 +1,44 @@
-import { parseReindexTriggerPollMs, resolveChunkSize } from './config.js';
+import {
+  parseReindexTriggerPollMs,
+  resolveChunkSize,
+  resolveIndexingBatchSize,
+} from './config.js';
+
+describe('resolveIndexingBatchSize (issue #236 — INDEXING_BATCH_SIZE)', () => {
+  const saved = process.env.INDEXING_BATCH_SIZE;
+
+  afterEach(() => {
+    if (saved === undefined) delete process.env.INDEXING_BATCH_SIZE; else process.env.INDEXING_BATCH_SIZE = saved;
+  });
+
+  it('uses conservative provider defaults when unset', () => {
+    delete process.env.INDEXING_BATCH_SIZE;
+    expect(resolveIndexingBatchSize('huggingface')).toBe(64);
+    expect(resolveIndexingBatchSize('openai')).toBe(64);
+    expect(resolveIndexingBatchSize('ollama')).toBe(16);
+  });
+
+  it('honors positive integer values', () => {
+    process.env.INDEXING_BATCH_SIZE = '7';
+    expect(resolveIndexingBatchSize('ollama')).toBe(7);
+  });
+
+  it('floors fractional values and caps very large batches', () => {
+    process.env.INDEXING_BATCH_SIZE = '7.9';
+    expect(resolveIndexingBatchSize('huggingface')).toBe(7);
+
+    process.env.INDEXING_BATCH_SIZE = '9999';
+    expect(resolveIndexingBatchSize('huggingface')).toBe(512);
+  });
+
+  it('falls back to the provider default for invalid values', () => {
+    process.env.INDEXING_BATCH_SIZE = 'not-a-number';
+    expect(resolveIndexingBatchSize('huggingface')).toBe(64);
+
+    process.env.INDEXING_BATCH_SIZE = '0';
+    expect(resolveIndexingBatchSize('ollama')).toBe(16);
+  });
+});
 
 describe('resolveChunkSize (#107 follow-up — KB_CHUNK_SIZE / KB_CHUNK_OVERLAP env vars)', () => {
   const savedSize = process.env.KB_CHUNK_SIZE;

--- a/src/config.ts
+++ b/src/config.ts
@@ -72,6 +72,33 @@ export const INGEST_EXCLUDE_PATHS: readonly string[] = parseCommaSeparatedList(
 );
 
 // ---------------------------------------------------------------------------
+// Indexing batch configuration (RFC 007 §6.2 / issue #236).
+// ---------------------------------------------------------------------------
+
+const DEFAULT_INDEXING_BATCH_SIZE = 64;
+const DEFAULT_OLLAMA_INDEXING_BATCH_SIZE = 16;
+const MAX_INDEXING_BATCH_SIZE = 512;
+
+export function resolveIndexingBatchSize(
+  provider: string = EMBEDDING_PROVIDER,
+): number {
+  const defaultForProvider = provider === 'ollama'
+    ? DEFAULT_OLLAMA_INDEXING_BATCH_SIZE
+    : DEFAULT_INDEXING_BATCH_SIZE;
+  const raw = process.env.INDEXING_BATCH_SIZE;
+  if (raw === undefined || raw.trim() === '') {
+    return defaultForProvider;
+  }
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return defaultForProvider;
+  }
+  return Math.min(MAX_INDEXING_BATCH_SIZE, Math.max(1, Math.floor(parsed)));
+}
+
+export const INDEXING_BATCH_SIZE: number = resolveIndexingBatchSize();
+
+// ---------------------------------------------------------------------------
 // Chunking configuration (#107 follow-up).
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Batch changed-file document chunks during `FaissIndexManager.updateIndex` using `INDEXING_BATCH_SIZE` with conservative provider defaults.
- Preserve the one-save-at-end behavior and post-save sidecar hash writes while reducing embedding provider round trips.
- Update requirements, testing trace, benchmark docs, and QA budgets for the new call-count behavior.

## Test plan
- [x] `npm test -- --runTestsByPath src/config.test.ts src/FaissIndexManager.test.ts --silent`
- [x] `npm run build`
- [x] `npm test -- --silent`
- [x] `BENCH_PROVIDER=stub BENCH_RESULTS_DIR=/tmp/kb-bench-236 npm run bench` (`cold_index`: `from_texts_calls=1`, `add_documents_calls=9`, `save_calls=1`, `chunks=600`)

Closes #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)