### PR TITLE
fix: recover stale model add sentinels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@
 
 - **`npm run dev:cli -- <kb args>` runs the TypeScript `kb` CLI source with source maps enabled.** The contributor-only wrapper forwards args to `src/cli.ts` without requiring a build or relink and prints the active `KNOWLEDGE_BASES_ROOT_DIR`, `FAISS_INDEX_PATH`, embedding provider, and embedding model to stderr before execution. Closes #246.
 
+## [Unreleased] — stale model-add recovery
+
+### Added
+
+- **`kb models add --recover --yes` now cleans up stale interrupted model registrations before retrying.** `.adding` sentinels are written as structured metadata with PID-only compatibility for older sentinels. Live writer PIDs still block, dead PIDs are reported as stale/interrupted, malformed sentinel state remains non-destructive, and `kb doctor` warns about stale incomplete model directories with a recovery command. Closes #228.
+
 ## [Unreleased] — atomic EOF appends for `kb remember` and `kb capture`
 
 ### Changed

--- a/src/active-model.test.ts
+++ b/src/active-model.test.ts
@@ -187,6 +187,26 @@ describe('active-model: resolveActiveModel precedence (RFC §4.7)', () => {
     await expect(resolveActiveModel({ explicitOverride: 'ollama__../etc/passwd' }))
       .rejects.toThrow(/Invalid --model/);
   });
+
+  it('active.txt pointing at a stale incomplete model gives the recover command', async () => {
+    jest.resetModules();
+    const { resolveActiveModel } = await import('./active-model.js');
+    const staleId = 'ollama__nomic-embed-text';
+    await fsp.mkdir(path.join(faissDir, 'models', staleId), { recursive: true });
+    await fsp.writeFile(path.join(faissDir, 'active.txt'), staleId);
+    await fsp.writeFile(path.join(faissDir, 'models', staleId, '.adding'), JSON.stringify({
+      schema_version: 'kb.model-adding.v1',
+      model_id: staleId,
+      provider: 'ollama',
+      model_name: 'nomic-embed-text',
+      pid: 999999999,
+      started_at: '2026-05-11T10:00:00.000Z',
+    }));
+
+    await expect(resolveActiveModel()).rejects.toThrow(
+      /kb models add ollama nomic-embed-text --recover --yes/,
+    );
+  });
 });
 
 describe('active-model: isRegisteredModel / listRegisteredModels', () => {
@@ -247,5 +267,69 @@ describe('active-model: isRegisteredModel / listRegisteredModels', () => {
 
     const models = await listRegisteredModels();
     expect(models.map((m) => m.model_id)).toEqual([REGISTERED_ID]);
+  });
+
+  it('writes and reads structured .adding sentinel metadata', async () => {
+    jest.resetModules();
+    const {
+      buildAddingSentinelMetadata,
+      readAddingSentinel,
+      writeAddingSentinel,
+    } = await import('./active-model.js');
+    await fsp.mkdir(path.join(faissDir, 'models', REGISTERED_ID), { recursive: true });
+
+    const metadata = buildAddingSentinelMetadata({
+      modelId: REGISTERED_ID,
+      provider: 'huggingface',
+      modelName: 'BAAI/bge-small-en-v1.5',
+      pid: 123,
+      startedAt: new Date('2026-05-11T10:00:00.000Z'),
+    });
+    await writeAddingSentinel(metadata);
+
+    expect(await readAddingSentinel(REGISTERED_ID)).toMatchObject({
+      kind: 'metadata',
+      metadata,
+    });
+  });
+
+  it('classifies live, dead, legacy PID, and malformed .adding sentinels conservatively', async () => {
+    jest.resetModules();
+    const {
+      buildAddingSentinelMetadata,
+      classifyIncompleteModelState,
+      writeAddingSentinel,
+    } = await import('./active-model.js');
+
+    await fsp.mkdir(path.join(faissDir, 'models', REGISTERED_ID), { recursive: true });
+    await writeAddingSentinel(buildAddingSentinelMetadata({
+      modelId: REGISTERED_ID,
+      provider: 'huggingface',
+      modelName: 'BAAI/bge-small-en-v1.5',
+      pid: 123,
+      startedAt: new Date('2026-05-11T10:00:00.000Z'),
+    }));
+    await expect(classifyIncompleteModelState(REGISTERED_ID, () => true))
+      .resolves.toMatchObject({ status: 'in_progress', pid: 123, recovery_command: null });
+    await expect(classifyIncompleteModelState(REGISTERED_ID, () => false))
+      .resolves.toMatchObject({
+        status: 'stale_interrupted',
+        pid: 123,
+        provider: 'huggingface',
+        model_name: 'BAAI/bge-small-en-v1.5',
+        recovery_command: 'kb models add huggingface BAAI/bge-small-en-v1.5 --recover --yes',
+      });
+
+    const legacyId = 'ollama__nomic-embed-text';
+    await fsp.mkdir(path.join(faissDir, 'models', legacyId), { recursive: true });
+    await fsp.writeFile(path.join(faissDir, 'models', legacyId, '.adding'), '456\n');
+    await expect(classifyIncompleteModelState(legacyId, () => false))
+      .resolves.toMatchObject({ status: 'stale_interrupted', pid: 456, provider: 'ollama' });
+
+    const malformedId = 'openai__text-embedding-3-small';
+    await fsp.mkdir(path.join(faissDir, 'models', malformedId), { recursive: true });
+    await fsp.writeFile(path.join(faissDir, 'models', malformedId, '.adding'), '{not-json');
+    await expect(classifyIncompleteModelState(malformedId, () => false))
+      .resolves.toMatchObject({ status: 'unknown', pid: null, recovery_command: null });
   });
 });

