### PR TITLE
test(property): fast-check property suite for ingest invariants

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "@types/pdf-parse": "^1.1.5",
         "@types/pdfkit": "^0.17.6",
         "@types/proper-lockfile": "^4.1.4",
+        "fast-check": "^4.7.0",
         "jest": "^29.7.0",
         "nodemon": "^3.0.3",
         "pdfkit": "^0.18.0",
@@ -4804,6 +4805,46 @@
       "engines": {
         "node": ">= 14.0.0"
       }
+    },
+    "node_modules/fast-check": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.7.0.tgz",
+      "integrity": "sha512-NsZRtqvSSoCP0HbNjUD+r1JH8zqZalyp6gLY9e7OYs7NK9b6AHOs2baBFeBG7bVNsuoukh89x2Yg3rPsul8ziQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
+    "node_modules/fast-check/node_modules/pure-rand": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz",
+      "integrity": "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@types/pdf-parse": "^1.1.5",
     "@types/pdfkit": "^0.17.6",
     "@types/proper-lockfile": "^4.1.4",
+    "fast-check": "^4.7.0",
     "jest": "^29.7.0",
     "nodemon": "^3.0.3",
     "pdfkit": "^0.18.0",

--- a/src/__property-tests__/file-ingest.property.test.ts
+++ b/src/__property-tests__/file-ingest.property.test.ts
@@ -1,0 +1,111 @@
+// Property tests for `buildChunkDocuments` (issue #219).
+//
+// Invariants covered:
+//   * Every non-frontmatter, non-whitespace "word" in the input appears in at
+//     least one emitted chunk's `pageContent` (total coverage).
+//   * `chunk.pageContent.length <= chunkSize + chunkOverlap` for every chunk
+//     (langchain splitter contract).
+//   * `chunk.metadata.chunkIndex` is `[0..N-1]` strictly increasing.
+//   * Metadata shape includes the wire-shape keys (`source`, `relativePath`,
+//     `knowledgeBase`, `extension`, `chunkIndex`, `tags`).
+//
+// `numRuns: 50` by default; `KB_PROPERTY_DEEP=1` raises it to 1000 for manual
+// sweeps. Chunk-size/overlap is supplied via `KB_CHUNK_SIZE` /
+// `KB_CHUNK_OVERLAP` because `resolveChunkSize` reads them at call time.
+
+import { describe, it, afterEach, expect } from '@jest/globals';
+import * as fc from 'fast-check';
+import * as os from 'os';
+import * as path from 'path';
+import { buildChunkDocuments } from '../file-ingest.js';
+
+const NUM_RUNS = process.env.KB_PROPERTY_DEEP === '1' ? 1000 : 50;
+
+const savedChunkSize = process.env.KB_CHUNK_SIZE;
+const savedChunkOverlap = process.env.KB_CHUNK_OVERLAP;
+
+afterEach(() => {
+  if (savedChunkSize === undefined) delete process.env.KB_CHUNK_SIZE;
+  else process.env.KB_CHUNK_SIZE = savedChunkSize;
+  if (savedChunkOverlap === undefined) delete process.env.KB_CHUNK_OVERLAP;
+  else process.env.KB_CHUNK_OVERLAP = savedChunkOverlap;
+});
+
+// A "word" is an alphanumeric run; tokens used as content. Avoiding spaces /
+// newlines as content keeps the test impervious to the splitter's incidental
+// whitespace trimming at chunk boundaries.
+const wordArb = fc
+  .stringMatching(/^[A-Za-z0-9]{1,12}$/)
+  .filter((s) => s.length > 0);
+
+// Newline-delimited list of words. The splitter prefers `\n` separators, so
+// chunk boundaries land between words; no word is ever split in half.
+const wordsArb = fc.array(wordArb, { minLength: 1, maxLength: 200 });
+
+const extensionArb = fc.constantFrom('.md', '.txt', '.rst', '.markdown');
+
+describe('buildChunkDocuments — property tests (issue #219)', () => {
+  it('covers every word, respects size bound, has monotonic chunkIndex', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        wordsArb,
+        extensionArb,
+        fc.integer({ min: 50, max: 500 }),
+        fc.integer({ min: 0, max: 100 }),
+        async (words, ext, chunkSize, chunkOverlap) => {
+          // langchain rejects chunkOverlap >= chunkSize.
+          const safeOverlap = Math.min(chunkOverlap, chunkSize - 1);
+          process.env.KB_CHUNK_SIZE = String(chunkSize);
+          process.env.KB_CHUNK_OVERLAP = String(safeOverlap);
+
+          const content = words.join('\n');
+          const fakeFile = path.join(os.tmpdir(), `kb-prop-${ext.slice(1)}-file${ext}`);
+          const docs = await buildChunkDocuments(fakeFile, content, 'kb-prop');
+
+          expect(docs.length).toBeGreaterThan(0);
+
+          // Size bound.
+          for (const d of docs) {
+            expect(d.pageContent.length).toBeLessThanOrEqual(chunkSize + safeOverlap);
+          }
+
+          // chunkIndex monotonicity.
+          for (let i = 0; i < docs.length; i += 1) {
+            expect(docs[i].metadata.chunkIndex).toBe(i);
+          }
+
+          // Metadata shape — wire-shape keys per RFC 011 §5.4.
+          for (const d of docs) {
+            expect(d.metadata.source).toBe(fakeFile);
+            expect(d.metadata.knowledgeBase).toBe('kb-prop');
+            expect(d.metadata.extension).toBe(ext);
+            expect(Array.isArray(d.metadata.tags)).toBe(true);
+            expect(typeof d.metadata.relativePath).toBe('string');
+          }
+
+          // Total coverage — every input word lives in some chunk.
+          const joined = docs.map((d) => d.pageContent).join('\n');
+          for (const w of words) {
+            expect(joined.includes(w)).toBe(true);
+          }
+        },
+      ),
+      { numRuns: NUM_RUNS },
+    );
+  });
+
+  it('empty content emits at most one (possibly-empty) chunk', async () => {
+    await fc.assert(
+      fc.asyncProperty(extensionArb, async (ext) => {
+        const fakeFile = path.join(os.tmpdir(), `kb-prop-empty${ext}`);
+        const docs = await buildChunkDocuments(fakeFile, '', 'kb-prop');
+        // langchain may emit zero or one chunk on empty input — both are fine,
+        // chunkIndex is still 0-based and increasing.
+        for (let i = 0; i < docs.length; i += 1) {
+          expect(docs[i].metadata.chunkIndex).toBe(i);
+        }
+      }),
+      { numRuns: Math.min(NUM_RUNS, 10) },
+    );
+  });
+});

