### PR TITLE
feat: add stable chunk citation handles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased] — stable chunk citation handles
+
+### Added
+
+- **`kb search` and `retrieve_knowledge` now surface stable chunk handles.** Results with KB/path/line metadata expose `chunk_id` values like `alpha/docs/deploy.md#L42-L78`, falling back to `#chunk-N` when line ranges are absent. `KB_EDITOR_URI=vscode|cursor|file|none` controls opt-in absolute-path `editor_uri` output; the default `none` keeps local paths hidden. `kb search --format=vimgrep` prints `path:line:col:preview` quickfix lines. Closes #220.
+
 ## [Unreleased] — atomic EOF appends for `kb remember` and `kb capture`
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ kb help search                # per-command help (also: kb search --help)
 
 The `kb` bin shares the same env vars as the MCP server (`KNOWLEDGE_BASES_ROOT_DIR`, `FAISS_INDEX_PATH`, `EMBEDDING_PROVIDER`, `OLLAMA_*`, `OPENAI_*`, `HUGGINGFACE_*`). `kb stats [--kb=<name>] [--format=md|json]` mirrors the MCP `kb_stats` payload for local shell use: per-KB file/chunk/byte counts, last indexed time, embedding model, index path, and version context. It is read-only and does not refresh the index. `kb search` also defaults to read-only dense retrieval — it loads the existing FAISS index but does not re-scan KB files. Pass `--refresh` to re-index. Use `--mode=hybrid` for explicit dense+BM25 rank fusion, or `--mode=auto` to keep dense for prose queries while selecting hybrid for code, path, flag, error-code, and issue-reference shaped queries. Add `--timing` to `kb search` or `kb ask` when you need per-stage elapsed milliseconds in either markdown or JSON output. Search output includes a freshness footer indicating whether the index is up-to-date relative to KB file mtimes.
 
+`kb search --format=vimgrep` prints one quickfix-compatible line per result: `path:line:col:preview`. JSON results include a stable `chunk_id` such as `alpha/docs/deploy.md#L42-L78` when chunk metadata has a KB, path, and line range; chunks without line metadata fall back to `#chunk-N`. Set `KB_EDITOR_URI=vscode`, `cursor`, or `file` to add opt-in absolute-path `editor_uri` fields and markdown `Open` links. The default `KB_EDITOR_URI=none` omits local absolute paths.
+
 `kb remember` is a conservative CLI write path for agent shells. `--suggest` lists likely existing targets from note filenames/headings, does not read stdin or write notes, and may update a small `.index` heading cache. Creates and appends require both `--stdin` and `--yes`; create uses a slugified `.md` filename and refuses overwrites, while append accepts only existing KB-relative paths. Plain EOF appends and `kb capture --append` serialize per target and commit through a temp-file fsync plus atomic rename. Add `--refresh` to re-index the affected KB after a successful write.
 
 `kb superseded --kb=<name>` is a read-only active-forgetting review. It scans markdown frontmatter for explicit contradiction, deprecated/dormant lifecycle status, stale verification dates, and low-confidence active notes, then uses the existing semantic index to add conservative newer-neighbor evidence when available. Use `--format=json` for agent workflows and `--include-clean` when you need a full inventory.
@@ -374,6 +376,7 @@ The output of the `retrieve_knowledge` tool is a markdown formatted string with 
 ````
 
 Each result includes the content of the most similar chunk, the source file, and a similarity score.
+When chunk metadata includes line information, the markdown source header links a stable chunk handle such as `alpha/docs/deploy.md#L42-L78` to the matching `kb://alpha/docs/deploy.md#L42-L78` resource URI. Set `KB_EDITOR_URI=vscode`, `cursor`, or `file` before launching the server to also include editor-open links with local absolute paths.
 
 ## Remote transport (optional)
 

