### PR TITLE
feat: add search timing and auto retrieval mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,14 @@ For an interactive shell or AI-agent shell-tool flow, install globally and use t
 npm install -g @jeanibarz/knowledge-base-mcp-server@latest
 kb list                       # list available knowledge bases
 kb stats                      # read-only index/corpus stats
-kb search "your query"                       # read-only dense search; cheap, fast (~0.6 s)
+kb search "your query"                       # read-only dense search
+kb search "your query" --timing              # include retrieval-stage timings
 kb search "query" --refresh                  # also re-scan KB files (write path)
 kb search "INDEX_NOT_INITIALIZED" --mode=lexical --refresh   # BM25 debug surface (#206 stage 1)
 kb search "INDEX_NOT_INITIALIZED" --mode=hybrid              # dense ⨁ BM25 fused via RRF (#206 stage 2)
+kb search "src/cli-search.ts" --mode=auto    # opt-in heuristic: hybrid for code/path/error-shaped queries
 kb llm use-endpoint http://127.0.0.1:8080/v1/chat/completions --profile=local-research-agent
-kb ask "what changed in the daemonization notes?"            # retrieval + local LLM answer
+kb ask "what changed in the daemonization notes?" --timing   # retrieval + local LLM answer with timings
 kb remember --suggest --kb=work --title="Quarterly plan"
 printf '# Quarterly plan\n\n...' | kb remember --kb=work --title="Quarterly plan" --stdin --yes
 printf '\nFollow-up note.\n' | kb remember --kb=work --append=quarterly-plan.md --stdin --yes
@@ -54,7 +56,7 @@ kb --help                     # top-level command list
 kb help search                # per-command help (also: kb search --help)
 ```
 
-The `kb` bin shares the same env vars as the MCP server (`KNOWLEDGE_BASES_ROOT_DIR`, `FAISS_INDEX_PATH`, `EMBEDDING_PROVIDER`, `OLLAMA_*`, `OPENAI_*`, `HUGGINGFACE_*`). `kb stats [--kb=<name>] [--format=md|json]` mirrors the MCP `kb_stats` payload for local shell use: per-KB file/chunk/byte counts, last indexed time, embedding model, index path, and version context. It is read-only and does not refresh the index. `kb search` also defaults to read-only — it loads the existing FAISS index but does not re-scan KB files. Pass `--refresh` to re-index. Output includes a freshness footer indicating whether the index is up-to-date relative to KB file mtimes.
+The `kb` bin shares the same env vars as the MCP server (`KNOWLEDGE_BASES_ROOT_DIR`, `FAISS_INDEX_PATH`, `EMBEDDING_PROVIDER`, `OLLAMA_*`, `OPENAI_*`, `HUGGINGFACE_*`). `kb stats [--kb=<name>] [--format=md|json]` mirrors the MCP `kb_stats` payload for local shell use: per-KB file/chunk/byte counts, last indexed time, embedding model, index path, and version context. It is read-only and does not refresh the index. `kb search` also defaults to read-only dense retrieval — it loads the existing FAISS index but does not re-scan KB files. Pass `--refresh` to re-index. Use `--mode=hybrid` for explicit dense+BM25 rank fusion, or `--mode=auto` to keep dense for prose queries while selecting hybrid for code, path, flag, error-code, and issue-reference shaped queries. Add `--timing` to `kb search` or `kb ask` when you need per-stage elapsed milliseconds in either markdown or JSON output. Search output includes a freshness footer indicating whether the index is up-to-date relative to KB file mtimes.
 
 `kb remember` is a conservative CLI write path for agent shells. `--suggest` is read-only and lists likely existing targets from note filenames/headings. Creates and appends require both `--stdin` and `--yes`; create uses a slugified `.md` filename and refuses overwrites, while append accepts only existing KB-relative paths. Add `--refresh` to re-index the affected KB after a successful write.
 

--- a/src/FaissIndexManager.ts
+++ b/src/FaissIndexManager.ts
@@ -129,6 +129,15 @@ export interface IndexUpdateSummary {
   failures: IndexUpdateFailureSummary[];
 }
 
+export interface SimilaritySearchTiming {
+  embed_query_ms?: number;
+  faiss_search_ms?: number;
+  query_search_ms?: number;
+  post_filter_ms?: number;
+  total_ms?: number;
+  fetch_k?: number;
+}
+
 const MAX_INDEX_UPDATE_FAILURES = 10;
 
 export function createNeverRunIndexUpdateSummary(modelId: string | null = null): IndexUpdateSummary {
@@ -920,7 +929,9 @@ export class FaissIndexManager {
     threshold: number = 2,
     knowledgeBaseName?: string,
     filters?: SimilaritySearchFilters,
+    timing?: SimilaritySearchTiming,
   ) {
+    const totalStartedAt = Date.now();
     if (!this.faissIndex) {
       throw new KBError('INDEX_NOT_INITIALIZED', 'FAISS index is not initialized');
     }
@@ -938,13 +949,37 @@ export class FaissIndexManager {
     const fetchK = postFilter.requiresOverfetch
       ? Math.max(k, this.faissIndex.index.ntotal())
       : k;
+    if (timing) timing.fetch_k = fetchK;
 
     // FaissStore.similaritySearchVectorWithScore accepts only (query, k) and
     // silently drops any filter argument, so threshold and KB scoping are both
     // applied as post-filters on the returned [doc, score] tuples.
-    const resultsWithScore = await this.faissIndex.similaritySearchWithScore(query, fetchK);
+    let resultsWithScore: Array<[Document, number]>;
+    const vectorSearch = (
+      this.faissIndex as unknown as {
+        similaritySearchVectorWithScore?: (queryEmbedding: number[], k: number) => Promise<Array<[Document, number]>>;
+      }
+    ).similaritySearchVectorWithScore;
+    if (timing && typeof vectorSearch === 'function') {
+      const embedStartedAt = Date.now();
+      const queryEmbedding = await this.embeddings.embedQuery(query);
+      timing.embed_query_ms = Date.now() - embedStartedAt;
 
+      const faissStartedAt = Date.now();
+      resultsWithScore = await vectorSearch.call(this.faissIndex, queryEmbedding, fetchK);
+      timing.faiss_search_ms = Date.now() - faissStartedAt;
+    } else {
+      const queryStartedAt = Date.now();
+      resultsWithScore = await this.faissIndex.similaritySearchWithScore(query, fetchK);
+      if (timing) timing.query_search_ms = Date.now() - queryStartedAt;
+    }
+
+    const postFilterStartedAt = Date.now();
     const filtered = postFilter.apply(resultsWithScore);
+    if (timing) {
+      timing.post_filter_ms = Date.now() - postFilterStartedAt;
+      timing.total_ms = Date.now() - totalStartedAt;
+    }
 
     return filtered.slice(0, k).map(([doc, score]) => ({
       ...doc,

--- a/src/cli-ask.test.ts
+++ b/src/cli-ask.test.ts
@@ -12,6 +12,7 @@ describe('parseAskArgs', () => {
       '--k=4',
       '--refresh',
       '--format=json',
+      '--timing',
     ])).toEqual({
       question: 'what changed?',
       kb: 'ops',
@@ -22,6 +23,7 @@ describe('parseAskArgs', () => {
       refresh: true,
       stdin: false,
       format: 'json',
+      timing: true,
     });
   });
 

--- a/src/cli-ask.ts
+++ b/src/cli-ask.ts
@@ -1,4 +1,4 @@
-import { FaissIndexManager } from './FaissIndexManager.js';
+import { FaissIndexManager, type SimilaritySearchTiming } from './FaissIndexManager.js';
 import { resolveActiveModel } from './active-model.js';
 import {
   classifyKbSearchError,
@@ -7,6 +7,13 @@ import {
   formatKbSearchFailureStderr,
 } from './cli-search-errors.js';
 import { loadManagerForModel, loadWithJsonRetry } from './cli-shared.js';
+import {
+  compactTimingPayload,
+  elapsedMs,
+  formatTimingFooter,
+  nowMs,
+  type TimingPayload,
+} from './cli-timing.js';
 import { FRONTMATTER_EXTRAS_WIRE_VISIBLE } from './config.js';
 import { formatRetrievalAsJson, type RetrievalJsonResult } from './formatter.js';
 import { callChatCompletion } from './llm-client.js';
@@ -37,6 +44,7 @@ Options:
   --endpoint=<url>      OpenAI-compatible chat endpoint for this call only.
   --llm-profile=<name>  Use a saved \`kb llm\` profile.
   --format=md|json      Output format (default: md).
+  --timing              Include elapsed milliseconds for retrieval and LLM stages.
   --stdin               Read question from stdin.
   --help, -h            Show this help.
 `;