--- a/src/__property-tests__/frontmatter.property.test.ts
+++ b/src/__property-tests__/frontmatter.property.test.ts
@@ -1,0 +1,93 @@
+// Property tests for `parseFrontmatter` (issue #219).
+//
+// Invariants covered:
+//   * Body preservation on missing/invalid frontmatter: when the input does
+//     NOT start with a `---\n` fence, `parseFrontmatter(s).body === s`.
+//   * Never-throws contract: any UTF-8 string returns a `ParsedFrontmatter`
+//     shape without throwing.
+//   * Empty-string short-circuit returns `{ tags: [], body: '', frontmatter: {} }`.
+//   * `frontmatter` is always a plain object (`Record<string, unknown>`),
+//     `tags` is always `string[]`.
+
+import { describe, it, expect } from '@jest/globals';
+import * as fc from 'fast-check';
+import { parseFrontmatter } from '../frontmatter.js';
+
+const NUM_RUNS = process.env.KB_PROPERTY_DEEP === '1' ? 1000 : 50;
+
+describe('parseFrontmatter — property tests (issue #219)', () => {
+  it('body === content when input does not begin with --- fence', () => {
+    fc.assert(
+      fc.property(
+        fc
+          .string({ minLength: 0, maxLength: 4096 })
+          .filter((s: string) => !/^---\r?\n/.test(s)),
+        (content) => {
+          const result = parseFrontmatter(content);
+          expect(result.body).toBe(content);
+          expect(result.tags).toEqual([]);
+          expect(result.frontmatter).toEqual({});
+        },
+      ),
+      { numRuns: NUM_RUNS },
+    );
+  });
+
+  it('never throws on arbitrary input; always returns the expected shape', () => {
+    fc.assert(
+      fc.property(fc.string({ minLength: 0, maxLength: 4096 }), (content) => {
+        const result = parseFrontmatter(content);
+        expect(Array.isArray(result.tags)).toBe(true);
+        for (const t of result.tags) expect(typeof t).toBe('string');
+        expect(typeof result.body).toBe('string');
+        expect(result.frontmatter).toEqual(expect.any(Object));
+        expect(Array.isArray(result.frontmatter)).toBe(false);
+      }),
+      { numRuns: NUM_RUNS },
+    );
+  });
+
+  it('round-trip body preservation: serialize → parse → identical body', () => {
+    // Build a well-formed frontmatter block from random keys + string scalars
+    // and assert that the body that follows is preserved verbatim.
+    const keyArb = fc.stringMatching(/^[A-Za-z][A-Za-z0-9_]{0,8}$/);
+    // Restrict to plain alphanumeric+space scalars; YAML special chars
+    // (`-`, `:`, `[`, `#`, etc.) would change the parse shape and make the
+    // round-trip assertion over-restrictive — those edge cases are covered by
+    // the never-throws property above.
+    const valArb = fc.stringMatching(/^[A-Za-z0-9][A-Za-z0-9 ]{0,30}[A-Za-z0-9]$/);
+    const fmArb = fc
+      .uniqueArray(fc.tuple(keyArb, valArb), {
+        minLength: 0,
+        maxLength: 5,
+        selector: ([k]) => k,
+      });
+    const bodyArb = fc
+      .string({ minLength: 0, maxLength: 200 })
+      // Avoid bodies that themselves begin with a `---\n` line; the parser
+      // does not see further fences past the first close, so this is fine
+      // for `body`, but exclude it to keep the property statement simple.
+      .filter((s: string) => !s.startsWith('---'));
+    fc.assert(
+      fc.property(fmArb, bodyArb, (pairs, body) => {
+        const yamlLines = pairs.map(([k, v]) => `${k}: ${v}`).join('\n');
+        const content = pairs.length === 0
+          ? `---\n---\n${body}`
+          : `---\n${yamlLines}\n---\n${body}`;
+        const result = parseFrontmatter(content);
+        expect(result.body).toBe(body);
+        // String-valued keys should round-trip into `frontmatter` for keys
+        // that exist; FAILSAFE coerces scalars to strings.
+        for (const [k, v] of pairs) {
+          expect(result.frontmatter[k]).toBe(v);
+        }
+      }),
+      { numRuns: NUM_RUNS },
+    );
+  });
+
+  it('empty input returns the empty short-circuit', () => {
+    const r = parseFrontmatter('');
+    expect(r).toEqual({ tags: [], body: '', frontmatter: {} });
+  });
+});

