### PR TITLE
fix(loaders): silence pdfjs-dist stdout noise during PDF ingest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased] — silence pdfjs-dist stdout noise during PDF ingest
+
+### Fixed
+
+- **`loadPdf` no longer leaks pdfjs-dist `Warning: TT: undefined function`, `Warning: FormatError: Required 'loca' table is not found`, `Warning: Empty 'FlateDecode' stream.`, `Info: ...`, and `Deprecated API usage: ...` lines onto stdout.** `pdf-parse@1.1.1` bundles pdfjs-dist v1.10.100, whose worker module emits font-sanitizer chatter via `console.log` from the fake-worker `LoopbackPort` path that Node always takes; the worker's verbosity is module-private and the configure message that would lower it is only sent on the real-Worker path. The loader now filters `console.log` for the duration of each parse with depth-counting reentrancy, so concurrent dense + lexical hybrid-search refresh legs both stay clean. PDF text extraction is unchanged.
+
 ## [Unreleased] — `kb stats` local index observability
 
 ### Added

--- a/src/loaders.test.ts
+++ b/src/loaders.test.ts
@@ -162,6 +162,156 @@ describe('PDF loader (pdf-parse) — routing + dispatch (pdf-parse is mocked)', 
   });
 });
 
+describe('PDF loader — pdfjs-dist stdout noise suppression', () => {
+  // Regression for the hybrid-search complaint: pdf-parse@1.1.1 bundles
+  // pdfjs-dist v1.10.100, whose worker emits TrueType-sanitizer chatter
+  // ("Warning: TT: undefined function: 32",
+  // "Warning: FormatError: Required 'loca' table is not found",
+  // "Warning: Empty 'FlateDecode' stream.") via console.log when it
+  // re-indexes a PDF whose fonts use glyph hints the sanitizer doesn't
+  // understand. Those lines used to land on stdout and pollute the
+  // retrieval markdown / JSON output. We filter them at the loader's
+  // boundary; this suite locks the filter in place.
+  let tempDir = '';
+  let originalConsoleLog: typeof console.log;
+  let stdoutSpy: jest.Mock;
+
+  beforeEach(async () => {
+    tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-loaders-pdf-noise-'));
+    pdfParseFnMock.mockReset();
+    originalConsoleLog = console.log;
+    stdoutSpy = jest.fn();
+    console.log = stdoutSpy as unknown as typeof console.log;
+  });
+
+  afterEach(async () => {
+    console.log = originalConsoleLog;
+    await fsp.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('drops "Warning: ", "Info: ", and "Deprecated API usage: " lines emitted during pdf-parse', async () => {
+    const filePath = path.join(tempDir, 'noisy.pdf');
+    await fsp.writeFile(filePath, Buffer.from('%PDF-1.4\n'));
+    pdfParseFnMock.mockImplementation(async () => {
+      // These three prefixes are exactly what pdfjs-dist v1.10.100's
+      // util.warn / util.info / util.deprecated emit. The test asserts
+      // every such line is dropped so the user's stdout (search results)
+      // stays clean.
+      console.log('Warning: TT: undefined function: 32');
+      console.log('Warning: FormatError: Required "loca" table is not found');
+      console.log('Info: Loading font fallback...');
+      console.log('Deprecated API usage: PDFJS.something');
+      return { text: 'extracted text' };
+    });
+
+    const text = await loadFile(filePath);
+    expect(text).toBe('extracted text');
+    // Filter swallowed all four pdfjs-style lines. Spy never saw them.
+    expect(stdoutSpy).not.toHaveBeenCalled();
+  });
+
+  it('passes non-pdfjs console.log calls through unchanged', async () => {
+    // Defensive: the filter must only match the three pdfjs prefixes.
+    // Anything else a downstream library logs during a PDF parse should
+    // still reach the real console.log. Otherwise we'd silently swallow
+    // legitimate user output if pdf-parse ever delegated to another lib.
+    const filePath = path.join(tempDir, 'mixed.pdf');
+    await fsp.writeFile(filePath, Buffer.from('%PDF-1.4\n'));
+    pdfParseFnMock.mockImplementation(async () => {
+      console.log('Warning: TT: undefined function: 32'); // dropped
+      console.log('user log line that must survive');     // passed through
+      console.log('warning: lower-case prefix is unrelated'); // passed through
+      return { text: 'ok' };
+    });
+
+    await loadFile(filePath);
+    expect(stdoutSpy).toHaveBeenCalledTimes(2);
+    expect(stdoutSpy.mock.calls[0][0]).toBe('user log line that must survive');
+    expect(stdoutSpy.mock.calls[1][0]).toBe('warning: lower-case prefix is unrelated');
+  });
+
+  it('restores console.log after the parse resolves', async () => {
+    const filePath = path.join(tempDir, 'restore.pdf');
+    await fsp.writeFile(filePath, Buffer.from('%PDF-1.4\n'));
+    pdfParseFnMock.mockResolvedValue({ text: 'ok' });
+    const before = console.log;
+
+    await loadFile(filePath);
+
+    // Reference equality — the filter wrapper is gone, our test spy is back.
+    expect(console.log).toBe(before);
+    // And the spy works as expected after restoration.
+    console.log('post-parse line');
+    expect(stdoutSpy).toHaveBeenCalledWith('post-parse line');
+  });
+
+  it('restores console.log even if pdf-parse rejects', async () => {
+    // The filter is installed via try/finally so a corrupt PDF that throws
+    // mid-parse cannot leave the wrapper permanently swallowing
+    // application-level "Warning: ..." logs.
+    const filePath = path.join(tempDir, 'bad.pdf');
+    await fsp.writeFile(filePath, Buffer.from('%PDF-1.4\n'));
+    pdfParseFnMock.mockRejectedValue(new Error('parse boom'));
+    const before = console.log;
+
+    await expect(loadFile(filePath)).rejects.toThrow('parse boom');
+    expect(console.log).toBe(before);
+  });
+
+  it('handles concurrent PDF loads via depth-counting (no early restore)', async () => {
+    // The hybrid-search dense + lexical legs both call into loadPdf in
+    // parallel under --refresh. If the inner load restored console.log
+    // when its own try/finally fired, the outer load's filter would be
+    // gone for the rest of its parse and Warning: lines would leak.
+    // Depth-count the install/restore so concurrent calls compose.
+    const slowPath = path.join(tempDir, 'slow.pdf');
+    const fastPath = path.join(tempDir, 'fast.pdf');
+    await fsp.writeFile(slowPath, Buffer.from('%PDF-1.4\n'));
+    await fsp.writeFile(fastPath, Buffer.from('%PDF-1.4\n'));
+
+    let releaseSlow!: (v: { text: string }) => void;
+    const slowDone = new Promise<{ text: string }>((resolve) => {
+      releaseSlow = resolve;
+    });
+
+    pdfParseFnMock.mockImplementation((buf: Buffer) => {
+      if (buf.length === Buffer.from('%PDF-1.4\n').length) {
+        // Both fixtures are byte-identical; differentiate by call count.
+        const callIdx = pdfParseFnMock.mock.calls.length;
+        if (callIdx === 1) {
+          // First call (slow): emit a Warning: line then await the gate
+          // that the second (fast) call's completion will open.
+          console.log('Warning: slow pre-await');
+          return slowDone.then((res) => {
+            console.log('Warning: slow post-await');
+            return res;
+          });
+        }
+        // Second call (fast): emits + resolves immediately, then opens
+        // the gate so the slow call can finish.
+        console.log('Warning: fast');
+        const result = { text: 'fast-text' };
+        releaseSlow({ text: 'slow-text' });
+        return Promise.resolve(result);
+      }
+      return Promise.resolve({ text: '' });
+    });
+
+    const slowPromise = loadFile(slowPath);
+    const fastPromise = loadFile(fastPath);
+    const [slowText, fastText] = await Promise.all([slowPromise, fastPromise]);
+
+    expect(slowText).toBe('slow-text');
+    expect(fastText).toBe('fast-text');
+    // All three Warning: lines (slow pre-await, fast, slow post-await)
+    // must be dropped — including the slow one that emits AFTER the fast
+    // load's try/finally has already run. Spy never sees them.
+    expect(stdoutSpy).not.toHaveBeenCalled();
+    // After both loads settle, console.log is back to the test spy.
+    expect(console.log).toBe(stdoutSpy);
+  });
+});
+
 describe('HTML loader (html-to-text)', () => {
   let tempDir = '';
 

--- a/src/loaders.ts
+++ b/src/loaders.ts
@@ -31,6 +31,71 @@ async function loadText(filePath: string): Promise<string> {
   return fsp.readFile(filePath, 'utf-8');
 }
 
+// Reentrancy depth for `silencePdfjsConsole` — pdf-parse calls can interleave
+// (the hybrid-search dense and lexical legs both load PDFs in parallel under
+// `--refresh`). Depth-counting ensures the first concurrent caller installs
+// the filter, the last one restores the real `console.log`, and intermediate
+// callers neither double-install nor restore early.
+let pdfjsSilenceDepth = 0;
+let pdfjsOriginalConsoleLog: typeof console.log | null = null;
+
+/**
+ * Filter `console.log` for the duration of `fn` so the pdfjs-dist v1.10.100
+ * bundle inside `pdf-parse@1.1.1` does not pollute stdout with TrueType
+ * sanitizer chatter.
+ *
+ * Why the noise exists. pdf-parse bundles pdfjs-dist v1.10.100. Inside that
+ * bundle, `warn(msg)` resolves to `console.log('Warning: ' + msg)` and is
+ * called by the TrueType-program sanitizer for every glyph hint it doesn't
+ * understand ("TT: undefined function: 32") and by the font loader on
+ * malformed font tables ("FormatError: Required 'loca' table is not found").
+ * Text extraction succeeds anyway — these are advisory, not failures.
+ *
+ * Why we cannot just lower verbosity. The bundled pdfjs has two copies of
+ * the verbosity flag: one in `pdf.js` (reachable via `PDFJS.verbosity`) and
+ * one in `pdf.worker.js` (module-private, only exposed to outside callers
+ * through `WorkerMessageHandler`). pdf.js synchronizes the two by sending a
+ * `configure` message — but ONLY on the real-Worker path. In Node we always
+ * take the fake-worker `LoopbackPort` path, where no `configure` message is
+ * sent and the worker keeps `verbosity = warnings` regardless of what we set
+ * on the main module. Setting `PDFJS.verbosity = 0` therefore has no effect
+ * on the warnings emitted from inside the worker bundle.
+ *
+ * Filtering the single Node process's `console.log` is the smallest fix that
+ * actually silences the noise. We match the three prefixes pdfjs uses
+ * (`Warning: `, `Info: `, `Deprecated API usage: `) and pass everything else
+ * through unchanged so user `console.log` calls are unaffected. Reentrant
+ * via depth-counting so concurrent PDF loads don't restore each other early.
+ */
+async function silencePdfjsConsole<T>(fn: () => Promise<T>): Promise<T> {
+  if (pdfjsSilenceDepth === 0) {
+    pdfjsOriginalConsoleLog = console.log;
+    const realLog = pdfjsOriginalConsoleLog;
+    console.log = (...args: unknown[]): void => {
+      const first = args[0];
+      if (
+        typeof first === 'string' &&
+        (first.startsWith('Warning: ') ||
+          first.startsWith('Info: ') ||
+          first.startsWith('Deprecated API usage: '))
+      ) {
+        return;
+      }
+      realLog(...args);
+    };
+  }
+  pdfjsSilenceDepth += 1;
+  try {
+    return await fn();
+  } finally {
+    pdfjsSilenceDepth -= 1;
+    if (pdfjsSilenceDepth === 0 && pdfjsOriginalConsoleLog !== null) {
+      console.log = pdfjsOriginalConsoleLog;
+      pdfjsOriginalConsoleLog = null;
+    }
+  }
+}
+
 async function loadPdf(filePath: string): Promise<string> {
   // pdf-parse@1 ships its main as a CJS function with `module.exports = PDF`
   // and a `parent`-less debug branch that fires on import (it tries to read
@@ -47,7 +112,7 @@ async function loadPdf(filePath: string): Promise<string> {
     buf: Buffer,
   ) => Promise<{ text: string }>;
   const buffer = await fsp.readFile(filePath);
-  const result = await pdfParse(buffer);
+  const result = await silencePdfjsConsole(() => pdfParse(buffer));
   return result.text;
 }
 


### PR DESCRIPTION
## Summary

- Hybrid search (and any path that re-builds a lexical / FAISS index over a KB containing PDFs) was leaking pdfjs-dist `Warning: TT: undefined function: 32`, `Warning: FormatError: Required 'loca' table is not found`, `Warning: Empty 'FlateDecode' stream.` lines to **stdout**, polluting the user-visible search markdown / JSON output.
- Lowering `PDFJS.verbosity` does not silence the warnings in Node. `pdf-parse@1.1.1` bundles `pdfjs-dist v1.10.100`, whose `pdf.worker.js` keeps an independent module-private `verbosity` variable. The `configure` message that would synchronize them is only sent on the real-Worker path; Node always takes the fake-worker `LoopbackPort` path, so the worker keeps `verbosity = warnings` regardless of what we set on `PDFJS`.
- `loadPdf` now wraps each parse in a depth-counted `console.log` filter that drops the three pdfjs prefixes (`Warning: `, `Info: `, `Deprecated API usage: `) and passes everything else through. Reentrancy via depth counting keeps concurrent dense+lexical refresh legs safe; try/finally guarantees restoration on errors.
- PDF text extraction is unchanged.

## Repro (before fix)

```
$ rm /home/jean/knowledge_bases/.faiss/lexical/llm-security/index.json
$ node build/cli.js search "test" --mode=hybrid --kb=llm-security
…
Warning: TT: undefined function: 32
Warning: TT: undefined function: 32
Warning: FormatError: Required "loca" table is not found
…
> _Hybrid status: dense fetched 40, lexical fetched 40 (refreshed 1, 0 failed); fused via RRF (c=60, fetch_k=40)._
```

After fix: `0 warnings` on stdout and stderr; refresh and fuse complete normally.

## Test plan

- [x] `npm run build` passes.
- [x] `npm test` — all 33 suites / 645 tests pass (5 new regression tests in `src/loaders.test.ts`).
- [x] Manual repro: deleted `llm-security` lexical index and re-ran `kb search --mode=hybrid --kb=llm-security`. Pre-fix: dozens of `Warning:` lines on stdout. Post-fix: clean output.
- [x] New regression tests cover: prefix filtering, non-pdfjs lines passing through, restoration on success, restoration on rejection, concurrent-load depth counting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)