### PR TITLE
feat(age-budget): per-KB time-based age budget + served-stale surface (closes #218)

### DIFF
--- a/src/age-budget.test.ts
+++ b/src/age-budget.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+  AgeBudgetConfigError,
+  computeAgeBudgetStatus,
+  formatAgeBudgetBreachRow,
+  formatAgeHours,
+  kbNameToEnvSuffix,
+  resolveAgeBudgetHours,
+} from './age-budget.js';
+
+describe('kbNameToEnvSuffix', () => {
+  it('upper-cases ASCII KB names', () => {
+    expect(kbNameToEnvSuffix('work')).toBe('WORK');
+    expect(kbNameToEnvSuffix('Work_KB')).toBe('WORK_KB');
+  });
+
+  it('replaces non-[A-Z0-9_] characters with underscores', () => {
+    expect(kbNameToEnvSuffix('rfcs-archived')).toBe('RFCS_ARCHIVED');
+    expect(kbNameToEnvSuffix('post.mortems')).toBe('POST_MORTEMS');
+    expect(kbNameToEnvSuffix('alpha beta')).toBe('ALPHA_BETA');
+  });
+
+  it('NFC-normalises before upper-casing', () => {
+    // "café" composed (NFC) and decomposed (NFD) should map to the same suffix.
+    const composed = 'café';
+    const decomposed = 'café';
+    expect(kbNameToEnvSuffix(composed)).toBe(kbNameToEnvSuffix(decomposed));
+  });
+});
+
+describe('resolveAgeBudgetHours', () => {
+  it('returns null when neither per-KB nor global var is set', () => {
+    expect(resolveAgeBudgetHours('work', {})).toBeNull();
+  });
+
+  it('prefers the per-KB var over the global fallback', () => {
+    const env = {
+      KB_AGE_BUDGET_HOURS: '12',
+      KB_AGE_BUDGET_HOURS_WORK: '24',
+    };
+    expect(resolveAgeBudgetHours('work', env)).toBe(24);
+  });
+
+  it('falls back to the global var when the per-KB var is unset', () => {
+    expect(resolveAgeBudgetHours('work', { KB_AGE_BUDGET_HOURS: '48' })).toBe(48);
+  });
+
+  it('falls back to the global var when the per-KB var is set to empty string', () => {
+    const env = {
+      KB_AGE_BUDGET_HOURS: '48',
+      KB_AGE_BUDGET_HOURS_WORK: '   ',
+    };
+    expect(resolveAgeBudgetHours('work', env)).toBe(48);
+  });
+
+  it('honours suffix normalisation for KB names with dashes / spaces', () => {
+    const env = { KB_AGE_BUDGET_HOURS_RFCS_ARCHIVED: '720' };
+    expect(resolveAgeBudgetHours('rfcs-archived', env)).toBe(720);
+  });
+
+  it.each([
+    ['0', /must be a positive integer/],
+    ['-1', /must be a positive integer/],
+    ['12.5', /must be a positive integer/],
+    ['abc', /must be a positive integer/],
+  ])('rejects malformed per-KB value %p', (raw, pattern) => {
+    expect(() => resolveAgeBudgetHours('work', { KB_AGE_BUDGET_HOURS_WORK: raw }))
+      .toThrow(pattern);
+  });
+
+  it('throws an AgeBudgetConfigError carrying envVar + raw value', () => {
+    let caught: unknown;
+    try {
+      resolveAgeBudgetHours('work', { KB_AGE_BUDGET_HOURS_WORK: '0' });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(AgeBudgetConfigError);
+    const err = caught as AgeBudgetConfigError;
+    expect(err.code).toBe('KB_AGE_BUDGET_INVALID');
+    expect(err.envVar).toBe('KB_AGE_BUDGET_HOURS_WORK');
+    expect(err.rawValue).toBe('0');
+  });
+
+  it('rejects malformed global value even when no per-KB override is set', () => {
+    expect(() => resolveAgeBudgetHours('work', { KB_AGE_BUDGET_HOURS: '0' }))
+      .toThrow(/KB_AGE_BUDGET_HOURS/);
+  });
+});
+
+describe('computeAgeBudgetStatus', () => {
+  const nowMs = Date.parse('2026-05-11T12:00:00.000Z');
+
+  it('returns no-breach when no budget is configured', () => {
+    const status = computeAgeBudgetStatus('work', nowMs - 100 * 3_600_000, nowMs, {});
+    expect(status).toEqual({
+      kb: 'work',
+      configuredHours: null,
+      currentAgeHours: 100,
+      breach: false,
+    });
+  });
+
+  it('marks breach when current age exceeds the budget', () => {
+    const lastIndexAtMs = nowMs - 47 * 3_600_000;
+    const status = computeAgeBudgetStatus('work', lastIndexAtMs, nowMs, {
+      KB_AGE_BUDGET_HOURS_WORK: '24',
+    });
+    expect(status).toEqual({
+      kb: 'work',
+      configuredHours: 24,
+      currentAgeHours: 47,
+      breach: true,
+    });
+  });
+
+  it('does not mark breach when current age equals the budget (strict >)', () => {
+    const lastIndexAtMs = nowMs - 24 * 3_600_000;
+    const status = computeAgeBudgetStatus('work', lastIndexAtMs, nowMs, {
+      KB_AGE_BUDGET_HOURS_WORK: '24',
+    });
+    expect(status.breach).toBe(false);
+  });
+
+  it('does not mark breach when current age is below the budget', () => {
+    const lastIndexAtMs = nowMs - 12 * 3_600_000;
+    const status = computeAgeBudgetStatus('work', lastIndexAtMs, nowMs, {
+      KB_AGE_BUDGET_HOURS_WORK: '72',
+    });
+    expect(status.breach).toBe(false);
+    expect(status.currentAgeHours).toBe(12);
+  });
+
+  it('treats never-indexed KBs as not-in-breach (null currentAgeHours)', () => {
+    const status = computeAgeBudgetStatus('work', null, nowMs, {
+      KB_AGE_BUDGET_HOURS_WORK: '24',
+    });
+    expect(status).toEqual({
+      kb: 'work',
+      configuredHours: 24,
+      currentAgeHours: null,
+      breach: false,
+    });
+  });
+
+  it('clamps a future-dated last-index timestamp to age=0 (no negative ages)', () => {
+    const lastIndexAtMs = nowMs + 10 * 3_600_000;
+    const status = computeAgeBudgetStatus('work', lastIndexAtMs, nowMs, {
+      KB_AGE_BUDGET_HOURS_WORK: '24',
+    });
+    expect(status.currentAgeHours).toBe(0);
+    expect(status.breach).toBe(false);
+  });
+});
+
+describe('formatAgeHours', () => {
+  it('floors fractional hours for display', () => {
+    expect(formatAgeHours(47.9)).toBe(47);
+    expect(formatAgeHours(0.5)).toBe(0);
+  });
+
+  it('returns null when input is null', () => {
+    expect(formatAgeHours(null)).toBeNull();
+  });
+});
+
+describe('formatAgeBudgetBreachRow', () => {
+  it('formats the breach row using the issue-spec template', () => {
+    const row = formatAgeBudgetBreachRow({
+      kb: 'work',
+      configuredHours: 24,
+      currentAgeHours: 47.9,
+      breach: true,
+    });
+    expect(row).toBe('AGE_BUDGET_BREACH: kb=work, age=47h, budget=24h');
+  });
+
+  it('returns null when not in breach', () => {
+    expect(
+      formatAgeBudgetBreachRow({
+        kb: 'work',
+        configuredHours: 24,
+        currentAgeHours: 12,
+        breach: false,
+      }),
+    ).toBeNull();
+  });
+
+  it('returns null when never indexed (currentAgeHours=null)', () => {
+    expect(
+      formatAgeBudgetBreachRow({
+        kb: 'work',
+        configuredHours: 24,
+        currentAgeHours: null,
+        breach: false,
+      }),
+    ).toBeNull();
+  });
+});

--- a/src/age-budget.ts
+++ b/src/age-budget.ts
@@ -1,0 +1,142 @@
+// Per-KB time-based age budget (issue #218).
+//
+// Operators set `KB_AGE_BUDGET_HOURS_<KB>=N` (or the unsuffixed
+// `KB_AGE_BUDGET_HOURS=N` as a global fallback) to declare the maximum
+// acceptable wall-clock age, in hours, between an index pass and the
+// current retrieval. Unset = no budget; `0`/negative/non-integer values
+// are rejected as malformed config.
+//
+// This module is intentionally pure: no filesystem reads, no clock
+// reads except as a caller-supplied parameter. Consumers wire it into
+// `kb doctor` and `kb search` (freshness footer).
+
+const ENV_PREFIX = 'KB_AGE_BUDGET_HOURS_';
+const ENV_DEFAULT = 'KB_AGE_BUDGET_HOURS';
+const MS_PER_HOUR = 3_600_000;
+
+export class AgeBudgetConfigError extends Error {
+  readonly code = 'KB_AGE_BUDGET_INVALID';
+  constructor(
+    readonly envVar: string,
+    readonly rawValue: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'AgeBudgetConfigError';
+  }
+}
+
+/**
+ * Map a KB name to its env-var suffix. The KB name is NFC-normalised,
+ * upper-cased, and any character outside `[A-Z0-9_]` is replaced with
+ * `_`. The mapping is one-way; two distinct KB names that collapse to
+ * the same suffix would share a budget (operator-visible if either
+ * `kb doctor` or the freshness footer is consulted).
+ */
+export function kbNameToEnvSuffix(kbName: string): string {
+  return kbName.normalize('NFC').toUpperCase().replace(/[^A-Z0-9_]/g, '_');
+}
+
+function parseAgeBudgetHours(
+  raw: string | undefined,
+  envVar: string,
+): number | null {
+  if (raw === undefined) return null;
+  const trimmed = raw.trim();
+  if (trimmed === '') return null;
+  const num = Number(trimmed);
+  if (!Number.isFinite(num) || !Number.isInteger(num) || num <= 0) {
+    throw new AgeBudgetConfigError(
+      envVar,
+      raw,
+      `${envVar}=${JSON.stringify(raw)} must be a positive integer (hours); ` +
+        `unset to disable, or set a value > 0.`,
+    );
+  }
+  return num;
+}
+
+/**
+ * Resolve the configured age budget for a KB. Resolution order:
+ *   1. `KB_AGE_BUDGET_HOURS_<suffix>` where `<suffix>` is the value
+ *      from `kbNameToEnvSuffix(kbName)`.
+ *   2. `KB_AGE_BUDGET_HOURS` (unsuffixed global fallback).
+ *   3. `null` (no budget configured).
+ *
+ * Throws `AgeBudgetConfigError` when either env var is set to a
+ * non-positive-integer value (`0`, `-1`, `12.5`, `abc`, etc.). The
+ * caller decides how to surface the error (typically: log + treat as
+ * "no budget" for the affected KB, then escalate via `kb doctor`).
+ */
+export function resolveAgeBudgetHours(
+  kbName: string,
+  env: NodeJS.ProcessEnv = process.env,
+): number | null {
+  const suffix = kbNameToEnvSuffix(kbName);
+  const perKbVar = `${ENV_PREFIX}${suffix}`;
+  const perKb = parseAgeBudgetHours(env[perKbVar], perKbVar);
+  if (perKb !== null) return perKb;
+  return parseAgeBudgetHours(env[ENV_DEFAULT], ENV_DEFAULT);
+}
+
+export interface AgeBudgetStatus {
+  kb: string;
+  configuredHours: number | null;
+  currentAgeHours: number | null;
+  breach: boolean;
+}
+
+/**
+ * Compute the age-budget status for a KB. `lastIndexAtMs` is the
+ * per-KB last-index timestamp in epoch milliseconds (typically derived
+ * from sidecar mtimes under `<kb>/.index/`); pass `null` when the KB
+ * has never been indexed. `nowMs` defaults to `Date.now()` and is
+ * injectable for testing.
+ *
+ * The "never indexed" case is treated as "no breach" rather than
+ * "infinite age" per the issue spec — an empty KB has no observable
+ * staleness signal until at least one pass has run.
+ */
+export function computeAgeBudgetStatus(
+  kbName: string,
+  lastIndexAtMs: number | null,
+  nowMs: number = Date.now(),
+  env: NodeJS.ProcessEnv = process.env,
+): AgeBudgetStatus {
+  const configuredHours = resolveAgeBudgetHours(kbName, env);
+  if (lastIndexAtMs === null) {
+    return { kb: kbName, configuredHours, currentAgeHours: null, breach: false };
+  }
+  const currentAgeHours = Math.max(0, (nowMs - lastIndexAtMs) / MS_PER_HOUR);
+  const breach =
+    configuredHours !== null && currentAgeHours > configuredHours;
+  return { kb: kbName, configuredHours, currentAgeHours, breach };
+}
+
+/**
+ * Floor `currentAgeHours` for human-facing display. Returns `null`
+ * when the input is null (KB has never been indexed).
+ */
+export function formatAgeHours(currentAgeHours: number | null): number | null {
+  if (currentAgeHours === null) return null;
+  return Math.floor(currentAgeHours);
+}
+
+/**
+ * Format an `AGE_BUDGET_BREACH` row for `kb doctor`. Returns `null`
+ * when the KB is not in breach (so callers can `.filter` to keep
+ * configured-but-fresh KBs out of the warning surface).
+ */
+export function formatAgeBudgetBreachRow(
+  status: AgeBudgetStatus,
+): string | null {
+  if (
+    !status.breach ||
+    status.configuredHours === null ||
+    status.currentAgeHours === null
+  ) {
+    return null;
+  }
+  const ageH = formatAgeHours(status.currentAgeHours);
+  return `AGE_BUDGET_BREACH: kb=${status.kb}, age=${ageH}h, budget=${status.configuredHours}h`;
+}

--- a/src/cli-doctor.test.ts
+++ b/src/cli-doctor.test.ts
@@ -10,6 +10,9 @@ const originalEnv = {
   HUGGINGFACE_MODEL_NAME: process.env.HUGGINGFACE_MODEL_NAME,
   HUGGINGFACE_API_KEY: process.env.HUGGINGFACE_API_KEY,
   KB_ACTIVE_MODEL: process.env.KB_ACTIVE_MODEL,
+  KB_AGE_BUDGET_HOURS: process.env.KB_AGE_BUDGET_HOURS,
+  KB_AGE_BUDGET_HOURS_ALPHA: process.env.KB_AGE_BUDGET_HOURS_ALPHA,
+  KB_AGE_BUDGET_HOURS_BETA: process.env.KB_AGE_BUDGET_HOURS_BETA,
 };
 
 const MODEL_ID = 'huggingface__BAAI-bge-small-en-v1.5';
@@ -231,5 +234,168 @@ describe('kb doctor', () => {
     expect(parseDoctorArgs(['--format=json'])).toEqual({ format: 'json' });
     expect(parseDoctorArgs([])).toEqual({ format: 'md' });
     expect(() => parseDoctorArgs(['--format=yaml'])).toThrow(/invalid --format/);
+  });
+
+  describe('age budgets (issue #218)', () => {
+    async function seedKbWithSidecarMtime(
+      rootDir: string,
+      kbName: string,
+      sidecarMtimeMs: number,
+    ): Promise<void> {
+      const indexDir = path.join(rootDir, kbName, '.index');
+      await fsp.mkdir(indexDir, { recursive: true });
+      const sidecar = path.join(indexDir, 'note.md');
+      await fsp.writeFile(sidecar, 'hash');
+      await fsp.utimes(sidecar, sidecarMtimeMs / 1000, sidecarMtimeMs / 1000);
+      await fsp.writeFile(path.join(rootDir, kbName, 'note.md'), 'note');
+    }
+
+    it('omits the age_budget check entirely when no budgets are configured', async () => {
+      const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-doctor-age-none-'));
+      try {
+        const rootDir = path.join(tempDir, 'kbs');
+        const faissDir = path.join(tempDir, '.faiss');
+        await fsp.mkdir(rootDir, { recursive: true });
+        await fsp.mkdir(faissDir, { recursive: true });
+        await seedKbWithSidecarMtime(rootDir, 'alpha', Date.now() - 1000);
+        const { buildDoctorReport, formatDoctorMarkdown } = await freshDoctor({
+          KNOWLEDGE_BASES_ROOT_DIR: rootDir,
+          FAISS_INDEX_PATH: faissDir,
+          EMBEDDING_PROVIDER: 'huggingface',
+          HUGGINGFACE_MODEL_NAME: MODEL_NAME,
+        });
+        const report = await buildDoctorReport({
+          backendHealthCheck: async () => ({ healthy: true, detail: 'ok' }),
+          packageRoot: tempDir,
+          invokedPath: null,
+          packageVersion: '9.9.9',
+        });
+        expect(report.age_budgets).toEqual({});
+        expect(report.age_budget_config_errors).toEqual([]);
+        expect(report.checks.some((c) => c.name === 'age_budget')).toBe(false);
+        expect(formatDoctorMarkdown(report)).toContain('Age budgets:\n  (no budgets configured)');
+      } finally {
+        await fsp.rm(tempDir, { recursive: true, force: true });
+      }
+    });
+
+    it('emits an AGE_BUDGET_BREACH warning when a KB is over budget', async () => {
+      const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-doctor-age-breach-'));
+      try {
+        const rootDir = path.join(tempDir, 'kbs');
+        const faissDir = path.join(tempDir, '.faiss');
+        await fsp.mkdir(rootDir, { recursive: true });
+        await fsp.mkdir(faissDir, { recursive: true });
+        const nowMs = Date.now();
+        // alpha aged ~47h (over budget=24); beta aged ~12h (within budget=72).
+        await seedKbWithSidecarMtime(rootDir, 'alpha', nowMs - 47 * 3_600_000);
+        await seedKbWithSidecarMtime(rootDir, 'beta', nowMs - 12 * 3_600_000);
+
+        const { buildDoctorReport, formatDoctorMarkdown } = await freshDoctor({
+          KNOWLEDGE_BASES_ROOT_DIR: rootDir,
+          FAISS_INDEX_PATH: faissDir,
+          EMBEDDING_PROVIDER: 'huggingface',
+          HUGGINGFACE_MODEL_NAME: MODEL_NAME,
+          KB_AGE_BUDGET_HOURS_ALPHA: '24',
+          KB_AGE_BUDGET_HOURS_BETA: '72',
+        });
+        const report = await buildDoctorReport({
+          backendHealthCheck: async () => ({ healthy: true, detail: 'ok' }),
+          packageRoot: tempDir,
+          invokedPath: null,
+          packageVersion: '9.9.9',
+        });
+        expect(report.age_budgets.alpha).toMatchObject({
+          configured_hours: 24,
+          breach: true,
+        });
+        expect(report.age_budgets.alpha.current_age_hours).not.toBeNull();
+        expect(report.age_budgets.beta).toMatchObject({
+          configured_hours: 72,
+          breach: false,
+        });
+        const ageBudgetCheck = report.checks.find((c) => c.name === 'age_budget');
+        expect(ageBudgetCheck?.status).toBe('warn');
+        expect(ageBudgetCheck?.detail).toContain('kb=alpha');
+        expect(ageBudgetCheck?.detail).toContain('budget=24h');
+        const md = formatDoctorMarkdown(report);
+        expect(md).toContain('AGE_BUDGET_BREACH: kb=alpha');
+        expect(md).toContain('beta: age=');
+        expect(md).toContain('budget=72h, ok');
+      } finally {
+        await fsp.rm(tempDir, { recursive: true, force: true });
+      }
+    });
+
+    it('uses the global KB_AGE_BUDGET_HOURS fallback for KBs without a per-KB override', async () => {
+      const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-doctor-age-global-'));
+      try {
+        const rootDir = path.join(tempDir, 'kbs');
+        const faissDir = path.join(tempDir, '.faiss');
+        await fsp.mkdir(rootDir, { recursive: true });
+        await fsp.mkdir(faissDir, { recursive: true });
+        const nowMs = Date.now();
+        await seedKbWithSidecarMtime(rootDir, 'alpha', nowMs - 100 * 3_600_000);
+        const { buildDoctorReport } = await freshDoctor({
+          KNOWLEDGE_BASES_ROOT_DIR: rootDir,
+          FAISS_INDEX_PATH: faissDir,
+          EMBEDDING_PROVIDER: 'huggingface',
+          HUGGINGFACE_MODEL_NAME: MODEL_NAME,
+          KB_AGE_BUDGET_HOURS: '24',
+        });
+        const report = await buildDoctorReport({
+          backendHealthCheck: async () => ({ healthy: true, detail: 'ok' }),
+          packageRoot: tempDir,
+          invokedPath: null,
+          packageVersion: '9.9.9',
+        });
+        expect(report.age_budgets.alpha).toMatchObject({
+          configured_hours: 24,
+          breach: true,
+        });
+      } finally {
+        await fsp.rm(tempDir, { recursive: true, force: true });
+      }
+    });
+
+    it('surfaces an error-level check when KB_AGE_BUDGET_HOURS_<KB> is malformed', async () => {
+      const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-doctor-age-bad-'));
+      try {
+        const rootDir = path.join(tempDir, 'kbs');
+        const faissDir = path.join(tempDir, '.faiss');
+        await fsp.mkdir(rootDir, { recursive: true });
+        await fsp.mkdir(faissDir, { recursive: true });
+        await seedKbWithSidecarMtime(rootDir, 'alpha', Date.now() - 1000);
+        const { buildDoctorReport, formatDoctorMarkdown } = await freshDoctor({
+          KNOWLEDGE_BASES_ROOT_DIR: rootDir,
+          FAISS_INDEX_PATH: faissDir,
+          EMBEDDING_PROVIDER: 'huggingface',
+          HUGGINGFACE_MODEL_NAME: MODEL_NAME,
+          KB_AGE_BUDGET_HOURS_ALPHA: '0',
+        });
+        const report = await buildDoctorReport({
+          backendHealthCheck: async () => ({ healthy: true, detail: 'ok' }),
+          packageRoot: tempDir,
+          invokedPath: null,
+          packageVersion: '9.9.9',
+        });
+        expect(report.age_budget_config_errors).toEqual([
+          expect.objectContaining({
+            env_var: 'KB_AGE_BUDGET_HOURS_ALPHA',
+            raw_value: '0',
+          }),
+        ]);
+        // Affected KB falls back to "no budget", so it does not appear in age_budgets.
+        expect(report.age_budgets.alpha).toBeUndefined();
+        const ageBudgetCheck = report.checks.find((c) => c.name === 'age_budget');
+        expect(ageBudgetCheck?.status).toBe('error');
+        expect(report.status).toBe('error');
+        expect(formatDoctorMarkdown(report)).toContain(
+          'CONFIG_ERROR: KB_AGE_BUDGET_HOURS_ALPHA="0"',
+        );
+      } finally {
+        await fsp.rm(tempDir, { recursive: true, force: true });
+      }
+    });
   });
 });

