### PR TITLE
feat(search): add freshness staleness manifest

### DIFF
--- a/src/FaissIndexManager.ts
+++ b/src/FaissIndexManager.ts
@@ -34,6 +34,7 @@ import {
   resolveActiveIndexFilePath as resolveActiveIndexFilePathFromLayout,
   saveFaissStoreAtomic,
 } from './faiss-store-layout.js';
+import { writeFreshnessManifest } from './freshness-manifest.js';
 import {
   createSimilaritySearchPostFilter,
   type ScoredDocument,
@@ -926,6 +927,21 @@ export class FaissIndexManager {
           recordFailure(null, 'sidecar', sidecarError);
           throw sidecarError;
         }
+      }
+      try {
+        const activeIndexFilePath = await this.resolveActiveIndexFilePath();
+        if (activeIndexFilePath !== null) {
+          const indexStat = await fsp.stat(activeIndexFilePath);
+          await writeFreshnessManifest({
+            modelId: this.modelId,
+            modelDir: this.modelDir,
+            indexMtimeMs: indexStat.mtimeMs,
+          });
+        }
+      } catch (manifestError: unknown) {
+        logger.warn(
+          `Could not write freshness manifest for ${this.modelId}: ${toError(manifestError).message}`,
+        );
       }
       logger.debug('FAISS index update process completed.');
       runSummary.status = runSummary.failure_count > 0 ? 'partial' : 'success';

--- a/src/cli-search-staleness.test.ts
+++ b/src/cli-search-staleness.test.ts
@@ -3,6 +3,7 @@ import * as fsp from 'fs/promises';
 import * as os from 'os';
 import * as path from 'path';
 import { buildAgeBudgetFooter } from './cli-search-staleness.js';
+import { writeFreshnessManifest } from './freshness-manifest.js';
 
 const ORIGINAL_ENV = {
   KNOWLEDGE_BASES_ROOT_DIR: process.env.KNOWLEDGE_BASES_ROOT_DIR,
@@ -81,6 +82,59 @@ describe('computeStaleness', () => {
       await fsp.rm(tempDir, { recursive: true, force: true });
     }
   }, 30_000);
