### PR TITLE
feat(observability): provider call telemetry histograms in kb_stats

### DIFF
--- a/docs/architecture/qa-budgets.md
+++ b/docs/architecture/qa-budgets.md
@@ -68,3 +68,12 @@ BENCH_PROVIDER=openai npm run bench    # real provider (requires OPENAI_API_KEY)
 ```
 
 Baselines in `benchmarks/results/` are keyed by `{provider}-{node_version}-{os}-{arch}`; compare apples to apples.
+
+## Runtime budget enforcement (issue #210)
+
+The bench harness above measures budgets offline. **At runtime**, the same wall-clock numbers are surfaced live in `kb_stats.provider_calls` (per-`model_id` count, errors, p50/p95/p99 latency, token-in sum) and rolled up in `kb doctor`'s `provider_calls` check. The doctor flips the row to `WARN` when `errors / count > 5%` for any active model_id, so an operator can observe both:
+
+- a regression against the latency budgets above (compare live `provider_calls.<model_id>.latency_ms.p95` to the bench baseline);
+- a sudden error-rate spike from the embedding provider (network blip, expired token, model decommission).
+
+The histogram is bounded — 10 log-spaced latency buckets in [1 ms, 30 s] plus an overflow bucket — and labelled only by `model_id`, so memory cost stays at ~200 bytes per model in the registered set. No on-disk state, no `/metrics` endpoint, no per-query labels.

--- a/src/FaissIndexManager.ts
+++ b/src/FaissIndexManager.ts
@@ -333,6 +333,11 @@ export class FaissIndexManager {
         this.embeddings = await createEmbeddingsClient({
           provider: this.embeddingProvider,
           modelName: this.modelName,
+          // Issue #210 — wrap the active provider with the runtime
+          // telemetry collector. Keyed by `modelId` so each
+          // (provider, model_name) gets its own histogram, matching
+          // the `kb_stats.provider_calls` payload shape.
+          modelId: this.modelId,
         });
       }
       // Ensure this model's directory exists. mkdir-p is cheap; first-run

--- a/src/cli-doctor.test.ts
+++ b/src/cli-doctor.test.ts
@@ -399,6 +399,122 @@ describe('kb doctor', () => {
     });
   });
 
+  describe('provider call telemetry (issue #210)', () => {
+    it('omits the provider_calls check when no telemetry has been recorded', async () => {
+      const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-doctor-pc-empty-'));
+      try {
+        const rootDir = path.join(tempDir, 'kbs');
+        const faissDir = path.join(tempDir, '.faiss');
+        await fsp.mkdir(rootDir, { recursive: true });
+        await fsp.mkdir(faissDir, { recursive: true });
+        const { buildDoctorReport, formatDoctorMarkdown } = await freshDoctor({
+          KNOWLEDGE_BASES_ROOT_DIR: rootDir,
+          FAISS_INDEX_PATH: faissDir,
+          EMBEDDING_PROVIDER: 'huggingface',
+          HUGGINGFACE_MODEL_NAME: MODEL_NAME,
+          HUGGINGFACE_API_KEY: 'test-key',
+        });
+        const { ProviderCallMetrics } = await import('./metrics.js');
+        const report = await buildDoctorReport({
+          backendHealthCheck: async () => ({ healthy: true, detail: 'ok' }),
+          packageRoot: tempDir,
+          invokedPath: null,
+          packageVersion: '9.9.9',
+          providerCallMetrics: new ProviderCallMetrics({ now: () => 0 }),
+        });
+        expect(report.provider_calls).toEqual({});
+        expect(report.checks.some((c) => c.name === 'provider_calls')).toBe(false);
+        expect(formatDoctorMarkdown(report)).toContain(
+          'Provider calls:\n  (no provider calls observed)',
+        );
+      } finally {
+        await fsp.rm(tempDir, { recursive: true, force: true });
+      }
+    });
+
+    it('emits an OK provider_calls check when error rate is within budget', async () => {
+      const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-doctor-pc-ok-'));
+      try {
+        const rootDir = path.join(tempDir, 'kbs');
+        const faissDir = path.join(tempDir, '.faiss');
+        await fsp.mkdir(rootDir, { recursive: true });
+        await fsp.mkdir(faissDir, { recursive: true });
+        const { buildDoctorReport, formatDoctorMarkdown } = await freshDoctor({
+          KNOWLEDGE_BASES_ROOT_DIR: rootDir,
+          FAISS_INDEX_PATH: faissDir,
+          EMBEDDING_PROVIDER: 'huggingface',
+          HUGGINGFACE_MODEL_NAME: MODEL_NAME,
+          HUGGINGFACE_API_KEY: 'test-key',
+        });
+        const { ProviderCallMetrics } = await import('./metrics.js');
+        const metrics = new ProviderCallMetrics({ now: () => 1_700_000_000_000 });
+        for (let index = 0; index < 100; index += 1) {
+          metrics.record('huggingface__bge', { latencyMs: index, ok: true });
+        }
+        // 1 error out of 101 — under the 5% threshold.
+        metrics.record('huggingface__bge', { latencyMs: 50, ok: false });
+
+        const report = await buildDoctorReport({
+          backendHealthCheck: async () => ({ healthy: true, detail: 'ok' }),
+          packageRoot: tempDir,
+          invokedPath: null,
+          packageVersion: '9.9.9',
+          providerCallMetrics: metrics,
+        });
+        const check = report.checks.find((c) => c.name === 'provider_calls');
+        expect(check?.status).toBe('ok');
+        expect(check?.detail).toContain('101 call(s)');
+        const md = formatDoctorMarkdown(report);
+        expect(md).toContain('model=huggingface__bge calls=101 errors=1');
+      } finally {
+        await fsp.rm(tempDir, { recursive: true, force: true });
+      }
+    });
+
+    it('warns when error rate is above 5% and renders a WARN marker in markdown', async () => {
+      const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-doctor-pc-warn-'));
+      try {
+        const rootDir = path.join(tempDir, 'kbs');
+        const faissDir = path.join(tempDir, '.faiss');
+        await fsp.mkdir(rootDir, { recursive: true });
+        await fsp.mkdir(faissDir, { recursive: true });
+        const { buildDoctorReport, formatDoctorMarkdown } = await freshDoctor({
+          KNOWLEDGE_BASES_ROOT_DIR: rootDir,
+          FAISS_INDEX_PATH: faissDir,
+          EMBEDDING_PROVIDER: 'huggingface',
+          HUGGINGFACE_MODEL_NAME: MODEL_NAME,
+          HUGGINGFACE_API_KEY: 'test-key',
+        });
+        const { ProviderCallMetrics } = await import('./metrics.js');
+        const metrics = new ProviderCallMetrics({ now: () => 1_700_000_000_000 });
+        // 8 errors / 10 calls — well above the 5% threshold.
+        for (let index = 0; index < 2; index += 1) {
+          metrics.record('ollama__nomic', { latencyMs: 5, ok: true });
+        }
+        for (let index = 0; index < 8; index += 1) {
+          metrics.record('ollama__nomic', { latencyMs: 250, ok: false });
+        }
+
+        const report = await buildDoctorReport({
+          backendHealthCheck: async () => ({ healthy: true, detail: 'ok' }),
+          packageRoot: tempDir,
+          invokedPath: null,
+          packageVersion: '9.9.9',
+          providerCallMetrics: metrics,
+        });
+        const check = report.checks.find((c) => c.name === 'provider_calls');
+        expect(check?.status).toBe('warn');
+        expect(check?.detail).toContain('model=ollama__nomic');
+        expect(check?.detail).toContain('errors=8/10');
+        const md = formatDoctorMarkdown(report);
+        expect(md).toContain('model=ollama__nomic calls=10 errors=8');
+        expect(md).toMatch(/p50=\d+(\.\d+)?ms p95=\d+(\.\d+)?ms p99=\d+(\.\d+)?ms tokens=n\/a, WARN/);
+      } finally {
+        await fsp.rm(tempDir, { recursive: true, force: true });
+      }
+    });
+  });
+
   describe('fake provider (issue #204)', () => {
     it('reports backend WARN with a "testing only" detail when active provider is fake', async () => {
       const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-doctor-fake-'));

--- a/src/cli-doctor.ts
+++ b/src/cli-doctor.ts
@@ -38,6 +38,19 @@ import {
   type AgeBudgetStatus,
 } from './age-budget.js';
 import { maxMtimeIso } from './kb-stats.js';
+import {
+  providerCallMetrics,
+  type ProviderCallMetrics,
+  type ProviderCallSnapshot,
+} from './metrics.js';
+
+/**
+ * Issue #210 — error-rate threshold above which the doctor surfaces a
+ * WARN row for a model_id. 5% matches the issue spec; intentionally
+ * coarse so transient one-off failures on a low-volume process don't
+ * trip an operator's alarm.
+ */
+export const PROVIDER_CALL_ERROR_RATE_WARN_THRESHOLD = 0.05;
 
 const execFileAsync = promisify(execFile);
 
@@ -140,6 +153,14 @@ export interface DoctorReport {
     relation: 'ahead' | 'behind' | 'diverged' | 'up-to-date' | 'unknown';
   } | null;
   last_index_update: IndexUpdateSummary;
+  /**
+   * Issue #210 — per-`model_id` runtime telemetry for the active
+   * embedding provider. Empty `{}` until the active provider has served
+   * at least one call. The doctor row is WARN when
+   * `errors / count > PROVIDER_CALL_ERROR_RATE_WARN_THRESHOLD` for any
+   * model_id; otherwise it is OK.
+   */
+  provider_calls: Record<string, ProviderCallSnapshot>;
 }
 
 export interface BuildDoctorReportOptions {
@@ -148,6 +169,12 @@ export interface BuildDoctorReportOptions {
   invokedPath?: string | null;
   packageVersion?: string;
   lastIndexUpdateSummary?: IndexUpdateSummary;
+  /**
+   * Issue #210 — test seam for the provider-call telemetry registry.
+   * Production callers leave this undefined so the process-wide
+   * singleton is read.
+   */
+  providerCallMetrics?: ProviderCallMetrics;
 }
 
 export type BackendHealthCheck = (
@@ -306,6 +333,41 @@ export async function buildDoctorReport(
     detail: backend.detail,
   });
 
+  const metricsSource = options.providerCallMetrics ?? providerCallMetrics;
+  const providerCalls = metricsSource.snapshot();
+  // Issue #210 — only emit the row when at least one call has been
+  // observed; otherwise the doctor on a fresh process would always show
+  // a noisy "no telemetry yet" line.
+  if (Object.keys(providerCalls).length > 0) {
+    const breaches = Object.entries(providerCalls)
+      .filter(([, row]) => row.count > 0
+        && row.errors / row.count > PROVIDER_CALL_ERROR_RATE_WARN_THRESHOLD);
+    if (breaches.length > 0) {
+      const summary = breaches
+        .map(([modelId, row]) =>
+          `model=${modelId}, errors=${row.errors}/${row.count}` +
+          ` (${formatErrorRate(row.errors, row.count)})`,
+        )
+        .join('; ');
+      checks.push({
+        name: 'provider_calls',
+        status: 'warn',
+        detail: `${breaches.length} model(s) over ` +
+          `${formatErrorRate(PROVIDER_CALL_ERROR_RATE_WARN_THRESHOLD * 100, 100)}` +
+          ` error rate: ${summary}`,
+      });
+    } else {
+      const totals = Object.values(providerCalls)
+        .reduce((sum, row) => sum + row.count, 0);
+      checks.push({
+        name: 'provider_calls',
+        status: 'ok',
+        detail: `${totals} call(s) across ${Object.keys(providerCalls).length}` +
+          ' model(s) within error budget',
+      });
+    }
+  }
+
   const packageRoot = options.packageRoot ?? resolvePackageRoot();
   const invokedPath = options.invokedPath ?? process.argv[1] ?? null;
   const cli = {
@@ -336,7 +398,14 @@ export async function buildDoctorReport(
     cli,
     git,
     last_index_update: lastIndexUpdate,
+    provider_calls: providerCalls,
   };
+}
+
+function formatErrorRate(errors: number, count: number): string {
+  if (count === 0) return '0%';
+  const pct = (errors / count) * 100;
+  return `${pct.toFixed(1)}%`;
 }
 
 async function readIndexHealth(activeModelId: string | null): Promise<DoctorReport['index']> {
@@ -677,6 +746,28 @@ export function formatDoctorMarkdown(report: DoctorReport): string {
     }
     for (const err of report.age_budget_config_errors) {
       lines.push(`  CONFIG_ERROR: ${err.env_var}=${JSON.stringify(err.raw_value)}`);
+    }
+  }
+  lines.push('');
+  lines.push('Provider calls:');
+  const providerModelIds = Object.keys(report.provider_calls).sort();
+  if (providerModelIds.length === 0) {
+    lines.push('  (no provider calls observed)');
+  } else {
+    for (const modelId of providerModelIds) {
+      const row = report.provider_calls[modelId];
+      const errorMarker = row.count > 0
+        && row.errors / row.count > PROVIDER_CALL_ERROR_RATE_WARN_THRESHOLD
+        ? ', WARN'
+        : '';
+      const tokens = row.tokens_in === null
+        ? 'tokens=n/a'
+        : `tokens=${row.tokens_in}`;
+      lines.push(
+        `  model=${modelId} calls=${row.count} errors=${row.errors}` +
+        ` p50=${row.latency_ms.p50}ms p95=${row.latency_ms.p95}ms` +
+        ` p99=${row.latency_ms.p99}ms ${tokens}${errorMarker}`,
+      );
     }
   }
   lines.push('');

--- a/src/cli-stats.test.ts
+++ b/src/cli-stats.test.ts
@@ -49,6 +49,10 @@ function payload(): KbStatsPayload {
       version: 'test-version',
       uptime_ms: 12,
     },
+    // Issue #210 — required since the KbStatsPayload now carries
+    // per-model provider call telemetry. Empty `{}` matches a fresh
+    // process where the active provider has not been called yet.
+    provider_calls: {},
   };
 }
 

--- a/src/embedding-provider.test.ts
+++ b/src/embedding-provider.test.ts
@@ -130,3 +130,37 @@ describe('createEmbeddingsClient — fake arm (issue #204)', () => {
     ).resolves.toBeDefined();
   });
 });
+
+describe('createEmbeddingsClient — provider call telemetry (issue #210)', () => {
+  it('does not record telemetry when modelId is omitted', async () => {
+    const { createEmbeddingsClient } = await loadFresh({ KB_FAKE_DIM: '32' });
+    const { ProviderCallMetrics } = await import('./metrics.js');
+    const metrics = new ProviderCallMetrics({ now: () => 0 });
+    const client = await createEmbeddingsClient({
+      provider: 'fake',
+      modelName: 'untracked',
+      metrics,
+    });
+    await client.embedQuery('hi');
+    expect(metrics.snapshot()).toEqual({});
+  });
+
+  it('records every embedQuery and embedDocuments call under the supplied modelId', async () => {
+    const { createEmbeddingsClient } = await loadFresh({ KB_FAKE_DIM: '16' });
+    const { ProviderCallMetrics } = await import('./metrics.js');
+    const metrics = new ProviderCallMetrics({ now: () => 0 });
+    const client = await createEmbeddingsClient({
+      provider: 'fake',
+      modelName: 'tracked',
+      modelId: 'fake__tracked',
+      metrics,
+    });
+    await client.embedQuery('one');
+    await client.embedQuery('two');
+    await client.embedDocuments(['a', 'b', 'c']);
+    const snap = metrics.snapshot();
+    expect(snap['fake__tracked'].count).toBe(3);
+    expect(snap['fake__tracked'].errors).toBe(0);
+    expect(snap['fake__tracked'].tokens_in).toBeNull();
+  });
+});

--- a/src/embedding-provider.ts
+++ b/src/embedding-provider.ts
@@ -18,6 +18,7 @@ import {
 } from './config.js';
 import { KBError } from './errors.js';
 import { logger } from './logger.js';
+import { instrumentEmbeddingsClient, type ProviderCallMetrics } from './metrics.js';
 import type { EmbeddingProvider } from './model-id.js';
 import { makeOllamaOnFailedAttempt } from './ollama-error.js';
 
@@ -55,6 +56,19 @@ export interface CreateEmbeddingsOptions {
   // legacy env path, model_id parsing) flow `'fake'` through unchanged.
   provider: EmbeddingProvider | 'fake';
   modelName: string;
+  /**
+   * Issue #210 — when provided, wrap the returned client so every
+   * `embedQuery`/`embedDocuments` call lands in the provider-call
+   * telemetry registry under this `model_id`. Optional so legacy
+   * callers and bench harnesses can opt out; `FaissIndexManager.initialize`
+   * passes its own `modelId`.
+   */
+  modelId?: string;
+  /**
+   * Test-seam for the metrics registry. Production callers leave this
+   * undefined so the process-wide singleton is used.
+   */
+  metrics?: ProviderCallMetrics;
 }
 
 /**
@@ -65,6 +79,21 @@ export interface CreateEmbeddingsOptions {
  */
 export async function createEmbeddingsClient(
   options: CreateEmbeddingsOptions,
+): Promise<EmbeddingsClient> {
+  const { provider, modelName } = options;
+
+  const client = await constructEmbeddingsClient({ provider, modelName });
+  if (options.modelId !== undefined) {
+    // Issue #210 — wrap once with the per-model_id telemetry collector.
+    // The wrap is idempotent so a second `initialize()` (e.g.
+    // corrupt-recovery in `FaissIndexManager`) does not double-count.
+    instrumentEmbeddingsClient(client, options.modelId, { metrics: options.metrics });
+  }
+  return client;
+}
+
+async function constructEmbeddingsClient(
+  options: { provider: EmbeddingProvider | 'fake'; modelName: string },
 ): Promise<EmbeddingsClient> {
   const { provider, modelName } = options;
 

--- a/src/kb-stats.test.ts
+++ b/src/kb-stats.test.ts
@@ -218,6 +218,46 @@ describe('computeKbStats', () => {
     await fsp.rm(tempDir, { recursive: true, force: true });
   });
 
+  it('returns an empty provider_calls map by default and a populated one after telemetry is recorded (issue #210)', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-stats-metrics-'));
+    try {
+      await fsp.mkdir(path.join(tempDir, 'alpha'));
+      await fsp.writeFile(path.join(tempDir, 'alpha', 'a.md'), 'a');
+
+      const { computeKbStats } = await freshKbStats({
+        KNOWLEDGE_BASES_ROOT_DIR: tempDir,
+        FAISS_INDEX_PATH: path.join(tempDir, '.faiss'),
+      });
+      const { ProviderCallMetrics } = await import('./metrics.js');
+      const metrics = new ProviderCallMetrics({ now: () => 1_700_000_000_000 });
+
+      const empty = await computeKbStats(makeManager({}) as any, {
+        serverVersion: '0.0.0',
+        startedAt: Date.now(),
+        metrics,
+      });
+      expect(empty.provider_calls).toEqual({});
+
+      metrics.record('huggingface__bge-small', { latencyMs: 5, ok: true });
+      metrics.record('huggingface__bge-small', { latencyMs: 50, ok: false });
+      metrics.record('huggingface__bge-small', { latencyMs: 250, ok: true, tokensIn: 12 });
+
+      const populated = await computeKbStats(makeManager({}) as any, {
+        serverVersion: '0.0.0',
+        startedAt: Date.now(),
+        metrics,
+      });
+      const row = populated.provider_calls['huggingface__bge-small'];
+      expect(row.count).toBe(3);
+      expect(row.errors).toBe(1);
+      expect(row.tokens_in).toBe(12);
+      expect(row.latency_ms.p95).toBeGreaterThanOrEqual(row.latency_ms.p50);
+      expect(row.since_started_at).toBe(new Date(1_700_000_000_000).toISOString());
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it('respects INGEST_EXCLUDE_PATHS so excluded files do not contribute to file_count or bytes', async () => {
     const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-stats-exclude-'));
     await fsp.mkdir(path.join(tempDir, 'alpha'));

--- a/src/kb-stats.ts
+++ b/src/kb-stats.ts
@@ -19,6 +19,11 @@ import {
 import { KBError } from './errors.js';
 import { enumerateIngestableKbFiles, listKnowledgeBases } from './kb-fs.js';
 import { logger } from './logger.js';
+import {
+  providerCallMetrics,
+  type ProviderCallMetrics,
+  type ProviderCallSnapshot,
+} from './metrics.js';
 
 export interface KbStatsRow {
   file_count: number;
@@ -33,6 +38,14 @@ export interface KbStatsPayload {
   index_path: string;
   last_index_update: IndexUpdateSummary;
   server: { version: string; uptime_ms: number };
+  /**
+   * Issue #210 — per-`model_id` runtime histograms for the active
+   * embedding provider's `embedQuery` / `embedDocuments` calls. Empty
+   * `{}` until the active provider has served at least one call;
+   * additive on the wire, so older clients that do not know about
+   * `provider_calls` keep working.
+   */
+  provider_calls: Record<string, ProviderCallSnapshot>;
 }
 
 export interface ComputeKbStatsOptions {
@@ -42,6 +55,12 @@ export interface ComputeKbStatsOptions {
   serverVersion: string;
   /** `Date.now()` baseline used to derive `server.uptime_ms`. */
   startedAt: number;
+  /**
+   * Issue #210 — test seam for the provider-call telemetry registry.
+   * Production callers leave this undefined so the process-wide
+   * singleton is read.
+   */
+  metrics?: ProviderCallMetrics;
 }
 
 /**
@@ -111,6 +130,7 @@ export async function computeKbStats(
     };
   }
 
+  const metricsSource = options.metrics ?? providerCallMetrics;
   return {
     knowledge_bases,
     embedding: {
@@ -124,6 +144,7 @@ export async function computeKbStats(
       version: options.serverVersion,
       uptime_ms: Date.now() - options.startedAt,
     },
+    provider_calls: metricsSource.snapshot(),
   };
 }
 

--- a/src/metrics.test.ts
+++ b/src/metrics.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+  bucketIndexForLatency,
+  instrumentEmbeddingsClient,
+  LATENCY_BUCKET_BOUNDS_MS,
+  ProviderCallMetrics,
+  quantileFromBuckets,
+} from './metrics.js';
+
+describe('bucketIndexForLatency (issue #210 — fixed-bucket histogram)', () => {
+  it('lands a sub-1ms sample in bucket 0 and a 30s sample in the last finite bucket', () => {
+    expect(bucketIndexForLatency(0)).toBe(0);
+    expect(bucketIndexForLatency(0.5)).toBe(0);
+    expect(bucketIndexForLatency(LATENCY_BUCKET_BOUNDS_MS[LATENCY_BUCKET_BOUNDS_MS.length - 1])).toBe(
+      LATENCY_BUCKET_BOUNDS_MS.length - 1,
+    );
+  });
+
+  it('is right-inclusive at every bucket boundary', () => {
+    for (let index = 0; index < LATENCY_BUCKET_BOUNDS_MS.length; index += 1) {
+      expect(bucketIndexForLatency(LATENCY_BUCKET_BOUNDS_MS[index])).toBe(index);
+    }
+  });
+
+  it('routes overflow latencies (> last bound) to the overflow bucket', () => {
+    const overflow = LATENCY_BUCKET_BOUNDS_MS[LATENCY_BUCKET_BOUNDS_MS.length - 1] + 1;
+    expect(bucketIndexForLatency(overflow)).toBe(LATENCY_BUCKET_BOUNDS_MS.length);
+    expect(bucketIndexForLatency(120_000)).toBe(LATENCY_BUCKET_BOUNDS_MS.length);
+  });
+
+  it('coerces NaN and negative latencies to bucket 0 instead of corrupting counts', () => {
+    expect(bucketIndexForLatency(Number.NaN)).toBe(0);
+    expect(bucketIndexForLatency(-5)).toBe(0);
+    expect(bucketIndexForLatency(Number.NEGATIVE_INFINITY)).toBe(0);
+  });
+
+  it('is monotonic non-decreasing in the input latency', () => {
+    let previous = -1;
+    for (const value of [0, 0.5, 1, 2, 5, 10, 50, 100, 500, 1000, 5000, 30_000, 60_000]) {
+      const index = bucketIndexForLatency(value);
+      expect(index).toBeGreaterThanOrEqual(previous);
+      previous = index;
+    }
+  });
+});
+
+describe('quantileFromBuckets', () => {
+  it('returns 0 when the histogram has no observations', () => {
+    const buckets = new Array<number>(LATENCY_BUCKET_BOUNDS_MS.length + 1).fill(0);
+    expect(quantileFromBuckets(buckets, 0, 0.5)).toBe(0);
+    expect(quantileFromBuckets(buckets, 0, 0.95)).toBe(0);
+  });
+
+  it('p50 lies between the bucket bounds containing the median sample', () => {
+    // 100 samples at exactly 5 ms — bucket index is the one whose upper
+    // bound is the smallest >= 5 (i.e. 10 ms). Lower bound for that
+    // bucket is the previous boundary (3 ms).
+    const targetBucket = bucketIndexForLatency(5);
+    const buckets = new Array<number>(LATENCY_BUCKET_BOUNDS_MS.length + 1).fill(0);
+    buckets[targetBucket] = 100;
+    const p50 = quantileFromBuckets(buckets, 100, 0.5);
+    const lower = targetBucket === 0 ? 0 : LATENCY_BUCKET_BOUNDS_MS[targetBucket - 1];
+    const upper = LATENCY_BUCKET_BOUNDS_MS[targetBucket];
+    expect(p50).toBeGreaterThanOrEqual(lower);
+    expect(p50).toBeLessThanOrEqual(upper);
+  });
+
+  it('overflow samples are reported as the largest finite bucket bound', () => {
+    const buckets = new Array<number>(LATENCY_BUCKET_BOUNDS_MS.length + 1).fill(0);
+    buckets[LATENCY_BUCKET_BOUNDS_MS.length] = 5; // overflow only
+    expect(quantileFromBuckets(buckets, 5, 0.95)).toBe(
+      LATENCY_BUCKET_BOUNDS_MS[LATENCY_BUCKET_BOUNDS_MS.length - 1],
+    );
+  });
+
+  it('quantiles are monotonic non-decreasing as q increases', () => {
+    const samples = [0.5, 5, 50, 200, 800, 1500, 4000, 9000, 25_000];
+    const buckets = new Array<number>(LATENCY_BUCKET_BOUNDS_MS.length + 1).fill(0);
+    for (const value of samples) buckets[bucketIndexForLatency(value)] += 1;
+    const p50 = quantileFromBuckets(buckets, samples.length, 0.5);
+    const p95 = quantileFromBuckets(buckets, samples.length, 0.95);
+    const p99 = quantileFromBuckets(buckets, samples.length, 0.99);
+    expect(p95).toBeGreaterThanOrEqual(p50);
+    expect(p99).toBeGreaterThanOrEqual(p95);
+  });
+});
+
+describe('ProviderCallMetrics', () => {
+  it('starts empty and yields {} from snapshot', () => {
+    const metrics = new ProviderCallMetrics({ now: () => 1_700_000_000_000 });
+    expect(metrics.snapshot()).toEqual({});
+    expect(metrics.knownModelIds()).toEqual([]);
+  });
+
+  it('counts successes and errors per model_id and surfaces since_started_at', () => {
+    const startMs = 1_700_000_000_000;
+    let clock = startMs;
+    const metrics = new ProviderCallMetrics({ now: () => clock });
+    metrics.record('huggingface__a', { latencyMs: 5, ok: true });
+    metrics.record('huggingface__a', { latencyMs: 50, ok: false });
+    metrics.record('ollama__b', { latencyMs: 200, ok: true });
+    clock = startMs + 1000; // later record under existing model — startedAt frozen.
+    metrics.record('huggingface__a', { latencyMs: 800, ok: true });
+
+    const snap = metrics.snapshot();
+    expect(snap['huggingface__a'].count).toBe(3);
+    expect(snap['huggingface__a'].errors).toBe(1);
+    expect(snap['huggingface__a'].since_started_at).toBe(new Date(startMs).toISOString());
+    expect(snap['ollama__b'].count).toBe(1);
+    expect(snap['ollama__b'].errors).toBe(0);
+    expect(metrics.knownModelIds()).toEqual(['huggingface__a', 'ollama__b']);
+  });
+
+  it('keeps tokens_in null until at least one call carries a token count', () => {
+    const metrics = new ProviderCallMetrics({ now: () => 1 });
+    metrics.record('m', { latencyMs: 1, ok: true });
+    metrics.record('m', { latencyMs: 2, ok: true, tokensIn: null });
+    expect(metrics.snapshot().m.tokens_in).toBeNull();
+    metrics.record('m', { latencyMs: 3, ok: true, tokensIn: 17 });
+    metrics.record('m', { latencyMs: 4, ok: true, tokensIn: 5 });
+    expect(metrics.snapshot().m.tokens_in).toBe(22);
+  });
+
+  it('p50/p95 are stable across a synthetic workload (idempotent over equal inputs)', () => {
+    const metrics = new ProviderCallMetrics({ now: () => 1 });
+    const samples = [1, 1, 2, 5, 10, 20, 50, 100, 200, 500, 1000, 5000];
+    for (const value of samples) metrics.record('m', { latencyMs: value, ok: true });
+    const first = metrics.snapshot();
+    const second = metrics.snapshot();
+    expect(second).toEqual(first);
+    expect(first.m.latency_ms.p95).toBeGreaterThanOrEqual(first.m.latency_ms.p50);
+    expect(first.m.latency_ms.p99).toBeGreaterThanOrEqual(first.m.latency_ms.p95);
+  });
+
+  it('reset() clears all recorded state', () => {
+    const metrics = new ProviderCallMetrics({ now: () => 1 });
+    metrics.record('m', { latencyMs: 1, ok: true });
+    expect(metrics.knownModelIds()).toEqual(['m']);
+    metrics.reset();
+    expect(metrics.snapshot()).toEqual({});
+    expect(metrics.knownModelIds()).toEqual([]);
+  });
+});
+
+describe('instrumentEmbeddingsClient', () => {
+  function makeClient(opts: { failQuery?: boolean; failDocs?: boolean } = {}) {
+    return {
+      embedQuery: async (_text: string): Promise<number[]> => {
+        if (opts.failQuery) throw new Error('boom');
+        return [0.1, 0.2];
+      },
+      embedDocuments: async (texts: string[]): Promise<number[][]> => {
+        if (opts.failDocs) throw new Error('boom-docs');
+        return texts.map(() => [0.1, 0.2]);
+      },
+    };
+  }
+
+  it('records one success per embedQuery call', async () => {
+    const metrics = new ProviderCallMetrics({ now: () => 0 });
+    let clock = 0;
+    const client = makeClient();
+    instrumentEmbeddingsClient(client, 'huggingface__bge', {
+      metrics,
+      now: () => {
+        clock += 5;
+        return clock;
+      },
+    });
+    await client.embedQuery('hello');
+    await client.embedQuery('world');
+    const snap = metrics.snapshot();
+    expect(snap['huggingface__bge'].count).toBe(2);
+    expect(snap['huggingface__bge'].errors).toBe(0);
+  });
+
+  it('records errors when the underlying call throws and re-throws the original error', async () => {
+    const metrics = new ProviderCallMetrics({ now: () => 0 });
+    const client = makeClient({ failQuery: true });
+    instrumentEmbeddingsClient(client, 'm', { metrics, now: () => 0 });
+    await expect(client.embedQuery('x')).rejects.toThrow('boom');
+    expect(metrics.snapshot().m).toMatchObject({ count: 1, errors: 1 });
+  });
+
+  it('records errors on embedDocuments without losing the underlying message', async () => {
+    const metrics = new ProviderCallMetrics({ now: () => 0 });
+    const client = makeClient({ failDocs: true });
+    instrumentEmbeddingsClient(client, 'm', { metrics, now: () => 0 });
+    await expect(client.embedDocuments(['a'])).rejects.toThrow('boom-docs');
+    expect(metrics.snapshot().m).toMatchObject({ count: 1, errors: 1 });
+  });
+
+  it('is idempotent — a second wrap with the same modelId does not double-count', async () => {
+    const metrics = new ProviderCallMetrics({ now: () => 0 });
+    const client = makeClient();
+    instrumentEmbeddingsClient(client, 'm', { metrics, now: () => 0 });
+    instrumentEmbeddingsClient(client, 'm', { metrics, now: () => 0 });
+    await client.embedQuery('x');
+    expect(metrics.snapshot().m.count).toBe(1);
+  });
+
+  it('preserves the original return value', async () => {
+    const metrics = new ProviderCallMetrics({ now: () => 0 });
+    const client = makeClient();
+    instrumentEmbeddingsClient(client, 'm', { metrics, now: () => 0 });
+    expect(await client.embedQuery('x')).toEqual([0.1, 0.2]);
+    expect(await client.embedDocuments(['a', 'b'])).toEqual([[0.1, 0.2], [0.1, 0.2]]);
+  });
+});

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -1,0 +1,294 @@
+// metrics.ts — issue #210, runtime provider-call telemetry surfaced in
+// `kb_stats` and `kb doctor`.
+//
+// Process-lifetime, in-memory only. No on-disk state, no network export.
+// One record per `model_id` (the active model id from `model-id.ts`); the
+// label set is intentionally fixed so cardinality stays bounded — we
+// record one bucket update per `embedQuery`/`embedDocuments` call, never
+// per-query labels. RFC 008 §6.8 capped `/health` at `{status:"ok"}`, so
+// runtime histograms live on the existing `kb_stats` MCP tool surface.
+
+/**
+ * Fixed log-spaced latency bucket upper bounds, in milliseconds. 10 bucket
+ * cap (issue #210 spec) — one per decade-ish step from sub-millisecond
+ * local FAISS calls to long remote provider tails. Anything above the
+ * last bound is counted in the overflow bucket so a 60 s outlier does not
+ * silently fall out of the histogram.
+ */
+export const LATENCY_BUCKET_BOUNDS_MS: readonly number[] = [
+  1, 3, 10, 30, 100, 300, 1000, 3000, 10000, 30000,
+];
+
+/**
+ * One record per active `model_id`. Lifetime = process; no rolling window
+ * today (the issue's "rolling histogram" framing maps to "since process
+ * start" — bounded by the absence of per-query labels rather than by
+ * time-decay). `tokens_in` is null until at least one call records a
+ * non-null token count: HuggingFace and OpenAI report token usage on
+ * embed responses, Ollama does not, so the field stays null when no
+ * provider in the mix supports it.
+ */
+export interface ProviderCallSnapshot {
+  count: number;
+  errors: number;
+  tokens_in: number | null;
+  latency_ms: { p50: number; p95: number; p99: number };
+  since_started_at: string;
+}
+
+interface MetricsState {
+  /**
+   * Bucket counts; length = LATENCY_BUCKET_BOUNDS_MS.length + 1. The
+   * extra slot is the overflow bucket for samples > the largest bound.
+   */
+  buckets: number[];
+  count: number;
+  errors: number;
+  tokensInSum: number;
+  /**
+   * Whether any recorded call carried a token count. When false, the
+   * snapshot surfaces `tokens_in: null` — an operator can tell apart
+   * "provider does not report tokens" from "provider reported zero".
+   */
+  tokensReported: boolean;
+  startedAtMs: number;
+}
+
+function emptyState(now: number): MetricsState {
+  return {
+    buckets: new Array<number>(LATENCY_BUCKET_BOUNDS_MS.length + 1).fill(0),
+    count: 0,
+    errors: 0,
+    tokensInSum: 0,
+    tokensReported: false,
+    startedAtMs: now,
+  };
+}
+
+/**
+ * Find the histogram bucket index for a given latency in ms. Returns
+ * `LATENCY_BUCKET_BOUNDS_MS.length` for samples greater than the largest
+ * bucket bound (overflow). Right-inclusive: a sample exactly equal to
+ * `bounds[i]` lands in bucket `i`.
+ */
+export function bucketIndexForLatency(latencyMs: number): number {
+  // Issue #210 — the histogram is the load-bearing structure for p50/p95
+  // accuracy. NaN (broken `performance.now()` consumer) and negative
+  // values (clock skew across `start = now()` and `now() - start` on a
+  // suspended host) would otherwise corrupt the bucket counts. Coerce to
+  // 0 so the call still increments `count` — losing one sample's
+  // resolution is preferable to skipping the call entirely and letting
+  // the `count` and the bucket sums diverge.
+  const safe = !Number.isFinite(latencyMs) || latencyMs < 0 ? 0 : latencyMs;
+  for (let index = 0; index < LATENCY_BUCKET_BOUNDS_MS.length; index += 1) {
+    if (safe <= LATENCY_BUCKET_BOUNDS_MS[index]) return index;
+  }
+  return LATENCY_BUCKET_BOUNDS_MS.length;
+}
+
+/**
+ * Linear-interpolate a quantile from the bucket counts. Within the bucket
+ * containing the target rank we assume uniform distribution between the
+ * bucket's lower and upper bounds — a standard cheap approximation that
+ * is accurate to within one bucket width. Returns the last finite bucket
+ * bound (30 s) when the target rank lands in the overflow bucket.
+ */
+export function quantileFromBuckets(
+  buckets: readonly number[],
+  count: number,
+  quantile: number,
+): number {
+  if (count === 0) return 0;
+  const target = quantile * count;
+  let cumulative = 0;
+  for (let index = 0; index < buckets.length; index += 1) {
+    const next = cumulative + buckets[index];
+    if (next >= target) {
+      if (index === LATENCY_BUCKET_BOUNDS_MS.length) {
+        // Overflow bucket — no upper bound; report the last finite one.
+        return LATENCY_BUCKET_BOUNDS_MS[LATENCY_BUCKET_BOUNDS_MS.length - 1];
+      }
+      const lower = index === 0 ? 0 : LATENCY_BUCKET_BOUNDS_MS[index - 1];
+      const upper = LATENCY_BUCKET_BOUNDS_MS[index];
+      const inBucket = buckets[index];
+      if (inBucket === 0) return upper;
+      const fraction = (target - cumulative) / inBucket;
+      return lower + fraction * (upper - lower);
+    }
+    cumulative = next;
+  }
+  return LATENCY_BUCKET_BOUNDS_MS[LATENCY_BUCKET_BOUNDS_MS.length - 1];
+}
+
+/**
+ * Process-lifetime registry of per-model_id provider call telemetry.
+ * Construct once via `providerCallMetrics`; tests can construct fresh
+ * instances or call `reset()`.
+ */
+export class ProviderCallMetrics {
+  private states = new Map<string, MetricsState>();
+  private readonly now: () => number;
+
+  constructor(options: { now?: () => number } = {}) {
+    this.now = options.now ?? Date.now;
+  }
+
+  /**
+   * Record one provider call. `ok=false` increments the error counter
+   * but still updates the latency histogram — operators want p95
+   * including failures, since a slow timeout is itself a latency
+   * regression worth surfacing.
+   */
+  record(
+    modelId: string,
+    sample: { latencyMs: number; ok: boolean; tokensIn?: number | null },
+  ): void {
+    let state = this.states.get(modelId);
+    if (state === undefined) {
+      state = emptyState(this.now());
+      this.states.set(modelId, state);
+    }
+    state.count += 1;
+    if (!sample.ok) state.errors += 1;
+    state.buckets[bucketIndexForLatency(sample.latencyMs)] += 1;
+    if (sample.tokensIn !== undefined && sample.tokensIn !== null) {
+      state.tokensInSum += sample.tokensIn;
+      state.tokensReported = true;
+    }
+  }
+
+  /**
+   * One-shot snapshot of every model_id seen since process start (or the
+   * last `reset()`). Quantiles are computed from the current bucket
+   * counts — cheap enough to call from the hot path of an MCP request.
+   */
+  snapshot(): Record<string, ProviderCallSnapshot> {
+    const out: Record<string, ProviderCallSnapshot> = {};
+    for (const [modelId, state] of this.states.entries()) {
+      out[modelId] = {
+        count: state.count,
+        errors: state.errors,
+        tokens_in: state.tokensReported ? state.tokensInSum : null,
+        latency_ms: {
+          p50: roundLatency(quantileFromBuckets(state.buckets, state.count, 0.5)),
+          p95: roundLatency(quantileFromBuckets(state.buckets, state.count, 0.95)),
+          p99: roundLatency(quantileFromBuckets(state.buckets, state.count, 0.99)),
+        },
+        since_started_at: new Date(state.startedAtMs).toISOString(),
+      };
+    }
+    return out;
+  }
+
+  /**
+   * Drop all recorded state. Intended for tests that need clean
+   * isolation between cases. Production code never calls this — the
+   * snapshot is process-lifetime by design.
+   */
+  reset(): void {
+    this.states.clear();
+  }
+
+  /**
+   * Read-only check used by tests and audit code that want to know
+   * which model_ids have been observed without taking a full snapshot.
+   */
+  knownModelIds(): string[] {
+    return Array.from(this.states.keys()).sort();
+  }
+}
+
+/**
+ * Round a latency to 3 significant decimal places. The histogram
+ * resolution is bounded by bucket width, so reporting full
+ * floating-point precision overstates accuracy; one decimal in
+ * milliseconds is plenty for an operator-facing p95.
+ */
+function roundLatency(latencyMs: number): number {
+  return Math.round(latencyMs * 10) / 10;
+}
+
+/**
+ * Process-wide singleton. Tests that need isolation should construct a
+ * fresh `ProviderCallMetrics` or call `reset()` between cases.
+ */
+export const providerCallMetrics = new ProviderCallMetrics();
+
+/**
+ * Wrap a langchain-shaped embeddings client so every `embedQuery` /
+ * `embedDocuments` call increments the registry under `modelId`.
+ * Mutates the input — returning the same reference keeps the type
+ * narrow and matches how `FaissIndexManager` already passes `this.embeddings`
+ * straight to `FaissStore`. Idempotent: a second wrap on the same
+ * client is a no-op so a re-`initialize()` does not double-count.
+ */
+export function instrumentEmbeddingsClient<
+  T extends {
+    embedQuery: (text: string) => Promise<number[]>;
+    embedDocuments: (texts: string[]) => Promise<number[][]>;
+  },
+>(
+  client: T,
+  modelId: string,
+  options: { metrics?: ProviderCallMetrics; now?: () => number } = {},
+): T {
+  const marker = '__kbProviderCallMetrics' as const;
+  const tagged = client as T & { [marker]?: string };
+  if (tagged[marker] !== undefined) return client;
+  // Defensive: tests and bench harnesses sometimes hand a partial
+  // langchain stub through the same factory path. Wrapping a client
+  // that does not implement both methods would crash on `.bind()` and
+  // mask the real test setup error, so skip silently — the wrap is
+  // strictly observability and never load-bearing.
+  if (typeof client.embedQuery !== 'function' || typeof client.embedDocuments !== 'function') {
+    return client;
+  }
+  const metrics = options.metrics ?? providerCallMetrics;
+  const now = options.now ?? performanceNow;
+
+  const originalQuery = client.embedQuery.bind(client);
+  const originalDocs = client.embedDocuments.bind(client);
+
+  client.embedQuery = async (text: string): Promise<number[]> => {
+    const start = now();
+    try {
+      const result = await originalQuery(text);
+      metrics.record(modelId, { latencyMs: now() - start, ok: true });
+      return result;
+    } catch (err) {
+      metrics.record(modelId, { latencyMs: now() - start, ok: false });
+      throw err;
+    }
+  };
+
+  client.embedDocuments = async (texts: string[]): Promise<number[][]> => {
+    const start = now();
+    try {
+      const result = await originalDocs(texts);
+      metrics.record(modelId, { latencyMs: now() - start, ok: true });
+      return result;
+    } catch (err) {
+      metrics.record(modelId, { latencyMs: now() - start, ok: false });
+      throw err;
+    }
+  };
+
+  Object.defineProperty(tagged, marker, {
+    value: modelId,
+    enumerable: false,
+    configurable: false,
+    writable: false,
+  });
+  return client;
+}
+
+function performanceNow(): number {
+  // performance.now() is monotonic across the process lifetime; falling
+  // back to Date.now() preserves correctness on any runtime where
+  // performance is shimmed away (older bundlers, REPLs) at the cost of
+  // wall-clock skew that the bucket assignment already absorbs.
+  if (typeof performance !== 'undefined' && typeof performance.now === 'function') {
+    return performance.now();
+  }
+  return Date.now();
+}


### PR DESCRIPTION
## Summary

Closes #210. Surfaces per-`model_id` runtime telemetry for the active embedding provider's `embedQuery` / `embedDocuments` calls inside the existing `kb_stats` MCP tool and `kb doctor` output. Closes the gap left by issue #54 between structural state (file/chunk counts) and live operational behaviour without introducing a new transport — RFC 008 §6.8 caps `/health` at liveness only, so `kb_stats` is the right home.

## What ships

- **`src/metrics.ts`** (new, ~80 LoC) — fixed-bucket histogram (10 log-spaced buckets in [1 ms, 30 s] + overflow), per-`model_id` registry, `instrumentEmbeddingsClient` helper. Process-lifetime, in-memory only. Bounded memory (~200 bytes per active model_id) and bounded perf cost (one timer + bucket update per call). Defensive: a non-conforming client (test mock, partial stub) is skipped silently — observability cannot break the request path.
- **`src/embedding-provider.ts`** — factory now accepts an optional `modelId`; when set, the constructed client is wrapped with the telemetry collector. Idempotent so a second `initialize()` after corrupt-recovery does not double-count. Legacy callers (bench harness, future audit code) opt out by omitting `modelId`.
- **`src/FaissIndexManager.ts`** — passes `this.modelId` through, so the active model's calls land in the registry.
- **`src/kb-stats.ts`** — `KbStatsPayload.provider_calls` is the wire surface: `Record<model_id, { count, errors, tokens_in: number | null, latency_ms: { p50, p95, p99 }, since_started_at }>`. Additive — older clients ignore unknown fields.
- **`src/cli-doctor.ts`** — per-model row with `WARN` when `errors / count > 5%`. The check is omitted entirely until at least one call has been observed so a fresh process stays quiet (matching the existing age-budget check pattern).
- **`docs/architecture/qa-budgets.md`** — new section pointing the offline bench numbers at the live `provider_calls.<model_id>.latency_ms.p95` so an operator can compare apples to apples.

## Design notes

- **Cardinality.** `model_id` is the only label; no per-query keys, so the registry stays bounded by the active-model set.
- **Token counts.** `tokens_in` stays `null` until at least one call carries a non-null token count. Today no SDK call site reports them through the langchain `Embeddings` interface, so the field surfaces `null` — the schema is in place for a future PR that taps the SDK responses directly without a wire-shape change.
- **Failure semantics.** Errors increment both `count` and `errors`; the latency histogram still records the failed call's wall time so a slow timeout is itself a latency regression worth surfacing.
- **No CHANGELOG entry** — parent batch forbids shared changelog edits for concurrent children.

## Test plan

- [x] `npm test -- src/metrics.test.ts src/embedding-provider.test.ts src/kb-stats.test.ts src/cli-doctor.test.ts` (53 focused tests, all green)
- [x] `npm test` full suite (953 tests, all green; 4 pre-existing skips)
- [x] `npm run build`
- [x] Property-style assertions on histogram bucket assignment (monotonic, idempotent, NaN/negative coercion)
- [x] Wrap correctly counts errors when provider throws and re-throws original error
- [x] `kb doctor` markdown shows the WARN marker only when error rate exceeds 5%

🤖 Generated with [Claude Code](https://claude.com/claude-code)