### PR TITLE
chore: remove issue 220 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Changelog
 
-## [Unreleased] — stable chunk citation handles
-
-### Added
-
-- **`kb search` and `retrieve_knowledge` now surface stable chunk handles.** Results with KB/path/line metadata expose `chunk_id` values like `alpha/docs/deploy.md#L42-L78`, falling back to `#chunk-N` when line ranges are absent. `KB_EDITOR_URI=vscode|cursor|file|none` controls opt-in absolute-path `editor_uri` output; the default `none` keeps local paths hidden. `kb search --format=vimgrep` prints `path:line:col:preview` quickfix lines. Closes #220.
-
 ## [Unreleased] — source-mapped `kb` CLI dev runner
 
 ### Added


### PR DESCRIPTION
## Summary
- remove the CHANGELOG.md entry introduced by PR #260 for issue #220
- leave the issue #220 implementation unchanged

## Verification
- npm run build
- npx jest src/chunk-id.test.ts src/formatter.test.ts src/cli-search.test.ts src/config.test.ts --runInBand
- npm install (to sync current main's dev dependencies in this worktree)
- npm test

Follow-up to #260.