+
+  it('uses a valid freshness manifest without walking the KB tree', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-search-manifest-'));
+    try {
+      const kbRoot = path.join(tempDir, 'kbs');
+      const faissDir = path.join(tempDir, '.faiss');
+      const modelId = 'ollama__manifest-stale-test';
+      process.env.KNOWLEDGE_BASES_ROOT_DIR = kbRoot;
+      process.env.FAISS_INDEX_PATH = faissDir;
+
+      const indexBinaryPath = path.join(
+        faissDir,
+        'models',
+        modelId,
+        'faiss.index',
+        'faiss.index',
+      );
+      await fsp.mkdir(path.dirname(indexBinaryPath), { recursive: true });
+      await fsp.writeFile(indexBinaryPath, 'index', 'utf-8');
+
+      const alphaModified = path.join(kbRoot, 'alpha', 'modified.md');
+      const betaNew = path.join(kbRoot, 'beta', 'new.md');
+      await fsp.mkdir(path.dirname(alphaModified), { recursive: true });
+      await fsp.mkdir(path.dirname(betaNew), { recursive: true });
+      await fsp.writeFile(alphaModified, '# Alpha modified\n', 'utf-8');
+      await fsp.writeFile(betaNew, '# Beta new\n', 'utf-8');
+
+      const indexTime = new Date('2026-05-03T15:30:00.000Z');
+      const afterIndex = new Date('2026-05-03T16:00:00.000Z');
+      await fsp.utimes(indexBinaryPath, indexTime, indexTime);
+      await fsp.utimes(alphaModified, afterIndex, afterIndex);
+      await fsp.utimes(betaNew, indexTime, indexTime);
+
+      await writeFreshnessManifest({
+        modelId,
+        modelDir: path.join(faissDir, 'models', modelId),
+        kbRootDir: kbRoot,
+        indexMtimeMs: indexTime.getTime(),
+      });
+      await fsp.rm(kbRoot, { recursive: true, force: true });
+
+      jest.resetModules();
+      const { computeStaleness } = await import('./cli-search.js');
+      await expect(computeStaleness(modelId, 'alpha')).resolves.toMatchObject({
+        modifiedFiles: 1,
+        newFiles: 1,
+        scope: { kb: 'alpha', modifiedFiles: 1, newFiles: 1 },
+        global: { modifiedFiles: 1, newFiles: 2 },
+      });
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('buildAgeBudgetFooter (issue #218)', () => {

--- a/src/cli-search.ts
+++ b/src/cli-search.ts
@@ -30,6 +30,7 @@ import { enumerateIngestableKbFiles, listKnowledgeBases } from './kb-fs.js';
 import { mapBounded, resolveFsConcurrency } from './bounded-concurrency.js';
 import { withWriteLock } from './write-lock.js';
 import { loadManagerForModel, loadWithJsonRetry } from './cli-shared.js';
+import { readFreshnessManifest } from './freshness-manifest.js';
 import {
   compactTimingPayload,
   elapsedMs,
@@ -470,6 +471,15 @@ export async function computeStaleness(modelId: string, scopedKb?: string): Prom
   }
   const indexMtimeMs = indexStat.mtimeMs;
   const indexMtime = new Date(indexMtimeMs).toISOString();
+  const manifest = await readFreshnessManifest({
+    modelId,
+    modelDir: path.dirname(path.dirname(binaryPath)),
+    indexMtimeMs,
+  });
+  if (manifest !== null) {
+    const fromManifest = stalenessFromManifest(manifest, indexMtime, scopedKb);
+    if (fromManifest !== null) return fromManifest;
+  }
 
   let kbs: string[];
   try {
@@ -550,6 +560,37 @@ function emptyStaleness(indexMtime: string | null, scopedKb?: string): Staleness
     newFiles: 0,
     scope: { kb: scopedKb, modifiedFiles: 0, newFiles: 0 },
     global: { modifiedFiles: 0, newFiles: 0 },
+  };
+}
+
+function stalenessFromManifest(
+  manifest: Awaited<ReturnType<typeof readFreshnessManifest>>,
+  indexMtime: string,
+  scopedKb?: string,
+): Staleness | null {
+  if (manifest === null) return null;
+  const global = Object.values(manifest.kbs).reduce<StalenessCounts>(
+    (counts, entry) => ({
+      modifiedFiles: counts.modifiedFiles + entry.modified_files,
+      newFiles: counts.newFiles + entry.new_files,
+    }),
+    { modifiedFiles: 0, newFiles: 0 },
+  );
+  if (!scopedKb) {
+    return { indexMtime, modifiedFiles: global.modifiedFiles, newFiles: global.newFiles };
+  }
+  const scopedEntry = manifest.kbs[scopedKb];
+  if (scopedEntry === undefined) return null;
+  const scopeCounts = {
+    modifiedFiles: scopedEntry.modified_files,
+    newFiles: scopedEntry.new_files,
+  };
+  return {
+    indexMtime,
+    modifiedFiles: scopeCounts.modifiedFiles,
+    newFiles: scopeCounts.newFiles,
+    scope: { kb: scopedKb, ...scopeCounts },
+    global,
   };
 }
 

--- a/src/freshness-manifest.test.ts
+++ b/src/freshness-manifest.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, describe, expect, it } from '@jest/globals';
+import * as fsp from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  computeFreshnessManifestFilterHash,
+  freshnessManifestPath,
+  readFreshnessManifest,
+  writeFreshnessManifest,
+} from './freshness-manifest.js';
+
+const TEMP_DIRS: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(TEMP_DIRS.splice(0).map((dir) => fsp.rm(dir, { recursive: true, force: true })));
+});
+
+describe('freshness manifest', () => {
+  it('persists per-KB stale counts beside the model index', async () => {
+    const tempDir = await mkTempDir();
+    const kbRoot = path.join(tempDir, 'kbs');
+    const modelDir = path.join(tempDir, '.faiss', 'models', 'huggingface__test');
+    const indexMtimeMs = Date.parse('2026-05-03T15:30:00.000Z');
+    const beforeIndex = new Date('2026-05-03T15:00:00.000Z');
+    const afterIndex = new Date('2026-05-03T16:00:00.000Z');
+
+    const alphaFresh = path.join(kbRoot, 'alpha', 'fresh.md');
+    const alphaModified = path.join(kbRoot, 'alpha', 'modified.md');
+    const betaNew = path.join(kbRoot, 'beta', 'new.md');
+    await fsp.mkdir(path.dirname(alphaFresh), { recursive: true });
+    await fsp.mkdir(path.dirname(betaNew), { recursive: true });
+    await fsp.writeFile(alphaFresh, '# fresh\n', 'utf-8');
+    await fsp.writeFile(alphaModified, '# modified\n', 'utf-8');
+    await fsp.writeFile(betaNew, '# beta\n', 'utf-8');
+    await fsp.utimes(alphaFresh, beforeIndex, beforeIndex);
+    await fsp.utimes(alphaModified, afterIndex, afterIndex);
+    await fsp.utimes(betaNew, beforeIndex, beforeIndex);
+    await fsp.mkdir(path.join(kbRoot, 'alpha', '.index'), { recursive: true });
+    await fsp.writeFile(path.join(kbRoot, 'alpha', '.index', 'fresh.md'), 'hash', 'utf-8');
+
+    const manifest = await writeFreshnessManifest({
+      modelId: 'huggingface__test',
+      modelDir,
+      kbRootDir: kbRoot,
+      indexMtimeMs,
+      now: new Date('2026-05-03T16:30:00.000Z'),
+    });
+
+    expect(manifest.kbs.alpha).toEqual({
+      file_count: 2,
+      sidecar_count: 1,
+      modified_files: 1,
+      new_files: 1,
+      last_scan_at: '2026-05-03T16:30:00.000Z',
+    });
+    expect(manifest.kbs.beta).toMatchObject({
+      file_count: 1,
+      sidecar_count: 0,
+      modified_files: 0,
+      new_files: 1,
+    });
+    await expect(fsp.stat(freshnessManifestPath(modelDir))).resolves.toMatchObject({
+      isFile: expect.any(Function),
+    });
+  });
+
+  it('invalidates when ingest-filter config changes', async () => {
+    const tempDir = await mkTempDir();
+    const kbRoot = path.join(tempDir, 'kbs');
+    const modelDir = path.join(tempDir, '.faiss', 'models', 'huggingface__test');
+    const docPath = path.join(kbRoot, 'alpha', 'doc.md');
+    await fsp.mkdir(path.dirname(docPath), { recursive: true });
+    await fsp.writeFile(docPath, '# doc\n', 'utf-8');
+
+    await writeFreshnessManifest({
+      modelId: 'huggingface__test',
+      modelDir,
+      kbRootDir: kbRoot,
+      indexMtimeMs: 1000,
+      filterConfig: { extraExtensions: [], excludePaths: [] },
+    });
+
+    await expect(readFreshnessManifest({
+      modelId: 'huggingface__test',
+      modelDir,
+      kbRootDir: kbRoot,
+      indexMtimeMs: 1000,
+      filterConfig: { extraExtensions: ['.adoc'], excludePaths: [] },
+    })).resolves.toBeNull();
+  });
+
+  it('invalidates when the requested model or index mtime changes', async () => {
+    const tempDir = await mkTempDir();
+    const kbRoot = path.join(tempDir, 'kbs');
+    const modelDir = path.join(tempDir, '.faiss', 'models', 'huggingface__test');
+    const docPath = path.join(kbRoot, 'alpha', 'doc.md');
+    await fsp.mkdir(path.dirname(docPath), { recursive: true });
+    await fsp.writeFile(docPath, '# doc\n', 'utf-8');
+
+    await writeFreshnessManifest({
+      modelId: 'huggingface__test',
+      modelDir,
+      kbRootDir: kbRoot,
+      indexMtimeMs: 1000,
+    });
+
+    await expect(readFreshnessManifest({
+      modelId: 'huggingface__other',
+      modelDir,
+      kbRootDir: kbRoot,
+      indexMtimeMs: 1000,
+    })).resolves.toBeNull();
+    await expect(readFreshnessManifest({
+      modelId: 'huggingface__test',
+      modelDir,
+      kbRootDir: kbRoot,
+      indexMtimeMs: 2000,
+    })).resolves.toBeNull();
+  });
+
+  it('hashes filter config deterministically', () => {
+    expect(computeFreshnessManifestFilterHash({
+      extraExtensions: ['.adoc'],
+      excludePaths: ['drafts/**'],
+    })).toBe(computeFreshnessManifestFilterHash({
+      extraExtensions: ['.adoc'],
+      excludePaths: ['drafts/**'],
+    }));
+    expect(computeFreshnessManifestFilterHash({
+      extraExtensions: ['.mdx'],
+      excludePaths: ['drafts/**'],
+    })).not.toBe(computeFreshnessManifestFilterHash({
+      extraExtensions: ['.adoc'],
+      excludePaths: ['drafts/**'],
+    }));
+  });
+});
+
+async function mkTempDir(): Promise<string> {
+  const dir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-freshness-manifest-'));
+  TEMP_DIRS.push(dir);
+  return dir;
+}

