### PR TITLE
feat(embedding): deterministic offline `fake` provider (#204)

### DIFF
--- a/src/cli-doctor.test.ts
+++ b/src/cli-doctor.test.ts
@@ -398,4 +398,52 @@ describe('kb doctor', () => {
       }
     });
   });
+
+  describe('fake provider (issue #204)', () => {
+    it('reports backend WARN with a "testing only" detail when active provider is fake', async () => {
+      const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-doctor-fake-'));
+      try {
+        const rootDir = path.join(tempDir, 'kbs');
+        const faissDir = path.join(tempDir, '.faiss');
+        await fsp.mkdir(rootDir, { recursive: true });
+        await fsp.mkdir(faissDir, { recursive: true });
+
+        const fakeModelId = 'fake__bag-256d';
+        const modelDir = path.join(faissDir, 'models', fakeModelId);
+        const versionDir = path.join(modelDir, 'index.v3');
+        await fsp.mkdir(versionDir, { recursive: true });
+        await fsp.writeFile(path.join(modelDir, 'model_name.txt'), 'bag-256d');
+        await fsp.writeFile(path.join(faissDir, 'active.txt'), fakeModelId);
+        await fsp.writeFile(path.join(versionDir, 'faiss.index'), 'fake-index');
+        await fsp.symlink('index.v3', path.join(modelDir, 'index'), 'dir');
+
+        const { buildDoctorReport, formatDoctorMarkdown } = await freshDoctor({
+          KNOWLEDGE_BASES_ROOT_DIR: rootDir,
+          FAISS_INDEX_PATH: faissDir,
+          EMBEDDING_PROVIDER: 'fake',
+        });
+
+        // Use the default backend health check — fake should report healthy
+        // (no daemon/key) but the doctor must elevate the row to WARN.
+        const report = await buildDoctorReport({
+          packageRoot: tempDir,
+          invokedPath: null,
+          packageVersion: '9.9.9',
+        });
+
+        expect(report.active_model.provider).toBe('fake');
+        expect(report.backend.healthy).toBe(true);
+        expect(report.backend.detail).toMatch(/testing only/i);
+        const backendCheck = report.checks.find((c) => c.name === 'backend');
+        expect(backendCheck?.status).toBe('warn');
+        // Backend WARN must not flip the overall status to error.
+        expect(report.status).toBe('warn');
+        const markdown = formatDoctorMarkdown(report);
+        expect(markdown).toMatch(/Backend: ok — fake provider/);
+        expect(markdown).toMatch(/WARN\s+backend: fake provider/);
+      } finally {
+        await fsp.rm(tempDir, { recursive: true, force: true });
+      }
+    });
+  });
 });

--- a/src/cli-doctor.ts
+++ b/src/cli-doctor.ts
@@ -295,9 +295,14 @@ export async function buildDoctorReport(
     activeModelName,
     options.backendHealthCheck ?? defaultBackendHealthCheck,
   );
+  // Issue #204 — the `fake` provider is functionally healthy (no network,
+  // no key, deterministic vectors) but must not silently power production.
+  // Surface the active fake provider as WARN so `kb doctor` is loud about
+  // it without forcing a non-zero exit code.
+  const backendIsFake = activeProvider === 'fake';
   checks.push({
     name: 'backend',
-    status: backend.healthy ? 'ok' : 'error',
+    status: !backend.healthy ? 'error' : (backendIsFake ? 'warn' : 'ok'),
     detail: backend.detail,
   });
 