--- a/src/active-model.ts
+++ b/src/active-model.ts
@@ -91,6 +91,219 @@ export function addingSentinelPath(modelId: string): string {
 }
 
 // ---------------------------------------------------------------------------
+// `.adding` sentinel — structured metadata with PID-only backward compatibility.
+// ---------------------------------------------------------------------------
+
+export const ADDING_SENTINEL_SCHEMA_VERSION = 'kb.model-adding.v1';
+
+export interface AddingSentinelMetadata {
+  schema_version: typeof ADDING_SENTINEL_SCHEMA_VERSION;
+  model_id: string;
+  provider: EmbeddingProvider;
+  model_name: string;
+  pid: number;
+  started_at: string;
+}
+
+export type AddingSentinelReadResult =
+  | { kind: 'missing' }
+  | { kind: 'legacy-pid'; pid: number; raw: string }
+  | { kind: 'metadata'; metadata: AddingSentinelMetadata; raw: string }
+  | { kind: 'unknown'; raw: string; detail: string };
+
+export type IncompleteModelStatus = 'in_progress' | 'stale_interrupted' | 'unknown';
+
+export interface IncompleteModelState {
+  model_id: string;
+  status: IncompleteModelStatus;
+  detail: string;
+  pid: number | null;
+  provider: string | null;
+  model_name: string | null;
+  started_at: string | null;
+  recovery_command: string | null;
+}
+
+type PidLivenessCheck = (pid: number) => boolean;
+
+export function buildAddingSentinelMetadata(args: {
+  modelId: string;
+  provider: EmbeddingProvider;
+  modelName: string;
+  pid?: number;
+  startedAt?: Date;
+}): AddingSentinelMetadata {
+  return {
+    schema_version: ADDING_SENTINEL_SCHEMA_VERSION,
+    model_id: args.modelId,
+    provider: args.provider,
+    model_name: args.modelName,
+    pid: args.pid ?? process.pid,
+    started_at: (args.startedAt ?? new Date()).toISOString(),
+  };
+}
+
+export async function writeAddingSentinel(metadata: AddingSentinelMetadata): Promise<void> {
+  await fsp.writeFile(
+    addingSentinelPath(metadata.model_id),
+    `${JSON.stringify(metadata, null, 2)}\n`,
+    'utf-8',
+  );
+}
+
+export async function readAddingSentinel(modelId: string): Promise<AddingSentinelReadResult> {
+  let raw: string;
+  try {
+    raw = await fsp.readFile(addingSentinelPath(modelId), 'utf-8');
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return { kind: 'missing' };
+    throw err;
+  }
+
+  const trimmed = raw.trim();
+  if (/^\d+$/.test(trimmed)) {
+    const pid = Number(trimmed);
+    if (Number.isSafeInteger(pid) && pid > 0) {
+      return { kind: 'legacy-pid', pid, raw };
+    }
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return { kind: 'unknown', raw, detail: 'sentinel is neither PID-only text nor valid JSON metadata' };
+  }
+
+  if (!isAddingSentinelMetadata(parsed)) {
+    return { kind: 'unknown', raw, detail: 'sentinel JSON does not match kb.model-adding.v1 metadata' };
+  }
+  if (parsed.model_id !== modelId) {
+    return {
+      kind: 'unknown',
+      raw,
+      detail: `sentinel model_id "${parsed.model_id}" does not match directory "${modelId}"`,
+    };
+  }
+  return { kind: 'metadata', metadata: parsed, raw };
+}
+
+export async function classifyIncompleteModelState(
+  modelId: string,
+  pidIsLive: PidLivenessCheck = isPidLive,
+): Promise<IncompleteModelState | null> {
+  if (!isValidModelId(modelId)) return null;
+  const dir = modelDir(modelId);
+  try {
+    const st = await fsp.stat(dir);
+    if (!st.isDirectory()) return null;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null;
+    throw err;
+  }
+
+  const sentinel = await readAddingSentinel(modelId);
+  if (sentinel.kind === 'metadata' || sentinel.kind === 'legacy-pid') {
+    const pid = sentinel.kind === 'metadata' ? sentinel.metadata.pid : sentinel.pid;
+    const provider = sentinel.kind === 'metadata' ? sentinel.metadata.provider : parseModelId(modelId).provider;
+    const modelName = sentinel.kind === 'metadata' ? sentinel.metadata.model_name : await readStoredModelName(modelId);
+    const startedAt = sentinel.kind === 'metadata' ? sentinel.metadata.started_at : null;
+    if (pidIsLive(pid)) {
+      return {
+        model_id: modelId,
+        status: 'in_progress',
+        detail: `kb models add is still running with pid ${pid}`,
+        pid,
+        provider,
+        model_name: modelName,
+        started_at: startedAt,
+        recovery_command: null,
+      };
+    }
+    return {
+      model_id: modelId,
+      status: 'stale_interrupted',
+      detail: `previous kb models add writer pid ${pid} is no longer running`,
+      pid,
+      provider,
+      model_name: modelName,
+      started_at: startedAt,
+      recovery_command: modelName === null ? null : `kb models add ${provider} ${modelName} --recover --yes`,
+    };
+  }
+
+  if (sentinel.kind === 'unknown') {
+    return {
+      model_id: modelId,
+      status: 'unknown',
+      detail: sentinel.detail,
+      pid: null,
+      provider: null,
+      model_name: null,
+      started_at: null,
+      recovery_command: null,
+    };
+  }
+
+  if (await isRegisteredModel(modelId)) return null;
+  return {
+    model_id: modelId,
+    status: 'unknown',
+    detail: 'model directory is incomplete and has no .adding sentinel',
+    pid: null,
+    provider: null,
+    model_name: await readStoredModelName(modelId),
+    started_at: null,
+    recovery_command: null,
+  };
+}
+
+export async function listIncompleteModelStates(): Promise<IncompleteModelState[]> {
+  let entries: string[];
+  try {
+    entries = await fsp.readdir(MODELS_DIR);
+  } catch {
+    return [];
+  }
+  const states: IncompleteModelState[] = [];
+  for (const entry of entries) {
+    if (!isValidModelId(entry)) continue;
+    const state = await classifyIncompleteModelState(entry);
+    if (state !== null) states.push(state);
+  }
+  return states.sort((a, b) => a.model_id.localeCompare(b.model_id));
+}
+
+function isAddingSentinelMetadata(value: unknown): value is AddingSentinelMetadata {
+  if (value === null || typeof value !== 'object') return false;
+  const candidate = value as Partial<AddingSentinelMetadata>;
+  return candidate.schema_version === ADDING_SENTINEL_SCHEMA_VERSION
+    && typeof candidate.model_id === 'string'
+    && isValidModelId(candidate.model_id)
+    && isEmbeddingProvider(candidate.provider)
+    && typeof candidate.model_name === 'string'
+    && candidate.model_name.trim().length > 0
+    && Number.isSafeInteger(candidate.pid)
+    && typeof candidate.pid === 'number'
+    && candidate.pid > 0
+    && typeof candidate.started_at === 'string'
+    && !Number.isNaN(Date.parse(candidate.started_at));
+}
+
+function isEmbeddingProvider(value: unknown): value is EmbeddingProvider {
+  return value === 'ollama' || value === 'openai' || value === 'huggingface';
+}
+
+function isPidLive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === 'EPERM';
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Read helpers.
 // ---------------------------------------------------------------------------
 
