### PR TITLE
feat(index): bound filesystem scan concurrency

### DIFF
--- a/src/FaissIndexManager.ts
+++ b/src/FaissIndexManager.ts
@@ -28,6 +28,7 @@ import {
   __resetBootstrapForTests as resetBootstrapLayoutForTests,
   bootstrapLayout as bootstrapIndexLayout,
 } from './layout-bootstrap.js';
+import { mapBounded, resolveFsConcurrency } from './bounded-concurrency.js';
 import {
   loadFaissStoreAtomic,
   resolveActiveIndexFilePath as resolveActiveIndexFilePathFromLayout,
@@ -730,90 +731,104 @@ export class FaissIndexManager {
         fileHash: string;
         documents: Document[];
       }> = [];
-      for (const { knowledgeBaseName, knowledgeBasePath, filePaths } of knowledgeBaseFiles) {
-        for (const filePath of filePaths) {
-          anyFileProcessed = true;
-          runSummary.files_scanned += 1;
-
+      const fsConcurrency = resolveFsConcurrency();
+      const fileScanJobs = knowledgeBaseFiles.flatMap(
+        ({ knowledgeBaseName, knowledgeBasePath, filePaths }) => filePaths.map((filePath) => {
           const relativePath = path.relative(knowledgeBasePath, filePath);
-          let fileHash: string;
+          const indexFilePath = path.join(
+            knowledgeBasePath,
+            '.index',
+            path.dirname(relativePath),
+            path.basename(filePath),
+          );
+          return {
+            knowledgeBaseName,
+            knowledgeBasePath,
+            filePath,
+            relativePath,
+            indexFilePath,
+          };
+        }),
+      );
+      const fileScanResults = await mapBounded(
+        fileScanJobs,
+        fsConcurrency,
+        async (job) => {
           try {
-            fileHash = await calculateSHA256(filePath);
+            const fileHash = await calculateSHA256(job.filePath);
+            let storedHash: string | null = null;
+            try {
+              const buffer = await fsp.readFile(job.indexFilePath);
+              storedHash = buffer.toString('utf-8');
+            } catch {
+              // The hash file may not exist yet; that's fine.
+            }
+            return { ...job, success: true as const, fileHash, storedHash };
           } catch (error: unknown) {
-            logger.error(`Error reading file ${filePath}:`, toError(error));
+            return { ...job, success: false as const, error };
+          }
+        },
+      );
+      for (const scan of fileScanResults) {
+        anyFileProcessed = true;
+        runSummary.files_scanned += 1;
+
+        if (!scan.success) {
+          logger.error(`Error reading file ${scan.filePath}:`, toError(scan.error));
+          runSummary.files_skipped += 1;
+          loaderFailurePaths.add(scan.filePath);
+          recordFailure(scan.relativePath, 'load', scan.error);
+          continue;
+        }
+
+        // If the file is new/changed, or the index itself is absent,
+        // process it. The missing-index case must ignore matching sidecars:
+        // otherwise a rebuild can silently omit files whose hashes were
+        // already current.
+        if (rebuildFromEmptyIndex || forceReindex || scan.fileHash !== scan.storedHash) {
+          runSummary.files_changed += 1;
+          logger.info(
+            rebuildFromEmptyIndex
+              ? `FAISS index is empty. Rebuilding from ${scan.filePath}...`
+              : forceReindex
+                ? `Force re-indexing ${scan.filePath}...`
+              : `File ${scan.filePath} has changed. Updating index...`,
+          );
+          // Issue #46 — extension-routed loader. `.pdf` runs through
+          // pdf-parse, `.html`/`.htm` through html-to-text, anything else
+          // (including operator-supplied INGEST_EXTRA_EXTENSIONS like
+          // `.json` or `.csv`) reads as UTF-8.
+          let content = '';
+          try {
+            content = await loadFile(scan.filePath);
+          } catch (error: unknown) {
+            logger.error(`Error loading file ${scan.filePath}:`, toError(error));
             runSummary.files_skipped += 1;
-            loaderFailurePaths.add(filePath);
-            recordFailure(relativePath, 'load', error);
+            loaderFailurePaths.add(scan.filePath);
+            recordFailure(scan.relativePath, 'load', error);
             continue;
           }
-          const indexDirPath = path.join(knowledgeBasePath, '.index', path.dirname(relativePath));
-          const indexFilePath = path.join(indexDirPath, path.basename(filePath));
 
-          if (!(await pathExists(indexDirPath))) {
-            try {
-              await fsp.mkdir(indexDirPath, { recursive: true });
-            } catch (error) {
-              handleFsOperationError('create index metadata directory', indexDirPath, error);
-            }
-          }
+          const documentsToAdd: Document[] = await buildChunkDocuments(
+            scan.filePath,
+            content,
+            scan.knowledgeBaseName,
+          );
+          runSummary.chunks_attempted += documentsToAdd.length;
 
-          let storedHash: string | null = null;
-          try {
-            const buffer = await fsp.readFile(indexFilePath);
-            storedHash = buffer.toString('utf-8');
-          } catch (error) {
-            // The hash file may not exist yet; that's fine.
-          }
-
-          // If the file is new/changed, or the index itself is absent,
-          // process it. The missing-index case must ignore matching sidecars:
-          // otherwise a rebuild can silently omit files whose hashes were
-          // already current.
-          if (rebuildFromEmptyIndex || forceReindex || fileHash !== storedHash) {
-            runSummary.files_changed += 1;
-            logger.info(
-              rebuildFromEmptyIndex
-                ? `FAISS index is empty. Rebuilding from ${filePath}...`
-                : forceReindex
-                  ? `Force re-indexing ${filePath}...`
-                : `File ${filePath} has changed. Updating index...`,
-            );
-            // Issue #46 — extension-routed loader. `.pdf` runs through
-            // pdf-parse, `.html`/`.htm` through html-to-text, anything else
-            // (including operator-supplied INGEST_EXTRA_EXTENSIONS like
-            // `.json` or `.csv`) reads as UTF-8.
-            let content = '';
-            try {
-              content = await loadFile(filePath);
-            } catch (error: unknown) {
-              logger.error(`Error loading file ${filePath}:`, toError(error));
-              runSummary.files_skipped += 1;
-              loaderFailurePaths.add(filePath);
-              recordFailure(relativePath, 'load', error);
-              continue;
-            }
-
-            const documentsToAdd: Document[] = await buildChunkDocuments(
-              filePath,
-              content,
-              knowledgeBaseName,
-            );
-            runSummary.chunks_attempted += documentsToAdd.length;
-
-            if (documentsToAdd.length > 0) {
-              changedFileDocuments.push({
-                filePath,
-                indexFilePath,
-                fileHash,
-                documents: documentsToAdd,
-              });
-            } else {
-              logger.debug(`No documents generated from ${filePath}. Skipping index update.`);
-            }
+          if (documentsToAdd.length > 0) {
+            changedFileDocuments.push({
+              filePath: scan.filePath,
+              indexFilePath: scan.indexFilePath,
+              fileHash: scan.fileHash,
+              documents: documentsToAdd,
+            });
           } else {
-            runSummary.files_unchanged += 1;
-            logger.debug(`File ${filePath} unchanged, skipping.`);
+            logger.debug(`No documents generated from ${scan.filePath}. Skipping index update.`);
           }
+        } else {
+          runSummary.files_unchanged += 1;
+          logger.debug(`File ${scan.filePath} unchanged, skipping.`);
         }
       }
       const documentsToAdd = changedFileDocuments.flatMap((entry) => entry.documents);

--- a/src/bounded-concurrency.test.ts
+++ b/src/bounded-concurrency.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+  DEFAULT_FS_CONCURRENCY,
+  mapBounded,
+  normalizeConcurrency,
+  resolveFsConcurrency,
+} from './bounded-concurrency.js';
+
+describe('mapBounded', () => {
+  it('preserves input order while bounding active work', async () => {
+    let active = 0;
+    let maxActive = 0;
+
+    const out = await mapBounded([30, 10, 20, 0], 2, async (delayMs, index) => {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+      active -= 1;
+      return `item-${index}`;
+    });
+
+    expect(out).toEqual(['item-0', 'item-1', 'item-2', 'item-3']);
+    expect(maxActive).toBeLessThanOrEqual(2);
+    expect(maxActive).toBeGreaterThan(1);
+  });
+
+  it('runs every item and aggregates failures in input order', async () => {
+    const seen: number[] = [];
+
+    await expect(
+      mapBounded([0, 1, 2, 3], 2, async (item) => {
+        seen.push(item);
+        if (item % 2 === 1) {
+          throw new Error(`failed-${item}`);
+        }
+        return item;
+      }),
+    ).rejects.toMatchObject({
+      name: 'BoundedConcurrencyError',
+      failures: [
+        { index: 1, item: 1, error: expect.objectContaining({ message: 'failed-1' }) },
+        { index: 3, item: 3, error: expect.objectContaining({ message: 'failed-3' }) },
+      ],
+      errors: [
+        expect.objectContaining({ message: 'failed-1' }),
+        expect.objectContaining({ message: 'failed-3' }),
+      ],
+    });
+
+    expect(seen.sort()).toEqual([0, 1, 2, 3]);
+  });
+
+  it('uses at least one worker for fractional or zero concurrency', async () => {
+    expect(normalizeConcurrency(0)).toBe(1);
+    expect(normalizeConcurrency(1.9)).toBe(1);
+    expect(normalizeConcurrency(2.1)).toBe(2);
+    expect(() => normalizeConcurrency(Number.NaN)).toThrow(RangeError);
+  });
+
+  it('resolves the filesystem concurrency from KB_FS_CONCURRENCY with a default of 8', () => {
+    expect(resolveFsConcurrency({} as NodeJS.ProcessEnv)).toBe(DEFAULT_FS_CONCURRENCY);
+    expect(resolveFsConcurrency({ KB_FS_CONCURRENCY: '4' } as NodeJS.ProcessEnv)).toBe(4);
+    expect(resolveFsConcurrency({ KB_FS_CONCURRENCY: '0' } as NodeJS.ProcessEnv)).toBe(DEFAULT_FS_CONCURRENCY);
+    expect(resolveFsConcurrency({ KB_FS_CONCURRENCY: 'not-a-number' } as NodeJS.ProcessEnv)).toBe(DEFAULT_FS_CONCURRENCY);
+  });
+});

--- a/src/bounded-concurrency.ts
+++ b/src/bounded-concurrency.ts
@@ -1,0 +1,79 @@
+export const DEFAULT_FS_CONCURRENCY = 8;
+export const FS_CONCURRENCY_ENV = 'KB_FS_CONCURRENCY';
+
+export interface BoundedConcurrencyFailure<T> {
+  index: number;
+  item: T;
+  error: unknown;
+}
+
+export class BoundedConcurrencyError<T> extends AggregateError {
+  readonly failures: Array<BoundedConcurrencyFailure<T>>;
+
+  constructor(failures: Array<BoundedConcurrencyFailure<T>>) {
+    super(
+      failures.map((failure) => failure.error),
+      `mapBounded failed for ${failures.length} item(s)`,
+    );
+    this.name = 'BoundedConcurrencyError';
+    this.failures = failures;
+  }
+}
+
+export function normalizeConcurrency(value: number): number {
+  if (!Number.isFinite(value)) {
+    throw new RangeError('concurrency must be a finite number');
+  }
+  return Math.max(1, Math.floor(value));
+}
+
+export function resolveFsConcurrency(env: NodeJS.ProcessEnv = process.env): number {
+  const raw = env[FS_CONCURRENCY_ENV];
+  if (raw === undefined || raw.trim() === '') {
+    return DEFAULT_FS_CONCURRENCY;
+  }
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 1) {
+    return DEFAULT_FS_CONCURRENCY;
+  }
+  return Math.floor(parsed);
+}
+
+export async function mapBounded<T, R>(
+  items: readonly T[],
+  concurrency: number,
+  mapper: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  if (items.length === 0) {
+    return [];
+  }
+
+  const workerCount = Math.min(normalizeConcurrency(concurrency), items.length);
+  const results = new Array<R>(items.length);
+  const failures: Array<BoundedConcurrencyFailure<T>> = [];
+  let nextIndex = 0;
+
+  async function worker(): Promise<void> {
+    for (;;) {
+      const index = nextIndex;
+      nextIndex += 1;
+      if (index >= items.length) {
+        return;
+      }
+      try {
+        results[index] = await mapper(items[index], index);
+      } catch (error: unknown) {
+        failures.push({ index, item: items[index], error });
+      }
+    }
+  }
+
+  await Promise.all(Array.from({ length: workerCount }, () => worker()));
+
+  if (failures.length > 0) {
+    failures.sort((a, b) => a.index - b.index);
+    throw new BoundedConcurrencyError(failures);
+  }
+
+  return results;
+}

--- a/src/cli-search-staleness.test.ts
+++ b/src/cli-search-staleness.test.ts
@@ -80,7 +80,7 @@ describe('computeStaleness', () => {
     } finally {
       await fsp.rm(tempDir, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 });
 
 describe('buildAgeBudgetFooter (issue #218)', () => {

--- a/src/cli-search.ts
+++ b/src/cli-search.ts
@@ -27,6 +27,7 @@ import {
 } from './formatter.js';
 import { runPicker } from './cli-search-picker.js';
 import { enumerateIngestableKbFiles, listKnowledgeBases } from './kb-fs.js';
+import { mapBounded, resolveFsConcurrency } from './bounded-concurrency.js';
 import { withWriteLock } from './write-lock.js';
 import { loadManagerForModel, loadWithJsonRetry } from './cli-shared.js';
 import {
@@ -498,17 +499,20 @@ async function countStaleness(
   enumerations: Awaited<ReturnType<typeof enumerateIngestableKbFiles>>,
   indexMtimeMs: number,
 ): Promise<StalenessCounts> {
+  const fsConcurrency = resolveFsConcurrency();
   let modifiedFiles = 0;
   let newFiles = 0;
   for (const { kbPath, filePaths } of enumerations) {
-    for (const filePath of filePaths) {
+    const modifiedFlags = await mapBounded(filePaths, fsConcurrency, async (filePath): Promise<number> => {
       try {
         const st = await fsp.stat(filePath);
-        if (st.mtimeMs > indexMtimeMs) modifiedFiles += 1;
+        return st.mtimeMs > indexMtimeMs ? 1 : 0;
       } catch {
         // file vanished between the walker and stat; ignore it
+        return 0;
       }
-    }
+    });
+    modifiedFiles += modifiedFlags.reduce((sum, value) => sum + value, 0);
 
     const sidecarCount = await countSidecarFiles(path.join(kbPath, '.index'));
     if (filePaths.length > sidecarCount) {
@@ -525,16 +529,17 @@ async function countSidecarFiles(dir: string): Promise<number> {
   } catch {
     return 0;
   }
-  let count = 0;
-  for (const entry of entries) {
+  const childCounts = await mapBounded(entries, resolveFsConcurrency(), async (entry) => {
     const entryPath = path.join(dir, entry.name);
     if (entry.isDirectory()) {
-      count += await countSidecarFiles(entryPath);
-    } else if (entry.isFile()) {
-      count += 1;
+      return countSidecarFiles(entryPath);
     }
-  }
-  return count;
+    if (entry.isFile()) {
+      return 1;
+    }
+    return 0;
+  });
+  return childCounts.reduce((sum, value) => sum + value, 0);
 }
 
 function emptyStaleness(indexMtime: string | null, scopedKb?: string): Staleness {

--- a/src/kb-stats.ts
+++ b/src/kb-stats.ts
@@ -16,6 +16,7 @@ import {
   INGEST_EXTRA_EXTENSIONS,
   KNOWLEDGE_BASES_ROOT_DIR,
 } from './config.js';
+import { mapBounded, resolveFsConcurrency } from './bounded-concurrency.js';
 import { KBError } from './errors.js';
 import { enumerateIngestableKbFiles, listKnowledgeBases } from './kb-fs.js';
 import { logger } from './logger.js';
@@ -90,18 +91,20 @@ export async function computeKbStats(
   );
 
   const knowledge_bases: Record<string, KbStatsRow> = {};
+  const fsConcurrency = resolveFsConcurrency();
   for (const { kbName, kbPath, filePaths } of enumerations) {
-    let totalBytes = 0;
-    for (const filePath of filePaths) {
+    const byteCounts = await mapBounded(filePaths, fsConcurrency, async (filePath) => {
       try {
         const st = await fsp.stat(filePath);
-        totalBytes += st.size;
+        return st.size;
       } catch (err) {
         // Best-effort: a TOCTOU between the walker and stat (e.g. concurrent
         // edit) shouldn't fail the whole stats call.
         logger.debug(`kb_stats: could not stat ${filePath}: ${(err as Error).message}`);
+        return 0;
       }
-    }
+    });
+    const totalBytes = byteCounts.reduce((sum, value) => sum + value, 0);
     const lastUpdatedAt = await maxMtimeIso(path.join(kbPath, '.index'));
     knowledge_bases[kbName] = {
       file_count: filePaths.length,
@@ -147,21 +150,24 @@ export async function maxMtimeIso(dir: string): Promise<string | null> {
       if (code === 'ENOENT' || code === 'ENOTDIR') return;
       throw err;
     }
-    for (const entry of entries) {
+    const mtimes = await mapBounded(entries, resolveFsConcurrency(), async (entry) => {
       const child = path.join(target, entry.name);
       if (entry.isDirectory()) {
         await walk(child);
-        continue;
+        return 0;
       }
-      if (!entry.isFile()) continue;
+      if (!entry.isFile()) return 0;
       try {
         const st = await fsp.stat(child);
-        if (st.mtimeMs > latest) latest = st.mtimeMs;
+        return st.mtimeMs;
       } catch (err) {
         const code = (err as NodeJS.ErrnoException).code;
-        if (code === 'ENOENT') continue;
+        if (code === 'ENOENT') return 0;
         throw err;
       }
+    });
+    for (const mtime of mtimes) {
+      if (mtime > latest) latest = mtime;
     }
   }
   await walk(dir);


### PR DESCRIPTION
## Summary
- add a small ordered bounded-concurrency helper with KB_FS_CONCURRENCY defaulting to 8
- parallelize pure filesystem hash/read-sidecar and stat/count phases while keeping loaders and embedding calls serial or separately governed
- preserve deterministic result ordering for downstream indexing/progress behavior

Closes #278.

## Tests
- npm test -- src/bounded-concurrency.test.ts src/FaissIndexManager.test.ts src/cli-search-staleness.test.ts src/kb-stats.test.ts
- npm run build
- npm test

## Pre-PR Review
- Detected project type: npm
- Build checks: passed
- Tests: passed
- Bug reproduction: skipped (feature PR)
- Diff review: done
- Portability check: helper absent; manual changed-line scan clean
- Reviewer specialists: skipped because this Codex session disallows spawning subagents unless explicitly requested
- OSS base-branch policy: skipped (same-repo PR)
- Gate file: created