### PR TITLE
feat(watcher): recursive fs.watch KB watcher with per-(kb, file) debounce

### DIFF
--- a/src/KnowledgeBaseServer.ts
+++ b/src/KnowledgeBaseServer.ts
@@ -21,6 +21,10 @@ import {
   ADD_DOCUMENT_DESCRIPTION,
   DELETE_DOCUMENT_DESCRIPTION,
   FRONTMATTER_EXTRAS_WIRE_VISIBLE,
+  INGEST_EXCLUDE_PATHS,
+  INGEST_EXTRA_EXTENSIONS,
+  KB_FS_WATCH,
+  KB_FS_WATCH_DEBOUNCE_MS,
   KB_STATS_DESCRIPTION,
   KNOWLEDGE_BASES_ROOT_DIR,
   LIST_KNOWLEDGE_BASES_DESCRIPTION,
@@ -56,6 +60,7 @@ import * as path from 'path';
 import { StreamableHttpHost } from './transport/http.js';
 import { SseHost } from './transport/sse.js';
 import { ReindexTriggerWatcher } from './triggerWatcher.js';
+import { RecursiveKbWatcher } from './recursive-fs-watch.js';
 import { KBError, type KBErrorCode } from './errors.js';
 import { LexicalIndex, type LexicalSearchResult } from './lexical-index.js';
 import { chunkIdFromMetadata, reciprocalRankFusion, type RankedList } from './rrf.js';
@@ -277,6 +282,10 @@ export class KnowledgeBaseServer {
   private sseHost?: SseHost;
   private transportMode: 'stdio' | 'sse' | 'http' | null = null;
   private triggerWatcher?: ReindexTriggerWatcher;
+  // RFC 007 §6.6 / issue #212 — opt-in recursive `fs.watch` per KB.
+  // Complements `triggerWatcher` (root-level dotfile poller); this one
+  // observes per-file edits *inside* each KB tree.
+  private fsWatcher?: RecursiveKbWatcher;
   private shutdownInstalled = false;
   // Issue #54 — uptime baseline for kb_stats.server.uptime_ms.
   private readonly startedAt: number = Date.now();
@@ -990,6 +999,7 @@ export class KnowledgeBaseServer {
     logger.info('Knowledge Base MCP server running on stdio');
     this.startActiveManagerWarmup();
     this.startTriggerWatcher();
+    await this.startFsWatcher();
   }
 
   private async runSse(config: TransportConfig): Promise<void> {
@@ -1005,6 +1015,7 @@ export class KnowledgeBaseServer {
     this.transportMode = 'sse';
     this.startActiveManagerWarmup();
     this.startTriggerWatcher();
+    await this.startFsWatcher();
   }
 
   private async runHttp(config: TransportConfig): Promise<void> {
@@ -1018,6 +1029,7 @@ export class KnowledgeBaseServer {
     this.transportMode = 'http';
     this.startActiveManagerWarmup();
     this.startTriggerWatcher();
+    await this.startFsWatcher();
   }
 
   /**
@@ -1099,6 +1111,55 @@ export class KnowledgeBaseServer {
     }
   }
 
+  /**
+   * RFC 007 §6.6 / issue #212 — opt-in recursive `fs.watch` watcher.
+   * Off by default; `KB_FS_WATCH=1` enables it. Failure to enumerate
+   * KBs or attach watchers is logged and swallowed so a partial
+   * filesystem doesn't prevent the server from coming up.
+   */
+  private async startFsWatcher(): Promise<void> {
+    if (this.fsWatcher) return;
+    if (!KB_FS_WATCH) return;
+
+    let kbNames: string[];
+    try {
+      kbNames = await listKnowledgeBases(KNOWLEDGE_BASES_ROOT_DIR);
+    } catch (err) {
+      logger.warn(
+        `RecursiveKbWatcher: could not enumerate KBs under ${KNOWLEDGE_BASES_ROOT_DIR}: ${(err as Error).message}`,
+      );
+      return;
+    }
+    if (kbNames.length === 0) {
+      logger.info('RecursiveKbWatcher: no KBs to watch (skipped)');
+      return;
+    }
+    const targets = kbNames.map((kbName) => ({
+      kbName,
+      kbPath: path.join(KNOWLEDGE_BASES_ROOT_DIR, kbName),
+    }));
+    this.fsWatcher = new RecursiveKbWatcher({
+      targets,
+      onChange: async (kbName) => {
+        try {
+          const activeId = await resolveActiveModel();
+          const manager = await this.managers.getOrCreate(activeId);
+          await withWriteLock(manager.modelDir, () => manager.updateIndex(kbName));
+        } catch (err) {
+          logger.warn(
+            `RecursiveKbWatcher updateIndex(${kbName}) failed: ${(err as Error).message}`,
+          );
+        }
+      },
+      debounceMs: KB_FS_WATCH_DEBOUNCE_MS,
+      ingestFilter: {
+        extraExtensions: INGEST_EXTRA_EXTENSIONS,
+        excludePaths: INGEST_EXCLUDE_PATHS,
+      },
+    });
+    await this.fsWatcher.start();
+  }
+
   private startTriggerWatcher(): void {
     if (this.triggerWatcher) return;
     if (REINDEX_TRIGGER_POLL_MS <= 0) {
@@ -1141,6 +1202,14 @@ export class KnowledgeBaseServer {
         logger.warn(`Error stopping reindex trigger watcher: ${(err as Error).message}`);
       }
       this.triggerWatcher = undefined;
+    }
+    if (this.fsWatcher) {
+      try {
+        await this.fsWatcher.stop();
+      } catch (err) {
+        logger.warn(`Error stopping recursive fs watcher: ${(err as Error).message}`);
+      }
+      this.fsWatcher = undefined;
     }
     if (this.sseHost) {
       try {

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,4 +1,6 @@
 import {
+  parseKbFsWatchDebounceMs,
+  parseKbFsWatchFlag,
   parseReindexTriggerPollMs,
   parseKBEditorUri,
   resolveChunkSize,
@@ -150,5 +152,54 @@ describe('parseKBEditorUri (#220 — KB_EDITOR_URI)', () => {
 
   it('rejects unsupported modes', () => {
     expect(() => parseKBEditorUri('vim')).toThrow(/KB_EDITOR_URI/);
+  });
+});
+
+describe('parseKbFsWatchFlag (#212 — KB_FS_WATCH)', () => {
+  it('defaults to false when unset, blank, or whitespace', () => {
+    expect(parseKbFsWatchFlag(undefined)).toBe(false);
+    expect(parseKbFsWatchFlag('')).toBe(false);
+    expect(parseKbFsWatchFlag('   ')).toBe(false);
+  });
+
+  it('accepts the documented truthy aliases (case-insensitive)', () => {
+    for (const truthy of ['1', 'true', 'TRUE', 'yes', 'on', ' On ']) {
+      expect(parseKbFsWatchFlag(truthy)).toBe(true);
+    }
+  });
+
+  it('treats anything else as false (default off)', () => {
+    expect(parseKbFsWatchFlag('0')).toBe(false);
+    expect(parseKbFsWatchFlag('false')).toBe(false);
+    expect(parseKbFsWatchFlag('no')).toBe(false);
+    expect(parseKbFsWatchFlag('off')).toBe(false);
+    expect(parseKbFsWatchFlag('garbage')).toBe(false);
+  });
+});
+
+describe('parseKbFsWatchDebounceMs (#212 — KB_FS_WATCH_DEBOUNCE_MS)', () => {
+  it('returns the 250 ms default when unset or blank', () => {
+    expect(parseKbFsWatchDebounceMs(undefined)).toBe(250);
+    expect(parseKbFsWatchDebounceMs('')).toBe(250);
+    expect(parseKbFsWatchDebounceMs('   ')).toBe(250);
+  });
+
+  it('honors positive integer values', () => {
+    expect(parseKbFsWatchDebounceMs('100')).toBe(100);
+    expect(parseKbFsWatchDebounceMs('1500')).toBe(1500);
+  });
+
+  it('clamps absurdly small / large values into [MIN, MAX]', () => {
+    // The lower clamp prevents a 5ms spin; the upper clamp prevents
+    // an operator-supplied multi-hour interval that defeats the point
+    // of the watcher.
+    expect(parseKbFsWatchDebounceMs('1')).toBe(25);
+    expect(parseKbFsWatchDebounceMs('999999999')).toBe(60_000);
+  });
+
+  it('falls back to default for non-numeric / non-positive inputs', () => {
+    expect(parseKbFsWatchDebounceMs('not-a-number')).toBe(250);
+    expect(parseKbFsWatchDebounceMs('0')).toBe(250);
+    expect(parseKbFsWatchDebounceMs('-50')).toBe(250);
   });
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -210,6 +210,58 @@ export const REINDEX_TRIGGER_PATH: string =
   || path.join(KNOWLEDGE_BASES_ROOT_DIR, '.reindex-trigger');
 
 // ---------------------------------------------------------------------------
+// Recursive fs.watch watcher (RFC 007 §6.6, issue #212).
+//
+// Observes per-file edits *inside* each registered KB directory, complementing
+// the RFC 011 trigger-file poller (which sees the root-level dotfile that
+// external workflows `touch`). Off by default for v1 because `fs.watch` has
+// platform quirks (NFS, FUSE, very large trees on Linux) we don't want to
+// surprise existing users with — operators opt in with `KB_FS_WATCH=1`.
+// ---------------------------------------------------------------------------
+
+/**
+ * @internal exported only for `config.test.ts`. Accepts the `1` / `true`
+ * / `yes` / `on` family (case-insensitive); everything else is `false`.
+ * Empty / unset → `false` (default off).
+ */
+export function parseKbFsWatchFlag(raw: string | undefined): boolean {
+  if (raw === undefined) return false;
+  const trimmed = raw.trim().toLowerCase();
+  if (trimmed === '') return false;
+  return trimmed === '1' || trimmed === 'true' || trimmed === 'yes' || trimmed === 'on';
+}
+
+export const KB_FS_WATCH: boolean = parseKbFsWatchFlag(process.env.KB_FS_WATCH);
+
+const DEFAULT_KB_FS_WATCH_DEBOUNCE_MS = 250;
+const MIN_KB_FS_WATCH_DEBOUNCE_MS = 25;
+const MAX_KB_FS_WATCH_DEBOUNCE_MS = 60_000;
+
+/**
+ * @internal exported only for `config.test.ts`. Parses the per-(kb, file)
+ * debounce window. Invalid / unset → default 250 ms; otherwise clamped
+ * into `[MIN, MAX]` so an operator-supplied `5` doesn't spin or `3600000`
+ * doesn't defeat the point of the watcher.
+ */
+export function parseKbFsWatchDebounceMs(raw: string | undefined): number {
+  if (raw === undefined || raw.trim() === '') {
+    return DEFAULT_KB_FS_WATCH_DEBOUNCE_MS;
+  }
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return DEFAULT_KB_FS_WATCH_DEBOUNCE_MS;
+  }
+  return Math.max(
+    MIN_KB_FS_WATCH_DEBOUNCE_MS,
+    Math.min(MAX_KB_FS_WATCH_DEBOUNCE_MS, Math.round(parsed)),
+  );
+}
+
+export const KB_FS_WATCH_DEBOUNCE_MS: number = parseKbFsWatchDebounceMs(
+  process.env.KB_FS_WATCH_DEBOUNCE_MS,
+);
+
+// ---------------------------------------------------------------------------
 // Tool description overrides (RFC 010 M2 / #52).
 // Operators can repurpose the same binary for different deployments (eng
 // docs vs. personal notes vs. postmortems) by overriding the model-facing

--- a/src/recursive-fs-watch.test.ts
+++ b/src/recursive-fs-watch.test.ts
@@ -1,0 +1,308 @@
+import * as fsp from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+
+import { enumerateDirectories, RecursiveKbWatcher } from './recursive-fs-watch.js';
+
+/**
+ * The watcher drives real `fs.watch` handles in production. Real events
+ * are inherently flaky across platforms (FSEvents coalescing, inotify
+ * delivery delays, WSL2 timing), so unit tests use the `handleFsEvent`
+ * test hook to dispatch synthetic events. This isolates the contract
+ * we actually care about — filter + debounce + coalesce + lifecycle —
+ * from the fs.watch backend.
+ *
+ * Real-timer test cadence: 25ms debounce + 30ms drain settles in well
+ * under 100ms even on a slow CI host, so the full file runs in ~1s.
+ */
+describe('RecursiveKbWatcher (RFC 007 §6.6 / issue #212)', () => {
+  let tempDir: string;
+  const KB = 'notes';
+
+  beforeEach(async () => {
+    tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-fs-watch-'));
+    await fsp.mkdir(path.join(tempDir, KB), { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fsp.rm(tempDir, { recursive: true, force: true });
+  });
+
+  function makeWatcher(opts: {
+    onChange: (kbName: string) => Promise<void>;
+    debounceMs?: number;
+    excludePaths?: readonly string[];
+  }): RecursiveKbWatcher {
+    return new RecursiveKbWatcher({
+      targets: [{ kbName: KB, kbPath: path.join(tempDir, KB) }],
+      onChange: opts.onChange,
+      debounceMs: opts.debounceMs ?? 25,
+      ingestFilter: opts.excludePaths
+        ? { excludePaths: opts.excludePaths }
+        : undefined,
+      // Force per-directory mode for deterministic dir-enumeration
+      // behavior across host platforms in `start()`.
+      forceNonRecursive: true,
+    });
+  }
+
+  async function drain(ms = 60): Promise<void> {
+    await new Promise((r) => setTimeout(r, ms));
+  }
+
+  it('coalesces ≥10 rapid events for the same (kb, file) into 1 onChange call', async () => {
+    const onChange = jest.fn().mockResolvedValue(undefined);
+    const watcher = makeWatcher({ onChange, debounceMs: 25 });
+    await watcher.start();
+
+    for (let i = 0; i < 12; i += 1) {
+      watcher.handleFsEvent(KB, 'note.md');
+    }
+    expect(onChange).not.toHaveBeenCalled();
+
+    await drain(80);
+    await watcher.stop();
+
+    // Twelve synchronous events collapse into one fire — the debounce
+    // restarts on each event, only the last timer survives.
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith(KB);
+  });
+
+  it('drops dotfile events (walker semantics: hidden paths are skipped)', async () => {
+    const onChange = jest.fn().mockResolvedValue(undefined);
+    const watcher = makeWatcher({ onChange, debounceMs: 25 });
+    await watcher.start();
+
+    watcher.handleFsEvent(KB, '.reindex-trigger');
+    watcher.handleFsEvent(KB, '.index/whatever.sha256');
+    watcher.handleFsEvent(KB, '.git/HEAD');
+    await drain(80);
+    await watcher.stop();
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('drops events whose extension is not on the ingest allowlist', async () => {
+    const onChange = jest.fn().mockResolvedValue(undefined);
+    const watcher = makeWatcher({ onChange, debounceMs: 25 });
+    await watcher.start();
+
+    watcher.handleFsEvent(KB, 'screenshot.png');
+    watcher.handleFsEvent(KB, 'archive.tar.gz');
+    watcher.handleFsEvent(KB, 'notes/_seen.jsonl');
+    await drain(80);
+    await watcher.stop();
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('honours INGEST_EXCLUDE_PATHS minimatch patterns from the ingest filter', async () => {
+    const onChange = jest.fn().mockResolvedValue(undefined);
+    const watcher = makeWatcher({
+      onChange,
+      debounceMs: 25,
+      excludePaths: ['pdfs/**'],
+    });
+    await watcher.start();
+
+    watcher.handleFsEvent(KB, 'pdfs/paper.pdf');
+    await drain(80);
+    expect(onChange).not.toHaveBeenCalled();
+
+    // A non-excluded file still fires.
+    watcher.handleFsEvent(KB, 'notes/paper.md');
+    await drain(80);
+    await watcher.stop();
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('coalesces bursts across multiple files into ≤ 2 onChange invocations per KB', async () => {
+    // Single in-flight + single pending: identical contract to the
+    // trigger watcher. Bursty events while onChange is running collapse
+    // into one tail call.
+    let resolveFirst: (() => void) | undefined;
+    const firstInFlight = new Promise<void>((resolve) => {
+      resolveFirst = resolve;
+    });
+    let callIndex = 0;
+    const onChange = jest.fn<Promise<void>, [string]>().mockImplementation(() => {
+      const idx = callIndex;
+      callIndex += 1;
+      if (idx === 0) return firstInFlight;
+      return Promise.resolve();
+    });
+
+    const watcher = makeWatcher({ onChange, debounceMs: 15 });
+    await watcher.start();
+
+    // Trigger debounce window → first onChange (in-flight, blocked).
+    watcher.handleFsEvent(KB, 'a.md');
+    await drain(30);
+    expect(onChange).toHaveBeenCalledTimes(1);
+
+    // Five additional file events while the first run is blocked.
+    // They debounce, then each tries to start a run — all collapse to
+    // a single pending flag.
+    for (const name of ['b.md', 'c.md', 'd.md', 'e.md', 'f.md']) {
+      watcher.handleFsEvent(KB, name);
+    }
+    await drain(30);
+    expect(onChange).toHaveBeenCalledTimes(1);
+
+    // Unblock the first run; the coalesced tail (one, not five) fires.
+    resolveFirst!();
+    await drain(30);
+    expect(onChange).toHaveBeenCalledTimes(2);
+
+    await watcher.stop();
+    expect(onChange).toHaveBeenCalledTimes(2);
+  });
+
+  it('stop() drains an in-flight onChange and suppresses queued follow-ups', async () => {
+    let resolveRun: (() => void) | undefined;
+    const inFlight = new Promise<void>((resolve) => {
+      resolveRun = resolve;
+    });
+    const onChange = jest.fn<Promise<void>, [string]>().mockImplementation(() => inFlight);
+
+    const watcher = makeWatcher({ onChange, debounceMs: 15 });
+    await watcher.start();
+    watcher.handleFsEvent(KB, 'note.md');
+    await drain(30);
+    // Run #1 is now in-flight, blocked on `inFlight`.
+    expect(onChange).toHaveBeenCalledTimes(1);
+
+    // Burst a second debounced run → queued pending.
+    watcher.handleFsEvent(KB, 'other.md');
+    await drain(30);
+    expect(onChange).toHaveBeenCalledTimes(1);
+
+    // stop() should drain the first run AND drop the queued one.
+    const stopPromise = watcher.stop();
+    resolveRun!();
+    await stopPromise;
+
+    // Any later raw event after stop() is a no-op.
+    watcher.handleFsEvent(KB, 'late.md');
+    await drain(30);
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps running when onChange rejects — next event re-invokes normally', async () => {
+    const onChange = jest
+      .fn<Promise<void>, [string]>()
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValue(undefined);
+
+    const watcher = makeWatcher({ onChange, debounceMs: 15 });
+    await watcher.start();
+    watcher.handleFsEvent(KB, 'first.md');
+    await drain(40);
+    // The first run rejected internally; the watcher swallows it.
+    expect(onChange).toHaveBeenCalledTimes(1);
+
+    watcher.handleFsEvent(KB, 'second.md');
+    await drain(40);
+    await watcher.stop();
+    expect(onChange).toHaveBeenCalledTimes(2);
+  });
+
+  it('handleFsEvent is a no-op for an unregistered KB name', async () => {
+    const onChange = jest.fn().mockResolvedValue(undefined);
+    const watcher = makeWatcher({ onChange, debounceMs: 15 });
+    await watcher.start();
+    watcher.handleFsEvent('does-not-exist', 'note.md');
+    await drain(40);
+    await watcher.stop();
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('start()/stop() are idempotent and survive a missing KB directory', async () => {
+    // The KB target points at a path that doesn't exist — start() must
+    // log + continue rather than throw, because the operator-facing
+    // contract is "watcher failures must not prevent the server from
+    // coming up". Subsequent stop() / start() are still safe to call.
+    const missingPath = path.join(tempDir, 'no-such-kb');
+    const onChange = jest.fn().mockResolvedValue(undefined);
+    const watcher = new RecursiveKbWatcher({
+      targets: [{ kbName: 'ghost', kbPath: missingPath }],
+      onChange,
+      debounceMs: 15,
+      forceNonRecursive: true,
+    });
+
+    await expect(watcher.start()).resolves.toBeUndefined();
+    // Second start() is a silent no-op.
+    await expect(watcher.start()).resolves.toBeUndefined();
+    await expect(watcher.stop()).resolves.toBeUndefined();
+    // Second stop() is a silent no-op.
+    await expect(watcher.stop()).resolves.toBeUndefined();
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('end-to-end: a real fs change inside the KB triggers exactly one onChange', async () => {
+    // The other tests use the synthetic `handleFsEvent` hook to avoid
+    // fs.watch flakiness. This single test exercises the real backend
+    // so a regression that breaks the `fs.watch → onRawFsEvent` wiring
+    // doesn't silently pass with all the hook-driven tests still green.
+    // Per-directory mode is forced so behavior is consistent across
+    // Linux/macOS/WSL.
+    const onChange = jest.fn().mockResolvedValue(undefined);
+    const watcher = makeWatcher({ onChange, debounceMs: 50 });
+    await watcher.start();
+
+    const target = path.join(tempDir, KB, 'note.md');
+    await fsp.writeFile(target, 'hello');
+    // Allow debounce + drain. fs.watch can deliver multiple events
+    // (rename + change) for one writeFile; the debounce is what
+    // collapses them.
+    await drain(200);
+    await watcher.stop();
+
+    // Skip the assertion when running under a backend that does not
+    // deliver events at all (e.g. NFS / FUSE in some CI environments)
+    // — the unit tests above already cover the contract; this is the
+    // smoke check.
+    if (onChange.mock.calls.length === 0) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        'recursive-fs-watch e2e smoke test: fs.watch backend delivered no events; ' +
+          'skipping count assertion (this can happen on NFS/FUSE filesystems).',
+      );
+      return;
+    }
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith(KB);
+  });
+});
+
+describe('enumerateDirectories', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-enumerate-dirs-'));
+  });
+
+  afterEach(async () => {
+    await fsp.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('returns the root plus every nested directory, skipping dot-prefixed ones', async () => {
+    await fsp.mkdir(path.join(tempDir, 'a/b/c'), { recursive: true });
+    await fsp.mkdir(path.join(tempDir, 'a/d'), { recursive: true });
+    // These dotfile directories MUST be skipped — they're indexer
+    // sidecars and never corpus content.
+    await fsp.mkdir(path.join(tempDir, '.index'), { recursive: true });
+    await fsp.mkdir(path.join(tempDir, 'a/.cache'), { recursive: true });
+
+    const dirs = await enumerateDirectories(tempDir);
+    const rel = dirs.map((d) => path.relative(tempDir, d) || '.').sort();
+    expect(rel).toEqual(['.', 'a', 'a/b', 'a/b/c', 'a/d'].sort());
+  });
+
+  it('returns just the root when there are no subdirectories', async () => {
+    const dirs = await enumerateDirectories(tempDir);
+    expect(dirs).toEqual([tempDir]);
+  });
+});

--- a/src/recursive-fs-watch.ts
+++ b/src/recursive-fs-watch.ts
@@ -1,0 +1,349 @@
+// RFC 007 §6.6 — recursive `fs.watch` KB watcher with per-(kb, file)
+// debounce (issue #212). Observes per-file edits *inside* each registered
+// KB tree, complementing the RFC 011 trigger-file poller in
+// `triggerWatcher.ts` (which observes a single dotfile at the KB root
+// touched by external batch workflows like the arxiv-ingestion n8n flow).
+//
+// Off by default — the `KB_FS_WATCH=1` flag opts in. `fs.watch` has well
+// known platform quirks (NFS / FUSE never deliver events, very large
+// trees on Linux exhaust inotify watch slots) that we don't want to
+// surprise existing users with on a minor release.
+//
+// Design contract (mirrors `ReindexTriggerWatcher`):
+//   1. Per registered KB, attach a recursive `fs.watch(kbPath,
+//      {recursive: true})` on macOS / Windows. On Linux + WSL fall back
+//      to a non-recursive watch on each subdirectory enumerated at
+//      startup (`getFilesRecursively` already supplies the subdir set
+//      we need; we re-walk it here to harvest the directory list).
+//   2. Filter events through the same dotfile + extension allowlist +
+//      `INGEST_EXCLUDE_PATHS` rules the indexer uses. Anything the
+//      walker would skip is dropped on the watcher path too.
+//   3. Debounce each `(kb, relativePath)` for `debounceMs` (default
+//      250 ms). Coalesce bursts — VSCode and similar editors save
+//      via `tmp + rename`, producing 2-3 events per logical save.
+//   4. After debounce, schedule a per-KB `updateIndex` under the
+//      existing write lock. The FaissIndexManager already uses sidecar
+//      hashes to skip unchanged files inside that KB, so the cost is
+//      proportional to what actually changed, not the full KB.
+//   5. Lifecycle: `start()` from `KnowledgeBaseServer.runStdio/Sse/Http`
+//      after the transport binds; `stop()` from the SIGINT shutdown
+//      path. Identical to the trigger watcher's start/stop semantics.
+//
+// Concurrency: a single in-flight `updateIndex(kbName)` runs per KB at
+// a time, with at most one queued follow-up — the same "single-slot
+// pending" coalescer the trigger watcher uses. Bursts of N debounced
+// per-file events collapse to ≤ 2 `updateIndex` calls per KB.
+//
+// Robustness:
+//   - Errors from `fs.watch` (ENOSPC = inotify slots exhausted, ENOTSUP
+//     = filesystem doesn't support fs.watch) are caught, logged, and
+//     the watcher continues running with the KBs it could attach to.
+//   - `stop()` is idempotent and awaits any in-flight `onChange`.
+import * as fs from 'fs';
+import * as fsp from 'fs/promises';
+import * as path from 'path';
+
+import { filterIngestablePaths } from './ingest-filter.js';
+import { logger } from './logger.js';
+
+/**
+ * Per-KB binding the watcher uses to translate `fs.watch` events back
+ * to `(kbName, kbRelativePath)`. `kbPath` is the absolute directory the
+ * watcher attaches to; `relPathFromKbRoot` is computed at event time.
+ */
+export interface RecursiveKbWatcherTarget {
+  kbName: string;
+  kbPath: string;
+}
+
+export interface RecursiveKbWatcherOptions {
+  targets: ReadonlyArray<RecursiveKbWatcherTarget>;
+  /**
+   * Invoked when at least one ingestable file inside a KB has settled
+   * past its debounce window. Receives the KB name; the implementation
+   * decides what to re-index (typical: `updateIndex(kbName)` under the
+   * write lock, which the FaissIndexManager narrows via sidecar hashes).
+   */
+  onChange: (kbName: string) => Promise<void>;
+  /** Per-(kb, file) debounce window in milliseconds. */
+  debounceMs: number;
+  /** Forwarded to `filterIngestablePaths`. Operator-extensible allowlist. */
+  ingestFilter?: {
+    extraExtensions?: readonly string[];
+    excludePaths?: readonly string[];
+  };
+  /**
+   * Force the non-recursive (per-directory) attach mode even on
+   * platforms where `{recursive: true}` is supported. Exposed for
+   * tests; production code picks the mode automatically from
+   * `process.platform`.
+   */
+  forceNonRecursive?: boolean;
+}
+
+interface PerKbState {
+  kbName: string;
+  kbPath: string;
+  watchers: fs.FSWatcher[];
+  debounceTimers: Map<string, NodeJS.Timeout>;
+  inFlight: Promise<void> | null;
+  pending: boolean;
+}
+
+export class RecursiveKbWatcher {
+  private readonly targets: ReadonlyArray<RecursiveKbWatcherTarget>;
+  private readonly onChange: (kbName: string) => Promise<void>;
+  private readonly debounceMs: number;
+  private readonly extraExtensions: readonly string[];
+  private readonly excludePaths: readonly string[];
+  private readonly forceNonRecursive: boolean;
+
+  private readonly states: Map<string, PerKbState> = new Map();
+  private started = false;
+  private stopped = false;
+
+  constructor(options: RecursiveKbWatcherOptions) {
+    this.targets = options.targets;
+    this.onChange = options.onChange;
+    this.debounceMs = options.debounceMs;
+    this.extraExtensions = options.ingestFilter?.extraExtensions ?? [];
+    this.excludePaths = options.ingestFilter?.excludePaths ?? [];
+    this.forceNonRecursive = options.forceNonRecursive ?? false;
+  }
+
+  /**
+   * Attaches `fs.watch` to every target KB. Idempotent: a second
+   * `start()` is a silent no-op so a caller can wire it into both
+   * stdio and HTTP startup paths without guarding. After `stop()` the
+   * instance is terminal.
+   */
+  async start(): Promise<void> {
+    if (this.started || this.stopped) return;
+    this.started = true;
+
+    for (const target of this.targets) {
+      const state: PerKbState = {
+        kbName: target.kbName,
+        kbPath: target.kbPath,
+        watchers: [],
+        debounceTimers: new Map(),
+        inFlight: null,
+        pending: false,
+      };
+      this.states.set(target.kbName, state);
+
+      try {
+        if (this.useRecursive()) {
+          this.attachRecursive(state);
+        } else {
+          await this.attachPerDirectory(state);
+        }
+      } catch (err) {
+        // ENOSPC (Linux inotify slots), ENOTSUP (some FUSE mounts), or
+        // ENOENT if the KB directory vanished mid-startup — log and
+        // keep going for other KBs rather than aborting the server.
+        logger.warn(
+          `RecursiveKbWatcher: failed to attach to ${target.kbPath} ` +
+            `(${target.kbName}): ${(err as Error).message}`,
+        );
+      }
+    }
+
+    if (this.states.size > 0) {
+      const mode = this.useRecursive() ? 'recursive' : 'per-directory';
+      logger.info(
+        `RecursiveKbWatcher started (${mode}); kbs=${this.targets.length} debounceMs=${this.debounceMs}`,
+      );
+    }
+  }
+
+  /**
+   * Closes every `fs.watch` handle, clears all pending debounce timers,
+   * and awaits any in-flight `onChange`. Idempotent.
+   */
+  async stop(): Promise<void> {
+    this.stopped = true;
+    for (const state of this.states.values()) {
+      for (const timer of state.debounceTimers.values()) {
+        clearTimeout(timer);
+      }
+      state.debounceTimers.clear();
+      for (const watcher of state.watchers) {
+        try {
+          watcher.close();
+        } catch {
+          // Already closed (e.g. dir was removed): no recovery needed.
+        }
+      }
+      state.watchers = [];
+    }
+    const drains = Array.from(this.states.values())
+      .map((state) => state.inFlight)
+      .filter((p): p is Promise<void> => p !== null);
+    if (drains.length > 0) {
+      await Promise.allSettled(drains);
+    }
+  }
+
+  /**
+   * Test hook — drive the debounce path deterministically without
+   * waiting on real timers. Bypasses the `fs.watch` callback so a unit
+   * test can assert filter + debounce + coalesce behavior on a fake
+   * event without standing up a real directory tree.
+   */
+  handleFsEvent(kbName: string, eventTarget: string): void {
+    const state = this.states.get(kbName);
+    if (state === undefined) return;
+    this.onRawFsEvent(state, eventTarget);
+  }
+
+  private useRecursive(): boolean {
+    if (this.forceNonRecursive) return false;
+    // Node 14+ supports `recursive: true` on macOS and Windows; Linux
+    // gained it in 20. Per the issue, Linux/WSL gets per-directory
+    // attach by default because inotify cost is the same either way
+    // and operators see clearer errors when they hit a watch-slot cap.
+    return process.platform === 'darwin' || process.platform === 'win32';
+  }
+
+  private attachRecursive(state: PerKbState): void {
+    const watcher = fs.watch(
+      state.kbPath,
+      { recursive: true },
+      (_event, filename) => {
+        if (filename === null) return;
+        this.onRawFsEvent(state, filename.toString());
+      },
+    );
+    watcher.on('error', (err) => {
+      logger.warn(
+        `RecursiveKbWatcher: error on ${state.kbPath} (${state.kbName}): ${err.message}`,
+      );
+    });
+    state.watchers.push(watcher);
+  }
+
+  private async attachPerDirectory(state: PerKbState): Promise<void> {
+    const dirs = await enumerateDirectories(state.kbPath);
+    for (const dir of dirs) {
+      try {
+        const watcher = fs.watch(dir, (_event, filename) => {
+          if (filename === null) return;
+          // `filename` is relative to the watched directory; rebuild a
+          // KB-root-relative path so the ingest filter sees the same
+          // shape it would from the recursive mode.
+          const absPath = path.join(dir, filename.toString());
+          const relFromKb = path.relative(state.kbPath, absPath);
+          if (relFromKb === '' || relFromKb.startsWith('..')) return;
+          this.onRawFsEvent(state, relFromKb);
+        });
+        watcher.on('error', (err) => {
+          logger.warn(
+            `RecursiveKbWatcher: error on ${dir} (${state.kbName}): ${err.message}`,
+          );
+        });
+        state.watchers.push(watcher);
+      } catch (err) {
+        // A subdir that disappeared between enumerate and attach is
+        // not a hard error — skip it.
+        logger.debug(
+          `RecursiveKbWatcher: skip ${dir} (${state.kbName}): ${(err as Error).message}`,
+        );
+      }
+    }
+  }
+
+  private onRawFsEvent(state: PerKbState, rawTarget: string): void {
+    if (this.stopped) return;
+
+    // POSIX-form the path so the ingest filter (which builds patterns
+    // with forward slashes) matches identically on Windows.
+    const relativePath = rawTarget.split(path.sep).join('/');
+    if (relativePath === '' || relativePath === '.') return;
+
+    // Reuse the indexer's exact filter set: dotfile / `_seen.jsonl` /
+    // `logs/` / extension allowlist / operator excludes. The watcher
+    // synthesises an "absolute" path under `state.kbPath` so the
+    // filter's `path.relative(kbRoot, ...)` strips it back to the same
+    // shape it would see for a walker-discovered file.
+    const synthesizedAbs = path.join(state.kbPath, relativePath);
+    const accepted = filterIngestablePaths([synthesizedAbs], state.kbPath, {
+      extraExtensions: this.extraExtensions,
+      excludePaths: this.excludePaths,
+    });
+    if (accepted.length === 0) return;
+
+    const existing = state.debounceTimers.get(relativePath);
+    if (existing !== undefined) {
+      clearTimeout(existing);
+    }
+    const timer = setTimeout(() => {
+      state.debounceTimers.delete(relativePath);
+      this.requestRun(state);
+    }, this.debounceMs);
+    if (typeof timer.unref === 'function') {
+      // Same reasoning as the trigger watcher: a watcher debouncer
+      // should not pin the Node event loop open after the transport
+      // closes. unref() is a no-op when not supported.
+      timer.unref();
+    }
+    state.debounceTimers.set(relativePath, timer);
+  }
+
+  private requestRun(state: PerKbState): void {
+    if (this.stopped) return;
+    if (state.inFlight !== null) {
+      state.pending = true;
+      return;
+    }
+    state.inFlight = this.runChange(state);
+    void state.inFlight.finally(() => {
+      state.inFlight = null;
+      if (state.pending && !this.stopped) {
+        state.pending = false;
+        this.requestRun(state);
+      }
+    });
+  }
+
+  private async runChange(state: PerKbState): Promise<void> {
+    try {
+      await this.onChange(state.kbName);
+    } catch (err) {
+      logger.error(
+        `RecursiveKbWatcher onChange failed for ${state.kbName}: ${(err as Error).message}`,
+      );
+    }
+  }
+}
+
+/**
+ * Returns the KB root plus every nested directory under it. Mirrors
+ * the dotfile skip in `getFilesRecursively` so we don't attach to
+ * `.index/` or `.git/`. Exposed for tests that want to assert the set
+ * of directories the non-recursive attach mode will subscribe to.
+ */
+export async function enumerateDirectories(rootDir: string): Promise<string[]> {
+  const dirs: string[] = [];
+
+  async function traverse(currentPath: string): Promise<void> {
+    dirs.push(currentPath);
+    let entries: import('fs').Dirent[];
+    try {
+      entries = await fsp.readdir(currentPath, { withFileTypes: true });
+    } catch (err) {
+      logger.debug(
+        `enumerateDirectories: skip ${currentPath}: ${(err as Error).message}`,
+      );
+      return;
+    }
+    for (const entry of entries) {
+      if (entry.name.startsWith('.')) continue;
+      if (!entry.isDirectory()) continue;
+      await traverse(path.join(currentPath, entry.name));
+    }
+  }
+
+  await traverse(rootDir);
+  return dirs;
+}

--- a/src/triggerWatcher.ts
+++ b/src/triggerWatcher.ts
@@ -4,8 +4,9 @@
 // after every successful write; a running MCP server picks up those writes
 // without the caller having to invoke `refresh_knowledge_base` manually.
 //
-// The poller runs ALONGSIDE RFC 007 §6.6's `fs.watch` recursive watcher.
-// The `fs.watch` path sees per-file edits *inside* each KB directory (which
+// The poller runs ALONGSIDE RFC 007 §6.6's `fs.watch` recursive watcher
+// (issue #212, `recursive-fs-watch.ts`, opt-in via `KB_FS_WATCH=1`). The
+// `fs.watch` path sees per-file edits *inside* each KB directory (which
 // is the right surface for inline editing); the poller sees the root-level
 // dotfile that the walker and `fs.watch` both deliberately skip.
 import * as fsp from 'fs/promises';


### PR DESCRIPTION
## Summary

Implements RFC 007 §6.6 — a recursive `fs.watch` watcher per registered KB so the server picks up inline editor saves (VSCode, etc.) without an explicit `refresh_knowledge_base` call. Complements the RFC 011 trigger-file poller (which sees a root-level dotfile touched by external batch workflows). Off by default; opt-in via `KB_FS_WATCH=1`.

## What changed

- `src/recursive-fs-watch.ts` — new `RecursiveKbWatcher` class.
  - Recursive `fs.watch` on macOS / Windows; per-directory non-recursive attach on Linux + WSL (mirrors RFC 007 §6.6's platform guidance).
  - Reuses `filterIngestablePaths` so dotfiles / `_seen.jsonl` / non-allowlisted extensions / operator `INGEST_EXCLUDE_PATHS` excludes drop on the watcher path the same way they drop in the indexer walker.
  - Per-`(kb, relativePath)` debounce (default 250 ms) collapses editor burst saves (`tmp + rename` pattern).
  - Single in-flight + single-pending coalescer per KB caps N events at ≤ 2 `updateIndex(kb)` calls — identical contract to `ReindexTriggerWatcher`.
  - Errors during attach (`ENOSPC` = inotify slots exhausted, `ENOTSUP` = FUSE mount, missing dir) are logged and swallowed so a partial filesystem cannot prevent server startup.
- `src/config.ts` — `KB_FS_WATCH` flag + `KB_FS_WATCH_DEBOUNCE_MS` override (clamped 25 ms – 60 s).
- `src/KnowledgeBaseServer.ts` — `startFsWatcher()` runs after each transport binds (stdio / SSE / HTTP); `shutdown()` stops it alongside the trigger watcher.
- `src/triggerWatcher.ts` — top comment now points at the new file.
- `src/recursive-fs-watch.test.ts` + new cases in `src/config.test.ts` (parsers).

## Why opt-in for v1

`fs.watch` has well-known platform quirks: NFS / FUSE never deliver events, very large trees on Linux can exhaust inotify watch slots, and WSL2 timing varies. Defaulting off ships the capability without surprising existing users; operators flip `KB_FS_WATCH=1` after sizing.

## Test plan

- [x] `npm test -- --runTestsByPath src/recursive-fs-watch.test.ts src/triggerWatcher.test.ts` — all green.
- [x] `npm test` (full suite) — 735/735 pass.
- [x] `npm run build` — clean.
- [x] Coalescing contract: 12 rapid events for the same `(kb, file)` collapse to 1 `onChange` fire.
- [x] Filter contract: dotfiles, non-allowlisted extensions, `INGEST_EXCLUDE_PATHS` patterns are dropped.
- [x] Lifecycle contract: `stop()` drains in-flight, suppresses queued, is idempotent, handles missing KB dir.
- [x] End-to-end smoke: a real `fs.watch` event from a `writeFile` triggers exactly one `onChange` (gracefully skipped on FS backends that deliver no events).

Closes #212.