@@ -279,7 +492,7 @@ export async function resolveActiveModel(opts: ResolveOptions = {}): Promise<str
       const available = (await listRegisteredModels()).map((m) => m.model_id).join(', ') || '<none>';
       throw new ActiveModelResolutionError(
         `Model "${id}" is not registered. Registered: ${available}. ` +
-        `Run \`kb models add <provider> <model>\` to register it first.`,
+        (await unregisteredModelHint(id)),
       );
     }
     return id;
@@ -297,7 +510,8 @@ export async function resolveActiveModel(opts: ResolveOptions = {}): Promise<str
     if (!(await isRegisteredModel(id))) {
       const available = (await listRegisteredModels()).map((m) => m.model_id).join(', ') || '<none>';
       throw new ActiveModelResolutionError(
-        `KB_ACTIVE_MODEL="${id}" is not registered. Registered: ${available}.`,
+        `KB_ACTIVE_MODEL="${id}" is not registered. Registered: ${available}. ` +
+        (await unregisteredModelHint(id)),
       );
     }
     return id;
@@ -317,8 +531,8 @@ export async function resolveActiveModel(opts: ResolveOptions = {}): Promise<str
     if (!(await isRegisteredModel(r.modelId!))) {
       throw new ActiveModelResolutionError(
         `active.txt names model "${r.modelId}" but it is not registered on disk. ` +
-        `Run \`kb models set-active <other>\` to point at a registered model, or remove the .adding sentinel ` +
-        `if a previous \`kb models add\` was interrupted.`,
+        `Run \`kb models set-active <other>\` to point at a registered model. ` +
+        (await unregisteredModelHint(r.modelId!)),
       );
     }
     return r.modelId!;
