### PR TITLE
feat(cli): add resident search daemon plumbing

### DIFF
--- a/src/cli-serve.test.ts
+++ b/src/cli-serve.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from '@jest/globals';
+import * as http from 'node:http';
+import { parseServeArgs, startDaemonServer } from './cli-serve.js';
+import type { DaemonRunResult } from './daemon-client.js';
+
+interface RawResponse {
+  statusCode: number;
+  body: string;
+}
+
+function request(
+  url: URL,
+  options: { method?: string; path: string; body?: unknown },
+): Promise<RawResponse> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        host: url.hostname,
+        port: url.port,
+        method: options.method ?? 'GET',
+        path: options.path,
+        headers: options.body === undefined ? undefined : { 'Content-Type': 'application/json' },
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on('data', (chunk) => chunks.push(Buffer.from(chunk)));
+        res.on('end', () => resolve({
+          statusCode: res.statusCode ?? 0,
+          body: Buffer.concat(chunks).toString('utf-8'),
+        }));
+      },
+    );
+    req.on('error', reject);
+    if (options.body !== undefined) req.write(JSON.stringify(options.body));
+    req.end();
+  });
+}
+
+describe('kb serve daemon', () => {
+  it('serves health and dispatches read-only commands through handlers', async () => {
+    const calls: Array<{ command: string; args: string[] }> = [];
+    const ok = (stdout: string): DaemonRunResult => ({ exitCode: 0, stdout, stderr: '' });
+    const daemon = await startDaemonServer({
+      port: 0,
+      idleTimeoutMs: 0,
+      handlers: {
+        search: async (args) => {
+          calls.push({ command: 'search', args });
+          return ok('search output\n');
+        },
+        list: async (args) => {
+          calls.push({ command: 'list', args });
+          return ok('list output\n');
+        },
+        stats: async (args) => {
+          calls.push({ command: 'stats', args });
+          return ok('stats output\n');
+        },
+      },
+    });
+    try {
+      const health = await request(daemon.url, { path: '/health' });
+      expect(health.statusCode).toBe(200);
+      expect(JSON.parse(health.body)).toEqual({ status: 'ok' });
+
+      const run = await request(daemon.url, {
+        method: 'POST',
+        path: '/v1/run',
+        body: { command: 'search', args: ['hello', '--format=json'] },
+      });
+      expect(run.statusCode).toBe(200);
+      expect(JSON.parse(run.body)).toEqual({ exitCode: 0, stdout: 'search output\n', stderr: '' });
+      expect(calls).toEqual([{ command: 'search', args: ['hello', '--format=json'] }]);
+    } finally {
+      await daemon.stop();
+    }
+  });
+
+  it('rejects mutating search refresh requests', async () => {
+    const daemon = await startDaemonServer({ port: 0, idleTimeoutMs: 0 });
+    try {
+      const res = await request(daemon.url, {
+        method: 'POST',
+        path: '/v1/run',
+        body: { command: 'search', args: ['q', '--refresh'] },
+      });
+      expect(res.statusCode).toBe(400);
+      expect(JSON.parse(res.body)).toMatchObject({ error: 'read_only_daemon' });
+    } finally {
+      await daemon.stop();
+    }
+  });
+
+  it('keeps serve binding loopback-only', () => {
+    expect(() => parseServeArgs(['--host=0.0.0.0'])).toThrow(/non-loopback/);
+  });
+});

