### PR TITLE
feat(loaders): cache extracted PDF/HTML text by content hash (#279)

### DIFF
--- a/src/extraction-cache.test.ts
+++ b/src/extraction-cache.test.ts
@@ -1,0 +1,387 @@
+// Issue #279 — extraction cache tests.
+//
+// Covers:
+//   - Cache key derivation is deterministic and changes when any of
+//     {loaderName, loaderVersion, ext, contentSha256} changes.
+//   - readCachedExtraction returns null on miss without throwing.
+//   - writeCachedExtraction is atomic (tmp + rename) and creates the dir.
+//   - writeCachedExtraction swallows I/O errors so callers stay on the cold path.
+//   - loadWithExtractionCache: miss → invokes parser, stores result.
+//   - loadWithExtractionCache: hit → returns cached text, does NOT invoke parser.
+//   - loadWithExtractionCache: content change ⇒ new key ⇒ parser invoked again.
+//   - loadWithExtractionCache: loaderVersion bump ⇒ miss against the previous entry.
+
+import * as fsp from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  computeContentSha256,
+  computeExtractionCacheKey,
+  defaultExtractionCacheDir,
+  EXTRACTION_CACHE_SCHEMA_VERSION,
+  loadWithExtractionCache,
+  readCachedExtraction,
+  writeCachedExtraction,
+} from './extraction-cache.js';
+
+describe('computeContentSha256', () => {
+  it('produces a stable 64-char hex digest for identical bytes', () => {
+    const a = computeContentSha256(Buffer.from('hello world'));
+    const b = computeContentSha256(Buffer.from('hello world'));
+    expect(a).toBe(b);
+    expect(a).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it('produces different digests for different bytes', () => {
+    expect(computeContentSha256(Buffer.from('a'))).not.toBe(
+      computeContentSha256(Buffer.from('b')),
+    );
+  });
+});
+
+describe('computeExtractionCacheKey', () => {
+  const base = {
+    loaderName: 'pdf-parse',
+    loaderVersion: 1,
+    ext: '.pdf',
+    contentSha256: 'a'.repeat(64),
+  };
+
+  it('is deterministic — same inputs always produce the same key', () => {
+    expect(computeExtractionCacheKey(base)).toBe(computeExtractionCacheKey(base));
+  });
+
+  it('returns a 64-char hex digest (sha256-shaped, filesystem-safe)', () => {
+    expect(computeExtractionCacheKey(base)).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it('changes when contentSha256 changes (different file bytes)', () => {
+    const other = { ...base, contentSha256: 'b'.repeat(64) };
+    expect(computeExtractionCacheKey(base)).not.toBe(computeExtractionCacheKey(other));
+  });
+
+  it('changes when loaderVersion is bumped (forces invalidation)', () => {
+    const bumped = { ...base, loaderVersion: 2 };
+    expect(computeExtractionCacheKey(base)).not.toBe(computeExtractionCacheKey(bumped));
+  });
+
+  it('changes when loaderName differs (PDF cache cannot collide with HTML cache)', () => {
+    const html = { ...base, loaderName: 'html-to-text' };
+    expect(computeExtractionCacheKey(base)).not.toBe(computeExtractionCacheKey(html));
+  });
+
+  it('changes when ext differs (same bytes routed through a different loader must not collide)', () => {
+    const htm = { ...base, ext: '.htm' };
+    expect(computeExtractionCacheKey(base)).not.toBe(computeExtractionCacheKey(htm));
+  });
+
+  it('is case-insensitive on extension (`.PDF` and `.pdf` share an entry)', () => {
+    const upper = { ...base, ext: '.PDF' };
+    expect(computeExtractionCacheKey(base)).toBe(computeExtractionCacheKey(upper));
+  });
+
+  it('declares a schema version so storage-layout changes can force a global invalidate', () => {
+    // Locking in the symbol so a future bump is intentional, not accidental.
+    expect(EXTRACTION_CACHE_SCHEMA_VERSION).toBe(1);
+  });
+});
+
+describe('defaultExtractionCacheDir', () => {
+  const originalOverride = process.env.EXTRACTION_TEXT_CACHE_DIR;
+
+  afterEach(() => {
+    if (originalOverride === undefined) {
+      delete process.env.EXTRACTION_TEXT_CACHE_DIR;
+    } else {
+      process.env.EXTRACTION_TEXT_CACHE_DIR = originalOverride;
+    }
+  });
+
+  it('honors EXTRACTION_TEXT_CACHE_DIR when set (test/dev redirect)', () => {
+    process.env.EXTRACTION_TEXT_CACHE_DIR = '/tmp/kb-fake-extraction-cache';
+    expect(defaultExtractionCacheDir()).toBe('/tmp/kb-fake-extraction-cache');
+  });
+
+  it('falls back to a path under FAISS_INDEX_PATH when no override is set', () => {
+    delete process.env.EXTRACTION_TEXT_CACHE_DIR;
+    expect(defaultExtractionCacheDir()).toMatch(/extracted-text$/);
+  });
+});
+
+describe('readCachedExtraction', () => {
+  let cacheDir = '';
+
+  beforeEach(async () => {
+    cacheDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-extract-cache-read-'));
+  });
+
+  afterEach(async () => {
+    await fsp.rm(cacheDir, { recursive: true, force: true });
+  });
+
+  it('returns null when the entry does not exist (miss)', async () => {
+    expect(await readCachedExtraction(cacheDir, 'nonexistent-key')).toBeNull();
+  });
+
+  it('returns the stored UTF-8 text on a hit', async () => {
+    await fsp.writeFile(path.join(cacheDir, 'mykey.txt'), 'cached extraction body');
+    expect(await readCachedExtraction(cacheDir, 'mykey')).toBe('cached extraction body');
+  });
+
+  it('returns null (does not throw) when the cache dir itself is missing', async () => {
+    // Hardened against operator misconfiguration: a broken cacheDir must not
+    // crash ingest; the loader will simply re-parse and try to write later.
+    expect(await readCachedExtraction(path.join(cacheDir, 'never-created'), 'k')).toBeNull();
+  });
+});
+
+describe('writeCachedExtraction', () => {
+  let cacheDir = '';
+
+  beforeEach(async () => {
+    cacheDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-extract-cache-write-'));
+  });
+
+  afterEach(async () => {
+    await fsp.rm(cacheDir, { recursive: true, force: true });
+  });
+
+  it('writes the text under the keyed filename and a round-trip read returns it verbatim', async () => {
+    await writeCachedExtraction(cacheDir, 'abc', 'parsed body');
+    expect(await fsp.readFile(path.join(cacheDir, 'abc.txt'), 'utf-8')).toBe('parsed body');
+    expect(await readCachedExtraction(cacheDir, 'abc')).toBe('parsed body');
+  });
+
+  it('creates the cache directory if it does not already exist', async () => {
+    const nested = path.join(cacheDir, 'deep', 'nested', 'dir');
+    await writeCachedExtraction(nested, 'k', 'v');
+    expect(await fsp.readFile(path.join(nested, 'k.txt'), 'utf-8')).toBe('v');
+  });
+
+  it('does not leave a `.tmp.*` sibling after a successful write (atomic rename completed)', async () => {
+    await writeCachedExtraction(cacheDir, 'tidy', 'body');
+    const entries = await fsp.readdir(cacheDir);
+    expect(entries).toEqual(['tidy.txt']);
+    // No stray atomic-write tmpfiles surviving the rename — important so the
+    // cache directory listing stays meaningful for operators eyeballing it.
+    expect(entries.every((e) => !e.includes('.tmp.'))).toBe(true);
+  });
+
+  it('overwrites a stale entry under the same key (re-parse case)', async () => {
+    await writeCachedExtraction(cacheDir, 'k', 'old body');
+    await writeCachedExtraction(cacheDir, 'k', 'new body');
+    expect(await readCachedExtraction(cacheDir, 'k')).toBe('new body');
+  });
+
+  it('swallows I/O errors so the caller stays on the cold path (cache write is best-effort)', async () => {
+    // Force a write failure by pointing cacheDir at an existing FILE rather
+    // than a directory — `mkdir { recursive }` on Linux fails with ENOTDIR
+    // partway through, which is the realistic operator-misconfiguration
+    // failure mode. The helper must not throw; the fresh parse output is
+    // already in the caller's hand and ingest must continue.
+    const bogusFile = path.join(cacheDir, 'not-a-dir.txt');
+    await fsp.writeFile(bogusFile, 'sentinel');
+    const collision = path.join(bogusFile, 'sub');
+    await expect(writeCachedExtraction(collision, 'k', 'v')).resolves.toBeUndefined();
+  });
+});
+
+describe('loadWithExtractionCache', () => {
+  let tempDir = '';
+  let cacheDir = '';
+
+  beforeEach(async () => {
+    tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-extract-cache-load-'));
+    cacheDir = path.join(tempDir, 'cache');
+  });
+
+  afterEach(async () => {
+    await fsp.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('on a miss, invokes parse with the file bytes and stores the result for next time', async () => {
+    const filePath = path.join(tempDir, 'doc.pdf');
+    await fsp.writeFile(filePath, Buffer.from('%PDF-1.4 fake'));
+    const parse = jest.fn().mockResolvedValue('parsed text');
+
+    const text = await loadWithExtractionCache({
+      filePath,
+      loaderName: 'pdf-parse',
+      loaderVersion: 1,
+      parse,
+      cacheDir,
+    });
+
+    expect(text).toBe('parsed text');
+    expect(parse).toHaveBeenCalledTimes(1);
+    const buf = parse.mock.calls[0][0] as Buffer;
+    expect(Buffer.isBuffer(buf)).toBe(true);
+    expect(buf.equals(Buffer.from('%PDF-1.4 fake'))).toBe(true);
+  });
+
+  it('on a hit (second call, same bytes), returns the cached text and does NOT invoke parse', async () => {
+    // This is the load-bearing behavior of the whole issue: a forced rebuild
+    // or a second model registration must skip the expensive parser.
+    const filePath = path.join(tempDir, 'doc.pdf');
+    await fsp.writeFile(filePath, Buffer.from('%PDF-1.4 fake'));
+    const parse = jest.fn().mockResolvedValue('parsed text');
+
+    await loadWithExtractionCache({
+      filePath,
+      loaderName: 'pdf-parse',
+      loaderVersion: 1,
+      parse,
+      cacheDir,
+    });
+    const second = await loadWithExtractionCache({
+      filePath,
+      loaderName: 'pdf-parse',
+      loaderVersion: 1,
+      parse,
+      cacheDir,
+    });
+
+    expect(second).toBe('parsed text');
+    expect(parse).toHaveBeenCalledTimes(1);
+  });
+
+  it('invalidates the cache when the file bytes change (different sha → different key)', async () => {
+    const filePath = path.join(tempDir, 'doc.pdf');
+    await fsp.writeFile(filePath, Buffer.from('first revision'));
+    const parse = jest.fn().mockResolvedValueOnce('FIRST').mockResolvedValueOnce('SECOND');
+
+    const t1 = await loadWithExtractionCache({
+      filePath,
+      loaderName: 'pdf-parse',
+      loaderVersion: 1,
+      parse,
+      cacheDir,
+    });
+    expect(t1).toBe('FIRST');
+
+    // Same path, new bytes — the cache must miss and the parser must be
+    // invoked a second time so the embedding pipeline sees up-to-date text.
+    await fsp.writeFile(filePath, Buffer.from('second revision'));
+    const t2 = await loadWithExtractionCache({
+      filePath,
+      loaderName: 'pdf-parse',
+      loaderVersion: 1,
+      parse,
+      cacheDir,
+    });
+
+    expect(t2).toBe('SECOND');
+    expect(parse).toHaveBeenCalledTimes(2);
+  });
+
+  it('invalidates the cache when loaderVersion is bumped (behavior change)', async () => {
+    const filePath = path.join(tempDir, 'doc.pdf');
+    await fsp.writeFile(filePath, Buffer.from('unchanged bytes'));
+    const parse = jest.fn().mockResolvedValueOnce('v1-output').mockResolvedValueOnce('v2-output');
+
+    await loadWithExtractionCache({
+      filePath,
+      loaderName: 'pdf-parse',
+      loaderVersion: 1,
+      parse,
+      cacheDir,
+    });
+    const afterBump = await loadWithExtractionCache({
+      filePath,
+      loaderName: 'pdf-parse',
+      loaderVersion: 2,
+      parse,
+      cacheDir,
+    });
+
+    expect(afterBump).toBe('v2-output');
+    expect(parse).toHaveBeenCalledTimes(2);
+  });
+
+  it('uses defaultExtractionCacheDir when no cacheDir override is supplied', async () => {
+    // Smoke-check the fallback wire: with `EXTRACTION_TEXT_CACHE_DIR` pointed
+    // at the test dir, the helper must honor it (so production paths land at
+    // FAISS_INDEX_PATH/extracted-text without us needing to mock fs).
+    const original = process.env.EXTRACTION_TEXT_CACHE_DIR;
+    process.env.EXTRACTION_TEXT_CACHE_DIR = cacheDir;
+    try {
+      const filePath = path.join(tempDir, 'doc.pdf');
+      await fsp.writeFile(filePath, Buffer.from('%PDF-default-dir'));
+      const parse = jest.fn().mockResolvedValue('via default dir');
+
+      await loadWithExtractionCache({
+        filePath,
+        loaderName: 'pdf-parse',
+        loaderVersion: 1,
+        parse,
+      });
+
+      const entries = await fsp.readdir(cacheDir);
+      expect(entries).toHaveLength(1);
+      expect(entries[0]).toMatch(/^[a-f0-9]{64}\.txt$/);
+    } finally {
+      if (original === undefined) delete process.env.EXTRACTION_TEXT_CACHE_DIR;
+      else process.env.EXTRACTION_TEXT_CACHE_DIR = original;
+    }
+  });
+
+  it('propagates parse errors to the caller (cache only stores successes)', async () => {
+    // A failed parse must not poison the cache. The next call with the same
+    // bytes should re-run the parser, not return a stale "error" placeholder.
+    const filePath = path.join(tempDir, 'doc.pdf');
+    await fsp.writeFile(filePath, Buffer.from('corrupt'));
+    const parse = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('parse boom'))
+      .mockResolvedValueOnce('recovered text');
+
+    await expect(
+      loadWithExtractionCache({
+        filePath,
+        loaderName: 'pdf-parse',
+        loaderVersion: 1,
+        parse,
+        cacheDir,
+      }),
+    ).rejects.toThrow('parse boom');
+
+    // No entry was stored after the failure.
+    await expect(fsp.readdir(cacheDir)).rejects.toMatchObject({ code: 'ENOENT' });
+
+    // Retrying the same file re-runs the parser and now stores the result.
+    const recovered = await loadWithExtractionCache({
+      filePath,
+      loaderName: 'pdf-parse',
+      loaderVersion: 1,
+      parse,
+      cacheDir,
+    });
+    expect(recovered).toBe('recovered text');
+    expect(parse).toHaveBeenCalledTimes(2);
+  });
+
+  it('continues to return the freshly parsed text even when the cache write fails', async () => {
+    // Operator-misconfiguration safety net: a write failure must not surface
+    // to the caller. The cold-path output is already in hand; ingest must
+    // proceed. We force the write to fail by aiming the cache at a path
+    // whose parent is a regular file (mkdir -p ENOTDIR).
+    const filePath = path.join(tempDir, 'doc.pdf');
+    await fsp.writeFile(filePath, Buffer.from('bytes'));
+    const fileMaskedAsDir = path.join(tempDir, 'masked-file');
+    await fsp.writeFile(fileMaskedAsDir, 'sentinel');
+    const brokenCacheDir = path.join(fileMaskedAsDir, 'cache');
+
+    const parse = jest.fn().mockResolvedValue('cold-path text');
+
+    const text = await loadWithExtractionCache({
+      filePath,
+      loaderName: 'pdf-parse',
+      loaderVersion: 1,
+      parse,
+      cacheDir: brokenCacheDir,
+    });
+
+    expect(text).toBe('cold-path text');
+    expect(parse).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/extraction-cache.ts
+++ b/src/extraction-cache.ts
@@ -1,0 +1,193 @@
+// Issue #279 — content-addressed cache for normalized text extracted from
+// expensive loaders (`.pdf` via pdf-parse, `.html`/`.htm` via html-to-text).
+//
+// Why this exists. Multi-model registration (RFC 013) plus the existing
+// per-file hash gate in `FaissIndexManager.updateIndex` together mean the
+// same source corpus can be parsed multiple times — once per model when
+// rebuilding from an empty index, and again on every `--force` reindex even
+// when the file bytes have not changed. PDF and HTML extraction is the
+// dominant cost on those rebuilds (pdfjs-dist glyph reconstruction + worker
+// loopback), so caching the extracted text by content hash lets subsequent
+// rebuilds skip the parse entirely and feed the existing splitter pipeline.
+//
+// Cache key. sha256(schemaVersion | loaderName | loaderVersion | ext |
+// contentSha256). Including loaderName + loaderVersion in the key means a
+// loader behavior change (bump the constant in `loaders.ts`) automatically
+// invalidates every cache entry produced by the previous behavior — operators
+// do not have to manually purge the cache directory. The extension is part of
+// the key because `getLoader` dispatches on extension, so the same bytes
+// renamed from `.pdf` to `.htm` would route through a different parser and
+// must not share a cache entry.
+//
+// Storage. Plain UTF-8 files under `${FAISS_INDEX_PATH}/extracted-text/`,
+// one file per key. Writes are atomic (tmp file + rename) so a crash mid-write
+// cannot leave a partial entry that a later run would treat as valid text.
+// Reads and writes are best-effort: any I/O error logs a warning and falls
+// back to the cold path (re-parse), so a misconfigured `EXTRACTION_TEXT_CACHE_DIR`
+// or a full disk degrades to "no cache" rather than failing the ingest.
+
+import { createHash } from 'crypto';
+import * as fsp from 'fs/promises';
+import * as path from 'path';
+import { FAISS_INDEX_PATH } from './config.js';
+import { logger } from './logger.js';
+
+/**
+ * Storage-format version. Bump only when the on-disk layout changes (e.g.
+ * compressed payloads, sidecar metadata). Loader-behavior changes bump the
+ * loader-specific `loaderVersion` instead — that scoping prevents a PDF-only
+ * loader bump from invalidating HTML cache entries.
+ */
+export const EXTRACTION_CACHE_SCHEMA_VERSION = 1;
+
+/**
+ * Inputs that uniquely identify an extracted-text cache entry. All five fields
+ * are folded into a sha256; any change produces a different cache key and a
+ * miss on the next read.
+ */
+export interface ExtractionCacheKeyInput {
+  loaderName: string;
+  loaderVersion: number;
+  ext: string;
+  contentSha256: string;
+}
+
+/** sha256 over the raw file bytes — hex, 64 chars. */
+export function computeContentSha256(buffer: Buffer): string {
+  return createHash('sha256').update(buffer).digest('hex');
+}
+
+/**
+ * Derive the cache filename stem from the key inputs. Pure: same inputs ⇒
+ * same output, no I/O. Encoded as a sha256 hex digest so the result is a
+ * fixed 64-char filename safe on every supported filesystem (no special
+ * characters from `loaderName`, no Windows path-length surprises).
+ */
+export function computeExtractionCacheKey(input: ExtractionCacheKeyInput): string {
+  const composite = [
+    `schema=${EXTRACTION_CACHE_SCHEMA_VERSION}`,
+    `loader=${input.loaderName}`,
+    `loaderVersion=${input.loaderVersion}`,
+    `ext=${input.ext.toLowerCase()}`,
+    `content=${input.contentSha256}`,
+  ].join('|');
+  return createHash('sha256').update(composite).digest('hex');
+}
+
+/**
+ * Resolve the cache directory at call time so tests can redirect the cache
+ * into a per-test tempdir via `EXTRACTION_TEXT_CACHE_DIR` after the module
+ * has loaded. Falls back to `${FAISS_INDEX_PATH}/extracted-text/` — the
+ * extracted text is model-independent so it lives at the index root, shared
+ * across every registered model.
+ */
+export function defaultExtractionCacheDir(): string {
+  const override = process.env.EXTRACTION_TEXT_CACHE_DIR;
+  if (override !== undefined && override.trim() !== '') return override;
+  return path.join(FAISS_INDEX_PATH, 'extracted-text');
+}
+
+function cacheEntryPath(cacheDir: string, cacheKey: string): string {
+  return path.join(cacheDir, `${cacheKey}.txt`);
+}
+
+/**
+ * Read the cached text for `cacheKey`. Returns `null` on a miss (ENOENT) and
+ * on any other read failure (logged at debug — the cold path will re-parse).
+ * Never throws: a broken cache must degrade to "no cache", not block ingest.
+ */
+export async function readCachedExtraction(
+  cacheDir: string,
+  cacheKey: string,
+): Promise<string | null> {
+  try {
+    return await fsp.readFile(cacheEntryPath(cacheDir, cacheKey), 'utf-8');
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT') return null;
+    logger.debug(
+      `extraction-cache: read failed for ${cacheKey} (${code ?? 'unknown'}): ${(err as Error).message}`,
+    );
+    return null;
+  }
+}
+
+/**
+ * Write `text` atomically under `cacheKey`. Writes the payload to a unique
+ * tmp file, fsyncs it, then renames into place — a crash before the rename
+ * leaves no partial entry, and the rename is atomic on every supported
+ * filesystem. Failures are logged at warn and swallowed so ingest continues
+ * with the freshly parsed text in-hand.
+ */
+export async function writeCachedExtraction(
+  cacheDir: string,
+  cacheKey: string,
+  text: string,
+): Promise<void> {
+  const targetPath = cacheEntryPath(cacheDir, cacheKey);
+  const tmpPath = `${targetPath}.tmp.${process.pid}.${Date.now()}.${Math.random().toString(16).slice(2)}`;
+  try {
+    await fsp.mkdir(cacheDir, { recursive: true });
+    const handle = await fsp.open(tmpPath, 'w');
+    try {
+      await handle.writeFile(text, 'utf-8');
+      await handle.sync();
+    } finally {
+      await handle.close();
+    }
+    try {
+      await fsp.rename(tmpPath, targetPath);
+    } catch (renameErr) {
+      await fsp.unlink(tmpPath).catch(() => {});
+      throw renameErr;
+    }
+  } catch (err) {
+    logger.warn(
+      `extraction-cache: write failed for ${cacheKey}: ${(err as Error).message}`,
+    );
+  }
+}
+
+/** Options for {@link loadWithExtractionCache}. */
+export interface CachedLoadOptions {
+  filePath: string;
+  loaderName: string;
+  loaderVersion: number;
+  /** Parse the file bytes into normalized text. Invoked only on a cache miss. */
+  parse: (buffer: Buffer) => Promise<string>;
+  /** Override the cache directory; defaults to {@link defaultExtractionCacheDir}. */
+  cacheDir?: string;
+}
+
+/**
+ * Read `filePath`, look up the extraction cache by content hash, and either
+ * return the cached text or invoke `parse` on the file bytes and store the
+ * result for the next caller. Used by `loadPdf` / `loadHtml` in `loaders.ts`.
+ *
+ * The buffer is read inside this helper (not by the caller) so the content
+ * hash and the parse input come from the same byte snapshot — important if
+ * the file is concurrently rewritten, since otherwise the cache key could
+ * describe one version of the bytes while the parser sees another.
+ */
+export async function loadWithExtractionCache(opts: CachedLoadOptions): Promise<string> {
+  const buffer = await fsp.readFile(opts.filePath);
+  const contentSha256 = computeContentSha256(buffer);
+  const ext = path.extname(opts.filePath).toLowerCase();
+  const cacheKey = computeExtractionCacheKey({
+    loaderName: opts.loaderName,
+    loaderVersion: opts.loaderVersion,
+    ext,
+    contentSha256,
+  });
+  const cacheDir = opts.cacheDir ?? defaultExtractionCacheDir();
+
+  const cached = await readCachedExtraction(cacheDir, cacheKey);
+  if (cached !== null) {
+    logger.debug(`extraction-cache: hit for ${opts.filePath} (key=${cacheKey})`);
+    return cached;
+  }
+
+  const text = await opts.parse(buffer);
+  await writeCachedExtraction(cacheDir, cacheKey, text);
+  return text;
+}

--- a/src/loaders.test.ts
+++ b/src/loaders.test.ts
@@ -9,6 +9,14 @@
 //     unregistered extensions (e.g. `.json` opted in via INGEST_EXTRA_EXTENSIONS)
 //     get the UTF-8 text fallback.
 //   - LOADERS registry is frozen so callers can't mutate it from outside.
+//
+// Issue #279 — every `describe` block that drives the PDF or HTML loader sets
+// `EXTRACTION_TEXT_CACHE_DIR` to a per-test temp path BEFORE calling loadFile.
+// The PDF and HTML loaders now consult an extraction cache by content hash;
+// without per-test redirection, the first test's parse output would land in
+// the global cache and every subsequent test on the same bytes would hit the
+// cache instead of the pdf-parse / html-to-text mock — destroying the call
+// count assertions and the noise-suppression coverage.
 
 import * as fsp from 'fs/promises';
 import * as os from 'os';
@@ -112,13 +120,18 @@ describe('getLoader / loadFile dispatch', () => {
 
 describe('PDF loader (pdf-parse) — routing + dispatch (pdf-parse is mocked)', () => {
   let tempDir = '';
+  let priorCacheDir: string | undefined;
 
   beforeEach(async () => {
     tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-loaders-pdf-'));
+    priorCacheDir = process.env.EXTRACTION_TEXT_CACHE_DIR;
+    process.env.EXTRACTION_TEXT_CACHE_DIR = path.join(tempDir, 'extraction-cache');
     pdfParseFnMock.mockReset();
   });
 
   afterEach(async () => {
+    if (priorCacheDir === undefined) delete process.env.EXTRACTION_TEXT_CACHE_DIR;
+    else process.env.EXTRACTION_TEXT_CACHE_DIR = priorCacheDir;
     await fsp.rm(tempDir, { recursive: true, force: true });
   });
 
@@ -175,9 +188,16 @@ describe('PDF loader — pdfjs-dist stdout noise suppression', () => {
   let tempDir = '';
   let originalConsoleLog: typeof console.log;
   let stdoutSpy: jest.Mock;
+  let priorCacheDir: string | undefined;
 
   beforeEach(async () => {
     tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-loaders-pdf-noise-'));
+    priorCacheDir = process.env.EXTRACTION_TEXT_CACHE_DIR;
+    // Issue #279 — redirect the extraction cache into the per-test tempdir so
+    // every test in this suite drives a real parse (the cache lives only for
+    // the duration of one test, which is what the noise-suppression assertions
+    // assume).
+    process.env.EXTRACTION_TEXT_CACHE_DIR = path.join(tempDir, 'extraction-cache');
     pdfParseFnMock.mockReset();
     originalConsoleLog = console.log;
     stdoutSpy = jest.fn();
@@ -186,6 +206,8 @@ describe('PDF loader — pdfjs-dist stdout noise suppression', () => {
 
   afterEach(async () => {
     console.log = originalConsoleLog;
+    if (priorCacheDir === undefined) delete process.env.EXTRACTION_TEXT_CACHE_DIR;
+    else process.env.EXTRACTION_TEXT_CACHE_DIR = priorCacheDir;
     await fsp.rm(tempDir, { recursive: true, force: true });
   });
 
@@ -315,12 +337,17 @@ describe('PDF loader — pdfjs-dist stdout noise suppression', () => {
 
 describe('HTML loader (html-to-text)', () => {
   let tempDir = '';
+  let priorCacheDir: string | undefined;
 
   beforeEach(async () => {
     tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-loaders-html-'));
+    priorCacheDir = process.env.EXTRACTION_TEXT_CACHE_DIR;
+    process.env.EXTRACTION_TEXT_CACHE_DIR = path.join(tempDir, 'extraction-cache');
   });
 
   afterEach(async () => {
+    if (priorCacheDir === undefined) delete process.env.EXTRACTION_TEXT_CACHE_DIR;
+    else process.env.EXTRACTION_TEXT_CACHE_DIR = priorCacheDir;
     await fsp.rm(tempDir, { recursive: true, force: true });
   });
 
@@ -371,5 +398,141 @@ describe('HTML loader (html-to-text)', () => {
     expect(text).toContain('the docs');
     expect(text).not.toContain('example.com');
     expect(text).not.toContain('https://');
+  });
+});
+
+describe('Issue #279 — PDF loader honors the extraction cache', () => {
+  // End-to-end coverage that the cache wire actually short-circuits the
+  // expensive parser path. We mock pdf-parse and assert the mock fires
+  // exactly once across two loadFile() calls on the same bytes; a third
+  // call after rewriting the file produces a cache miss and re-fires.
+  let tempDir = '';
+  let priorCacheDir: string | undefined;
+
+  beforeEach(async () => {
+    tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-loaders-pdf-cache-'));
+    priorCacheDir = process.env.EXTRACTION_TEXT_CACHE_DIR;
+    process.env.EXTRACTION_TEXT_CACHE_DIR = path.join(tempDir, 'extraction-cache');
+    pdfParseFnMock.mockReset();
+  });
+
+  afterEach(async () => {
+    if (priorCacheDir === undefined) delete process.env.EXTRACTION_TEXT_CACHE_DIR;
+    else process.env.EXTRACTION_TEXT_CACHE_DIR = priorCacheDir;
+    await fsp.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('skips pdf-parse on the second load of identical bytes (cache hit)', async () => {
+    const filePath = path.join(tempDir, 'doc.pdf');
+    await fsp.writeFile(filePath, Buffer.from('%PDF-1.4 fixed bytes'));
+    pdfParseFnMock.mockResolvedValue({ text: 'parsed body' });
+
+    const first = await loadFile(filePath);
+    const second = await loadFile(filePath);
+
+    expect(first).toBe('parsed body');
+    expect(second).toBe('parsed body');
+    // The whole point of #279: forced rebuilds and multi-model registration
+    // must not re-drive pdf-parse on bytes whose extraction is already cached.
+    expect(pdfParseFnMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-runs pdf-parse when the file bytes change (sha256 differs → cache miss)', async () => {
+    const filePath = path.join(tempDir, 'doc.pdf');
+    await fsp.writeFile(filePath, Buffer.from('%PDF-1.4 first'));
+    pdfParseFnMock
+      .mockResolvedValueOnce({ text: 'first body' })
+      .mockResolvedValueOnce({ text: 'second body' });
+
+    expect(await loadFile(filePath)).toBe('first body');
+
+    await fsp.writeFile(filePath, Buffer.from('%PDF-1.4 second'));
+    expect(await loadFile(filePath)).toBe('second body');
+
+    // First call landed a cache entry, second call's bytes hash to a
+    // different key so the parser must be invoked again — embeddings must
+    // reflect the latest content, not a stale cached extraction.
+    expect(pdfParseFnMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not cache a failed parse (next call re-runs the parser)', async () => {
+    // A poisoned-cache regression would let one bad PDF permanently break
+    // ingest of that file even after the source was fixed. The loader must
+    // only store successful extractions.
+    const filePath = path.join(tempDir, 'flaky.pdf');
+    await fsp.writeFile(filePath, Buffer.from('%PDF-1.4 flaky'));
+    pdfParseFnMock
+      .mockRejectedValueOnce(new Error('parse boom'))
+      .mockResolvedValueOnce({ text: 'recovered' });
+
+    await expect(loadFile(filePath)).rejects.toThrow('parse boom');
+    expect(await loadFile(filePath)).toBe('recovered');
+    expect(pdfParseFnMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('Issue #279 — HTML loader honors the extraction cache', () => {
+  // The real html-to-text runs end-to-end here (mocking it is brittle because
+  // the loader's `await import('html-to-text')` is lazy and other suites in
+  // this file already pulled in the real module). Instead of counting parser
+  // invocations we inspect the cache directory directly — that is sufficient
+  // to verify the wire because:
+  //   - a successful load with a fresh cacheDir MUST create exactly one entry
+  //     (proves the writeCachedExtraction path runs and points at the right dir);
+  //   - a second load with identical bytes MUST NOT create a second entry
+  //     (proves the readCachedExtraction path is consulted before re-parsing);
+  //   - rewriting the file MUST produce a second, differently-named entry
+  //     (proves the cache key tracks the content hash).
+  let tempDir = '';
+  let cacheDir = '';
+  let priorCacheDir: string | undefined;
+
+  beforeEach(async () => {
+    tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-loaders-html-cache-'));
+    cacheDir = path.join(tempDir, 'extraction-cache');
+    priorCacheDir = process.env.EXTRACTION_TEXT_CACHE_DIR;
+    process.env.EXTRACTION_TEXT_CACHE_DIR = cacheDir;
+  });
+
+  afterEach(async () => {
+    if (priorCacheDir === undefined) delete process.env.EXTRACTION_TEXT_CACHE_DIR;
+    else process.env.EXTRACTION_TEXT_CACHE_DIR = priorCacheDir;
+    await fsp.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('writes a cache entry on first load and reuses it (no new entry) on a second load of identical bytes', async () => {
+    const filePath = path.join(tempDir, 'doc.html');
+    await fsp.writeFile(filePath, '<p>Stable HTML body.</p>');
+
+    const first = await loadFile(filePath);
+    const firstEntries = await fsp.readdir(cacheDir);
+
+    const second = await loadFile(filePath);
+    const secondEntries = await fsp.readdir(cacheDir);
+
+    expect(second).toBe(first);
+    expect(firstEntries).toHaveLength(1);
+    // Cache-hit path: second load found the entry and did not write a new one.
+    expect(secondEntries).toEqual(firstEntries);
+  });
+
+  it('writes a second, differently-keyed entry when the file bytes change', async () => {
+    const filePath = path.join(tempDir, 'doc.html');
+    await fsp.writeFile(filePath, '<p>version one</p>');
+    const firstText = await loadFile(filePath);
+    const afterFirst = await fsp.readdir(cacheDir);
+    expect(afterFirst).toHaveLength(1);
+
+    await fsp.writeFile(filePath, '<p>version two</p>');
+    const secondText = await loadFile(filePath);
+    const afterSecond = await fsp.readdir(cacheDir);
+
+    expect(secondText).not.toBe(firstText);
+    // Two distinct cache entries: one per content hash. The first remains on
+    // disk because the key is content-addressed, not path-addressed — a
+    // rollback to v1 of the file would hit the original entry without re-parsing.
+    expect(afterSecond).toHaveLength(2);
+    expect(new Set(afterSecond).size).toBe(2);
+    expect(afterSecond).toEqual(expect.arrayContaining(afterFirst));
   });
 });

--- a/src/loaders.ts
+++ b/src/loaders.ts
@@ -23,11 +23,28 @@
 
 import * as fsp from 'fs/promises';
 import * as path from 'path';
+import { loadWithExtractionCache } from './extraction-cache.js';
 
 /** Loader contract: filePath in, plain text out. Throws on parse failure. */
 export type Loader = (filePath: string) => Promise<string>;
 
+// Issue #279 — bump these constants whenever the extraction behavior of the
+// corresponding loader changes in a way that would affect chunk content
+// (different html-to-text selectors, a pdf-parse upgrade that alters text
+// flow, etc.). The version is folded into the extraction-cache key so a bump
+// transparently invalidates every cached entry produced by the previous
+// behavior; operators do not need to manually purge `extracted-text/`.
+const PDF_LOADER_NAME = 'pdf-parse';
+const PDF_LOADER_VERSION = 1;
+const HTML_LOADER_NAME = 'html-to-text';
+const HTML_LOADER_VERSION = 1;
+
 async function loadText(filePath: string): Promise<string> {
+  // `.md` / `.txt` / `INGEST_EXTRA_EXTENSIONS` opt-ins ride this loader. They
+  // are already a single fsp.readFile away from "normalized text", so caching
+  // would only add overhead (sha256 + a second copy on disk) without saving
+  // any parse work. Skip the cache here on purpose; only the expensive PDF
+  // and HTML parsers cache.
   return fsp.readFile(filePath, 'utf-8');
 }
 
@@ -106,27 +123,47 @@ async function loadPdf(filePath: string): Promise<string> {
   // truthy value at load time. The `@ts-expect-error` is for the
   // un-typed subpath; pdf-parse/lib/pdf-parse.js is the same function as
   // the package main, just without the debug branch wrapper.
-  // @ts-expect-error: subpath import resolved at runtime, not by tsc
-  const mod = await import('pdf-parse/lib/pdf-parse.js');
-  const pdfParse = (mod.default ?? mod) as (
-    buf: Buffer,
-  ) => Promise<{ text: string }>;
-  const buffer = await fsp.readFile(filePath);
-  const result = await silencePdfjsConsole(() => pdfParse(buffer));
-  return result.text;
+  //
+  // Issue #279 — gate the heavy parse behind the content-addressed extraction
+  // cache. On a cache hit we never touch pdfjs-dist at all; on a miss we run
+  // the original parse and store its output for the next caller.
+  return loadWithExtractionCache({
+    filePath,
+    loaderName: PDF_LOADER_NAME,
+    loaderVersion: PDF_LOADER_VERSION,
+    parse: async (buffer) => {
+      // @ts-expect-error: subpath import resolved at runtime, not by tsc
+      const mod = await import('pdf-parse/lib/pdf-parse.js');
+      const pdfParse = (mod.default ?? mod) as (
+        buf: Buffer,
+      ) => Promise<{ text: string }>;
+      const result = await silencePdfjsConsole(() => pdfParse(buffer));
+      return result.text;
+    },
+  });
 }
 
 async function loadHtml(filePath: string): Promise<string> {
-  const { htmlToText } = await import('html-to-text');
-  const raw = await fsp.readFile(filePath, 'utf-8');
-  return htmlToText(raw, {
-    wordwrap: false,
-    selectors: [
-      // Hrefs are noise inside an embedding; the link text is what matters.
-      { selector: 'a', options: { ignoreHref: true } },
-      // Images carry no embeddable text; skip the alt-text-only line they'd produce.
-      { selector: 'img', format: 'skip' },
-    ],
+  // Issue #279 — same caching gate as `loadPdf`. html-to-text is cheap per
+  // call but quadratic in document size on large structured documents, so
+  // skipping it on rebuilds is still a meaningful win.
+  return loadWithExtractionCache({
+    filePath,
+    loaderName: HTML_LOADER_NAME,
+    loaderVersion: HTML_LOADER_VERSION,
+    parse: async (buffer) => {
+      const { htmlToText } = await import('html-to-text');
+      const raw = buffer.toString('utf-8');
+      return htmlToText(raw, {
+        wordwrap: false,
+        selectors: [
+          // Hrefs are noise inside an embedding; the link text is what matters.
+          { selector: 'a', options: { ignoreHref: true } },
+          // Images carry no embeddable text; skip the alt-text-only line they'd produce.
+          { selector: 'img', format: 'skip' },
+        ],
+      });
+    },
   });
 }
 


### PR DESCRIPTION
## Summary

Closes #279.

- New `src/extraction-cache.ts`: content-addressed cache for normalized text extracted from `.pdf` (pdf-parse) and `.html`/`.htm` (html-to-text). Cache key = sha256 of (schemaVersion | loaderName | loaderVersion | ext | sha256(bytes)). Entries land under `${FAISS_INDEX_PATH}/extracted-text/<key>.txt`.
- `loaders.ts`: `loadPdf` / `loadHtml` now consult the cache before parsing. Loader-version constants (`PDF_LOADER_VERSION`, `HTML_LOADER_VERSION`) let a behavior change transparently invalidate every previous entry — no operator-side cache purge needed.
- Writes are atomic (tmp + fsync + rename). Any I/O error logs and falls back to the cold path, so a misconfigured cache dir or full disk degrades to "no cache" rather than failing ingest. `EXTRACTION_TEXT_CACHE_DIR` env var overrides the default location (used by tests).

## Why

Forced reindexes and the RFC 013 multi-model registration path repeatedly parse the same `.pdf` and `.html` files because the per-file-hash gate in `FaissIndexManager.updateIndex` runs *after* the loader. Extraction is the dominant cost there (pdfjs-dist glyph reconstruction, html-to-text traversal), and the extracted text is model-independent — exactly the work worth amortizing across rebuilds.

## Test plan

- [x] `npm test -- src/loaders.test.ts src/extraction-cache.test.ts` (49/49 passing)
- [x] `npm run build` (clean tsc)
- [x] Full suite: `npm test` — 55 suites / 960 tests passing, no new failures
- [x] New `extraction-cache.test.ts`: key determinism + invalidation on every key field, atomic write (no `.tmp.*` stragglers), `mkdir -p` failure swallowed, cache hit/miss/poisoning behavior on `loadWithExtractionCache`
- [x] `loaders.test.ts` cache-integration block: PDF mock invoked exactly once across two `loadFile` calls on identical bytes; re-fires when bytes change; failed parses are NOT cached. HTML: cache dir contains exactly one entry after first load, no new entry after second identical load, two distinct entries after bytes change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)