--- a/src/__property-tests__/ingest-filter.property.test.ts
+++ b/src/__property-tests__/ingest-filter.property.test.ts
@@ -1,0 +1,155 @@
+// Property tests for `filterIngestablePaths` (issue #219).
+//
+// Invariants covered:
+//   * Allow-list monotonicity: adding an extra extension never removes a path
+//     that was already admitted under the smaller set.
+//   * Operator-supplied excludes do not weaken base exclusions: a path that
+//     matches a base exclusion (segment literal, basename literal, or
+//     first-segment subtree) is rejected regardless of `extraExtensions` /
+//     `excludePaths` settings.
+//   * Idempotency: filtering twice returns the same output (the predicate is
+//     pure modulo the one-shot logger, which we reset before each iteration).
+//   * Determinism: same input → same output across repeated calls.
+
+// Logger info-level chatter (the "Skipping filesystem-metadata sidecar …"
+// one-shot) is suppressed by raising LOG_LEVEL before the logger module is
+// evaluated; the env value is read once at module load.
+process.env.LOG_LEVEL = process.env.LOG_LEVEL ?? 'warn';
+
+import { describe, it, expect } from '@jest/globals';
+import * as fc from 'fast-check';
+import * as path from 'path';
+import {
+  filterIngestablePaths,
+  INGEST_BASE_EXTENSIONS,
+  __resetSkippedFilenameLogForTests,
+} from '../ingest-filter.js';
+
+const NUM_RUNS = process.env.KB_PROPERTY_DEEP === '1' ? 1000 : 50;
+
+const KB_ROOT = '/tmp/kb-prop';
+
+const SAFE_SEGMENT_REGEX = /^[A-Za-z0-9_-]{1,12}$/;
+
+const safeSegmentArb = fc.stringMatching(SAFE_SEGMENT_REGEX);
+
+// Build a relative path of 1..4 segments + a basename with a chosen extension.
+const relPathArb = fc.tuple(
+  fc.array(safeSegmentArb, { minLength: 0, maxLength: 3 }),
+  fc.stringMatching(/^[A-Za-z0-9_-]{1,12}$/),
+  fc.constantFrom(
+    '.md',
+    '.markdown',
+    '.txt',
+    '.rst',
+    '.pdf',
+    '.html',
+    '.htm',
+    '.png',
+    '.jpg',
+    '.bin',
+    '.json',
+    '.csv',
+    '.yaml',
+  ),
+).map(([dirs, base, ext]) => {
+  const rel = [...dirs, `${base}${ext}`].join('/');
+  return path.join(KB_ROOT, rel);
+});
+
+const extraExtensionArb = fc
+  .stringMatching(/^[A-Za-z0-9]{1,5}$/)
+  .map((s) => `.${s.toLowerCase()}`);
+
+describe('filterIngestablePaths — property tests (issue #219)', () => {
+  it('extra-extensions monotonicity: adding an allowlist entry never excludes prior matches', () => {
+    fc.assert(
+      fc.property(
+        fc.array(relPathArb, { minLength: 0, maxLength: 20 }),
+        fc.array(extraExtensionArb, { minLength: 0, maxLength: 3 }),
+        extraExtensionArb,
+        (paths, baseExtras, addedExt) => {
+          __resetSkippedFilenameLogForTests();
+          const before = new Set(
+            filterIngestablePaths(paths, KB_ROOT, { extraExtensions: baseExtras }),
+          );
+          const after = new Set(
+            filterIngestablePaths(paths, KB_ROOT, {
+              extraExtensions: [...baseExtras, addedExt],
+            }),
+          );
+          // Every path admitted before is still admitted after.
+          for (const p of before) expect(after.has(p)).toBe(true);
+        },
+      ),
+      { numRuns: NUM_RUNS },
+    );
+  });
+
+  it('operator cannot override base exclusions (sidecar segments, OS turds, log subtree)', () => {
+    const sidecarBasenames = ['_seen.jsonl', '_seen.json', '_index.jsonl'];
+    const turds = ['.DS_Store', 'Thumbs.db', 'desktop.ini'];
+
+    fc.assert(
+      fc.property(
+        fc.array(extraExtensionArb, { minLength: 0, maxLength: 3 }),
+        fc.array(fc.string({ minLength: 1, maxLength: 20 }), { minLength: 0, maxLength: 3 }),
+        fc.constantFrom(...INGEST_BASE_EXTENSIONS),
+        safeSegmentArb,
+        (extraExts, exclude, allowedExt, leaf) => {
+          __resetSkippedFilenameLogForTests();
+          // Construct paths that match each base exclusion rule. Even with
+          // every extension allowlisted and *no* extra excludes, none should
+          // be admitted.
+          const sidecarSegmentPath = path.join(KB_ROOT, 'docs', sidecarBasenames[0]);
+          const turdPath = path.join(KB_ROOT, 'docs', turds[0]);
+          const logSubtreePath = path.join(KB_ROOT, 'logs', `${leaf}${allowedExt}`);
+          const tmpSubtreePath = path.join(KB_ROOT, 'tmp', `${leaf}${allowedExt}`);
+
+          const out = filterIngestablePaths(
+            [sidecarSegmentPath, turdPath, logSubtreePath, tmpSubtreePath],
+            KB_ROOT,
+            { extraExtensions: extraExts, excludePaths: exclude },
+          );
+          expect(out).toEqual([]);
+        },
+      ),
+      { numRuns: NUM_RUNS },
+    );
+  });
+
+  it('idempotency: filter(filter(x)) === filter(x) for already-filtered inputs', () => {
+    fc.assert(
+      fc.property(
+        fc.array(relPathArb, { minLength: 0, maxLength: 20 }),
+        fc.array(extraExtensionArb, { minLength: 0, maxLength: 3 }),
+        (paths, extras) => {
+          __resetSkippedFilenameLogForTests();
+          const opts = { extraExtensions: extras };
+          const once = filterIngestablePaths(paths, KB_ROOT, opts);
+          const twice = filterIngestablePaths(once, KB_ROOT, opts);
+          expect(twice).toEqual(once);
+        },
+      ),
+      { numRuns: NUM_RUNS },
+    );
+  });
+
+  it('determinism: same inputs → same output across repeated calls', () => {
+    fc.assert(
+      fc.property(
+        fc.array(relPathArb, { minLength: 0, maxLength: 20 }),
+        fc.array(extraExtensionArb, { minLength: 0, maxLength: 3 }),
+        fc.array(safeSegmentArb, { minLength: 0, maxLength: 3 }),
+        (paths, extras, excludes) => {
+          __resetSkippedFilenameLogForTests();
+          const opts = { extraExtensions: extras, excludePaths: excludes };
+          const a = filterIngestablePaths(paths, KB_ROOT, opts);
+          const b = filterIngestablePaths(paths, KB_ROOT, opts);
+          expect(b).toEqual(a);
+        },
+      ),
+      { numRuns: NUM_RUNS },
+    );
+  });
+});

