### PR TITLE
feat(ingest): bound large-file extraction

### DIFF
--- a/src/__property-tests__/file-ingest.property.test.ts
+++ b/src/__property-tests__/file-ingest.property.test.ts
@@ -23,12 +23,18 @@ const NUM_RUNS = process.env.KB_PROPERTY_DEEP === '1' ? 1000 : 50;
 
 const savedChunkSize = process.env.KB_CHUNK_SIZE;
 const savedChunkOverlap = process.env.KB_CHUNK_OVERLAP;
+const savedMaxExtractedTextBytes = process.env.KB_MAX_EXTRACTED_TEXT_BYTES;
+const savedLargeFilePolicy = process.env.KB_LARGE_FILE_POLICY;
 
 afterEach(() => {
   if (savedChunkSize === undefined) delete process.env.KB_CHUNK_SIZE;
   else process.env.KB_CHUNK_SIZE = savedChunkSize;
   if (savedChunkOverlap === undefined) delete process.env.KB_CHUNK_OVERLAP;
   else process.env.KB_CHUNK_OVERLAP = savedChunkOverlap;
+  if (savedMaxExtractedTextBytes === undefined) delete process.env.KB_MAX_EXTRACTED_TEXT_BYTES;
+  else process.env.KB_MAX_EXTRACTED_TEXT_BYTES = savedMaxExtractedTextBytes;
+  if (savedLargeFilePolicy === undefined) delete process.env.KB_LARGE_FILE_POLICY;
+  else process.env.KB_LARGE_FILE_POLICY = savedLargeFilePolicy;
 });
 
 // A "word" is an alphanumeric run; tokens used as content. Avoiding spaces /
@@ -107,5 +113,17 @@ describe('buildChunkDocuments — property tests (issue #219)', () => {
       }),
       { numRuns: Math.min(NUM_RUNS, 10) },
     );
+  });
+
+  it('bounds direct chunk-building input by KB_MAX_EXTRACTED_TEXT_BYTES', async () => {
+    process.env.KB_CHUNK_SIZE = '100';
+    process.env.KB_CHUNK_OVERLAP = '0';
+    process.env.KB_MAX_EXTRACTED_TEXT_BYTES = '5';
+    process.env.KB_LARGE_FILE_POLICY = 'truncate';
+
+    const fakeFile = path.join(os.tmpdir(), 'kb-prop-large.txt');
+    const docs = await buildChunkDocuments(fakeFile, 'abcdefghij', 'kb-prop');
+
+    expect(docs.map((doc) => doc.pageContent).join('')).toBe('abcde');
   });
 });

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -2,15 +2,44 @@ import {
   isKnownEmbeddingProvider,
   KNOWN_EMBEDDING_PROVIDERS,
   parseEmbeddingProvider,
+  parseKbLargeFilePolicy,
   parseKbFakeDim,
   parseKbFsWatchDebounceMs,
   parseKbFsWatchFlag,
+  parseKbMaxExtractedTextBytes,
+  parseKbMaxFileBytes,
   parseReindexTriggerPollMs,
   parseKBEditorUri,
   resolveChunkSize,
   resolveIndexingBatchSize,
   UnknownEmbeddingProviderError,
 } from './config.js';
