### PR TITLE
feat(bench): expand cli search benchmark matrix

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -23,7 +23,8 @@ Optional environment variables:
 - `BENCH_RESULTS_PREFIX` changes the output filename prefix. The default is `run`. Use `baseline` when you want a committed baseline file.
 - `BENCH_STUB_EMBED_MS_PER_INPUT` changes the stub embedding latency model. The default is `20` milliseconds per document chunk.
 - `BENCH_INCLUDE_CLI_SEARCH=1` opts into the issue #284 `cli_search` scenario. It is off by default because each repetition spawns the built `kb` binary as a child process; the cost is what the scenario measures, so it stays heavier than the in-process scenarios.
-- `BENCH_CLI_SEARCH_REPETITIONS` sets the per-variant repetition count for `cli_search`. Defaults to 10.
+- `BENCH_CLI_SEARCH_REPETITIONS` sets the per-variant repetition count for `cli_search`. Defaults to 5.
+- `BENCH_CLI_SEARCH_PROFILE=matrix` expands `cli_search` from the compact default profile to a broader local matrix across retrieval modes, scopes, formats, grouping, query shapes, and `k` values.
 
 ## Result file naming
 
@@ -102,22 +103,36 @@ The scenario keys stay flat so CI can query them with tools like `jq`, for examp
 jq '.scenarios.warm_query.p50_ms' benchmarks/results/run-stub-node22-linux-x64.json
 ```
 
-### `cli_search` — phase timings for the real `kb search` CLI (issue #284)
+### `cli_search` — phase timings for the real `kb search` CLI (issues #284 and #303)
 
-When `BENCH_INCLUDE_CLI_SEARCH=1` is set, the harness adds a `cli_search` scenario that spawns the built `kb` binary against an offline `fake` model (issue #204) with a pre-built fixture index. Each repetition reports an externally measured wall time plus the internal phase timings the CLI emits with `--timing`:
+When `BENCH_INCLUDE_CLI_SEARCH=1` is set, the harness adds a `cli_search` scenario that spawns the built `kb` binary against an offline `fake` model (issue #204) with a pre-built fixture index. The scenario builds two synthetic knowledge bases so scoped `--kb=<name>` and global searches exercise different CLI paths. Each repetition reports an externally measured wall time plus the internal phase timings the CLI emits with `--timing`:
 
 ```json
 "cli_search": {
-  "fixture_files": 20,
-  "fixture_chunk_count": 110,
+  "schema_version": 2,
+  "profile": "default",
+  "fixture_knowledge_bases": 2,
+  "fixture_files": 22,
+  "fixture_chunk_count": 114,
   "variants": [
     {
-      "variant": "json-global",
+      "variant": "dense-json-global-k10-prose",
       "format": "json",
-      "repetitions": 10,
+      "mode": "dense",
+      "effective_mode": "dense",
+      "scope": "global",
+      "query_shape": "prose",
+      "k": 10,
+      "group_by_source": false,
+      "repetitions": 5,
       "wall_p50_ms": 540,
       "wall_p95_ms": 612,
       "wall_p99_ms": 612,
+      "phase_percentiles": {
+        "process_start_ms": { "samples": 5, "p50_ms": 318, "p95_ms": 340, "p99_ms": 340 },
+        "bootstrap_ms": { "samples": 5, "p50_ms": 4, "p95_ms": 6, "p99_ms": 6 },
+        "total_ms": { "samples": 5, "p50_ms": 222, "p95_ms": 260, "p99_ms": 260 }
+      },
       "process_start_p50_ms": 318,
       "bootstrap_p50_ms": 4,
       "model_resolution_p50_ms": 2,
@@ -136,7 +151,15 @@ When `BENCH_INCLUDE_CLI_SEARCH=1` is set, the harness adds a `cli_search` scenar
 
 `process_start_p50_ms` is derived per repetition as `wall_ms - cli_total_ms`, i.e. the Node startup + module-import cost incurred BEFORE the CLI's first internal timer fires, plus the formatting / stdout write that happens AFTER the CLI's `total_ms` clock stops. `rss_peak_bytes` is the maximum `VmHWM` observed across repetitions via `/proc/<pid>/status` polling; on non-Linux kernels this field is `null`.
 
-Each variant exercises a different output shape so format-related costs (JSON serialization vs markdown rendering, including the staleness footer) are comparable side-by-side. `cli_search` does not run inside `bench:compare`.
+The default profile is compact enough for CI smoke coverage while still distinguishing dense, lexical, hybrid, and auto retrieval; global vs scoped KB search; JSON vs markdown output; grouped source output; prose vs code-like query shapes; and representative `k` values. `phase_percentiles` reports p50/p95/p99 for every timing phase emitted by that variant, including mode-specific phases such as `lexical_search_ms` and `fusion_ms`. The legacy flat p50 fields remain for existing consumers.
+
+Use the broader profile for local reliability runs:
+
+```bash
+BENCH_INCLUDE_CLI_SEARCH=1 BENCH_CLI_SEARCH_PROFILE=matrix npm run bench
+```
+
+`cli_search` does not run inside `bench:compare`.
 
 ## Stub vs real-provider mode
 

--- a/benchmarks/scenarios/cli-search.test.ts
+++ b/benchmarks/scenarios/cli-search.test.ts
@@ -1,7 +1,10 @@
 import {
   aggregateCliSearchVariant,
+  buildCliSearchVariants,
+  parseCliSearchProfile,
   parseCliSearchTimingFromStdout,
   type CliSearchRepetition,
+  type CliSearchVariantSpec,
 } from './cli-search.js';
 
 describe('parseCliSearchTimingFromStdout', () => {
@@ -18,6 +21,8 @@ describe('parseCliSearchTimingFromStdout', () => {
       timing: {
         requested_mode: 'dense',
         effective_mode: 'dense',
+        lexical_kb_list_ms: 2,
+        lexical_search_ms: 11,
         bootstrap_ms: 3,
         model_resolution_ms: 1,
         manager_load_ms: 7,
@@ -26,6 +31,7 @@ describe('parseCliSearchTimingFromStdout', () => {
         embed_query_ms: 12,
         faiss_search_ms: 5,
         query_search_ms: 17,
+        fusion_ms: 4,
         post_filter_ms: 1,
         staleness_ms: 9,
         total_ms: 82,
@@ -36,6 +42,8 @@ describe('parseCliSearchTimingFromStdout', () => {
 
     expect(timing).not.toBeNull();
     expect(timing).toEqual({
+      lexical_kb_list_ms: 2,
+      lexical_search_ms: 11,
       bootstrap_ms: 3,
       model_resolution_ms: 1,
       manager_load_ms: 7,
@@ -44,6 +52,7 @@ describe('parseCliSearchTimingFromStdout', () => {
       embed_query_ms: 12,
       faiss_search_ms: 5,
       query_search_ms: 17,
+      fusion_ms: 4,
       post_filter_ms: 1,
       staleness_ms: 9,
       total_ms: 82,
@@ -102,16 +111,37 @@ describe('aggregateCliSearchVariant', () => {
     return { wall_ms: wallMs, rss_peak_bytes: rss, timing: timing as never };
   }
 
+  function variant(overrides: Partial<CliSearchVariantSpec> = {}): CliSearchVariantSpec {
+    return {
+      name: 'dense-json-global-k10-prose',
+      format: 'json',
+      mode: 'dense',
+      effectiveMode: 'dense',
+      scope: 'global',
+      queryShape: 'prose',
+      k: 10,
+      groupBySource: false,
+      args: ['--mode=dense', '--format=json', '--k=10', '--timing'],
+      ...overrides,
+    };
+  }
+
   it('computes wall p50/p95/p99 and derives process_start_ms = wall_ms - total_ms', () => {
     const reps: CliSearchRepetition[] = [
       makeRep(500, { bootstrap_ms: 10, total_ms: 200 }, 100_000),
       makeRep(520, { bootstrap_ms: 12, total_ms: 210 }, 110_000),
       makeRep(540, { bootstrap_ms: 14, total_ms: 220 }, 105_000),
     ];
-    const result = aggregateCliSearchVariant('json-global', 'json', reps);
+    const result = aggregateCliSearchVariant(variant(), reps);
 
-    expect(result.variant).toBe('json-global');
+    expect(result.variant).toBe('dense-json-global-k10-prose');
     expect(result.format).toBe('json');
+    expect(result.mode).toBe('dense');
+    expect(result.effective_mode).toBe('dense');
+    expect(result.scope).toBe('global');
+    expect(result.query_shape).toBe('prose');
+    expect(result.k).toBe(10);
+    expect(result.group_by_source).toBe(false);
     expect(result.repetitions).toBe(3);
     expect(result.wall_p50_ms).toBe(520);
     expect(result.wall_p95_ms).toBe(540);
@@ -120,6 +150,9 @@ describe('aggregateCliSearchVariant', () => {
     expect(result.cli_total_p50_ms).toBe(210);
     // process_start_p50 is derived per-rep then percentile'd: (300, 310, 320) → p50 = 310.
     expect(result.process_start_p50_ms).toBe(310);
+    expect(result.phase_percentiles.process_start_ms).toEqual({ samples: 3, p50_ms: 310, p95_ms: 320, p99_ms: 320 });
+    expect(result.phase_percentiles.bootstrap_ms).toEqual({ samples: 3, p50_ms: 12, p95_ms: 14, p99_ms: 14 });
+    expect(result.phase_percentiles.total_ms).toEqual({ samples: 3, p50_ms: 210, p95_ms: 220, p99_ms: 220 });
     expect(result.rss_peak_bytes).toBe(110_000);
   });
 
@@ -128,12 +161,13 @@ describe('aggregateCliSearchVariant', () => {
       makeRep(500, { bootstrap_ms: 10 }),
       makeRep(520, { bootstrap_ms: 12 }),
     ];
-    const result = aggregateCliSearchVariant('md-global', 'md', reps);
+    const result = aggregateCliSearchVariant(variant({ name: 'dense-md-global-k10-prose', format: 'md' }), reps);
     expect(result.bootstrap_p50_ms).toBe(10);
     // No rep emitted total_ms, so process_start_ms cannot be derived either.
     expect(result.cli_total_p50_ms).toBeNull();
     expect(result.process_start_p50_ms).toBeNull();
     expect(result.faiss_search_p50_ms).toBeNull();
+    expect(result.phase_percentiles.total_ms).toBeUndefined();
   });
 
   it('returns null rss_peak_bytes when all repetitions lack RSS data (e.g. non-Linux)', () => {
@@ -141,7 +175,7 @@ describe('aggregateCliSearchVariant', () => {
       makeRep(500, { bootstrap_ms: 10, total_ms: 200 }),
       makeRep(520, { bootstrap_ms: 12, total_ms: 210 }),
     ];
-    const result = aggregateCliSearchVariant('json-global', 'json', reps);
+    const result = aggregateCliSearchVariant(variant(), reps);
     expect(result.rss_peak_bytes).toBeNull();
   });
 
@@ -153,7 +187,7 @@ describe('aggregateCliSearchVariant', () => {
       makeRep(520, { total_ms: 210 }, 200_000),
       makeRep(540, { total_ms: 220 }, 100_000),
     ];
-    const result = aggregateCliSearchVariant('json-global', 'json', reps);
+    const result = aggregateCliSearchVariant(variant(), reps);
     expect(result.rss_peak_bytes).toBe(200_000);
   });
 
@@ -163,7 +197,7 @@ describe('aggregateCliSearchVariant', () => {
       makeRep(520, { bootstrap_ms: 12 }), // missing total_ms
       makeRep(540, { bootstrap_ms: 14, total_ms: 220 }),
     ];
-    const result = aggregateCliSearchVariant('json-global', 'json', reps);
+    const result = aggregateCliSearchVariant(variant(), reps);
     // All three reps still contribute to wall and bootstrap percentiles…
     expect(result.repetitions).toBe(3);
     expect(result.bootstrap_p50_ms).toBe(12);
@@ -174,7 +208,7 @@ describe('aggregateCliSearchVariant', () => {
   });
 
   it('throws when called with no repetitions (rather than emitting NaN percentiles)', () => {
-    expect(() => aggregateCliSearchVariant('json-global', 'json', [])).toThrow(/no repetitions/);
+    expect(() => aggregateCliSearchVariant(variant(), [])).toThrow(/no repetitions/);
   });
 
   it('clamps a derived negative process_start_ms to zero', () => {
@@ -184,7 +218,44 @@ describe('aggregateCliSearchVariant', () => {
     const reps: CliSearchRepetition[] = [
       makeRep(100, { total_ms: 150 }),
     ];
-    const result = aggregateCliSearchVariant('json-global', 'json', reps);
+    const result = aggregateCliSearchVariant(variant(), reps);
     expect(result.process_start_p50_ms).toBe(0);
+  });
+});
+
+describe('buildCliSearchVariants', () => {
+  it('keeps the default profile compact while covering modes, scope, formats, grouping, query shapes, and k values', () => {
+    const variants = buildCliSearchVariants('default', 'default');
+    const names = variants.map((v) => v.name);
+
+    expect(variants).toHaveLength(7);
+    expect(new Set(variants.map((v) => v.mode))).toEqual(new Set(['dense', 'lexical', 'hybrid', 'auto']));
+    expect(new Set(variants.map((v) => v.scope))).toEqual(new Set(['global', 'scoped']));
+    expect(new Set(variants.map((v) => v.format))).toEqual(new Set(['json', 'md']));
+    expect(variants.some((v) => v.groupBySource)).toBe(true);
+    expect(new Set(variants.map((v) => v.queryShape))).toEqual(new Set(['prose', 'code']));
+    expect(new Set(variants.map((v) => v.k))).toEqual(new Set([5, 10, 25]));
+    expect(names).toContain('auto-hybrid-json-global-k10-code');
+  });
+
+  it('builds a broader matrix profile for local runs', () => {
+    const variants = buildCliSearchVariants('matrix', 'default');
+    expect(variants.length).toBeGreaterThan(7);
+    expect(variants).toContainEqual(expect.objectContaining({
+      name: 'auto-dense-md-scoped-k25-prose',
+      args: expect.arrayContaining(['--mode=auto', '--format=md', '--k=25', '--kb=default']),
+      effectiveMode: 'dense',
+    }));
+    expect(variants).toContainEqual(expect.objectContaining({
+      name: 'dense-json-global-k5-prose-grouped',
+      args: expect.arrayContaining(['--group-by-source']),
+      groupBySource: true,
+    }));
+  });
+
+  it('defaults unknown profile values to the CI-safe default profile', () => {
+    expect(parseCliSearchProfile(undefined)).toBe('default');
+    expect(parseCliSearchProfile('unexpected')).toBe('default');
+    expect(parseCliSearchProfile('matrix')).toBe('matrix');
   });
 });

--- a/benchmarks/scenarios/cli-search.ts
+++ b/benchmarks/scenarios/cli-search.ts
@@ -30,6 +30,8 @@ const FAKE_MODEL_ID = 'fake__bench-fake';
 const FAKE_MODEL_NAME = 'bench-fake';
 
 export interface CliSearchTimingFields {
+  lexical_kb_list_ms?: number;
+  lexical_search_ms?: number;
   bootstrap_ms?: number;
   model_resolution_ms?: number;
   manager_load_ms?: number;
@@ -38,6 +40,7 @@ export interface CliSearchTimingFields {
   embed_query_ms?: number;
   faiss_search_ms?: number;
   query_search_ms?: number;
+  fusion_ms?: number;
   post_filter_ms?: number;
   staleness_ms?: number;
   total_ms?: number;
@@ -49,9 +52,21 @@ export interface CliSearchRepetition {
   timing: CliSearchTimingFields | null;
 }
 
-interface CliSearchVariantSpec {
+type CliSearchMode = 'dense' | 'lexical' | 'hybrid' | 'auto';
+type CliSearchEffectiveMode = Exclude<CliSearchMode, 'auto'>;
+type CliSearchScope = 'global' | 'scoped';
+type CliSearchQueryShape = 'prose' | 'code';
+type CliSearchProfile = 'default' | 'matrix';
+
+export interface CliSearchVariantSpec {
   name: string;
   format: 'json' | 'md';
+  mode: CliSearchMode;
+  effectiveMode: CliSearchEffectiveMode;
+  scope: CliSearchScope;
+  queryShape: CliSearchQueryShape;
+  k: number;
+  groupBySource: boolean;
   args: string[];
 }
 
@@ -62,7 +77,8 @@ interface CliSearchScenarioOptions {
   chunkSize?: number;
 }
 
-const DEFAULT_REPETITIONS = 10;
+const DEFAULT_REPETITIONS = 5;
+const DEFAULT_MATRIX_K_VALUES = [5, 10, 25] as const;
 
 export async function runCliSearchScenario(
   context: ScenarioContext,
@@ -85,6 +101,14 @@ export async function runCliSearchScenario(
     targetChunksPerFile,
     chunkSize: fixtureOverrides.chunkSize ?? options.chunkSize,
   });
+  const secondaryFixture = await generateKnowledgeBaseFixture({
+    files: Math.max(1, Math.min(2, files)),
+    knowledgeBaseName: `${context.knowledgeBaseName}-secondary`,
+    rootDir: context.knowledgeBasesRootDir,
+    seed: context.fixtureSeed + 71,
+    targetChunksPerFile: Math.max(1, Math.min(2, targetChunksPerFile)),
+    chunkSize: fixtureOverrides.chunkSize ?? options.chunkSize,
+  });
 
   await registerFakeModel(context.faissIndexPath);
 
@@ -93,28 +117,142 @@ export async function runCliSearchScenario(
 
   await prebuildIndex(cliPath, childEnv, fixture.query);
 
-  const variants: CliSearchVariantSpec[] = [
-    { name: 'json-global', format: 'json', args: ['--format=json', '--timing'] },
-    { name: 'md-global', format: 'md', args: ['--format=md', '--timing'] },
-  ];
+  const profile = parseCliSearchProfile(process.env.BENCH_CLI_SEARCH_PROFILE);
+  const variants = buildCliSearchVariants(profile, context.knowledgeBaseName);
+  const queries: Record<CliSearchQueryShape, string> = {
+    prose: fixture.query,
+    code: 'doc-001.md --refresh INDEX_NOT_INITIALIZED',
+  };
 
   const variantResults: CliSearchVariantResult[] = [];
   for (const variant of variants) {
     // One warmup invocation to absorb fs / page-cache cold-start noise so the
     // measured `process_start_ms` reflects steady-state Node import cost.
-    await spawnCliSearch(cliPath, [fixture.query, ...variant.args], childEnv);
+    await spawnCliSearch(cliPath, [queries[variant.queryShape], ...variant.args], childEnv);
 
     const reps: CliSearchRepetition[] = [];
     for (let r = 0; r < repetitions; r += 1) {
-      reps.push(await spawnCliSearch(cliPath, [fixture.query, ...variant.args], childEnv));
+      reps.push(await spawnCliSearch(cliPath, [queries[variant.queryShape], ...variant.args], childEnv));
     }
-    variantResults.push(aggregateCliSearchVariant(variant.name, variant.format, reps));
+    variantResults.push(aggregateCliSearchVariant(variant, reps));
   }
 
   return {
-    fixture_files: fixture.files,
-    fixture_chunk_count: fixture.chunkCount,
+    schema_version: 2,
+    profile,
+    fixture_knowledge_bases: 2,
+    fixture_files: fixture.files + secondaryFixture.files,
+    fixture_chunk_count: fixture.chunkCount + secondaryFixture.chunkCount,
     variants: variantResults,
+  };
+}
+
+export function parseCliSearchProfile(value: string | undefined): CliSearchProfile {
+  return value === 'matrix' ? 'matrix' : 'default';
+}
+
+export function buildCliSearchVariants(
+  profile: CliSearchProfile = 'default',
+  scopedKnowledgeBaseName = 'default',
+): CliSearchVariantSpec[] {
+  if (profile === 'matrix') {
+    return buildMatrixCliSearchVariants(scopedKnowledgeBaseName);
+  }
+
+  return [
+    makeVariant({ mode: 'dense', format: 'json', scope: 'global', k: 10, queryShape: 'prose', scopedKnowledgeBaseName }),
+    makeVariant({ mode: 'lexical', format: 'json', scope: 'global', k: 10, queryShape: 'prose', scopedKnowledgeBaseName }),
+    makeVariant({ mode: 'hybrid', format: 'json', scope: 'global', k: 10, queryShape: 'prose', scopedKnowledgeBaseName }),
+    makeVariant({ mode: 'auto', effectiveMode: 'hybrid', format: 'json', scope: 'global', k: 10, queryShape: 'code', scopedKnowledgeBaseName }),
+    makeVariant({ mode: 'dense', format: 'md', scope: 'scoped', k: 10, queryShape: 'prose', scopedKnowledgeBaseName }),
+    makeVariant({ mode: 'dense', format: 'json', scope: 'global', k: 5, queryShape: 'prose', scopedKnowledgeBaseName }),
+    makeVariant({ mode: 'dense', format: 'json', scope: 'global', k: 25, queryShape: 'prose', groupBySource: true, scopedKnowledgeBaseName }),
+  ];
+}
+
+function buildMatrixCliSearchVariants(scopedKnowledgeBaseName: string): CliSearchVariantSpec[] {
+  const variants: CliSearchVariantSpec[] = [];
+  const modes: Array<{
+    mode: CliSearchMode;
+    effectiveMode?: CliSearchEffectiveMode;
+    queryShape: CliSearchQueryShape;
+  }> = [
+    { mode: 'dense', queryShape: 'prose' },
+    { mode: 'lexical', queryShape: 'prose' },
+    { mode: 'hybrid', queryShape: 'prose' },
+    { mode: 'auto', effectiveMode: 'dense', queryShape: 'prose' },
+    { mode: 'auto', effectiveMode: 'hybrid', queryShape: 'code' },
+  ];
+
+  for (const mode of modes) {
+    for (const scope of ['global', 'scoped'] as const) {
+      for (const format of ['json', 'md'] as const) {
+        for (const k of DEFAULT_MATRIX_K_VALUES) {
+          variants.push(makeVariant({ ...mode, format, scope, k, scopedKnowledgeBaseName }));
+        }
+      }
+    }
+  }
+
+  for (const scope of ['global', 'scoped'] as const) {
+    for (const format of ['json', 'md'] as const) {
+      for (const k of DEFAULT_MATRIX_K_VALUES) {
+        variants.push(makeVariant({
+          mode: 'dense',
+          format,
+          scope,
+          k,
+          queryShape: 'prose',
+          groupBySource: true,
+          scopedKnowledgeBaseName,
+        }));
+      }
+    }
+  }
+
+  return variants;
+}
+
+function makeVariant(input: {
+  mode: CliSearchMode;
+  effectiveMode?: CliSearchEffectiveMode;
+  format: 'json' | 'md';
+  scope: CliSearchScope;
+  queryShape: CliSearchQueryShape;
+  k: number;
+  groupBySource?: boolean;
+  scopedKnowledgeBaseName: string;
+}): CliSearchVariantSpec {
+  const groupBySource = input.groupBySource ?? false;
+  const effectiveMode = input.effectiveMode ?? (input.mode === 'auto' ? 'dense' : input.mode);
+  const args = [
+    `--mode=${input.mode}`,
+    `--format=${input.format}`,
+    `--k=${input.k}`,
+    '--timing',
+  ];
+  if (input.scope === 'scoped') args.push(`--kb=${input.scopedKnowledgeBaseName}`);
+  if (groupBySource) args.push('--group-by-source');
+
+  const nameParts = [
+    input.mode === 'auto' ? `auto-${effectiveMode}` : input.mode,
+    input.format,
+    input.scope,
+    `k${input.k}`,
+    input.queryShape,
+    ...(groupBySource ? ['grouped'] : []),
+  ];
+
+  return {
+    name: nameParts.join('-'),
+    format: input.format,
+    mode: input.mode,
+    effectiveMode,
+    scope: input.scope,
+    queryShape: input.queryShape,
+    k: input.k,
+    groupBySource,
+    args,
   };
 }
 
@@ -156,16 +294,16 @@ export function parseCliSearchTimingFromStdout(stdout: string): CliSearchTimingF
 /**
  * Reduce a list of per-repetition measurements to p50/p95/p99 across wall
  * time and each named phase timing. Missing phase values are skipped (the
- * percentile is computed only over reps that emitted the field); a variant
- * with zero phase samples reports `null` for that percentile.
+ * percentile is computed only over reps that emitted the field). The legacy
+ * flat fields report `null` with zero samples; `phase_percentiles` omits the
+ * phase when no repetition emitted it.
  */
 export function aggregateCliSearchVariant(
-  name: string,
-  format: 'json' | 'md',
+  variant: CliSearchVariantSpec,
   reps: readonly CliSearchRepetition[],
 ): CliSearchVariantResult {
   if (reps.length === 0) {
-    throw new Error(`cli-search scenario: aggregateCliSearchVariant("${name}") called with no repetitions`);
+    throw new Error(`cli-search scenario: aggregateCliSearchVariant("${variant.name}") called with no repetitions`);
   }
   const wallSamples = reps.map((r) => r.wall_ms);
   const rssSamples = reps.map((r) => r.rss_peak_bytes).filter((v): v is number => v !== null);
@@ -187,14 +325,38 @@ export function aggregateCliSearchVariant(
       processStartSamples.push(Math.max(0, r.wall_ms - totalMs));
     }
   }
+  const phaseSamples: Record<string, number[]> = {
+    process_start_ms: processStartSamples,
+    lexical_kb_list_ms: sampleFor('lexical_kb_list_ms'),
+    lexical_search_ms: sampleFor('lexical_search_ms'),
+    bootstrap_ms: sampleFor('bootstrap_ms'),
+    model_resolution_ms: sampleFor('model_resolution_ms'),
+    manager_load_ms: sampleFor('manager_load_ms'),
+    index_load_ms: sampleFor('index_load_ms'),
+    dense_search_ms: sampleFor('dense_search_ms'),
+    embed_query_ms: sampleFor('embed_query_ms'),
+    faiss_search_ms: sampleFor('faiss_search_ms'),
+    query_search_ms: sampleFor('query_search_ms'),
+    fusion_ms: sampleFor('fusion_ms'),
+    post_filter_ms: sampleFor('post_filter_ms'),
+    staleness_ms: sampleFor('staleness_ms'),
+    total_ms: cliTotalSamples,
+  };
 
   return {
-    variant: name,
-    format,
+    variant: variant.name,
+    format: variant.format,
+    mode: variant.mode,
+    effective_mode: variant.effectiveMode,
+    scope: variant.scope,
+    query_shape: variant.queryShape,
+    k: variant.k,
+    group_by_source: variant.groupBySource,
     repetitions: reps.length,
     wall_p50_ms: percentile(wallSamples, 50),
     wall_p95_ms: percentile(wallSamples, 95),
     wall_p99_ms: percentile(wallSamples, 99),
+    phase_percentiles: buildPhasePercentiles(phaseSamples),
     process_start_p50_ms: processStartSamples.length > 0 ? percentile(processStartSamples, 50) : null,
     bootstrap_p50_ms: percentileOrNull(sampleFor('bootstrap_ms'), 50),
     model_resolution_p50_ms: percentileOrNull(sampleFor('model_resolution_ms'), 50),
@@ -209,6 +371,20 @@ export function aggregateCliSearchVariant(
   };
 }
 
+function buildPhasePercentiles(samplesByPhase: Record<string, number[]>): CliSearchVariantResult['phase_percentiles'] {
+  const out: CliSearchVariantResult['phase_percentiles'] = {};
+  for (const [phase, samples] of Object.entries(samplesByPhase)) {
+    if (samples.length === 0) continue;
+    out[phase] = {
+      samples: samples.length,
+      p50_ms: percentile(samples, 50),
+      p95_ms: percentile(samples, 95),
+      p99_ms: percentile(samples, 99),
+    };
+  }
+  return out;
+}
+
 function percentileOrNull(samples: number[], p: number): number | null {
   return samples.length > 0 ? percentile(samples, p) : null;
 }
@@ -216,9 +392,10 @@ function percentileOrNull(samples: number[], p: number): number | null {
 function pickTimingFields(source: Record<string, unknown>): CliSearchTimingFields {
   const out: CliSearchTimingFields = {};
   const keys: Array<keyof CliSearchTimingFields> = [
-    'bootstrap_ms', 'model_resolution_ms', 'manager_load_ms', 'index_load_ms',
-    'dense_search_ms', 'embed_query_ms', 'faiss_search_ms', 'query_search_ms',
-    'post_filter_ms', 'staleness_ms', 'total_ms',
+    'lexical_kb_list_ms', 'lexical_search_ms', 'bootstrap_ms', 'model_resolution_ms',
+    'manager_load_ms', 'index_load_ms', 'dense_search_ms', 'embed_query_ms',
+    'faiss_search_ms', 'query_search_ms', 'fusion_ms', 'post_filter_ms',
+    'staleness_ms', 'total_ms',
   ];
   for (const key of keys) {
     const value = source[key];

--- a/benchmarks/types.ts
+++ b/benchmarks/types.ts
@@ -69,10 +69,22 @@ export interface IndexStorageScenarioResult {
 export interface CliSearchVariantResult {
   variant: string;
   format: 'json' | 'md';
+  mode: 'dense' | 'lexical' | 'hybrid' | 'auto';
+  effective_mode: 'dense' | 'lexical' | 'hybrid';
+  scope: 'global' | 'scoped';
+  query_shape: 'prose' | 'code';
+  k: number;
+  group_by_source: boolean;
   repetitions: number;
   wall_p50_ms: number;
   wall_p95_ms: number;
   wall_p99_ms: number;
+  phase_percentiles: Record<string, {
+    samples: number;
+    p50_ms: number;
+    p95_ms: number;
+    p99_ms: number;
+  }>;
   process_start_p50_ms: number | null;
   bootstrap_p50_ms: number | null;
   model_resolution_p50_ms: number | null;
@@ -87,6 +99,9 @@ export interface CliSearchVariantResult {
 }
 
 export interface CliSearchScenarioResult {
+  schema_version: 2;
+  profile: 'default' | 'matrix';
+  fixture_knowledge_bases: number;
   fixture_files: number;
   fixture_chunk_count: number;
   variants: CliSearchVariantResult[];


### PR DESCRIPTION
## Summary
- expand the opt-in cli_search benchmark into a compact default matrix covering retrieval modes, scope, formats, grouping, query shape, and k values
- add scenario schema_version 2 metadata plus per-phase p50/p95/p99 percentiles while keeping legacy flat p50 fields
- document the default profile and BENCH_CLI_SEARCH_PROFILE=matrix local expansion

Closes #303

## Verification
- npm run build
- npm test
- npm test -- /home/jean/git/knowledge-base-mcp-server-issue-303-cli-search-benchmark-matrix/benchmarks/scenarios/cli-search.test.ts
- npm test -- src/KnowledgeBaseServer.test.ts (rerun after one full-suite load-related timeout)
- npx tsc -p /home/jean/git/knowledge-base-mcp-server-issue-303-cli-search-benchmark-matrix/tsconfig.bench.json
- npx tsc -p /home/jean/git/knowledge-base-mcp-server/tsconfig.bench.json

Note: the literal prompt Jest path points at the protected main checkout from this feature worktree, so Jest found no matching test there; the worktree-path suite above is the meaningful run.