### PR TITLE
docs(architecture): refresh data + threat models for current shipped surfaces

### DIFF
--- a/docs/architecture/data-model.md
+++ b/docs/architecture/data-model.md
@@ -131,3 +131,14 @@ For markdown chunks only, `detectSiblingPdfPath` looks for a same-stem PDF in th
 - Query text is not written to disk by the retrieval path; it flows to the embedding provider for the request and then is discarded.
 - Embedding provider keys (`HUGGINGFACE_API_KEY`, `OPENAI_API_KEY`) are held in `process.env` for the life of the process. They are not written to sidecars, model registry files, or FAISS docstore metadata.
 - There is no cache, queue, or scratch directory outside `$KNOWLEDGE_BASES_ROOT_DIR` and `$FAISS_INDEX_PATH`.
+
+## Checked against
+
+This page is verified against the following source files. If one of these files moves or its cited lines drift, refresh this doc rather than letting the claim go stale.
+
+- Chunk metadata wire shape: `src/file-ingest.ts:37-104`.
+- Frontmatter whitelist + sanitisation: `src/frontmatter-lift.ts:19-218`, `src/formatter.ts:34-90`.
+- Atomic FAISS save / pinned load: `src/faiss-store-layout.ts:58-179`.
+- Sidecar write path: `src/file-ingest.ts:118-144`, `src/FaissIndexManager.ts:782-793`.
+- Active-model resolution: `src/active-model.ts:5-26`, `:259-330`.
+- Per-model directory and `model_name.txt`: `src/active-model.ts:107-127`, `src/FaissIndexManager.ts:327-334`.

--- a/docs/architecture/threat-model.md
+++ b/docs/architecture/threat-model.md
@@ -2,7 +2,7 @@
 
 This page captures the security posture of the server **as it is today** — what we trust, what we don't, and where the sharp edges are. It covers both open issues it is filed under ([#43](https://github.com/jeanibarz/knowledge-base-mcp-server/issues/43) and [#44](https://github.com/jeanibarz/knowledge-base-mcp-server/issues/44)) and a small number of additional concerns that arose while documenting them.
 
-The server is designed to run as a **local tool**: one user, one machine, one trusted terminal. It has no authentication layer because MCP stdio transport inherits the launching user's permissions (`src/KnowledgeBaseServer.ts:126-127`). The threat model below assumes that baseline.
+The server is designed to run as a **local tool**: one user, one machine, one trusted terminal. The default MCP `stdio` transport has no authentication layer because it inherits the launching user's permissions. The opt-in `MCP_TRANSPORT=sse` and `MCP_TRANSPORT=http` modes are guarded by a bearer token, an origin allow-list, and a loopback bind by default — see §8 below. The threat model below assumes the local-tool baseline unless an item explicitly calls out remote transport.
 
 ## Trust boundaries at a glance
 
@@ -10,8 +10,10 @@ The server is designed to run as a **local tool**: one user, one machine, one tr
 | --------------------------------------- | ------------------------------------ | ------------------------------------------------------------ |
 | `$FAISS_INDEX_PATH`                     | Arbitrary code execution             | Everyone with write access to this directory.                |
 | `$KNOWLEDGE_BASES_ROOT_DIR`             | Prompt-injection of downstream agent | Everyone who can author files here.                          |
+| KB-relative paths from MCP write tools / `kb://` resources | Path traversal out of `$KNOWLEDGE_BASES_ROOT_DIR` | The MCP client (paths are validated server-side, see §5). |
 | Embedding-provider network path         | Data confidentiality                 | The configured provider + the transport network.             |
-| Process-to-process concurrency          | Index corruption                     | The operator (to run only one process per index).            |
+| Process-to-process concurrency          | Index corruption                     | The per-model write lock + atomic save (no operator action required, see §4). |
+| `MCP_TRANSPORT=sse` / `=http` listener  | Remote callers reaching MCP tools    | Whoever holds `MCP_AUTH_TOKEN` + matches `MCP_ALLOWED_ORIGINS` (see §8). |
 
 Sections below go one level deeper on each.
 
@@ -62,11 +64,27 @@ Query text and knowledge-base chunks leave the machine over TLS to the configure
 
 **Multiple MCP servers per `$FAISS_INDEX_PATH` are now supported.** The single-instance advisory at `src/instance-lock.ts` was removed. Two concurrent MCP servers serialize writes via the per-model lock, never produce torn reads thanks to atomic save, and have always coexisted safely at read time. Any leftover `${FAISS_INDEX_PATH}/.kb-mcp.pid` file from a prior install is now an orphan that the operator may delete (no code reads it).
 
-## 5. Path-traversal (forward-looking)
+## 5. Path-traversal (path-taking tools and `kb://` resources)
 
