### PR TITLE
perf(search): progressive overfetch for filtered similarity search

### DIFF
--- a/src/FaissIndexManager.test.ts
+++ b/src/FaissIndexManager.test.ts
@@ -3124,3 +3124,250 @@ describe('FaissIndexManager similaritySearch metadata filters (#53)', () => {
     );
   });
 });
+
+describe('progressiveFetchSizes (#229)', () => {
+  let progressiveFetchSizes: (k: number, ntotal: number) => number[];
+
+  beforeAll(async () => {
+    jest.resetModules();
+    ({ progressiveFetchSizes } = await import('./FaissIndexManager.js'));
+  });
+
+  it('returns [ntotal] when the floor window already meets or exceeds ntotal', () => {
+    expect(progressiveFetchSizes(10, 5)).toEqual([5]);
+    expect(progressiveFetchSizes(10, 19)).toEqual([19]);
+    expect(progressiveFetchSizes(10, 20)).toEqual([20]);
+  });
+
+  it('emits the geometric ladder for typical k=10 and large ntotal', () => {
+    expect(progressiveFetchSizes(10, 1000)).toEqual([20, 40, 160, 1000]);
+  });
+
+  it('collapses rungs that meet or exceed ntotal so the sequence stays monotonic', () => {
+    expect(progressiveFetchSizes(10, 100)).toEqual([20, 40, 100]);
+    expect(progressiveFetchSizes(10, 50)).toEqual([20, 40, 50]);
+    expect(progressiveFetchSizes(10, 30)).toEqual([20, 30]);
+  });
+
+  it('keeps a floor of 20 even when k is very small', () => {
+    expect(progressiveFetchSizes(1, 1000)).toEqual([20, 1000]);
+    expect(progressiveFetchSizes(2, 1000)).toEqual([20, 32, 1000]);
+  });
+
+  it('drops duplicate rungs when 4*k equals the floor', () => {
+    // k=5: max(k,20)=20, 4k=20 (duplicate), 16k=80. Expect [20, 80, ntotal].
+    expect(progressiveFetchSizes(5, 1000)).toEqual([20, 80, 1000]);
+  });
+
+  it('caps the whole ladder at ntotal when k itself exceeds ntotal', () => {
+    expect(progressiveFetchSizes(1000, 100)).toEqual([100]);
+  });
+
+  it('returns [] when ntotal is zero so the caller can short-circuit', () => {
+    expect(progressiveFetchSizes(10, 0)).toEqual([]);
+  });
+});
+
+describe('FaissIndexManager progressive overfetch (#229)', () => {
+  const originalEnv = {
+    KNOWLEDGE_BASES_ROOT_DIR: process.env.KNOWLEDGE_BASES_ROOT_DIR,
+    FAISS_INDEX_PATH: process.env.FAISS_INDEX_PATH,
+    EMBEDDING_PROVIDER: process.env.EMBEDDING_PROVIDER,
+    HUGGINGFACE_API_KEY: process.env.HUGGINGFACE_API_KEY,
+  };
+
+  beforeEach(() => {
+    saveMock.mockReset();
+    addDocumentsMock.mockReset();
+    fromTextsMock.mockReset();
+    loadMock.mockReset();
+    similaritySearchMock.mockReset();
+    embeddingConstructorMock.mockReset();
+  });
+
+  afterEach(() => {
+    const keys = Object.keys(originalEnv) as Array<keyof typeof originalEnv>;
+    for (const key of keys) {
+      const value = originalEnv[key];
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+    jest.restoreAllMocks();
+  });
+
+  async function setupManagerWithNtotal(ntotal: number) {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-faiss-overfetch-'));
+    const kbDir = path.join(tempDir, 'kb');
+    const defaultKb = path.join(kbDir, 'default');
+    await fsp.mkdir(defaultKb, { recursive: true });
+    await fsp.writeFile(path.join(defaultKb, 'doc.md'), '# Title\n\nProgressive overfetch fixture.');
+
+    process.env.KNOWLEDGE_BASES_ROOT_DIR = kbDir;
+    process.env.FAISS_INDEX_PATH = path.join(tempDir, '.faiss');
+    process.env.EMBEDDING_PROVIDER = 'huggingface';
+    process.env.HUGGINGFACE_API_KEY = 'test-key';
+
+    jest.resetModules();
+    const { FaissIndexManager } = await import('./FaissIndexManager.js');
+    const manager = new FaissIndexManager();
+    await manager.initialize();
+    await manager.updateIndex();
+    const internal = manager as unknown as {
+      faissIndex: { index: { ntotal: () => number } };
+    };
+    internal.faissIndex.index = { ntotal: () => ntotal };
+    return manager;
+  }
+
+  it('unfiltered search makes a single FAISS call with fetchK = k', async () => {
+    const manager = await setupManagerWithNtotal(500);
+    const doc = { pageContent: 'a', metadata: { source: 'a' } };
+    similaritySearchMock.mockResolvedValueOnce([[doc, 0.1]]);
+
+    const results = await manager.similaritySearch('q', 10);
+
+    expect(similaritySearchMock).toHaveBeenCalledTimes(1);
+    expect(similaritySearchMock).toHaveBeenCalledWith('q', 10);
+    expect(results).toHaveLength(1);
+  });
+
+  it('filtered search terminates after the first window when it yields ≥ k hits', async () => {
+    const manager = await setupManagerWithNtotal(1000);
+    // First window is fetchK = max(k=5, 20) = 20. Return 20 items, 6 of which
+    // satisfy the .md filter — more than enough for k=5, so no expansion.
+    const mdHits: Array<[unknown, number]> = Array.from({ length: 6 }, (_, i) => [
+      { pageContent: `m${i}`, metadata: { extension: '.md', relativePath: `kb/m${i}.md` } },
+      0.1 + i * 0.01,
+    ]);
+    const pdfPad: Array<[unknown, number]> = Array.from({ length: 14 }, (_, i) => [
+      { pageContent: `p${i}`, metadata: { extension: '.pdf', relativePath: `kb/p${i}.pdf` } },
+      0.2 + i * 0.01,
+    ]);
+    similaritySearchMock.mockResolvedValueOnce([...mdHits, ...pdfPad]);
+
+    const results = await manager.similaritySearch('q', 5, undefined, undefined, {
+      extensions: ['.md'],
+    });
+
+    expect(similaritySearchMock).toHaveBeenCalledTimes(1);
+    expect(similaritySearchMock).toHaveBeenCalledWith('q', 20);
+    expect(results.map((r) => r.pageContent)).toEqual(['m0', 'm1', 'm2', 'm3', 'm4']);
+  });
+
+  it('expands the fetch window when the first window starves the filter', async () => {
+    const manager = await setupManagerWithNtotal(1000);
+    // Ladder for k=2: [max(k,20)=20, 16k=32, 1000]. The 4k rung collapses
+    // because 4*2 sits below the floor of 20.
+    // Window 1 (fetchK=20): 20 .pdf items, 0 matches. raw.length == fetchK so
+    // we cannot short-circuit on exhaustion; loop must move to window 2.
+    const noMatches: Array<[unknown, number]> = Array.from({ length: 20 }, (_, i) => [
+      { pageContent: `p${i}`, metadata: { extension: '.pdf', relativePath: `kb/p${i}.pdf` } },
+      0.1 + i * 0.01,
+    ]);
+    // Window 2 (fetchK=32): the last 3 items are .md, so the filter clears k=2.
+    const wider: Array<[unknown, number]> = Array.from({ length: 32 }, (_, i) => {
+      const isMd = i >= 29;
+      return [
+        {
+          pageContent: isMd ? `m${i - 29}` : `p${i}`,
+          metadata: {
+            extension: isMd ? '.md' : '.pdf',
+            relativePath: isMd ? `kb/m${i - 29}.md` : `kb/p${i}.pdf`,
+          },
+        },
+        0.1 + i * 0.01,
+      ];
+    });
+    similaritySearchMock.mockResolvedValueOnce(noMatches);
+    similaritySearchMock.mockResolvedValueOnce(wider);
+
+    const results = await manager.similaritySearch('q', 2, undefined, undefined, {
+      extensions: ['.md'],
+    });
+
+    expect(similaritySearchMock).toHaveBeenCalledTimes(2);
+    expect(similaritySearchMock).toHaveBeenNthCalledWith(1, 'q', 20);
+    expect(similaritySearchMock).toHaveBeenNthCalledWith(2, 'q', 32);
+    expect(results.map((r) => r.pageContent)).toEqual(['m0', 'm1']);
+  });
+
+  it('stops early when FAISS returns fewer items than the requested window', async () => {
+    // ntotal=1000 from the patched index, but the live docstore only has 12
+    // chunks for this query. raw.length < fetchK should short-circuit the
+    // loop on the first call — no extra rungs even though the filter starves.
+    const manager = await setupManagerWithNtotal(1000);
+    const items: Array<[unknown, number]> = Array.from({ length: 12 }, (_, i) => [
+      { pageContent: `p${i}`, metadata: { extension: '.pdf', relativePath: `kb/p${i}.pdf` } },
+      0.1 + i * 0.01,
+    ]);
+    similaritySearchMock.mockResolvedValueOnce(items);
+
+    const results = await manager.similaritySearch('q', 10, undefined, undefined, {
+      extensions: ['.md'],
+    });
+
+    expect(similaritySearchMock).toHaveBeenCalledTimes(1);
+    expect(similaritySearchMock).toHaveBeenCalledWith('q', 20);
+    expect(results).toEqual([]);
+  });
+
+  it('worst case: matches buried late still surface via the ntotal fallback rung', async () => {
+    // ntotal=50, k=10 → ladder = [20, 40, 50]. The needle sits at index 45,
+    // which only the final rung can reach. Simulate FAISS returning the top
+    // `fetchK` items by score order.
+    const manager = await setupManagerWithNtotal(50);
+    const items: Array<[unknown, number]> = Array.from({ length: 50 }, (_, i) => {
+      const isMatch = i === 45;
+      return [
+        {
+          pageContent: isMatch ? 'needle' : `p${i}`,
+          metadata: {
+            extension: isMatch ? '.md' : '.pdf',
+            relativePath: isMatch ? 'kb/needle.md' : `kb/p${i}.pdf`,
+          },
+        },
+        0.1 + i * 0.001,
+      ];
+    });
+    similaritySearchMock.mockImplementation(async (...args: unknown[]) => {
+      const fetchK = args[1] as number;
+      return items.slice(0, Math.min(fetchK, items.length));
+    });
+
+    const results = await manager.similaritySearch('q', 10, undefined, undefined, {
+      extensions: ['.md'],
+    });
+
+    expect(similaritySearchMock).toHaveBeenCalledTimes(3);
+    expect(similaritySearchMock).toHaveBeenNthCalledWith(1, 'q', 20);
+    expect(similaritySearchMock).toHaveBeenNthCalledWith(2, 'q', 40);
+    expect(similaritySearchMock).toHaveBeenNthCalledWith(3, 'q', 50);
+    expect(results.map((r) => r.pageContent)).toEqual(['needle']);
+  });
+
+  it('scoped search uses progressive overfetch even without metadata filters', async () => {
+    const manager = await setupManagerWithNtotal(1000);
+    const inScope: Array<[unknown, number]> = Array.from({ length: 4 }, (_, i) => [
+      {
+        pageContent: `s${i}`,
+        metadata: {
+          source: `${process.env.KNOWLEDGE_BASES_ROOT_DIR}/scoped/file${i}.md`,
+          extension: '.md',
+        },
+      },
+      0.1 + i * 0.01,
+    ]);
+    similaritySearchMock.mockResolvedValueOnce(inScope);
+
+    const results = await manager.similaritySearch('q', 10, undefined, 'scoped');
+
+    // First rung is 20. Result count is 4 → less than k=10, but raw.length=4
+    // < fetchK=20 means FAISS is exhausted, so we stop after one call.
+    expect(similaritySearchMock).toHaveBeenCalledTimes(1);
+    expect(similaritySearchMock).toHaveBeenCalledWith('q', 20);
+    expect(results.map((r) => r.pageContent)).toEqual(['s0', 's1', 's2', 's3']);
+  });
+});

--- a/src/FaissIndexManager.ts
+++ b/src/FaissIndexManager.ts
@@ -33,7 +33,11 @@ import {
   resolveActiveIndexFilePath as resolveActiveIndexFilePathFromLayout,
   saveFaissStoreAtomic,
 } from './faiss-store-layout.js';
-import { createSimilaritySearchPostFilter, type SimilaritySearchFilters } from './search-filters.js';
+import {
+  createSimilaritySearchPostFilter,
+  type ScoredDocument,
+  type SimilaritySearchFilters,
+} from './search-filters.js';
 import { withSidecarLock } from './write-lock.js';
 
 export { MigrationRefusedError } from './layout-bootstrap.js';
@@ -70,6 +74,44 @@ async function writeModelNameAtomic(modelNameFile: string, modelName: string): P
 // ---------------------------------------------------------------------------
 
 export const DEFAULT_REBUILD_PROGRESS_INTERVAL_FILES = 10;
+
+/**
+ * Issue #229 — progressive overfetch sequence for filtered similarity search.
+ *
+ * The langchain FaissStore wrapper silently drops filter arguments (see PR #73
+ * + #53), so KB scope, extension, path-glob, and tag filters all run as
+ * post-filters after FAISS returns. Pre-#229 the manager defended against
+ * filter starvation by fetching `ntotal` whenever any filter was active — a
+ * full-index pass on every scoped query, even when the first 20 hits already
+ * satisfied the request.
+ *
+ * Progressive overfetch swaps the single full pass for a short ladder of
+ * increasing windows. The caller iterates `fetchK` values in order, applies
+ * the post-filter after each FAISS call, and stops once at least `k` filtered
+ * hits exist or FAISS has returned the whole docstore. Worst case still ends
+ * at `ntotal` and preserves the #71/#73 correctness guarantee; the common
+ * case terminates at the first or second rung.
+ *
+ * Ladder = `[max(k, 20), 4k, 16k, ntotal]` with duplicates and rungs that
+ * meet or exceed `ntotal` collapsed. The floor of 20 keeps very small `k`
+ * callers (e.g. `k = 1`) from probing FAISS one item at a time when a single
+ * filter would otherwise reject the top hit. The geometric 4× growth caps
+ * the number of attempts at four for any realistic `ntotal`.
+ */
+export function progressiveFetchSizes(k: number, ntotal: number): number[] {
+  if (ntotal <= 0) return [];
+  const sizes: number[] = [];
+  const candidates = [Math.max(k, 20), k * 4, k * 16];
+  let prev = 0;
+  for (const candidate of candidates) {
+    if (candidate <= prev) continue;
+    if (candidate >= ntotal) break;
+    sizes.push(candidate);
+    prev = candidate;
+  }
+  sizes.push(ntotal);
+  return sizes;
+}
 
 function totalFileCount(
   entries: ReadonlyArray<{ filePaths: readonly string[] }>,
@@ -907,8 +949,9 @@ export class FaissIndexManager {
    * the score + KB filter that already runs here. Each filter is applied to
    * `doc.metadata` after FAISS returns; the FAISS index itself is never
    * pre-filtered (langchain's FaissStore silently drops filter args). When
-   * any filter is active we over-fetch up to `ntotal` so a small `k` doesn't
-   * starve once the post-filter drops the top-ranked unfiltered hits.
+   * any filter is active we over-fetch via progressive windows so a small
+   * `k` doesn't starve once the post-filter drops the top-ranked unfiltered
+   * hits — see `progressiveFetchSizes` (#229) for the ladder.
    *
    *   `extensions`  AND-with-existing — exact match on `metadata.extension`
    *                 (already lowercased + dotted at ingest, so ".md" works
@@ -943,48 +986,85 @@ export class FaissIndexManager {
       filters,
     });
 
-    // Over-fetch when scoping or when any metadata post-filter is active so
-    // the post-filter doesn't starve `k` when other docs dominate the
-    // unfiltered top-K. The cost (linear in ntotal) is bounded by KB size.
-    const fetchK = postFilter.requiresOverfetch
-      ? Math.max(k, this.faissIndex.index.ntotal())
-      : k;
-    if (timing) timing.fetch_k = fetchK;
-
     // FaissStore.similaritySearchVectorWithScore accepts only (query, k) and
     // silently drops any filter argument, so threshold and KB scoping are both
-    // applied as post-filters on the returned [doc, score] tuples.
-    let resultsWithScore: Array<[Document, number]>;
+    // applied as post-filters on the returned [doc, score] tuples. When the
+    // caller wants timing AND the wrapper exposes the vector-first entry
+    // point, embed once up front and reuse the embedding across every
+    // progressive-overfetch rung so the embed cost is paid exactly once.
     const vectorSearch = (
       this.faissIndex as unknown as {
-        similaritySearchVectorWithScore?: (queryEmbedding: number[], k: number) => Promise<Array<[Document, number]>>;
+        similaritySearchVectorWithScore?: (
+          queryEmbedding: number[],
+          k: number,
+        ) => Promise<Array<[Document, number]>>;
       }
     ).similaritySearchVectorWithScore;
-    if (timing && typeof vectorSearch === 'function') {
+    const useVectorPath = timing !== undefined && typeof vectorSearch === 'function';
+    let queryEmbedding: number[] | undefined;
+    if (useVectorPath) {
       const embedStartedAt = Date.now();
-      const queryEmbedding = await this.embeddings.embedQuery(query);
-      timing.embed_query_ms = Date.now() - embedStartedAt;
-
-      const faissStartedAt = Date.now();
-      resultsWithScore = await vectorSearch.call(this.faissIndex, queryEmbedding, fetchK);
-      timing.faiss_search_ms = Date.now() - faissStartedAt;
-    } else {
-      const queryStartedAt = Date.now();
-      resultsWithScore = await this.faissIndex.similaritySearchWithScore(query, fetchK);
-      if (timing) timing.query_search_ms = Date.now() - queryStartedAt;
+      queryEmbedding = await this.embeddings.embedQuery(query);
+      timing!.embed_query_ms = Date.now() - embedStartedAt;
     }
 
-    const postFilterStartedAt = Date.now();
-    const filtered = postFilter.apply(resultsWithScore);
+    const runFaissSearch = async (
+      fetchK: number,
+    ): Promise<Array<[Document, number]>> => {
+      if (useVectorPath) {
+        const faissStartedAt = Date.now();
+        const out = await vectorSearch!.call(this.faissIndex, queryEmbedding!, fetchK);
+        timing!.faiss_search_ms = (timing!.faiss_search_ms ?? 0) + (Date.now() - faissStartedAt);
+        return out;
+      }
+      const queryStartedAt = Date.now();
+      const out = await this.faissIndex!.similaritySearchWithScore(query, fetchK);
+      if (timing) {
+        timing.query_search_ms = (timing.query_search_ms ?? 0) + (Date.now() - queryStartedAt);
+      }
+      return out;
+    };
+
+    if (!postFilter.requiresOverfetch) {
+      // No scope or metadata filter — FAISS top-k is already the final result
+      // set (threshold is a cheap drop-in post-filter). One call.
+      if (timing) timing.fetch_k = k;
+      const resultsWithScore = await runFaissSearch(k);
+      const postFilterStartedAt = Date.now();
+      const filtered = postFilter.apply(resultsWithScore);
+      if (timing) {
+        timing.post_filter_ms = Date.now() - postFilterStartedAt;
+        timing.total_ms = Date.now() - totalStartedAt;
+      }
+      return filtered.slice(0, k).map(([doc, score]) => ({ ...doc, score }));
+    }
+
+    // Issue #229 — progressive overfetch. Walk increasing fetch windows and
+    // stop as soon as the post-filter yields at least `k` hits, or FAISS has
+    // already returned its entire docstore (raw length below the requested
+    // window ⇒ ntotal exhausted). Worst case ends at `ntotal` and matches
+    // the pre-#229 cost; common filtered queries terminate at the first rung.
+    const ntotal = this.faissIndex.index.ntotal();
+    const fetchSizes = progressiveFetchSizes(k, ntotal);
+    let filtered: ScoredDocument[] = [];
+    let lastFetchK = k;
+    let cumulativePostFilterMs = 0;
+    for (const fetchK of fetchSizes) {
+      lastFetchK = fetchK;
+      const resultsWithScore = await runFaissSearch(fetchK);
+      const postFilterStartedAt = Date.now();
+      filtered = postFilter.apply(resultsWithScore);
+      cumulativePostFilterMs += Date.now() - postFilterStartedAt;
+      if (filtered.length >= k) break;
+      if (resultsWithScore.length < fetchK) break;
+    }
     if (timing) {
-      timing.post_filter_ms = Date.now() - postFilterStartedAt;
+      timing.fetch_k = lastFetchK;
+      timing.post_filter_ms = cumulativePostFilterMs;
       timing.total_ms = Date.now() - totalStartedAt;
     }
 
-    return filtered.slice(0, k).map(([doc, score]) => ({
-      ...doc,
-      score,
-    }));
+    return filtered.slice(0, k).map(([doc, score]) => ({ ...doc, score }));
   }
 
   /**


### PR DESCRIPTION
## Summary

- Replace `fetchK = ntotal()` with a progressive ladder `[max(k, 20), 4k, 16k, ntotal]` for scoped and metadata-filtered similarity searches.
- Stop expanding as soon as the post-filter yields ≥ `k` hits, or FAISS returns fewer items than the requested window (docstore exhausted). Worst case still ends at `ntotal`, preserving the #71/#73 correctness guarantee.
- Unfiltered queries continue to make a single FAISS call with `fetchK = k`.
- New `progressiveFetchSizes(k, ntotal)` helper exported from `FaissIndexManager.ts` so the ladder is unit-testable in isolation.

Closes #229.

## Test plan

- [x] `npm test -- --runTestsByPath src/FaissIndexManager.test.ts` — 91 tests pass, including 13 new ones covering the helper sequence and the loop's early-stop / expansion / exhaustion / worst-case rungs.
- [x] `npm test` — full suite, 658 tests pass.
- [x] `npm run build` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)