--- a/src/chunk-id.test.ts
+++ b/src/chunk-id.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from '@jest/globals';
+import { buildChunkCitation, buildChunkId, buildEditorUri } from './chunk-id.js';
+
+describe('chunk citation handles', () => {
+  it('builds a line-range chunk_id from KB, relative path, and loc.lines', () => {
+    expect(buildChunkId({
+      knowledgeBase: 'alpha',
+      relativePath: 'alpha/docs/deploy.md',
+      loc: { lines: { from: 42, to: 78 } },
+      chunkIndex: 3,
+    })).toBe('alpha/docs/deploy.md#L42-L78');
+  });
+
+  it('falls back to chunk index when line information is absent', () => {
+    expect(buildChunkId({
+      knowledgeBase: 'alpha',
+      relativePath: 'alpha/pdfs/report.pdf',
+      chunkIndex: 12,
+    })).toBe('alpha/pdfs/report.pdf#chunk-12');
+  });
+
+  it('percent-encodes reserved path characters in handles and kb:// URIs', () => {
+    const citation = buildChunkCitation({
+      knowledgeBase: 'alpha',
+      relativePath: 'alpha/docs/bug #123?.md',
+      loc: { lines: { from: 4, to: 5 } },
+      chunkIndex: 0,
+    }, 'none');
+
+    expect(citation?.chunk_id).toBe('alpha/docs/bug%20%23123%3F.md#L4-L5');
+    expect(citation?.resource_uri).toBe('kb://alpha/docs/bug%20%23123%3F.md#L4-L5');
+  });
+
+  it('omits citation data when metadata lacks a stable KB/path/chunk anchor', () => {
+    expect(buildChunkId({ source: 'doc.md' })).toBeNull();
+  });
+});
+
+describe('editor URI output', () => {
+  const metadata = {
+    source: '/tmp/kbs/alpha/docs/deploy note.md',
+    knowledgeBase: 'alpha',
+    relativePath: 'alpha/docs/deploy note.md',
+    loc: { lines: { from: 42, to: 78 } },
+    chunkIndex: 0,
+  };
+
+  it('omits editor_uri by default', () => {
+    expect(buildEditorUri(metadata, 'none')).toBeNull();
+  });
+
+  it('builds vscode and cursor line-jump URIs from absolute paths', () => {
+    expect(buildEditorUri(metadata, 'vscode')).toBe(
+      'vscode://file/tmp/kbs/alpha/docs/deploy note.md:42:0',
+    );
+    expect(buildEditorUri(metadata, 'cursor')).toBe(
+      'cursor://file/tmp/kbs/alpha/docs/deploy note.md:42:0',
+    );
+  });
+
+  it('builds file URIs with a line fragment', () => {
+    expect(buildEditorUri(metadata, 'file')).toBe(
+      'file:///tmp/kbs/alpha/docs/deploy%20note.md#L42',
+    );
+  });
+});