--- a/src/cli-doctor.ts
+++ b/src/cli-doctor.ts
@@ -30,6 +30,14 @@ import {
   FaissIndexManager,
   type IndexUpdateSummary,
 } from './FaissIndexManager.js';
+import {
+  AgeBudgetConfigError,
+  computeAgeBudgetStatus,
+  formatAgeBudgetBreachRow,
+  formatAgeHours,
+  type AgeBudgetStatus,
+} from './age-budget.js';
+import { maxMtimeIso } from './kb-stats.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -79,6 +87,31 @@ export interface DoctorReport {
     mtime: string | null;
   };
   stale_counts_by_kb: Record<string, { modified_files: number; new_files: number }>;
+  /**
+   * Per-KB time-based age budget status (issue #218). Only KBs that have
+   * a configured budget (per-KB or via the global `KB_AGE_BUDGET_HOURS`
+   * fallback) appear in this map. `current_age_hours` is `null` when the
+   * KB has never been indexed.
+   */
+  age_budgets: Record<
+    string,
+    {
+      configured_hours: number;
+      current_age_hours: number | null;
+      breach: boolean;
+    }
+  >;
+  /**
+   * Malformed `KB_AGE_BUDGET_HOURS*` env-var values surfaced as a
+   * separate list so the operator notices a typo even when the
+   * affected KB falls back to "no budget". Empty when all configured
+   * values parsed cleanly.
+   */
+  age_budget_config_errors: Array<{
+    env_var: string;
+    raw_value: string;
+    message: string;
+  }>;
   incomplete_models: Array<{
     model_id: string;
     status: 'in_progress' | 'stale_interrupted' | 'unknown';
@@ -207,6 +240,46 @@ export async function buildDoctorReport(
       : `${staleTotal} modified/new ingestable file(s) detected`,
   });
 
