### PR TITLE
feat(bench): cli_search phase-timing scenario (#284)

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -22,6 +22,8 @@ Optional environment variables:
 
 - `BENCH_RESULTS_PREFIX` changes the output filename prefix. The default is `run`. Use `baseline` when you want a committed baseline file.
 - `BENCH_STUB_EMBED_MS_PER_INPUT` changes the stub embedding latency model. The default is `20` milliseconds per document chunk.
+- `BENCH_INCLUDE_CLI_SEARCH=1` opts into the issue #284 `cli_search` scenario. It is off by default because each repetition spawns the built `kb` binary as a child process; the cost is what the scenario measures, so it stays heavier than the in-process scenarios.
+- `BENCH_CLI_SEARCH_REPETITIONS` sets the per-variant repetition count for `cli_search`. Defaults to 10.
 
 ## Result file naming
 
@@ -99,6 +101,42 @@ The scenario keys stay flat so CI can query them with tools like `jq`, for examp
 ```bash
 jq '.scenarios.warm_query.p50_ms' benchmarks/results/run-stub-node22-linux-x64.json
 ```
+
+### `cli_search` — phase timings for the real `kb search` CLI (issue #284)
+
+When `BENCH_INCLUDE_CLI_SEARCH=1` is set, the harness adds a `cli_search` scenario that spawns the built `kb` binary against an offline `fake` model (issue #204) with a pre-built fixture index. Each repetition reports an externally measured wall time plus the internal phase timings the CLI emits with `--timing`:
+
+```json
+"cli_search": {
+  "fixture_files": 20,
+  "fixture_chunk_count": 110,
+  "variants": [
+    {
+      "variant": "json-global",
+      "format": "json",
+      "repetitions": 10,
+      "wall_p50_ms": 540,
+      "wall_p95_ms": 612,
+      "wall_p99_ms": 612,
+      "process_start_p50_ms": 318,
+      "bootstrap_p50_ms": 4,
+      "model_resolution_p50_ms": 2,
+      "manager_load_p50_ms": 6,
+      "index_load_p50_ms": 71,
+      "embed_query_p50_ms": 1,
+      "faiss_search_p50_ms": 9,
+      "post_filter_p50_ms": 0,
+      "staleness_p50_ms": 12,
+      "cli_total_p50_ms": 222,
+      "rss_peak_bytes": 118800384
+    }
+  ]
+}
+```
+
+`process_start_p50_ms` is derived per repetition as `wall_ms - cli_total_ms`, i.e. the Node startup + module-import cost incurred BEFORE the CLI's first internal timer fires, plus the formatting / stdout write that happens AFTER the CLI's `total_ms` clock stops. `rss_peak_bytes` is the maximum `VmHWM` observed across repetitions via `/proc/<pid>/status` polling; on non-Linux kernels this field is `null`.
+
+Each variant exercises a different output shape so format-related costs (JSON serialization vs markdown rendering, including the staleness footer) are comparable side-by-side. `cli_search` does not run inside `bench:compare`.
 
 ## Stub vs real-provider mode
 

--- a/benchmarks/run.ts
+++ b/benchmarks/run.ts
@@ -4,6 +4,7 @@ import { readFileSync } from 'fs';
 import type { BenchmarkReport, BenchProvider, ScenarioContext } from './types.js';
 import { installStubProvider } from './stub.js';
 import { runBatchQueryScenario } from './scenarios/batch-query.js';
+import { runCliSearchScenario } from './scenarios/cli-search.js';
 import { runColdIndexScenario } from './scenarios/cold-index.js';
 import { runColdStartScenario } from './scenarios/cold-start.js';
 import { runIndexStorageScenario } from './scenarios/index-storage.js';
@@ -52,6 +53,10 @@ async function main(): Promise<void> {
 
   const includeBatchQuery = parseBoolEnv(process.env.BENCH_INCLUDE_BATCH_QUERY, true);
   const includeIndexStorage = parseBoolEnv(process.env.BENCH_INCLUDE_INDEX_STORAGE, true);
+  // Issue #284 — cli-search spawns the built `kb` binary per repetition; it is
+  // structurally heavier than the in-process scenarios so it stays opt-in.
+  const includeCliSearch = parseBoolEnv(process.env.BENCH_INCLUDE_CLI_SEARCH, false);
+  const cliSearchReps = parsePositiveIntEnv(process.env.BENCH_CLI_SEARCH_REPETITIONS);
 
   const concurrencies = parseConcurrencies(process.env.BENCH_BATCH_CONCURRENCIES);
   const queries = parseQueriesEnv(process.env.BENCH_QUERIES);
@@ -86,6 +91,9 @@ async function main(): Promise<void> {
         chunkSize: fixtureOverrides.chunkSize,
       })
     : undefined;
+  const cli_search = includeCliSearch
+    ? await runCliSearchScenario(context, fixtureOverrides, { repetitions: cliSearchReps })
+    : undefined;
 
   const report: BenchmarkReport = {
     arch: os.arch(),
@@ -102,6 +110,7 @@ async function main(): Promise<void> {
       retrieval_quality,
       warm_query,
       ...(batch_query ? { batch_query } : {}),
+      ...(cli_search ? { cli_search } : {}),
       ...(index_storage ? { index_storage } : {}),
     },
     version: 1,

--- a/benchmarks/scenarios/cli-search.test.ts
+++ b/benchmarks/scenarios/cli-search.test.ts
@@ -1,0 +1,190 @@
+import {
+  aggregateCliSearchVariant,
+  parseCliSearchTimingFromStdout,
+  type CliSearchRepetition,
+} from './cli-search.js';
+
+describe('parseCliSearchTimingFromStdout', () => {
+  it('extracts the timing block from a kb search --format=json --timing payload', () => {
+    const payload = {
+      results: [],
+      index_mtime: '2026-05-12T00:00:00.000Z',
+      stale: false,
+      modified_files: 0,
+      new_files: 0,
+      global_stale: false,
+      global_modified_files: 0,
+      global_new_files: 0,
+      timing: {
+        requested_mode: 'dense',
+        effective_mode: 'dense',
+        bootstrap_ms: 3,
+        model_resolution_ms: 1,
+        manager_load_ms: 7,
+        index_load_ms: 42,
+        dense_search_ms: 18,
+        embed_query_ms: 12,
+        faiss_search_ms: 5,
+        query_search_ms: 17,
+        post_filter_ms: 1,
+        staleness_ms: 9,
+        total_ms: 82,
+      },
+    };
+    const stdout = `${JSON.stringify(payload, null, 2)}\n`;
+    const timing = parseCliSearchTimingFromStdout(stdout);
+
+    expect(timing).not.toBeNull();
+    expect(timing).toEqual({
+      bootstrap_ms: 3,
+      model_resolution_ms: 1,
+      manager_load_ms: 7,
+      index_load_ms: 42,
+      dense_search_ms: 18,
+      embed_query_ms: 12,
+      faiss_search_ms: 5,
+      query_search_ms: 17,
+      post_filter_ms: 1,
+      staleness_ms: 9,
+      total_ms: 82,
+    });
+  });
+
+  it('returns null when the JSON payload has no timing field', () => {
+    const stdout = `${JSON.stringify({ results: [] }, null, 2)}\n`;
+    expect(parseCliSearchTimingFromStdout(stdout)).toBeNull();
+  });
+
+  it('parses the markdown timing footer when the CLI runs with --format=md', () => {
+    // Real shape of formatTimingFooter('Timing', timing) for a dense run.
+    const stdout = [
+      '# Result',
+      '',
+      'body…',
+      '',
+      '> _Index up-to-date as of 2026-05-12T00:00:00.000Z._',
+      '> _Timing (dense): bootstrap_ms=3ms, index_load_ms=42ms, embed_query_ms=12ms, faiss_search_ms=5ms, post_filter_ms=1ms, staleness_ms=9ms, total_ms=82ms._',
+      '',
+    ].join('\n');
+
+    const timing = parseCliSearchTimingFromStdout(stdout);
+    expect(timing).toEqual({
+      bootstrap_ms: 3,
+      index_load_ms: 42,
+      embed_query_ms: 12,
+      faiss_search_ms: 5,
+      post_filter_ms: 1,
+      staleness_ms: 9,
+      total_ms: 82,
+    });
+  });
+
+  it('returns null on completely unrelated output (e.g. an error line)', () => {
+    expect(parseCliSearchTimingFromStdout('kb search: missing <query>\n')).toBeNull();
+  });
+
+  it('ignores non-numeric or out-of-schema fields inside the timing block', () => {
+    const payload = {
+      timing: {
+        bootstrap_ms: 3,
+        total_ms: 'fast',                // wrong type → dropped
+        unrelated_field: 100,             // not in schema → dropped
+        post_filter_ms: NaN,              // non-finite → dropped
+      },
+    };
+    const timing = parseCliSearchTimingFromStdout(JSON.stringify(payload));
+    expect(timing).toEqual({ bootstrap_ms: 3 });
+  });
+});
+
+describe('aggregateCliSearchVariant', () => {
+  function makeRep(wallMs: number, timing: Record<string, number> | null, rss: number | null = null): CliSearchRepetition {
+    return { wall_ms: wallMs, rss_peak_bytes: rss, timing: timing as never };
+  }
+
+  it('computes wall p50/p95/p99 and derives process_start_ms = wall_ms - total_ms', () => {
+    const reps: CliSearchRepetition[] = [
+      makeRep(500, { bootstrap_ms: 10, total_ms: 200 }, 100_000),
+      makeRep(520, { bootstrap_ms: 12, total_ms: 210 }, 110_000),
+      makeRep(540, { bootstrap_ms: 14, total_ms: 220 }, 105_000),
+    ];
+    const result = aggregateCliSearchVariant('json-global', 'json', reps);
+
+    expect(result.variant).toBe('json-global');
+    expect(result.format).toBe('json');
+    expect(result.repetitions).toBe(3);
+    expect(result.wall_p50_ms).toBe(520);
+    expect(result.wall_p95_ms).toBe(540);
+    expect(result.wall_p99_ms).toBe(540);
+    expect(result.bootstrap_p50_ms).toBe(12);
+    expect(result.cli_total_p50_ms).toBe(210);
+    // process_start_p50 is derived per-rep then percentile'd: (300, 310, 320) → p50 = 310.
+    expect(result.process_start_p50_ms).toBe(310);
+    expect(result.rss_peak_bytes).toBe(110_000);
+  });
+
+  it('returns null phase percentiles when no rep emitted that field', () => {
+    const reps: CliSearchRepetition[] = [
+      makeRep(500, { bootstrap_ms: 10 }),
+      makeRep(520, { bootstrap_ms: 12 }),
+    ];
+    const result = aggregateCliSearchVariant('md-global', 'md', reps);
+    expect(result.bootstrap_p50_ms).toBe(10);
+    // No rep emitted total_ms, so process_start_ms cannot be derived either.
+    expect(result.cli_total_p50_ms).toBeNull();
+    expect(result.process_start_p50_ms).toBeNull();
+    expect(result.faiss_search_p50_ms).toBeNull();
+  });
+
+  it('returns null rss_peak_bytes when all repetitions lack RSS data (e.g. non-Linux)', () => {
+    const reps: CliSearchRepetition[] = [
+      makeRep(500, { bootstrap_ms: 10, total_ms: 200 }),
+      makeRep(520, { bootstrap_ms: 12, total_ms: 210 }),
+    ];
+    const result = aggregateCliSearchVariant('json-global', 'json', reps);
+    expect(result.rss_peak_bytes).toBeNull();
+  });
+
+  it('reports the MAX rss across repetitions, not the median', () => {
+    // Peak resident memory is a worst-case measure; reporting median would
+    // hide the fact that one rep allocated 2× the baseline.
+    const reps: CliSearchRepetition[] = [
+      makeRep(500, { total_ms: 200 }, 100_000),
+      makeRep(520, { total_ms: 210 }, 200_000),
+      makeRep(540, { total_ms: 220 }, 100_000),
+    ];
+    const result = aggregateCliSearchVariant('json-global', 'json', reps);
+    expect(result.rss_peak_bytes).toBe(200_000);
+  });
+
+  it('skips repetitions where a phase field is missing without dropping the rep entirely', () => {
+    const reps: CliSearchRepetition[] = [
+      makeRep(500, { bootstrap_ms: 10, total_ms: 200 }),
+      makeRep(520, { bootstrap_ms: 12 }), // missing total_ms
+      makeRep(540, { bootstrap_ms: 14, total_ms: 220 }),
+    ];
+    const result = aggregateCliSearchVariant('json-global', 'json', reps);
+    // All three reps still contribute to wall and bootstrap percentiles…
+    expect(result.repetitions).toBe(3);
+    expect(result.bootstrap_p50_ms).toBe(12);
+    // …but cli_total_p50_ms only sees two samples: (200, 220) → p50 = 200.
+    expect(result.cli_total_p50_ms).toBe(200);
+    // process_start derivation only fires for reps with total_ms: (300, 320) → p50 = 300.
+    expect(result.process_start_p50_ms).toBe(300);
+  });
+
+  it('throws when called with no repetitions (rather than emitting NaN percentiles)', () => {
+    expect(() => aggregateCliSearchVariant('json-global', 'json', [])).toThrow(/no repetitions/);
+  });
+
+  it('clamps a derived negative process_start_ms to zero', () => {
+    // If the CLI's internal total_ms ever exceeds external wall_ms (e.g.
+    // due to monotonic-clock skew between Date.now() and process.hrtime),
+    // process_start cannot be negative — clamp at 0.
+    const reps: CliSearchRepetition[] = [
+      makeRep(100, { total_ms: 150 }),
+    ];
+    const result = aggregateCliSearchVariant('json-global', 'json', reps);
+    expect(result.process_start_p50_ms).toBe(0);
+  });
+});

--- a/benchmarks/scenarios/cli-search.ts
+++ b/benchmarks/scenarios/cli-search.ts
@@ -1,0 +1,347 @@
+import * as fsp from 'fs/promises';
+import * as path from 'path';
+import { spawn } from 'child_process';
+import type { CliSearchScenarioResult, CliSearchVariantResult, FixtureOverrides, ScenarioContext } from '../types.js';
+import { generateKnowledgeBaseFixture } from '../fixtures/generator.js';
+import { durationMs, percentile, resetDirectory } from '../utils.js';
+
+/**
+ * Issue #284 — phase-timing benchmark for the real `kb search` CLI path.
+ *
+ * The other scenarios drive `FaissIndexManager` in-process and miss the user-
+ * visible cost of `kb search`: Node startup, argv parse, layout bootstrap,
+ * active-model resolution, manager load, optional refresh, retrieval, the
+ * staleness scan, grouping/formatting, and stdout/stderr write. This scenario
+ * spawns the built `kb` binary against an offline `fake` model with a
+ * pre-built index, parses the JSON `--timing` payload, and combines it with
+ * externally measured wall time + (Linux-only) peak RSS.
+ *
+ * The scenario is opt-in via `BENCH_INCLUDE_CLI_SEARCH=1` because each
+ * repetition spawns a Node process; the cost is what we are measuring, so it
+ * is structurally heavier than the in-process scenarios.
+ *
+ * The `fake` provider (issue #204) is required: it is offline, deterministic,
+ * and has no API-key or daemon dependency, so the spawned CLI can run inside
+ * CI without provider stubbing (the existing stub patches embeddings in the
+ * parent process only and would not survive the child fork).
+ */
+
+const FAKE_MODEL_ID = 'fake__bench-fake';
+const FAKE_MODEL_NAME = 'bench-fake';
+
+export interface CliSearchTimingFields {
+  bootstrap_ms?: number;
+  model_resolution_ms?: number;
+  manager_load_ms?: number;
+  index_load_ms?: number;
+  dense_search_ms?: number;
+  embed_query_ms?: number;
+  faiss_search_ms?: number;
+  query_search_ms?: number;
+  post_filter_ms?: number;
+  staleness_ms?: number;
+  total_ms?: number;
+}
+
+export interface CliSearchRepetition {
+  wall_ms: number;
+  rss_peak_bytes: number | null;
+  timing: CliSearchTimingFields | null;
+}
+
+interface CliSearchVariantSpec {
+  name: string;
+  format: 'json' | 'md';
+  args: string[];
+}
+
+interface CliSearchScenarioOptions {
+  repetitions?: number;
+  files?: number;
+  targetChunksPerFile?: number;
+  chunkSize?: number;
+}
+
+const DEFAULT_REPETITIONS = 10;
+
+export async function runCliSearchScenario(
+  context: ScenarioContext,
+  fixtureOverrides: FixtureOverrides = {},
+  options: CliSearchScenarioOptions = {},
+): Promise<CliSearchScenarioResult> {
+  const repetitions = clampPositiveInt(options.repetitions, DEFAULT_REPETITIONS);
+  const files = fixtureOverrides.files ?? options.files ?? 20;
+  const targetChunksPerFile = fixtureOverrides.targetChunksPerFile ?? options.targetChunksPerFile ?? 5;
+
+  await resetDirectory(context.knowledgeBasesRootDir);
+  await resetDirectory(context.faissIndexPath);
+  context.stubController?.resetCounters();
+
+  const fixture = await generateKnowledgeBaseFixture({
+    files,
+    knowledgeBaseName: context.knowledgeBaseName,
+    rootDir: context.knowledgeBasesRootDir,
+    seed: context.fixtureSeed + 7,
+    targetChunksPerFile,
+    chunkSize: fixtureOverrides.chunkSize ?? options.chunkSize,
+  });
+
+  await registerFakeModel(context.faissIndexPath);
+
+  const cliPath = path.join(context.buildRoot, 'cli.js');
+  const childEnv = buildChildEnv(context);
+
+  await prebuildIndex(cliPath, childEnv, fixture.query);
+
+  const variants: CliSearchVariantSpec[] = [
+    { name: 'json-global', format: 'json', args: ['--format=json', '--timing'] },
+    { name: 'md-global', format: 'md', args: ['--format=md', '--timing'] },
+  ];
+
+  const variantResults: CliSearchVariantResult[] = [];
+  for (const variant of variants) {
+    // One warmup invocation to absorb fs / page-cache cold-start noise so the
+    // measured `process_start_ms` reflects steady-state Node import cost.
+    await spawnCliSearch(cliPath, [fixture.query, ...variant.args], childEnv);
+
+    const reps: CliSearchRepetition[] = [];
+    for (let r = 0; r < repetitions; r += 1) {
+      reps.push(await spawnCliSearch(cliPath, [fixture.query, ...variant.args], childEnv));
+    }
+    variantResults.push(aggregateCliSearchVariant(variant.name, variant.format, reps));
+  }
+
+  return {
+    fixture_files: fixture.files,
+    fixture_chunk_count: fixture.chunkCount,
+    variants: variantResults,
+  };
+}
+
+/**
+ * Parse the `timing` block out of `kb search --format=json --timing` stdout.
+ * Returns null when no JSON payload or no `timing` field is present so the
+ * caller can record the repetition's external wall time without internal phase
+ * detail. Markdown output lines like `> _Timing (dense): bootstrap_ms=4ms, …_`
+ * are parsed too, so the same helper handles both formats.
+ */
+export function parseCliSearchTimingFromStdout(stdout: string): CliSearchTimingFields | null {
+  const json = tryExtractJson(stdout);
+  if (json && typeof json === 'object' && json !== null && 'timing' in json) {
+    const timing = (json as { timing?: unknown }).timing;
+    if (timing && typeof timing === 'object') {
+      return pickTimingFields(timing as Record<string, unknown>);
+    }
+  }
+  // Markdown timing footer: `> _Timing (dense): k=Vms, …._`. The body itself
+  // contains `_` characters (e.g. `bootstrap_ms`) so the lazy capture must be
+  // anchored to end-of-line via the `m` flag instead of trying to exclude `_`.
+  const footerMatch = /_Timing[^:]*:\s*(.+?)\._\s*$/m.exec(stdout);
+  if (footerMatch) {
+    const pairs = footerMatch[1].split(',').map((s) => s.trim());
+    const out: Record<string, unknown> = {};
+    for (const pair of pairs) {
+      const eqIndex = pair.indexOf('=');
+      if (eqIndex <= 0) continue;
+      const key = pair.slice(0, eqIndex).trim();
+      const valueRaw = pair.slice(eqIndex + 1).trim();
+      const numericMatch = /^(-?\d+(?:\.\d+)?)/.exec(valueRaw);
+      if (numericMatch) out[key] = Number(numericMatch[1]);
+    }
+    return pickTimingFields(out);
+  }
+  return null;
+}
+
+/**
+ * Reduce a list of per-repetition measurements to p50/p95/p99 across wall
+ * time and each named phase timing. Missing phase values are skipped (the
+ * percentile is computed only over reps that emitted the field); a variant
+ * with zero phase samples reports `null` for that percentile.
+ */
+export function aggregateCliSearchVariant(
+  name: string,
+  format: 'json' | 'md',
+  reps: readonly CliSearchRepetition[],
+): CliSearchVariantResult {
+  if (reps.length === 0) {
+    throw new Error(`cli-search scenario: aggregateCliSearchVariant("${name}") called with no repetitions`);
+  }
+  const wallSamples = reps.map((r) => r.wall_ms);
+  const rssSamples = reps.map((r) => r.rss_peak_bytes).filter((v): v is number => v !== null);
+
+  const sampleFor = (key: keyof CliSearchTimingFields): number[] => {
+    const out: number[] = [];
+    for (const r of reps) {
+      const v = r.timing?.[key];
+      if (typeof v === 'number' && Number.isFinite(v)) out.push(v);
+    }
+    return out;
+  };
+
+  const cliTotalSamples = sampleFor('total_ms');
+  const processStartSamples: number[] = [];
+  for (const r of reps) {
+    const totalMs = r.timing?.total_ms;
+    if (typeof totalMs === 'number' && Number.isFinite(totalMs)) {
+      processStartSamples.push(Math.max(0, r.wall_ms - totalMs));
+    }
+  }
+
+  return {
+    variant: name,
+    format,
+    repetitions: reps.length,
+    wall_p50_ms: percentile(wallSamples, 50),
+    wall_p95_ms: percentile(wallSamples, 95),
+    wall_p99_ms: percentile(wallSamples, 99),
+    process_start_p50_ms: processStartSamples.length > 0 ? percentile(processStartSamples, 50) : null,
+    bootstrap_p50_ms: percentileOrNull(sampleFor('bootstrap_ms'), 50),
+    model_resolution_p50_ms: percentileOrNull(sampleFor('model_resolution_ms'), 50),
+    manager_load_p50_ms: percentileOrNull(sampleFor('manager_load_ms'), 50),
+    index_load_p50_ms: percentileOrNull(sampleFor('index_load_ms'), 50),
+    embed_query_p50_ms: percentileOrNull(sampleFor('embed_query_ms'), 50),
+    faiss_search_p50_ms: percentileOrNull(sampleFor('faiss_search_ms'), 50),
+    post_filter_p50_ms: percentileOrNull(sampleFor('post_filter_ms'), 50),
+    staleness_p50_ms: percentileOrNull(sampleFor('staleness_ms'), 50),
+    cli_total_p50_ms: percentileOrNull(cliTotalSamples, 50),
+    rss_peak_bytes: rssSamples.length > 0 ? Math.max(...rssSamples) : null,
+  };
+}
+
+function percentileOrNull(samples: number[], p: number): number | null {
+  return samples.length > 0 ? percentile(samples, p) : null;
+}
+
+function pickTimingFields(source: Record<string, unknown>): CliSearchTimingFields {
+  const out: CliSearchTimingFields = {};
+  const keys: Array<keyof CliSearchTimingFields> = [
+    'bootstrap_ms', 'model_resolution_ms', 'manager_load_ms', 'index_load_ms',
+    'dense_search_ms', 'embed_query_ms', 'faiss_search_ms', 'query_search_ms',
+    'post_filter_ms', 'staleness_ms', 'total_ms',
+  ];
+  for (const key of keys) {
+    const value = source[key];
+    if (typeof value === 'number' && Number.isFinite(value)) out[key] = value;
+  }
+  return out;
+}
+
+function tryExtractJson(stdout: string): unknown {
+  const trimmed = stdout.trimStart();
+  if (!trimmed.startsWith('{')) return null;
+  // The CLI emits `${JSON.stringify(payload, null, 2)}\n`; nothing else on stdout.
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return null;
+  }
+}
+
+function clampPositiveInt(value: number | undefined, fallback: number): number {
+  if (value === undefined || !Number.isFinite(value) || value < 1) return fallback;
+  return Math.floor(value);
+}
+
+async function registerFakeModel(faissIndexPath: string): Promise<void> {
+  // Issue #284 — minimum on-disk registration (active-model.ts isRegisteredModel):
+  // models/<id>/ dir + model_name.txt; no .adding sentinel. active.txt names
+  // the model so resolveActiveModel step 3 wins without needing KB_ACTIVE_MODEL.
+  const modelDir = path.join(faissIndexPath, 'models', FAKE_MODEL_ID);
+  await fsp.mkdir(modelDir, { recursive: true });
+  await fsp.writeFile(path.join(modelDir, 'model_name.txt'), FAKE_MODEL_NAME, 'utf-8');
+  await fsp.writeFile(path.join(faissIndexPath, 'active.txt'), FAKE_MODEL_ID, 'utf-8');
+}
+
+function buildChildEnv(context: ScenarioContext): NodeJS.ProcessEnv {
+  // Copy parent env then override the keys the CLI reads at boot. The bench
+  // parent has already pointed KNOWLEDGE_BASES_ROOT_DIR / FAISS_INDEX_PATH at
+  // the per-pid workspace; the child needs the same plus EMBEDDING_PROVIDER=fake.
+  return {
+    ...process.env,
+    EMBEDDING_PROVIDER: 'fake',
+    KNOWLEDGE_BASES_ROOT_DIR: context.knowledgeBasesRootDir,
+    FAISS_INDEX_PATH: context.faissIndexPath,
+    KB_ACTIVE_MODEL: FAKE_MODEL_ID,
+    // Silence the structured log file the CLI opens at boot so the bench's
+    // temp dir does not accumulate per-rep log files.
+    LOG_FILE: path.join(context.faissIndexPath, 'cli-search-bench.log'),
+  };
+}
+
+async function prebuildIndex(cliPath: string, env: NodeJS.ProcessEnv, query: string): Promise<void> {
+  const result = await spawnCliSearch(
+    cliPath,
+    [query, '--refresh', '--format=json'],
+    env,
+  );
+  // The prebuild result is discarded — only the persisted index matters.
+  if (result.wall_ms < 0) {
+    throw new Error('cli-search scenario: prebuild produced negative wall time (clock skew?)');
+  }
+}
+
+async function spawnCliSearch(
+  cliPath: string,
+  args: string[],
+  env: NodeJS.ProcessEnv,
+): Promise<CliSearchRepetition> {
+  return new Promise((resolve, reject) => {
+    const start = process.hrtime.bigint();
+    const child = spawn(process.execPath, [cliPath, 'search', ...args], {
+      env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    const stdoutChunks: Buffer[] = [];
+    const stderrChunks: Buffer[] = [];
+    child.stdout.on('data', (chunk: Buffer) => stdoutChunks.push(chunk));
+    child.stderr.on('data', (chunk: Buffer) => stderrChunks.push(chunk));
+
+    // Linux-only: poll /proc/<pid>/status for VmHWM (peak RSS). Best-effort —
+    // the file disappears on exit and may be unreadable on non-Linux kernels.
+    let rssPeak: number | null = null;
+    const pollHandle = process.platform === 'linux' && child.pid !== undefined
+      ? setInterval(() => {
+          if (child.pid === undefined) return;
+          readVmHwmKb(child.pid).then((kb) => {
+            if (kb !== null) {
+              const bytes = kb * 1024;
+              if (rssPeak === null || bytes > rssPeak) rssPeak = bytes;
+            }
+          }).catch(() => undefined);
+        }, 10)
+      : null;
+
+    child.on('error', (err) => {
+      if (pollHandle) clearInterval(pollHandle);
+      reject(err);
+    });
+    child.on('exit', (code) => {
+      if (pollHandle) clearInterval(pollHandle);
+      const end = process.hrtime.bigint();
+      const wall_ms = Number(durationMs(start, end).toFixed(3));
+      const stdout = Buffer.concat(stdoutChunks).toString('utf-8');
+      const stderr = Buffer.concat(stderrChunks).toString('utf-8');
+      if (code !== 0) {
+        reject(new Error(
+          `kb search exited with code ${code}.\nstderr:\n${stderr}\nstdout:\n${stdout.slice(0, 4000)}`,
+        ));
+        return;
+      }
+      const timing = parseCliSearchTimingFromStdout(stdout);
+      resolve({ wall_ms, rss_peak_bytes: rssPeak, timing });
+    });
+  });
+}
+
+async function readVmHwmKb(pid: number): Promise<number | null> {
+  try {
+    const raw = await fsp.readFile(`/proc/${pid}/status`, 'utf-8');
+    const match = /^VmHWM:\s+(\d+)\s+kB/m.exec(raw);
+    if (!match) return null;
+    const value = Number(match[1]);
+    return Number.isFinite(value) ? value : null;
+  } catch {
+    return null;
+  }
+}

--- a/benchmarks/types.ts
+++ b/benchmarks/types.ts
@@ -66,6 +66,32 @@ export interface IndexStorageScenarioResult {
   vectors: number;
 }
 
+export interface CliSearchVariantResult {
+  variant: string;
+  format: 'json' | 'md';
+  repetitions: number;
+  wall_p50_ms: number;
+  wall_p95_ms: number;
+  wall_p99_ms: number;
+  process_start_p50_ms: number | null;
+  bootstrap_p50_ms: number | null;
+  model_resolution_p50_ms: number | null;
+  manager_load_p50_ms: number | null;
+  index_load_p50_ms: number | null;
+  embed_query_p50_ms: number | null;
+  faiss_search_p50_ms: number | null;
+  post_filter_p50_ms: number | null;
+  staleness_p50_ms: number | null;
+  cli_total_p50_ms: number | null;
+  rss_peak_bytes: number | null;
+}
+
+export interface CliSearchScenarioResult {
+  fixture_files: number;
+  fixture_chunk_count: number;
+  variants: CliSearchVariantResult[];
+}
+
 export interface BenchmarkReport {
   arch: string;
   git_sha: string;
@@ -81,6 +107,7 @@ export interface BenchmarkReport {
     retrieval_quality: RetrievalQualityScenarioResult;
     warm_query: WarmQueryScenarioResult;
     batch_query?: BatchQueryScenarioResult;
+    cli_search?: CliSearchScenarioResult;
     index_storage?: IndexStorageScenarioResult;
   };
   version: 1;


### PR DESCRIPTION
## Summary

Adds the issue-#284 `cli_search` benchmark scenario: spawns the built `kb search` CLI per repetition against an offline `fake` provider with a pre-built fixture index, then merges externally measured wall time + Linux `VmHWM` peak RSS with the CLI's internal `--timing` phase emissions.

Surfaces these phase timings at p50 per variant (`json-global` and `md-global`):

- `process_start_ms` — derived `wall_ms - cli_total_ms`; Node startup + module import before bootstrap, plus format/stdout-write after the CLI's internal timer stops
- `bootstrap_ms`, `model_resolution_ms`, `manager_load_ms`, `index_load_ms`
- `embed_query_ms`, `faiss_search_ms`, `post_filter_ms`, `staleness_ms`
- `cli_total_ms`
- Wall time at `p50` / `p95` / `p99`
- `rss_peak_bytes` (max `VmHWM` across reps; `null` on non-Linux)

## Opt-in by default

The scenario is gated on `BENCH_INCLUDE_CLI_SEARCH=1` because each repetition pays real Node startup cost; that cost is precisely what the scenario measures, but it would slow the CI bench-suite materially if it ran unconditionally. `BENCH_CLI_SEARCH_REPETITIONS` overrides the default of 10.

## Why `fake` and not the existing `stub` provider

The existing `stub` provider monkey-patches embeddings/FaissStore in the *parent* process; that patch does not survive a `spawn`. The `fake` provider (#204) is offline, deterministic, and has no API-key/daemon dependency, so the spawned `kb search` runs end-to-end without provider stubbing.

## Files

- `benchmarks/scenarios/cli-search.ts` (new) — scenario + pure parser/aggregator helpers
- `benchmarks/scenarios/cli-search.test.ts` (new) — 12 focused unit tests for the parser + aggregator (no spawning)
- `benchmarks/types.ts` — new `CliSearchScenarioResult` / `CliSearchVariantResult` types, optional `cli_search` slot
- `benchmarks/run.ts` — wires the scenario behind `BENCH_INCLUDE_CLI_SEARCH`
- `benchmarks/README.md` — documents the new env vars and the JSON shape

## Test plan

- [x] `npm test -- benchmarks/scenarios/cli-search.test.ts` — 12 passed
- [x] `npm test -- benchmarks` — 26 passed (cli-search + model-ctx)
- [x] `npm test` (full repo suite) — 940 passed, 4 skipped, 55 suites
- [x] End-to-end smoke: `BENCH_PROVIDER=stub BENCH_INCLUDE_CLI_SEARCH=1 BENCH_CLI_SEARCH_REPETITIONS=2 npm run bench` emits the expected JSON shape with realistic timings (e.g. `process_start_p50_ms ≈ 350`, `cli_total_p50_ms ≈ 36`)

Closes #284.