### PR TITLE
feat(eval): support retrieval mode selection

### DIFF
--- a/docs/testing/fixtures/hybrid-vs-dense.yml
+++ b/docs/testing/fixtures/hybrid-vs-dense.yml
@@ -12,6 +12,7 @@
 # Run with:
 #   kb eval docs/testing/fixtures/hybrid-vs-dense.yml --mode=dense
 #   kb eval docs/testing/fixtures/hybrid-vs-dense.yml --mode=hybrid
+#   kb eval docs/testing/fixtures/hybrid-vs-dense.yml --mode=auto --format=json
 #
 # The fixture is `gate: false` — failures print a warning and exit 0.
 # This is a guidance pack for operators / contributors to verify the

--- a/docs/testing/retrieval-eval.md
+++ b/docs/testing/retrieval-eval.md
@@ -9,6 +9,16 @@ The unit tests in `src/retrieval-eval.test.ts` cover:
 - Forbidden source failures.
 - Duplicate-source budget failures.
 - Exit-code behavior where ungated failures warn and gated failures fail CI.
+- Retrieval mode parsing for `dense`, `lexical`, `hybrid`, and `auto`.
+- Fixture-level and case-level retrieval mode normalization.
+- Per-case requested/effective retrieval mode reporting.
 - Parse coverage for the worked example in `docs/testing/fixtures/methodology-starter.yml`.
+
+`kb eval` defaults to dense retrieval to preserve the original evaluator behavior.
+Pass `--mode=lexical`, `--mode=hybrid`, or `--mode=auto` to exercise the same
+mode choices exposed by `kb search`. A fixture can also set top-level `mode` as
+its default, and individual cases can override it with case-level `mode`.
+JSON output records `requested_mode`, `effective_mode`, and `auto_mode` when
+auto selection is used.
 
 For authoring guidance, see [Retrieval eval fixture methodology](retrieval-eval-methodology.md).

--- a/src/cli-eval.ts
+++ b/src/cli-eval.ts
@@ -5,12 +5,13 @@ import {
   ActiveModelResolutionError,
   resolveActiveModel,
 } from './active-model.js';
