### PR TITLE
feat(search): add neighbor context expansion

### DIFF
--- a/src/FaissIndexManager.test.ts
+++ b/src/FaissIndexManager.test.ts
@@ -3371,3 +3371,105 @@ describe('FaissIndexManager progressive overfetch (#229)', () => {
     expect(results.map((r) => r.pageContent)).toEqual(['s0', 's1', 's2', 's3']);
   });
 });
+
+describe('FaissIndexManager neighbor context expansion', () => {
+  it('adds adjacent chunks from the same source while keeping the semantic match distinct', async () => {
+    jest.resetModules();
+    const { FaissIndexManager } = await import('./FaissIndexManager.js');
+    const manager = new FaissIndexManager({
+      provider: 'huggingface',
+      modelName: 'BAAI/bge-small-en-v1.5',
+    });
+    const docs = new Map([
+      ['0', { pageContent: 'before', metadata: { knowledgeBase: 'kb', source: '/kb/doc.md', chunkIndex: 0 } }],
+      ['1', { pageContent: 'match', metadata: { knowledgeBase: 'kb', source: '/kb/doc.md', chunkIndex: 1 } }],
+      ['2', { pageContent: 'after', metadata: { knowledgeBase: 'kb', source: '/kb/doc.md', chunkIndex: 2 } }],
+      ['other', { pageContent: 'wrong source', metadata: { knowledgeBase: 'kb', source: '/kb/other.md', chunkIndex: 0 } }],
+    ]);
+    (manager as any).faissIndex = { docstore: { _docs: docs } };
+
+    const expanded = manager.expandWithNeighborContext([
+      {
+        pageContent: 'match',
+        metadata: { knowledgeBase: 'kb', source: '/kb/doc.md', chunkIndex: 1 },
+        score: 0.12,
+      },
+    ], { before: 1, after: 1 });
+
+    expect(expanded).toHaveLength(1);
+    expect(expanded[0]).toMatchObject({
+      pageContent: 'match',
+      score: 0.12,
+      matchType: 'semantic',
+      semanticMatch: true,
+    });
+    expect(expanded[0].contextChunks?.map((chunk) => ({
+      content: chunk.pageContent,
+      type: chunk.matchType,
+      semantic: chunk.semanticMatch,
+      direction: chunk.contextDirection,
+    }))).toEqual([
+      { content: 'before', type: 'context', semantic: false, direction: 'before' },
+      { content: 'after', type: 'context', semantic: false, direction: 'after' },
+    ]);
+  });
+
+  it('deduplicates overlapping context and never reclassifies another semantic match as context', async () => {
+    jest.resetModules();
+    const { FaissIndexManager } = await import('./FaissIndexManager.js');
+    const manager = new FaissIndexManager({
+      provider: 'huggingface',
+      modelName: 'BAAI/bge-small-en-v1.5',
+    });
+    const docs = new Map([
+      ['0', { pageContent: 'zero', metadata: { knowledgeBase: 'kb', source: '/kb/doc.md', chunkIndex: 0 } }],
+      ['1', { pageContent: 'one', metadata: { knowledgeBase: 'kb', source: '/kb/doc.md', chunkIndex: 1 } }],
+      ['2', { pageContent: 'two', metadata: { knowledgeBase: 'kb', source: '/kb/doc.md', chunkIndex: 2 } }],
+      ['3', { pageContent: 'three', metadata: { knowledgeBase: 'kb', source: '/kb/doc.md', chunkIndex: 3 } }],
+    ]);
+    (manager as any).faissIndex = { docstore: { _docs: docs } };
+
+    const expanded = manager.expandWithNeighborContext([
+      {
+        pageContent: 'one',
+        metadata: { knowledgeBase: 'kb', source: '/kb/doc.md', chunkIndex: 1 },
+        score: 0.1,
+      },
+      {
+        pageContent: 'two',
+        metadata: { knowledgeBase: 'kb', source: '/kb/doc.md', chunkIndex: 2 },
+        score: 0.2,
+      },
+    ], { before: 1, after: 1 });
+
+    expect(expanded.map((result) => result.pageContent)).toEqual(['one', 'two']);
+    expect(expanded[0].contextChunks?.map((chunk) => chunk.pageContent)).toEqual(['zero']);
+    expect(expanded[1].contextChunks?.map((chunk) => chunk.pageContent)).toEqual(['three']);
+  });
+
+  it('caps context chunks per response', async () => {
+    jest.resetModules();
+    const { FaissIndexManager } = await import('./FaissIndexManager.js');
+    const manager = new FaissIndexManager({
+      provider: 'huggingface',
+      modelName: 'BAAI/bge-small-en-v1.5',
+    });
+    const docs = new Map([
+      ['0', { pageContent: 'zero', metadata: { knowledgeBase: 'kb', source: '/kb/doc.md', chunkIndex: 0 } }],
+      ['1', { pageContent: 'one', metadata: { knowledgeBase: 'kb', source: '/kb/doc.md', chunkIndex: 1 } }],
+      ['2', { pageContent: 'two', metadata: { knowledgeBase: 'kb', source: '/kb/doc.md', chunkIndex: 2 } }],
+    ]);
+    (manager as any).faissIndex = { docstore: { _docs: docs } };
+
+    const expanded = manager.expandWithNeighborContext([
+      {
+        pageContent: 'one',
+        metadata: { knowledgeBase: 'kb', source: '/kb/doc.md', chunkIndex: 1 },
+        score: 0.1,
+      },
+    ], { before: 1, after: 1, maxContextChunks: 1 });
+
+    expect(expanded[0].contextChunks?.map((chunk) => chunk.pageContent)).toEqual(['zero']);
+    expect(expanded[0].contextTruncated).toBe(true);
+  });
+});