+  const ageBudgetResult = await computeAgeBudgetsByKb(
+    Object.keys(staleCounts),
+  );
+  if (
+    Object.keys(ageBudgetResult.byKb).length > 0 ||
+    ageBudgetResult.configErrors.length > 0
+  ) {
+    const breaches = Object.entries(ageBudgetResult.byKb)
+      .filter(([, row]) => row.breach);
+    if (ageBudgetResult.configErrors.length > 0) {
+      const summary = ageBudgetResult.configErrors
+        .map((e) => `${e.env_var}=${JSON.stringify(e.raw_value)}`)
+        .join(', ');
+      checks.push({
+        name: 'age_budget',
+        status: 'error',
+        detail: `malformed age-budget config: ${summary}`,
+      });
+    } else if (breaches.length > 0) {
+      const summary = breaches
+        .map(([kb, row]) =>
+          `kb=${kb}, age=${formatAgeHours(row.current_age_hours)}h, ` +
+          `budget=${row.configured_hours}h`,
+        )
+        .join('; ');
+      checks.push({
+        name: 'age_budget',
+        status: 'warn',
+        detail: `${breaches.length} KB age-budget breach(es): ${summary}`,
+      });
+    } else {
+      const configured = Object.keys(ageBudgetResult.byKb).length;
+      checks.push({
+        name: 'age_budget',
+        status: 'ok',
+        detail: `no breaches across ${configured} KB(s) with configured budgets`,
+      });
+    }
+  }
+
   const incompleteModels = await listIncompleteModelStates();
   const staleIncompleteModels = incompleteModels.filter((m) => m.status === 'stale_interrupted');
   checks.push({
@@ -251,6 +324,8 @@ export async function buildDoctorReport(
     },
     index,
     stale_counts_by_kb: staleCounts,
+    age_budgets: ageBudgetResult.byKb,
+    age_budget_config_errors: ageBudgetResult.configErrors,
     incomplete_models: incompleteModels,
     backend,
     cli,
@@ -319,6 +394,53 @@ async function computeStaleCountsByKb(
     out[kbName] = { modified_files: modified, new_files: added };
   }
   return out;
+}
+
+/**
+ * Iterate KBs and produce the per-KB age-budget rows for the doctor
+ * report. Only KBs whose name resolves to a configured budget (either
+ * the per-KB env var or the global `KB_AGE_BUDGET_HOURS` fallback) are
+ * included. Malformed env values are collected separately so the
+ * operator notices the typo while the affected KB silently falls back
+ * to "no budget".
+ */
+async function computeAgeBudgetsByKb(
+  kbNames: string[],
+): Promise<{
+  byKb: DoctorReport['age_budgets'];
+  configErrors: DoctorReport['age_budget_config_errors'];
+}> {
+  const nowMs = Date.now();
+  const byKb: DoctorReport['age_budgets'] = {};
+  const configErrors: DoctorReport['age_budget_config_errors'] = [];
+  for (const kbName of kbNames) {
+    const lastIndexAtIso = await maxMtimeIso(
+      path.join(KNOWLEDGE_BASES_ROOT_DIR, kbName, '.index'),
+    );
+    const lastIndexAtMs = lastIndexAtIso === null
+      ? null
+      : Date.parse(lastIndexAtIso);
+    let status: AgeBudgetStatus;
+    try {
+      status = computeAgeBudgetStatus(kbName, lastIndexAtMs, nowMs);
+    } catch (err) {
+      if (!(err instanceof AgeBudgetConfigError)) throw err;
+      configErrors.push({
+        env_var: err.envVar,
+        raw_value: err.rawValue,
+        message: err.message,
+      });
+      continue;
+    }
+    if (status.configuredHours === null) continue;
+    byKb[kbName] = {
+      configured_hours: status.configuredHours,
+      current_age_hours:
+        status.currentAgeHours === null ? null : status.currentAgeHours,
+      breach: status.breach,
+    };
+  }
+  return { byKb, configErrors };
 }
 
 async function countFiles(dir: string): Promise<number> {
@@ -512,6 +634,34 @@ export function formatDoctorMarkdown(report: DoctorReport): string {
     for (const name of names) {
       const row = report.stale_counts_by_kb[name];
       lines.push(`  ${name}: ${row.modified_files} modified, ${row.new_files} new`);
+    }
+  }
+  lines.push('');
+  lines.push('Age budgets:');
+  const budgetNames = Object.keys(report.age_budgets).sort();
+  if (budgetNames.length === 0 && report.age_budget_config_errors.length === 0) {
+    lines.push('  (no budgets configured)');
+  } else {
+    for (const name of budgetNames) {
+      const row = report.age_budgets[name];
+      const age = formatAgeHours(row.current_age_hours);
+      const ageDisplay = age === null ? 'never indexed' : `${age}h`;
+      if (row.breach) {
+        const breachRow = formatAgeBudgetBreachRow({
+          kb: name,
+          configuredHours: row.configured_hours,
+          currentAgeHours: row.current_age_hours,
+          breach: true,
+        });
+        lines.push(`  ${breachRow ?? `${name}: age=${ageDisplay}, budget=${row.configured_hours}h, BREACH`}`);
+      } else {
+        lines.push(
+          `  ${name}: age=${ageDisplay}, budget=${row.configured_hours}h, ok`,
+        );
+      }
+    }
+    for (const err of report.age_budget_config_errors) {
+      lines.push(`  CONFIG_ERROR: ${err.env_var}=${JSON.stringify(err.raw_value)}`);
     }
   }
   lines.push('');

--- a/src/cli-search-staleness.test.ts
+++ b/src/cli-search-staleness.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, jest } from '@jest/globals';
 import * as fsp from 'fs/promises';
 import * as os from 'os';
 import * as path from 'path';
+import { buildAgeBudgetFooter } from './cli-search-staleness.js';
 
 const ORIGINAL_ENV = {
   KNOWLEDGE_BASES_ROOT_DIR: process.env.KNOWLEDGE_BASES_ROOT_DIR,
@@ -79,5 +80,94 @@ describe('computeStaleness', () => {
     } finally {
       await fsp.rm(tempDir, { recursive: true, force: true });
     }
+  });
+});
+
+describe('buildAgeBudgetFooter (issue #218)', () => {
+  const nowMs = Date.parse('2026-05-11T12:00:00.000Z');
+
+  it('returns line=null when no age budget is configured', () => {
+    const result = buildAgeBudgetFooter({
+      kb: 'work',
+      lastIndexAtMs: nowMs - 100 * 3_600_000,
+      nowMs,
+      env: {},
+    });
+    expect(result.line).toBeNull();
+    expect(result.status.breach).toBe(false);
+    expect(result.configError).toBeNull();
+  });
+
+  it('returns line=null when the KB is within budget', () => {
+    const result = buildAgeBudgetFooter({
+      kb: 'work',
+      lastIndexAtMs: nowMs - 12 * 3_600_000,
+      nowMs,
+      env: { KB_AGE_BUDGET_HOURS_WORK: '24' },
+    });
+    expect(result.line).toBeNull();
+    expect(result.status.breach).toBe(false);
+  });
+
+  it('returns the spec-exact footer line on breach (47h vs 24h)', () => {
+    const result = buildAgeBudgetFooter({
+      kb: 'work',
+      lastIndexAtMs: nowMs - 47 * 3_600_000,
+      nowMs,
+      env: { KB_AGE_BUDGET_HOURS_WORK: '24' },
+    });
+    expect(result.status.breach).toBe(true);
+    expect(result.line).toBe(
+      '> _Served from index aged 47h, budget 24h. Run `kb search --refresh` to update._',
+    );
+  });
+
+  it('uses the global KB_AGE_BUDGET_HOURS fallback when no per-KB override is set', () => {
+    const result = buildAgeBudgetFooter({
+      kb: 'work',
+      lastIndexAtMs: nowMs - 100 * 3_600_000,
+      nowMs,
+      env: { KB_AGE_BUDGET_HOURS: '24' },
+    });
+    expect(result.status.breach).toBe(true);
+    expect(result.line).toContain('aged 100h, budget 24h');
+  });
+
+  it('returns line=null when the KB has never been indexed (lastIndexAtMs=null)', () => {
+    const result = buildAgeBudgetFooter({
+      kb: 'work',
+      lastIndexAtMs: null,
+      nowMs,
+      env: { KB_AGE_BUDGET_HOURS_WORK: '24' },
+    });
+    expect(result.line).toBeNull();
+    expect(result.status.currentAgeHours).toBeNull();
+    expect(result.status.breach).toBe(false);
+  });
+
+  it('surfaces a config-error footer when the per-KB env value is malformed', () => {
+    const result = buildAgeBudgetFooter({
+      kb: 'work',
+      lastIndexAtMs: nowMs - 50 * 3_600_000,
+      nowMs,
+      env: { KB_AGE_BUDGET_HOURS_WORK: '0' },
+    });
+    expect(result.configError).not.toBeNull();
+    expect(result.configError?.envVar).toBe('KB_AGE_BUDGET_HOURS_WORK');
+    expect(result.line).toContain('Age-budget config error');
+    expect(result.line).toContain('KB_AGE_BUDGET_HOURS_WORK="0"');
+    expect(result.status.configuredHours).toBeNull();
+    expect(result.status.breach).toBe(false);
+  });
+
+  it('uses the normalised env-suffix for KB names with dashes', () => {
+    const result = buildAgeBudgetFooter({
+      kb: 'rfcs-archived',
+      lastIndexAtMs: nowMs - 100 * 3_600_000,
+      nowMs,
+      env: { KB_AGE_BUDGET_HOURS_RFCS_ARCHIVED: '24' },
+    });
+    expect(result.status.breach).toBe(true);
+    expect(result.line).toContain('aged 100h, budget 24h');
   });
 });