@@ -486,6 +491,16 @@ async function defaultBackendHealthCheck(
   provider: string,
   modelName: string,
 ): Promise<{ healthy: boolean; detail: string }> {
+  if (provider === 'fake') {
+    // Issue #204 — deterministic offline provider. No reachability check
+    // possible; the doctor row is marked WARN at the call site so the
+    // operator sees the "testing only" note in the status report.
+    return {
+      healthy: true,
+      detail: `fake provider active for ${modelName} — testing only, do not deploy to production`,
+    };
+  }
+
   if (provider === 'ollama') {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), 2000);

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,10 +1,15 @@
 import {
+  isKnownEmbeddingProvider,
+  KNOWN_EMBEDDING_PROVIDERS,
+  parseEmbeddingProvider,
+  parseKbFakeDim,
   parseKbFsWatchDebounceMs,
   parseKbFsWatchFlag,
   parseReindexTriggerPollMs,
   parseKBEditorUri,
   resolveChunkSize,
   resolveIndexingBatchSize,
+  UnknownEmbeddingProviderError,
 } from './config.js';
 
 describe('resolveIndexingBatchSize (issue #236 — INDEXING_BATCH_SIZE)', () => {
@@ -201,5 +206,60 @@ describe('parseKbFsWatchDebounceMs (#212 — KB_FS_WATCH_DEBOUNCE_MS)', () => {
     expect(parseKbFsWatchDebounceMs('not-a-number')).toBe(250);
     expect(parseKbFsWatchDebounceMs('0')).toBe(250);
     expect(parseKbFsWatchDebounceMs('-50')).toBe(250);
+  });
+});
+
+describe('parseEmbeddingProvider (#204 — EMBEDDING_PROVIDER whitelist incl. fake)', () => {
+  it('includes the deterministic offline fake provider', () => {
+    expect(KNOWN_EMBEDDING_PROVIDERS).toEqual(
+      expect.arrayContaining(['huggingface', 'ollama', 'openai', 'fake']),
+    );
+    expect(isKnownEmbeddingProvider('fake')).toBe(true);
+  });
+
+  it('returns the default huggingface provider when unset or blank', () => {
+    expect(parseEmbeddingProvider(undefined)).toBe('huggingface');
+    expect(parseEmbeddingProvider('')).toBe('huggingface');
+    expect(parseEmbeddingProvider('   ')).toBe('huggingface');
+  });
+
+  it('accepts each of the known providers verbatim', () => {
+    for (const p of KNOWN_EMBEDDING_PROVIDERS) {
+      expect(parseEmbeddingProvider(p)).toBe(p);
+    }
+  });
+
+  it('throws UnknownEmbeddingProviderError on a typo', () => {
+    expect(() => parseEmbeddingProvider('hugginface')).toThrow(UnknownEmbeddingProviderError);
+    expect(() => parseEmbeddingProvider('stub')).toThrow(/EMBEDDING_PROVIDER/);
+  });
+});
+
+describe('parseKbFakeDim (#204 — KB_FAKE_DIM)', () => {
+  it('returns the 256 default when unset or blank', () => {
+    expect(parseKbFakeDim(undefined)).toBe(256);
+    expect(parseKbFakeDim('')).toBe(256);
+    expect(parseKbFakeDim('   ')).toBe(256);
+  });
+
+  it('honors positive integer values within [MIN, MAX]', () => {
+    expect(parseKbFakeDim('64')).toBe(64);
+    expect(parseKbFakeDim('1024')).toBe(1024);
+  });
+
+  it('floors fractional values', () => {
+    expect(parseKbFakeDim('128.9')).toBe(128);
+  });
+
+  it('clamps tiny and huge values into [MIN, MAX]', () => {
+    // MIN=8 prevents collapsing the hash bag; MAX=4096 caps memory.
+    expect(parseKbFakeDim('1')).toBe(8);
+    expect(parseKbFakeDim('999999')).toBe(4096);
+  });
+
+  it('falls back to default for non-numeric / non-positive inputs', () => {
+    expect(parseKbFakeDim('not-a-number')).toBe(256);
+    expect(parseKbFakeDim('0')).toBe(256);
+    expect(parseKbFakeDim('-50')).toBe(256);
   });
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,8 +7,77 @@ export const KNOWLEDGE_BASES_ROOT_DIR = process.env.KNOWLEDGE_BASES_ROOT_DIR ||
 export const DEFAULT_FAISS_INDEX_PATH = path.join(KNOWLEDGE_BASES_ROOT_DIR, '.faiss');
 export const FAISS_INDEX_PATH = process.env.FAISS_INDEX_PATH || DEFAULT_FAISS_INDEX_PATH;
 
-// Embedding provider configuration
+// Embedding provider configuration.
+//
+// Issue #204 — `fake` is a deterministic, offline embedding provider used by
+// CI and local development. It produces hash-bag, L2-normalized vectors with
+// no network, no API key, and no Ollama daemon. Whitelisted here so callers
+// that validate against `KNOWN_EMBEDDING_PROVIDERS` accept it; ranking
+// quality is poor by design (testing only, never deploy).
+export const KNOWN_EMBEDDING_PROVIDERS = [
+  'huggingface',
+  'ollama',
+  'openai',
+  'fake',
+] as const;
+
+export type KnownEmbeddingProvider = (typeof KNOWN_EMBEDDING_PROVIDERS)[number];
+
+export class UnknownEmbeddingProviderError extends Error {
+  constructor(rawValue: string) {
+    super(
+      `unknown EMBEDDING_PROVIDER=${JSON.stringify(rawValue)} ` +
+      `(expected one of: ${KNOWN_EMBEDDING_PROVIDERS.join(', ')})`,
+    );
+    this.name = 'UnknownEmbeddingProviderError';
+  }
+}
+
+/**
+ * Issue #204 — soft validator for `EMBEDDING_PROVIDER`. Existing callers
+ * cast the raw env string at use-sites, so wiring a strict throw here would
+ * break boot for anyone with a typo. Callers that want enforcement
+ * (`kb doctor`, future config-lint surfaces) invoke this directly; the
+ * exported `EMBEDDING_PROVIDER` constant preserves pre-#204 behavior.
+ */
+export function parseEmbeddingProvider(raw: string | undefined): KnownEmbeddingProvider {
+  const trimmed = (raw ?? '').trim();
+  if (trimmed === '') return 'huggingface';
+  if ((KNOWN_EMBEDDING_PROVIDERS as readonly string[]).includes(trimmed)) {
+    return trimmed as KnownEmbeddingProvider;
+  }
+  throw new UnknownEmbeddingProviderError(trimmed);
+}
+
+export function isKnownEmbeddingProvider(raw: string): raw is KnownEmbeddingProvider {
+  return (KNOWN_EMBEDDING_PROVIDERS as readonly string[]).includes(raw);
+}
+
 export const EMBEDDING_PROVIDER = process.env.EMBEDDING_PROVIDER || 'huggingface';
+
+// Issue #204 — vector dimension for the deterministic `fake` provider.
+// Defaults to 256; clamped to `[MIN, MAX]` so an operator-supplied `2` does
+// not collapse the hash bag and `999999` does not balloon memory.
+const DEFAULT_KB_FAKE_DIM = 256;
+const MIN_KB_FAKE_DIM = 8;
+const MAX_KB_FAKE_DIM = 4096;
+
+/**
+ * @internal exported only for `config.test.ts`. Parses `KB_FAKE_DIM`.
+ * Invalid / unset → default 256; otherwise floored, then clamped into
+ * `[MIN, MAX]`.
+ */
+export function parseKbFakeDim(raw: string | undefined): number {
+  if (raw === undefined || raw.trim() === '') return DEFAULT_KB_FAKE_DIM;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_KB_FAKE_DIM;
+  return Math.max(
+    MIN_KB_FAKE_DIM,
+    Math.min(MAX_KB_FAKE_DIM, Math.floor(parsed)),
+  );
+}
+
+export const KB_FAKE_DIM: number = parseKbFakeDim(process.env.KB_FAKE_DIM);
 
 // RFC 013 §4.7 — per-process override for the active model. When set, takes
 // precedence over `${FAISS_INDEX_PATH}/active.txt` for the lifetime of this

--- a/src/embedding-provider.test.ts
+++ b/src/embedding-provider.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
+
+const originalEnv = {
+  EMBEDDING_PROVIDER: process.env.EMBEDDING_PROVIDER,
+  KB_FAKE_DIM: process.env.KB_FAKE_DIM,
+  HUGGINGFACE_API_KEY: process.env.HUGGINGFACE_API_KEY,
+  OPENAI_API_KEY: process.env.OPENAI_API_KEY,
+};
+
+afterEach(() => {
+  for (const [key, value] of Object.entries(originalEnv)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+async function loadFresh(env: Record<string, string | undefined>): Promise<typeof import('./embedding-provider.js')> {
+  for (const [key, value] of Object.entries(env)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  jest.resetModules();
+  return import('./embedding-provider.js');
+}
+
+describe('FakeEmbeddings (issue #204 — deterministic offline provider)', () => {
+  it('returns the configured dimension (default 256)', async () => {
+    const { FakeEmbeddings } = await loadFresh({ KB_FAKE_DIM: undefined });
+    const embedder = new FakeEmbeddings();
+    expect(embedder.dim).toBe(256);
+    const vector = await embedder.embedQuery('hello');
+    expect(vector).toHaveLength(256);
+  });
+
+  it('produces byte-identical vectors across calls for the same input', async () => {
+    const { FakeEmbeddings } = await loadFresh({});
+    const embedder = new FakeEmbeddings({ dim: 128 });
+    const a = await embedder.embedQuery('the quick brown fox');
+    const b = await embedder.embedQuery('the quick brown fox');
+    expect(a).toEqual(b);
+  });
+
+  it('produces byte-identical vectors across fresh constructions (cross-process determinism)', async () => {
+    const { FakeEmbeddings: A } = await loadFresh({});
+    const va = await new A({ dim: 64 }).embedQuery('reproducible across machines');
+    const { FakeEmbeddings: B } = await loadFresh({});
+    const vb = await new B({ dim: 64 }).embedQuery('reproducible across machines');
+    expect(va).toEqual(vb);
+  });
+
+  it('L2-normalizes the output for non-empty input', async () => {
+    const { FakeEmbeddings } = await loadFresh({});
+    const embedder = new FakeEmbeddings({ dim: 256 });
+    const vector = await embedder.embedQuery('alpha beta gamma alpha');
+    const norm = Math.sqrt(vector.reduce((sum, v) => sum + v * v, 0));
+    // Rounded to 6 decimals so the magnitude is within ~1e-3 of unity.
+    expect(norm).toBeGreaterThan(0.999);
+    expect(norm).toBeLessThan(1.001);
+  });
+
+  it('returns the zero vector for empty or punctuation-only input (no NaN from divide-by-zero)', async () => {
+    const { FakeEmbeddings } = await loadFresh({});
+    const embedder = new FakeEmbeddings({ dim: 32 });
+    const empty = await embedder.embedQuery('');
+    const punct = await embedder.embedQuery('!!! ??? ...');
+    expect(empty).toHaveLength(32);
+    expect(empty.every((v) => v === 0)).toBe(true);
+    expect(punct.every((v) => v === 0)).toBe(true);
+    expect(empty.every((v) => Number.isFinite(v))).toBe(true);
+  });
+
+  it('produces distinct vectors for distinct token bags', async () => {
+    const { FakeEmbeddings } = await loadFresh({});
+    const embedder = new FakeEmbeddings({ dim: 256 });
+    const v1 = await embedder.embedQuery('apple banana cherry');
+    const v2 = await embedder.embedQuery('zebra yak xenon');
+    expect(v1).not.toEqual(v2);
+  });
+
+  it('embedDocuments preserves order and per-text determinism', async () => {
+    const { FakeEmbeddings } = await loadFresh({});
+    const embedder = new FakeEmbeddings({ dim: 64 });
+    const docs = ['alpha beta', 'gamma delta', 'alpha beta'];
+    const out = await embedder.embedDocuments(docs);
+    expect(out).toHaveLength(3);
+    expect(out[0]).toEqual(out[2]); // same text → same vector
+    expect(out[0]).not.toEqual(out[1]);
+    expect(out[0]).toEqual(await embedder.embedQuery('alpha beta'));
+  });
+
+  it('is case- and punctuation-folded (tokenizer treats "Foo, bar." == "foo bar")', async () => {
+    const { FakeEmbeddings } = await loadFresh({});
+    const embedder = new FakeEmbeddings({ dim: 64 });
+    const a = await embedder.embedQuery('Foo, bar.');
+    const b = await embedder.embedQuery('foo bar');
+    expect(a).toEqual(b);
+  });
+
+  it('honors KB_FAKE_DIM env var at module load', async () => {
+    const { FakeEmbeddings } = await loadFresh({ KB_FAKE_DIM: '512' });
+    const embedder = new FakeEmbeddings();
+    expect(embedder.dim).toBe(512);
+    const vector = await embedder.embedQuery('dim from env');
+    expect(vector).toHaveLength(512);
+  });
+});
+
+describe('createEmbeddingsClient — fake arm (issue #204)', () => {
+  it('returns a FakeEmbeddings instance when provider="fake"', async () => {
+    const { createEmbeddingsClient, FakeEmbeddings } = await loadFresh({
+      KB_FAKE_DIM: '64',
+      // No API keys set — must not be required for the fake arm.
+      HUGGINGFACE_API_KEY: undefined,
+      OPENAI_API_KEY: undefined,
+    });
+    const client = await createEmbeddingsClient({ provider: 'fake', modelName: 'bag-256d' });
+    expect(client).toBeInstanceOf(FakeEmbeddings);
+    const v = await client.embedQuery('round-trip');
+    expect(v).toHaveLength(64);
+  });
+
+  it('does not require any embedding API key', async () => {
+    const { createEmbeddingsClient } = await loadFresh({
+      HUGGINGFACE_API_KEY: undefined,
+      OPENAI_API_KEY: undefined,
+    });
+    // Must not throw a PROVIDER_AUTH error.
+    await expect(
+      createEmbeddingsClient({ provider: 'fake', modelName: 'anything' }),
+    ).resolves.toBeDefined();
+  });
+});

--- a/src/embedding-provider.ts
+++ b/src/embedding-provider.ts
@@ -13,6 +13,7 @@ import {
   HUGGINGFACE_ENDPOINT_URL,
   HUGGINGFACE_ENDPOINT_URL_OVERRIDDEN,
   HUGGINGFACE_PROVIDER,
+  KB_FAKE_DIM,
   OLLAMA_BASE_URL,
 } from './config.js';
 import { KBError } from './errors.js';
@@ -20,13 +21,39 @@ import { logger } from './logger.js';
 import type { EmbeddingProvider } from './model-id.js';
 import { makeOllamaOnFailedAttempt } from './ollama-error.js';
 
+/**
+ * Issue #204 — deterministic, network-free embedding host. Hash-bag over a
+ * fixed-dim vector, L2-normalized, pure-function. Same input → same vector
+ * across runs and across machines. Public API matches the langchain
+ * Embeddings interface (`embedDocuments` / `embedQuery`) so `FaissStore` can
+ * consume it without any provider-specific glue.
+ */
+export class FakeEmbeddings {
+  readonly dim: number;
+  constructor(options: { dim?: number } = {}) {
+    this.dim = options.dim ?? KB_FAKE_DIM;
+  }
+  async embedDocuments(texts: string[]): Promise<number[][]> {
+    return texts.map((text) => vectorizeFake(text, this.dim));
+  }
+  async embedQuery(text: string): Promise<number[]> {
+    return vectorizeFake(text, this.dim);
+  }
+}
+
 export type EmbeddingsClient =
   | HuggingFaceInferenceEmbeddings
   | OllamaEmbeddings
-  | OpenAIEmbeddings;
+  | OpenAIEmbeddings
+  | FakeEmbeddings;
 
 export interface CreateEmbeddingsOptions {
-  provider: EmbeddingProvider;
+  // Issue #204 — `'fake'` is accepted at the factory boundary but is not in
+  // the strict `EmbeddingProvider` union (model-id.ts) on purpose: model-id
+  // slug derivation, registered-model schema, and cost-estimates do not need
+  // a new arm. Callers that already cast `EMBEDDING_PROVIDER` (active-model
+  // legacy env path, model_id parsing) flow `'fake'` through unchanged.
+  provider: EmbeddingProvider | 'fake';
   modelName: string;
 }
 
@@ -40,6 +67,15 @@ export async function createEmbeddingsClient(
   options: CreateEmbeddingsOptions,
 ): Promise<EmbeddingsClient> {
   const { provider, modelName } = options;
+
+  if (provider === 'fake') {
+    // Issue #204 — no network, no API key, no daemon. The model name is
+    // recorded for slug derivation but does not influence the vector.
+    logger.info(
+      `Initializing FaissIndexManager with FAKE embeddings (model: ${modelName}, dim: ${KB_FAKE_DIM}) — testing only, do not deploy`,
+    );
+    return new FakeEmbeddings({ dim: KB_FAKE_DIM });
+  }
 
   if (provider === 'ollama') {
     logger.info(`Initializing FaissIndexManager with Ollama embeddings (model: ${modelName})`);
@@ -96,4 +132,32 @@ export async function createEmbeddingsClient(
       ? undefined
       : (HUGGINGFACE_PROVIDER as InferenceProviderOrPolicy),
   });
+}
+
+/**
+ * Issue #204 — deterministic hash-bag vectorizer. Tokenize on
+ * whitespace+punctuation, accumulate `vec[fnv1a(token) mod dim] += 1`,
+ * L2-normalize, round to 6 decimals so the byte-stable property holds
+ * across machines (Node's float printing is platform-stable but rounding
+ * removes any last-bit ambiguity from sqrt/division).
+ */
+function vectorizeFake(text: string, dim: number): number[] {
+  const vector = new Array<number>(dim).fill(0);
+  const tokens = text.toLowerCase().split(/\W+/).filter(Boolean);
+  for (const token of tokens) {
+    vector[fnv1a(token) % dim] += 1;
+  }
+  let sumSq = 0;
+  for (const value of vector) sumSq += value * value;
+  const magnitude = sumSq === 0 ? 1 : Math.sqrt(sumSq);
+  return vector.map((value) => Number((value / magnitude).toFixed(6)));
+}
+
+function fnv1a(value: string): number {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return hash >>> 0;
 }


### PR DESCRIPTION
## Summary
- New `fake` arm in `createEmbeddingsClient` returns deterministic L2-normalized hash-bag vectors — no network, no API key, no Ollama daemon. Same input ⇒ same vector across runs and machines.
- `KB_FAKE_DIM` env var (default 256, clamped `[8, 4096]`) controls vector dimension.
- `KNOWN_EMBEDDING_PROVIDERS` whitelist + `parseEmbeddingProvider` validator in `config.ts` accept `fake` alongside `huggingface`, `ollama`, `openai`.
- `kb doctor` flags an active `fake` provider as WARN with a "testing only, do not deploy to production" detail; backend stays `healthy: true` so exit code is 0.

Closes #204.

## Design notes
- `EmbeddingProvider` (the strict slug-derivation union in `model-id.ts`) is **not** widened. The factory accepts `EmbeddingProvider | 'fake'` locally. This keeps cost-estimates, sentinel parsing, and slug derivation unchanged — the cascade of edits the issue would otherwise trigger is avoided.
- The vectorizer is a pure function on top of FNV-1a, matching the bench stub's algorithm (`benchmarks/stub.ts`) so retrieval-eval fixtures stay byte-stable.
- Doctor markdown header still reads `Backend: ok — fake …` (driven by `backend.healthy`), but the per-check row in the Checks block is `WARN backend: fake …`. The overall report status becomes `warn` (non-zero exit only on `error`).

## Test plan
- [x] `npm test -- --runTestsByPath src/embedding-provider.test.ts src/config.test.ts src/cli-doctor.test.ts` — all green
- [x] `npm run build` — clean
- [x] full `npm test` — 47 suites / 843 tests pass
- [x] `FakeEmbeddings` determinism across fresh module instances (cross-process proxy)
- [x] empty / punctuation-only input returns zero vector (no NaN from divide-by-zero)
- [x] doctor surfaces WARN backend row for `EMBEDDING_PROVIDER=fake` with active model `fake__bag-256d`
- [ ] manual smoke: `EMBEDDING_PROVIDER=fake kb models add fake bag-256d --yes && kb search …` (deferred to follow-up — out of write scope for this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)