### PR TITLE
fix: rollback add_document writes on indexing failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased] — `add_document` rollback on indexing failure
+
+### Changed
+
+- **`add_document` now compensates filesystem writes when immediate indexing fails.** If a new document was written and `updateIndex` rejects, the server removes the new file and prunes only parent directories created by that call. If an existing document was overwritten, the previous bytes and file mode are restored. The MCP error payload includes rollback status so callers can tell whether durable KB content was restored or still needs manual remediation. Closes #235.
+
 ## [Unreleased] — Batched changed-file embeddings during updateIndex (#236)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- **`add_document` now compensates filesystem writes when immediate indexing fails.** If a new document was written and `updateIndex` rejects, the server removes the new file and prunes only parent directories created by that call. If an existing document was overwritten, the previous bytes and file mode are restored. The MCP error payload includes rollback status so callers can tell whether durable KB content was restored or still needs manual remediation. Closes #235.
+- **`add_document` now compensates filesystem writes when immediate indexing fails.** If a new document was written and `updateIndex` rejects, the server removes the new file and prunes only parent directories created by that call. If an existing document was overwritten, the previous bytes and file mode are restored. If indexing had already mutated FAISS state, the server reloads the previous persisted index or force-rebuilds from rolled-back files so retrieval does not keep rejected content alive. The MCP error payload includes rollback status so callers can tell whether durable KB content was restored or still needs manual remediation. Closes #235.
 
 ## [Unreleased] — Batched changed-file embeddings during updateIndex (#236)
 