--- a/src/cli-search-staleness.ts
+++ b/src/cli-search-staleness.ts
@@ -1,0 +1,100 @@
+// `kb search` freshness-footer helpers driven by the per-KB time-based
+// age budget (issue #218).
+//
+// Content-modification staleness (`modified_files` / `new_files`) is
+// handled by `cli-search.ts:formatFreshnessFooter`; this module is a
+// separate, orthogonal layer that surfaces a wall-clock age breach
+// when `KB_AGE_BUDGET_HOURS_<KB>` (or the unsuffixed global default)
+// is configured. The two layers compose: a KB can be content-fresh
+// but age-budget-stale, or vice versa.
+
+import {
+  AgeBudgetConfigError,
+  computeAgeBudgetStatus,
+  formatAgeHours,
+  type AgeBudgetStatus,
+} from './age-budget.js';
+
+export interface AgeBudgetFooterInput {
+  /** KB name scoped by the search. The footer is per-KB, so callers
+   *  in the unscoped (all-KBs) path should iterate and emit one
+   *  line per breached KB. */
+  kb: string;
+  /** Last-index timestamp for the scoped KB in epoch milliseconds.
+   *  Typically derived from sidecar mtimes under `<kb>/.index/`; pass
+   *  `null` when the KB has never been indexed. */
+  lastIndexAtMs: number | null;
+  /** Injectable clock for testing. Defaults to `Date.now()`. */
+  nowMs?: number;
+  /** Injectable env for testing. Defaults to `process.env`. */
+  env?: NodeJS.ProcessEnv;
+}
+
+export interface AgeBudgetFooterResult {
+  status: AgeBudgetStatus;
+  /** The footer line to append to `kb search` markdown output, or
+   *  `null` when there is nothing to surface (no budget configured,
+   *  KB never indexed, or within budget). */
+  line: string | null;
+  /** Set when env-var parsing failed (e.g. `KB_AGE_BUDGET_HOURS_<KB>=0`).
+   *  Callers can surface this as a warning footer line. The
+   *  underlying `status` falls back to "no budget configured". */
+  configError: AgeBudgetConfigError | null;
+}
+
+/**
+ * Compute the age-budget footer line for a scoped `kb search` run.
+ *
+ * Returns `{ status, line, configError }`. When no budget is
+ * configured, when the KB has never been indexed, or when the KB is
+ * within budget, `line` is `null`. When a budget is configured and
+ * the wall-clock age exceeds it, `line` is the rendered footer line.
+ * When env-var parsing throws `AgeBudgetConfigError`, the error is
+ * returned in `configError` and `line` carries a malformed-config
+ * warning so the operator notices.
+ */
+export function buildAgeBudgetFooter(
+  input: AgeBudgetFooterInput,
+): AgeBudgetFooterResult {
+  const nowMs = input.nowMs ?? Date.now();
+  const env = input.env ?? process.env;
+  let status: AgeBudgetStatus;
+  let configError: AgeBudgetConfigError | null = null;
+  try {
+    status = computeAgeBudgetStatus(input.kb, input.lastIndexAtMs, nowMs, env);
+  } catch (err) {
+    if (!(err instanceof AgeBudgetConfigError)) throw err;
+    configError = err;
+    status = {
+      kb: input.kb,
+      configuredHours: null,
+      currentAgeHours:
+        input.lastIndexAtMs === null
+          ? null
+          : Math.max(0, (nowMs - input.lastIndexAtMs) / 3_600_000),
+      breach: false,
+    };
+  }
+  if (configError !== null) {
+    return {
+      status,
+      line:
+        `> _Age-budget config error: ${configError.envVar}=` +
+        `${JSON.stringify(configError.rawValue)} is not a positive ` +
+        `integer; age budget for KB "${input.kb}" is disabled until ` +
+        `the value is fixed._`,
+      configError,
+    };
+  }
+  if (!status.breach) {
+    return { status, line: null, configError: null };
+  }
+  const ageH = formatAgeHours(status.currentAgeHours);
+  return {
+    status,
+    line:
+      `> _Served from index aged ${ageH}h, budget ${status.configuredHours}h. ` +
+      `Run \`kb search --refresh\` to update._`,
+    configError: null,
+  };
+}