--- a/src/__property-tests__/kb-fs.property.test.ts
+++ b/src/__property-tests__/kb-fs.property.test.ts
@@ -1,0 +1,149 @@
+// Property tests for kb-fs path resolution helpers (issue #219).
+//
+// Invariants covered:
+//   * `assertNoTraversal` rejects any path containing a `..` segment, a POSIX
+//     `/` prefix, a Win32 drive-letter prefix, or a `\\?\` prefix.
+//   * `assertNoTraversal` accepts any pure-segment path (no separators).
+//   * `resolveKbPath` traversal safety: for arbitrary relative input, the
+//     call either throws `KBError('VALIDATION')` or returns an absolute path
+//     strictly inside the KB root.
+//   * `resolveKbPath` idempotency: feeding the returned absolute path back
+//     as a KB-relative path yields the same absolute path.
+
+import { describe, it, beforeAll, afterAll, expect } from '@jest/globals';
+import * as fc from 'fast-check';
+import * as fsp from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { KBError } from '../errors.js';
+import { assertNoTraversal, resolveKbPath } from '../kb-fs.js';
+
+const NUM_RUNS = process.env.KB_PROPERTY_DEEP === '1' ? 1000 : 50;
+
+const safeNameArb = fc.stringMatching(/^[A-Za-z0-9_-]{1,12}$/);
+
+describe('assertNoTraversal — property tests (issue #219)', () => {
+  it('rejects any path containing a `..` segment', () => {
+    fc.assert(
+      fc.property(
+        fc.array(safeNameArb, { minLength: 0, maxLength: 3 }),
+        fc.array(safeNameArb, { minLength: 0, maxLength: 3 }),
+        (before, after) => {
+          const rel = [...before, '..', ...after].join('/');
+          expect(() => assertNoTraversal(rel)).toThrow(/escapes KB root/);
+        },
+      ),
+      { numRuns: NUM_RUNS },
+    );
+  });
+
+  it('rejects POSIX-absolute paths', () => {
+    fc.assert(
+      fc.property(safeNameArb, fc.array(safeNameArb, { maxLength: 3 }), (head, tail) => {
+        const rel = ['', head, ...tail].join('/');
+        expect(() => assertNoTraversal(rel)).toThrow(/escapes KB root/);
+      }),
+      { numRuns: NUM_RUNS },
+    );
+  });
+
+  it('rejects Win32-absolute drive-letter paths', () => {
+    fc.assert(
+      fc.property(
+        fc.stringMatching(/^[A-Za-z]$/),
+        fc.array(safeNameArb, { maxLength: 3 }),
+        (letter, tail) => {
+          const rel = `${letter}:\\` + tail.join('\\');
+          expect(() => assertNoTraversal(rel)).toThrow(/escapes KB root/);
+        },
+      ),
+      { numRuns: NUM_RUNS },
+    );
+  });
+
+  it('accepts pure-segment relative paths', () => {
+    fc.assert(
+      fc.property(
+        fc.array(safeNameArb, { minLength: 1, maxLength: 4 }),
+        (segments) => {
+          const rel = segments.join('/');
+          expect(() => assertNoTraversal(rel)).not.toThrow();
+        },
+      ),
+      { numRuns: NUM_RUNS },
+    );
+  });
+});
+
+describe('resolveKbPath — property tests (issue #219)', () => {
+  let rootDir: string;
+  const kbName = 'kb-prop';
+  let kbDir: string;
+
+  beforeAll(async () => {
+    rootDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-prop-resolve-'));
+    kbDir = path.join(rootDir, kbName);
+    await fsp.mkdir(kbDir, { recursive: true });
+    // Create a couple of real files so mustExist-true probes can hit one.
+    await fsp.writeFile(path.join(kbDir, 'present.md'), '# present\n');
+    await fsp.mkdir(path.join(kbDir, 'nested'), { recursive: true });
+    await fsp.writeFile(path.join(kbDir, 'nested', 'inner.md'), '# inner\n');
+  });
+
+  afterAll(async () => {
+    await fsp.rm(rootDir, { recursive: true, force: true });
+  });
+
+  // Arbitrary mix of segment-shaped strings, the `..` segment, and a leading
+  // `/` prefix — the predicate "either throws VALIDATION or returns inside
+  // the KB root" must hold across the whole shape.
+  const segArb = fc.oneof(
+    safeNameArb,
+    fc.constantFrom('..', '.', 'present.md', 'nested'),
+  );
+  const relArb = fc
+    .array(segArb, { minLength: 1, maxLength: 4 })
+    .map((segs) => segs.join('/'))
+    // Trim empty heads/tails that minimatch interprets as POSIX-absolute.
+    .filter((s) => s.length > 0 && !s.includes('\0'));
+
+  it('either rejects with VALIDATION or returns a path strictly inside the KB root', async () => {
+    await fc.assert(
+      fc.asyncProperty(relArb, async (rel) => {
+        try {
+          const result = await resolveKbPath(rootDir, kbName, rel, {
+            mustExist: false,
+          });
+          // Returned path must be inside the KB root.
+          const prefix = kbDir.endsWith(path.sep) ? kbDir : `${kbDir}${path.sep}`;
+          expect(result === kbDir || result.startsWith(prefix)).toBe(true);
+        } catch (err) {
+          // Acceptable failure modes: VALIDATION (traversal, null byte,
+          // empty) or plain Error("path not found") under mustExist=true.
+          // mustExist=false should NEVER throw "path not found".
+          if (err instanceof KBError) {
+            expect(err.code).toBe('VALIDATION');
+          } else {
+            throw err;
+          }
+        }
+      }),
+      { numRuns: NUM_RUNS },
+    );
+  });
+
+  it('idempotency: round-tripping the resolved path through KB-relative form is stable', async () => {
+    const goodRelArb = fc.constantFrom('present.md', 'nested/inner.md', 'nested');
+    await fc.assert(
+      fc.asyncProperty(goodRelArb, async (rel) => {
+        const first = await resolveKbPath(rootDir, kbName, rel, { mustExist: true });
+        const back = path.relative(kbDir, first).split(path.sep).join('/');
+        const second = await resolveKbPath(rootDir, kbName, back, {
+          mustExist: true,
+        });
+        expect(second).toBe(first);
+      }),
+      { numRuns: Math.min(NUM_RUNS, 30) },
+    );
+  });
+});