-Today neither exposed tool takes a filesystem path as input — `list_knowledge_bases` reads `KNOWLEDGE_BASES_ROOT_DIR` directly (`src/KnowledgeBaseServer.ts:52-72`), and `retrieve_knowledge` takes a `query` string, an optional `knowledge_base_name`, and an optional numeric `threshold` (`src/KnowledgeBaseServer.ts:43-47`). The `knowledge_base_name` is joined to `KNOWLEDGE_BASES_ROOT_DIR` at `src/FaissIndexManager.ts:222` with no `..` check — but a traversal value that tries to escape the root would just point at a directory that `getFilesRecursively` would walk harmlessly. There is no code path today that writes based on a client-supplied name.
+Three exposed surfaces now accept client-supplied paths into `$KNOWLEDGE_BASES_ROOT_DIR`. All of them route the candidate through the same `resolveKbPath` validator (`src/kb-fs.ts:216-274`) so the guard chain is implemented once:
 
-RFC 010's proposed ingest / resources tools **will** take user-supplied paths. When that lands, the path resolution must canonicalize the value and reject components that escape `$KNOWLEDGE_BASES_ROOT_DIR`. Flagged here so it doesn't ship without guard rails.
+1. **Lexical guards** — empty path, embedded null byte, and `..` traversal are rejected before any I/O (`src/kb-fs.ts:223-235`).
+2. **KB-name validation** — `knowledge_base_name` must match `isValidKbName` (`src/kb-paths.ts:12-20`); the resolved KB directory must exist as a real directory under `KNOWLEDGE_BASES_ROOT_DIR`.
+3. **Lexical inside-or-equal check** — the resolved candidate is required to live under the KB root before any `realpath` call (`src/kb-fs.ts:243-249`).
+4. **`realpath` check** — when the target (or its nearest existing ancestor in `mustExist:false` mode) resolves through symlinks, the realpath must still be inside the KB realpath (`src/kb-fs.ts:251-260`). Symlink jailbreaks fail closed.
+
+The current path-taking surfaces are:
+
+| Surface | Where the path comes in | mustExist | Notes |
+| --- | --- | --- | --- |
+| `add_document` | `path` arg, joined with `knowledge_base_name` | `false` | Snapshots existing content first; index update failure rolls the file write back (`src/KnowledgeBaseServer.ts:501-568`). |
+| `delete_document` | `path` arg, joined with `knowledge_base_name` | `false` | Removes the source file and its hash sidecar; FAISS orphan vectors persist until `reindex_knowledge_base` (`src/KnowledgeBaseServer.ts:570-624`). |
+| `reindex_knowledge_base` | optional `knowledge_base_name` only — no per-file path | n/a | Resolves the KB directory to validate the name; the rebuild is global (no per-vector deletion in this server). |
+| `resources/read` for `kb://<kb>/<rel-path>` | URI authority + path | `true` | URI parser additionally rejects `%2F` / `%5C` and `..` segments before per-segment `decodeURIComponent` (`src/mcp-resources.ts:59-120`). PDFs are returned as base64 blobs; everything else as UTF-8 text. |
+
+`list_knowledge_bases` continues to read `KNOWLEDGE_BASES_ROOT_DIR` directly without taking any client path. `retrieve_knowledge` takes only `query`, optional `knowledge_base_name`, optional numeric filters, and never writes based on the name.
+
+**Requirement.** The KB root and every per-KB directory must not contain symlinks pointing outside `KNOWLEDGE_BASES_ROOT_DIR`. The realpath check would catch a jailbreak attempt at request time, but symlinks-out-of-root represent operator-side trust intent. Treat the KB root the way you'd treat a static-content directory served to anonymous callers — own every entry, even the symlink targets.
 
 ## 6. Log file (`LOG_FILE`)
 
@@ -76,8 +94,35 @@ Setting `LOG_FILE` (`src/logger.ts:18-49`) mirrors stderr to disk. The server wr
 
 Setting `KB_MUTATION_AUDIT_LOG` (`src/audit-log.ts`) opts into an append-only JSONL ledger of content mutations performed by `kb remember`, `kb capture`, MCP `add_document`, and MCP `delete_document`. Each record carries `surface`, `operation`, `kb`, `relative_path`, before/after `sha256` hashes, `write_performed`, refresh status, and `decision_flags`. Note bodies are **not** written; the hashes are the only content-derived field. KB names and relative paths reveal the same surface area as the underlying KB directory listing, so secure the ledger with the same permissions you grant `$KNOWLEDGE_BASES_ROOT_DIR`. Audit writes are best-effort: a failed append degrades to a `warn` line on stderr and never blocks the primary mutation.
 
