### PR TITLE
feat(cli): per-subcommand --help and clean top-level command list

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ printf '# Quarterly plan\n\n...' | kb remember --kb=work --title="Quarterly plan
 printf '\nFollow-up note.\n' | kb remember --kb=work --append=quarterly-plan.md --stdin --yes
 kb superseded --kb=work       # read-only review for obsolete/contradicted notes
 kb eval retrieval-eval.yml     # run fixture-driven retrieval checks
-kb --help
+kb --help                     # top-level command list
+kb help search                # per-command help (also: kb search --help)
 ```
 
 The `kb` bin shares the same env vars as the MCP server (`KNOWLEDGE_BASES_ROOT_DIR`, `FAISS_INDEX_PATH`, `EMBEDDING_PROVIDER`, `OLLAMA_*`, `OPENAI_*`, `HUGGINGFACE_*`). `kb stats [--kb=<name>] [--format=md|json]` mirrors the MCP `kb_stats` payload for local shell use: per-KB file/chunk/byte counts, last indexed time, embedding model, index path, and version context. It is read-only and does not refresh the index. `kb search` also defaults to read-only — it loads the existing FAISS index but does not re-scan KB files. Pass `--refresh` to re-index. Output includes a freshness footer indicating whether the index is up-to-date relative to KB file mtimes.

--- a/docs/agent-task-lessons.md
+++ b/docs/agent-task-lessons.md
@@ -96,7 +96,7 @@ for one call.
 
 ## Related
 
-- `kb remember` — see `kb --help` for the full flag matrix.
+- `kb remember` — see `kb remember --help` for the full flag matrix.
 - `kb where --topic=<query>` — pre-write recommendation for the best KB
   + file to update.
 - Issue #200 — original feature request.

--- a/src/cli-capture.ts
+++ b/src/cli-capture.ts
@@ -42,6 +42,43 @@ const LANGUAGE_BY_EXT: Record<string, string> = {
   yaml: 'yaml',
 };
 
+export const CAPTURE_HELP = `kb capture — run a command and append its stdout to a KB note as a fenced block
+
+Usage:
+  kb capture --kb=<name> --append=<path> [options] -- <cmd> [args...]
+
+Spawns the command (\`shell: false\`), captures up to \`--max-bytes\` of stdout,
+and appends a fenced, provenance-tagged code block to the target KB note.
+The \`--\` separator is required: everything after it is the command + args
+passed verbatim to spawn. Composes with \`kb remember --append=<path>\` for the
+write path.
+
+Targeting:
+  --kb=<name>           Target knowledge base. Required.
+  --append=<path>       Existing KB-relative note path. Required. Rejects
+                        path traversal and absolute paths before spawning.
+
+Capture options:
+  --note=<text>         Optional "### <text>" header above the captured block.
+  --language=<hint>     Code-fence language hint. Auto-detected from the
+                        command's first .json / .yml / .yaml argument if
+                        absent (e.g. \`-- gh pr view --json title\` → \`json\`).
+  --max-bytes=<N>       Truncate captured stdout at N bytes
+                        (default: ${DEFAULT_MAX_BYTES}).
+  --allow-fail          Capture even when the command exits non-zero.
+                        Without this flag, a non-zero exit aborts the write.
+  --refresh             Re-index the affected KB after a successful write.
+  --                    End of options; remaining argv is the command + args.
+  --help, -h            Show this help.
+
+Examples:
+  kb capture --kb=work --append=oncall.md --note="incident snapshot" -- \\
+    gh pr view 123 --json title,body
+  kb capture --kb=ops --append=deploys.md --language=yaml -- \\
+    kubectl get deployment api -o yaml
+  kb capture --kb=work --append=models.md --allow-fail -- ollama list
+`;
+
 export async function runCapture(rest: string[]): Promise<number> {
   let parsed: CaptureArgs;
   try {

--- a/src/cli-compare.ts
+++ b/src/cli-compare.ts
@@ -5,6 +5,34 @@ import {
 } from './active-model.js';
 import { loadManagerForModel, loadWithJsonRetry } from './cli-shared.js';
 
+export const COMPARE_HELP = `kb compare — side-by-side rank/score table for two embedding models
+
+Usage:
+  kb compare <query> <model_a> <model_b> [--k=<int>] [--kb=<name>]
+
+Runs the same query against two registered models' indexes and prints a
+joined table of \`rank_a / rank_b / score_a / score_b / in_both / source\`,
+sorted by best rank in either column. Useful when evaluating a candidate
+embedding model against the current active one.
+
+Scores are per-model L2 distances and are NOT directly comparable across
+models — read the relative ordering, not the magnitudes.
+
+Arguments:
+  <query>               Query string (positional).
+  <model_a>             First model id (\`<provider>__<slug>\`); see \`kb models list\`.
+  <model_b>             Second model id; must differ from <model_a>.
+
+Options:
+  --k=<int>             Top-K results per model (default: 10).
+  --kb=<name>           Scope to one knowledge base. Omit to search ALL KBs.
+  --help, -h            Show this help.
+
+Examples:
+  kb compare "rollback procedure" ollama__nomic-embed-text openai__text-embedding-3-small
+  kb compare "deploy" ollama__nomic-embed-text huggingface__bge-small-en --k=5 --kb=work
+`;
+
 export async function runCompare(rest: string[]): Promise<number> {
   // Parse: <query> <model_a> <model_b> [--k=<int>] [--kb=<name>]
   const positionals: string[] = [];

--- a/src/cli-doctor.ts
+++ b/src/cli-doctor.ts
@@ -32,6 +32,31 @@ import {
 
 const execFileAsync = promisify(execFile);
 
+export const DOCTOR_HELP = `kb doctor — aggregate model / index / backend health report
+
+Usage:
+  kb doctor [--format=md|json]
+
+Composes existing read-only checks (env vars, registered models, active
+model, FAISS index presence + mtime, knowledge-base count, embedding
+backend reachability) into a single status report. Does NOT load the
+FAISS store or embed documents.
+
+Report status is one of \`ok\`, \`warn\`, or \`error\`. The exit code is non-zero
+when any required check fails, so \`kb doctor && kb search ...\` is a safe
+gate from a script.
+
+Options:
+  --format=md|json      Output format (default: md). \`json\` emits the same
+                        underlying report shape for agent shells.
+  --help, -h            Show this help.
+
+Examples:
+  kb doctor
+  kb doctor --format=json
+  kb doctor && kb search "rollback"
+`;
+
 export interface DoctorArgs {
   format: 'md' | 'json';
 }
@@ -107,9 +132,6 @@ export async function runDoctor(rest: string[]): Promise<number> {
 export function parseDoctorArgs(rest: string[]): DoctorArgs {
   const out: DoctorArgs = { format: 'md' };
   for (const raw of rest) {
-    if (raw === '--help' || raw === '-h') {
-      throw new Error('usage: kb doctor [--format=md|json]');
-    }
     if (raw.startsWith('--format=')) {
       const value = raw.slice('--format='.length);
       if (value !== 'md' && value !== 'json') {

--- a/src/cli-eval.ts
+++ b/src/cli-eval.ts
@@ -27,6 +27,45 @@ interface EvalArgs {
 const DEFAULT_K = 10;
 const DEFAULT_THRESHOLD = 2;
 
+export const EVAL_HELP = `kb eval — run fixture-driven retrieval checks
+
+Usage:
+  kb eval <fixture.yml|json> [--model=<id>] [--k=<int>] [--threshold=<float>]
+                              [--format=md|json]
+
+Reads cases from a YAML or JSON fixture and runs each query against the
+active model's index. Each case can set \`query\`, optional \`kb\`,
+\`required_sources\`, \`forbidden_sources\`, \`expected_metadata\`,
+\`max_duplicate_groups\`, \`stale_policy\`, and \`gate\`.
+
+Failing ungated cases print warnings and exit 0; failing GATED cases
+exit 1, suitable for CI gates.
+
+Arguments:
+  <fixture.yml|json>    Path to fixture file. Format inferred from extension.
+
+Options:
+  --model=<id>          Override the active model for the run (RFC 013).
+  --k=<int>             Top-K results per case (default: ${DEFAULT_K}).
+  --threshold=<float>   Max similarity score; lower = closer (default: ${DEFAULT_THRESHOLD}).
+  --format=md|json      Output format (default: md).
+  --help, -h            Show this help.
+
+Fixture example (YAML):
+  gate: false
+  cases:
+    - name: deployment runbook
+      query: rollback procedure
+      kb: work
+      gate: true
+      required_sources: [runbooks/deploy.md]
+      forbidden_sources: [archive/old-deploy.md]
+      expected_metadata:
+        frontmatter.status: approved
+      max_duplicate_groups: 1
+      stale_policy: fresh
+`;
+
 export async function runEval(rest: string[]): Promise<number> {
   let parsed: EvalArgs;
   try {
@@ -112,11 +151,6 @@ export function parseEvalArgs(rest: string[]): EvalArgs {
   };
 
   for (const raw of rest) {
-    if (raw === '--help' || raw === '-h') {
-      throw new Error(
-        'usage: kb eval <fixture.yml|json> [--model=<id>] [--k=<int>] [--threshold=<float>] [--format=md|json]',
-      );
-    }
     if (raw.startsWith('--fixture=')) {
       const value = raw.slice('--fixture='.length);
       if (value.length === 0) throw new Error('--fixture=<path> requires a non-empty value');

--- a/src/cli-list.ts
+++ b/src/cli-list.ts
@@ -1,6 +1,29 @@
 import { KNOWLEDGE_BASES_ROOT_DIR } from './config.js';
 import { describeKnowledgeBase, listKnowledgeBases } from './kb-fs.js';
 
+export const LIST_HELP = `kb list — list available knowledge bases
+
+Usage:
+  kb list [--describe|-v] [--format=md|json]
+
+Reads \`KNOWLEDGE_BASES_ROOT_DIR\` and prints one knowledge-base name per
+line (text format) or a JSON array (\`--format=json\`). Strictly read-only —
+does not touch the FAISS index.
+
+Options:
+  --describe, -v        Append a one-line description sourced from each
+                        KB's README.md. With \`--format=json\`, adds a
+                        \`description\` field to each entry.
+  --format=md|json      Output format (default: md). \`md\` is plain text;
+                        \`json\` is a stable shape suitable for agent shells.
+  --help, -h            Show this help.
+
+Examples:
+  kb list
+  kb list --describe
+  kb list --format=json
+`;
+
 interface ListArgs {
   describe: boolean;
   format: 'md' | 'json';

--- a/src/cli-models.ts
+++ b/src/cli-models.ts
@@ -17,6 +17,52 @@ import { withWriteLock } from './write-lock.js';
 import { estimateCostUsd } from './cost-estimates.js';
 import { pathExists } from './file-utils.js';
 
+export const MODELS_HELP = `kb models — manage embedding models (RFC 013)
+
+Usage:
+  kb models list
+  kb models add <provider> <model> [--yes] [--dry-run]
+  kb models set-active <id>
+  kb models remove <id>
+
+Each model gets its own per-model FAISS index under
+\`\${FAISS_INDEX_PATH}/models/<id>/\`. The active model is the default for
+both the MCP server and the CLI; explicit \`--model=<id>\` overrides that
+per-call (RFC 013 §4.7).
+
+Verbs:
+  list                  Print one row per registered model. The active
+                        model is marked with \`*\`. Models with both the
+                        RFC-014 versioned layout AND a legacy \`faiss.index/\`
+                        directory get a trailing \`[downgrade-hazard]\` flag.
+  add <provider> <model>
+                        Register a new model and run an initial ingest pass
+                        under the per-model write lock. \`<provider>\` is one
+                        of \`ollama\`, \`openai\`, \`huggingface\`. \`<model>\` is
+                        the provider-specific name (e.g. \`nomic-embed-text\`,
+                        \`text-embedding-3-small\`). The CLI computes a model
+                        id of the form \`<provider>__<slug>\`.
+  set-active <id>       Change the default model. Atomically rewrites
+                        \`\${FAISS_INDEX_PATH}/active.txt\`. Subsequent calls
+                        without an explicit \`--model=\` use the new active id.
+  remove <id>           Delete the per-model index directory. Forces a
+                        rebuild on the next \`kb models add <same id>\`.
+
+Options for \`add\`:
+  --yes                 Skip the cost-estimate confirmation prompt.
+  --dry-run             Print the cost estimate; don't embed.
+
+Global:
+  --help, -h            Show this help.
+
+Examples:
+  kb models list
+  kb models add ollama nomic-embed-text
+  kb models add openai text-embedding-3-small --dry-run
+  kb models set-active openai__text-embedding-3-small
+  kb models remove ollama__nomic-embed-text
+`;
+
 export async function runModels(rest: string[]): Promise<number> {
   const verb = rest[0];
   if (!verb) {

--- a/src/cli-remember.ts
+++ b/src/cli-remember.ts
@@ -30,6 +30,85 @@ export type {
   PreflightDecisionHint,
 } from './cli-remember-similarity.js';
 
+export const REMEMBER_HELP = `kb remember — write or extend knowledge-base notes (conservative write path)
+
+Usage:
+  kb remember --suggest --kb=<name> --title=<title>
+  kb remember --kb=<name> --title=<title> --stdin --yes
+  kb remember --kb=<name> --append=<path> --stdin --yes
+  kb remember --kb=<name> --append=<path> --append-section="<#level> <text>"
+              [--occurrence=<N>] --stdin --yes
+  kb remember --lesson --title=<title> --stdin --yes
+
+Modes:
+  --suggest             Read-only: list likely existing note targets for
+                        the given title. Does NOT read stdin and does NOT
+                        write anything.
+  (no --suggest)        Create or append. Both require \`--stdin --yes\`.
+                        Create uses a slugified \`.md\` filename and refuses
+                        to overwrite. Append accepts only existing
+                        KB-relative paths and rejects path traversal.
+
+Targeting:
+  --kb=<name>           Target knowledge base. Required (except with
+                        \`--lesson\`, which defaults to \`agent-task-lessons\`).
+  --title=<title>       Note title; create uses a slugified \`.md\` filename.
+  --append=<path>       Existing KB-relative note path; rejects traversal.
+  --append-section=<spec>
+                        Heading-aware append target. Spec is "<#level> <text>"
+                        (e.g. "## OSS gate flow"). Requires \`--append=<path>\`.
+                        Inserts at the END of the named section (after every
+                        subsection), atomically rewrites the file, and refuses
+                        to fall back to EOF if the heading is missing.
+  --occurrence=<N>      1-indexed disambiguation when the heading appears
+                        multiple times. Requires \`--append-section\`.
+
+Templates:
+  --lesson              Apply the agent-task-lesson template: defaults
+                        \`--kb\` to \`agent-task-lessons\`, validates that the
+                        body has the H2 sections "## Mistake",
+                        "## Why it happened", and "## Better next time".
+                        On empty or malformed input, prints a guided
+                        skeleton and exits 2 instead of writing.
+
+Similarity preflight (default ON, RFC issue #154):
+  --check-similar       Force the preflight ON (default). Surface
+                        index-load failures as exit 1/2 errors instead of
+                        degrading to a warning.
+  --no-check-similar    Disable the preflight for this write.
+  --similar-threshold=<float>
+                        Max FAISS distance treated as related (default 1.0;
+                        lower distance = closer match).
+  --similar-k=<int>     Top-K candidate chunks to surface (default 5).
+  --force               Override the similarity guard and write anyway.
+                        The success response reports that the guard was
+                        overridden so the action stays auditable.
+
+Input / output:
+  --stdin               Read note content from stdin. Required for writes.
+  --yes                 Required for non-interactive writes.
+  --refresh             Re-index the affected KB after a successful write.
+  --format=md|json      Output format for similarity-guard reports
+                        (default: json — agent-friendly machine-readable).
+  --model=<id>          Override the active model for the preflight
+                        similarity search (RFC 013).
+  --help, -h            Show this help.
+
+Exit codes:
+  0   write succeeded (or --suggest produced suggestions)
+  1   runtime / index error
+  2   argv / template-validation error (e.g. \`--lesson\` missing sections)
+  3   similarity preflight refused to write; rerun with --force to override.
+
+Examples:
+  kb remember --suggest --kb=work --title="Quarterly plan"
+  printf '# Quarterly plan\\n\\n...' | \\
+    kb remember --kb=work --title="Quarterly plan" --stdin --yes
+  printf '\\nFollow-up.\\n' | \\
+    kb remember --kb=work --append=quarterly-plan.md --stdin --yes
+  cat lesson.md | kb remember --lesson --title="don't mock the DB" --stdin --yes
+`;
+
 interface RememberArgs {
   kb?: string;
   title?: string;

--- a/src/cli-search.ts
+++ b/src/cli-search.ts
@@ -28,6 +28,53 @@ import { loadManagerForModel, loadWithJsonRetry } from './cli-shared.js';
 import { LexicalIndex, type LexicalSearchResult } from './lexical-index.js';
 import { chunkIdFromMetadata, reciprocalRankFusion, type RankedList } from './rrf.js';
 
+export const SEARCH_HELP = `kb search — semantic search across knowledge bases
+
+Usage:
+  kb search <query> [options]
+  kb search --stdin [options]
+  kb search <query> --refresh [options]
+
+Default is dense (FAISS) similarity search, read-only. \`--refresh\` re-scans
+KB files under a per-model write lock before searching. \`--mode=lexical\`
+runs a BM25 debug surface; \`--mode=hybrid\` fuses dense + lexical via RRF.
+
+Output ends with a freshness footer (markdown) or staleness fields (JSON)
+indicating whether the index is up-to-date relative to KB file mtimes.
+
+Scope:
+  --kb=<name>           Scope to one knowledge base. Omit to search ALL KBs.
+  --model=<id>          Override the active model for this call (RFC 013).
+
+Result tuning:
+  --threshold=<float>   Max similarity score; lower = closer match (default 2).
+  --threshold=auto      Pick a knee-based cutoff from the top-K score curve.
+  --k=<int>             Top-K results (default 10).
+  --mode=dense|lexical|hybrid
+                        Retrieval mode (default: dense). \`hybrid\` fuses
+                        dense + BM25 via reciprocal rank fusion (#206).
+
+Output:
+  --format=md|json      Output format (default: md).
+  --group-by-source     Collapse repeated chunks from the same source file
+                        in markdown output. With \`--format=json\`, adds a
+                        \`grouped_results\` field alongside raw results.
+
+Indexing:
+  --refresh             Re-scan KB files; acquires the per-model write lock.
+
+Input:
+  --stdin               Read query from stdin (multi-line safe).
+  --help, -h            Show this help.
+
+Examples:
+  kb search "rollback procedure"
+  kb search "deploy" --kb=work --k=5
+  kb search "INDEX_NOT_INITIALIZED" --mode=lexical --refresh
+  kb search "INDEX_NOT_INITIALIZED" --mode=hybrid
+  kb search --stdin --format=json < query.txt
+`;
+
 export type SearchMode = 'dense' | 'lexical' | 'hybrid';
 
 interface SearchArgs {

--- a/src/cli-stale-check.ts
+++ b/src/cli-stale-check.ts
@@ -18,6 +18,37 @@ import * as os from 'os';
 import { KNOWLEDGE_BASES_ROOT_DIR } from './config.js';
 import { listKnowledgeBases, resolveKnowledgeBaseDir } from './kb-fs.js';
 
+export const STALE_CHECK_HELP = `kb stale-check — find broken references in markdown notes (read-only)
+
+Usage:
+  kb stale-check [--kb=<name>] [--no-cache] [--verbose|-v]
+
+Walks every \`.md\` / \`.markdown\` file under one or all KBs and extracts:
+  - tilde-rooted absolute paths       (\`~/foo/bar\`)
+  - http(s) URLs                      (bare or inside markdown links)
+  - markdown-link relative paths      (\`[label](relative/path.md)\`)
+
+Resolves each reference and reports the ones that no longer exist (paths)
+or no longer answer 200/30x (URLs). Strictly read-only.
+
+URL HEAD results are cached for 24h under
+\`<KNOWLEDGE_BASES_ROOT_DIR>/.stale-check-cache.json\` so consecutive runs
+don't replay every request.
+
+Options:
+  --kb=<name>           Scope to one knowledge base. Omit for all KBs.
+  --no-cache            Bypass the URL cache for this run; freshly probe
+                        every URL and overwrite cached entries.
+  --verbose, -v         Include OK references in the report (default:
+                        only print broken/error references).
+  --help, -h            Show this help.
+
+Examples:
+  kb stale-check
+  kb stale-check --kb=work
+  kb stale-check --no-cache --verbose
+`;
+
 export type ReferenceType = 'tilde-path' | 'rel-path' | 'url';
 
 export interface Reference {
@@ -109,11 +140,6 @@ export function parseStaleCheckArgs(rest: string[]): ParsedArgs {
       out.kb = raw.slice('--kb='.length);
       if (out.kb.length === 0) throw new Error('--kb=<name> requires a non-empty value');
       continue;
-    }
-    if (raw === '--help' || raw === '-h') {
-      throw new Error(
-        'usage: kb stale-check [--kb=<name>] [--no-cache] [--verbose]',
-      );
     }
     if (raw.startsWith('--')) throw new Error(`unknown flag: ${raw}`);
     throw new Error(`unexpected argument: ${JSON.stringify(raw)}`);

--- a/src/cli-stats.ts
+++ b/src/cli-stats.ts
@@ -13,6 +13,27 @@ import { computeKbStats, type ComputeKbStatsOptions, type KbStatsPayload } from 
 
 const CLI_STARTED_AT = Date.now();
 
+export const STATS_HELP = `kb stats — read-only index/corpus stats
+
+Usage:
+  kb stats [--kb=<name>] [--format=md|json]
+
+Mirrors the MCP \`kb_stats\` payload for local shell use: per-KB file/chunk/byte
+counts, last-indexed time, embedding model, index path, and version context.
+Strictly read-only — does not refresh the index.
+
+Options:
+  --kb=<name>           Scope to one knowledge base. Omit for all KBs.
+  --format=md|json      Output format (default: md). \`json\` emits the
+                        underlying \`KbStatsPayload\` shape verbatim.
+  --help, -h            Show this help.
+
+Examples:
+  kb stats
+  kb stats --kb=work
+  kb stats --format=json
+`;
+
 export interface StatsArgs {
   kb?: string;
   format: 'md' | 'json';
@@ -83,9 +104,6 @@ export async function runStats(rest: string[], deps: RunStatsDeps = DEFAULT_DEPS
 export function parseStatsArgs(rest: string[]): StatsArgs {
   const out: StatsArgs = { format: 'md' };
   for (const raw of rest) {
-    if (raw === '--help' || raw === '-h') {
-      throw new Error('usage: kb stats [--kb=<name>] [--format=md|json]');
-    }
     if (raw.startsWith('--kb=')) {
       const value = raw.slice('--kb='.length);
       if (value === '') throw new Error('empty --kb value');

--- a/src/cli-superseded.ts
+++ b/src/cli-superseded.ts
@@ -12,6 +12,42 @@ import { liftFrontmatter, type LiftedFrontmatter } from './frontmatter-lift.js';
 import { resolveKnowledgeBaseDir } from './kb-fs.js';
 import type { ScoredDocument } from './formatter.js';
 
+export const SUPERSEDED_HELP = `kb superseded — review workflow for obsolete / contradicted / stale notes (read-only)
+
+Usage:
+  kb superseded --kb=<name> [--format=md|json] [--k=<int>] [--include-clean]
+                [--model=<id>]
+
+Scans markdown frontmatter under one KB for:
+  - explicit \`contradicted_by:\` references
+  - deprecated / dormant lifecycle (\`status:\` / \`review_status:\`)
+  - stale \`last_verified_at\` dates
+  - low \`confidence\` on active notes
+
+Then uses the active semantic index to add conservative
+"newer-or-stronger neighbor" evidence when the index is reachable.
+Strictly read-only.
+
+Required:
+  --kb=<name>           Knowledge base to scan.
+
+Options:
+  --format=md|json      Output format (default: md). Use \`json\` for agent
+                        workflows.
+  --k=<int>             Top-K semantic neighbors to consider per note
+                        (default depends on the implementation; typically 5).
+  --include-clean       Include notes with no candidate reasons in the
+                        report — useful for full-inventory views.
+  --model=<id>          Override the active model for the semantic
+                        neighbor lookup (RFC 013).
+  --help, -h            Show this help.
+
+Examples:
+  kb superseded --kb=work
+  kb superseded --kb=work --format=json
+  kb superseded --kb=work --include-clean --k=10
+`;
+
 export type SupersededReason =
   | 'explicit_contradiction'
   | 'deprecated_status'
@@ -142,11 +178,6 @@ export function parseSupersededArgs(rest: string[]): SupersededArgs {
     includeClean: false,
   };
   for (const raw of rest) {
-    if (raw === '--help' || raw === '-h') {
-      throw new Error(
-        'usage: kb superseded --kb=<name> [--format=md|json] [--k=<int>] [--include-clean] [--model=<id>]',
-      );
-    }
     if (raw === '--include-clean') {
       out.includeClean = true;
       continue;

--- a/src/cli-where.ts
+++ b/src/cli-where.ts
@@ -26,6 +26,37 @@ import {
 import { loadManagerForModel, loadWithJsonRetry } from './cli-shared.js';
 import type { ScoredDocument } from './formatter.js';
 
+export const WHERE_HELP = `kb where — recommend the best KB and file for a topic (read-only)
+
+Usage:
+  kb where --topic=<query> [--threshold=<float>] [--k=<int>]
+           [--format=md|json] [--model=<id>]
+
+Runs a similarity search across all KBs, picks the KB with the
+highest-scoring hit, and recommends the single best existing file inside
+it. When the top score is above \`--threshold\` (lower = closer), suggests
+\`kb remember --title=...\` to create a new note instead of appending.
+
+Strictly read-only — same posture as \`kb search\` without \`--refresh\`.
+
+Required:
+  --topic=<query>       The topic / one-line description to place.
+
+Options:
+  --threshold=<float>   Confidence cutoff (default: 1.0). Top scores
+                        BELOW this distance are "high confidence existing
+                        target"; above it, recommend creating a new note.
+  --k=<int>             Top-K results to consider when grouping.
+  --format=md|json      Output format (default: md). \`json\` is suitable
+                        for agent shells.
+  --model=<id>          Override the active model for this call (RFC 013).
+  --help, -h            Show this help.
+
+Examples:
+  kb where --topic="quarterly retro template"
+  kb where --topic="oncall rotation" --threshold=0.8 --format=json
+`;
+
 export interface WhereArgs {
   topic: string | null;
   model?: string;
@@ -134,11 +165,6 @@ export function parseWhereArgs(rest: string[]): WhereArgs {
     format: 'md',
   };
   for (const raw of rest) {
-    if (raw === '--help' || raw === '-h') {
-      throw new Error(
-        'usage: kb where --topic=<query> [--threshold=<float>] [--k=<int>] [--format=md|json] [--model=<id>]',
-      );
-    }
     if (raw.startsWith('--topic=')) {
       const v = raw.slice('--topic='.length);
       if (v.length === 0) throw new Error('--topic=<query> requires a non-empty value');

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -39,19 +39,93 @@ function runCli(args: string[], env: Record<string, string> = {}, input?: string
 }
 
 describe('kb CLI — argv parsing and dispatch', () => {
-  it('--help exits 0 with usage text', () => {
+  it('--help exits 0 with usage text and a clean Available commands list', () => {
     const r = runCli(['--help']);
     expect(r.code).toBe(0);
     expect(r.stdout).toContain('kb — knowledge-base CLI');
-    expect(r.stdout).toContain('kb list');
+    expect(r.stdout).toContain('Available commands:');
+    // Each subcommand appears as a top-level entry in the new clean list.
+    for (const sub of [
+      'list',
+      'search',
+      'remember',
+      'capture',
+      'compare',
+      'doctor',
+      'stats',
+      'eval',
+      'stale-check',
+      'superseded',
+      'where',
+      'models',
+    ]) {
+      expect(r.stdout).toMatch(new RegExp(`\\n  ${sub.replace('-', '\\-')}\\s`));
+    }
+    // The hint pointing users at per-command help.
+    expect(r.stdout).toContain('kb <command> --help');
+  });
+
+  // Per-subcommand `--help` interception (regression: every subcommand used
+  // to fail with "unknown flag: --help" or write a one-line usage to stderr
+  // and exit 2). The central interceptor in cli.ts now answers --help / -h
+  // for every registered subcommand on stdout with exit 0.
+  describe.each([
+    ['list', 'kb list'],
+    ['search', 'kb search'],
+    ['remember', 'kb remember'],
+    ['capture', 'kb capture'],
+    ['compare', 'kb compare'],
+    ['doctor', 'kb doctor'],
+    ['stats', 'kb stats'],
+    ['eval', 'kb eval'],
+    ['stale-check', 'kb stale-check'],
+    ['superseded', 'kb superseded'],
+    ['where', 'kb where'],
+    ['models', 'kb models'],
+  ])('kb %s --help', (sub, marker) => {
+    it('exits 0 with detailed help on stdout', () => {
+      const long = runCli([sub, '--help']);
+      expect(long.code).toBe(0);
+      expect(long.stderr).toBe('');
+      expect(long.stdout).toContain(marker);
+      expect(long.stdout).toContain('Usage:');
+
+      const short = runCli([sub, '-h']);
+      expect(short.code).toBe(0);
+      expect(short.stdout).toBe(long.stdout);
+    });
+  });
+
+  it('kb help (no args) prints the top-level help', () => {
+    const r = runCli(['help']);
+    expect(r.code).toBe(0);
+    expect(r.stdout).toContain('kb — knowledge-base CLI');
+    expect(r.stdout).toContain('Available commands:');
+  });
+
+  it('kb help <command> mirrors `kb <command> --help`', () => {
+    const a = runCli(['help', 'search']);
+    const b = runCli(['search', '--help']);
+    expect(a.code).toBe(0);
+    expect(b.code).toBe(0);
+    expect(a.stdout).toBe(b.stdout);
+  });
+
+  it('kb help unknown-cmd exits 2 with a stderr error', () => {
+    const r = runCli(['help', 'not-a-real-command']);
+    expect(r.code).toBe(2);
+    expect(r.stderr).toContain("unknown command 'not-a-real-command'");
+    expect(r.stdout).toBe('');
+  });
+
+  it('--help anywhere in argv intercepts before the subcommand runs', () => {
+    // Even when the user fat-fingers extra args, --help wins: no spawn,
+    // no index load, no stderr noise.
+    const r = runCli(['search', 'some-query', '--help']);
+    expect(r.code).toBe(0);
+    expect(r.stderr).toBe('');
     expect(r.stdout).toContain('kb search');
-    expect(r.stdout).toContain('kb remember');
-    expect(r.stdout).toContain('kb capture');
-    expect(r.stdout).toContain('kb doctor');
-    expect(r.stdout).toContain('kb stats');
-    expect(r.stdout).toContain('kb eval');
-    expect(r.stdout).toContain('kb stale-check');
-    expect(r.stdout).toContain('kb superseded');
+    expect(r.stdout).toContain('Usage:');
   });
 
   it('no args exits 0 with usage text', () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,187 +1,98 @@
 #!/usr/bin/env node
 // RFC 012 — `kb` CLI alongside the MCP server.
 //
-// Subcommands:
-//   - `kb list`               → list ingested knowledge bases (one per line)
-//   - `kb search <query>`     → similarity search; default read-only
-//                               (skips updateIndex, no write lock)
-//   - `kb search --refresh`   → also runs updateIndex under the write lock
-//   - `kb remember ...`       → conservative CLI write/suggest surface
-//   - `kb capture -- <cmd>`   → run a command and append its stdout to a
-//                               KB note as a fenced, provenance-tagged block
-//
-// Both subcommands check `model_name.txt` against the configured embedding
-// model on every invocation and exit non-zero on mismatch (RFC §4.7) so a
-// shell-launched CLI with different env from the MCP server's mcp.json
-// can't silently return wrong-vector-space results.
+// Top-level help is built from the SUBCOMMANDS registry below; per-command
+// help text lives next to each subcommand in its own `cli-<name>.ts` file
+// and is intercepted here BEFORE delegating to the handler. That way every
+// subcommand answers `--help` / `-h` consistently (stdout, exit 0).
 
 import { readFileSync, realpathSync } from 'fs';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
-import { runCapture } from './cli-capture.js';
-import { runCompare } from './cli-compare.js';
-import { runDoctor } from './cli-doctor.js';
-import { runEval } from './cli-eval.js';
-import { runList } from './cli-list.js';
-import { runModels } from './cli-models.js';
-import { runRemember } from './cli-remember.js';
-import { runSearch } from './cli-search.js';
-import { runStaleCheck } from './cli-stale-check.js';
-import { runStats } from './cli-stats.js';
-import { runSuperseded } from './cli-superseded.js';
-import { runWhere } from './cli-where.js';
+import { CAPTURE_HELP, runCapture } from './cli-capture.js';
+import { COMPARE_HELP, runCompare } from './cli-compare.js';
+import { DOCTOR_HELP, runDoctor } from './cli-doctor.js';
+import { EVAL_HELP, runEval } from './cli-eval.js';
+import { LIST_HELP, runList } from './cli-list.js';
+import { MODELS_HELP, runModels } from './cli-models.js';
+import { REMEMBER_HELP, runRemember } from './cli-remember.js';
+import { SEARCH_HELP, runSearch } from './cli-search.js';
+import { STALE_CHECK_HELP, runStaleCheck } from './cli-stale-check.js';
+import { STATS_HELP, runStats } from './cli-stats.js';
+import { SUPERSEDED_HELP, runSuperseded } from './cli-superseded.js';
+import { WHERE_HELP, runWhere } from './cli-where.js';
 
-// ----- Entry point -----------------------------------------------------------
+// ----- Subcommand registry --------------------------------------------------
 
-const HELP = `kb — knowledge-base CLI (RFC 012 + RFC 013)
+interface Subcommand {
+  /** Verb used on the command line, e.g. `search`. */
+  name: string;
+  /** One-line summary for the top-level command list. */
+  summary: string;
+  /** Full help text shown by `kb <name> --help` and `kb help <name>`. */
+  help: string;
+  /** Argv handler. */
+  handler: (rest: string[]) => Promise<number>;
+}
+
+const SUBCOMMANDS: readonly Subcommand[] = [
+  { name: 'list',         summary: 'List available knowledge bases.',                                         help: LIST_HELP,         handler: runList },
+  { name: 'search',       summary: 'Semantic search across one or all knowledge bases.',                     help: SEARCH_HELP,       handler: runSearch },
+  { name: 'remember',     summary: 'Suggest, create, or append knowledge-base notes (write path).',          help: REMEMBER_HELP,     handler: runRemember },
+  { name: 'capture',      summary: 'Run a command and append its stdout to a KB note as a fenced block.',    help: CAPTURE_HELP,      handler: runCapture },
+  { name: 'compare',      summary: 'Side-by-side rank/score table for two embedding models.',                help: COMPARE_HELP,      handler: runCompare },
+  { name: 'doctor',       summary: 'Aggregate model / index / backend health report.',                       help: DOCTOR_HELP,       handler: runDoctor },
+  { name: 'stats',        summary: 'Read-only index/corpus stats (mirrors the MCP kb_stats payload).',       help: STATS_HELP,        handler: runStats },
+  { name: 'eval',         summary: 'Run fixture-driven retrieval checks.',                                   help: EVAL_HELP,         handler: runEval },
+  { name: 'stale-check',  summary: 'Scan markdown notes for path / URL references that no longer resolve.',  help: STALE_CHECK_HELP,  handler: runStaleCheck },
+  { name: 'superseded',   summary: 'Scan a KB for obsolete / contradicted / deprecated / stale notes.',      help: SUPERSEDED_HELP,   handler: runSuperseded },
+  { name: 'where',        summary: 'Recommend the best KB and file for a given topic.',                      help: WHERE_HELP,        handler: runWhere },
+  { name: 'models',       summary: 'Manage embedding models (list, add, set-active, remove).',               help: MODELS_HELP,       handler: runModels },
+];
+
+// ----- Top-level help -------------------------------------------------------
+
+function buildTopLevelHelp(): string {
+  const nameWidth = SUBCOMMANDS.reduce((m, s) => Math.max(m, s.name.length), 0);
+  const commandLines = SUBCOMMANDS
+    .map((s) => `  ${s.name.padEnd(nameWidth)}   ${s.summary}`)
+    .join('\n');
+  return `kb — knowledge-base CLI (RFC 012 + RFC 013)
 
 Usage:
-  kb list [--describe|-v] [--format=md|json]
-                                           List available knowledge bases. With
-                                           --describe (alias -v) include a
-                                           one-line description sourced from
-                                           each KB's README.md.
-  kb search <query> [opts]                Semantic search (read-only).
-  kb search <query> --refresh             Also re-scan KB files (write path).
-  kb search --stdin                       Read query from stdin.
-  kb remember --suggest --kb=<name> --title=<title>
-                                           Suggest likely existing note targets.
-  kb remember --kb=<name> --title=<title> --stdin --yes
-                                           Create a new markdown note.
-  kb remember --kb=<name> --append=<path> --stdin --yes
-                                           Append to an existing KB-relative note.
-  kb remember --kb=<name> --append=<path> --append-section="<#level> <text>"
-             [--occurrence=<N>] --stdin --yes
-                                           Append at the END of a named heading
-                                           section (after all subsections), not
-                                           at EOF. Heading spec must include the
-                                           level prefix (e.g. "## OSS gate flow").
-  kb remember --lesson --title=<title> --stdin --yes
-                                           Write a generic agent-task lesson
-                                           into the agent-task-lessons KB
-                                           (override with --kb=<other>). Body
-                                           must include "## Mistake",
-                                           "## Why it happened", and
-                                           "## Better next time" sections;
-                                           empty or malformed input prints a
-                                           guided skeleton (exit 2) instead of
-                                           writing.
-  kb remember ... [--similar-threshold=<float>] [--similar-k=<int>]
-                  [--force] [--format=md|json] [--no-check-similar]
-                                           Writes run a semantic preflight
-                                           against the active index by default
-                                           and refuse (exit 3) when similar
-                                           chunks already exist. Bypass with
-                                           --force; disable with
-                                           --no-check-similar.
-  kb capture --kb=<name> --append=<path> [--note=<text>] [--language=<hint>]
-             [--max-bytes=<N>] [--allow-fail] [--refresh] -- <cmd> [args...]
-                                           Run a command and append its stdout
-                                           to a KB note as a fenced block.
-  kb compare <query> <a> <b>              Side-by-side rank/score table.
-  kb doctor [--format=md|json]            Aggregate model/index/backend health.
-  kb stats [--kb=<name>] [--format=md|json]
-                                           Read-only index/corpus stats, mirroring
-                                           the MCP kb_stats payload.
-  kb eval <fixture.yml|json> [--model=<id>] [--format=md|json]
-                                           Run fixture-driven retrieval checks.
-  kb stale-check [--kb=<name>] [--no-cache] [--verbose]
-                                           Scan markdown notes for path / URL
-                                           references that no longer resolve.
-                                           Strictly read-only.
-  kb superseded --kb=<name> [--format=md|json] [--k=<n>] [--include-clean]
-                                           Scan markdown notes for obsolete,
-                                           contradicted, deprecated, stale, or
-                                           semantically superseded memory
-                                           candidates. Strictly read-only.
-  kb where --topic=<query> [--threshold=<float>] [--k=<int>] [--format=md|json]
-                                           One-shot recommendation: which KB
-                                           and which file should I update for
-                                           the given topic? Strictly read-only.
-  kb models list                          List registered embedding models.
-  kb models add <provider> <model>        Register a new model + ingest.
-  kb models set-active <id>               Change the default model.
-  kb models remove <id>                   Delete a model's index.
+  kb <command> [options]
+  kb help [<command>]
+  kb <command> --help
   kb --version
-  kb --help
 
-Search options:
-  --kb=<name>           Scope to one knowledge base. Omit to search ALL KBs (default).
-  --model=<id>          Override active model for this call (RFC 013).
-  --threshold=<float>   Max similarity score (default 2).
-  --k=<int>             Top-K results (default 10).
-  --format=md|json      Output format (default md).
-  --group-by-source     Collapse repeated chunks from the same source file in
-                        markdown output. With --format=json, keeps raw
-                        results and adds grouped_results.
-  --refresh             Re-scan KB files; acquires per-model write lock.
-  --stdin               Read query from stdin (multi-line safe).
+Available commands:
+${commandLines}
 
-Remember options:
-  --kb=<name>           Target knowledge base.
-  --title=<title>       Note title; create uses a slugified .md filename.
-  --append=<path>       Existing KB-relative note path; rejects traversal.
-  --append-section=<spec>
-                        Heading-aware append target. Spec is "<#level> <text>"
-                        (e.g. "## OSS gate flow"). Requires --append=<path>.
-                        Inserts at the end of the named section (after every
-                        subsection), atomically rewrites the file, and refuses
-                        to fall back to EOF if the heading is missing.
-  --occurrence=<N>      1-indexed disambiguation when the heading appears
-                        multiple times. Requires --append-section.
-  --suggest             Read-only suggestions; does not read stdin.
-  --lesson              Apply the agent-task-lesson template: defaults --kb to
-                        agent-task-lessons (override with --kb=<other>),
-                        validates that the body has "## Mistake", "## Why it
-                        happened", and "## Better next time" H2 sections
-                        (level is enforced — H1 / H3 do not count), and prints
-                        a guided skeleton (exit 2) when stdin is empty or
-                        sections are missing instead of writing.
-  --stdin               Read note content from stdin.
-  --yes                 Required for non-interactive writes.
-  --refresh             Re-index the affected KB after a successful write.
-  --check-similar       Force the semantic preflight ON (default). Surface
-                        index-load failures as exit-1/2 errors; without this
-                        flag a missing index degrades to a stderr warning
-                        and the write proceeds without the guard.
-  --no-check-similar    Disable the semantic preflight for this write.
-  --similar-threshold=<float>
-                        Max FAISS distance treated as related (default 1.0;
-                        lower distance = closer match).
-  --similar-k=<int>     Top-K candidate chunks to surface (default 5).
-  --force               Override the similarity guard and write anyway; the
-                        success response reports that the guard was
-                        overridden so the action stays auditable.
-  --format=md|json      Output format for similarity-guard reports (default
-                        json — agent-friendly machine-readable shape).
-  --model=<id>          Override active model for the preflight similarity
-                        search (RFC 013).
+Run \`kb <command> --help\` (or \`kb help <command>\`) for command-specific help.
 
-Capture options:
-  --kb=<name>           Target knowledge base.
-  --append=<path>       Existing KB-relative note path; rejects traversal.
-  --note=<text>         Optional "### <text>" header above the captured block.
-  --language=<hint>     Code-fence language hint; auto-detected from .json /
-                        .yml / .yaml args if absent.
-  --max-bytes=<N>       Truncate captured stdout at N bytes (default 65536).
-  --allow-fail          Capture even when the command exits non-zero.
-  --refresh             Re-index the affected KB after a successful write.
-  --                    End of options; remaining argv is the command + args
-                        passed verbatim to spawn(..., { shell: false }).
-
-Models add options:
-  --yes                 Skip the cost-estimate confirmation prompt.
-  --dry-run             Print the estimate; don't embed.
-
-Env vars: KNOWLEDGE_BASES_ROOT_DIR, FAISS_INDEX_PATH, EMBEDDING_PROVIDER,
-KB_ACTIVE_MODEL (RFC 013 §4.7), OLLAMA_*, OPENAI_*, HUGGINGFACE_*.
+Environment:
+  KNOWLEDGE_BASES_ROOT_DIR  Root directory containing one folder per KB.
+  FAISS_INDEX_PATH          Where FAISS stores per-model indexes.
+  EMBEDDING_PROVIDER        ollama | openai | huggingface
+  KB_ACTIVE_MODEL           Override the active model for this process (RFC 013 §4.7).
+  OLLAMA_*, OPENAI_*, HUGGINGFACE_*
+                            Provider-specific config; see the provider's docs.
 
 Exit codes:
-  0  success (results found or empty)
-  1  runtime / index error
-  2  argv / env / model-resolution error
-  3  kb remember --check-similar found similar chunks and refused to write
+  0   success (results found or empty)
+  1   runtime / index error
+  2   argv / env / model-resolution error
+  3   \`kb remember\` similarity guard refused to write
 `;
+}
+
+const HELP = buildTopLevelHelp();
+
+// ----- Entry point ----------------------------------------------------------
+
+function wantsHelp(args: readonly string[]): boolean {
+  return args.some((a) => a === '--help' || a === '-h');
+}
 
 export async function main(argv: string[]): Promise<number> {
   // Strip the conventional argv[0]/argv[1] before delegating.
@@ -199,45 +110,33 @@ export async function main(argv: string[]): Promise<number> {
   const sub = args[0];
   const rest = args.slice(1);
 
-  if (sub === 'list') {
-    return runList(rest);
-  }
-  if (sub === 'search') {
-    return runSearch(rest);
-  }
-  if (sub === 'remember') {
-    return runRemember(rest);
-  }
-  if (sub === 'capture') {
-    return runCapture(rest);
-  }
-  if (sub === 'models') {
-    return runModels(rest);
-  }
-  if (sub === 'compare') {
-    return runCompare(rest);
-  }
-  if (sub === 'doctor') {
-    return runDoctor(rest);
-  }
-  if (sub === 'stats') {
-    return runStats(rest);
-  }
-  if (sub === 'eval') {
-    return runEval(rest);
-  }
-  if (sub === 'stale-check') {
-    return runStaleCheck(rest);
-  }
-  if (sub === 'superseded') {
-    return runSuperseded(rest);
-  }
-  if (sub === 'where') {
-    return runWhere(rest);
+  // `kb help` and `kb help <command>` mirror `kb --help` and `kb <command> --help`.
+  if (sub === 'help') {
+    if (rest.length === 0 || wantsHelp(rest)) {
+      process.stdout.write(HELP);
+      return 0;
+    }
+    const target = SUBCOMMANDS.find((s) => s.name === rest[0]);
+    if (!target) {
+      process.stderr.write(`kb help: unknown command '${rest[0]}'\n`);
+      return 2;
+    }
+    process.stdout.write(target.help);
+    return 0;
   }
 
-  process.stderr.write(`kb: unknown subcommand '${sub}'\n${HELP}`);
-  return 2;
+  const target = SUBCOMMANDS.find((s) => s.name === sub);
+  if (!target) {
+    process.stderr.write(`kb: unknown subcommand '${sub}'\n${HELP}`);
+    return 2;
+  }
+
+  if (wantsHelp(rest)) {
+    process.stdout.write(target.help);
+    return 0;
+  }
+
+  return target.handler(rest);
 }
 
 // ----- version --------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Every subcommand now answers `--help` / `-h`** on stdout with exit 0. Previously `kb search/list/remember/capture/compare/models --help` errored with "unknown flag: --help" (exit 2, stderr), and `kb doctor/stats/eval/stale-check/superseded/where --help` printed a single `usage:` line to stderr (exit 2). Help is intercepted centrally in `cli.ts` before delegating, so the behavior is uniform.
- **`kb --help` is restructured** with a clean `Available commands:` table, plus `Environment:` and `Exit codes:` sections. The dense ~70-line "Usage:" block is gone — per-command flag detail moved to per-subcommand `*_HELP` exports that live next to their handlers.
- **New `kb help` and `kb help <command>` aliases** mirror `kb --help` / `kb <command> --help`.

## Why

`kb --help` was discoverable but dense, and `kb <subcommand> --help` either errored or returned a one-line blurb. There was no way to learn a subcommand's flags without reading the source or grepping the global help text.

## What changed

- `src/cli.ts` — collapses inline HELP into a `SUBCOMMANDS` registry; builds the top-level help from it; intercepts `--help` / `-h` per subcommand; adds the `kb help` verb.
- `src/cli-{list,search,remember,capture,compare,doctor,stats,eval,stale-check,superseded,where,models}.ts` — each exports a detailed `*_HELP` constant. The half-implemented `--help` handlers in `doctor/stats/eval/stale-check/superseded/where` (which threw a one-line `usage:` to stderr with exit 2) are removed; the central interceptor handles them.
- `src/cli.test.ts` — 17 new tests: parameterized `kb <sub> --help` for all 12 subcommands, `kb help`, `kb help <sub>` mirror, `kb help <unknown>` exit 2, and a regression for `--help` mid-argv.
- `README.md` — adds `kb help <command>` to the install snippet.
- `docs/agent-task-lessons.md` — points at `kb remember --help` instead of generic `kb --help`.

## Test plan

- [x] `npx jest --runInBand` — **640/640 pass** (~86s).
- [x] `node build/cli.js --help` — clean Available commands table, exit 0.
- [x] `node build/cli.js search --help` (and all other subcommands) — detailed help on stdout, exit 0.
- [x] `node build/cli.js help`, `kb help search`, `kb help unknown-cmd` — top-level help, mirrored subcommand help, exit-2 stderr error respectively.
- [x] `node build/cli.js search "query" --help` — `--help` wins; no spawn, no index load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)