--- a/src/freshness-manifest.ts
+++ b/src/freshness-manifest.ts
@@ -1,0 +1,237 @@
+import * as crypto from 'crypto';
+import * as fsp from 'fs/promises';
+import * as path from 'path';
+import {
+  INGEST_EXCLUDE_PATHS,
+  INGEST_EXTRA_EXTENSIONS,
+  KNOWLEDGE_BASES_ROOT_DIR,
+} from './config.js';
+import { enumerateIngestableKbFiles, listKnowledgeBases } from './kb-fs.js';
+
+export const FRESHNESS_MANIFEST_SCHEMA_VERSION = 'kb.freshness-manifest.v1';
+export const FRESHNESS_MANIFEST_FILE = 'freshness.json';
+
+export interface FreshnessManifestFilterConfig {
+  extraExtensions: readonly string[];
+  excludePaths: readonly string[];
+}
+
+export interface FreshnessManifestKbEntry {
+  file_count: number;
+  sidecar_count: number;
+  modified_files: number;
+  new_files: number;
+  last_scan_at: string;
+}
+
+export interface FreshnessManifest {
+  schema_version: typeof FRESHNESS_MANIFEST_SCHEMA_VERSION;
+  model_id: string;
+  kb_root: string;
+  index_mtime: string;
+  index_mtime_ms: number;
+  filter_hash: string;
+  filter: {
+    extra_extensions: string[];
+    exclude_paths: string[];
+  };
+  complete: boolean;
+  kbs: Record<string, FreshnessManifestKbEntry>;
+}
+
+export interface WriteFreshnessManifestInput {
+  modelId: string;
+  modelDir: string;
+  indexMtimeMs: number;
+  kbRootDir?: string;
+  filterConfig?: FreshnessManifestFilterConfig;
+  now?: Date;
+}
+
+export interface ReadFreshnessManifestInput {
+  modelId: string;
+  modelDir: string;
+  indexMtimeMs: number;
+  kbRootDir?: string;
+  filterConfig?: FreshnessManifestFilterConfig;
+}
+
+export function freshnessManifestPath(modelDir: string): string {
+  return path.join(modelDir, FRESHNESS_MANIFEST_FILE);
+}
+
+export function computeFreshnessManifestFilterHash(
+  config: FreshnessManifestFilterConfig = defaultFilterConfig(),
+): string {
+  return crypto
+    .createHash('sha256')
+    .update(JSON.stringify(normalizeFilterConfig(config)))
+    .digest('hex');
+}
+
+export async function writeFreshnessManifest(
+  input: WriteFreshnessManifestInput,
+): Promise<FreshnessManifest> {
+  const kbRootDir = input.kbRootDir ?? KNOWLEDGE_BASES_ROOT_DIR;
+  const filterConfig = input.filterConfig ?? defaultFilterConfig();
+  const normalizedFilter = normalizeFilterConfig(filterConfig);
+  const filterHash = computeFreshnessManifestFilterHash(filterConfig);
+  const indexMtime = new Date(input.indexMtimeMs).toISOString();
+  const scanTime = (input.now ?? new Date()).toISOString();
+  const kbs = await listKnowledgeBases(kbRootDir);
+  const enumerations = await enumerateIngestableKbFiles(kbRootDir, kbs, {
+    extraExtensions: normalizedFilter.extraExtensions,
+    excludePaths: normalizedFilter.excludePaths,
+  });
+  const entries: Record<string, FreshnessManifestKbEntry> = {};
+
+  for (const { kbName, kbPath, filePaths } of enumerations) {
+    let modifiedFiles = 0;
+    for (const filePath of filePaths) {
+      try {
+        const st = await fsp.stat(filePath);
+        if (st.mtimeMs > input.indexMtimeMs) modifiedFiles += 1;
+      } catch {
+        // File vanished between enumeration and stat; ignore it.
+      }
+    }
+    const sidecarCount = await countSidecarFiles(path.join(kbPath, '.index'));
+    entries[kbName] = {
+      file_count: filePaths.length,
+      sidecar_count: sidecarCount,
+      modified_files: modifiedFiles,
+      new_files: Math.max(0, filePaths.length - sidecarCount),
+      last_scan_at: scanTime,
+    };
+  }
+
+  const manifest: FreshnessManifest = {
+    schema_version: FRESHNESS_MANIFEST_SCHEMA_VERSION,
+    model_id: input.modelId,
+    kb_root: kbRootDir,
+    index_mtime: indexMtime,
+    index_mtime_ms: input.indexMtimeMs,
+    filter_hash: filterHash,
+    filter: {
+      extra_extensions: [...normalizedFilter.extraExtensions],
+      exclude_paths: [...normalizedFilter.excludePaths],
+    },
+    complete: true,
+    kbs: entries,
+  };
+
+  await writeJsonAtomic(freshnessManifestPath(input.modelDir), manifest);
+  return manifest;
+}
+
+export async function readFreshnessManifest(
+  input: ReadFreshnessManifestInput,
+): Promise<FreshnessManifest | null> {
+  let raw: string;
+  try {
+    raw = await fsp.readFile(freshnessManifestPath(input.modelDir), 'utf-8');
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException | undefined)?.code;
+    if (code === 'ENOENT' || code === 'ENOTDIR') return null;
+    return null;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!isFreshnessManifest(parsed)) return null;
+
+  const kbRootDir = input.kbRootDir ?? KNOWLEDGE_BASES_ROOT_DIR;
+  const expectedFilterHash = computeFreshnessManifestFilterHash(
+    input.filterConfig ?? defaultFilterConfig(),
+  );
+  if (parsed.model_id !== input.modelId) return null;
+  if (parsed.kb_root !== kbRootDir) return null;
+  if (parsed.filter_hash !== expectedFilterHash) return null;
+  if (Math.abs(parsed.index_mtime_ms - input.indexMtimeMs) >= 1) return null;
+  return parsed;
+}
+
+export async function countSidecarFiles(dir: string): Promise<number> {
+  let entries;
+  try {
+    entries = await fsp.readdir(dir, { withFileTypes: true });
+  } catch {
+    return 0;
+  }
+  let count = 0;
+  for (const entry of entries) {
+    const entryPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      count += await countSidecarFiles(entryPath);
+    } else if (entry.isFile()) {
+      count += 1;
+    }
+  }
+  return count;
+}
+
+function defaultFilterConfig(): FreshnessManifestFilterConfig {
+  return {
+    extraExtensions: INGEST_EXTRA_EXTENSIONS,
+    excludePaths: INGEST_EXCLUDE_PATHS,
+  };
+}
+
+function normalizeFilterConfig(
+  config: FreshnessManifestFilterConfig,
+): { extraExtensions: string[]; excludePaths: string[] } {
+  return {
+    extraExtensions: [...config.extraExtensions],
+    excludePaths: [...config.excludePaths],
+  };
+}
+
+function isFreshnessManifest(value: unknown): value is FreshnessManifest {
+  if (!isRecord(value)) return false;
+  if (value.schema_version !== FRESHNESS_MANIFEST_SCHEMA_VERSION) return false;
+  if (typeof value.model_id !== 'string') return false;
+  if (typeof value.kb_root !== 'string') return false;
+  if (typeof value.index_mtime !== 'string') return false;
+  if (typeof value.index_mtime_ms !== 'number') return false;
+  if (typeof value.filter_hash !== 'string') return false;
+  if (!isRecord(value.filter)) return false;
+  if (!isStringArray(value.filter.extra_extensions)) return false;
+  if (!isStringArray(value.filter.exclude_paths)) return false;
+  if (value.complete !== true) return false;
+  if (!isRecord(value.kbs)) return false;
+  return Object.values(value.kbs).every(isFreshnessManifestKbEntry);
+}
+
+function isFreshnessManifestKbEntry(value: unknown): value is FreshnessManifestKbEntry {
+  if (!isRecord(value)) return false;
+  return (
+    isNonNegativeInteger(value.file_count) &&
+    isNonNegativeInteger(value.sidecar_count) &&
+    isNonNegativeInteger(value.modified_files) &&
+    isNonNegativeInteger(value.new_files) &&
+    typeof value.last_scan_at === 'string'
+  );
+}
+
+function isNonNegativeInteger(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 0;
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((entry) => typeof entry === 'string');
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+async function writeJsonAtomic(targetPath: string, value: unknown): Promise<void> {
+  await fsp.mkdir(path.dirname(targetPath), { recursive: true });
+  const tmpPath = `${targetPath}.${process.pid}.${Date.now()}.tmp`;
+  await fsp.writeFile(tmpPath, `${JSON.stringify(value, null, 2)}\n`, 'utf-8');
+  await fsp.rename(tmpPath, targetPath);
+}


### PR DESCRIPTION
## Summary
- add per-model `freshness.json` manifests with schema/model/index/filter validation
- have `kb search` staleness read a valid manifest before falling back to the full source/sidecar walk
- refresh manifests after `updateIndex` and add a CLI-search staleness benchmark scenario

Closes #277.

## Tests
- `npm test -- src/freshness-manifest.test.ts src/cli-search-staleness.test.ts src/cli-search.test.ts benchmarks/scenarios/cli-search.test.ts`
- `npm run build`
- `npx tsc -p tsconfig.bench.json`
- `npm test`

## Pre-PR review
- detected project type: npm
- type/build checks: passed (`npm run build`, `npx tsc -p tsconfig.bench.json`)
- tests: passed (`npm test`)
- portability/diff hygiene: clean
- reviewer subagents: skipped because this Codex session only permits subagents when explicitly requested