+## 8. Remote MCP transport (`MCP_TRANSPORT=sse` / `=http`)
+
+`MCP_TRANSPORT` defaults to `stdio` and the rest of this document assumes that baseline. When the operator opts into `sse` or `http`, the server stands up a `node:http` listener (`src/transport/sse.ts:1-22`, `src/transport/http.ts:1-38`) sharing the dispatch gates defined in `src/transport/base-http-host.ts`. The exposed surface is `GET /health` (unauthenticated, returns only `{"status":"ok"}`), plus `GET /sse` + `POST /messages` (SSE) or `POST|GET|DELETE /mcp` (streamable HTTP).
+
+**Mandatory auth.** The server refuses to start in either remote mode without `MCP_AUTH_TOKEN`, and rejects tokens shorter than 32 characters (`src/transport-config.ts:96-119`). The bearer comparison uses `timingSafeEqual` with a latin1-encoded token buffer so an attacker-controlled `Authorization` header can't be silently re-encoded into an equal-length payload (`src/transport/base-http-host.ts:60-70`). Only `/health` is unauthenticated.
+
+**Origin allow-list.** `MCP_ALLOWED_ORIGINS` is a comma-separated list of explicit origins; the wildcard `*` is rejected at config load (`src/transport-config.ts:80-94`). When set, browser-originated requests whose `Origin` header is not in the normalized list are denied before any handler runs. When unset, browser origins are denied; only same-process clients without an `Origin` header (and the operator's allow-listed entries) reach the auth gate.
+
+**Default loopback bind.** `MCP_BIND_ADDR` defaults to `127.0.0.1` (`src/transport-config.ts:14-15`, `:96-101`). Operators who want off-host reach must set `MCP_BIND_ADDR=0.0.0.0` **and** terminate TLS in a reverse proxy: this server does not negotiate TLS, does not load certificates, and does not rate-limit. Without those, the bearer token travels in cleartext over the LAN.
+
+**`/health` reveals no fingerprint.** Per RFC 008 §6.8 the body is `{"status":"ok"}` and nothing else — no version, uptime, build hash, or KB path is exposed to unauthenticated callers (`src/transport/base-http-host.ts` `/health` branch).
+
+**Session isolation.** Each SSE or streamable-HTTP session gets its own `McpServer` (`src/KnowledgeBaseServer.ts:929-955`); tools cannot cross sessions. Long-lived `GET /sse` does not increment the drain counter so shutdown cannot stall on idle viewers (`src/transport/sse.ts:61-75`).
+
+**Out of scope for the remote transport.** TLS termination, rate-limiting, audit logging beyond the per-request access line, and any kind of multi-tenant access control. The operator must layer those in front of the listener if remote exposure is intended for anyone other than the launching user.
+
 ## Out of scope
 
 - Denial-of-service by a malicious KB file large enough to OOM the embedding provider. Possible, but unlisted — the mitigation is operational (file-size cap in the source tree).
 - Supply-chain attacks on the dependency graph. The repo does not currently pin peer deps or vendor; audit via `npm audit` is the user's responsibility.
-- Remote MCP transport. Not implemented — RFC 008 covers it. The threat model will gain an auth section when that lands.
+- TLS / certificate handling for `MCP_TRANSPORT=sse|http`. Terminate TLS in a reverse proxy if the listener is exposed off-host (see §8).
+
+## Checked against
+
+This page is verified against the following source files and README sections. If one of these moves or its cited lines drift, refresh this doc rather than letting the claim go stale.
+
+- Path validation (write tools + resources): `src/kb-fs.ts:216-274`, `src/kb-paths.ts:12-20`, `src/mcp-resources.ts:59-120`.
+- Write-tool surfaces: `src/KnowledgeBaseServer.ts:501-661`.
+- `resources/read` body: `src/mcp-resources.ts:153-180`.
+- Per-model write lock + atomic save: `src/write-lock.ts`, `src/faiss-store-layout.ts:58-179`.
+- Transport config + bearer / origin gates: `src/transport-config.ts:14-122`, `src/transport/base-http-host.ts`.
+- Remote transport hosts: `src/transport/sse.ts:1-139`, `src/transport/http.ts:1-220`.


### PR DESCRIPTION
## Summary

- `docs/architecture/data-model.md` and `docs/architecture/threat-model.md` were created as as-is snapshots before metadata filters, MCP resources, path-taking write tools, remote HTTP/SSE transport, per-model write locks, and atomic FAISS save landed. Pull both back into agreement with `src/`.
- Replace the forward-looking §5 ("no exposed tool takes a path") with the current `add_document` / `delete_document` / `reindex_knowledge_base` / `resources/read` surfaces and the four-step `resolveKbPath` guard chain.
- Add §7 for the `MCP_TRANSPORT=sse|http` listener — mandatory `MCP_AUTH_TOKEN` (≥32 chars), `MCP_ALLOWED_ORIGINS` allow-list, default loopback bind, unauthenticated `/health` with no fingerprint, per-session `McpServer` isolation, TLS out of scope.
- Realign the trust-boundaries table and three lingering README claims so concurrent writers per `FAISS_INDEX_PATH` are no longer described as unsupported (per-model write lock + atomic save handle that now).
- Pin each doc to its source files via a "Checked against" anchor list at the bottom so the next drift is mechanically detectable.

Closes #227

## Test plan

- [x] `npm run docs:check-anchors` — no new stale anchors in `data-model.md` / `threat-model.md` (pre-existing 31 stale anchors in RFC/utils docs are untouched).
- [x] `npm test -- --runTestsByPath src/mcp-resources.test.ts src/kb-stats.test.ts` — 27/27 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)