### PR DESCRIPTION
## Summary
- New `src/age-budget.ts` resolves `KB_AGE_BUDGET_HOURS_<KB>` (and unsuffixed global fallback) with NFC + uppercase suffix normalisation, rejects `0`/negatives/non-integers as malformed config, and computes per-KB breach status against a caller-supplied clock.
- New `src/cli-search-staleness.ts` returns the freshness-footer line (`> _Served from index aged 47h, budget 24h. Run \`kb search --refresh\` to update._`) when a configured KB is over budget, plus a malformed-config warning footer when env values fail to parse.
- `src/cli-doctor.ts` gains an `age_budgets` map, an `age_budget_config_errors` list, and an `age_budget` check that warns on breach / errors on malformed config; the markdown report grows an `Age budgets:` section with per-KB `AGE_BUDGET_BREACH: kb=…, age=Nh, budget=Mh` rows.

## Behaviour
- Default behaviour is byte-equal when no `KB_AGE_BUDGET_HOURS*` env is set (no new `age_budget` check row, no new footer line, `age_budgets: {}`).
- Per-KB precedence: `KB_AGE_BUDGET_HOURS_<SUFFIX>` → `KB_AGE_BUDGET_HOURS` → unset.
- Suffix derivation: NFC-normalise → uppercase → replace any character outside `[A-Z0-9_]` with `_`.
- Breach is strict (`current_age_hours > configured_hours`), so equality is not a breach.
- Never-indexed KBs report `current_age_hours: null` and never breach, matching the v0 spec.

## Out of scope (deferred per the issue)
- Canonical log event (`served_stale`, `kb_age_hours`, `kb_age_budget_hours`) — additive to `kb-canonical.v1`, future work.
- `kb_stats` MCP tool `age_budget` block — kept out of write scope; `kb-stats.ts` is unchanged.
- `KB_AGE_BUDGET_POLICY={block|serve-and-tag}` — v0 ships `warn` only; `block`/`serve-and-tag` reserved.
- KB-frontmatter overrides and `kb eval` `age_policy` knob — explicit follow-ups.

## Test plan
- [x] `npm test -- --runTestsByPath src/age-budget.test.ts src/cli-doctor.test.ts src/cli-search-staleness.test.ts` (3 suites, 41 tests, all green)
- [x] `npm test` (full suite, 44 suites / 752 tests, all green)
- [x] `npm run build`

Closes #218.

🤖 Generated with [Claude Code](https://claude.com/claude-code)