--- a/src/chunk-id.ts
+++ b/src/chunk-id.ts
@@ -1,0 +1,169 @@
+import * as path from 'path';
+import { pathToFileURL } from 'url';
+import type { KBEditorUriMode } from './config.js';
+import { KNOWLEDGE_BASES_ROOT_DIR } from './config.js';
+import { buildResourceUri } from './mcp-resources.js';
+
+export interface ChunkCitation {
+  chunk_id: string;
+  resource_uri: string;
+  path: string;
+  line: number;
+  column: number;
+  editor_uri?: string;
+}
+
+interface LineRange {
+  from: number;
+  to: number;
+}
+
+export function buildChunkCitation(
+  metadata: Record<string, unknown>,
+  editorUriMode: KBEditorUriMode,
+): ChunkCitation | null {
+  const identity = resolveChunkIdentity(metadata);
+  if (identity === null) return null;
+
+  const fragment = buildChunkFragment(metadata);
+  if (fragment === null) return null;
+
+  const resourceUri = `${buildResourceUri(identity.knowledgeBase, identity.kbRelativePath)}#${fragment}`;
+  const chunkId = `${identity.knowledgeBase}/${encodeRelativePath(identity.kbRelativePath)}#${fragment}`;
+  const lineRange = getLineRange(metadata);
+  const line = lineRange?.from ?? 1;
+  const citation: ChunkCitation = {
+    chunk_id: chunkId,
+    resource_uri: resourceUri,
+    path: identity.displayPath,
+    line,
+    column: 0,
+  };
+  const editorUri = buildEditorUri(metadata, editorUriMode, line);
+  if (editorUri !== null) {
+    citation.editor_uri = editorUri;
+  }
+  return citation;
+}
+
+export function buildChunkId(metadata: Record<string, unknown>): string | null {
+  return buildChunkCitation(metadata, 'none')?.chunk_id ?? null;
+}
+
+export function buildEditorUri(
+  metadata: Record<string, unknown>,
+  mode: KBEditorUriMode,
+  lineOverride?: number,
+): string | null {
+  if (mode === 'none') return null;
+  const absolutePath = resolveAbsolutePath(metadata);
+  if (absolutePath === null) return null;
+  const line = lineOverride ?? getLineRange(metadata)?.from;
+  if (mode === 'file') {
+    const url = pathToFileURL(absolutePath).href;
+    return line === undefined ? url : `${url}#L${line}`;
+  }
+  const suffix = line === undefined ? '' : `:${line}:0`;
+  return `${mode}://file${absolutePath}${suffix}`;
+}
+
+function resolveChunkIdentity(metadata: Record<string, unknown>): {
+  knowledgeBase: string;
+  kbRelativePath: string;
+  displayPath: string;
+} | null {
+  const knowledgeBase = resolveKnowledgeBase(metadata);
+  const displayPath = resolveDisplayPath(metadata, knowledgeBase);
+  if (knowledgeBase === null || displayPath === null) return null;
+  const kbRelativePath = stripKnowledgeBasePrefix(displayPath, knowledgeBase);
+  if (kbRelativePath === '') return null;
+  return { knowledgeBase, kbRelativePath, displayPath };
+}
+
+function resolveKnowledgeBase(metadata: Record<string, unknown>): string | null {
+  const knowledgeBase = metadata.knowledgeBase;
+  if (typeof knowledgeBase === 'string' && knowledgeBase.trim() !== '') {
+    return knowledgeBase;
+  }
+  const relativePath = normalizePosix(metadata.relativePath);
+  if (relativePath !== null) {
+    const [head] = relativePath.split('/');
+    if (head && head !== '.' && head !== '..') return head;
+  }
+  const source = typeof metadata.source === 'string' ? metadata.source : null;
+  if (source) {
+    const relative = path.relative(KNOWLEDGE_BASES_ROOT_DIR, source).split(path.sep).join('/');
+    const [head] = relative.split('/');
+    if (head && head !== '.' && head !== '..' && !head.startsWith('..')) return head;
+  }
+  return null;
+}
+
+function resolveDisplayPath(metadata: Record<string, unknown>, knowledgeBase: string | null): string | null {
+  const relativePath = normalizePosix(metadata.relativePath);
+  if (relativePath !== null) return relativePath;
+  const source = typeof metadata.source === 'string' ? metadata.source : null;
+  if (source && path.isAbsolute(source)) {
+    const relative = path.relative(KNOWLEDGE_BASES_ROOT_DIR, source).split(path.sep).join('/');
+    if (!relative.startsWith('..') && relative !== '') return relative;
+  }
+  if (source && knowledgeBase !== null && source.trim() !== '') {
+    return `${knowledgeBase}/${source.split(path.sep).join('/')}`;
+  }
+  return null;
+}
+
+function stripKnowledgeBasePrefix(displayPath: string, knowledgeBase: string): string {
+  return displayPath === knowledgeBase
+    ? ''
+    : displayPath.startsWith(`${knowledgeBase}/`)
+      ? displayPath.slice(knowledgeBase.length + 1)
+      : displayPath;
+}
+
+function buildChunkFragment(metadata: Record<string, unknown>): string | null {
+  const lines = getLineRange(metadata);
+  if (lines !== null) return `L${lines.from}-L${lines.to}`;
+  const chunkIndex = metadata.chunkIndex ?? metadata.chunk_index;
+  if (typeof chunkIndex === 'number' && Number.isInteger(chunkIndex) && chunkIndex >= 0) {
+    return `chunk-${chunkIndex}`;
+  }
+  return null;
+}
+
+function getLineRange(metadata: Record<string, unknown>): LineRange | null {
+  const loc = metadata.loc;
+  if (!loc || typeof loc !== 'object') return null;
+  const lines = (loc as Record<string, unknown>).lines;
+  if (!lines || typeof lines !== 'object') return null;
+  const from = (lines as Record<string, unknown>).from;
+  const to = (lines as Record<string, unknown>).to;
+  if (!isPositiveInteger(from)) return null;
+  return { from, to: isPositiveInteger(to) ? to : from };
+}
+
+function resolveAbsolutePath(metadata: Record<string, unknown>): string | null {
+  const source = typeof metadata.source === 'string' ? metadata.source : null;
+  if (source && path.isAbsolute(source)) return source;
+  const identity = resolveChunkIdentity(metadata);
+  if (identity === null) return null;
+  return path.join(KNOWLEDGE_BASES_ROOT_DIR, identity.knowledgeBase, identity.kbRelativePath);
+}
+
+function normalizePosix(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  if (trimmed === '') return null;
+  return trimmed.split(path.sep).join('/');
+}
+
+function encodeRelativePath(relativePath: string): string {
+  return relativePath
+    .split('/')
+    .map((segment) => encodeURIComponent(segment))
+    .join('/');
+}
+
+function isPositiveInteger(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value > 0;
+}

--- a/src/cli-search.test.ts
+++ b/src/cli-search.test.ts
@@ -5,6 +5,7 @@ import {
   formatAutoModeHeader,
   formatAutoThresholdHeader,
   formatFreshnessFooter,
+  parseSearchArgs,
   resolveAutoSearchMode,
   Staleness,
 } from './cli-search.js';
@@ -132,6 +133,19 @@ describe('lock contention output (issue #181 + #199 unified shape)', () => {
     expect(out).toContain('category: lock');
     expect(out).toContain('Retry in a few seconds');
     expect(out).toContain('/tmp/model/.kb-write.lock');
+  });
+});
+
+describe('parseSearchArgs output format', () => {
+  it('accepts vimgrep as a search output format', () => {
+    expect(parseSearchArgs(['query', '--format=vimgrep'])).toMatchObject({
+      query: 'query',
+      format: 'vimgrep',
+    });
+  });
+
+  it('still rejects unknown output formats', () => {
+    expect(() => parseSearchArgs(['query', '--format=xml'])).toThrow(/invalid --format/);
   });
 });
 