--- a/src/FaissIndexManager.ts
+++ b/src/FaissIndexManager.ts
@@ -182,6 +182,30 @@ export interface SimilaritySearchTiming {
   fetch_k?: number;
 }
 
+export const MAX_NEIGHBOR_CONTEXT_WINDOW = 5;
+export const MAX_NEIGHBOR_CONTEXT_CHUNKS = 50;
+
+export interface NeighborContextOptions {
+  before?: number;
+  after?: number;
+  maxContextChunks?: number;
+}
+
+export interface NeighborContextChunk extends Document {
+  matchType: 'context';
+  semanticMatch: false;
+  contextDirection: 'before' | 'after';
+  contextDistance: number;
+}
+
+export interface SearchResultDocument extends Document {
+  score: number;
+  matchType?: 'semantic';
+  semanticMatch?: true;
+  contextChunks?: NeighborContextChunk[];
+  contextTruncated?: boolean;
+}
+
 const MAX_INDEX_UPDATE_FAILURES = 10;
 
 export function createNeverRunIndexUpdateSummary(modelId: string | null = null): IndexUpdateSummary {
@@ -1009,7 +1033,7 @@ export class FaissIndexManager {
     knowledgeBaseName?: string,
     filters?: SimilaritySearchFilters,
     timing?: SimilaritySearchTiming,
-  ) {
+  ): Promise<SearchResultDocument[]> {
     const totalStartedAt = Date.now();
     if (!this.faissIndex) {
       throw new KBError('INDEX_NOT_INITIALIZED', 'FAISS index is not initialized');
@@ -1103,6 +1127,80 @@ export class FaissIndexManager {
     return filtered.slice(0, k).map(([doc, score]) => ({ ...doc, score }));
   }
 
+  expandWithNeighborContext(
+    results: readonly SearchResultDocument[],
+    options: NeighborContextOptions,
+  ): SearchResultDocument[] {
+    const normalized = normalizeNeighborContextOptions(options);
+    if (normalized.before === 0 && normalized.after === 0) {
+      return [...results];
+    }
+    if (!this.faissIndex || results.length === 0) {
+      return results.map(markSemanticResult);
+    }
+
+    const docs = this.getDocstoreDocuments();
+    if (docs.length === 0) {
+      return results.map(markSemanticResult);
+    }
+
+    const byKey = new Map<string, Document>();
+    for (const doc of docs) {
+      const identity = chunkIdentity(doc);
+      if (identity) byKey.set(identity.key, doc);
+    }
+
+    const semanticKeys = new Set<string>();
+    for (const result of results) {
+      const identity = chunkIdentity(result);
+      if (identity) semanticKeys.add(identity.key);
+    }
+
+    const usedContextKeys = new Set<string>();
+    let contextCount = 0;
+    let capReached = false;
+
+    return results.map((result) => {
+      const semantic = markSemanticResult(result);
+      const identity = chunkIdentity(result);
+      if (!identity) return semantic;
+
+      const contextChunks: NeighborContextChunk[] = [];
+      const addContext = (chunkIndex: number, direction: 'before' | 'after'): void => {
+        const key = chunkKey(identity.knowledgeBase, identity.source, chunkIndex);
+        if (semanticKeys.has(key) || usedContextKeys.has(key)) return;
+        const doc = byKey.get(key);
+        if (!doc) return;
+        if (contextCount >= normalized.maxContextChunks) {
+          capReached = true;
+          return;
+        }
+        usedContextKeys.add(key);
+        contextCount += 1;
+        contextChunks.push({
+          ...doc,
+          matchType: 'context',
+          semanticMatch: false,
+          contextDirection: direction,
+          contextDistance: Math.abs(chunkIndex - identity.chunkIndex),
+        });
+      };
+
+      for (let i = normalized.before; i >= 1; i -= 1) {
+        addContext(identity.chunkIndex - i, 'before');
+      }
+      for (let i = 1; i <= normalized.after; i += 1) {
+        addContext(identity.chunkIndex + i, 'after');
+      }
+
+      return {
+        ...semantic,
+        ...(contextChunks.length > 0 ? { contextChunks } : {}),
+        ...(capReached ? { contextTruncated: true } : {}),
+      };
+    });
+  }
+
   /**
    * Issue #54 — observability snapshot for the kb_stats MCP tool.
    *
@@ -1147,6 +1245,16 @@ export class FaissIndexManager {
     return { totalChunks, chunkCountsByKb, dim };
   }
 
+  private getDocstoreDocuments(): Document[] {
+    const docs = (
+      this.faissIndex?.docstore as unknown as {
+        _docs?: Map<string, Document>;
+      } | undefined
+    )?._docs;
+    if (!(docs instanceof Map)) return [];
+    return Array.from(docs.values());
+  }
+
   /**
    * Issue #54 — resolve the path of the active `faiss.index` file used for
    * `last_updated_at`. Handles both the RFC 014 versioned layout
@@ -1157,4 +1265,67 @@ export class FaissIndexManager {
   async resolveActiveIndexFilePath(): Promise<string | null> {
     return resolveActiveIndexFilePathFromLayout(this.modelDir);
   }
+}
+
+function normalizeNeighborContextOptions(options: NeighborContextOptions): Required<NeighborContextOptions> {
+  return {
+    before: normalizeContextCount(options.before ?? 0, 'before'),
+    after: normalizeContextCount(options.after ?? 0, 'after'),
+    maxContextChunks: normalizeMaxContextChunks(options.maxContextChunks ?? MAX_NEIGHBOR_CONTEXT_CHUNKS),
+  };
+}
+
+function normalizeContextCount(value: number, name: string): number {
+  if (!Number.isInteger(value) || value < 0 || value > MAX_NEIGHBOR_CONTEXT_WINDOW) {
+    throw new KBError(
+      'VALIDATION',
+      `neighbor context ${name} must be an integer between 0 and ${MAX_NEIGHBOR_CONTEXT_WINDOW}`,
+    );
+  }
+  return value;
+}
+
+function normalizeMaxContextChunks(value: number): number {
+  if (!Number.isInteger(value) || value < 0 || value > MAX_NEIGHBOR_CONTEXT_CHUNKS) {
+    throw new KBError(
+      'VALIDATION',
+      `neighbor context maxContextChunks must be an integer between 0 and ${MAX_NEIGHBOR_CONTEXT_CHUNKS}`,
+    );
+  }
+  return value;
+}
+
+function markSemanticResult(result: SearchResultDocument): SearchResultDocument {
+  return {
+    ...result,
+    matchType: 'semantic',
+    semanticMatch: true,
+  };
+}
+
+function chunkIdentity(doc: Document): {
+  key: string;
+  knowledgeBase: string;
+  source: string;
+  chunkIndex: number;
+} | null {
+  const metadata = doc.metadata as Record<string, unknown> | undefined;
+  if (!metadata) return null;
+  const sourceValue = metadata.source ?? metadata.relativePath;
+  if (typeof sourceValue !== 'string' || sourceValue.length === 0) return null;
+  const chunkIndexValue = metadata.chunkIndex ?? metadata.chunk_index;
+  if (!Number.isInteger(chunkIndexValue)) return null;
+  const knowledgeBase = typeof metadata.knowledgeBase === 'string' ? metadata.knowledgeBase : '';
+  const source = sourceValue;
+  const chunkIndex = chunkIndexValue as number;
+  return {
+    key: chunkKey(knowledgeBase, source, chunkIndex),
+    knowledgeBase,
+    source,
+    chunkIndex,
+  };
+}
+
+function chunkKey(knowledgeBase: string, source: string, chunkIndex: number): string {
+  return `${knowledgeBase}\u0000${source}\u0000${chunkIndex}`;
 }

--- a/src/KnowledgeBaseServer.test.ts
+++ b/src/KnowledgeBaseServer.test.ts
@@ -6,6 +6,7 @@ const initializeMock = jest.fn();
 const updateIndexMock = jest.fn();
 const reloadPersistedIndexMock = jest.fn();
 const similaritySearchMock = jest.fn();
+const expandWithNeighborContextMock = jest.fn((results: unknown) => results);
 const hasLoadedIndexMock = jest.fn(() => true);
 // Issue #54 — kb_stats reads chunk_count + dim from the manager. Default to
 // an empty store so tests that don't care about stats still see a sane shape.
@@ -48,6 +49,7 @@ const FaissIndexManagerMock: any = jest.fn().mockImplementation((opts?: { provid
     updateIndex: updateIndexMock,
     reloadPersistedIndex: reloadPersistedIndexMock,
     similaritySearch: similaritySearchMock,
+    expandWithNeighborContext: expandWithNeighborContextMock,
     getStats: getStatsMock,
     getLastIndexUpdateSummary: getLastIndexUpdateSummaryMock,
     modelDir,
@@ -88,6 +90,8 @@ describe('KnowledgeBaseServer handlers', () => {
     updateIndexMock.mockReset();
     reloadPersistedIndexMock.mockReset();
     similaritySearchMock.mockReset();
+    expandWithNeighborContextMock.mockReset();
+    expandWithNeighborContextMock.mockImplementation((results: unknown) => results);
     hasLoadedIndexMock.mockReset();
     hasLoadedIndexMock.mockReturnValue(true);
     getStatsMock.mockReset();
@@ -312,6 +316,66 @@ describe('KnowledgeBaseServer handlers', () => {
     const server = await freshServer();
     const result = await server['handleRetrieveKnowledge']({ query: 'q' });
     expect(result.content[0].text).not.toContain('Model:');
+  });
+
+  it('handleRetrieveKnowledge expands neighbor context only when requested', async () => {
+    await setRetrieveEnv();
+    updateIndexMock.mockResolvedValue(undefined);
+    const semanticResults = [
+      {
+        pageContent: 'match',
+        metadata: { source: '/tmp/doc.md', chunkIndex: 1 },
+        score: 0.5,
+      },
+    ];
+    similaritySearchMock.mockResolvedValue(semanticResults);
+    expandWithNeighborContextMock.mockReturnValue([
+      {
+        ...semanticResults[0],
+        matchType: 'semantic',
+        semanticMatch: true,
+        contextChunks: [
+          {
+            pageContent: 'neighbor',
+            metadata: { source: '/tmp/doc.md', chunkIndex: 2 },
+            matchType: 'context',
+            semanticMatch: false,
+            contextDirection: 'after',
+            contextDistance: 1,
+          },
+        ],
+      },
+    ]);
+
+    const server = await freshServer();
+    const result = await server['handleRetrieveKnowledge']({
+      query: 'q',
+      context_before: 1,
+      context_after: 1,
+    });
+
+    expect(expandWithNeighborContextMock).toHaveBeenCalledWith(
+      semanticResults,
+      { before: 1, after: 1 },
+    );
+    expect(result.content[0].text).toContain('semantic match');
+    expect(result.content[0].text).toContain('Context chunks');
+    expect(result.content[0].text).toContain('neighbor');
+  });
+
+  it('handleRetrieveKnowledge rejects neighbor context for hybrid mode', async () => {
+    await setRetrieveEnv();
+
+    const server = await freshServer();
+    const result = await server['handleRetrieveKnowledge']({
+      query: 'q',
+      search_mode: 'hybrid',
+      context_window: 1,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content[0].text).error.code).toBe('VALIDATION');
+    expect(similaritySearchMock).not.toHaveBeenCalled();
   });
 
   // --- handleKbStats (#54) -------------------------------------------------

--- a/src/KnowledgeBaseServer.ts
+++ b/src/KnowledgeBaseServer.ts
@@ -9,7 +9,11 @@ import {
   type TextContent,
 } from '@modelcontextprotocol/sdk/types.js';
 import { FaissIndexManager } from './FaissIndexManager.js';
-import type { IndexUpdateProgress, SimilaritySearchTiming } from './FaissIndexManager.js';
+import type {
+  IndexUpdateProgress,
+  NeighborContextOptions,
+  SimilaritySearchTiming,
+} from './FaissIndexManager.js';
 import {
   ActiveModelResolutionError,
   listRegisteredModels,
@@ -85,6 +89,21 @@ function mcpErrorContent(error: Error): TextContent {
       },
     }),
   };
+}
+
+function resolveNeighborContextOptions(args: {
+  context_before?: number;
+  context_after?: number;
+  context_window?: number;
+}): NeighborContextOptions | undefined {
+  const before = args.context_before ?? args.context_window ?? 0;
+  const after = args.context_after ?? args.context_window ?? 0;
+  if (before === 0 && after === 0) return undefined;
+  return { before, after };
+}
+
+function hasNeighborContext(options: NeighborContextOptions | undefined): boolean {
+  return (options?.before ?? 0) > 0 || (options?.after ?? 0) > 0;
 }
 
 interface AddDocumentSnapshot {
@@ -355,6 +374,9 @@ export class KnowledgeBaseServer {
         extensions: z.array(z.string()).optional().describe('Limit results to chunks whose source file has one of these extensions (e.g. [".md", ".pdf"]). Case-insensitive; leading dot optional.'),
         path_glob: z.string().optional().describe('Limit results to chunks whose KB-internal relative path matches this glob (e.g. "runbooks/**"). The KB-name segment is stripped before matching.'),
         tags: z.array(z.string()).optional().describe('Limit results to chunks whose source file has ALL of these tags in its YAML frontmatter.'),
+        context_before: z.number().int().min(0).max(5).optional().describe('Opt-in neighbor context: include up to this many preceding chunks from the same source around each dense semantic match. Defaults to 0.'),
+        context_after: z.number().int().min(0).max(5).optional().describe('Opt-in neighbor context: include up to this many following chunks from the same source around each dense semantic match. Defaults to 0.'),
+        context_window: z.number().int().min(0).max(5).optional().describe('Shorthand for setting context_before and context_after to the same value. Defaults to 0.'),
         // #206 stage 2 — sparse+dense hybrid retrieval. Default 'dense' is
         // wire-compatible with 0.x clients: when the field is absent the
         // server runs the unmodified dense path. 'hybrid' fuses dense FAISS
@@ -815,6 +837,9 @@ export class KnowledgeBaseServer {
     extensions?: string[];
     path_glob?: string;
     tags?: string[];
+    context_before?: number;
+    context_after?: number;
+    context_window?: number;
     search_mode?: 'dense' | 'hybrid';
   }): Promise<CallToolResult> {
     const canonical: Partial<CanonicalLogInput> = {};
@@ -826,6 +851,7 @@ export class KnowledgeBaseServer {
       ? { extensions: args.extensions, pathGlob: args.path_glob, tags: args.tags }
       : undefined;
     const searchMode: 'dense' | 'hybrid' = args.search_mode ?? 'dense';
+    const neighborContext = resolveNeighborContextOptions(args);
 
     return this.withCanonicalTool({
       tool: 'retrieve_knowledge',
@@ -836,6 +862,20 @@ export class KnowledgeBaseServer {
       search_mode: searchMode,
     }, async () => {
       if (searchMode === 'hybrid') {
+        if (hasNeighborContext(neighborContext)) {
+          return {
+            content: [{
+              type: 'text',
+              text: JSON.stringify({
+                error: {
+                  code: 'VALIDATION',
+                  message: 'neighbor context expansion is only supported with dense retrieve_knowledge',
+                },
+              }),
+            }],
+            isError: true,
+          };
+        }
         return this.handleRetrieveKnowledgeHybrid({
           query,
           knowledgeBaseName,
@@ -878,7 +918,7 @@ export class KnowledgeBaseServer {
 
       // Perform similarity search using the provided query.
       const timing: SimilaritySearchTiming = {};
-      const similaritySearchResults = await manager.similaritySearch(
+      let similaritySearchResults = await manager.similaritySearch(
         query,
         10,
         threshold,
@@ -886,6 +926,12 @@ export class KnowledgeBaseServer {
         filters,
         timing,
       );
+      if (neighborContext) {
+        similaritySearchResults = manager.expandWithNeighborContext(
+          similaritySearchResults,
+          neighborContext,
+        );
+      }
       if (process.env.KB_LOG_VERBOSE === '1') {
         logger.debug(`[${Date.now()}] Similarity search completed`);
       }

--- a/src/cli-search.test.ts
+++ b/src/cli-search.test.ts
@@ -161,6 +161,31 @@ describe('parseSearchArgs --interactive (#215)', () => {
   });
 });
 
+describe('parseSearchArgs neighbor context (#225)', () => {
+  it('accepts explicit before/after context windows', () => {
+    expect(parseSearchArgs([
+      'query',
+      '--context-before=1',
+      '--context-after=2',
+    ])).toMatchObject({
+      query: 'query',
+      neighborContext: { before: 1, after: 2 },
+    });
+  });
+
+  it('accepts --context-window as a before/after shorthand', () => {
+    expect(parseSearchArgs(['query', '--context-window=2'])).toMatchObject({
+      neighborContext: { before: 2, after: 2 },
+    });
+  });
+
+  it('rejects unbounded context windows', () => {
+    expect(() => parseSearchArgs(['query', '--context-window=99'])).toThrow(
+      /invalid --context-window/,
+    );
+  });
+});
+
 describe('shouldUsePicker (#215)', () => {
   it('returns false when --interactive is not set', () => {
     expect(shouldUsePicker({ interactive: false, format: 'md' })).toBe(false);

--- a/src/cli-search.ts
+++ b/src/cli-search.ts
@@ -1,6 +1,11 @@
 import * as fsp from 'fs/promises';
 import * as path from 'path';
-import { FaissIndexManager, type SimilaritySearchTiming } from './FaissIndexManager.js';
+import {
+  FaissIndexManager,
+  MAX_NEIGHBOR_CONTEXT_WINDOW,
+  type NeighborContextOptions,
+  type SimilaritySearchTiming,
+} from './FaissIndexManager.js';
 import {
   resolveActiveModel,
   resolveFaissIndexBinaryPath,
@@ -68,6 +73,11 @@ Result tuning:
   --mode=dense|lexical|hybrid|auto
                         Retrieval mode (default: dense). \`hybrid\` fuses
                         dense + BM25 via reciprocal rank fusion (#206).
+  --context-before=<n>  Include up to n preceding chunks from the same source
+                        around each dense semantic match (0-${MAX_NEIGHBOR_CONTEXT_WINDOW}).
+  --context-after=<n>   Include up to n following chunks from the same source
+                        around each dense semantic match (0-${MAX_NEIGHBOR_CONTEXT_WINDOW}).
+  --context-window=<n>  Shorthand for --context-before=n --context-after=n.
 
 Output:
   --format=md|json|vimgrep
@@ -114,6 +124,7 @@ interface SearchArgs {
   mode: SearchMode;
   timing: boolean;
   interactive: boolean;
+  neighborContext?: NeighborContextOptions;
 }
 
 export interface Staleness {
@@ -183,6 +194,10 @@ export async function runSearch(rest: string[]): Promise<number> {
       }
     : null;
   const effectiveParsed: SearchArgs = { ...parsed, mode: effectiveMode };
+  if (hasNeighborContext(parsed) && effectiveMode !== 'dense') {
+    process.stderr.write('kb search: neighbor context expansion is only supported with --mode=dense\n');
+    return 2;
+  }
 
   if (effectiveMode === 'lexical') {
     return runLexicalSearch(effectiveParsed, timing, totalStartedAt, autoModeDecision);
@@ -257,6 +272,9 @@ export async function runSearch(rest: string[]): Promise<number> {
         undefined,
         timing ? denseTiming : undefined,
       );
+    }
+    if (parsed.neighborContext) {
+      results = manager.expandWithNeighborContext(results, parsed.neighborContext);
     }
     if (timing) {
       timing.dense_search_ms = elapsedMs(startedAt);
@@ -381,6 +399,25 @@ export function parseSearchArgs(rest: string[]): SearchArgs {
     if (raw === '--group-by-source') { out.groupBySource = true; continue; }
     if (raw === '--timing') { out.timing = true; continue; }
     if (raw === '--interactive' || raw === '-i') { out.interactive = true; continue; }
+    if (raw.startsWith('--context-before=')) {
+      out.neighborContext = {
+        ...out.neighborContext,
+        before: parseNeighborContextCount(raw, '--context-before='),
+      };
+      continue;
+    }
+    if (raw.startsWith('--context-after=')) {
+      out.neighborContext = {
+        ...out.neighborContext,
+        after: parseNeighborContextCount(raw, '--context-after='),
+      };
+      continue;
+    }
+    if (raw.startsWith('--context-window=')) {
+      const count = parseNeighborContextCount(raw, '--context-window=');
+      out.neighborContext = { ...out.neighborContext, before: count, after: count };
+      continue;
+    }
     if (raw.startsWith('--kb=')) { out.kb = raw.slice('--kb='.length); continue; }
     if (raw.startsWith('--model=')) { out.model = raw.slice('--model='.length); continue; }
     if (raw.startsWith('--mode=')) {
@@ -412,6 +449,20 @@ export function parseSearchArgs(rest: string[]): SearchArgs {
     throw new Error(`unexpected argument: ${raw}`);
   }
   return out;
+}
+
+function parseNeighborContextCount(raw: string, prefix: string): number {
+  const n = Number(raw.slice(prefix.length));
+  if (!Number.isInteger(n) || n < 0 || n > MAX_NEIGHBOR_CONTEXT_WINDOW) {
+    throw new Error(`invalid ${prefix.slice(0, -1)}: ${raw} (expected integer 0-${MAX_NEIGHBOR_CONTEXT_WINDOW})`);
+  }
+  return n;
+}
+
+function hasNeighborContext(parsed: SearchArgs): boolean {
+  const before = parsed.neighborContext?.before ?? 0;
+  const after = parsed.neighborContext?.after ?? 0;
+  return before > 0 || after > 0;
 }
 
 /**

--- a/src/formatter.test.ts
+++ b/src/formatter.test.ts
@@ -171,6 +171,34 @@ describe('formatRetrievalAsMarkdown', () => {
     expect(out).not.toContain('shh');
     expect(out).toContain('"title": "T"');
   });
+
+  it('labels semantic matches and context-only chunks when neighbor context is present', () => {
+    const doc: ScoredDocument = {
+      pageContent: 'matched chunk',
+      metadata: { source: 'kb/doc.md', chunkIndex: 2 },
+      score: 0.42,
+      matchType: 'semantic',
+      semanticMatch: true,
+      contextChunks: [
+        {
+          pageContent: 'previous chunk',
+          metadata: { source: 'kb/doc.md', chunkIndex: 1 },
+          matchType: 'context',
+          semanticMatch: false,
+          contextDirection: 'before',
+          contextDistance: 1,
+        },
+      ],
+    } as unknown as ScoredDocument;
+
+    const out = formatRetrievalAsMarkdown([doc], false);
+
+    expect(out).toContain('**Result 1 (semantic match):**');
+    expect(out).toContain('matched chunk');
+    expect(out).toContain('**Context chunks:**');
+    expect(out).toContain('**Context (before, distance 1):**');
+    expect(out).toContain('previous chunk');
+  });
 });
 
 describe('formatRetrievalAsJson', () => {
@@ -351,6 +379,49 @@ describe('formatRetrievalAsJson', () => {
     });
     expect(out[0].metadata).not.toHaveProperty('frontmatter');
   });
+
+  it('keeps semantic matches distinct from context-only chunks in JSON output', () => {
+    const doc: ScoredDocument = {
+      pageContent: 'matched chunk',
+      metadata: { source: 'kb/doc.md', chunkIndex: 2 },
+      score: 0.42,
+      matchType: 'semantic',
+      semanticMatch: true,
+      contextChunks: [
+        {
+          pageContent: 'next chunk',
+          metadata: { source: 'kb/doc.md', chunkIndex: 3 },
+          matchType: 'context',
+          semanticMatch: false,
+          contextDirection: 'after',
+          contextDistance: 1,
+        },
+      ],
+    } as unknown as ScoredDocument;
+
+    const out = formatRetrievalAsJson([doc], false);
+
+    expect(out[0]).toMatchObject({
+      score: 0.42,
+      content: 'matched chunk',
+      match_type: 'semantic',
+      semantic_match: true,
+      context_chunks: [
+        {
+          match_type: 'context',
+          semantic_match: false,
+          direction: 'after',
+          distance: 1,
+          content: 'next chunk',
+        },
+      ],
+    });
+    expect(out[0].metadata).toMatchObject({ source: 'kb/doc.md', chunkIndex: 2 });
+    expect(out[0].context_chunks?.[0].metadata).toMatchObject({
+      source: 'kb/doc.md',
+      chunkIndex: 3,
+    });
+  });
 });
 
 describe('formatRetrievalAsVimgrep', () => {
@@ -436,6 +507,37 @@ describe('groupRetrievalBySource', () => {
       source: 'kb/doc.md',
       frontmatter: { title: 'Visible' },
       injection_signals: [],
+    });
+  });
+
+  it('carries context-only chunks under grouped semantic chunks', () => {
+    const docs: ScoredDocument[] = [
+      {
+        pageContent: 'match',
+        metadata: { source: 'kb/doc.md', chunkIndex: 1 },
+        score: 0.2,
+        matchType: 'semantic',
+        semanticMatch: true,
+        contextChunks: [
+          {
+            pageContent: 'context',
+            metadata: { source: 'kb/doc.md', chunkIndex: 0 },
+            matchType: 'context',
+            semanticMatch: false,
+            contextDirection: 'before',
+            contextDistance: 1,
+          },
+        ],
+      } as unknown as ScoredDocument,
+    ];
+
+    const grouped = groupRetrievalBySource(docs, false);
+
+    expect(grouped[0].chunks[0].match_type).toBe('semantic');
+    expect(grouped[0].chunks[0].context_chunks?.[0]).toMatchObject({
+      match_type: 'context',
+      direction: 'before',
+      content: 'context',
     });
   });
 });

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -20,6 +20,17 @@ import { getInjectionSignals, type InjectionSignal } from './kb-shield.js';
  */
 export interface ScoredDocument extends Document {
   score?: number;
+  matchType?: 'semantic';
+  semanticMatch?: true;
+  contextChunks?: ContextDocument[];
+  contextTruncated?: boolean;
+}
+
+export interface ContextDocument extends Document {
+  matchType: 'context';
+  semanticMatch: false;
+  contextDirection: 'before' | 'after';
+  contextDistance: number;
 }
 
 export interface RetrievalJsonResult {
@@ -34,6 +45,22 @@ export interface RetrievalJsonResult {
    * omitted when `KB_SHIELD=off`. Signals are evidence the downstream agent
    * uses to decide policy — the chunk's `content` is **never** modified.
    */
+  injection_signals?: InjectionSignal[];
+  match_type?: 'semantic';
+  semantic_match?: true;
+  context_chunks?: RetrievalJsonContextChunk[];
+  context_truncated?: boolean;
+}
+
+export interface RetrievalJsonContextChunk {
+  match_type: 'context';
+  semantic_match: false;
+  direction: 'before' | 'after';
+  distance: number;
+  content: string;
+  metadata: Record<string, unknown>;
+  chunk_id?: string;
+  editor_uri?: string;
   injection_signals?: InjectionSignal[];
 }
 
@@ -91,7 +118,10 @@ export function formatRetrievalAsMarkdown(
     const guardOptions = resolveInjectionGuardOptions();
     formattedResults = results
       .map((doc, idx) => {
-        const resultHeader = `**Result ${idx + 1}:**`;
+        const hasContextAnnotation = hasNeighborContextAnnotation(doc);
+        const resultHeader = hasContextAnnotation
+          ? `**Result ${idx + 1} (semantic match):**`
+          : `**Result ${idx + 1}:**`;
         const sanitizedMetadata = sanitizeMetadataForWire(
           doc.metadata as Record<string, unknown>,
           extrasVisible,
@@ -103,7 +133,8 @@ export function formatRetrievalAsMarkdown(
         const scoreText = doc.score !== undefined ? `**Score:** ${doc.score.toFixed(2)}\n\n` : '';
         const signals = getShieldSignals(doc.pageContent, sanitizedMetadata, guardOptions);
         const shieldFooter = formatInjectionMarkdown(signals);
-        return `${resultHeader}\n\n${scoreText}${content}\n\n${shieldFooter}${formatSourceBlock(metadata, citation)}`;
+        const contextText = formatContextChunksAsMarkdown(doc, extrasVisible, editorUriMode);
+        return `${resultHeader}\n\n${scoreText}${content}\n\n${shieldFooter}${formatSourceBlock(metadata, citation)}${contextText}`;
       })
       .join('\n\n---\n\n');
   } else {
@@ -129,7 +160,9 @@ export function formatRetrievalGroupedBySourceAsMarkdown(
             const locationText = formatLocation(chunk.location);
             const openText = chunk.editor_uri ? `\n   **Open:** ${chunk.editor_uri}` : '';
             const shieldText = formatInjectionGrouped(chunk.injection_signals);
-            return `${chunkIdx + 1}. **Score:** ${scoreText}\n   **Location:** ${locationText}${openText}\n\n   ${indentChunkContent(chunk.content.trim())}${shieldText}`;
+            const typeText = chunk.match_type ? `\n   **Type:** ${chunk.match_type}` : '';
+            const contextText = formatJsonContextChunksForGroupedMarkdown(chunk.context_chunks);
+            return `${chunkIdx + 1}. **Score:** ${scoreText}${typeText}\n   **Location:** ${locationText}${openText}\n\n   ${indentChunkContent(chunk.content.trim())}${shieldText}${contextText}`;
           })
           .join('\n\n');
         return (
@@ -174,6 +207,16 @@ export function formatRetrievalAsJson(
       ...(citation ? { chunk_id: citation.chunk_id } : {}),
       ...(citation?.editor_uri ? { editor_uri: citation.editor_uri } : {}),
       ...(signals !== undefined ? { injection_signals: signals } : {}),
+      ...(hasNeighborContextAnnotation(doc)
+        ? {
+            match_type: 'semantic' as const,
+            semantic_match: true as const,
+          }
+        : {}),
+      ...(doc.contextChunks && doc.contextChunks.length > 0
+        ? { context_chunks: formatContextChunksAsJson(doc.contextChunks, extrasVisible, editorUriMode) }
+        : {}),
+      ...(doc.contextTruncated ? { context_truncated: true } : {}),
     };
   });
 }
@@ -218,6 +261,16 @@ export function groupRetrievalBySource(
       ...(citation ? { chunk_id: citation.chunk_id } : {}),
       ...(citation?.editor_uri ? { editor_uri: citation.editor_uri } : {}),
       ...(signals !== undefined ? { injection_signals: signals } : {}),
+      ...(hasNeighborContextAnnotation(doc)
+        ? {
+            match_type: 'semantic' as const,
+            semantic_match: true as const,
+          }
+        : {}),
+      ...(doc.contextChunks && doc.contextChunks.length > 0
+        ? { context_chunks: formatContextChunksAsJson(doc.contextChunks, extrasVisible, editorUriMode) }
+        : {}),
+      ...(doc.contextTruncated ? { context_truncated: true } : {}),
     });
   });
 
@@ -303,6 +356,14 @@ function formatInjectionGrouped(signals: InjectionSignal[] | undefined): string 
   return lines;
 }
 