+
+describe('large-file ingest bounds (#285)', () => {
+  it('uses conservative defaults for unset or invalid byte caps', () => {
+    expect(parseKbMaxFileBytes(undefined)).toBe(100 * 1024 * 1024);
+    expect(parseKbMaxFileBytes('')).toBe(100 * 1024 * 1024);
+    expect(parseKbMaxFileBytes('not-a-number')).toBe(100 * 1024 * 1024);
+    expect(parseKbMaxFileBytes('0')).toBe(100 * 1024 * 1024);
+
+    expect(parseKbMaxExtractedTextBytes(undefined)).toBe(16 * 1024 * 1024);
+    expect(parseKbMaxExtractedTextBytes('-1')).toBe(16 * 1024 * 1024);
+  });
+
+  it('honors positive byte caps and floors fractions', () => {
+    expect(parseKbMaxFileBytes('4096')).toBe(4096);
+    expect(parseKbMaxFileBytes('4096.9')).toBe(4096);
+    expect(parseKbMaxExtractedTextBytes('8192')).toBe(8192);
+  });
+
+  it('parses the large-file policy', () => {
+    expect(parseKbLargeFilePolicy(undefined)).toBe('skip');
+    expect(parseKbLargeFilePolicy('')).toBe('skip');
+    expect(parseKbLargeFilePolicy(' TrUnCaTe ')).toBe('truncate');
+    expect(parseKbLargeFilePolicy('error')).toBe('error');
+    expect(() => parseKbLargeFilePolicy('quarantine')).toThrow(/KB_LARGE_FILE_POLICY/);
+  });
+});
 
 describe('resolveIndexingBatchSize (issue #236 — INDEXING_BATCH_SIZE)', () => {
   const saved = process.env.INDEXING_BATCH_SIZE;

--- a/src/config.ts
+++ b/src/config.ts
@@ -141,6 +141,51 @@ export const INGEST_EXCLUDE_PATHS: readonly string[] = parseCommaSeparatedList(
 );
 
 // ---------------------------------------------------------------------------
+// Large-file ingest bounds (#285).
+// ---------------------------------------------------------------------------
+
+const DEFAULT_KB_MAX_FILE_BYTES = 100 * 1024 * 1024;
+const DEFAULT_KB_MAX_EXTRACTED_TEXT_BYTES = 16 * 1024 * 1024;
+
+export type KBLargeFilePolicy = 'skip' | 'truncate' | 'error';
+
+function parsePositiveByteLimit(raw: string | undefined, fallback: number): number {
+  if (raw === undefined || raw.trim() === '') return fallback;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+  return Math.floor(parsed);
+}
+
+export function parseKbMaxFileBytes(raw: string | undefined): number {
+  return parsePositiveByteLimit(raw, DEFAULT_KB_MAX_FILE_BYTES);
+}
+
+export function parseKbMaxExtractedTextBytes(raw: string | undefined): number {
+  return parsePositiveByteLimit(raw, DEFAULT_KB_MAX_EXTRACTED_TEXT_BYTES);
+}
+
+export function parseKbLargeFilePolicy(raw: string | undefined): KBLargeFilePolicy {
+  if (raw === undefined || raw.trim() === '') return 'skip';
+  const value = raw.trim().toLowerCase();
+  if (value === 'skip' || value === 'truncate' || value === 'error') {
+    return value;
+  }
+  throw new Error(`invalid KB_LARGE_FILE_POLICY=${JSON.stringify(raw)} (expected skip, truncate, or error)`);
+}
+
+export function resolveLargeFileLimits(): {
+  maxFileBytes: number;
+  maxExtractedTextBytes: number;
+  policy: KBLargeFilePolicy;
+} {
+  return {
+    maxFileBytes: parseKbMaxFileBytes(process.env.KB_MAX_FILE_BYTES),
+    maxExtractedTextBytes: parseKbMaxExtractedTextBytes(process.env.KB_MAX_EXTRACTED_TEXT_BYTES),
+    policy: parseKbLargeFilePolicy(process.env.KB_LARGE_FILE_POLICY),
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Indexing batch configuration (RFC 007 §6.2 / issue #236).
 // ---------------------------------------------------------------------------
 

--- a/src/file-ingest.ts
+++ b/src/file-ingest.ts
@@ -25,6 +25,7 @@ import { KNOWLEDGE_BASES_ROOT_DIR, resolveChunkSize } from './config.js';
 import { handleFsOperationError } from './error-utils.js';
 import { parseFrontmatter } from './frontmatter.js';
 import { detectSiblingPdfPath, liftFrontmatter } from './frontmatter-lift.js';
+import { applyExtractedTextLimit } from './loaders.js';
 import { withSidecarLock } from './write-lock.js';
 
 export interface PendingSidecarWrite {
@@ -65,7 +66,8 @@ export async function buildChunkDocuments(
         chunkOverlap,
       });
 
-  const { tags, body, frontmatter } = parseFrontmatter(content);
+  const boundedContent = applyExtractedTextLimit(filePath, content);
+  const { tags, body, frontmatter } = parseFrontmatter(boundedContent);
   const relativePath = path
     .relative(KNOWLEDGE_BASES_ROOT_DIR, filePath)
     .split(path.sep)

--- a/src/loaders.test.ts
+++ b/src/loaders.test.ts
@@ -23,6 +23,7 @@ import * as os from 'os';
 import * as path from 'path';
 import {
   getLoader,
+  LargeFileIngestError,
   LOADERS,
   loadFile,
   SUPPORTED_LOADER_EXTENSIONS,
@@ -332,6 +333,96 @@ describe('PDF loader — pdfjs-dist stdout noise suppression', () => {
     expect(stdoutSpy).not.toHaveBeenCalled();
     // After both loads settle, console.log is back to the test spy.
     expect(console.log).toBe(stdoutSpy);
+  });
+});
+
+describe('large-file bounds (#285)', () => {
+  const savedMaxFileBytes = process.env.KB_MAX_FILE_BYTES;
+  const savedMaxExtractedTextBytes = process.env.KB_MAX_EXTRACTED_TEXT_BYTES;
+  const savedLargeFilePolicy = process.env.KB_LARGE_FILE_POLICY;
+  let tempDir = '';
+
+  beforeEach(async () => {
+    tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-loaders-large-'));
+    pdfParseFnMock.mockReset();
+  });
+
+  afterEach(async () => {
+    if (savedMaxFileBytes === undefined) delete process.env.KB_MAX_FILE_BYTES;
+    else process.env.KB_MAX_FILE_BYTES = savedMaxFileBytes;
+    if (savedMaxExtractedTextBytes === undefined) delete process.env.KB_MAX_EXTRACTED_TEXT_BYTES;
+    else process.env.KB_MAX_EXTRACTED_TEXT_BYTES = savedMaxExtractedTextBytes;
+    if (savedLargeFilePolicy === undefined) delete process.env.KB_LARGE_FILE_POLICY;
+    else process.env.KB_LARGE_FILE_POLICY = savedLargeFilePolicy;
+    await fsp.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('skips files that exceed KB_MAX_FILE_BYTES before invoking the PDF parser', async () => {
+    process.env.KB_MAX_FILE_BYTES = '4';
+    process.env.KB_LARGE_FILE_POLICY = 'skip';
+    const filePath = path.join(tempDir, 'large.pdf');
+    await fsp.writeFile(filePath, Buffer.from('%PDF-1.4\nbody'));
+    pdfParseFnMock.mockResolvedValue({ text: 'should not parse' });
+
+    await expect(loadFile(filePath)).rejects.toMatchObject({
+      code: 'KB_LARGE_FILE_SKIPPED',
+      limitKind: 'file_bytes',
+      policy: 'skip',
+    });
+    expect(pdfParseFnMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects extracted text over the cap when KB_LARGE_FILE_POLICY=error', async () => {
+    process.env.KB_MAX_FILE_BYTES = '100';
+    process.env.KB_MAX_EXTRACTED_TEXT_BYTES = '5';
+    process.env.KB_LARGE_FILE_POLICY = 'error';
+    const filePath = path.join(tempDir, 'large.txt');
+    await fsp.writeFile(filePath, 'abcdef');
+
+    let thrown: unknown;
+    try {
+      await loadFile(filePath);
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeInstanceOf(LargeFileIngestError);
+    expect(thrown).toMatchObject({
+      code: 'KB_LARGE_FILE_TOO_LARGE',
+      limitKind: 'extracted_text_bytes',
+      observedBytes: 6,
+      limitBytes: 5,
+      policy: 'error',
+    });
+  });
+
+  it('streams and truncates text under KB_LARGE_FILE_POLICY=truncate', async () => {
+    process.env.KB_MAX_FILE_BYTES = '100';
+    process.env.KB_MAX_EXTRACTED_TEXT_BYTES = '5';
+    process.env.KB_LARGE_FILE_POLICY = 'truncate';
+    const filePath = path.join(tempDir, 'large.txt');
+    await fsp.writeFile(filePath, 'abcdef');
+
+    await expect(loadFile(filePath)).resolves.toBe('abcde');
+  });
+
+  it('does not split a multibyte UTF-8 character while truncating', async () => {
+    process.env.KB_MAX_FILE_BYTES = '100';
+    process.env.KB_MAX_EXTRACTED_TEXT_BYTES = '5';
+    process.env.KB_LARGE_FILE_POLICY = 'truncate';
+    const filePath = path.join(tempDir, 'emoji.txt');
+    await fsp.writeFile(filePath, 'abcdé');
+
+    await expect(loadFile(filePath)).resolves.toBe('abcd');
+  });
+
+  it('truncates extracted HTML text after markup conversion', async () => {
+    process.env.KB_MAX_FILE_BYTES = '100';
+    process.env.KB_MAX_EXTRACTED_TEXT_BYTES = '5';
+    process.env.KB_LARGE_FILE_POLICY = 'truncate';
+    const filePath = path.join(tempDir, 'large.html');
+    await fsp.writeFile(filePath, '<html><body><p>abcdef</p></body></html>');
+
+    await expect(loadFile(filePath)).resolves.toBe('abcde');
   });
 });
 

--- a/src/loaders.ts
+++ b/src/loaders.ts
@@ -21,8 +21,10 @@
 // Both modules are imported lazily inside the loader so the cold-start cost is
 // only paid by KBs that actually contain PDFs or HTML.
 
+import { createReadStream } from 'fs';
 import * as fsp from 'fs/promises';
 import * as path from 'path';
+import { resolveLargeFileLimits, type KBLargeFilePolicy } from './config.js';
 import { loadWithExtractionCache } from './extraction-cache.js';
 
 /** Loader contract: filePath in, plain text out. Throws on parse failure. */
@@ -39,13 +41,150 @@ const PDF_LOADER_VERSION = 1;
 const HTML_LOADER_NAME = 'html-to-text';
 const HTML_LOADER_VERSION = 1;
 
+export type LargeFileLimitKind = 'file_bytes' | 'extracted_text_bytes';
+
+export class LargeFileIngestError extends Error {
+  readonly code: 'KB_LARGE_FILE_SKIPPED' | 'KB_LARGE_FILE_TOO_LARGE';
+  readonly filePath: string;
+  readonly limitKind: LargeFileLimitKind;
+  readonly observedBytes: number;
+  readonly limitBytes: number;
+  readonly policy: KBLargeFilePolicy;
+
+  constructor(args: {
+    filePath: string;
+    limitKind: LargeFileLimitKind;
+    observedBytes: number;
+    limitBytes: number;
+    policy: KBLargeFilePolicy;
+  }) {
+    const action = args.policy === 'skip' ? 'skipped' : 'rejected';
+    super(
+      `Large file ${action}: ${args.filePath} ${args.limitKind}=${args.observedBytes} ` +
+      `exceeds limit ${args.limitBytes} (KB_LARGE_FILE_POLICY=${args.policy})`,
+    );
+    this.name = 'LargeFileIngestError';
+    this.code = args.policy === 'skip' ? 'KB_LARGE_FILE_SKIPPED' : 'KB_LARGE_FILE_TOO_LARGE';
+    this.filePath = args.filePath;
+    this.limitKind = args.limitKind;
+    this.observedBytes = args.observedBytes;
+    this.limitBytes = args.limitBytes;
+    this.policy = args.policy;
+  }
+}
+
+type LargeFileLimits = ReturnType<typeof resolveLargeFileLimits>;
+
+function throwLargeFileLimit(args: {
+  filePath: string;
+  limitKind: LargeFileLimitKind;
+  observedBytes: number;
+  limitBytes: number;
+  policy: KBLargeFilePolicy;
+}): never {
+  throw new LargeFileIngestError(args);
+}
+
+async function statSize(filePath: string): Promise<number> {
+  return (await fsp.stat(filePath)).size;
+}
+
+function enforceFileSizeLimit(
+  filePath: string,
+  size: number,
+  limits: LargeFileLimits,
+): void {
+  if (size > limits.maxFileBytes) {
+    throwLargeFileLimit({
+      filePath,
+      limitKind: 'file_bytes',
+      observedBytes: size,
+      limitBytes: limits.maxFileBytes,
+      policy: limits.policy,
+    });
+  }
+}
+
+function trimIncompleteUtf8(buffer: Buffer): Buffer {
+  if (buffer.length === 0) return buffer;
+  let leadIndex = buffer.length - 1;
+  while (leadIndex >= 0 && (buffer[leadIndex] & 0xc0) === 0x80) {
+    leadIndex -= 1;
+  }
+  if (leadIndex < 0) return Buffer.alloc(0);
+  const lead = buffer[leadIndex];
+  const expectedLength = lead < 0x80
+    ? 1
+    : (lead & 0xe0) === 0xc0
+      ? 2
+      : (lead & 0xf0) === 0xe0
+        ? 3
+        : (lead & 0xf8) === 0xf0
+          ? 4
+          : 1;
+  const actualLength = buffer.length - leadIndex;
+  return actualLength < expectedLength ? buffer.subarray(0, leadIndex) : buffer;
+}
+
+function utf8Prefix(text: string, maxBytes: number): string {
+  const buffer = Buffer.from(text, 'utf-8');
+  if (buffer.length <= maxBytes) return text;
+  return trimIncompleteUtf8(buffer.subarray(0, maxBytes)).toString('utf-8');
+}
+
+async function readUtf8Prefix(filePath: string, maxBytes: number): Promise<string> {
+  if (maxBytes <= 0) return '';
+  const chunks: Buffer[] = [];
+  let total = 0;
+  for await (const chunk of createReadStream(filePath)) {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    const remaining = maxBytes - total;
+    if (remaining <= 0) break;
+    if (buffer.length > remaining) {
+      chunks.push(buffer.subarray(0, remaining));
+      total += remaining;
+      break;
+    }
+    chunks.push(buffer);
+    total += buffer.length;
+  }
+  return trimIncompleteUtf8(Buffer.concat(chunks, total)).toString('utf-8');
+}
+
+export function applyExtractedTextLimit(filePath: string, text: string): string {
+  const limits = resolveLargeFileLimits();
+  const bytes = Buffer.byteLength(text, 'utf-8');
+  if (bytes <= limits.maxExtractedTextBytes) return text;
+  if (limits.policy === 'truncate') {
+    return utf8Prefix(text, limits.maxExtractedTextBytes);
+  }
+  return throwLargeFileLimit({
+    filePath,
+    limitKind: 'extracted_text_bytes',
+    observedBytes: bytes,
+    limitBytes: limits.maxExtractedTextBytes,
+    policy: limits.policy,
+  });
+}
+
 async function loadText(filePath: string): Promise<string> {
-  // `.md` / `.txt` / `INGEST_EXTRA_EXTENSIONS` opt-ins ride this loader. They
-  // are already a single fsp.readFile away from "normalized text", so caching
-  // would only add overhead (sha256 + a second copy on disk) without saving
-  // any parse work. Skip the cache here on purpose; only the expensive PDF
-  // and HTML parsers cache.
-  return fsp.readFile(filePath, 'utf-8');
+  const limits = resolveLargeFileLimits();
+  const size = await statSize(filePath);
+  if (limits.policy !== 'truncate') {
+    enforceFileSizeLimit(filePath, size, limits);
+    if (size > limits.maxExtractedTextBytes) {
+      throwLargeFileLimit({
+        filePath,
+        limitKind: 'extracted_text_bytes',
+        observedBytes: size,
+        limitBytes: limits.maxExtractedTextBytes,
+        policy: limits.policy,
+      });
+    }
+    return fsp.readFile(filePath, 'utf-8');
+  }
+  const maxReadBytes = Math.min(size, limits.maxFileBytes, limits.maxExtractedTextBytes);
+  return readUtf8Prefix(filePath, maxReadBytes);
 }
 
 // Reentrancy depth for `silencePdfjsConsole` — pdf-parse calls can interleave
@@ -114,6 +253,9 @@ async function silencePdfjsConsole<T>(fn: () => Promise<T>): Promise<T> {
 }
 
 async function loadPdf(filePath: string): Promise<string> {
+  const limits = resolveLargeFileLimits();
+  const size = await statSize(filePath);
+  enforceFileSizeLimit(filePath, size, limits);
   // pdf-parse@1 ships its main as a CJS function with `module.exports = PDF`
   // and a `parent`-less debug branch that fires on import (it tries to read
   // a bundled test fixture from `./test/data/...`). Importing under that
@@ -127,7 +269,7 @@ async function loadPdf(filePath: string): Promise<string> {
   // Issue #279 — gate the heavy parse behind the content-addressed extraction
   // cache. On a cache hit we never touch pdfjs-dist at all; on a miss we run
   // the original parse and store its output for the next caller.
-  return loadWithExtractionCache({
+  const text = await loadWithExtractionCache({
     filePath,
     loaderName: PDF_LOADER_NAME,
     loaderVersion: PDF_LOADER_VERSION,
@@ -141,13 +283,30 @@ async function loadPdf(filePath: string): Promise<string> {
       return result.text;
     },
   });
+  return applyExtractedTextLimit(filePath, text);
 }
 
 async function loadHtml(filePath: string): Promise<string> {
+  const limits = resolveLargeFileLimits();
+  const size = await statSize(filePath);
+  if (limits.policy === 'truncate') {
+    const { htmlToText } = await import('html-to-text');
+    const raw = await readUtf8Prefix(filePath, Math.min(size, limits.maxFileBytes));
+    return applyExtractedTextLimit(filePath, htmlToText(raw, {
+      wordwrap: false,
+      selectors: [
+        // Hrefs are noise inside an embedding; the link text is what matters.
+        { selector: 'a', options: { ignoreHref: true } },
+        // Images carry no embeddable text; skip the alt-text-only line they'd produce.
+        { selector: 'img', format: 'skip' },
+      ],
+    }));
+  }
+  enforceFileSizeLimit(filePath, size, limits);
   // Issue #279 — same caching gate as `loadPdf`. html-to-text is cheap per
   // call but quadratic in document size on large structured documents, so
   // skipping it on rebuilds is still a meaningful win.
-  return loadWithExtractionCache({
+  const text = await loadWithExtractionCache({
     filePath,
     loaderName: HTML_LOADER_NAME,
     loaderVersion: HTML_LOADER_VERSION,
@@ -165,6 +324,7 @@ async function loadHtml(filePath: string): Promise<string> {
       });
     },
   });
+  return applyExtractedTextLimit(filePath, text);
 }
 
 /**


### PR DESCRIPTION
## Summary
- add KB_MAX_FILE_BYTES, KB_MAX_EXTRACTED_TEXT_BYTES, and KB_LARGE_FILE_POLICY parsing
- bound text, HTML, and PDF loader extraction with structured large-file errors
- cap direct chunk-building input before splitter document creation

Closes #285

## Tests
- npm test -- src/loaders.test.ts src/config.test.ts src/__property-tests__/file-ingest.property.test.ts
- npm run build
- npm test