--- a/src/cli-search.ts
+++ b/src/cli-search.ts
@@ -14,11 +14,13 @@ import {
 } from './cli-search-errors.js';
 import {
   FRONTMATTER_EXTRAS_WIRE_VISIBLE,
+  KB_EDITOR_URI,
   KNOWLEDGE_BASES_ROOT_DIR,
 } from './config.js';
 import {
   formatRetrievalAsJson,
   formatRetrievalAsMarkdown,
+  formatRetrievalAsVimgrep,
   formatRetrievalGroupedBySourceAsMarkdown,
   groupRetrievalBySource,
 } from './formatter.js';
@@ -64,7 +66,9 @@ Result tuning:
                         dense + BM25 via reciprocal rank fusion (#206).
 
 Output:
-  --format=md|json      Output format (default: md).
+  --format=md|json|vimgrep
+                        Output format (default: md). vimgrep prints
+                        path:line:col:preview for editor quickfix flows.
   --group-by-source     Collapse repeated chunks from the same source file
                         in markdown output. With \`--format=json\`, adds a
                         \`grouped_results\` field alongside raw results.
@@ -88,6 +92,7 @@ Examples:
 
 export type SearchMode = 'dense' | 'lexical' | 'hybrid' | 'auto';
 export type EffectiveSearchMode = Exclude<SearchMode, 'auto'>;
+type SearchFormat = 'md' | 'json' | 'vimgrep';
 
 interface SearchArgs {
   query: string | null;
@@ -96,7 +101,7 @@ interface SearchArgs {
   threshold?: number;
   thresholdAuto: boolean;
   k: number;
-  format: 'md' | 'json';
+  format: SearchFormat;
   refresh: boolean;
   stdin: boolean;
   groupBySource: boolean;
@@ -255,7 +260,7 @@ export async function runSearch(rest: string[]): Promise<number> {
   if (timing) timing.total_ms = elapsedMs(totalStartedAt);
 
   if (parsed.format === 'json') {
-    const body = formatRetrievalAsJson(results, FRONTMATTER_EXTRAS_WIRE_VISIBLE);
+    const body = formatRetrievalAsJson(results, FRONTMATTER_EXTRAS_WIRE_VISIBLE, KB_EDITOR_URI);
     const effectiveCounts = parsed.refresh
       ? { modifiedFiles: 0, newFiles: 0 }
       : { modifiedFiles: staleness.modifiedFiles, newFiles: staleness.newFiles };
@@ -282,7 +287,7 @@ export async function runSearch(rest: string[]): Promise<number> {
           }
         : {}),
       ...(parsed.groupBySource
-        ? { grouped_results: groupRetrievalBySource(results, FRONTMATTER_EXTRAS_WIRE_VISIBLE) }
+        ? { grouped_results: groupRetrievalBySource(results, FRONTMATTER_EXTRAS_WIRE_VISIBLE, KB_EDITOR_URI) }
         : {}),
       index_mtime: staleness.indexMtime,
       stale: hasStaleCounts(effectiveCounts),
@@ -313,6 +318,9 @@ export async function runSearch(rest: string[]): Promise<number> {
       ...(timing ? { timing: compactTimingPayload(timing) } : {}),
     };
     process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+  } else if (parsed.format === 'vimgrep') {
+    const out = formatRetrievalAsVimgrep(results);
+    if (out !== '') process.stdout.write(`${out}\n`);
   } else {
     if (autoModeDecision !== null) {
       process.stdout.write(formatAutoModeHeader(autoModeDecision));
@@ -323,8 +331,8 @@ export async function runSearch(rest: string[]): Promise<number> {
       process.stdout.write('\n\n');
     }
     const md = parsed.groupBySource
-      ? formatRetrievalGroupedBySourceAsMarkdown(results, FRONTMATTER_EXTRAS_WIRE_VISIBLE)
-      : formatRetrievalAsMarkdown(results, FRONTMATTER_EXTRAS_WIRE_VISIBLE);
+      ? formatRetrievalGroupedBySourceAsMarkdown(results, FRONTMATTER_EXTRAS_WIRE_VISIBLE, KB_EDITOR_URI)
+      : formatRetrievalAsMarkdown(results, FRONTMATTER_EXTRAS_WIRE_VISIBLE, KB_EDITOR_URI);
     process.stdout.write(md);
     process.stdout.write('\n\n');
     process.stdout.write(formatFreshnessFooter(staleness, parsed.refresh));
@@ -338,7 +346,7 @@ export async function runSearch(rest: string[]): Promise<number> {
   return 0;
 }
 
-function parseSearchArgs(rest: string[]): SearchArgs {
+export function parseSearchArgs(rest: string[]): SearchArgs {
   const out: SearchArgs = {
     query: null,
     k: 10,
@@ -378,7 +386,7 @@ function parseSearchArgs(rest: string[]): SearchArgs {
     }
     if (raw.startsWith('--format=')) {
       const v = raw.slice('--format='.length);
-      if (v !== 'md' && v !== 'json') throw new Error(`invalid --format: ${raw}`);
+      if (v !== 'md' && v !== 'json' && v !== 'vimgrep') throw new Error(`invalid --format: ${raw}`);
       out.format = v; continue;
     }
     if (raw.startsWith('--')) throw new Error(`unknown flag: ${raw}`);
@@ -564,7 +572,7 @@ function hasStaleCounts(counts: StalenessCounts): boolean {
   return counts.modifiedFiles + counts.newFiles > 0;
 }
 
-function reportFailure(failure: SearchFailure, format: 'md' | 'json'): number {
+function reportFailure(failure: SearchFailure, format: SearchFormat): number {
   if (format === 'json') {
     process.stdout.write(formatKbSearchFailureJson(failure));
   } else {
@@ -757,7 +765,7 @@ async function runLexicalSearch(
       ...(autoModeDecision
         ? { requested_mode: 'auto' as const, auto_mode: autoModeDecision }
         : {}),
-      results: formatRetrievalAsJson(formatted as never, FRONTMATTER_EXTRAS_WIRE_VISIBLE),
+      results: formatRetrievalAsJson(formatted as never, FRONTMATTER_EXTRAS_WIRE_VISIBLE, KB_EDITOR_URI),
       knowledge_bases: perKb.map((r) => ({
         kb: r.kbName,
         files: r.refreshSummary?.totalFiles ?? null,
@@ -775,6 +783,9 @@ async function runLexicalSearch(
       ...(timing ? { timing: compactTimingPayload(timing) } : {}),
     };
     process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+  } else if (parsed.format === 'vimgrep') {
+    const out = formatRetrievalAsVimgrep(formatted as never);
+    if (out !== '') process.stdout.write(`${out}\n`);
   } else {
     if (autoModeDecision) {
       process.stdout.write(formatAutoModeHeader(autoModeDecision));
@@ -784,7 +795,7 @@ async function runLexicalSearch(
     if (formatted.length === 0) {
       process.stdout.write(`_No matches._\n\n`);
     } else {
-      process.stdout.write(formatRetrievalAsMarkdown(formatted as never, FRONTMATTER_EXTRAS_WIRE_VISIBLE));
+      process.stdout.write(formatRetrievalAsMarkdown(formatted as never, FRONTMATTER_EXTRAS_WIRE_VISIBLE, KB_EDITOR_URI));
       process.stdout.write('\n\n');
     }
     const summaryLines = perKb.map((r) => {
@@ -977,7 +988,7 @@ async function runHybridSearch(
       ...(autoModeDecision
         ? { requested_mode: 'auto' as const, auto_mode: autoModeDecision }
         : {}),
-      results: formatRetrievalAsJson(ranked as never, FRONTMATTER_EXTRAS_WIRE_VISIBLE),
+      results: formatRetrievalAsJson(ranked as never, FRONTMATTER_EXTRAS_WIRE_VISIBLE, KB_EDITOR_URI),
       retrievers: {
         dense: { fetched: denseResults.length, model: activeModelId },
         lexical: { fetched: lexicalResults.length, refreshed: lexicalResultsRow.refreshed, failed: lexicalResultsRow.failed },
@@ -986,6 +997,9 @@ async function runHybridSearch(
       ...(timing ? { timing: compactTimingPayload(timing) } : {}),
     };
     process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+  } else if (parsed.format === 'vimgrep') {
+    const out = formatRetrievalAsVimgrep(ranked as never);
+    if (out !== '') process.stdout.write(`${out}\n`);
   } else {
     if (autoModeDecision) {
       process.stdout.write(formatAutoModeHeader(autoModeDecision));
@@ -995,7 +1009,7 @@ async function runHybridSearch(
     if (ranked.length === 0) {
       process.stdout.write(`_No matches._\n\n`);
     } else {
-      process.stdout.write(formatRetrievalAsMarkdown(ranked as never, FRONTMATTER_EXTRAS_WIRE_VISIBLE));
+      process.stdout.write(formatRetrievalAsMarkdown(ranked as never, FRONTMATTER_EXTRAS_WIRE_VISIBLE, KB_EDITOR_URI));
       process.stdout.write('\n\n');
     }
     process.stdout.write(

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,5 +1,6 @@
 import {
   parseReindexTriggerPollMs,
+  parseKBEditorUri,
   resolveChunkSize,
   resolveIndexingBatchSize,
 } from './config.js';
@@ -130,5 +131,24 @@ describe('parseReindexTriggerPollMs (RFC 011 §5.5)', () => {
   it('rounds fractional in-range values to an integer', () => {
     expect(parseReindexTriggerPollMs('1500.7')).toBe(1501);
     expect(parseReindexTriggerPollMs('59999.4')).toBe(59999);
+  });
+});
+
+describe('parseKBEditorUri (#220 — KB_EDITOR_URI)', () => {
+  it('defaults to none when unset or blank', () => {
+    expect(parseKBEditorUri(undefined)).toBe('none');
+    expect(parseKBEditorUri('')).toBe('none');
+    expect(parseKBEditorUri('  ')).toBe('none');
+  });
+
+  it('accepts supported editor URI modes case-insensitively', () => {
+    expect(parseKBEditorUri('vscode')).toBe('vscode');
+    expect(parseKBEditorUri('Cursor')).toBe('cursor');
+    expect(parseKBEditorUri('FILE')).toBe('file');
+    expect(parseKBEditorUri('none')).toBe('none');
+  });
+
+  it('rejects unsupported modes', () => {
+    expect(() => parseKBEditorUri('vim')).toThrow(/KB_EDITOR_URI/);
   });
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -141,6 +141,23 @@ export const FRONTMATTER_EXTRAS_WIRE_VISIBLE: boolean =
   process.env.FRONTMATTER_EXTRAS_WIRE_VISIBLE === 'true';
 
 // ---------------------------------------------------------------------------
+// Retrieval citation output (#220).
+// ---------------------------------------------------------------------------
+
+export type KBEditorUriMode = 'vscode' | 'cursor' | 'file' | 'none';
+
+export function parseKBEditorUri(raw: string | undefined): KBEditorUriMode {
+  if (raw === undefined || raw.trim() === '') return 'none';
+  const value = raw.trim().toLowerCase();
+  if (value === 'vscode' || value === 'cursor' || value === 'file' || value === 'none') {
+    return value;
+  }
+  throw new Error(`invalid KB_EDITOR_URI=${JSON.stringify(raw)} (expected vscode, cursor, file, or none)`);
+}
+
+export const KB_EDITOR_URI: KBEditorUriMode = parseKBEditorUri(process.env.KB_EDITOR_URI);
+
+// ---------------------------------------------------------------------------
 // Reindex-trigger watcher (RFC 011 §5.5).
 // External workflows (e.g. the arxiv-ingestion n8n flow) signal the server
 // that new content has landed by `touch`ing a dotfile at the KB root. The

--- a/src/formatter.test.ts
+++ b/src/formatter.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from '@jest/globals';
 import {
   formatRetrievalAsJson,
+  formatRetrievalAsVimgrep,
   formatRetrievalGroupedBySourceAsMarkdown,
   formatRetrievalAsMarkdown,
   groupRetrievalBySource,
@@ -73,6 +74,42 @@ describe('formatRetrievalAsMarkdown', () => {
     expect(out).toContain('"source": "kb/doc.md"');
   });
 
+  it('adds a chunk citation link when stable chunk metadata is present', () => {
+    const doc: ScoredDocument = {
+      pageContent: 'sample content',
+      metadata: {
+        source: '/tmp/kbs/alpha/docs/deploy.md',
+        knowledgeBase: 'alpha',
+        relativePath: 'alpha/docs/deploy.md',
+        loc: { lines: { from: 42, to: 58 } },
+        chunkIndex: 0,
+      },
+      score: 0.42,
+    } as unknown as ScoredDocument;
+
+    const out = formatRetrievalAsMarkdown([doc], false, 'none');
+
+    expect(out).toContain('**Source:** [alpha/docs/deploy.md#L42-L58](kb://alpha/docs/deploy.md#L42-L58)');
+    expect(out).not.toContain('**Open:**');
+  });
+
+  it('adds an editor URI only when opted in', () => {
+    const doc: ScoredDocument = {
+      pageContent: 'sample content',
+      metadata: {
+        source: '/tmp/kbs/alpha/docs/deploy.md',
+        knowledgeBase: 'alpha',
+        relativePath: 'alpha/docs/deploy.md',
+        loc: { lines: { from: 42, to: 58 } },
+        chunkIndex: 0,
+      },
+    } as unknown as ScoredDocument;
+
+    const out = formatRetrievalAsMarkdown([doc], false, 'vscode');
+
+    expect(out).toContain('**Open:** vscode://file/tmp/kbs/alpha/docs/deploy.md:42:0');
+  });
+
   it('separates multiple results with --- and numbers them', () => {
     const docs = [sampleDoc, { ...sampleDoc, pageContent: 'second' } as ScoredDocument];
     const out = formatRetrievalAsMarkdown(docs, false);
@@ -109,6 +146,25 @@ describe('formatRetrievalAsJson', () => {
     expect(formatRetrievalAsJson([doc], false)).toEqual([
       { score: 1.5, content: 'c', metadata: { source: 'doc.md' } },
     ]);
+  });
+
+  it('adds chunk_id and opt-in editor_uri as additive result fields', () => {
+    const doc: ScoredDocument = {
+      pageContent: 'c',
+      metadata: {
+        source: '/tmp/kbs/alpha/docs/deploy.md',
+        knowledgeBase: 'alpha',
+        relativePath: 'alpha/docs/deploy.md',
+        loc: { lines: { from: 10, to: 12 } },
+        chunkIndex: 0,
+      },
+      score: 1.5,
+    } as unknown as ScoredDocument;
+
+    expect(formatRetrievalAsJson([doc], false, 'cursor')[0]).toMatchObject({
+      chunk_id: 'alpha/docs/deploy.md#L10-L12',
+      editor_uri: 'cursor://file/tmp/kbs/alpha/docs/deploy.md:10:0',
+    });
   });
 
   it('exposes score as null when missing', () => {
@@ -175,6 +231,27 @@ describe('formatRetrievalAsJson', () => {
 
     expect(out[0]).toEqual({ score: 0.4, content: 'c', metadata: { source: 'doc.md' } });
     expect(out[0].metadata).not.toHaveProperty('frontmatter');
+  });
+});
+
+describe('formatRetrievalAsVimgrep', () => {
+  it('prints path:line:col:preview lines for quickfix consumers', () => {
+    const docs: ScoredDocument[] = [
+      {
+        pageContent: 'Deploy procedure starts here.\nAlways verify pods before continuing.',
+        metadata: {
+          source: '/tmp/kbs/work/runbooks/deploy.md',
+          knowledgeBase: 'work',
+          relativePath: 'work/runbooks/deploy.md',
+          loc: { lines: { from: 42, to: 58 } },
+          chunkIndex: 0,
+        },
+      } as unknown as ScoredDocument,
+    ];
+
+    expect(formatRetrievalAsVimgrep(docs)).toBe(
+      'work/runbooks/deploy.md:42:0:Deploy procedure starts here. Always verify pods before continuing.',
+    );
   });
 });
 

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -4,6 +4,8 @@
 // StdioServerTransport, SseHost, ReindexTriggerWatcher, and zod).
 
 import type { Document } from '@langchain/core/documents';
+import { buildChunkCitation, type ChunkCitation } from './chunk-id.js';
+import { KB_EDITOR_URI, type KBEditorUriMode } from './config.js';
 
 /**
  * Score-bearing search result. Mirrors the shape `FaissIndexManager.similaritySearch`
@@ -17,6 +19,8 @@ export interface RetrievalJsonResult {
   score: number | null;
   content: string;
   metadata: Record<string, unknown>;
+  chunk_id?: string;
+  editor_uri?: string;
 }
 
 export interface GroupedRetrievalChunk extends RetrievalJsonResult {
@@ -66,6 +70,7 @@ export function sanitizeMetadataForWire(
 export function formatRetrievalAsMarkdown(
   results: ScoredDocument[] | null | undefined,
   extrasVisible: boolean,
+  editorUriMode: KBEditorUriMode = KB_EDITOR_URI,
 ): string {
   let formattedResults = '';
   if (results && results.length > 0) {
@@ -77,9 +82,10 @@ export function formatRetrievalAsMarkdown(
           doc.metadata as Record<string, unknown>,
           extrasVisible,
         );
+        const citation = buildChunkCitation(sanitizedMetadata, editorUriMode);
         const metadata = JSON.stringify(sanitizedMetadata, null, 2);
         const scoreText = doc.score !== undefined ? `**Score:** ${doc.score.toFixed(2)}\n\n` : '';
-        return `${resultHeader}\n\n${scoreText}${content}\n\n**Source:**\n\`\`\`json\n${metadata}\n\`\`\``;
+        return `${resultHeader}\n\n${scoreText}${content}\n\n${formatSourceBlock(metadata, citation)}`;
       })
       .join('\n\n---\n\n');
   } else {
@@ -92,8 +98,9 @@ export function formatRetrievalAsMarkdown(
 export function formatRetrievalGroupedBySourceAsMarkdown(
   results: ScoredDocument[] | null | undefined,
   extrasVisible: boolean,
+  editorUriMode: KBEditorUriMode = KB_EDITOR_URI,
 ): string {
-  const grouped = groupRetrievalBySource(results, extrasVisible);
+  const grouped = groupRetrievalBySource(results, extrasVisible, editorUriMode);
   let formattedResults = '';
   if (grouped.length > 0) {
     formattedResults = grouped
@@ -102,7 +109,8 @@ export function formatRetrievalGroupedBySourceAsMarkdown(
           .map((chunk, chunkIdx) => {
             const scoreText = formatScore(chunk.score);
             const locationText = formatLocation(chunk.location);
-            return `${chunkIdx + 1}. **Score:** ${scoreText}\n   **Location:** ${locationText}\n\n   ${indentChunkContent(chunk.content.trim())}`;
+            const openText = chunk.editor_uri ? `\n   **Open:** ${chunk.editor_uri}` : '';
+            return `${chunkIdx + 1}. **Score:** ${scoreText}\n   **Location:** ${locationText}${openText}\n\n   ${indentChunkContent(chunk.content.trim())}`;
           })
           .join('\n\n');
         return (
@@ -128,21 +136,29 @@ export function formatRetrievalGroupedBySourceAsMarkdown(
 export function formatRetrievalAsJson(
   results: ScoredDocument[] | null | undefined,
   extrasVisible: boolean,
+  editorUriMode: KBEditorUriMode = KB_EDITOR_URI,
 ): RetrievalJsonResult[] {
   if (!results || results.length === 0) return [];
-  return results.map((doc) => ({
-    score: doc.score ?? null,
-    content: doc.pageContent,
-    metadata: sanitizeMetadataForWire(
+  return results.map((doc) => {
+    const metadata = sanitizeMetadataForWire(
       doc.metadata as Record<string, unknown>,
       extrasVisible,
-    ),
-  }));
+    );
+    const citation = buildChunkCitation(metadata, editorUriMode);
+    return {
+      score: doc.score ?? null,
+      content: doc.pageContent,
+      metadata,
+      ...(citation ? { chunk_id: citation.chunk_id } : {}),
+      ...(citation?.editor_uri ? { editor_uri: citation.editor_uri } : {}),
+    };
+  });
 }
 
 export function groupRetrievalBySource(
   results: ScoredDocument[] | null | undefined,
   extrasVisible: boolean,
+  editorUriMode: KBEditorUriMode = KB_EDITOR_URI,
 ): GroupedRetrievalSource[] {
   if (!results || results.length === 0) return [];
 
@@ -164,6 +180,7 @@ export function groupRetrievalBySource(
 
     const score = doc.score ?? null;
     const location = getChunkLocation(sanitizedMetadata);
+    const citation = buildChunkCitation(sanitizedMetadata, editorUriMode);
     group.chunk_count += 1;
     group.best_score = bestScore(group.best_score, score);
     group.locations.push({ score, location });
@@ -172,10 +189,27 @@ export function groupRetrievalBySource(
       content: doc.pageContent,
       metadata: sanitizedMetadata,
       location,
+      ...(citation ? { chunk_id: citation.chunk_id } : {}),
+      ...(citation?.editor_uri ? { editor_uri: citation.editor_uri } : {}),
     });
   });
 
   return groups;
+}
+
+export function formatRetrievalAsVimgrep(
+  results: ScoredDocument[] | null | undefined,
+): string {
+  if (!results || results.length === 0) return '';
+  return results
+    .map((doc, idx) => {
+      const metadata = doc.metadata as Record<string, unknown>;
+      const citation = buildChunkCitation(metadata, 'none');
+      const fallbackPath = getSourcePath(metadata, idx);
+      const preview = doc.pageContent.trim().replace(/\s+/g, ' ').slice(0, 80);
+      return `${citation?.path ?? fallbackPath}:${citation?.line ?? 1}:${citation?.column ?? 0}:${preview}`;
+    })
+    .join('\n');
 }
 
 function getSourcePath(metadata: Record<string, unknown>, idx: number): string {
@@ -215,4 +249,12 @@ function formatLocation(location: unknown | null): string {
 function indentChunkContent(content: string): string {
   if (content === '') return '';
   return content.replace(/\n/g, '\n   ');
+}
+
+function formatSourceBlock(metadata: string, citation: ChunkCitation | null): string {
+  if (citation === null) {
+    return `**Source:**\n\`\`\`json\n${metadata}\n\`\`\``;
+  }
+  const openLine = citation.editor_uri ? `\n**Open:** ${citation.editor_uri}` : '';
+  return `**Source:** [${citation.chunk_id}](${citation.resource_uri})${openLine}\n\n\`\`\`json\n${metadata}\n\`\`\``;
 }


### PR DESCRIPTION
## Summary
- add stable per-result chunk_id handles with line-range and chunk-index fallback
- add opt-in KB_EDITOR_URI editor_uri output plus markdown open links
- add kb search --format=vimgrep quickfix output

## Verification
- npm run build
- npm test
- node build/cli.js search "stable chunk citation editor uri vimgrep" --k=1 --format=vimgrep
- KB_EDITOR_URI=vscode node build/cli.js search "stable chunk citation editor uri vimgrep" --k=1 --format=json | rg '"chunk_id"|"editor_uri"'

Closes #220