--- a/src/FaissIndexManager.ts
+++ b/src/FaissIndexManager.ts
@@ -474,6 +474,15 @@ export class FaissIndexManager {
   }
 
   /**
+   * Reload the last persisted FAISS store into memory, discarding any
+   * in-memory additions from a failed updateIndex run. Callers that pair this
+   * with a write mutation should already hold this manager's write lock.
+   */
+  async reloadPersistedIndex(): Promise<void> {
+    this.faissIndex = await this.loadAtomic();
+  }
+
+  /**
    * RFC 014 — atomic save via versioned dirs + symlink swap.
    *
    * PRECONDITION: caller MUST hold withWriteLock(this.modelDir). Verified

--- a/src/KnowledgeBaseServer.test.ts
+++ b/src/KnowledgeBaseServer.test.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 
 const initializeMock = jest.fn();
 const updateIndexMock = jest.fn();
+const reloadPersistedIndexMock = jest.fn();
 const similaritySearchMock = jest.fn();
 const hasLoadedIndexMock = jest.fn(() => true);
 // Issue #54 — kb_stats reads chunk_count + dim from the manager. Default to
@@ -45,6 +46,7 @@ const FaissIndexManagerMock: any = jest.fn().mockImplementation((opts?: { provid
   return {
     initialize: initializeMock,
     updateIndex: updateIndexMock,
+    reloadPersistedIndex: reloadPersistedIndexMock,
     similaritySearch: similaritySearchMock,
     getStats: getStatsMock,
     getLastIndexUpdateSummary: getLastIndexUpdateSummaryMock,
@@ -83,6 +85,7 @@ describe('KnowledgeBaseServer handlers', () => {
   beforeEach(() => {
     initializeMock.mockReset();
     updateIndexMock.mockReset();
+    reloadPersistedIndexMock.mockReset();
     similaritySearchMock.mockReset();
     hasLoadedIndexMock.mockReset();
     hasLoadedIndexMock.mockReturnValue(true);
@@ -512,6 +515,96 @@ describe('KnowledgeBaseServer handlers', () => {
       },
     });
     expect(payload.error.message).toContain('index boom');
+  });
+
+  it('handleAddDocument reloads the previous FAISS state when indexing mutates memory but does not save', async () => {
+    const tempDir = await setRetrieveEnv();
+    await fsp.mkdir(path.join(tempDir, 'alpha'));
+    updateIndexMock.mockRejectedValueOnce(new Error('save boom'));
+    getLastIndexUpdateSummaryMock.mockReturnValue({
+      status: 'failed',
+      scope: null,
+      model_id: 'huggingface__BAAI-bge-small-en-v1.5',
+      started_at: null,
+      finished_at: null,
+      duration_ms: null,
+      files_scanned: 1,
+      files_changed: 1,
+      files_unchanged: 0,
+      files_skipped: 0,
+      chunks_attempted: 1,
+      chunks_added: 1,
+      index_mutated: true,
+      saved: false,
+      sidecars_written: false,
+      failure_count: 1,
+      failures: [],
+    });
+
+    const server = await freshServer();
+    const result = await server['handleAddDocument']({
+      knowledge_base_name: 'alpha',
+      path: 'notes/new.md',
+      content: '# New note\n',
+    });
+
+    expect(result.isError).toBe(true);
+    expect(updateIndexMock).toHaveBeenCalledTimes(1);
+    expect(updateIndexMock).toHaveBeenCalledWith('alpha');
+    expect(reloadPersistedIndexMock).toHaveBeenCalledTimes(1);
+    await expect(exists(path.join(tempDir, 'alpha', 'notes', 'new.md'))).resolves.toBe(false);
+    const payload = JSON.parse(result.content[0].text);
+    expect(payload.error.rollback).toMatchObject({
+      attempted: true,
+      succeeded: true,
+      message: 'removed newly written document; reloaded previous FAISS index state',
+    });
+  });
+
+  it('handleAddDocument force-rebuilds FAISS when indexing saved before failing sidecar writes', async () => {
+    const tempDir = await setRetrieveEnv();
+    await fsp.mkdir(path.join(tempDir, 'alpha'));
+    updateIndexMock
+      .mockRejectedValueOnce(new Error('sidecar boom'))
+      .mockResolvedValueOnce(undefined);
+    getLastIndexUpdateSummaryMock.mockReturnValue({
+      status: 'failed',
+      scope: null,
+      model_id: 'huggingface__BAAI-bge-small-en-v1.5',
+      started_at: null,
+      finished_at: null,
+      duration_ms: null,
+      files_scanned: 1,
+      files_changed: 1,
+      files_unchanged: 0,
+      files_skipped: 0,
+      chunks_attempted: 1,
+      chunks_added: 1,
+      index_mutated: true,
+      saved: true,
+      sidecars_written: false,
+      failure_count: 1,
+      failures: [],
+    });
+
+    const server = await freshServer();
+    const result = await server['handleAddDocument']({
+      knowledge_base_name: 'alpha',
+      path: 'notes/new.md',
+      content: '# New note\n',
+    });
+
+    expect(result.isError).toBe(true);
+    expect(updateIndexMock).toHaveBeenNthCalledWith(1, 'alpha');
+    expect(updateIndexMock).toHaveBeenNthCalledWith(2, undefined, { force: true });
+    expect(reloadPersistedIndexMock).not.toHaveBeenCalled();
+    await expect(exists(path.join(tempDir, 'alpha', 'notes', 'new.md'))).resolves.toBe(false);
+    const payload = JSON.parse(result.content[0].text);
+    expect(payload.error.rollback).toMatchObject({
+      attempted: true,
+      succeeded: true,
+      message: 'removed newly written document; rebuilt FAISS index from rolled-back files',
+    });
   });
 
   it('handleAddDocument reports rollback failure when cleanup cannot remove the new file', async () => {

--- a/src/KnowledgeBaseServer.test.ts
+++ b/src/KnowledgeBaseServer.test.ts
@@ -451,6 +451,97 @@ describe('KnowledgeBaseServer handlers', () => {
     });
   });
 
+  it('handleAddDocument removes a new file when indexing fails after the write', async () => {
+    const tempDir = await setRetrieveEnv();
+    await fsp.mkdir(path.join(tempDir, 'alpha'));
+    updateIndexMock.mockRejectedValue(new Error('index boom'));
+
+    const server = await freshServer();
+    const result = await server['handleAddDocument']({
+      knowledge_base_name: 'alpha',
+      path: 'notes/new.md',
+      content: '# New note\n',
+    });
+
+    expect(result.isError).toBe(true);
+    expect(updateIndexMock).toHaveBeenCalledWith('alpha');
+    const documentPath = path.join(tempDir, 'alpha', 'notes', 'new.md');
+    await expect(exists(documentPath)).resolves.toBe(false);
+    await expect(exists(path.dirname(documentPath))).resolves.toBe(false);
+    const payload = JSON.parse(result.content[0].text);
+    expect(payload).toMatchObject({
+      error: {
+        code: 'INTERNAL',
+        rollback: {
+          attempted: true,
+          succeeded: true,
+          message: 'removed newly written document',
+        },
+      },
+    });
+    expect(payload.error.message).toContain('index boom');
+  });
+
+  it('handleAddDocument restores overwritten content when indexing fails after the write', async () => {
+    const tempDir = await setRetrieveEnv();
+    const documentPath = path.join(tempDir, 'alpha', 'notes', 'existing.md');
+    await fsp.mkdir(path.dirname(documentPath), { recursive: true });
+    await fsp.writeFile(documentPath, 'old content');
+    await fsp.chmod(documentPath, 0o640);
+    updateIndexMock.mockRejectedValue(new Error('index boom'));
+
+    const server = await freshServer();
+    const result = await server['handleAddDocument']({
+      knowledge_base_name: 'alpha',
+      path: 'notes/existing.md',
+      content: 'new content',
+    });
+
+    expect(result.isError).toBe(true);
+    await expect(fsp.readFile(documentPath, 'utf-8')).resolves.toBe('old content');
+    const stat = await fsp.stat(documentPath);
+    expect(stat.mode & 0o777).toBe(0o640);
+    const payload = JSON.parse(result.content[0].text);
+    expect(payload).toMatchObject({
+      error: {
+        rollback: {
+          attempted: true,
+          succeeded: true,
+          message: 'restored previous document content',
+        },
+      },
+    });
+    expect(payload.error.message).toContain('index boom');
+  });
+
+  it('handleAddDocument reports rollback failure when cleanup cannot remove the new file', async () => {
+    const tempDir = await setRetrieveEnv();
+    const notesDir = path.join(tempDir, 'alpha', 'notes');
+    await fsp.mkdir(path.join(tempDir, 'alpha'));
+    updateIndexMock.mockImplementationOnce(async () => {
+      await fsp.chmod(notesDir, 0o500);
+      throw new Error('index boom');
+    });
+
+    const server = await freshServer();
+    const result = await server['handleAddDocument']({
+      knowledge_base_name: 'alpha',
+      path: 'notes/new.md',
+      content: 'new content',
+    });
+
+    await fsp.chmod(notesDir, 0o700);
+    expect(result.isError).toBe(true);
+    await expect(fsp.readFile(path.join(notesDir, 'new.md'), 'utf-8')).resolves.toBe('new content');
+    const payload = JSON.parse(result.content[0].text);
+    expect(payload.error.message).toContain('index boom');
+    expect(payload.error.rollback).toMatchObject({
+      attempted: true,
+      succeeded: false,
+    });
+    expect(payload.error.rollback.message).toBeTruthy();
+  });
+
   it('handleAddDocument rejects path traversal and does not update the index', async () => {
     const tempDir = await setRetrieveEnv();
     await fsp.mkdir(path.join(tempDir, 'alpha'));

--- a/src/KnowledgeBaseServer.ts
+++ b/src/KnowledgeBaseServer.ts
@@ -227,6 +227,43 @@ async function rollbackAddDocumentWrite(options: {
   }
 }
 
+async function restoreIndexAfterAddDocumentRollback(
+  manager: FaissIndexManager,
+  rollback: RollbackStatus,
+): Promise<RollbackStatus> {
+  if (!rollback.succeeded) {
+    return rollback;
+  }
+
+  const summary = manager.getLastIndexUpdateSummary();
+  if (!summary.index_mutated) {
+    return rollback;
+  }
+
+  try {
+    if (summary.saved) {
+      await manager.updateIndex(undefined, { force: true });
+      return {
+        ...rollback,
+        message: `${rollback.message}; rebuilt FAISS index from rolled-back files`,
+      };
+    }
+
+    await manager.reloadPersistedIndex();
+    return {
+      ...rollback,
+      message: `${rollback.message}; reloaded previous FAISS index state`,
+    };
+  } catch (error: unknown) {
+    const err = toError(error);
+    return {
+      attempted: true,
+      succeeded: false,
+      message: `${rollback.message}; FAISS index restore failed: ${err.message}`,
+    };
+  }
+}
+
 export class KnowledgeBaseServer {
   private mcp: McpServer;
   // RFC 013 M1 (#157 step 3): per-model FaissIndexManager cache. Lazily
@@ -488,12 +525,13 @@ export class KnowledgeBaseServer {
           await manager.updateIndex(args.knowledge_base_name);
         } catch (error: unknown) {
           const originalError = toError(error);
-          const rollback = await rollbackAddDocumentWrite({
+          const fileRollback = await rollbackAddDocumentWrite({
             documentPath,
             kbDir,
             snapshot,
             existingDirs,
           });
+          const rollback = await restoreIndexAfterAddDocumentRollback(manager, fileRollback);
           throw new AddDocumentRollbackError(originalError, rollback);
         }
       });

--- a/src/KnowledgeBaseServer.ts
+++ b/src/KnowledgeBaseServer.ts
@@ -75,6 +75,158 @@ function mcpErrorContent(error: Error): TextContent {
   };
 }
 
+interface AddDocumentSnapshot {
+  existed: boolean;
+  content?: Buffer;
+  mode?: number;
+}
+
+interface RollbackStatus {
+  attempted: true;
+  succeeded: boolean;
+  message: string;
+}
+
+class AddDocumentRollbackError extends Error {
+  readonly originalError: Error;
+  readonly rollback: RollbackStatus;
+
+  constructor(originalError: Error, rollback: RollbackStatus) {
+    super(`indexing failed after writing document: ${originalError.message}`, {
+      cause: originalError,
+    });
+    this.name = 'AddDocumentRollbackError';
+    this.originalError = originalError;
+    this.rollback = rollback;
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+function addDocumentRollbackErrorContent(error: AddDocumentRollbackError): TextContent {
+  const code: KBErrorCode = error.originalError instanceof KBError
+    ? error.originalError.code
+    : 'INTERNAL';
+  return {
+    type: 'text',
+    text: JSON.stringify({
+      error: {
+        code,
+        message: error.message,
+        rollback: error.rollback,
+      },
+    }),
+  };
+}
+
+function isMissingPathError(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException | undefined)?.code;
+  return code === 'ENOENT' || code === 'ENOTDIR';
+}
+
+async function snapshotDocumentForRollback(documentPath: string): Promise<AddDocumentSnapshot> {
+  try {
+    const [stat, content] = await Promise.all([
+      fsp.stat(documentPath),
+      fsp.readFile(documentPath),
+    ]);
+    return {
+      existed: true,
+      content,
+      mode: stat.mode,
+    };
+  } catch (error: unknown) {
+    if (isMissingPathError(error)) {
+      return { existed: false };
+    }
+    throw error;
+  }
+}
+
+async function collectExistingAncestorDirs(parentDir: string, stopDir: string): Promise<Set<string>> {
+  const existing = new Set<string>();
+  let current = parentDir;
+  while (current.startsWith(stopDir) && current !== path.dirname(current)) {
+    try {
+      const stat = await fsp.stat(current);
+      if (stat.isDirectory()) {
+        existing.add(current);
+      }
+    } catch (error: unknown) {
+      if (!isMissingPathError(error)) {
+        throw error;
+      }
+    }
+    if (current === stopDir) {
+      break;
+    }
+    current = path.dirname(current);
+  }
+  return existing;
+}
+
+async function pruneDirsCreatedForDocument(
+  parentDir: string,
+  stopDir: string,
+  existingDirs: Set<string>,
+): Promise<void> {
+  let current = parentDir;
+  while (current !== stopDir && current.startsWith(stopDir)) {
+    if (existingDirs.has(current)) {
+      break;
+    }
+    try {
+      await fsp.rmdir(current);
+    } catch (error: unknown) {
+      const code = (error as NodeJS.ErrnoException | undefined)?.code;
+      if (code === 'ENOENT') {
+        // Already gone is equivalent to a successful cleanup for this path.
+      } else if (code === 'ENOTEMPTY' || code === 'EEXIST') {
+        break;
+      } else {
+        throw error;
+      }
+    }
+    current = path.dirname(current);
+  }
+}
+
+async function rollbackAddDocumentWrite(options: {
+  documentPath: string;
+  kbDir: string;
+  snapshot: AddDocumentSnapshot;
+  existingDirs: Set<string>;
+}): Promise<RollbackStatus> {
+  const { documentPath, kbDir, snapshot, existingDirs } = options;
+  try {
+    if (snapshot.existed) {
+      await fsp.writeFile(documentPath, snapshot.content ?? Buffer.alloc(0));
+      if (snapshot.mode !== undefined) {
+        await fsp.chmod(documentPath, snapshot.mode);
+      }
+      return {
+        attempted: true,
+        succeeded: true,
+        message: 'restored previous document content',
+      };
+    }
+
+    await fsp.unlink(documentPath);
+    await pruneDirsCreatedForDocument(path.dirname(documentPath), kbDir, existingDirs);
+    return {
+      attempted: true,
+      succeeded: true,
+      message: 'removed newly written document',
+    };
+  } catch (error: unknown) {
+    const err = toError(error);
+    return {
+      attempted: true,
+      succeeded: false,
+      message: err.message,
+    };
+  }
+}
+
 export class KnowledgeBaseServer {
   private mcp: McpServer;
   // RFC 013 M1 (#157 step 3): per-model FaissIndexManager cache. Lazily
@@ -324,9 +476,26 @@ export class KnowledgeBaseServer {
           args.path,
           { mustExist: false },
         );
+        const kbDir = await resolveKnowledgeBaseDir(
+          KNOWLEDGE_BASES_ROOT_DIR,
+          args.knowledge_base_name,
+        );
+        const existingDirs = await collectExistingAncestorDirs(path.dirname(documentPath), kbDir);
+        const snapshot = await snapshotDocumentForRollback(documentPath);
         await fsp.mkdir(path.dirname(documentPath), { recursive: true });
         await fsp.writeFile(documentPath, args.content, 'utf-8');
-        await manager.updateIndex(args.knowledge_base_name);
+        try {
+          await manager.updateIndex(args.knowledge_base_name);
+        } catch (error: unknown) {
+          const originalError = toError(error);
+          const rollback = await rollbackAddDocumentWrite({
+            documentPath,
+            kbDir,
+            snapshot,
+            existingDirs,
+          });
+          throw new AddDocumentRollbackError(originalError, rollback);
+        }
       });
 
       return {
@@ -343,6 +512,13 @@ export class KnowledgeBaseServer {
     } catch (error: unknown) {
       if (error instanceof ActiveModelResolutionError) {
         return { content: [{ type: 'text', text: error.message }], isError: true };
+      }
+      if (error instanceof AddDocumentRollbackError) {
+        logger.error('Error adding document:', error);
+        if (error.stack) {
+          logger.error(error.stack);
+        }
+        return { content: [addDocumentRollbackErrorContent(error)], isError: true };
       }
       const err = toError(error);
       logger.error('Error adding document:', err);


### PR DESCRIPTION
## Summary
- Added compensating rollback around `add_document` when the post-write `updateIndex` step fails.
- Restores overwritten document bytes and mode, or removes newly written files plus only directories created by the failed call.
- Returns rollback status in the MCP error payload and documents the user-visible behavior in the changelog.

## Test plan
- [x] `npm test -- --runTestsByPath src/KnowledgeBaseServer.test.ts --silent`
- [x] `npm run build`
- [x] `npm test -- --silent`
- [x] `git diff --check`

Closes #235

Generated with [Claude Code](https://claude.com/claude-code)