+function formatInjectionContext(signals: InjectionSignal[] | undefined): string {
+  if (!signals || signals.length === 0) return '';
+  const lines = signals
+    .map((s) => `\n  > ⚠ injection-signal: ${s.rule} [${s.span_start}, ${s.span_end})`)
+    .join('');
+  return lines;
+}
+
 function guardRetrievalChunk(
   content: string,
   metadata: Record<string, unknown>,
@@ -318,6 +379,87 @@ function getShieldSignals(
 ): InjectionSignal[] | undefined {
   if (isInjectionGuardBypassed(metadata, options)) return undefined;
   return getInjectionSignals(content);
+}
+
+function hasNeighborContextAnnotation(doc: ScoredDocument): boolean {
+  return doc.matchType === 'semantic' || doc.semanticMatch === true || doc.contextChunks !== undefined;
+}
+
+function formatContextChunksAsMarkdown(
+  doc: ScoredDocument,
+  extrasVisible: boolean,
+  editorUriMode: KBEditorUriMode,
+): string {
+  if (!doc.contextChunks || doc.contextChunks.length === 0) {
+    return doc.contextTruncated ? '\n\n**Context chunks:** truncated by response cap.' : '';
+  }
+  const guardOptions = resolveInjectionGuardOptions();
+  const chunks = doc.contextChunks
+    .map((chunk) => {
+      const metadata = sanitizeMetadataForWire(
+        chunk.metadata as Record<string, unknown>,
+        extrasVisible,
+      );
+      const guarded = guardRetrievalChunk(chunk.pageContent, metadata, guardOptions);
+      const citation = buildChunkCitation(guarded.metadata, editorUriMode);
+      const signals = getShieldSignals(chunk.pageContent, metadata, guardOptions);
+      const openText = citation?.editor_uri ? `\n   **Open:** ${citation.editor_uri}` : '';
+      const sourceText = citation ? `\n   **Source:** ${citation.chunk_id}` : '';
+      const shieldText = formatInjectionContext(signals);
+      return (
+        `- **Context (${chunk.contextDirection}, distance ${chunk.contextDistance}):**${sourceText}${openText}\n\n` +
+        `  ${indentListContent(guarded.content.trim())}${shieldText}`
+      );
+    })
+    .join('\n\n');
+  const truncated = doc.contextTruncated ? '\n\n_Context truncated by response cap._' : '';
+  return `\n\n**Context chunks:**\n\n${chunks}${truncated}`;
+}
+
+function formatContextChunksAsJson(
+  chunks: ContextDocument[],
+  extrasVisible: boolean,
+  editorUriMode: KBEditorUriMode,
+): RetrievalJsonContextChunk[] {
+  const guardOptions = resolveInjectionGuardOptions();
+  return chunks.map((chunk) => {
+    const metadata = sanitizeMetadataForWire(
+      chunk.metadata as Record<string, unknown>,
+      extrasVisible,
+    );
+    const guarded = guardRetrievalChunk(chunk.pageContent, metadata, guardOptions);
+    const citation = buildChunkCitation(guarded.metadata, editorUriMode);
+    const signals = getShieldSignals(chunk.pageContent, metadata, guardOptions);
+    return {
+      match_type: 'context',
+      semantic_match: false,
+      direction: chunk.contextDirection,
+      distance: chunk.contextDistance,
+      content: guarded.content,
+      metadata: guarded.metadata,
+      ...(citation ? { chunk_id: citation.chunk_id } : {}),
+      ...(citation?.editor_uri ? { editor_uri: citation.editor_uri } : {}),
+      ...(signals !== undefined ? { injection_signals: signals } : {}),
+    };
+  });
+}
+
+function formatJsonContextChunksForGroupedMarkdown(
+  chunks: RetrievalJsonContextChunk[] | undefined,
+): string {
+  if (!chunks || chunks.length === 0) return '';
+  const lines = chunks
+    .map((chunk) => (
+      `   - **Context (${chunk.direction}, distance ${chunk.distance}):**\n\n` +
+      `     ${indentListContent(chunk.content.trim())}${formatInjectionGrouped(chunk.injection_signals)}`
+    ))
+    .join('\n\n');
+  return `\n\n   **Context chunks:**\n\n${lines}`;
+}
+
+function indentListContent(content: string): string {
+  if (content === '') return '';
+  return content.replace(/\n/g, '\n  ');
 }
 
 function formatSourceBlock(metadata: string, citation: ChunkCitation | null): string {


### PR DESCRIPTION
Closes #225.

## Summary
- add opt-in dense neighbor context expansion from the loaded FAISS docstore
- expose `kb search` flags and MCP `retrieve_knowledge` context arguments
- mark semantic matches separately from context-only chunks in markdown, grouped markdown, and JSON
- cap and deduplicate expanded context chunks

## Verification
- `npm test -- /home/jean/git/knowledge-base-mcp-server-issue-225-neighbor-context/src/FaissIndexManager.test.ts /home/jean/git/knowledge-base-mcp-server-issue-225-neighbor-context/src/KnowledgeBaseServer.test.ts /home/jean/git/knowledge-base-mcp-server-issue-225-neighbor-context/src/cli-search.test.ts /home/jean/git/knowledge-base-mcp-server-issue-225-neighbor-context/src/formatter.test.ts && npm run build`
- `npm test`

## Pre-PR review
- detected project type: npm
- type/build checks: passed (`npm run build`)
- tests: passed (`npm test`; focused test set also passed)
- bug reproduction: skipped (feature PR)
- diff review: done
- portability check: helper missing; manual changed-line scan clean
- reviewer specialists: skipped; session did not have user authorization to spawn subagents
- OSS base-branch policy: skipped (same-repo PR)
- gate file: created