--- a/src/__property-tests__/markdown-section.property.test.ts
+++ b/src/__property-tests__/markdown-section.property.test.ts
@@ -1,0 +1,119 @@
+// Property tests for `markdown-section` heading helpers (issue #219).
+//
+// Status: `describe.skip` under the project's default jest config.
+//
+// `markdown-section.ts` imports `mdast-util-from-markdown`, which is pure ESM
+// and is not transformed by the ts-jest pipeline this project uses. The same
+// blocker is documented in `cli-remember.test.ts` ("ts-jest cannot transform"),
+// where the cli-remember tests deliberately avoid loading `markdown-section`
+// and exercise the parser end-to-end via the child-process tests in
+// `cli.test.ts` instead.
+//
+// The property statements below are kept here so a future change that enables
+// transforming third-party ESM (e.g. `transformIgnorePatterns` allowlist or a
+// move to babel-jest) can flip `describe.skip` to `describe` and the
+// invariants run unchanged. They mirror the issue #219 plan:
+//
+//   * `parseHeadingSpec` round-trip on `"#{n} <text>"`.
+//   * `listHeadings` never returns headings inside fenced code blocks.
+//   * `locateSection` finds a unique heading and produces an in-range
+//     `splitLineIndex`.
+//   * `appendSectionInDocument` preserves the frontmatter prefix
+//     byte-identical.
+//   * `spliceAppend` keeps the original heading and inserts the new content.
+
+import { describe, it, expect } from '@jest/globals';
+import * as fc from 'fast-check';
+
+const NUM_RUNS = process.env.KB_PROPERTY_DEEP === '1' ? 1000 : 50;
+
+const headingTextArb = fc.stringMatching(/^[A-Za-z0-9][A-Za-z0-9 ]{0,28}[A-Za-z0-9]$/);
+const headingLevelArb = fc.integer({ min: 1, max: 6 });
+
+describe.skip('markdown-section — property tests (issue #219, gated by ESM transform)', () => {
+  // Dynamic import keeps the file loadable under the default jest config; the
+  // body only runs if `describe.skip` is flipped to `describe`.
+  let mod: typeof import('../markdown-section.js');
+
+  it('parseHeadingSpec round-trips `"#{n} <text>"` for n in 1..6', async () => {
+    mod = mod ?? (await import('../markdown-section.js'));
+    fc.assert(
+      fc.property(headingLevelArb, headingTextArb, (level, text) => {
+        const spec = `${'#'.repeat(level)} ${text}`;
+        const parsed = mod.parseHeadingSpec(spec);
+        expect(parsed.level).toBe(level);
+        expect(parsed.text).toBe(text.trim());
+      }),
+      { numRuns: NUM_RUNS },
+    );
+  });
+
+  it('listHeadings ignores headings inside fenced code blocks', async () => {
+    mod = mod ?? (await import('../markdown-section.js'));
+    fc.assert(
+      fc.property(headingLevelArb, headingTextArb, (level, text) => {
+        const codeFenced = '```\n' + `${'#'.repeat(level)} ${text}\n` + '```\n';
+        expect(mod.listHeadings(codeFenced)).toEqual([]);
+      }),
+      { numRuns: NUM_RUNS },
+    );
+  });
+
+  it('appendSectionInDocument preserves the frontmatter prefix byte-identical', async () => {
+    mod = mod ?? (await import('../markdown-section.js'));
+    const fmKeyArb = fc.stringMatching(/^[A-Za-z][A-Za-z0-9_]{0,8}$/);
+    const fmValArb = fc.stringMatching(/^[A-Za-z0-9][A-Za-z0-9 ]{0,18}[A-Za-z0-9]$/);
+    const fmPairArb = fc.uniqueArray(fc.tuple(fmKeyArb, fmValArb), {
+      minLength: 1,
+      maxLength: 4,
+      selector: ([k]) => k,
+    });
+    fc.assert(
+      fc.property(
+        fmPairArb,
+        headingLevelArb,
+        headingTextArb,
+        fc.stringMatching(/^[A-Za-z0-9][A-Za-z0-9 ]{0,38}[A-Za-z0-9]$/),
+        (pairs, level, text, newContent) => {
+          const fmBlock = pairs.map(([k, v]) => `${k}: ${v}`).join('\n');
+          const heading = `${'#'.repeat(level)} ${text}`;
+          const body = `${heading}\n\nexisting section body.\n`;
+          const doc = `---\n${fmBlock}\n---\n${body}`;
+          const result = mod.appendSectionInDocument(doc, { level, text }, newContent);
+          const prefixLen = doc.length - body.length;
+          expect(result.content.slice(0, prefixLen)).toBe(doc.slice(0, prefixLen));
+        },
+      ),
+      { numRuns: NUM_RUNS },
+    );
+  });
+
+  it('locateSection + spliceAppend keep heading and append new content', async () => {
+    mod = mod ?? (await import('../markdown-section.js'));
+    fc.assert(
+      fc.property(
+        headingLevelArb,
+        headingTextArb,
+        fc.stringMatching(/^[A-Za-z0-9][A-Za-z0-9 ]{0,38}[A-Za-z0-9]$/),
+        (level, text, newContent) => {
+          const heading = `${'#'.repeat(level)} ${text}`;
+          const body = `${heading}\n\nexisting body.\n`;
+          const located = mod.locateSection(body, { level, text });
+          const spliced = mod.spliceAppend(body, located.splitLineIndex, newContent);
+          expect(spliced.includes(heading)).toBe(true);
+          expect(spliced.includes(newContent.trim())).toBe(true);
+        },
+      ),
+      { numRuns: NUM_RUNS },
+    );
+  });
+});
+
+// Sentinel test so the file reports a passing case under the default config —
+// without it, `describe.skip` would surface as "0 tests" and a future grep for
+// `markdown-section.property` would miss it.
+describe('markdown-section property tests — gating sentinel', () => {
+  it('is skipped under the default jest config; see file-level comment', () => {
+    expect(true).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #219.

Adds `fast-check` as a dev-only dependency and a property-test layer under `src/__property-tests__/` for the project's pure ingest invariants. Targets pure code only — no FAISS, no embedding I/O.

- **file-ingest** — every input word covered by some chunk's `pageContent`; `len(chunk) <= chunkSize + chunkOverlap`; monotonic `chunkIndex`; wire-shape metadata keys (`source`, `relativePath`, `knowledgeBase`, `extension`, `chunkIndex`, `tags`).
- **ingest-filter** — extra-extensions monotonicity (adding to the allowlist never excludes a previously-admitted path); base exclusions (sidecar segments `_seen.jsonl`, OS turds `.DS_Store` / `Thumbs.db`, `logs/` & `tmp/` subtrees) cannot be overridden by operator extras; idempotency; determinism.
- **frontmatter** — body preservation when input does not begin with `---\n`; never-throws shape on arbitrary input; scalar round-trip on FAILSAFE-compatible values; empty-input short-circuit.
- **kb-fs** — `assertNoTraversal` rejects `..` segments, POSIX-absolute, and Win32 drive-letter paths; accepts pure-segment relatives. `resolveKbPath` either rejects with `KBError('VALIDATION')` or returns a path strictly inside the KB root; idempotent under round-trip through the KB-relative form.
- **markdown-section** — properties authored, currently `describe.skip` gated. `mdast-util-from-markdown` is pure ESM that ts-jest cannot transform under the project's jest config (same blocker documented in `src/cli-remember.test.ts:9-11`, where cli-remember explicitly avoids loading `markdown-section`). A sentinel test keeps the file visible in suite output; flipping the skip is a one-line change once an ESM transform path lands.

## Operational guards

- `numRuns: 50` by default — ~1 s of extra `npm test` time.
- `KB_PROPERTY_DEEP=1` lifts to 1000 for manual sweeps.
- No production-dep change; only `fast-check` in `devDependencies`.

## Test plan

- [x] `npm test -- --runInBand src/__property-tests__` — 5 suites, 17 passing, 4 skipped (the gated markdown-section block).
- [x] `npm test` — full suite, 51 passing, 0 failing.
- [x] `npm run build` — tsc green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)