@@ -51,6 +59,7 @@ interface AskArgs {
   refresh: boolean;
   stdin: boolean;
   format: 'md' | 'json';
+  timing: boolean;
 }
 
 interface LlmTarget {
@@ -59,6 +68,7 @@ interface LlmTarget {
 }
 
 export async function runAsk(rest: string[]): Promise<number> {
+  const totalStartedAt = nowMs();
   let args: AskArgs;
   try {
     args = parseAskArgs(rest);
@@ -76,10 +86,18 @@ export async function runAsk(rest: string[]): Promise<number> {
 
   let activeModelId: string;
   let results;
+  const timing: TimingPayload | null = args.timing ? {} : null;
   try {
+    let startedAt = nowMs();
     await FaissIndexManager.bootstrapLayout();
+    if (timing) timing.bootstrap_ms = elapsedMs(startedAt);
+    startedAt = nowMs();
     activeModelId = await resolveActiveModel({ explicitOverride: args.model });
+    if (timing) timing.model_resolution_ms = elapsedMs(startedAt);
+    startedAt = nowMs();
     const manager = await loadManagerForModel(activeModelId);
+    if (timing) timing.manager_load_ms = elapsedMs(startedAt);
+    startedAt = nowMs();
     if (args.refresh) {
       await withWriteLock(manager.modelDir, async () => {
         await manager.initialize();
@@ -88,7 +106,21 @@ export async function runAsk(rest: string[]): Promise<number> {
     } else {
       await loadWithJsonRetry(manager);
     }
-    results = await manager.similaritySearch(args.question, args.k, undefined, args.kb);
+    if (timing) timing.index_load_ms = elapsedMs(startedAt);
+    const denseTiming: SimilaritySearchTiming = {};
+    startedAt = nowMs();
+    results = await manager.similaritySearch(
+      args.question,
+      args.k,
+      undefined,
+      args.kb,
+      undefined,
+      timing ? denseTiming : undefined,
+    );
+    if (timing) {
+      timing.retrieval_ms = elapsedMs(startedAt);
+      mergeAskDenseTiming(timing, denseTiming);
+    }
   } catch (err) {
     const failure = classifyKbSearchError(err);
     if (args.format === 'json') process.stdout.write(formatKbSearchFailureJson(failure));
@@ -98,7 +130,9 @@ export async function runAsk(rest: string[]): Promise<number> {
 
   let target: LlmTarget;
   try {
+    const startedAt = nowMs();
     target = await resolveLlmTarget(args);
+    if (timing) timing.llm_profile_resolution_ms = elapsedMs(startedAt);
   } catch (err) {
     return reportAskError(args.format, `kb ask: ${(err as Error).message}`, 2);
   }
@@ -115,11 +149,16 @@ export async function runAsk(rest: string[]): Promise<number> {
   let answer: string;
   let llmModel: string | null = null;
   try {
+    const startedAt = nowMs();
     const response = await callChatCompletion({
       endpoint: target.profile.endpoint,
       messages: buildAskMessages(args.question, retrieval),
       temperature: 0.2,
     });
+    if (timing) {
+      timing.llm_first_token_ms = null;
+      timing.llm_total_ms = elapsedMs(startedAt);
+    }
     answer = response.content;
     llmModel = response.model;
   } catch (err) {
@@ -127,6 +166,7 @@ export async function runAsk(rest: string[]): Promise<number> {
   }
 
   const citations = buildCitations(retrieval);
+  if (timing) timing.total_ms = elapsedMs(totalStartedAt);
   if (args.format === 'json') {
     process.stdout.write(`${JSON.stringify({
       answer,
@@ -144,6 +184,7 @@ export async function runAsk(rest: string[]): Promise<number> {
         refreshed: args.refresh,
         knowledge_base: args.kb ?? null,
       },
+      ...(timing ? { timing: compactTimingPayload(timing) } : {}),
     }, null, 2)}\n`);
   } else {
     process.stdout.write(`${answer}\n\n`);
@@ -156,6 +197,10 @@ export async function runAsk(rest: string[]): Promise<number> {
       }
     }
     process.stdout.write(`\n> _LLM: ${target.profile.name} (${target.profile.mode}) at ${target.profile.endpoint}; retrieval model: ${activeModelId}._\n`);
+    if (timing) {
+      process.stdout.write(formatTimingFooter('Timing', timing));
+      process.stdout.write('\n');
+    }
   }
   return 0;
 }
@@ -167,10 +212,12 @@ export function parseAskArgs(rest: string[]): AskArgs {
     refresh: false,
     stdin: false,
     format: 'md',
+    timing: false,
   };
   for (const raw of rest) {
     if (raw === '--refresh') { out.refresh = true; continue; }
     if (raw === '--stdin') { out.stdin = true; continue; }
+    if (raw === '--timing') { out.timing = true; continue; }
     if (raw.startsWith('--kb=')) { out.kb = raw.slice('--kb='.length); continue; }
     if (raw.startsWith('--model=')) { out.model = raw.slice('--model='.length); continue; }
     if (raw.startsWith('--llm-profile=')) { out.llmProfile = raw.slice('--llm-profile='.length); continue; }
@@ -259,6 +306,15 @@ function reportAskError(format: 'md' | 'json', message: string, code: number): n
     process.stderr.write(`${message}\n`);
   }
   return code;
+}
+
+function mergeAskDenseTiming(target: TimingPayload, source: SimilaritySearchTiming): void {
+  if (source.embed_query_ms !== undefined) target.embed_query_ms = source.embed_query_ms;
+  if (source.faiss_search_ms !== undefined) target.faiss_search_ms = source.faiss_search_ms;
+  if (source.query_search_ms !== undefined) target.query_search_ms = source.query_search_ms;
+  if (source.post_filter_ms !== undefined) target.post_filter_ms = source.post_filter_ms;
+  if (source.total_ms !== undefined) target.retrieval_total_ms = source.total_ms;
+  if (source.fetch_k !== undefined) target.fetch_k = source.fetch_k;
 }
 
 async function readAllStdin(): Promise<string> {

--- a/src/cli-search.test.ts
+++ b/src/cli-search.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from '@jest/globals';
 import {
   AutoThresholdDecision,
   computeAutoThreshold,
+  formatAutoModeHeader,
   formatAutoThresholdHeader,
   formatFreshnessFooter,
+  resolveAutoSearchMode,
   Staleness,
 } from './cli-search.js';
 import {
@@ -219,5 +221,37 @@ describe('formatAutoThresholdHeader', () => {
   it('handles the empty-result case', () => {
     const d: AutoThresholdDecision = { threshold: 0, kneeIndex: null, kept: 0 };
     expect(formatAutoThresholdHeader(d)).toBe('> _Auto-threshold: no results to score._');
+  });
+});
+
+describe('resolveAutoSearchMode', () => {
+  it('keeps prose queries on dense retrieval', () => {
+    expect(resolveAutoSearchMode('how should I roll back a deployment?')).toEqual({
+      mode: 'dense',
+      reason: 'prose query',
+    });
+  });
+
+  it('uses hybrid for exact error and identifier shaped queries', () => {
+    expect(resolveAutoSearchMode('INDEX_NOT_INITIALIZED')).toMatchObject({
+      mode: 'hybrid',
+    });
+    expect(resolveAutoSearchMode('FaissIndexManager batch size')).toMatchObject({
+      mode: 'hybrid',
+    });
+  });
+
+  it('uses hybrid for flags, paths, and issue references', () => {
+    expect(resolveAutoSearchMode('--refresh behavior')).toMatchObject({ mode: 'hybrid' });
+    expect(resolveAutoSearchMode('src/cli-search.ts')).toMatchObject({ mode: 'hybrid' });
+    expect(resolveAutoSearchMode('PR #253')).toMatchObject({ mode: 'hybrid' });
+  });
+});
+
+describe('formatAutoModeHeader', () => {
+  it('renders the selected mode and reason', () => {
+    expect(formatAutoModeHeader({ mode: 'hybrid', reason: 'file-like token' })).toBe(
+      '> _Mode: auto -> hybrid (file-like token)._',
+    );
   });
 });

--- a/src/cli-search.ts
+++ b/src/cli-search.ts
@@ -1,6 +1,6 @@
 import * as fsp from 'fs/promises';
 import * as path from 'path';
-import { FaissIndexManager } from './FaissIndexManager.js';
+import { FaissIndexManager, type SimilaritySearchTiming } from './FaissIndexManager.js';
 import {
   resolveActiveModel,
   resolveFaissIndexBinaryPath,
@@ -25,6 +25,13 @@ import {
 import { enumerateIngestableKbFiles, listKnowledgeBases } from './kb-fs.js';
 import { withWriteLock } from './write-lock.js';
 import { loadManagerForModel, loadWithJsonRetry } from './cli-shared.js';
+import {
+  compactTimingPayload,
+  elapsedMs,
+  formatTimingFooter,
+  nowMs,
+  type TimingPayload,
+} from './cli-timing.js';
 import { LexicalIndex, type LexicalSearchResult } from './lexical-index.js';
 import { chunkIdFromMetadata, reciprocalRankFusion, type RankedList } from './rrf.js';
 
@@ -38,6 +45,8 @@ Usage:
 Default is dense (FAISS) similarity search, read-only. \`--refresh\` re-scans
 KB files under a per-model write lock before searching. \`--mode=lexical\`
 runs a BM25 debug surface; \`--mode=hybrid\` fuses dense + lexical via RRF.
+\`--mode=auto\` currently keeps dense for prose queries and chooses hybrid for
+code/path/error-token-shaped queries.
 
 Output ends with a freshness footer (markdown) or staleness fields (JSON)
 indicating whether the index is up-to-date relative to KB file mtimes.
@@ -50,7 +59,7 @@ Result tuning:
   --threshold=<float>   Max similarity score; lower = closer match (default 2).
   --threshold=auto      Pick a knee-based cutoff from the top-K score curve.
   --k=<int>             Top-K results (default 10).
-  --mode=dense|lexical|hybrid
+  --mode=dense|lexical|hybrid|auto
                         Retrieval mode (default: dense). \`hybrid\` fuses
                         dense + BM25 via reciprocal rank fusion (#206).
 
@@ -59,6 +68,7 @@ Output:
   --group-by-source     Collapse repeated chunks from the same source file
                         in markdown output. With \`--format=json\`, adds a
                         \`grouped_results\` field alongside raw results.
+  --timing              Include elapsed milliseconds for retrieval stages.
 
 Indexing:
   --refresh             Re-scan KB files; acquires the per-model write lock.
@@ -72,10 +82,12 @@ Examples:
   kb search "deploy" --kb=work --k=5
   kb search "INDEX_NOT_INITIALIZED" --mode=lexical --refresh
   kb search "INDEX_NOT_INITIALIZED" --mode=hybrid
+  kb search "src/cli.ts" --mode=auto --timing
   kb search --stdin --format=json < query.txt
 `;
 
-export type SearchMode = 'dense' | 'lexical' | 'hybrid';
+export type SearchMode = 'dense' | 'lexical' | 'hybrid' | 'auto';
+export type EffectiveSearchMode = Exclude<SearchMode, 'auto'>;
 
 interface SearchArgs {
   query: string | null;
@@ -89,6 +101,7 @@ interface SearchArgs {
   stdin: boolean;
   groupBySource: boolean;
   mode: SearchMode;
+  timing: boolean;
 }
 
 export interface Staleness {
@@ -114,7 +127,13 @@ export interface AutoThresholdDecision {
   kept: number;
 }
 
+export interface AutoSearchModeDecision {
+  mode: EffectiveSearchMode;
+  reason: string;
+}
+
 export async function runSearch(rest: string[]): Promise<number> {
+  const totalStartedAt = nowMs();
   let parsed: SearchArgs;
   try {
     parsed = parseSearchArgs(rest);
@@ -134,34 +153,55 @@ export async function runSearch(rest: string[]): Promise<number> {
     return 2;
   }
 
-  if (parsed.mode === 'lexical') {
-    return runLexicalSearch(parsed);
+  const autoModeDecision = parsed.mode === 'auto'
+    ? resolveAutoSearchMode(parsed.query)
+    : null;
+  const effectiveMode: EffectiveSearchMode = autoModeDecision
+    ? autoModeDecision.mode
+    : (parsed.mode as EffectiveSearchMode);
+  const timing: TimingPayload | null = parsed.timing
+    ? {
+        requested_mode: parsed.mode,
+        effective_mode: effectiveMode,
+      }
+    : null;
+  const effectiveParsed: SearchArgs = { ...parsed, mode: effectiveMode };
+
+  if (effectiveMode === 'lexical') {
+    return runLexicalSearch(effectiveParsed, timing, totalStartedAt, autoModeDecision);
   }
-  if (parsed.mode === 'hybrid') {
-    return runHybridSearch(parsed);
+  if (effectiveMode === 'hybrid') {
+    return runHybridSearch(effectiveParsed, timing, totalStartedAt, autoModeDecision);
   }
 
   try {
+    const startedAt = nowMs();
     await FaissIndexManager.bootstrapLayout();
+    if (timing) timing.bootstrap_ms = elapsedMs(startedAt);
   } catch (err) {
     return reportFailure(classifyKbSearchError(err), parsed.format);
   }
 
   let activeModelId: string;
   try {
+    const startedAt = nowMs();
     activeModelId = await resolveActiveModel({ explicitOverride: parsed.model });
+    if (timing) timing.model_resolution_ms = elapsedMs(startedAt);
   } catch (err) {
     return reportFailure(classifyKbSearchError(err), parsed.format);
   }
 
   let manager: FaissIndexManager;
   try {
+    const startedAt = nowMs();
     manager = await loadManagerForModel(activeModelId);
+    if (timing) timing.manager_load_ms = elapsedMs(startedAt);
   } catch (err) {
     return reportFailure(classifyKbSearchError(err), parsed.format);
   }
 
   try {
+    const startedAt = nowMs();
     if (parsed.refresh) {
       await withWriteLock(manager.modelDir, async () => {
         await manager.initialize();
@@ -170,35 +210,49 @@ export async function runSearch(rest: string[]): Promise<number> {
     } else {
       await loadWithJsonRetry(manager);
     }
+    if (timing) timing.index_load_ms = elapsedMs(startedAt);
   } catch (err) {
     return reportFailure(classifyKbSearchError(err), parsed.format);
   }
 
   let results;
-  let autoDecision: AutoThresholdDecision | null = null;
+  let autoThresholdDecision: AutoThresholdDecision | null = null;
+  const denseTiming: SimilaritySearchTiming = {};
   try {
+    const startedAt = nowMs();
     if (parsed.thresholdAuto) {
       const rawResults = await manager.similaritySearch(
         parsed.query,
         parsed.k,
         Number.POSITIVE_INFINITY,
         parsed.kb,
+        undefined,
+        timing ? denseTiming : undefined,
       );
-      autoDecision = computeAutoThreshold(rawResults.map((r) => r.score));
-      results = rawResults.slice(0, autoDecision.kept);
+      autoThresholdDecision = computeAutoThreshold(rawResults.map((r) => r.score));
+      results = rawResults.slice(0, autoThresholdDecision.kept);
     } else {
       results = await manager.similaritySearch(
         parsed.query,
         parsed.k,
         parsed.threshold,
         parsed.kb,
+        undefined,
+        timing ? denseTiming : undefined,
       );
+    }
+    if (timing) {
+      timing.dense_search_ms = elapsedMs(startedAt);
+      mergeDenseTiming(timing, denseTiming);
     }
   } catch (err) {
     return reportFailure(classifyKbSearchError(err), parsed.format);
   }
 
+  const stalenessStartedAt = nowMs();
   const staleness = await computeStaleness(activeModelId, parsed.kb);
+  if (timing) timing.staleness_ms = elapsedMs(stalenessStartedAt);
+  if (timing) timing.total_ms = elapsedMs(totalStartedAt);
 
   if (parsed.format === 'json') {
     const body = formatRetrievalAsJson(results, FRONTMATTER_EXTRAS_WIRE_VISIBLE);
@@ -220,6 +274,13 @@ export async function runSearch(rest: string[]): Promise<number> {
       : globalCounts;
     const payload = {
       results: body,
+      ...(parsed.mode === 'auto'
+        ? {
+            mode: effectiveMode,
+            requested_mode: 'auto' as const,
+            auto_mode: autoModeDecision,
+          }
+        : {}),
       ...(parsed.groupBySource
         ? { grouped_results: groupRetrievalBySource(results, FRONTMATTER_EXTRAS_WIRE_VISIBLE) }
         : {}),
@@ -240,20 +301,25 @@ export async function runSearch(rest: string[]): Promise<number> {
             },
           }
         : {}),
-      ...(autoDecision !== null
+      ...(autoThresholdDecision !== null
         ? {
             auto_threshold: {
-              threshold: autoDecision.threshold,
-              knee_index: autoDecision.kneeIndex,
-              kept: autoDecision.kept,
+              threshold: autoThresholdDecision.threshold,
+              knee_index: autoThresholdDecision.kneeIndex,
+              kept: autoThresholdDecision.kept,
             },
           }
         : {}),
+      ...(timing ? { timing: compactTimingPayload(timing) } : {}),
     };
     process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
   } else {
-    if (autoDecision !== null) {
-      process.stdout.write(formatAutoThresholdHeader(autoDecision));
+    if (autoModeDecision !== null) {
+      process.stdout.write(formatAutoModeHeader(autoModeDecision));
+      process.stdout.write('\n\n');
+    }
+    if (autoThresholdDecision !== null) {
+      process.stdout.write(formatAutoThresholdHeader(autoThresholdDecision));
       process.stdout.write('\n\n');
     }
     const md = parsed.groupBySource
@@ -263,6 +329,10 @@ export async function runSearch(rest: string[]): Promise<number> {
     process.stdout.write('\n\n');
     process.stdout.write(formatFreshnessFooter(staleness, parsed.refresh));
     process.stdout.write('\n');
+    if (timing) {
+      process.stdout.write(formatTimingFooter('Timing', timing));
+      process.stdout.write('\n');
+    }
   }
 
   return 0;
@@ -278,17 +348,19 @@ function parseSearchArgs(rest: string[]): SearchArgs {
     thresholdAuto: false,
     groupBySource: false,
     mode: 'dense',
+    timing: false,
   };
   for (const raw of rest) {
     if (raw === '--refresh') { out.refresh = true; continue; }
     if (raw === '--stdin')   { out.stdin = true; continue; }
     if (raw === '--group-by-source') { out.groupBySource = true; continue; }
+    if (raw === '--timing') { out.timing = true; continue; }
     if (raw.startsWith('--kb=')) { out.kb = raw.slice('--kb='.length); continue; }
     if (raw.startsWith('--model=')) { out.model = raw.slice('--model='.length); continue; }
     if (raw.startsWith('--mode=')) {
       const v = raw.slice('--mode='.length);
-      if (v !== 'dense' && v !== 'lexical' && v !== 'hybrid') {
-        throw new Error(`invalid --mode: ${raw} (expected 'dense', 'lexical', or 'hybrid')`);
+      if (v !== 'dense' && v !== 'lexical' && v !== 'hybrid' && v !== 'auto') {
+        throw new Error(`invalid --mode: ${raw} (expected 'dense', 'lexical', 'hybrid', or 'auto')`);
       }
       out.mode = v; continue;
     }
@@ -314,6 +386,38 @@ function parseSearchArgs(rest: string[]): SearchArgs {
     throw new Error(`unexpected argument: ${raw}`);
   }
   return out;
+}
+
+export function resolveAutoSearchMode(query: string): AutoSearchModeDecision {
+  const trimmed = query.trim();
+  const hybridMatchers: Array<[RegExp, string]> = [
+    [/(^|[\s`'"])-{1,2}[A-Za-z0-9][\w-]*/, 'CLI flag token'],
+    [/\b[A-Z0-9]+_[A-Z0-9_]+\b/, 'constant or error-code token'],
+    [/\b[A-Za-z0-9_.-]+\.(?:ts|tsx|js|mjs|cjs|json|md|py|go|rs|java|cpp|c|h|yaml|yml|toml|lock)\b/i, 'file-like token'],
+    [/[./\\][A-Za-z0-9_.-]+/, 'path-like token'],
+    [/\b[A-Z][a-z]+[A-Z][A-Za-z0-9]*\b/, 'identifier-like token'],
+    [/\b[A-Za-z_][A-Za-z0-9_]*\([^)]*\)/, 'function-call-like token'],
+    [/\b(?:PR|issue)\s*#?\d+\b/i, 'issue or PR reference'],
+    [/#\d+\b/, 'numbered reference'],
+  ];
+
+  for (const [pattern, reason] of hybridMatchers) {
+    if (pattern.test(trimmed)) return { mode: 'hybrid', reason };
+  }
+  return { mode: 'dense', reason: 'prose query' };
+}
+
+export function formatAutoModeHeader(decision: AutoSearchModeDecision): string {
+  return `> _Mode: auto -> ${decision.mode} (${decision.reason})._`;
+}
+
+function mergeDenseTiming(target: TimingPayload, source: SimilaritySearchTiming): void {
+  if (source.embed_query_ms !== undefined) target.embed_query_ms = source.embed_query_ms;
+  if (source.faiss_search_ms !== undefined) target.faiss_search_ms = source.faiss_search_ms;
+  if (source.query_search_ms !== undefined) target.query_search_ms = source.query_search_ms;
+  if (source.post_filter_ms !== undefined) target.post_filter_ms = source.post_filter_ms;
+  if (source.total_ms !== undefined) target.dense_total_ms = source.total_ms;
+  if (source.fetch_k !== undefined) target.fetch_k = source.fetch_k;
 }
 
 export async function computeStaleness(modelId: string, scopedKb?: string): Promise<Staleness> {
@@ -556,7 +660,12 @@ async function listLexicalKbs(scoped?: string): Promise<Array<{ kbName: string; 
   }));
 }
 
-async function runLexicalSearch(parsed: SearchArgs): Promise<number> {
+async function runLexicalSearch(
+  parsed: SearchArgs,
+  timing: TimingPayload | null = null,
+  totalStartedAt: number = nowMs(),
+  autoModeDecision: AutoSearchModeDecision | null = null,
+): Promise<number> {
   if (parsed.thresholdAuto || parsed.threshold !== undefined) {
     process.stderr.write('kb search: --threshold/--threshold=auto are dense-only; ignored under --mode=lexical\n');
   }
@@ -568,7 +677,9 @@ async function runLexicalSearch(parsed: SearchArgs): Promise<number> {
 
   let kbs: Array<{ kbName: string; kbPath: string }>;
   try {
+    const startedAt = nowMs();
     kbs = await listLexicalKbs(parsed.kb);
+    if (timing) timing.lexical_kb_list_ms = elapsedMs(startedAt);
   } catch (err) {
     process.stderr.write(`kb search (lexical): could not list KBs: ${(err as Error).message}\n`);
     return 1;
@@ -579,6 +690,7 @@ async function runLexicalSearch(parsed: SearchArgs): Promise<number> {
   }
 
   const perKb: LexicalKbResult[] = [];
+  const lexicalStartedAt = nowMs();
   for (const { kbName, kbPath } of kbs) {
     let index: LexicalIndex;
     try {
@@ -607,6 +719,10 @@ async function runLexicalSearch(parsed: SearchArgs): Promise<number> {
       continue;
     }
     perKb.push({ kbName, kbPath, refreshSummary, hits });
+  }
+  if (timing) {
+    timing.lexical_search_ms = elapsedMs(lexicalStartedAt);
+    timing.total_ms = elapsedMs(totalStartedAt);
   }
 
   // Merge across KBs by score (BM25 score is positive; higher is better).
@@ -638,6 +754,9 @@ async function runLexicalSearch(parsed: SearchArgs): Promise<number> {
   if (parsed.format === 'json') {
     const payload = {
       mode: 'lexical' as const,
+      ...(autoModeDecision
+        ? { requested_mode: 'auto' as const, auto_mode: autoModeDecision }
+        : {}),
       results: formatRetrievalAsJson(formatted as never, FRONTMATTER_EXTRAS_WIRE_VISIBLE),
       knowledge_bases: perKb.map((r) => ({
         kb: r.kbName,
@@ -653,9 +772,14 @@ async function runLexicalSearch(parsed: SearchArgs): Promise<number> {
           : null,
         error: r.error ? r.error.message : null,
       })),
+      ...(timing ? { timing: compactTimingPayload(timing) } : {}),
     };
     process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
   } else {
+    if (autoModeDecision) {
+      process.stdout.write(formatAutoModeHeader(autoModeDecision));
+      process.stdout.write('\n\n');
+    }
     process.stdout.write(`> _Mode: lexical (BM25). Stage 1 — debug surface; see #206._\n\n`);
     if (formatted.length === 0) {
       process.stdout.write(`_No matches._\n\n`);
@@ -675,6 +799,11 @@ async function runLexicalSearch(parsed: SearchArgs): Promise<number> {
       return `- ${r.kbName}: ${counts}`;
     });
     process.stdout.write(`> _Lexical index status:_\n${summaryLines.join('\n')}\n`);
+    if (timing) {
+      process.stdout.write(`\n`);
+      process.stdout.write(formatTimingFooter('Timing', timing));
+      process.stdout.write('\n');
+    }
   }
 
   return errors.length > 0 ? 1 : 0;
@@ -691,7 +820,12 @@ interface HybridChunk {
   score: number;
 }
 
-async function runHybridSearch(parsed: SearchArgs): Promise<number> {
+async function runHybridSearch(
+  parsed: SearchArgs,
+  timing: TimingPayload | null = null,
+  totalStartedAt: number = nowMs(),
+  autoModeDecision: AutoSearchModeDecision | null = null,
+): Promise<number> {
   if (parsed.thresholdAuto || parsed.threshold !== undefined) {
     process.stderr.write('kb search: --threshold/--threshold=auto are dense-only; ignored under --mode=hybrid\n');
   }
@@ -707,18 +841,25 @@ async function runHybridSearch(parsed: SearchArgs): Promise<number> {
   let denseError: Error | null = null;
   let activeModelId: string | null = null;
   try {
+    let startedAt = nowMs();
     await FaissIndexManager.bootstrapLayout();
+    if (timing) timing.bootstrap_ms = elapsedMs(startedAt);
+    startedAt = nowMs();
     activeModelId = await resolveActiveModel({ explicitOverride: parsed.model });
+    if (timing) timing.model_resolution_ms = elapsedMs(startedAt);
   } catch (err) {
     return reportFailure(classifyKbSearchError(err), parsed.format);
   }
   let manager: FaissIndexManager;
   try {
+    const startedAt = nowMs();
     manager = await loadManagerForModel(activeModelId);
+    if (timing) timing.manager_load_ms = elapsedMs(startedAt);
   } catch (err) {
     return reportFailure(classifyKbSearchError(err), parsed.format);
   }
   try {
+    const startedAt = nowMs();
     if (parsed.refresh) {
       await withWriteLock(manager.modelDir, async () => {
         await manager.initialize();
@@ -727,12 +868,28 @@ async function runHybridSearch(parsed: SearchArgs): Promise<number> {
     } else {
       await loadWithJsonRetry(manager);
     }
+    if (timing) timing.index_load_ms = elapsedMs(startedAt);
   } catch (err) {
     return reportFailure(classifyKbSearchError(err), parsed.format);
   }
+  const denseTiming: SimilaritySearchTiming = {};
+  const denseStartedAt = nowMs();
   densePromise = manager
-    .similaritySearch(query, fetchK, Number.POSITIVE_INFINITY, parsed.kb)
-    .then((rs) => rs.map((r) => ({ pageContent: r.pageContent, metadata: r.metadata, score: r.score })))
+    .similaritySearch(
+      query,
+      fetchK,
+      Number.POSITIVE_INFINITY,
+      parsed.kb,
+      undefined,
+      timing ? denseTiming : undefined,
+    )
+    .then((rs) => {
+      if (timing) {
+        timing.dense_search_ms = elapsedMs(denseStartedAt);
+        mergeDenseTiming(timing, denseTiming);
+      }
+      return rs.map((r) => ({ pageContent: r.pageContent, metadata: r.metadata, score: r.score }));
+    })
     .catch((err) => {
       denseError = err as Error;
       return [];
@@ -741,12 +898,15 @@ async function runHybridSearch(parsed: SearchArgs): Promise<number> {
   // -- lexical leg ---------------------------------------------------------
   let lexicalKbs: Array<{ kbName: string; kbPath: string }>;
   try {
+    const startedAt = nowMs();
     lexicalKbs = await listLexicalKbs(parsed.kb);
+    if (timing) timing.lexical_kb_list_ms = elapsedMs(startedAt);
   } catch (err) {
     process.stderr.write(`kb search (hybrid): could not list KBs: ${(err as Error).message}\n`);
     return 1;
   }
 
+  const lexicalStartedAt = nowMs();
   const lexicalPromise: Promise<{ hits: HybridChunk[]; refreshed: number; failed: number }> = (async () => {
     let refreshed = 0;
     let failed = 0;
@@ -773,7 +933,10 @@ async function runHybridSearch(parsed: SearchArgs): Promise<number> {
       refreshed,
       failed,
     };
-  })();
+  })().then((row) => {
+    if (timing) timing.lexical_search_ms = elapsedMs(lexicalStartedAt);
+    return row;
+  });
 
   const [denseResults, lexicalResultsRow] = await Promise.all([densePromise, lexicalPromise]);
   if (denseError) {
@@ -782,6 +945,7 @@ async function runHybridSearch(parsed: SearchArgs): Promise<number> {
   const lexicalResults = lexicalResultsRow.hits;
 
   // -- fuse ----------------------------------------------------------------
+  const fusionStartedAt = nowMs();
   const denseList: RankedList = {
     retriever: 'dense',
     results: denseResults.map((r, i) => ({ id: chunkIdFromMetadata(r.metadata), rank: i + 1 })),
@@ -802,19 +966,31 @@ async function runHybridSearch(parsed: SearchArgs): Promise<number> {
     const chunk = byId.get(f.id);
     return chunk ? { ...chunk, score: f.fusedScore } : null;
   }).filter((x): x is HybridChunk => x !== null);
+  if (timing) {
+    timing.fusion_ms = elapsedMs(fusionStartedAt);
+    timing.total_ms = elapsedMs(totalStartedAt);
+  }
 
   if (parsed.format === 'json') {
     const payload = {
       mode: 'hybrid' as const,
+      ...(autoModeDecision
+        ? { requested_mode: 'auto' as const, auto_mode: autoModeDecision }
+        : {}),
       results: formatRetrievalAsJson(ranked as never, FRONTMATTER_EXTRAS_WIRE_VISIBLE),
       retrievers: {
         dense: { fetched: denseResults.length, model: activeModelId },
         lexical: { fetched: lexicalResults.length, refreshed: lexicalResultsRow.refreshed, failed: lexicalResultsRow.failed },
       },
       rrf: { c: HYBRID_RRF_C, fetch_k: fetchK },
+      ...(timing ? { timing: compactTimingPayload(timing) } : {}),
     };
     process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
   } else {
+    if (autoModeDecision) {
+      process.stdout.write(formatAutoModeHeader(autoModeDecision));
+      process.stdout.write('\n\n');
+    }
     process.stdout.write(`> _Mode: hybrid (RRF c=${HYBRID_RRF_C}). Stage 2 — dense ⨁ lexical; see #206._\n\n`);
     if (ranked.length === 0) {
       process.stdout.write(`_No matches._\n\n`);
@@ -825,6 +1001,10 @@ async function runHybridSearch(parsed: SearchArgs): Promise<number> {
     process.stdout.write(
       `> _Hybrid status: dense fetched ${denseResults.length}, lexical fetched ${lexicalResults.length} (refreshed ${lexicalResultsRow.refreshed}, ${lexicalResultsRow.failed} failed); fused via RRF (c=${HYBRID_RRF_C}, fetch_k=${fetchK})._\n`,
     );
+    if (timing) {
+      process.stdout.write(formatTimingFooter('Timing', timing));
+      process.stdout.write('\n');
+    }
   }
 
   return 0;

--- a/src/cli-timing.test.ts
+++ b/src/cli-timing.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from '@jest/globals';
+import { compactTimingPayload, formatTimingFooter } from './cli-timing.js';
+
+describe('compactTimingPayload', () => {
+  it('drops undefined values and rounds numeric measurements', () => {
+    expect(compactTimingPayload({
+      total_ms: 12.6,
+      fetch_k: 4,
+      skipped: undefined,
+      llm_first_token_ms: null,
+    })).toEqual({
+      total_ms: 13,
+      fetch_k: 4,
+      llm_first_token_ms: null,
+    });
+  });
+});
+
+describe('formatTimingFooter', () => {
+  it('uses ms suffixes only for *_ms fields', () => {
+    expect(formatTimingFooter('Timing', {
+      requested_mode: 'auto',
+      effective_mode: 'hybrid',
+      total_ms: 42,
+      fetch_k: 4,
+    })).toBe('> _Timing (auto -> hybrid): total_ms=42ms, fetch_k=4._');
+  });
+});

--- a/src/cli-timing.ts
+++ b/src/cli-timing.ts
@@ -1,0 +1,46 @@
+export type TimingValue = number | string | boolean | null;
+
+export type TimingPayload = Record<string, TimingValue | undefined>;
+
+export function nowMs(): number {
+  return Date.now();
+}
+
+export function elapsedMs(startedAtMs: number): number {
+  return Math.max(0, Date.now() - startedAtMs);
+}
+
+export function roundedMs(value: number | null | undefined): number | null {
+  if (value === null || value === undefined || !Number.isFinite(value)) return null;
+  return Math.round(value);
+}
+
+export function compactTimingPayload(timing: TimingPayload): Record<string, TimingValue> {
+  const out: Record<string, TimingValue> = {};
+  for (const [key, value] of Object.entries(timing)) {
+    if (value !== undefined) out[key] = typeof value === 'number' ? Math.round(value) : value;
+  }
+  return out;
+}
+
+export function formatTimingFooter(label: string, timing: TimingPayload): string {
+  const entries = Object.entries(compactTimingPayload(timing))
+    .filter(([key]) => key !== 'requested_mode' && key !== 'effective_mode')
+    .map(([key, value]) => `${key}=${formatTimingValue(key, value)}`);
+  const modeText = formatModeText(timing);
+  const body = entries.length > 0 ? entries.join(', ') : 'no timing data';
+  return `> _${label}${modeText}: ${body}._`;
+}
+
+function formatModeText(timing: TimingPayload): string {
+  const requested = timing.requested_mode;
+  const effective = timing.effective_mode;
+  if (typeof requested !== 'string' || typeof effective !== 'string') return '';
+  if (requested === effective) return ` (${effective})`;
+  return ` (${requested} -> ${effective})`;
+}
+
+function formatTimingValue(key: string, value: TimingValue): string {
+  if (typeof value === 'number' && key.endsWith('_ms')) return `${value}ms`;
+  return String(value);
+}


### PR DESCRIPTION
## Summary

- add `kb search --timing` and `kb ask --timing` for per-stage elapsed milliseconds
- add opt-in `kb search --mode=auto`, keeping the default dense mode unchanged
- choose hybrid automatically only for code/path/error/flag/issue-shaped queries
- split dense retrieval timing into query embedding, FAISS lookup, post-filtering, and fetch count where supported
- document the new CLI flags and add focused tests

## Verification

- `npm run build`
- `npm test -- --runTestsByPath src/cli-search.test.ts src/cli-ask.test.ts src/cli-timing.test.ts --silent`
- `npm test -- --silent` — 38 suites, 663 tests passed
- `git diff --check`
- Smoke: `node build/cli.js search "src/cli-search.ts" --mode=auto --timing --format=json --k=1` selected hybrid and reported timing
- Smoke: `node build/cli.js search "how should I roll back a deployment?" --mode=auto --timing --format=json --k=1` selected dense and reported timing
- Smoke: `node build/cli.js ask "Which service keeps the local research LLM loaded?" --kb=operating-environment --k=1 --timing --format=json` reported retrieval and LLM timings

## Pre-PR Review

- detected project type: npm
- type/build checks: passed
- tests: passed
- bug reproduction: skipped, this is a feature PR
- diff review: done
- portability check: manual scan done; helper is not present in this repo
- specialist subagent review: skipped because the active Codex instruction only permits spawning subagents when the user explicitly asks for subagents/delegation