--- a/src/cli-serve.ts
+++ b/src/cli-serve.ts
@@ -1,0 +1,305 @@
+import * as http from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { runList } from './cli-list.js';
+import { runSearch } from './cli-search.js';
+import { runStats } from './cli-stats.js';
+import type { DaemonCommand, DaemonRunResult } from './daemon-client.js';
+
+export const SERVE_HELP = `kb serve — resident local daemon for warm CLI reads
+
+Usage:
+  kb serve [--host=127.0.0.1] [--port=17799] [--idle-timeout-ms=300000]
+
+Starts a localhost-only JSON HTTP daemon used by \`kb search --daemon\`.
+The daemon accepts read-only search/list/stats requests and exits after the
+idle timeout.
+
+Options:
+  --host=<host>             Loopback host to bind (default: 127.0.0.1).
+  --port=<port>             TCP port to bind (default: 17799; 0 for tests).
+  --idle-timeout-ms=<ms>    Stop after this much idle time (default: 300000).
+  --help, -h                Show this help.
+`;
+
+interface ServeArgs {
+  host: string;
+  port: number;
+  idleTimeoutMs: number;
+}
+
+export interface DaemonCommandHandlers {
+  search: (args: string[]) => Promise<DaemonRunResult>;
+  list: (args: string[]) => Promise<DaemonRunResult>;
+  stats: (args: string[]) => Promise<DaemonRunResult>;
+}
+
+export interface StartDaemonServerOptions extends Partial<ServeArgs> {
+  handlers?: DaemonCommandHandlers;
+}
+
+export interface ResidentDaemon {
+  server: http.Server;
+  url: URL;
+  stop: () => Promise<void>;
+  closed: Promise<void>;
+}
+
+const DEFAULT_SERVE_ARGS: ServeArgs = {
+  host: '127.0.0.1',
+  port: 17799,
+  idleTimeoutMs: 300_000,
+};
+
+export async function runServe(rest: string[]): Promise<number> {
+  let parsed: ServeArgs;
+  try {
+    parsed = parseServeArgs(rest);
+  } catch (err) {
+    process.stderr.write(`kb serve: ${(err as Error).message}\n`);
+    return 2;
+  }
+
+  let daemon: ResidentDaemon;
+  try {
+    daemon = await startDaemonServer(parsed);
+  } catch (err) {
+    process.stderr.write(`kb serve: ${(err as Error).message}\n`);
+    return 1;
+  }
+
+  process.stdout.write(`kb serve: listening on ${daemon.url.href}\n`);
+  const stop = () => {
+    void daemon.stop();
+  };
+  process.once('SIGINT', stop);
+  process.once('SIGTERM', stop);
+  await daemon.closed;
+  process.off('SIGINT', stop);
+  process.off('SIGTERM', stop);
+  return 0;
+}
+
+export async function startDaemonServer(
+  options: StartDaemonServerOptions = {},
+): Promise<ResidentDaemon> {
+  const parsed: ServeArgs = {
+    host: options.host ?? DEFAULT_SERVE_ARGS.host,
+    port: options.port ?? DEFAULT_SERVE_ARGS.port,
+    idleTimeoutMs: options.idleTimeoutMs ?? DEFAULT_SERVE_ARGS.idleTimeoutMs,
+  };
+  assertLoopbackHost(parsed.host);
+  const handlers = options.handlers ?? defaultHandlers();
+  let idleTimer: NodeJS.Timeout | undefined;
+  let queue: Promise<void> = Promise.resolve();
+
+  let resolveClosed!: () => void;
+  const closed = new Promise<void>((resolve) => {
+    resolveClosed = resolve;
+  });
+
+  const server = http.createServer((req, res) => {
+    resetIdleTimer();
+    void handleRequest(req, res, handlers, (job) => {
+      queue = queue.then(job, job);
+      return queue;
+    });
+  });
+
+  server.on('close', () => {
+    if (idleTimer) clearTimeout(idleTimer);
+    resolveClosed();
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    const onError = (err: Error) => {
+      server.off('listening', onListening);
+      reject(err);
+    };
+    const onListening = () => {
+      server.off('error', onError);
+      resolve();
+    };
+    server.once('error', onError);
+    server.once('listening', onListening);
+    server.listen(parsed.port, parsed.host);
+  });
+
+  resetIdleTimer();
+  const address = server.address() as AddressInfo;
+  const hostForUrl = parsed.host.includes(':') ? `[${parsed.host}]` : parsed.host;
+  return {
+    server,
+    url: new URL(`http://${hostForUrl}:${address.port}`),
+    stop: () => new Promise<void>((resolve, reject) => {
+      if (!server.listening) {
+        resolve();
+        return;
+      }
+      server.close((err) => {
+        if (err) reject(err);
+        else resolve();
+      });
+    }),
+    closed,
+  };
+
+  function resetIdleTimer(): void {
+    if (idleTimer) clearTimeout(idleTimer);
+    if (parsed.idleTimeoutMs <= 0) return;
+    idleTimer = setTimeout(() => {
+      void new Promise<void>((resolve) => server.close(() => resolve()));
+    }, parsed.idleTimeoutMs);
+  }
+}
+
+export function parseServeArgs(rest: string[]): ServeArgs {
+  const out = { ...DEFAULT_SERVE_ARGS };
+  for (const raw of rest) {
+    if (raw.startsWith('--host=')) {
+      out.host = raw.slice('--host='.length);
+      continue;
+    }
+    if (raw.startsWith('--port=')) {
+      const port = Number(raw.slice('--port='.length));
+      if (!Number.isInteger(port) || port < 0 || port > 65535) {
+        throw new Error(`invalid --port: ${raw}`);
+      }
+      out.port = port;
+      continue;
+    }
+    if (raw.startsWith('--idle-timeout-ms=')) {
+      const idleTimeoutMs = Number(raw.slice('--idle-timeout-ms='.length));
+      if (!Number.isInteger(idleTimeoutMs) || idleTimeoutMs < 0) {
+        throw new Error(`invalid --idle-timeout-ms: ${raw}`);
+      }
+      out.idleTimeoutMs = idleTimeoutMs;
+      continue;
+    }
+    if (raw.startsWith('--')) throw new Error(`unknown flag: ${raw}`);
+    throw new Error(`unexpected argument: ${raw}`);
+  }
+  assertLoopbackHost(out.host);
+  return out;
+}
+
+function defaultHandlers(): DaemonCommandHandlers {
+  return {
+    search: async (args) => captureProcessOutput(() => runSearch(args)),
+    list: async (args) => captureProcessOutput(() => runList(args)),
+    stats: async (args) => captureProcessOutput(() => runStats(args)),
+  };
+}
+
+async function handleRequest(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  handlers: DaemonCommandHandlers,
+  enqueue: (job: () => Promise<void>) => Promise<void>,
+): Promise<void> {
+  if (req.method === 'GET' && req.url === '/health') {
+    writeJson(res, 200, { status: 'ok' });
+    return;
+  }
+  if (req.method !== 'POST' || req.url !== '/v1/run') {
+    writeJson(res, 404, { error: 'not_found' });
+    return;
+  }
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(await readBody(req));
+  } catch {
+    writeJson(res, 400, { error: 'invalid_json' });
+    return;
+  }
+
+  const command = readDaemonCommand(payload);
+  const args = readArgs(payload);
+  if (command === null || args === null) {
+    writeJson(res, 400, { error: 'invalid_request' });
+    return;
+  }
+  if (command === 'search' && args.includes('--refresh')) {
+    writeJson(res, 400, { error: 'read_only_daemon', message: 'kb serve does not run search --refresh' });
+    return;
+  }
+
+  await enqueue(async () => {
+    try {
+      writeJson(res, 200, await handlers[command](args));
+    } catch (err) {
+      writeJson(res, 500, {
+        exitCode: 1,
+        stdout: '',
+        stderr: `kb serve: ${(err as Error).message}\n`,
+      });
+    }
+  });
+}
+
+function readDaemonCommand(payload: unknown): DaemonCommand | null {
+  const command = (payload as { command?: unknown } | null)?.command;
+  if (command === 'search' || command === 'list' || command === 'stats') return command;
+  return null;
+}
+
+function readArgs(payload: unknown): string[] | null {
+  const args = (payload as { args?: unknown } | null)?.args;
+  if (!Array.isArray(args) || !args.every((item) => typeof item === 'string')) return null;
+  return args;
+}
+
+function writeJson(res: http.ServerResponse, statusCode: number, payload: unknown): void {
+  res.writeHead(statusCode, { 'Content-Type': 'application/json' });
+  res.end(`${JSON.stringify(payload)}\n`);
+}
+
+function readBody(req: http.IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = [];
+  return new Promise((resolve, reject) => {
+    req.on('data', (chunk) => {
+      chunks.push(Buffer.from(chunk));
+      if (Buffer.concat(chunks).byteLength > 1024 * 1024) {
+        reject(new Error('request body too large'));
+        req.destroy();
+      }
+    });
+    req.on('end', () => resolve(Buffer.concat(chunks).toString('utf-8')));
+    req.on('error', reject);
+  });
+}
+
+async function captureProcessOutput(fn: () => Promise<number>): Promise<DaemonRunResult> {
+  const stdoutChunks: string[] = [];
+  const stderrChunks: string[] = [];
+  const originalStdout = process.stdout.write;
+  const originalStderr = process.stderr.write;
+  process.stdout.write = ((chunk: unknown, ...args: unknown[]) => {
+    stdoutChunks.push(String(chunk));
+    const callback = args.find((arg): arg is (err?: Error) => void => typeof arg === 'function');
+    if (callback) callback();
+    return true;
+  }) as typeof process.stdout.write;
+  process.stderr.write = ((chunk: unknown, ...args: unknown[]) => {
+    stderrChunks.push(String(chunk));
+    const callback = args.find((arg): arg is (err?: Error) => void => typeof arg === 'function');
+    if (callback) callback();
+    return true;
+  }) as typeof process.stderr.write;
+  try {
+    const exitCode = await fn();
+    return {
+      exitCode,
+      stdout: stdoutChunks.join(''),
+      stderr: stderrChunks.join(''),
+    };
+  } finally {
+    process.stdout.write = originalStdout;
+    process.stderr.write = originalStderr;
+  }
+}
+
+function assertLoopbackHost(host: string): void {
+  if (host === '127.0.0.1' || host === 'localhost' || host === '::1') return;
+  throw new Error(`refusing to bind non-loopback host: ${host}`);
+}

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -48,6 +48,7 @@ describe('kb CLI — argv parsing and dispatch', () => {
     for (const sub of [
       'list',
       'search',
+      'serve',
       'ask',
       'remember',
       'capture',
@@ -76,6 +77,7 @@ describe('kb CLI — argv parsing and dispatch', () => {
   describe.each([
     ['list', 'kb list'],
     ['search', 'kb search'],
+    ['serve', 'kb serve'],
     ['ask', 'kb ask'],
     ['remember', 'kb remember'],
     ['capture', 'kb capture'],
@@ -189,6 +191,11 @@ describe('kb CLI — argv parsing and dispatch', () => {
     const r = runCli(['search', 'q', '--threshold=notanumber']);
     expect(r.code).toBe(2);
     expect(r.stderr).toContain('invalid --threshold');
+  });
+
+  it('search with --daemon is accepted and falls back to direct mode when no daemon is listening', () => {
+    const r = runCli(['search', 'q', '--daemon']);
+    expect(r.stderr).not.toContain('unknown flag');
   });
 
   it('search with --threshold=auto is accepted by the parser', () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -21,10 +21,12 @@ import { MODELS_HELP, runModels } from './cli-models.js';
 import { PROMOTE_HELP, runPromote } from './cli-promote.js';
 import { REMEMBER_HELP, runRemember } from './cli-remember.js';
 import { SEARCH_HELP, runSearch } from './cli-search.js';
+import { SERVE_HELP, runServe } from './cli-serve.js';
 import { STALE_CHECK_HELP, runStaleCheck } from './cli-stale-check.js';
 import { STATS_HELP, runStats } from './cli-stats.js';
 import { SUPERSEDED_HELP, runSuperseded } from './cli-superseded.js';
 import { WHERE_HELP, runWhere } from './cli-where.js';
+import { tryRunDaemonCommand } from './daemon-client.js';
 
 // ----- Subcommand registry --------------------------------------------------
 
@@ -42,6 +44,7 @@ interface Subcommand {
 const SUBCOMMANDS: readonly Subcommand[] = [
   { name: 'list',         summary: 'List available knowledge bases.',                                         help: LIST_HELP,         handler: runList },
   { name: 'search',       summary: 'Semantic search across one or all knowledge bases.',                     help: SEARCH_HELP,       handler: runSearch },
+  { name: 'serve',        summary: 'Run a localhost daemon for warm read-only CLI requests.',                 help: SERVE_HELP,        handler: runServe },
   { name: 'ask',          summary: 'Answer from retrieved KB context using a local LLM endpoint.',            help: ASK_HELP,          handler: runAsk },
   { name: 'remember',     summary: 'Suggest, create, or append knowledge-base notes (write path).',          help: REMEMBER_HELP,     handler: runRemember },
   { name: 'capture',      summary: 'Run a command and append its stdout to a KB note as a fenced block.',    help: CAPTURE_HELP,      handler: runCapture },
@@ -83,6 +86,7 @@ Environment:
   FAISS_INDEX_PATH          Where FAISS stores per-model indexes.
   EMBEDDING_PROVIDER        ollama | openai | huggingface
   KB_ACTIVE_MODEL           Override the active model for this process (RFC 013 §4.7).
+  KB_DAEMON_URL             URL for \`kb search --daemon\` (default http://127.0.0.1:17799).
   KB_LLM_ENDPOINT           OpenAI-compatible endpoint used by \`kb ask\`.
   OLLAMA_*, OPENAI_*, HUGGINGFACE_*
                             Provider-specific config; see the provider's docs.
@@ -145,7 +149,29 @@ export async function main(argv: string[]): Promise<number> {
     return 0;
   }
 
+  if (sub === 'search') {
+    return runSearchMaybeViaDaemon(rest);
+  }
+
   return target.handler(rest);
+}
+
+async function runSearchMaybeViaDaemon(rest: string[]): Promise<number> {
+  const daemonIndex = rest.indexOf('--daemon');
+  if (daemonIndex === -1) return runSearch(rest);
+
+  const directRest = rest.filter((arg) => arg !== '--daemon');
+  if (directRest.includes('--refresh')) {
+    return runSearch(directRest);
+  }
+
+  const daemonResult = await tryRunDaemonCommand('search', directRest);
+  if (daemonResult === null) {
+    return runSearch(directRest);
+  }
+  if (daemonResult.stdout !== '') process.stdout.write(daemonResult.stdout);
+  if (daemonResult.stderr !== '') process.stderr.write(daemonResult.stderr);
+  return daemonResult.exitCode;
 }
 
 // ----- version --------------------------------------------------------------

--- a/src/daemon-client.test.ts
+++ b/src/daemon-client.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from '@jest/globals';
+import * as http from 'node:http';
+import type { AddressInfo } from 'node:net';
+import {
+  DaemonProtocolError,
+  daemonUrlFromEnv,
+  runDaemonCommand,
+  tryRunDaemonCommand,
+} from './daemon-client.js';
+
+async function withServer(
+  handler: http.RequestListener,
+  fn: (url: URL) => Promise<void>,
+): Promise<void> {
+  const server = http.createServer(handler);
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => resolve());
+  });
+  const address = server.address() as AddressInfo;
+  try {
+    await fn(new URL(`http://127.0.0.1:${address.port}`));
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+}
+
+describe('daemon client', () => {
+  it('builds a default loopback URL from env overrides', () => {
+    expect(daemonUrlFromEnv({ KB_DAEMON_PORT: '18888' }).href).toBe('http://127.0.0.1:18888/');
+    expect(daemonUrlFromEnv({ KB_DAEMON_URL: 'http://127.0.0.1:19999' }).href).toBe('http://127.0.0.1:19999/');
+  });
+
+  it('posts command requests and parses daemon output', async () => {
+    await withServer((req, res) => {
+      expect(req.method).toBe('POST');
+      expect(req.url).toBe('/v1/run');
+      const chunks: Buffer[] = [];
+      req.on('data', (chunk) => chunks.push(Buffer.from(chunk)));
+      req.on('end', () => {
+        expect(JSON.parse(Buffer.concat(chunks).toString('utf-8'))).toEqual({
+          command: 'search',
+          args: ['hello'],
+        });
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ exitCode: 0, stdout: 'ok\n', stderr: '' }));
+      });
+    }, async (url) => {
+      await expect(runDaemonCommand('search', ['hello'], { env: { KB_DAEMON_URL: url.href } }))
+        .resolves.toEqual({ exitCode: 0, stdout: 'ok\n', stderr: '' });
+    });
+  });
+
+  it('returns null from tryRunDaemonCommand when the daemon is unreachable', async () => {
+    const result = await tryRunDaemonCommand('search', ['q'], {
+      env: { KB_DAEMON_URL: 'http://127.0.0.1:17798' },
+      timeoutMs: 50,
+    });
+    expect(result).toBeNull();
+  });
+
+  it('treats malformed daemon payloads as protocol errors', async () => {
+    await withServer((_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ stdout: 'missing exitCode', stderr: '' }));
+    }, async (url) => {
+      await expect(runDaemonCommand('search', ['q'], { env: { KB_DAEMON_URL: url.href } }))
+        .rejects.toBeInstanceOf(DaemonProtocolError);
+    });
+  });
+});

--- a/src/daemon-client.ts
+++ b/src/daemon-client.ts
@@ -1,0 +1,116 @@
+export interface DaemonRunResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+export type DaemonCommand = 'search' | 'list' | 'stats';
+
+export interface DaemonClientOptions {
+  env?: NodeJS.ProcessEnv;
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+}
+
+export class DaemonUnavailableError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'DaemonUnavailableError';
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+export class DaemonProtocolError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'DaemonProtocolError';
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+export function daemonUrlFromEnv(env: NodeJS.ProcessEnv = process.env): URL {
+  if (env.KB_DAEMON_URL !== undefined && env.KB_DAEMON_URL.trim() !== '') {
+    return new URL(env.KB_DAEMON_URL);
+  }
+  const host = env.KB_DAEMON_HOST?.trim() || '127.0.0.1';
+  const portRaw = env.KB_DAEMON_PORT?.trim() || '17799';
+  const port = Number(portRaw);
+  if (!Number.isInteger(port) || port <= 0 || port > 65535) {
+    throw new DaemonProtocolError(`invalid KB_DAEMON_PORT: ${portRaw}`);
+  }
+  return new URL(`http://${host}:${port}`);
+}
+
+export async function tryRunDaemonCommand(
+  command: DaemonCommand,
+  args: string[],
+  options: DaemonClientOptions = {},
+): Promise<DaemonRunResult | null> {
+  try {
+    return await runDaemonCommand(command, args, options);
+  } catch (err) {
+    if (err instanceof DaemonUnavailableError) return null;
+    throw err;
+  }
+}
+
+export async function runDaemonCommand(
+  command: DaemonCommand,
+  args: string[],
+  options: DaemonClientOptions = {},
+): Promise<DaemonRunResult> {
+  const baseUrl = daemonUrlFromEnv(options.env);
+  const endpoint = new URL('/v1/run', baseUrl);
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), options.timeoutMs ?? 1500);
+  try {
+    const response = await fetchImpl(endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ command, args }),
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      const text = await response.text().catch(() => '');
+      throw new DaemonProtocolError(`daemon returned HTTP ${response.status}${text ? `: ${text}` : ''}`);
+    }
+    const payload = await response.json();
+    return parseDaemonRunResult(payload);
+  } catch (err) {
+    if (err instanceof DaemonProtocolError) throw err;
+    const code = (err as NodeJS.ErrnoException | undefined)?.code;
+    if (
+      code === 'ECONNREFUSED' ||
+      code === 'ECONNRESET' ||
+      code === 'ENOTFOUND' ||
+      code === 'EHOSTUNREACH' ||
+      (err as Error | undefined)?.name === 'AbortError' ||
+      (err as Error | undefined)?.name === 'TypeError'
+    ) {
+      throw new DaemonUnavailableError(`kb daemon is not reachable at ${endpoint.href}`, { cause: err });
+    }
+    throw err;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function parseDaemonRunResult(payload: unknown): DaemonRunResult {
+  if (typeof payload !== 'object' || payload === null) {
+    throw new DaemonProtocolError('daemon returned a non-object payload');
+  }
+  const obj = payload as Partial<DaemonRunResult>;
+  const exitCode = obj.exitCode;
+  if (!Number.isInteger(exitCode)) {
+    throw new DaemonProtocolError('daemon response missing integer exitCode');
+  }
+  if (typeof obj.stdout !== 'string' || typeof obj.stderr !== 'string') {
+    throw new DaemonProtocolError('daemon response missing stdout/stderr strings');
+  }
+  return {
+    exitCode: exitCode as number,
+    stdout: obj.stdout,
+    stderr: obj.stderr,
+  };
+}


### PR DESCRIPTION
## Summary
- add `kb serve` as a localhost-only resident JSON daemon for read-only CLI commands
- add daemon client plumbing and `kb search --daemon` dispatch with direct fallback when no daemon is reachable
- cover daemon protocol, read-only rejection, and CLI help/dispatch behavior

Closes #282

## Tests
- `npm run build`
- `npm test -- src/cli-serve.test.ts src/daemon-client.test.ts /home/jean/git/knowledge-base-mcp-server/src/cli.test.ts` (Jest matched the two worktree-relative daemon tests; the parent absolute path did not select `cli.test.ts` from this worktree)
- `npm test -- src/cli-serve.test.ts src/daemon-client.test.ts src/cli.test.ts`
- `npm test`

## Pre-PR review
- build: passed
- tests: passed
- diff review: done
- portability: manual scan clean; `scripts/check-portability.sh` is not present in this repo
- reviewer specialists: skipped because this environment only permits spawning subagents when explicitly requested by the user