-import { computeStaleness } from './cli-search.js';
+import { computeStaleness, type SearchMode } from './cli-search.js';
 import { loadManagerForModel, loadWithJsonRetry } from './cli-shared.js';
 import {
   evaluateRetrievalCase,
   formatRetrievalEvalMarkdown,
   normalizeRetrievalEvalFixture,
+  retrieveForRetrievalEvalCase,
   retrievalEvalExitCode,
   summarizeRetrievalEval,
   type RetrievalEvalFixture,
@@ -22,6 +23,7 @@ interface EvalArgs {
   format: 'md' | 'json';
   k: number;
   threshold: number;
+  mode?: SearchMode;
 }
 
 const DEFAULT_K = 10;
@@ -31,7 +33,7 @@ export const EVAL_HELP = `kb eval — run fixture-driven retrieval checks
 
 Usage:
   kb eval <fixture.yml|json> [--model=<id>] [--k=<int>] [--threshold=<float>]
-                              [--format=md|json]
+                              [--mode=dense|lexical|hybrid|auto] [--format=md|json]
 
 Reads cases from a YAML or JSON fixture and runs each query against the
 active model's index. Each case can set \`query\`, optional \`kb\`,
@@ -48,6 +50,10 @@ Options:
   --model=<id>          Override the active model for the run (RFC 013).
   --k=<int>             Top-K results per case (default: ${DEFAULT_K}).
   --threshold=<float>   Max similarity score; lower = closer (default: ${DEFAULT_THRESHOLD}).
+                        Dense-only; lexical and hybrid modes ignore it.
+  --mode=dense|lexical|hybrid|auto
+                        Retrieval mode (default: dense). Fixture-level mode
+                        sets a default; case-level mode overrides both.
   --format=md|json      Output format (default: md).
   --help, -h            Show this help.
 
@@ -119,14 +125,14 @@ export async function runEval(rest: string[]): Promise<number> {
   const results = [];
   for (const fixtureCase of fixture.cases) {
     try {
-      const caseResults = await manager.similaritySearch(
-        fixtureCase.query,
-        fixtureCase.k ?? parsed.k,
-        fixtureCase.threshold ?? parsed.threshold,
-        fixtureCase.kb,
-      );
+      const requestedMode = fixtureCase.mode ?? parsed.mode ?? fixture.mode ?? 'dense';
+      const search = await retrieveForRetrievalEvalCase(fixtureCase, {
+        manager,
+        defaultK: parsed.k,
+        defaultThreshold: parsed.threshold,
+      }, requestedMode);
       const staleness = await computeStaleness(activeModelId, fixtureCase.kb);
-      results.push(evaluateRetrievalCase(fixtureCase, caseResults, staleness, fixture.gate));
+      results.push(evaluateRetrievalCase(fixtureCase, search.results, staleness, fixture.gate, search));
     } catch (err) {
       process.stderr.write(`kb eval: ${fixtureCase.name}: ${(err as Error).message}\n`);
       return 1;
@@ -165,6 +171,14 @@ export function parseEvalArgs(rest: string[]): EvalArgs {
       const value = raw.slice('--format='.length);
       if (value !== 'md' && value !== 'json') throw new Error(`invalid --format: ${raw}`);
       out.format = value;
+      continue;
+    }
+    if (raw.startsWith('--mode=')) {
+      const value = raw.slice('--mode='.length);
+      if (value !== 'dense' && value !== 'lexical' && value !== 'hybrid' && value !== 'auto') {
+        throw new Error(`invalid --mode: ${raw} (expected 'dense', 'lexical', 'hybrid', or 'auto')`);
+      }
+      out.mode = value;
       continue;
     }
     if (raw.startsWith('--k=')) {
@@ -206,6 +220,9 @@ function toJsonReport(report: ReturnType<typeof summarizeRetrievalEval>): unknow
       query: result.query,
       ...(result.kb !== undefined ? { kb: result.kb } : {}),
       gate: result.gate,
+      requested_mode: result.requestedMode,
+      effective_mode: result.effectiveMode,
+      ...(result.autoMode !== undefined ? { auto_mode: result.autoMode } : {}),
       passed: result.passed,
       failures: result.failures,
       warnings: result.warnings,

--- a/src/retrieval-eval.test.ts
+++ b/src/retrieval-eval.test.ts
@@ -2,12 +2,14 @@ import { describe, expect, it } from '@jest/globals';
 import * as fsp from 'fs/promises';
 import * as path from 'path';
 import yaml from 'js-yaml';
+import { parseEvalArgs } from './cli-eval.js';
 import type { ScoredDocument } from './formatter.js';
 import type { Staleness } from './cli-search.js';
 import {
   evaluateRetrievalCase,
   normalizeRetrievalEvalFixture,
   retrievalEvalExitCode,
+  resolveRetrievalEvalMode,
   summarizeRetrievalEval,
   type RetrievalEvalCase,
 } from './retrieval-eval.js';
@@ -39,6 +41,28 @@ function fixtureCase(overrides: Partial<RetrievalEvalCase> = {}): RetrievalEvalC
 }
 
 describe('normalizeRetrievalEvalFixture', () => {
+  it('normalizes fixture-level and case-level retrieval modes', () => {
+    const fixture = normalizeRetrievalEvalFixture({
+      gate: false,
+      mode: 'hybrid',
+      cases: [{
+        name: 'auto exact token',
+        query: 'INDEX_NOT_INITIALIZED',
+        mode: 'auto',
+      }],
+    });
+
+    expect(fixture.mode).toBe('hybrid');
+    expect(fixture.cases[0].mode).toBe('auto');
+  });
+
+  it('rejects invalid retrieval modes in fixtures', () => {
+    expect(() => normalizeRetrievalEvalFixture({
+      mode: 'sparse',
+      cases: [{ query: 'deployment notes' }],
+    })).toThrow('fixture mode must be "dense", "lexical", "hybrid", or "auto"');
+  });
+
   it('normalizes fixture cases with source, metadata, duplicate, gate, and stale policy fields', () => {
     const fixture = normalizeRetrievalEvalFixture({
       gate: true,
@@ -99,6 +123,36 @@ describe('normalizeRetrievalEvalFixture', () => {
   });
 });
 
+describe('parseEvalArgs', () => {
+  it('parses retrieval mode selection', () => {
+    expect(parseEvalArgs(['fixture.yml', '--mode=hybrid']).mode).toBe('hybrid');
+    expect(parseEvalArgs(['fixture.yml']).mode).toBeUndefined();
+  });
+
+  it('rejects invalid retrieval modes', () => {
+    expect(() => parseEvalArgs(['fixture.yml', '--mode=sparse'])).toThrow(
+      "invalid --mode: --mode=sparse (expected 'dense', 'lexical', 'hybrid', or 'auto')",
+    );
+  });
+});
+
+describe('resolveRetrievalEvalMode', () => {
+  it('preserves explicit dense mode', () => {
+    expect(resolveRetrievalEvalMode('dense', 'INDEX_NOT_INITIALIZED')).toEqual({
+      requestedMode: 'dense',
+      effectiveMode: 'dense',
+    });
+  });
+
+  it('records auto mode decisions per query', () => {
+    expect(resolveRetrievalEvalMode('auto', 'INDEX_NOT_INITIALIZED')).toEqual({
+      requestedMode: 'auto',
+      effectiveMode: 'hybrid',
+      autoMode: { mode: 'hybrid', reason: 'constant or error-code token' },
+    });
+  });
+});
+
 describe('evaluateRetrievalCase', () => {
   it('passes when required sources and metadata are present and duplicate budget is respected', () => {
     const result = evaluateRetrievalCase(
@@ -121,6 +175,28 @@ describe('evaluateRetrievalCase', () => {
     expect(result.passed).toBe(true);
     expect(result.duplicateGroups).toBe(1);
     expect(result.failures).toEqual([]);
+    expect(result.requestedMode).toBe('dense');
+    expect(result.effectiveMode).toBe('dense');
+  });
+
+  it('records requested and effective retrieval mode in case results', () => {
+    const result = evaluateRetrievalCase(
+      fixtureCase(),
+      [],
+      FRESH,
+      false,
+      {
+        requestedMode: 'auto',
+        effectiveMode: 'hybrid',
+        autoMode: { mode: 'hybrid', reason: 'constant or error-code token' },
+      },
+    );
+
+    expect(summarizeRetrievalEval([result]).cases[0]).toMatchObject({
+      requestedMode: 'auto',
+      effectiveMode: 'hybrid',
+      autoMode: { mode: 'hybrid', reason: 'constant or error-code token' },
+    });
   });
 
   it('fails when a required source is missing', () => {

--- a/src/retrieval-eval.ts
+++ b/src/retrieval-eval.ts
@@ -1,8 +1,23 @@
+import * as path from 'path';
 import { minimatch } from 'minimatch';
+import type { FaissIndexManager } from './FaissIndexManager.js';
 import type { ScoredDocument } from './formatter.js';
-import type { Staleness } from './cli-search.js';
+import {
+  resolveAutoSearchMode,
+  type AutoSearchModeDecision,
+  type EffectiveSearchMode,
+  type SearchMode,
+  type Staleness,
+} from './cli-search.js';
+import { KNOWLEDGE_BASES_ROOT_DIR } from './config.js';
+import { listKnowledgeBases } from './kb-fs.js';
+import { LexicalIndex, type LexicalSearchResult } from './lexical-index.js';
+import { chunkIdFromMetadata, reciprocalRankFusion, type RankedList } from './rrf.js';
 
 export type StalePolicy = 'allow_stale' | 'fresh' | 'stale';
+
+const HYBRID_FETCH_MULTIPLIER = 4;
+const HYBRID_RRF_C = 60;
 
 export interface ExpectedMetadataRule {
   path: string;
@@ -15,6 +30,7 @@ export interface RetrievalEvalCase {
   kb?: string;
   k?: number;
   threshold?: number;
+  mode?: SearchMode;
   gate?: boolean;
   requiredSources: string[];
   forbiddenSources: string[];
@@ -29,6 +45,7 @@ export interface RetrievalEvalCaseInput {
   kb?: string;
   k?: number;
   threshold?: number;
+  mode?: SearchMode;
   gate?: boolean;
   required_sources?: string[];
   forbidden_sources?: string[];
@@ -39,6 +56,7 @@ export interface RetrievalEvalCaseInput {
 
 export interface RetrievalEvalFixture {
   gate: boolean;
+  mode?: SearchMode;
   cases: RetrievalEvalCase[];
 }
 
@@ -46,6 +64,9 @@ export interface RetrievalEvalCaseResult {
   name: string;
   query: string;
   kb?: string;
+  requestedMode: SearchMode;
+  effectiveMode: EffectiveSearchMode;
+  autoMode?: AutoSearchModeDecision;
   gate: boolean;
   passed: boolean;
   failures: string[];
@@ -62,6 +83,19 @@ export interface RetrievalEvalReport {
   gateFailed: number;
 }
 
+export interface RetrievalEvalSearchContext {
+  manager: Pick<FaissIndexManager, 'similaritySearch'>;
+  defaultK: number;
+  defaultThreshold: number;
+}
+
+export interface RetrievalEvalSearchResult {
+  results: ScoredDocument[];
+  requestedMode: SearchMode;
+  effectiveMode: EffectiveSearchMode;
+  autoMode?: AutoSearchModeDecision;
+}
+
 export function normalizeRetrievalEvalFixture(input: unknown): RetrievalEvalFixture {
   if (!isRecord(input)) {
     throw new Error('fixture must be an object with a cases array');
@@ -73,7 +107,44 @@ export function normalizeRetrievalEvalFixture(input: unknown): RetrievalEvalFixt
   }
   return {
     gate,
+    ...readOptionalSearchMode(input, 'mode', 'fixture'),
     cases: rawCases.map((raw, idx) => normalizeCase(raw, idx + 1)),
+  };
+}
+
+export async function retrieveForRetrievalEvalCase(
+  fixtureCase: RetrievalEvalCase,
+  context: RetrievalEvalSearchContext,
+  requestedMode: SearchMode,
+): Promise<RetrievalEvalSearchResult> {
+  const mode = resolveRetrievalEvalMode(requestedMode, fixtureCase.query);
+  let results: ScoredDocument[];
+  if (mode.effectiveMode === 'dense') {
+    results = await retrieveDense(fixtureCase, context);
+  } else if (mode.effectiveMode === 'lexical') {
+    results = await retrieveLexical(
+      fixtureCase.query,
+      fixtureCase.k ?? context.defaultK,
+      fixtureCase.kb,
+    );
+  } else {
+    results = await retrieveHybrid(fixtureCase, context);
+  }
+  return { ...mode, results };
+}
+
+export function resolveRetrievalEvalMode(
+  requestedMode: SearchMode,
+  query: string,
+): Omit<RetrievalEvalSearchResult, 'results'> {
+  if (requestedMode !== 'auto') {
+    return { requestedMode, effectiveMode: requestedMode };
+  }
+  const autoMode = resolveAutoSearchMode(query);
+  return {
+    requestedMode,
+    effectiveMode: autoMode.mode,
+    autoMode,
   };
 }
 
@@ -82,6 +153,7 @@ export function evaluateRetrievalCase(
   results: readonly ScoredDocument[],
   staleness: Staleness,
   fixtureGate = false,
+  search?: Omit<RetrievalEvalSearchResult, 'results'>,
 ): RetrievalEvalCaseResult {
   const failures: string[] = [];
   const warnings: string[] = [];
@@ -128,6 +200,9 @@ export function evaluateRetrievalCase(
     name: fixtureCase.name,
     query: fixtureCase.query,
     ...(fixtureCase.kb !== undefined ? { kb: fixtureCase.kb } : {}),
+    requestedMode: search?.requestedMode ?? 'dense',
+    effectiveMode: search?.effectiveMode ?? 'dense',
+    ...(search?.autoMode !== undefined ? { autoMode: search.autoMode } : {}),
     gate,
     passed: failures.length === 0,
     failures,
@@ -157,8 +232,11 @@ export function formatRetrievalEvalMarkdown(report: RetrievalEvalReport): string
   for (const result of report.cases) {
     const status = result.passed ? 'PASS' : result.gate ? 'FAIL' : 'WARN';
     const scope = result.kb === undefined ? 'all KBs' : `kb=${result.kb}`;
+    const mode = result.requestedMode === result.effectiveMode
+      ? result.effectiveMode
+      : `${result.requestedMode} -> ${result.effectiveMode}`;
     lines.push(
-      `- ${status} ${result.name} (${scope}, ${result.resultCount} result(s), duplicate groups: ${result.duplicateGroups})`,
+      `- ${status} ${result.name} (${scope}, mode: ${mode}, ${result.resultCount} result(s), duplicate groups: ${result.duplicateGroups})`,
     );
     for (const failure of result.failures) {
       lines.push(`  - ${failure}`);
@@ -190,12 +268,99 @@ function normalizeCase(raw: unknown, caseNumber: number): RetrievalEvalCase {
     ...(kb !== undefined ? { kb } : {}),
     ...(k !== undefined ? { k } : {}),
     ...(threshold !== undefined ? { threshold } : {}),
+    ...readOptionalSearchMode(raw, 'mode', `case ${caseNumber}`),
     ...(gate !== undefined ? { gate } : {}),
     requiredSources: readOptionalStringArray(raw, 'required_sources') ?? [],
     forbiddenSources: readOptionalStringArray(raw, 'forbidden_sources') ?? [],
     expectedMetadata: normalizeExpectedMetadata(raw.expected_metadata, caseNumber),
     ...(maxDuplicateGroups !== undefined ? { maxDuplicateGroups } : {}),
     stalePolicy: normalizeStalePolicy(raw.stale_policy, caseNumber),
+  };
+}
+
+async function retrieveDense(
+  fixtureCase: RetrievalEvalCase,
+  context: RetrievalEvalSearchContext,
+): Promise<ScoredDocument[]> {
+  return context.manager.similaritySearch(
+    fixtureCase.query,
+    fixtureCase.k ?? context.defaultK,
+    fixtureCase.threshold ?? context.defaultThreshold,
+    fixtureCase.kb,
+  );
+}
+
+async function retrieveLexical(
+  query: string,
+  k: number,
+  scopedKb?: string,
+): Promise<ScoredDocument[]> {
+  const kbs = await listLexicalKbs(scopedKb);
+  const merged: LexicalSearchResult[] = [];
+  for (const { kbName, kbPath } of kbs) {
+    const index = await LexicalIndex.load(kbName, kbPath);
+    if (index.numFiles() === 0) {
+      await index.refresh();
+      await index.save();
+    }
+    merged.push(...await index.query(query, k));
+  }
+  merged.sort((a, b) => b.score - a.score);
+  return merged.slice(0, k).map(toScoredDocument);
+}
+
+async function retrieveHybrid(
+  fixtureCase: RetrievalEvalCase,
+  context: RetrievalEvalSearchContext,
+): Promise<ScoredDocument[]> {
+  const k = fixtureCase.k ?? context.defaultK;
+  const fetchK = Math.max(k * HYBRID_FETCH_MULTIPLIER, k);
+  const [denseResults, lexicalResults] = await Promise.all([
+    context.manager.similaritySearch(
+      fixtureCase.query,
+      fetchK,
+      Number.POSITIVE_INFINITY,
+      fixtureCase.kb,
+    ),
+    retrieveLexical(fixtureCase.query, fetchK, fixtureCase.kb),
+  ]);
+  const denseList: RankedList = {
+    retriever: 'dense',
+    results: denseResults.map((r, i) => ({ id: chunkIdFromMetadata(r.metadata), rank: i + 1 })),
+  };
+  const lexicalList: RankedList = {
+    retriever: 'lexical',
+    results: lexicalResults.map((r, i) => ({ id: chunkIdFromMetadata(r.metadata), rank: i + 1 })),
+  };
+  const fused = reciprocalRankFusion([denseList, lexicalList], { c: HYBRID_RRF_C });
+  const byId = new Map<string, ScoredDocument>();
+  for (const result of lexicalResults) byId.set(chunkIdFromMetadata(result.metadata), result);
+  for (const result of denseResults) byId.set(chunkIdFromMetadata(result.metadata), result);
+  const ranked: ScoredDocument[] = [];
+  for (const entry of fused.slice(0, k)) {
+    const result = byId.get(entry.id);
+    if (result) ranked.push({ ...result, score: entry.fusedScore });
+  }
+  return ranked;
+}
+
+async function listLexicalKbs(scopedKb?: string): Promise<Array<{ kbName: string; kbPath: string }>> {
+  const all = await listKnowledgeBases(KNOWLEDGE_BASES_ROOT_DIR);
+  const filtered = scopedKb ? all.filter((name) => name === scopedKb) : all;
+  if (scopedKb !== undefined && filtered.length === 0) {
+    throw new Error(`KB not found: ${scopedKb}`);
+  }
+  return filtered.map((kbName) => ({
+    kbName,
+    kbPath: path.join(KNOWLEDGE_BASES_ROOT_DIR, kbName),
+  }));
+}
+
+function toScoredDocument(result: LexicalSearchResult): ScoredDocument {
+  return {
+    pageContent: result.pageContent,
+    metadata: result.metadata,
+    score: result.score,
   };
 }
 
@@ -217,6 +382,19 @@ function normalizeExpectedMetadata(raw: unknown, caseNumber: number): ExpectedMe
     return rules;
   }
   throw new Error(`case ${caseNumber} expected_metadata must be an object or array of objects`);
+}
+
+function readOptionalSearchMode(
+  input: Record<string, unknown>,
+  key: string,
+  context: string,
+): { mode?: SearchMode } {
+  const value = input[key];
+  if (value === undefined) return {};
+  if (value === 'dense' || value === 'lexical' || value === 'hybrid' || value === 'auto') {
+    return { mode: value };
+  }
+  throw new Error(`${context} ${key} must be "dense", "lexical", "hybrid", or "auto"`);
 }
 
 function normalizeStalePolicy(raw: unknown, caseNumber: number): StalePolicy {


### PR DESCRIPTION
## Summary
- add --mode=dense|lexical|hybrid|auto to kb eval, with dense preserved as the default
- support fixture-level and case-level mode defaults, plus per-case requested/effective mode reporting
- update retrieval eval tests and hybrid-vs-dense fixture guidance

## Verification
- npm test -- /home/jean/git/knowledge-base-mcp-server/src/retrieval-eval.test.ts (no tests found in feature worktree because the absolute path points at the main checkout)
- npm test -- /home/jean/git/knowledge-base-mcp-server-issue-301-eval-mode-selection/src/retrieval-eval.test.ts
- npm run build
- npm test

Closes #301