### PR TITLE
feat(logging): emit canonical call log lines

### DIFF
--- a/docs/architecture/adr/0007-canonical-log-line-format.md
+++ b/docs/architecture/adr/0007-canonical-log-line-format.md
@@ -1,0 +1,55 @@
+# 0007 - Canonical log line format
+
+- **Status:** Accepted (#216)
+- **Date:** 2026-05-12
+- **Deciders:** Repo owner
+
+## Context and Problem Statement
+
+The MCP server and `kb` CLI have historically emitted human-readable log
+fragments. Those fragments are useful at a terminal, but they cannot answer
+request-shaped questions such as "which retrieve calls timed out?", "what was
+the p99 latency for this model?", or "which KB scope produced empty results?"
+without reconstructing state from multiple unrelated lines.
+
+The project is local-first and stdout-sensitive: MCP JSON-RPC must stay on
+stdout, and observability should not introduce a metrics endpoint, exporter, or
+new runtime service.
+
+## Decision
+
+Emit one schema-versioned JSON event at the end of each MCP tool call and each
+dispatched `kb` subcommand invocation.
+
+The event uses `schema_version: "kb-canonical.v1"` and is written through the
+existing logger destinations: `LOG_FILE` when configured and stderr otherwise.
+It never writes to stdout. The event contains stable request fields such as
+`request_id`, `process`, `tool` or `cmd`, `model_id`, `kb_scope`,
+`query_sha256`, `result_count`, `top_score`, `top_sources`, timing fields, and
+an optional `{ code, category }` error object.
+
+Queries are redacted by default. The raw query is never serialized; only a
+16-character SHA-256 prefix of the whitespace-normalized query is emitted.
+`top_sources` is capped at three entries to bound line size and cardinality.
+
+Operators choose log output with `KB_LOG_FORMAT=text|canonical|both`. The
+default is `both`. `text` preserves legacy human-readable output, while
+`canonical` emits only canonical JSON lines.
+
+## Consequences
+
+- Existing JSON-RPC response shapes are unchanged.
+- Existing logger destinations and `LOG_FILE` setup remain the only transport.
+- Downstream scripts can rely on additive evolution within `kb-canonical.v1`.
+- High-volume users need normal file log rotation if `LOG_FILE` is enabled.
+
+## Validation
+
+The validation gate for #216 is:
+
+1. `KB_LOG_FORMAT=text` suppresses canonical events and keeps text logging.
+2. `KB_LOG_FORMAT=canonical` writes only JSON canonical events.
+3. Canonical events never include the raw query string.
+4. MCP retrieve emits exactly one canonical event with model, scope, count,
+   top score/source, and timing fields.
+5. CLI subcommands emit exactly one invocation event from the central dispatcher.

--- a/src/KnowledgeBaseServer.test.ts
+++ b/src/KnowledgeBaseServer.test.ts
@@ -78,6 +78,7 @@ describe('KnowledgeBaseServer handlers', () => {
     EMBEDDING_PROVIDER: process.env.EMBEDDING_PROVIDER,
     HUGGINGFACE_API_KEY: process.env.HUGGINGFACE_API_KEY,
     LOG_FILE: process.env.LOG_FILE,
+    KB_LOG_FORMAT: process.env.KB_LOG_FORMAT,
     RETRIEVE_KNOWLEDGE_DESCRIPTION: process.env.RETRIEVE_KNOWLEDGE_DESCRIPTION,
     LIST_KNOWLEDGE_BASES_DESCRIPTION: process.env.LIST_KNOWLEDGE_BASES_DESCRIPTION,
   };
@@ -91,6 +92,7 @@ describe('KnowledgeBaseServer handlers', () => {
     hasLoadedIndexMock.mockReturnValue(true);
     getStatsMock.mockReset();
     getStatsMock.mockReturnValue({ totalChunks: 0, chunkCountsByKb: {}, dim: null });
+    process.env.KB_LOG_FORMAT = 'text';
     getLastIndexUpdateSummaryMock.mockReset();
     getLastIndexUpdateSummaryMock.mockReturnValue({
       status: 'never_run',
@@ -163,6 +165,16 @@ describe('KnowledgeBaseServer handlers', () => {
       }
       throw error;
     }
+  }
+
+  async function readCanonicalEvents(logFile: string): Promise<Array<Record<string, any>>> {
+    await new Promise((resolve) => setImmediate(resolve));
+    const contents = await fsp.readFile(logFile, 'utf-8');
+    return contents
+      .trim()
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => JSON.parse(line));
   }
 
   // --- handleListKnowledgeBases ---------------------------------------------
@@ -1036,6 +1048,44 @@ describe('KnowledgeBaseServer handlers', () => {
     expect(text.indexOf('**Result 1:**')).toBeLessThan(text.indexOf('**Result 2:**'));
   });
 
+  it('handleRetrieveKnowledge emits one canonical event with redacted query and result fields (#216)', async () => {
+    const tempDir = await setRetrieveEnv();
+    const logFile = path.join(tempDir, 'canonical.log');
+    process.env.LOG_FILE = logFile;
+    process.env.KB_LOG_FORMAT = 'canonical';
+    updateIndexMock.mockResolvedValue(undefined);
+    similaritySearchMock.mockResolvedValue([
+      { pageContent: 'Alpha content', metadata: { source: '/kb/a.md' }, score: 0.129876 },
+      { pageContent: 'Beta content', metadata: { source: '/kb/b.md' }, score: 0.34567 },
+    ]);
+
+    const server = await freshServer();
+    const result = await server['handleRetrieveKnowledge']({
+      query: 'raw private query',
+      knowledge_base_name: 'alpha',
+      threshold: 0.75,
+    });
+
+    expect(result.isError).toBeUndefined();
+    const events = await readCanonicalEvents(logFile);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      schema_version: 'kb-canonical.v1',
+      process: 'mcp',
+      tool: 'retrieve_knowledge',
+      model_id: 'huggingface__BAAI-bge-small-en-v1.5',
+      kb_scope: 'alpha',
+      k: 10,
+      threshold: 0.75,
+      search_mode: 'dense',
+      result_count: 2,
+      top_score: 0.129876,
+      top_sources: ['/kb/a.md', '/kb/b.md'],
+    });
+    expect(events[0].query_sha256).toMatch(/^[a-f0-9]{16}$/);
+    expect(JSON.stringify(events[0])).not.toContain('raw private query');
+  });
+
   it('handleRetrieveKnowledge returns "_No similar results found._" when similaritySearch returns []', async () => {
     await setRetrieveEnv();
     updateIndexMock.mockResolvedValue(undefined);
@@ -1118,6 +1168,32 @@ describe('KnowledgeBaseServer handlers', () => {
     });
   });
 
+  it('handleRetrieveKnowledge emits canonical errors with RFC 009 category mapping (#216)', async () => {
+    const tempDir = await setRetrieveEnv();
+    const logFile = path.join(tempDir, 'canonical-error.log');
+    process.env.LOG_FILE = logFile;
+    process.env.KB_LOG_FORMAT = 'canonical';
+
+    const server = await freshServer();
+    const { KBError } = await import('./errors.js');
+    updateIndexMock.mockRejectedValue(new KBError('PROVIDER_TIMEOUT', 'provider timed out'));
+
+    const result = await server['handleRetrieveKnowledge']({ query: 'q' });
+
+    expect(result.isError).toBe(true);
+    const events = await readCanonicalEvents(logFile);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      schema_version: 'kb-canonical.v1',
+      process: 'mcp',
+      tool: 'retrieve_knowledge',
+      error: {
+        code: 'PROVIDER_TIMEOUT',
+        category: 'provider',
+      },
+    });
+  });
+
   it('threshold argument flows through to similaritySearch(query, 10, threshold, kb, filters)', async () => {
     await setRetrieveEnv();
     updateIndexMock.mockResolvedValue(undefined);
@@ -1126,10 +1202,10 @@ describe('KnowledgeBaseServer handlers', () => {
     const server = await freshServer();
 
     await server['handleRetrieveKnowledge']({ query: 'q', threshold: 0.5 });
-    expect(similaritySearchMock).toHaveBeenLastCalledWith('q', 10, 0.5, undefined, undefined);
+    expect(similaritySearchMock).toHaveBeenLastCalledWith('q', 10, 0.5, undefined, undefined, expect.any(Object));
 
     await server['handleRetrieveKnowledge']({ query: 'q' });
-    expect(similaritySearchMock).toHaveBeenLastCalledWith('q', 10, undefined, undefined, undefined);
+    expect(similaritySearchMock).toHaveBeenLastCalledWith('q', 10, undefined, undefined, undefined, expect.any(Object));
 
     expect(similaritySearchMock).toHaveBeenCalledTimes(2);
   });
@@ -1142,14 +1218,14 @@ describe('KnowledgeBaseServer handlers', () => {
     const server = await freshServer();
 
     await server['handleRetrieveKnowledge']({ query: 'q', knowledge_base_name: 'alpha' });
-    expect(similaritySearchMock).toHaveBeenLastCalledWith('q', 10, undefined, 'alpha', undefined);
+    expect(similaritySearchMock).toHaveBeenLastCalledWith('q', 10, undefined, 'alpha', undefined, expect.any(Object));
 
     await server['handleRetrieveKnowledge']({
       query: 'q',
       knowledge_base_name: 'alpha',
       threshold: 0.25,
     });
-    expect(similaritySearchMock).toHaveBeenLastCalledWith('q', 10, 0.25, 'alpha', undefined);
+    expect(similaritySearchMock).toHaveBeenLastCalledWith('q', 10, 0.25, 'alpha', undefined, expect.any(Object));
   });
 
   it('handleRetrieveKnowledge forwards extensions / path_glob / tags filters (#53)', async () => {
@@ -1171,6 +1247,7 @@ describe('KnowledgeBaseServer handlers', () => {
       undefined,
       undefined,
       { extensions: ['.md'], pathGlob: 'runbooks/**', tags: ['ops', 'oncall'] },
+      expect.any(Object),
     );
 
     await server['handleRetrieveKnowledge']({ query: 'q', extensions: ['.pdf'] });
@@ -1180,6 +1257,7 @@ describe('KnowledgeBaseServer handlers', () => {
       undefined,
       undefined,
       { extensions: ['.pdf'], pathGlob: undefined, tags: undefined },
+      expect.any(Object),
     );
   });
 

--- a/src/KnowledgeBaseServer.ts
+++ b/src/KnowledgeBaseServer.ts
@@ -9,7 +9,7 @@ import {
   type TextContent,
 } from '@modelcontextprotocol/sdk/types.js';
 import { FaissIndexManager } from './FaissIndexManager.js';
-import type { IndexUpdateProgress } from './FaissIndexManager.js';
+import type { IndexUpdateProgress, SimilaritySearchTiming } from './FaissIndexManager.js';
 import {
   ActiveModelResolutionError,
   listRegisteredModels,
@@ -64,6 +64,12 @@ import { RecursiveKbWatcher } from './recursive-fs-watch.js';
 import { KBError, type KBErrorCode } from './errors.js';
 import { LexicalIndex, type LexicalSearchResult } from './lexical-index.js';
 import { chunkIdFromMetadata, reciprocalRankFusion, type RankedList } from './rrf.js';
+import {
+  canonicalErrorFromToolResult,
+  classifyCanonicalError,
+  emitCanonicalLog,
+  type CanonicalLogInput,
+} from './canonical-log.js';
 
 const SERVER_NAME = 'knowledge-base-server';
 const SERVER_VERSION = '0.1.0';
@@ -127,6 +133,20 @@ function addDocumentRollbackErrorContent(error: AddDocumentRollbackError): TextC
 function isMissingPathError(error: unknown): boolean {
   const code = (error as NodeJS.ErrnoException | undefined)?.code;
   return code === 'ENOENT' || code === 'ENOTDIR';
+}
+
+function topSourcesForCanonicalLog(
+  results: ReadonlyArray<{ metadata?: Record<string, unknown> }>,
+): string[] {
+  const sources: string[] = [];
+  for (const result of results) {
+    const source = result.metadata?.source;
+    if (typeof source === 'string' && !sources.includes(source)) {
+      sources.push(source);
+    }
+    if (sources.length === 3) break;
+  }
+  return sources;
 }
 
 async function snapshotDocumentForRollback(documentPath: string): Promise<AddDocumentSnapshot> {
@@ -401,6 +421,34 @@ export class KnowledgeBaseServer {
     );
   }
 
+  private async withCanonicalTool<T extends CallToolResult>(
+    base: Omit<CanonicalLogInput, 'process' | 'took_ms'>,
+    operation: () => Promise<T>,
+    enrich?: (result: T) => Partial<CanonicalLogInput>,
+  ): Promise<T> {
+    const startedAt = Date.now();
+    try {
+      const result = await operation();
+      const extra = enrich?.(result) ?? {};
+      emitCanonicalLog({
+        process: 'mcp',
+        ...base,
+        ...extra,
+        took_ms: Date.now() - startedAt,
+        error: extra.error ?? canonicalErrorFromToolResult(result),
+      });
+      return result;
+    } catch (error: unknown) {
+      emitCanonicalLog({
+        process: 'mcp',
+        ...base,
+        took_ms: Date.now() - startedAt,
+        error: classifyCanonicalError(error),
+      });
+      throw error;
+    }
+  }
+
   // Issue #157 step 2 — `mcp-resources.ts` owns the wire surface and pure
   // handler bodies. These remain on the class as thin delegates so the
   // existing private-method test surface (KnowledgeBaseServer.test.ts) keeps
@@ -420,7 +468,8 @@ export class KnowledgeBaseServer {
    * surfaced to the agent).
    */
   private async handleListModels(): Promise<CallToolResult> {
-    try {
+    return this.withCanonicalTool({ tool: 'list_models' }, async () => {
+      try {
       const models = await listRegisteredModels();
       let activeId: string | null = null;
       try {
@@ -437,15 +486,17 @@ export class KnowledgeBaseServer {
       return {
         content: [{ type: 'text', text: JSON.stringify(enriched, null, 2) }],
       };
-    } catch (error: unknown) {
+      } catch (error: unknown) {
       const err = toError(error);
       logger.error('Error listing models:', err);
       return { content: [mcpErrorContent(err)], isError: true };
-    }
+      }
+    });
   }
 
   private async handleListKnowledgeBases(): Promise<CallToolResult> {
-    try {
+    return this.withCanonicalTool({ tool: 'list_knowledge_bases' }, async () => {
+      try {
       const knowledgeBases = await listKnowledgeBases(KNOWLEDGE_BASES_ROOT_DIR);
       const content: TextContent = {
         type: 'text',
@@ -459,7 +510,8 @@ export class KnowledgeBaseServer {
         logger.error(err.stack);
       }
       return { content: [mcpErrorContent(err)], isError: true };
-    }
+      }
+    });
   }
 
   /**
@@ -471,7 +523,11 @@ export class KnowledgeBaseServer {
   private async handleKbStats(args: {
     knowledge_base_name?: string;
   }): Promise<CallToolResult> {
-    try {
+    return this.withCanonicalTool({
+      tool: 'kb_stats',
+      kb_scope: args.knowledge_base_name ?? null,
+    }, async () => {
+      try {
       let activeModelId: string;
       try {
         activeModelId = await resolveActiveModel();
@@ -500,7 +556,8 @@ export class KnowledgeBaseServer {
         logger.error(err.stack);
       }
       return { content: [mcpErrorContent(err)], isError: true };
-    }
+      }
+    });
   }
 
   private async getActiveManagerForMutation(): Promise<FaissIndexManager> {
@@ -513,6 +570,10 @@ export class KnowledgeBaseServer {
     path: string;
     content: string;
   }): Promise<CallToolResult> {
+    return this.withCanonicalTool({
+      tool: 'add_document',
+      kb_scope: args.knowledge_base_name,
+    }, async () => {
     const auditing = auditEnabled();
     let documentPath = '';
     let beforeHash: string | null = null;
@@ -609,12 +670,17 @@ export class KnowledgeBaseServer {
       await auditOnExit(err);
       return { content: [mcpErrorContent(err)], isError: true };
     }
+    });
   }
 
   private async handleDeleteDocument(args: {
     knowledge_base_name: string;
     path: string;
   }): Promise<CallToolResult> {
+    return this.withCanonicalTool({
+      tool: 'delete_document',
+      kb_scope: args.knowledge_base_name,
+    }, async () => {
     const auditing = auditEnabled();
     let documentPath = '';
     let sidecarPath = '';
@@ -696,12 +762,17 @@ export class KnowledgeBaseServer {
       await auditOnExit(err);
       return { content: [mcpErrorContent(err)], isError: true };
     }
+    });
   }
 
   private async handleReindexKnowledgeBase(args: {
     knowledge_base_name?: string;
   }): Promise<CallToolResult> {
-    try {
+    return this.withCanonicalTool({
+      tool: 'reindex_knowledge_base',
+      kb_scope: args.knowledge_base_name ?? null,
+    }, async () => {
+      try {
       const manager = await this.getActiveManagerForMutation();
       await withWriteLock(manager.modelDir, async () => {
         if (args.knowledge_base_name !== undefined) {
@@ -732,7 +803,8 @@ export class KnowledgeBaseServer {
         logger.error(err.stack);
       }
       return { content: [mcpErrorContent(err)], isError: true };
-    }
+      }
+    });
   }
 
   private async handleRetrieveKnowledge(args: {
@@ -745,6 +817,7 @@ export class KnowledgeBaseServer {
     tags?: string[];
     search_mode?: 'dense' | 'hybrid';
   }): Promise<CallToolResult> {
+    const canonical: Partial<CanonicalLogInput> = {};
     const query: string = args.query;
     const knowledgeBaseName: string | undefined = args.knowledge_base_name;
     const threshold: number | undefined = args.threshold;
@@ -754,18 +827,29 @@ export class KnowledgeBaseServer {
       : undefined;
     const searchMode: 'dense' | 'hybrid' = args.search_mode ?? 'dense';
 
-    if (searchMode === 'hybrid') {
-      return this.handleRetrieveKnowledgeHybrid({
-        query,
-        knowledgeBaseName,
-        modelNameOverride,
-        filters,
-      });
-    }
+    return this.withCanonicalTool({
+      tool: 'retrieve_knowledge',
+      query,
+      kb_scope: knowledgeBaseName ?? null,
+      k: 10,
+      threshold: threshold ?? 2,
+      search_mode: searchMode,
+    }, async () => {
+      if (searchMode === 'hybrid') {
+        return this.handleRetrieveKnowledgeHybrid({
+          query,
+          knowledgeBaseName,
+          modelNameOverride,
+          filters,
+          canonical,
+        });
+      }
 
     try {
       const startTime = Date.now();
-      logger.debug(`[${startTime}] handleRetrieveKnowledge started`);
+      if (process.env.KB_LOG_VERBOSE === '1') {
+        logger.debug(`[${startTime}] handleRetrieveKnowledge started`);
+      }
 
       // RFC 013 §4.7 — resolve active model per call. M3 honors args.model_name
       // as the explicit per-call override (resolveActiveModel validates it +
@@ -782,28 +866,42 @@ export class KnowledgeBaseServer {
         }
         throw err;
       }
+      canonical.model_id = activeModelId;
       const manager = await this.managers.getOrCreate(activeModelId);
 
       // RFC 013 §4.6 — write lock is per-model (resource = `models/<id>/`).
       // A `kb models add B` against another model never blocks retrievals on A.
       await withWriteLock(manager.modelDir, () => manager.updateIndex(knowledgeBaseName));
-      logger.debug(`[${Date.now()}] FAISS index update completed`);
+      if (process.env.KB_LOG_VERBOSE === '1') {
+        logger.debug(`[${Date.now()}] FAISS index update completed`);
+      }
 
       // Perform similarity search using the provided query.
+      const timing: SimilaritySearchTiming = {};
       const similaritySearchResults = await manager.similaritySearch(
         query,
         10,
         threshold,
         knowledgeBaseName,
         filters,
+        timing,
       );
-      logger.debug(`[${Date.now()}] Similarity search completed`);
+      if (process.env.KB_LOG_VERBOSE === '1') {
+        logger.debug(`[${Date.now()}] Similarity search completed`);
+      }
+      canonical.result_count = similaritySearchResults.length;
+      canonical.top_score = similaritySearchResults[0]?.score;
+      canonical.top_sources = topSourcesForCanonicalLog(similaritySearchResults);
+      canonical.embed_ms = timing.embed_query_ms;
+      canonical.faiss_ms = timing.faiss_search_ms ?? timing.query_search_ms;
 
       // Build a nicely formatted markdown response including the similarity score.
+      const formatStartedAt = Date.now();
       let responseText = formatRetrievalAsMarkdown(
         similaritySearchResults,
         FRONTMATTER_EXTRAS_WIRE_VISIBLE,
       );
+      canonical.format_ms = Date.now() - formatStartedAt;
 
       // RFC 013 M3 §4.5 + round-1 minimalist F5 — emit `model_id` on the
       // response envelope (NOT per-chunk) so an agent comparing two models
@@ -815,7 +913,9 @@ export class KnowledgeBaseServer {
       }
 
       const endTime = Date.now();
-      logger.debug(`[${endTime}] handleRetrieveKnowledge completed in ${endTime - startTime}ms`);
+      if (process.env.KB_LOG_VERBOSE === '1') {
+        logger.debug(`[${endTime}] handleRetrieveKnowledge completed in ${endTime - startTime}ms`);
+      }
 
       const content: TextContent = { type: 'text', text: responseText };
       return { content: [content] };
@@ -827,6 +927,7 @@ export class KnowledgeBaseServer {
       }
       return { content: [mcpErrorContent(err)], isError: true };
     }
+    }, () => canonical);
   }
 
   /**
@@ -854,8 +955,9 @@ export class KnowledgeBaseServer {
     knowledgeBaseName?: string;
     modelNameOverride?: string;
     filters?: { extensions?: string[]; pathGlob?: string; tags?: string[] };
+    canonical?: Partial<CanonicalLogInput>;
   }): Promise<CallToolResult> {
-    const { query, knowledgeBaseName, modelNameOverride, filters } = input;
+    const { query, knowledgeBaseName, modelNameOverride, filters, canonical } = input;
     const HYBRID_FETCH_K = 40;
     const HYBRID_TOP_K = 10;
     const HYBRID_RRF_C = 60;
@@ -870,12 +972,14 @@ export class KnowledgeBaseServer {
         }
         throw err;
       }
+      if (canonical) canonical.model_id = activeModelId;
       const manager = await this.managers.getOrCreate(activeModelId);
       await withWriteLock(manager.modelDir, () => manager.updateIndex(knowledgeBaseName));
 
       // Dense leg — over-fetch to give RRF room.
+      const denseTiming: SimilaritySearchTiming = {};
       const densePromise = manager
-        .similaritySearch(query, HYBRID_FETCH_K, Number.POSITIVE_INFINITY, knowledgeBaseName, filters)
+        .similaritySearch(query, HYBRID_FETCH_K, Number.POSITIVE_INFINITY, knowledgeBaseName, filters, denseTiming)
         .then((rs) => rs.map((r) => ({ pageContent: r.pageContent, metadata: r.metadata, score: r.score })));
 
       // Lexical leg — BM25 over the same chunks the FAISS path embeds, but
@@ -907,6 +1011,10 @@ export class KnowledgeBaseServer {
       })();
 
       const [denseResults, lexicalResults] = await Promise.all([densePromise, lexicalPromise]);
+      if (canonical) {
+        canonical.embed_ms = denseTiming.embed_query_ms;
+        canonical.faiss_ms = denseTiming.faiss_search_ms ?? denseTiming.query_search_ms;
+      }
 
       const denseList: RankedList = {
         retriever: 'dense',
@@ -927,7 +1035,14 @@ export class KnowledgeBaseServer {
         return chunk ? { ...chunk, score: f.fusedScore } : null;
       }).filter((x): x is { pageContent: string; metadata: Record<string, unknown>; score: number } => x !== null);
 
+      const formatStartedAt = Date.now();
       let responseText = formatRetrievalAsMarkdown(ranked as never, FRONTMATTER_EXTRAS_WIRE_VISIBLE);
+      if (canonical) {
+        canonical.result_count = ranked.length;
+        canonical.top_score = ranked[0]?.score;
+        canonical.top_sources = topSourcesForCanonicalLog(ranked);
+        canonical.format_ms = Date.now() - formatStartedAt;
+      }
       const header = `> _Mode: hybrid (RRF c=${HYBRID_RRF_C}); dense fetched ${denseResults.length}, lexical fetched ${lexicalResults.length} (#206 stage 2)._`;
       responseText = modelNameOverride !== undefined
         ? `> _Model: ${activeModelId}_\n${header}\n\n${responseText}`

--- a/src/canonical-log.test.ts
+++ b/src/canonical-log.test.ts
@@ -1,0 +1,63 @@
+import {
+  CANONICAL_SCHEMA_VERSION,
+  canonicalErrorFromToolResult,
+  hashQuery,
+  normalizeCanonicalEvent,
+  stableCanonicalJson,
+} from './canonical-log.js';
+
+describe('canonical log line schema (#216)', () => {
+  it('pins schema version and redacts raw queries to a stable sha256 prefix', () => {
+    const query = '  rollback   procedure  ';
+    const event = normalizeCanonicalEvent({
+      request_id: 'req-test',
+      ts: '2026-05-12T00:00:00.000Z',
+      process: 'mcp',
+      tool: 'retrieve_knowledge',
+      query,
+      took_ms: 12.4,
+    });
+
+    expect(event.schema_version).toBe(CANONICAL_SCHEMA_VERSION);
+    expect(event.query_sha256).toBe(hashQuery('rollback procedure'));
+    expect(event.query_len_chars).toBe(query.length);
+    expect(JSON.stringify(event)).not.toContain('rollback');
+    expect(event.took_ms).toBe(12);
+  });
+
+  it('caps top_sources at three and serializes in canonical field order', () => {
+    const event = normalizeCanonicalEvent({
+      request_id: 'req-test',
+      ts: '2026-05-12T00:00:00.000Z',
+      process: 'mcp',
+      tool: 'retrieve_knowledge',
+      took_ms: 5,
+      top_sources: ['a.md', 'b.md', 'c.md', 'd.md'],
+    });
+
+    const json = stableCanonicalJson(event);
+    expect(JSON.parse(json)).toEqual({
+      schema_version: 'kb-canonical.v1',
+      ts: '2026-05-12T00:00:00.000Z',
+      request_id: 'req-test',
+      process: 'mcp',
+      tool: 'retrieve_knowledge',
+      top_sources: ['a.md', 'b.md', 'c.md'],
+      took_ms: 5,
+    });
+    expect(json.indexOf('"schema_version"')).toBeLessThan(json.indexOf('"request_id"'));
+    expect(json.indexOf('"top_sources"')).toBeLessThan(json.indexOf('"took_ms"'));
+  });
+
+  it('extracts error code and category from MCP tool error payloads', () => {
+    const error = canonicalErrorFromToolResult({
+      isError: true,
+      content: [{
+        type: 'text',
+        text: JSON.stringify({ error: { code: 'PROVIDER_TIMEOUT' } }),
+      }],
+    });
+
+    expect(error).toEqual({ code: 'PROVIDER_TIMEOUT', category: 'provider' });
+  });
+});

--- a/src/canonical-log.ts
+++ b/src/canonical-log.ts
@@ -1,0 +1,239 @@
+import { createHash, randomBytes } from 'crypto';
+import { logger } from './logger.js';
+import { KBError, type KBErrorCode } from './errors.js';
+import { ActiveModelResolutionError } from './active-model.js';
+
+export const CANONICAL_SCHEMA_VERSION = 'kb-canonical.v1';
+
+export type CanonicalProcess = 'mcp' | 'cli';
+export type CanonicalCacheStatus = 'hit_l1' | 'hit_disk' | 'miss';
+export type CanonicalSearchMode = 'dense' | 'lexical' | 'hybrid' | 'auto';
+export type CanonicalErrorCategory =
+  | 'configuration'
+  | 'indexing'
+  | 'provider'
+  | 'permissions'
+  | 'input'
+  | 'lock'
+  | 'unknown';
+
+export interface CanonicalError {
+  code: string;
+  category: CanonicalErrorCategory;
+}
+
+export interface CanonicalLogEvent {
+  schema_version: typeof CANONICAL_SCHEMA_VERSION;
+  ts: string;
+  request_id: string;
+  process: CanonicalProcess;
+  tool?: string;
+  cmd?: string;
+  model_id?: string;
+  kb_scope?: string | null;
+  query_sha256?: string;
+  query_len_chars?: number;
+  k?: number;
+  threshold?: number;
+  search_mode?: CanonicalSearchMode;
+  result_count?: number;
+  top_score?: number;
+  top_sources?: string[];
+  took_ms: number;
+  embed_ms?: number;
+  faiss_ms?: number;
+  format_ms?: number;
+  cache?: CanonicalCacheStatus;
+  error?: CanonicalError;
+}
+
+export type CanonicalLogInput = Omit<
+  CanonicalLogEvent,
+  'schema_version' | 'ts' | 'request_id' | 'query_sha256'
+> & {
+  request_id?: string;
+  ts?: string;
+  query?: string;
+  query_sha256?: string;
+};
+
+const CANONICAL_FIELD_ORDER: readonly (keyof CanonicalLogEvent)[] = [
+  'schema_version',
+  'ts',
+  'request_id',
+  'process',
+  'tool',
+  'cmd',
+  'model_id',
+  'kb_scope',
+  'query_sha256',
+  'query_len_chars',
+  'k',
+  'threshold',
+  'search_mode',
+  'result_count',
+  'top_score',
+  'top_sources',
+  'took_ms',
+  'embed_ms',
+  'faiss_ms',
+  'format_ms',
+  'cache',
+  'error',
+];
+
+export function createCanonicalRequestId(): string {
+  const now = Date.now().toString(36).padStart(8, '0');
+  return `${now}${randomBytes(8).toString('hex')}`;
+}
+
+export function hashQuery(query: string): string {
+  return createHash('sha256')
+    .update(query.trim().replace(/\s+/g, ' '), 'utf-8')
+    .digest('hex')
+    .slice(0, 16);
+}
+
+export function normalizeCanonicalEvent(input: CanonicalLogInput): CanonicalLogEvent {
+  const event: CanonicalLogEvent = {
+    schema_version: CANONICAL_SCHEMA_VERSION,
+    ts: input.ts ?? new Date().toISOString(),
+    request_id: input.request_id ?? createCanonicalRequestId(),
+    process: input.process,
+    took_ms: Math.max(0, Math.round(input.took_ms)),
+  };
+
+  assignIfDefined(event, 'tool', input.tool);
+  assignIfDefined(event, 'cmd', input.cmd);
+  assignIfDefined(event, 'model_id', input.model_id);
+  assignIfDefined(event, 'kb_scope', input.kb_scope);
+  assignIfDefined(event, 'query_sha256', input.query_sha256 ?? (input.query !== undefined ? hashQuery(input.query) : undefined));
+  assignIfDefined(event, 'query_len_chars', input.query_len_chars ?? (input.query !== undefined ? input.query.length : undefined));
+  assignIfDefined(event, 'k', input.k);
+  assignIfDefined(event, 'threshold', input.threshold);
+  assignIfDefined(event, 'search_mode', input.search_mode);
+  assignIfDefined(event, 'result_count', input.result_count);
+  assignIfDefined(event, 'top_score', input.top_score);
+  assignIfDefined(event, 'top_sources', input.top_sources?.slice(0, 3));
+  assignIfDefined(event, 'embed_ms', roundNonNegative(input.embed_ms));
+  assignIfDefined(event, 'faiss_ms', roundNonNegative(input.faiss_ms));
+  assignIfDefined(event, 'format_ms', roundNonNegative(input.format_ms));
+  assignIfDefined(event, 'cache', input.cache);
+  assignIfDefined(event, 'error', input.error);
+
+  return event;
+}
+
+export function stableCanonicalJson(event: CanonicalLogEvent): string {
+  const ordered: Record<string, unknown> = {};
+  for (const key of CANONICAL_FIELD_ORDER) {
+    if (event[key] !== undefined) {
+      ordered[key] = event[key];
+    }
+  }
+  return JSON.stringify(ordered);
+}
+
+export function emitCanonicalLog(input: CanonicalLogInput): void {
+  logger.canonical(stableCanonicalJson(normalizeCanonicalEvent(input)));
+}
+
+export function classifyCanonicalError(error: unknown): CanonicalError {
+  if (error instanceof ActiveModelResolutionError) {
+    return { code: 'ACTIVE_MODEL_UNRESOLVED', category: 'configuration' };
+  }
+  if (error instanceof KBError) {
+    return { code: error.code, category: categoryForKBError(error.code) };
+  }
+  const code = typeof (error as { code?: unknown } | undefined)?.code === 'string'
+    ? String((error as { code: string }).code)
+    : 'INTERNAL';
+  return { code, category: 'unknown' };
+}
+
+export function canonicalErrorFromToolResult(result: {
+  isError?: boolean;
+  content?: Array<{ type: string; text?: string }>;
+}): CanonicalError | undefined {
+  if (result.isError !== true) return undefined;
+  const text = result.content?.find((entry) => entry.type === 'text' && typeof entry.text === 'string')?.text;
+  if (text === undefined) return { code: 'INTERNAL', category: 'unknown' };
+  try {
+    const parsed = JSON.parse(text) as { error?: { code?: unknown; category?: unknown } };
+    const code = typeof parsed.error?.code === 'string' ? parsed.error.code : 'INTERNAL';
+    const category = typeof parsed.error?.category === 'string'
+      ? normalizeErrorCategory(parsed.error.category)
+      : categoryForCode(code);
+    return { code, category };
+  } catch {
+    return { code: 'INTERNAL', category: 'unknown' };
+  }
+}
+
+function categoryForCode(code: string): CanonicalErrorCategory {
+  return isKBErrorCode(code) ? categoryForKBError(code) : 'unknown';
+}
+
+function categoryForKBError(code: KBErrorCode): CanonicalErrorCategory {
+  switch (code) {
+    case 'INDEX_NOT_INITIALIZED':
+    case 'CORRUPT_INDEX':
+      return 'indexing';
+    case 'PROVIDER_AUTH':
+      return 'configuration';
+    case 'PROVIDER_UNAVAILABLE':
+    case 'PROVIDER_TIMEOUT':
+      return 'provider';
+    case 'KB_NOT_FOUND':
+      return 'configuration';
+    case 'PERMISSION_DENIED':
+      return 'permissions';
+    case 'VALIDATION':
+      return 'input';
+    case 'INTERNAL':
+      return 'unknown';
+  }
+}
+
+function isKBErrorCode(code: string): code is KBErrorCode {
+  return [
+    'INDEX_NOT_INITIALIZED',
+    'PROVIDER_UNAVAILABLE',
+    'PROVIDER_TIMEOUT',
+    'PROVIDER_AUTH',
+    'KB_NOT_FOUND',
+    'PERMISSION_DENIED',
+    'CORRUPT_INDEX',
+    'VALIDATION',
+    'INTERNAL',
+  ].includes(code);
+}
+
+function normalizeErrorCategory(raw: string): CanonicalErrorCategory {
+  if ([
+    'configuration',
+    'indexing',
+    'provider',
+    'permissions',
+    'input',
+    'lock',
+    'unknown',
+  ].includes(raw)) {
+    return raw as CanonicalErrorCategory;
+  }
+  return 'unknown';
+}
+
+function assignIfDefined<K extends keyof CanonicalLogEvent>(
+  event: CanonicalLogEvent,
+  key: K,
+  value: CanonicalLogEvent[K] | undefined,
+): void {
+  if (value !== undefined) {
+    event[key] = value;
+  }
+}
+
+function roundNonNegative(value: number | undefined): number | undefined {
+  return value === undefined ? undefined : Math.max(0, Math.round(value));
+}

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -26,7 +26,7 @@ interface RunResult {
 
 function runCli(args: string[], env: Record<string, string> = {}, input?: string): RunResult {
   const result = spawnSync('node', [cliPath, ...args], {
-    env: { PATH: process.env.PATH ?? '', ...env },
+    env: { PATH: process.env.PATH ?? '', KB_LOG_FORMAT: 'text', ...env },
     encoding: 'utf-8',
     input,
   });
@@ -179,6 +179,37 @@ describe('kb CLI — argv parsing and dispatch', () => {
     const r = runCli(['search']);
     expect(r.code).toBe(2);
     expect(r.stderr).toContain('missing <query>');
+  });
+
+  it('emits a canonical event for a kb subcommand invocation (#216)', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-cli-canonical-'));
+    const logFile = path.join(tempDir, 'canonical.log');
+
+    try {
+      const r = runCli(['search'], {
+        KB_LOG_FORMAT: 'canonical',
+        LOG_FILE: logFile,
+      });
+
+      expect(r.code).toBe(2);
+      expect(r.stderr).toContain('missing <query>');
+      const lines = (await fsp.readFile(logFile, 'utf-8')).trim().split('\n');
+      expect(lines).toHaveLength(1);
+      const event = JSON.parse(lines[0]);
+      expect(event).toMatchObject({
+        schema_version: 'kb-canonical.v1',
+        process: 'cli',
+        cmd: 'kb search',
+        error: {
+          code: 'EXIT_2',
+          category: 'input',
+        },
+      });
+      expect(typeof event.request_id).toBe('string');
+      expect(typeof event.took_ms).toBe('number');
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
   });
 
   it('search with bogus flag exits 2', () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -27,6 +27,7 @@ import { STATS_HELP, runStats } from './cli-stats.js';
 import { SUPERSEDED_HELP, runSuperseded } from './cli-superseded.js';
 import { WHERE_HELP, runWhere } from './cli-where.js';
 import { tryRunDaemonCommand } from './daemon-client.js';
+import { emitCanonicalLog } from './canonical-log.js';
 
 // ----- Subcommand registry --------------------------------------------------
 
@@ -149,11 +150,43 @@ export async function main(argv: string[]): Promise<number> {
     return 0;
   }
 
-  if (sub === 'search') {
-    return runSearchMaybeViaDaemon(rest);
-  }
+  return runSubcommandWithCanonicalLog(
+    target,
+    sub === 'search'
+      ? () => runSearchMaybeViaDaemon(rest)
+      : () => target.handler(rest),
+  );
+}
 
-  return target.handler(rest);
+async function runSubcommandWithCanonicalLog(
+  target: Subcommand,
+  operation: () => Promise<number>,
+): Promise<number> {
+  const startedAt = Date.now();
+  try {
+    const code = await operation();
+    emitCanonicalLog({
+      process: 'cli',
+      cmd: `kb ${target.name}`,
+      took_ms: Date.now() - startedAt,
+      error: code === 0 ? undefined : {
+        code: `EXIT_${code}`,
+        category: code === 2 ? 'input' : 'unknown',
+      },
+    });
+    return code;
+  } catch (error: unknown) {
+    emitCanonicalLog({
+      process: 'cli',
+      cmd: `kb ${target.name}`,
+      took_ms: Date.now() - startedAt,
+      error: {
+        code: (error as { code?: string })?.code ?? 'INTERNAL',
+        category: 'unknown',
+      },
+    });
+    throw error;
+  }
 }
 
 async function runSearchMaybeViaDaemon(rest: string[]): Promise<number> {

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -6,6 +6,7 @@ import {
   parseKbFakeDim,
   parseKbFsWatchDebounceMs,
   parseKbFsWatchFlag,
+  parseKBLogFormat,
   parseKbMaxExtractedTextBytes,
   parseKbMaxFileBytes,
   parseReindexTriggerPollMs,
@@ -186,6 +187,20 @@ describe('parseKBEditorUri (#220 — KB_EDITOR_URI)', () => {
 
   it('rejects unsupported modes', () => {
     expect(() => parseKBEditorUri('vim')).toThrow(/KB_EDITOR_URI/);
+  });
+});
+
+describe('parseKBLogFormat (#216 — KB_LOG_FORMAT)', () => {
+  it('defaults to both when unset, blank, or invalid', () => {
+    expect(parseKBLogFormat(undefined)).toBe('both');
+    expect(parseKBLogFormat('')).toBe('both');
+    expect(parseKBLogFormat('nope')).toBe('both');
+  });
+
+  it('accepts text, canonical, and both case-insensitively', () => {
+    expect(parseKBLogFormat('text')).toBe('text');
+    expect(parseKBLogFormat('CANONICAL')).toBe('canonical');
+    expect(parseKBLogFormat(' Both ')).toBe('both');
   });
 });
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -272,6 +272,23 @@ export function parseKBEditorUri(raw: string | undefined): KBEditorUriMode {
 export const KB_EDITOR_URI: KBEditorUriMode = parseKBEditorUri(process.env.KB_EDITOR_URI);
 
 // ---------------------------------------------------------------------------
+// Canonical log line configuration (#216).
+// ---------------------------------------------------------------------------
+
+export type KBLogFormat = 'text' | 'canonical' | 'both';
+
+export function parseKBLogFormat(raw: string | undefined): KBLogFormat {
+  if (raw === undefined || raw.trim() === '') return 'both';
+  const value = raw.trim().toLowerCase();
+  if (value === 'text' || value === 'canonical' || value === 'both') {
+    return value;
+  }
+  return 'both';
+}
+
+export const KB_LOG_FORMAT: KBLogFormat = parseKBLogFormat(process.env.KB_LOG_FORMAT);
+
+// ---------------------------------------------------------------------------
 // Reindex-trigger watcher (RFC 011 §5.5).
 // External workflows (e.g. the arxiv-ingestion n8n flow) signal the server
 // that new content has landed by `touch`ing a dotfile at the KB root. The

--- a/src/logger.test.ts
+++ b/src/logger.test.ts
@@ -6,6 +6,7 @@ describe('logger', () => {
   const originalEnv = {
     LOG_FILE: process.env.LOG_FILE,
     LOG_LEVEL: process.env.LOG_LEVEL,
+    KB_LOG_FORMAT: process.env.KB_LOG_FORMAT,
   };
 
   afterEach(() => {
@@ -18,6 +19,11 @@ describe('logger', () => {
       delete process.env.LOG_LEVEL;
     } else {
       process.env.LOG_LEVEL = originalEnv.LOG_LEVEL;
+    }
+    if (originalEnv.KB_LOG_FORMAT === undefined) {
+      delete process.env.KB_LOG_FORMAT;
+    } else {
+      process.env.KB_LOG_FORMAT = originalEnv.KB_LOG_FORMAT;
     }
     jest.restoreAllMocks();
     jest.resetModules();
@@ -64,5 +70,40 @@ describe('logger', () => {
 
     const stderrOutput = stderrSpy.mock.calls.flat().join('');
     expect(stderrOutput).toMatch(/Failed to (initialize|write log)|Log file stream error/);
+  });
+
+  it('routes canonical JSON lines without text logs when KB_LOG_FORMAT=canonical', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-logger-canonical-'));
+    const logFile = path.join(tempDir, 'logs', 'app.log');
+    process.env.LOG_FILE = logFile;
+    process.env.KB_LOG_FORMAT = 'canonical';
+
+    await jest.isolateModulesAsync(async () => {
+      const { logger } = await import('./logger.js');
+      logger.info('text should be suppressed');
+      logger.canonical('{"schema_version":"kb-canonical.v1"}');
+      await new Promise((resolve) => setImmediate(resolve));
+    });
+
+    const fileContents = await fsp.readFile(logFile, 'utf-8');
+    expect(fileContents).toBe('{"schema_version":"kb-canonical.v1"}\n');
+  });
+
+  it('suppresses canonical lines when KB_LOG_FORMAT=text', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-logger-text-'));
+    const logFile = path.join(tempDir, 'logs', 'app.log');
+    process.env.LOG_FILE = logFile;
+    process.env.KB_LOG_FORMAT = 'text';
+
+    await jest.isolateModulesAsync(async () => {
+      const { logger } = await import('./logger.js');
+      logger.info('text remains');
+      logger.canonical('{"schema_version":"kb-canonical.v1"}');
+      await new Promise((resolve) => setImmediate(resolve));
+    });
+
+    const fileContents = await fsp.readFile(logFile, 'utf-8');
+    expect(fileContents).toContain('text remains');
+    expect(fileContents).not.toContain('kb-canonical.v1');
   });
 });

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -3,6 +3,7 @@ import { dirname } from 'path';
 import { format } from 'util';
 
 type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+type LogFormat = 'text' | 'canonical' | 'both';
 
 const LEVEL_PRIORITY: Record<LogLevel, number> = {
   debug: 10,
@@ -13,6 +14,8 @@ const LEVEL_PRIORITY: Record<LogLevel, number> = {
 
 const envLevel = (process.env.LOG_LEVEL || 'info').toLowerCase() as LogLevel;
 const activeLevel = LEVEL_PRIORITY[envLevel] ? envLevel : 'info';
+const envFormat = (process.env.KB_LOG_FORMAT || 'both').toLowerCase() as LogFormat;
+const activeFormat: LogFormat = ['text', 'canonical', 'both'].includes(envFormat) ? envFormat : 'both';
 const destinations: NodeJS.WritableStream[] = [process.stderr];
 
 const logFilePath = process.env.LOG_FILE;
@@ -49,6 +52,9 @@ if (logFilePath) {
 }
 
 function write(level: LogLevel, args: unknown[]): void {
+  if (activeFormat === 'canonical') {
+    return;
+  }
   if (LEVEL_PRIORITY[level] < LEVEL_PRIORITY[activeLevel]) {
     return;
   }
@@ -66,9 +72,30 @@ function write(level: LogLevel, args: unknown[]): void {
   }
 }
 
+function writeCanonical(jsonLine: string): void {
+  if (activeFormat === 'text') {
+    return;
+  }
+  const line = `${jsonLine}\n`;
+  if (logFilePath) {
+    try {
+      appendFileSync(logFilePath, line);
+    } catch (error) {
+      process.stderr.write(`${new Date().toISOString()} [ERROR] Failed to write canonical log: ${format(error)}\n`);
+    }
+    return;
+  }
+  try {
+    process.stderr.write(line);
+  } catch {
+    // canonical logging is best-effort and must not affect the caller
+  }
+}
+
 export const logger = {
   debug: (...args: unknown[]) => write('debug', args),
   info: (...args: unknown[]) => write('info', args),
   warn: (...args: unknown[]) => write('warn', args),
   error: (...args: unknown[]) => write('error', args),
+  canonical: (jsonLine: string) => writeCanonical(jsonLine),
 };


### PR DESCRIPTION
## Summary
- add `kb-canonical.v1` structured canonical log events with query hashing and stable field order
- route canonical output through existing logger destinations with `KB_LOG_FORMAT=text|canonical|both`
- emit MCP retrieve metadata/timings and central `kb` subcommand invocation events
- document the schema decision in ADR 0007

Closes #216.

## Verification
- `npm test -- src/canonical-log.test.ts src/logger.test.ts src/config.test.ts src/KnowledgeBaseServer.test.ts src/cli.test.ts`
- `npm run build`

## Pre-PR checklist
- Project type: npm
- Build/type checks: passed via `npm run build`
- Tests: passed via targeted Jest command above
- Diff review: done; no package, lockfile, changelog, or unrelated generated files
- Portability check: skipped; `scripts/check-portability.sh` is not present in this repo
- Reviewer specialists: skipped; subagent delegation was not explicitly authorized in this session
- OSS base-branch policy: skipped; same-repo PR to `main`