@@ -334,6 +548,20 @@ export async function resolveActiveModel(opts: ResolveOptions = {}): Promise<str
     );
   }
   return envId;
+}
+
+async function unregisteredModelHint(modelId: string): Promise<string> {
+  const incomplete = await classifyIncompleteModelState(modelId);
+  if (incomplete === null) {
+    return 'Run `kb models add <provider> <model>` to register it first.';
+  }
+  if (incomplete.status === 'in_progress') {
+    return `A \`kb models add\` is still in progress for this model (${incomplete.detail}); wait for it to finish.`;
+  }
+  if (incomplete.status === 'stale_interrupted' && incomplete.recovery_command !== null) {
+    return `A previous \`kb models add\` appears stale/interrupted (${incomplete.detail}); run \`${incomplete.recovery_command}\` to clean up and retry.`;
+  }
+  return `Incomplete model state exists but is not safe to recover automatically (${incomplete.detail}); inspect ${modelDir(modelId)}.`;
 }
 
 export interface LegacyEnvModelSpec {

--- a/src/cli-doctor.test.ts
+++ b/src/cli-doctor.test.ts
@@ -124,6 +124,7 @@ describe('kb doctor', () => {
       expect(report.cli.symlinked_checkout_path).toBe(tempDir);
       expect(report.stale_counts_by_kb.alpha).toEqual({ modified_files: 1, new_files: 0 });
       expect(report.stale_counts_by_kb.beta).toEqual({ modified_files: 0, new_files: 1 });
+      expect(report.incomplete_models).toEqual([]);
 
       const markdown = formatDoctorMarkdown(report);
       expect(markdown).toContain('Status: WARN');
@@ -131,10 +132,63 @@ describe('kb doctor', () => {
       expect(markdown).toContain('Last index update: success (global, 1000ms, 1 changed, 1 unchanged, 0 skipped)');
       expect(markdown).toContain('alpha: 1 modified, 0 new');
       expect(markdown).toContain('beta: 0 modified, 1 new');
+      expect(markdown).toContain('Incomplete model dirs:\n  (none)');
 
       const json = JSON.parse(JSON.stringify(report)) as typeof report;
       expect(json.stale_counts_by_kb.alpha.modified_files).toBe(1);
       expect(json.last_index_update.saved).toBe(true);
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('warns about stale incomplete model directories', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-doctor-incomplete-'));
+    try {
+      const rootDir = path.join(tempDir, 'kbs');
+      const faissDir = path.join(tempDir, '.faiss');
+      await fsp.mkdir(path.join(rootDir, 'alpha'), { recursive: true });
+      const staleId = 'ollama__nomic-embed-text';
+      await seedRegisteredModel(faissDir);
+      await fsp.mkdir(path.join(faissDir, 'models', staleId), { recursive: true });
+      await fsp.writeFile(path.join(faissDir, 'models', staleId, '.adding'), JSON.stringify({
+        schema_version: 'kb.model-adding.v1',
+        model_id: staleId,
+        provider: 'ollama',
+        model_name: 'nomic-embed-text',
+        pid: 999999999,
+        started_at: '2026-05-11T10:00:00.000Z',
+      }));
+
+      const { buildDoctorReport, formatDoctorMarkdown } = await freshDoctor({
+        KNOWLEDGE_BASES_ROOT_DIR: rootDir,
+        FAISS_INDEX_PATH: faissDir,
+        EMBEDDING_PROVIDER: 'huggingface',
+        HUGGINGFACE_MODEL_NAME: MODEL_NAME,
+        HUGGINGFACE_API_KEY: 'test-key',
+      });
+
+      const report = await buildDoctorReport({
+        backendHealthCheck: async () => ({ healthy: true, detail: 'backend ok' }),
+        packageRoot: tempDir,
+        invokedPath: null,
+        packageVersion: '9.9.9',
+      });
+
+      expect(report.checks).toContainEqual({
+        name: 'incomplete_models',
+        status: 'warn',
+        detail: '1 stale incomplete model directory detected',
+      });
+      expect(report.incomplete_models).toEqual([expect.objectContaining({
+        model_id: staleId,
+        status: 'stale_interrupted',
+        pid: 999999999,
+        recovery_command: 'kb models add ollama nomic-embed-text --recover --yes',
+      })]);
+      expect(formatDoctorMarkdown(report)).toContain(
+        `stale_interrupted ${staleId}: previous kb models add writer pid 999999999 is no longer running`,
+      );
     } finally {
       await fsp.rm(tempDir, { recursive: true, force: true });
     }

--- a/src/cli-doctor.ts
+++ b/src/cli-doctor.ts
@@ -10,6 +10,7 @@ import { execFile } from 'child_process';
 import { promisify } from 'util';
 import {
   ActiveModelResolutionError,
+  listIncompleteModelStates,
   listRegisteredModels,
   parseModelId,
   resolveActiveModel,
@@ -78,6 +79,16 @@ export interface DoctorReport {
     mtime: string | null;
   };
   stale_counts_by_kb: Record<string, { modified_files: number; new_files: number }>;
+  incomplete_models: Array<{
+    model_id: string;
+    status: 'in_progress' | 'stale_interrupted' | 'unknown';
+    detail: string;
+    pid: number | null;
+    provider: string | null;
+    model_name: string | null;
+    started_at: string | null;
+    recovery_command: string | null;
+  }>;
   backend: {
     provider: string | null;
     healthy: boolean;
@@ -196,6 +207,16 @@ export async function buildDoctorReport(
       : `${staleTotal} modified/new ingestable file(s) detected`,
   });
 
+  const incompleteModels = await listIncompleteModelStates();
+  const staleIncompleteModels = incompleteModels.filter((m) => m.status === 'stale_interrupted');
+  checks.push({
+    name: 'incomplete_models',
+    status: staleIncompleteModels.length > 0 ? 'warn' : 'ok',
+    detail: staleIncompleteModels.length === 0
+      ? 'no stale incomplete model directories detected'
+      : `${staleIncompleteModels.length} stale incomplete model director${staleIncompleteModels.length === 1 ? 'y' : 'ies'} detected`,
+  });
+
   const backend = await readBackendHealth(
     activeProvider,
     activeModelName,
@@ -230,6 +251,7 @@ export async function buildDoctorReport(
     },
     index,
     stale_counts_by_kb: staleCounts,
+    incomplete_models: incompleteModels,
     backend,
     cli,
     git,
@@ -490,6 +512,16 @@ export function formatDoctorMarkdown(report: DoctorReport): string {
     for (const name of names) {
       const row = report.stale_counts_by_kb[name];
       lines.push(`  ${name}: ${row.modified_files} modified, ${row.new_files} new`);
+    }
+  }
+  lines.push('');
+  lines.push('Incomplete model dirs:');
+  if (report.incomplete_models.length === 0) {
+    lines.push('  (none)');
+  } else {
+    for (const model of report.incomplete_models) {
+      const recovery = model.recovery_command === null ? '' : `; recovery: ${model.recovery_command}`;
+      lines.push(`  ${model.status} ${model.model_id}: ${model.detail}${recovery}`);
     }
   }
   lines.push('');

--- a/src/cli-models.ts
+++ b/src/cli-models.ts
@@ -3,11 +3,14 @@ import { FaissIndexManager } from './FaissIndexManager.js';
 import {
   ActiveModelResolutionError,
   addingSentinelPath,
+  buildAddingSentinelMetadata,
+  classifyIncompleteModelState,
   isRegisteredModel,
   listRegisteredModels,
   modelDir,
   parseModelId,
   resolveActiveModel,
+  writeAddingSentinel,
   writeActiveModelAtomic,
 } from './active-model.js';
 import { deriveModelId, type EmbeddingProvider } from './model-id.js';
@@ -21,7 +24,7 @@ export const MODELS_HELP = `kb models — manage embedding models (RFC 013)
 
 Usage:
   kb models list
-  kb models add <provider> <model> [--yes] [--dry-run]
+  kb models add <provider> <model> [--yes] [--dry-run] [--recover]
   kb models set-active <id>
   kb models remove <id>
 
@@ -51,6 +54,9 @@ Verbs:
 Options for \`add\`:
   --yes                 Skip the cost-estimate confirmation prompt.
   --dry-run             Print the cost estimate; don't embed.
+  --recover             When a previous add left a stale .adding sentinel
+                        whose writer PID is dead, delete that incomplete
+                        model directory before retrying. Requires --yes.
 
 Global:
   --help, -h            Show this help.
@@ -120,9 +126,11 @@ async function runModelsAdd(rest: string[]): Promise<number> {
   const positionals: string[] = [];
   let yes = false;
   let dryRun = false;
+  let recover = false;
   for (const raw of rest) {
     if (raw === '--yes') { yes = true; continue; }
     if (raw === '--dry-run') { dryRun = true; continue; }
+    if (raw === '--recover') { recover = true; continue; }
     if (raw.startsWith('--')) {
       process.stderr.write(`kb models add: unknown flag: ${raw}\n`);
       return 2;
@@ -155,12 +163,26 @@ async function runModelsAdd(rest: string[]): Promise<number> {
     );
     return 2;
   }
-  if (await pathExists(addingSentinelPath(modelId))) {
-    process.stderr.write(
-      `kb models add: previous \`kb models add ${modelId}\` was interrupted (.adding sentinel present). ` +
-      `Run \`kb models remove ${modelId} --force-incomplete\` to clean up, then retry.\n`,
-    );
-    return 2;
+  const incomplete = await classifyIncompleteModelState(modelId);
+  if (incomplete !== null) {
+    if (incomplete.status === 'stale_interrupted' && recover) {
+      if (dryRun) {
+        process.stderr.write('kb models add: --recover cannot be combined with --dry-run because recovery deletes incomplete state.\n');
+        return 2;
+      }
+      if (!yes) {
+        process.stderr.write(
+          `kb models add: stale incomplete model "${modelId}" found, but recovery deletes ${modelDir(modelId)}. ` +
+          `Pass both --recover and --yes to clean up and retry.\n`,
+        );
+        return 2;
+      }
+      await fsp.rm(modelDir(modelId), { recursive: true, force: true });
+      process.stderr.write(`Recovered stale incomplete model "${modelId}" (${incomplete.detail}); retrying add.\n`);
+    } else {
+      process.stderr.write(formatIncompleteAddBlock(modelId, incomplete.status, incomplete.detail));
+      return 2;
+    }
   }
 
   let totalBytes = 0;
@@ -223,7 +245,11 @@ async function runModelsAdd(rest: string[]): Promise<number> {
 
   await fsp.mkdir(modelDir(modelId), { recursive: true });
   const sentinel = addingSentinelPath(modelId);
-  await fsp.writeFile(sentinel, `${process.pid}\n`, 'utf-8');
+  await writeAddingSentinel(buildAddingSentinelMetadata({
+    modelId,
+    provider: provider as EmbeddingProvider,
+    modelName,
+  }));
   let interrupted = false;
   try {
     await withWriteLock(modelDir(modelId), async () => {
@@ -258,6 +284,23 @@ async function runModelsAdd(rest: string[]): Promise<number> {
 
   process.stderr.write(`Successfully added ${modelId}.\n`);
   return 0;
+}
+
+function formatIncompleteAddBlock(modelId: string, status: string, detail: string): string {
+  if (status === 'in_progress') {
+    return `kb models add: model "${modelId}" is already being added (${detail}). Wait for it to finish before retrying.\n`;
+  }
+  if (status === 'stale_interrupted') {
+    return (
+      `kb models add: previous add for "${modelId}" appears stale/interrupted (${detail}). ` +
+      `Pass --recover --yes to delete the incomplete model directory and retry, or run ` +
+      `\`kb models remove ${modelId} --force-incomplete --yes\` to clean up manually.\n`
+    );
+  }
+  return (
+    `kb models add: model "${modelId}" has incomplete state that cannot be recovered automatically (${detail}). ` +
+    `Inspect ${modelDir(modelId)} or run \`kb models remove ${modelId} --force-incomplete --yes\` if you intend to delete it.\n`
+  );
 }
 
 async function runModelsSetActive(rest: string[]): Promise<number> {

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1554,6 +1554,127 @@ describe('kb search — active-model resolution (RFC 013 §4.7)', () => {
     }
   });
 
+  it('kb models add blocks while a live .adding writer PID still exists', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-cli-add-live-'));
+    try {
+      const faissDir = path.join(tempDir, '.faiss');
+      const kbDir = path.join(tempDir, 'kb');
+      const id = 'ollama__nomic-embed-text';
+      await fsp.mkdir(path.join(kbDir, 'sample'), { recursive: true });
+      await fsp.mkdir(path.join(faissDir, 'models', id), { recursive: true });
+      await fsp.writeFile(path.join(faissDir, 'models', id, '.adding'), `${process.pid}\n`);
+
+      const r = runCli(['models', 'add', 'ollama', 'nomic-embed-text', '--dry-run'], {
+        KNOWLEDGE_BASES_ROOT_DIR: kbDir,
+        FAISS_INDEX_PATH: faissDir,
+        EMBEDDING_PROVIDER: 'ollama',
+        OLLAMA_MODEL: 'nomic-embed-text',
+      });
+      expect(r.code).toBe(2);
+      expect(r.stderr).toContain('already being added');
+      expect(r.stderr).toContain(`pid ${process.pid}`);
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('kb models add reports stale .adding sentinels but requires --recover and --yes before cleanup', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-cli-add-stale-gate-'));
+    try {
+      const faissDir = path.join(tempDir, '.faiss');
+      const kbDir = path.join(tempDir, 'kb');
+      const id = 'ollama__nomic-embed-text';
+      await fsp.mkdir(path.join(kbDir, 'sample'), { recursive: true });
+      await fsp.mkdir(path.join(faissDir, 'models', id), { recursive: true });
+      await fsp.writeFile(path.join(faissDir, 'models', id, '.adding'), '999999999\n');
+
+      const withoutRecover = runCli(['models', 'add', 'ollama', 'nomic-embed-text', '--yes'], {
+        KNOWLEDGE_BASES_ROOT_DIR: kbDir,
+        FAISS_INDEX_PATH: faissDir,
+        EMBEDDING_PROVIDER: 'ollama',
+        OLLAMA_MODEL: 'nomic-embed-text',
+      });
+      expect(withoutRecover.code).toBe(2);
+      expect(withoutRecover.stderr).toContain('stale/interrupted');
+      expect(withoutRecover.stderr).toContain('--recover --yes');
+
+      const withoutYes = runCli(['models', 'add', 'ollama', 'nomic-embed-text', '--recover'], {
+        KNOWLEDGE_BASES_ROOT_DIR: kbDir,
+        FAISS_INDEX_PATH: faissDir,
+        EMBEDDING_PROVIDER: 'ollama',
+        OLLAMA_MODEL: 'nomic-embed-text',
+      });
+      expect(withoutYes.code).toBe(2);
+      expect(withoutYes.stderr).toContain('Pass both --recover and --yes');
+      await expect(fsp.access(path.join(faissDir, 'models', id, '.adding'))).resolves.toBeUndefined();
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('kb models add refuses --recover for malformed .adding sentinels', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-cli-add-malformed-'));
+    try {
+      const faissDir = path.join(tempDir, '.faiss');
+      const kbDir = path.join(tempDir, 'kb');
+      const id = 'ollama__nomic-embed-text';
+      await fsp.mkdir(path.join(kbDir, 'sample'), { recursive: true });
+      await fsp.mkdir(path.join(faissDir, 'models', id), { recursive: true });
+      await fsp.writeFile(path.join(faissDir, 'models', id, '.adding'), '{not-json');
+
+      const r = runCli(['models', 'add', 'ollama', 'nomic-embed-text', '--recover', '--yes'], {
+        KNOWLEDGE_BASES_ROOT_DIR: kbDir,
+        FAISS_INDEX_PATH: faissDir,
+        EMBEDDING_PROVIDER: 'ollama',
+        OLLAMA_MODEL: 'nomic-embed-text',
+      });
+      expect(r.code).toBe(2);
+      expect(r.stderr).toContain('cannot be recovered automatically');
+      await expect(fsp.readFile(path.join(faissDir, 'models', id, '.adding'), 'utf-8'))
+        .resolves.toBe('{not-json');
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('kb models add --recover --yes deletes a stale incomplete dir before retrying', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-cli-add-recover-'));
+    try {
+      const faissDir = path.join(tempDir, '.faiss');
+      const kbDir = path.join(tempDir, 'kb');
+      const id = 'ollama__nomic-embed-text';
+      await fsp.mkdir(kbDir, { recursive: true });
+      await fsp.mkdir(path.join(faissDir, 'models', id), { recursive: true });
+      await fsp.writeFile(path.join(faissDir, 'models', id, '.adding'), JSON.stringify({
+        schema_version: 'kb.model-adding.v1',
+        model_id: id,
+        provider: 'ollama',
+        model_name: 'nomic-embed-text',
+        pid: 999999999,
+        started_at: '2026-05-11T10:00:00.000Z',
+      }));
+      await fsp.writeFile(path.join(faissDir, 'models', id, 'old-partial-file'), 'old');
+
+      const r = runCli(['models', 'add', 'ollama', 'nomic-embed-text', '--recover', '--yes'], {
+        KNOWLEDGE_BASES_ROOT_DIR: kbDir,
+        FAISS_INDEX_PATH: faissDir,
+        EMBEDDING_PROVIDER: 'ollama',
+        OLLAMA_MODEL: 'nomic-embed-text',
+      });
+      expect(r.code).toBe(0);
+      expect(r.stderr).toContain('Recovered stale incomplete model');
+      expect(r.stderr).toContain(`Successfully added ${id}`);
+      await expect(fsp.access(path.join(faissDir, 'models', id, 'old-partial-file')))
+        .rejects.toMatchObject({ code: 'ENOENT' });
+      await expect(fsp.access(path.join(faissDir, 'models', id, '.adding')))
+        .rejects.toMatchObject({ code: 'ENOENT' });
+      await expect(fsp.readFile(path.join(faissDir, 'models', id, 'model_name.txt'), 'utf-8'))
+        .resolves.toBe('nomic-embed-text');
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it('kb models set-active exits 2 for non-registered model_id', async () => {
     const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-cli-setactive-bad-'));
     try {


### PR DESCRIPTION
## Summary

- write structured `.adding` metadata while preserving legacy PID-only sentinels
- classify incomplete model dirs as live, stale/interrupted, or unknown and gate destructive retry behind `kb models add --recover --yes`
- surface stale incomplete model dirs in `kb doctor` and improve active-model recovery hints

Closes #228.

## Verification

- Reproduced the stale-sentinel path in CLI coverage by seeding an incomplete `models/<id>/.adding` with a dead writer PID. Without `--recover --yes`, `kb models add` exits 2 and leaves the sentinel intact.
- Verified the fix with `kb models add <provider> <model> --recover --yes`: it deletes the stale incomplete directory, retries registration, removes `.adding` on success, and writes `model_name.txt`.
- Verified live writer PIDs still block, malformed `.adding` remains non-destructive, active-model errors include the recovery command when safe, and `kb doctor` reports stale incomplete model dirs.

## Tests

- `npm run build`
- `npm test -- --runTestsByPath src/active-model.test.ts src/cli-doctor.test.ts src/cli.test.ts`
- `npm test` (41 suites, 709 tests)

## Pre-PR checklist

- Project type: npm
- Build: passed
- Tests: passed
- Diff review: done
- Portability: clean by manual changed-line scan; `scripts/check-portability.sh` is not present in this repo
- Reviewer specialists: skipped due session policy forbidding unsolicited subagents; direct diff review performed
