### PR TITLE
feat(bench): score compare reports with golden labels

### DIFF
--- a/benchmarks/compare/golden.ts
+++ b/benchmarks/compare/golden.ts
@@ -1,0 +1,276 @@
+import * as fsp from 'fs/promises';
+
+export type GoldenRelevance = 0 | 1 | 2 | 3;
+
+export interface GoldenLabel {
+  source: string;
+  relevance: GoldenRelevance;
+}
+
+export type GoldenLabels = Record<string, GoldenLabel[]>;
+
+export interface RankedSource {
+  doc: string;
+  score: number;
+}
+
+export interface GoldenModelQueryMetrics {
+  hit_rate_at_10: number;
+  map: number;
+  map_at_10: number;
+  mrr_at_10: number;
+  ndcg_at_10: number;
+  recall_at_5: number;
+  recall_at_10: number;
+  recall_at_20: number;
+  unique_retrieved_count: number;
+}
+
+export interface GoldenAggregateMetrics {
+  hit_rate_at_10: number;
+  map: number;
+  map_at_10: number;
+  mrr_at_10: number;
+  ndcg_at_10: number;
+  recall_at_5: number;
+  recall_at_10: number;
+  recall_at_20: number;
+}
+
+export interface GoldenQueryDiagnostics {
+  query: string;
+  status: 'scored' | 'missing-labels' | 'no-positive-labels';
+  relevant_source_count: number;
+  labels: GoldenLabel[];
+  model_a?: GoldenModelQueryMetrics;
+  model_b?: GoldenModelQueryMetrics;
+}
+
+export interface GoldenQualityReport {
+  schema: 'query-to-source-relevance';
+  query_count: number;
+  labelled_query_count: number;
+  missing_query_count: number;
+  no_positive_label_query_count: number;
+  model_a: GoldenAggregateMetrics;
+  model_b: GoldenAggregateMetrics;
+  per_query: GoldenQueryDiagnostics[];
+}
+
+export async function loadGoldenFile(filePath: string): Promise<GoldenLabels> {
+  const raw = await fsp.readFile(filePath, 'utf-8');
+  try {
+    return parseGoldenLabels(JSON.parse(raw) as unknown, filePath);
+  } catch (err) {
+    if (err instanceof SyntaxError) {
+      throw new Error(`${filePath}: invalid JSON: ${err.message}`);
+    }
+    throw err;
+  }
+}
+
+export function parseGoldenLabels(value: unknown, label = 'golden'): GoldenLabels {
+  if (!isRecord(value) || Array.isArray(value)) {
+    throw new Error(`${label}: expected an object mapping query strings to label arrays`);
+  }
+
+  const out: GoldenLabels = {};
+  for (const [query, labels] of Object.entries(value)) {
+    if (!query.trim()) {
+      throw new Error(`${label}: query keys must be non-empty strings`);
+    }
+    if (!Array.isArray(labels)) {
+      throw new Error(`${label}: "${query}" must map to an array of labels`);
+    }
+
+    const bySource = new Map<string, GoldenRelevance>();
+    labels.forEach((entry, i) => {
+      const parsed = parseLabel(entry, `${label}: "${query}"[${i}]`);
+      const existing = bySource.get(parsed.source);
+      bySource.set(parsed.source, existing === undefined ? parsed.relevance : maxRelevance(existing, parsed.relevance));
+    });
+    out[query] = Array.from(bySource.entries()).map(([source, relevance]) => ({ source, relevance }));
+  }
+  return out;
+}
+
+export function scoreGoldenQuality(
+  labels: GoldenLabels,
+  perQuery: { query: string; topK_a: RankedSource[]; topK_b: RankedSource[] }[],
+): GoldenQualityReport {
+  const diagnostics = perQuery.map((queryResult): GoldenQueryDiagnostics => {
+    const queryLabels = labels[queryResult.query];
+    if (!queryLabels) {
+      return {
+        query: queryResult.query,
+        status: 'missing-labels',
+        relevant_source_count: 0,
+        labels: [],
+      };
+    }
+
+    const relevantCount = queryLabels.filter((label) => label.relevance > 0).length;
+    if (relevantCount === 0) {
+      return {
+        query: queryResult.query,
+        status: 'no-positive-labels',
+        relevant_source_count: 0,
+        labels: queryLabels,
+      };
+    }
+
+    return {
+      query: queryResult.query,
+      status: 'scored',
+      relevant_source_count: relevantCount,
+      labels: queryLabels,
+      model_a: scoreRanking(queryLabels, queryResult.topK_a),
+      model_b: scoreRanking(queryLabels, queryResult.topK_b),
+    };
+  });
+
+  const scored = diagnostics.filter((q) => q.status === 'scored');
+  return {
+    schema: 'query-to-source-relevance',
+    query_count: perQuery.length,
+    labelled_query_count: scored.length,
+    missing_query_count: diagnostics.filter((q) => q.status === 'missing-labels').length,
+    no_positive_label_query_count: diagnostics.filter((q) => q.status === 'no-positive-labels').length,
+    model_a: aggregate(scored.map((q) => q.model_a)),
+    model_b: aggregate(scored.map((q) => q.model_b)),
+    per_query: diagnostics,
+  };
+}
+
+function parseLabel(entry: unknown, label: string): GoldenLabel {
+  if (typeof entry === 'string') {
+    if (!entry.trim()) {
+      throw new Error(`${label}: source strings must be non-empty`);
+    }
+    return { source: entry, relevance: 1 };
+  }
+
+  if (!isRecord(entry)) {
+    throw new Error(`${label}: expected { "source": string, "relevance": 0|1|2|3 }`);
+  }
+  const source = entry.source;
+  if (typeof source !== 'string' || !source.trim()) {
+    throw new Error(`${label}: source must be a non-empty string`);
+  }
+  const relevance = entry.relevance;
+  if (!isGoldenRelevance(relevance)) {
+    throw new Error(`${label}: relevance must be one of 0, 1, 2, or 3`);
+  }
+  return { source, relevance };
+}
+
+function scoreRanking(labels: GoldenLabel[], ranking: RankedSource[]): GoldenModelQueryMetrics {
+  const uniqueRanking = dedupeRanking(ranking).slice(0, 20);
+  const relevanceBySource = new Map(labels.map((label) => [label.source, label.relevance]));
+  const relevantSources = labels.filter((label) => label.relevance > 0).map((label) => label.source);
+  const relevantSourceSet = new Set(relevantSources);
+
+  return {
+    hit_rate_at_10: hitRateAt(uniqueRanking, relevantSourceSet, 10),
+    map: averagePrecisionAt(uniqueRanking, relevantSourceSet, 20),
+    map_at_10: averagePrecisionAt(uniqueRanking, relevantSourceSet, 10),
+    mrr_at_10: reciprocalRankAt(uniqueRanking, relevantSourceSet, 10),
+    ndcg_at_10: ndcgAt(uniqueRanking, relevanceBySource, 10),
+    recall_at_5: recallAt(uniqueRanking, relevantSourceSet, 5),
+    recall_at_10: recallAt(uniqueRanking, relevantSourceSet, 10),
+    recall_at_20: recallAt(uniqueRanking, relevantSourceSet, 20),
+    unique_retrieved_count: uniqueRanking.length,
+  };
+}
+
+function dedupeRanking(ranking: RankedSource[]): RankedSource[] {
+  const seen = new Set<string>();
+  const out: RankedSource[] = [];
+  for (const item of ranking) {
+    if (seen.has(item.doc)) continue;
+    seen.add(item.doc);
+    out.push(item);
+  }
+  return out;
+}
+
+function recallAt(ranking: RankedSource[], relevantSources: Set<string>, k: number): number {
+  if (relevantSources.size === 0) return 0;
+  const hits = new Set<string>();
+  ranking.slice(0, k).forEach((item) => {
+    if (relevantSources.has(item.doc)) hits.add(item.doc);
+  });
+  return roundMetric(hits.size / relevantSources.size);
+}
+
+function hitRateAt(ranking: RankedSource[], relevantSources: Set<string>, k: number): number {
+  return ranking.slice(0, k).some((item) => relevantSources.has(item.doc)) ? 1 : 0;
+}
+
+function reciprocalRankAt(ranking: RankedSource[], relevantSources: Set<string>, k: number): number {
+  const rank = ranking.slice(0, k).findIndex((item) => relevantSources.has(item.doc));
+  return rank === -1 ? 0 : roundMetric(1 / (rank + 1));
+}
+
+function averagePrecisionAt(ranking: RankedSource[], relevantSources: Set<string>, k: number): number {
+  if (relevantSources.size === 0 || k <= 0) return 0;
+  let hitCount = 0;
+  let precisionSum = 0;
+  ranking.slice(0, k).forEach((item, i) => {
+    if (!relevantSources.has(item.doc)) return;
+    hitCount += 1;
+    precisionSum += hitCount / (i + 1);
+  });
+  return roundMetric(precisionSum / Math.min(relevantSources.size, k));
+}
+
+function ndcgAt(ranking: RankedSource[], relevanceBySource: Map<string, GoldenRelevance>, k: number): number {
+  const dcg = ranking.slice(0, k).reduce((sum, item, i) => {
+    const relevance = relevanceBySource.get(item.doc) ?? 0;
+    return sum + dcgGain(relevance, i + 1);
+  }, 0);
+  const ideal = Array.from(relevanceBySource.values())
+    .sort((a, b) => b - a)
+    .slice(0, k)
+    .reduce<number>((sum, relevance, i) => sum + dcgGain(relevance, i + 1), 0);
+  return ideal === 0 ? 0 : roundMetric(dcg / ideal);
+}
+
+function dcgGain(relevance: GoldenRelevance, rank: number): number {
+  return (2 ** relevance - 1) / Math.log2(rank + 1);
+}
+
+function aggregate(metrics: Array<GoldenModelQueryMetrics | undefined>): GoldenAggregateMetrics {
+  const present = metrics.filter((metric): metric is GoldenModelQueryMetrics => metric !== undefined);
+  return {
+    hit_rate_at_10: meanMetric(present, 'hit_rate_at_10'),
+    map: meanMetric(present, 'map'),
+    map_at_10: meanMetric(present, 'map_at_10'),
+    mrr_at_10: meanMetric(present, 'mrr_at_10'),
+    ndcg_at_10: meanMetric(present, 'ndcg_at_10'),
+    recall_at_5: meanMetric(present, 'recall_at_5'),
+    recall_at_10: meanMetric(present, 'recall_at_10'),
+    recall_at_20: meanMetric(present, 'recall_at_20'),
+  };
+}
+
+function meanMetric(metrics: GoldenModelQueryMetrics[], key: keyof GoldenAggregateMetrics): number {
+  if (metrics.length === 0) return 0;
+  return roundMetric(metrics.reduce((sum, metric) => sum + metric[key], 0) / metrics.length);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isGoldenRelevance(value: unknown): value is GoldenRelevance {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 0 && value <= 3;
+}
+
+function maxRelevance(a: GoldenRelevance, b: GoldenRelevance): GoldenRelevance {
+  return (a > b ? a : b) as GoldenRelevance;
+}
+
+function roundMetric(value: number): number {
+  return Number(value.toFixed(6));
+}

--- a/benchmarks/compare/model-quality.test.ts
+++ b/benchmarks/compare/model-quality.test.ts
@@ -1,0 +1,128 @@
+import { parseGoldenLabels, scoreGoldenQuality } from './golden.js';
+
+describe('golden model quality scoring', () => {
+  it('scores binary labels with recall, MRR, hit rate, and MAP', () => {
+    const labels = parseGoldenLabels({
+      'cache invalidation': [
+        { source: 'a.md', relevance: 1 },
+        { source: 'b.md', relevance: 1 },
+      ],
+    });
+
+    const scored = scoreGoldenQuality(labels, [{
+      query: 'cache invalidation',
+      topK_a: [
+        { doc: 'a.md', score: 0.9 },
+        { doc: 'x.md', score: 0.8 },
+        { doc: 'b.md', score: 0.7 },
+      ],
+      topK_b: [
+        { doc: 'x.md', score: 0.9 },
+        { doc: 'y.md', score: 0.8 },
+      ],
+    }]);
+
+    expect(scored.labelled_query_count).toBe(1);
+    expect(scored.model_a.hit_rate_at_10).toBe(1);
+    expect(scored.model_a.mrr_at_10).toBe(1);
+    expect(scored.model_a.recall_at_5).toBe(1);
+    expect(scored.model_a.map_at_10).toBeCloseTo((1 + 2 / 3) / 2, 6);
+    expect(scored.model_b.hit_rate_at_10).toBe(0);
+    expect(scored.model_b.recall_at_10).toBe(0);
+  });
+
+  it('uses graded relevance for nDCG@10', () => {
+    const labels = parseGoldenLabels({
+      'ranking quality': [
+        { source: 'best.md', relevance: 3 },
+        { source: 'ok.md', relevance: 1 },
+      ],
+    });
+
+    const scored = scoreGoldenQuality(labels, [{
+      query: 'ranking quality',
+      topK_a: [
+        { doc: 'best.md', score: 0.9 },
+        { doc: 'ok.md', score: 0.8 },
+      ],
+      topK_b: [
+        { doc: 'ok.md', score: 0.9 },
+        { doc: 'best.md', score: 0.8 },
+      ],
+    }]);
+
+    expect(scored.model_a.ndcg_at_10).toBe(1);
+    expect(scored.model_b.ndcg_at_10).toBeGreaterThan(0);
+    expect(scored.model_b.ndcg_at_10).toBeLessThan(1);
+  });
+
+  it('reports missing query labels without failing the run', () => {
+    const labels = parseGoldenLabels({
+      'labelled query': [{ source: 'answer.md', relevance: 1 }],
+    });
+
+    const scored = scoreGoldenQuality(labels, [
+      {
+        query: 'labelled query',
+        topK_a: [{ doc: 'answer.md', score: 1 }],
+        topK_b: [],
+      },
+      {
+        query: 'unlabelled query',
+        topK_a: [{ doc: 'other.md', score: 1 }],
+        topK_b: [{ doc: 'answer.md', score: 1 }],
+      },
+    ]);
+
+    expect(scored.query_count).toBe(2);
+    expect(scored.labelled_query_count).toBe(1);
+    expect(scored.missing_query_count).toBe(1);
+    expect(scored.per_query[1]?.status).toBe('missing-labels');
+    expect(scored.model_a.recall_at_10).toBe(1);
+  });
+
+  it('deduplicates retrieved sources before scoring', () => {
+    const labels = parseGoldenLabels({
+      duplicates: [
+        { source: 'a.md', relevance: 1 },
+        { source: 'b.md', relevance: 1 },
+      ],
+    });
+
+    const scored = scoreGoldenQuality(labels, [{
+      query: 'duplicates',
+      topK_a: [
+        { doc: 'a.md', score: 0.9 },
+        { doc: 'a.md', score: 0.8 },
+        { doc: 'b.md', score: 0.7 },
+      ],
+      topK_b: [
+        { doc: 'a.md', score: 0.9 },
+        { doc: 'a.md', score: 0.8 },
+      ],
+    }]);
+
+    expect(scored.per_query[0]?.model_a?.unique_retrieved_count).toBe(2);
+    expect(scored.model_a.recall_at_10).toBe(1);
+    expect(scored.model_a.map_at_10).toBe(1);
+    expect(scored.model_b.recall_at_10).toBe(0.5);
+    expect(scored.model_b.map_at_10).toBe(0.5);
+  });
+
+  it('fails invalid golden labels with a clear error', () => {
+    expect(() => parseGoldenLabels({
+      broken: [{ source: 'a.md', relevance: 4 }],
+    }, 'fixture.json')).toThrow('fixture.json: "broken"[0]: relevance must be one of 0, 1, 2, or 3');
+  });
+
+  it('accepts legacy string source arrays as binary labels', () => {
+    const labels = parseGoldenLabels({
+      legacy: ['a.md', 'b.md'],
+    });
+
+    expect(labels.legacy).toEqual([
+      { source: 'a.md', relevance: 1 },
+      { source: 'b.md', relevance: 1 },
+    ]);
+  });
+});

--- a/benchmarks/compare/render.ts
+++ b/benchmarks/compare/render.ts
@@ -8,6 +8,7 @@ import * as path from 'path';
 import { fileURLToPath } from 'url';
 import type { BenchmarkReport } from '../types.js';
 import { renderBarChart, renderLegend, renderLineChart, renderStackedBar } from './chart.js';
+import type { GoldenQualityReport } from './golden.js';
 
 export interface CrossModelQueryResult {
   query: string;
@@ -38,6 +39,7 @@ export interface RenderInput {
   modelB: { id: string; name: string };
   fixture: { profile: string; chunks: number };
   crossModel: CrossModelAggregate;
+  goldenQuality?: GoldenQualityReport;
   cost: CostBreakdownPair;
   generatedAt: string;
 }
@@ -57,6 +59,7 @@ export async function renderReport(input: RenderInput): Promise<string> {
   const template = await loadTemplate();
   const summaryRows = buildSummaryRows(input);
   const recommendationRows = buildRecommendation(input);
+  const qualitySection = buildQualitySection(input);
   const queryDetails = buildQueryDetails(input);
 
   const warmChart = renderBarChart(
@@ -90,6 +93,7 @@ export async function renderReport(input: RenderInput): Promise<string> {
       { name: `B — ${input.modelB.id}`, color: COLOR_B },
     ]))
     .replace('{{SUMMARY_ROWS}}', summaryRows.map(rowHtml).join(''))
+    .replace('{{QUALITY_SECTION}}', qualitySection)
     .replace('{{CHART_WARM}}', warmChart)
     .replace('{{CHART_BATCH_LATENCY}}', batchLatencyChart)
     .replace('{{CHART_THROUGHPUT}}', throughputChart)
@@ -188,6 +192,28 @@ function buildSummaryRows(input: RenderInput): SummaryRow[] {
     ),
   });
 
+  if (input.goldenQuality) {
+    rows.push({
+      metric: 'golden_nDCG@10',
+      a: input.goldenQuality.model_a.ndcg_at_10.toFixed(3),
+      b: input.goldenQuality.model_b.ndcg_at_10.toFixed(3),
+      winner: higherIsBetter(input.goldenQuality.model_a.ndcg_at_10, input.goldenQuality.model_b.ndcg_at_10),
+      detail: `${input.goldenQuality.labelled_query_count} labelled queries`,
+    });
+    rows.push({
+      metric: 'golden_MRR@10',
+      a: input.goldenQuality.model_a.mrr_at_10.toFixed(3),
+      b: input.goldenQuality.model_b.mrr_at_10.toFixed(3),
+      winner: higherIsBetter(input.goldenQuality.model_a.mrr_at_10, input.goldenQuality.model_b.mrr_at_10),
+    });
+    rows.push({
+      metric: 'golden_recall@20',
+      a: input.goldenQuality.model_a.recall_at_20.toFixed(3),
+      b: input.goldenQuality.model_b.recall_at_20.toFixed(3),
+      winner: higherIsBetter(input.goldenQuality.model_a.recall_at_20, input.goldenQuality.model_b.recall_at_20),
+    });
+  }
+
   rows.push({
     metric: 'jaccard_top10_p50',
     a: input.crossModel.jaccard_p50.toFixed(2),
@@ -283,6 +309,66 @@ function renderStorageChart(input: RenderInput): string {
   );
 }
 
+function buildQualitySection(input: RenderInput): string {
+  const quality = input.goldenQuality;
+  if (!quality) {
+    return '<p class="meta">No golden label file was provided; quality rows use only the benchmark fixture recall proxy.</p>';
+  }
+
+  const metricRows = [
+    qualityMetricRow('nDCG@10', quality.model_a.ndcg_at_10, quality.model_b.ndcg_at_10),
+    qualityMetricRow('MRR@10', quality.model_a.mrr_at_10, quality.model_b.mrr_at_10),
+    qualityMetricRow('Recall@5', quality.model_a.recall_at_5, quality.model_b.recall_at_5),
+    qualityMetricRow('Recall@10', quality.model_a.recall_at_10, quality.model_b.recall_at_10),
+    qualityMetricRow('Recall@20', quality.model_a.recall_at_20, quality.model_b.recall_at_20),
+    qualityMetricRow('Hit rate@10', quality.model_a.hit_rate_at_10, quality.model_b.hit_rate_at_10),
+    qualityMetricRow('MAP', quality.model_a.map, quality.model_b.map),
+    qualityMetricRow('MAP@10', quality.model_a.map_at_10, quality.model_b.map_at_10),
+  ].join('');
+
+  const diagnosticRows = quality.per_query.slice(0, 50).map((q) => {
+    if (q.status !== 'scored') {
+      return `<tr><td>${escHtml(q.query)}</td><td>${escHtml(q.status)}</td><td colspan="6" class="tie">not scored</td></tr>`;
+    }
+    return `<tr><td>${escHtml(q.query)}</td><td>${q.relevant_source_count}</td>` +
+      qualityDiagnosticCells(q.model_a) +
+      qualityDiagnosticCells(q.model_b) +
+      '</tr>';
+  }).join('');
+
+  return `<p class="meta">Scored ${quality.labelled_query_count}/${quality.query_count} queries from golden labels` +
+    `${quality.missing_query_count > 0 ? `; ${quality.missing_query_count} missing labels` : ''}` +
+    `${quality.no_positive_label_query_count > 0 ? `; ${quality.no_positive_label_query_count} without positive labels` : ''}.` +
+    `</p>
+<table>
+  <thead><tr><th>Metric</th><th>Model A</th><th>Model B</th><th>Winner</th></tr></thead>
+  <tbody>${metricRows}</tbody>
+</table>
+<h3>Per-query quality diagnostics</h3>
+<table>
+  <thead><tr><th>Query</th><th>Labels</th><th>A nDCG@10</th><th>A MRR@10</th><th>A R@10</th><th>B nDCG@10</th><th>B MRR@10</th><th>B R@10</th></tr></thead>
+  <tbody>${diagnosticRows}</tbody>
+</table>`;
+}
+
+function qualityMetricRow(metric: string, a: number, b: number): string {
+  return rowHtml({
+    metric,
+    a: a.toFixed(3),
+    b: b.toFixed(3),
+    winner: higherIsBetter(a, b),
+  });
+}
+
+function qualityDiagnosticCells(metrics: GoldenQueryMetricsLike | undefined): string {
+  if (!metrics) {
+    return '<td class="tie">N/A</td><td class="tie">N/A</td><td class="tie">N/A</td>';
+  }
+  return `<td>${metrics.ndcg_at_10.toFixed(3)}</td><td>${metrics.mrr_at_10.toFixed(3)}</td><td>${metrics.recall_at_10.toFixed(3)}</td>`;
+}
+
+type GoldenQueryMetricsLike = GoldenQualityReport['per_query'][number]['model_a'];
+
 function buildQueryDetails(input: RenderInput): string {
   if (input.crossModel.per_query.length === 0) {
     return '<p class="meta">no per-query results captured</p>';
@@ -341,10 +427,20 @@ function buildRecommendation(input: RenderInput): string {
     }
   }
 
-  // recall: 5%+ higher
-  const recallA = reportA.scenarios.retrieval_quality.default_recall_at_10;
-  const recallB = reportB.scenarios.retrieval_quality.default_recall_at_10;
-  axes.push(recallAxis(recallA, recallB, 0.05));
+  if (input.goldenQuality) {
+    axes.push(qualityAxis(
+      'labelled quality (nDCG@10)',
+      input.goldenQuality.model_a.ndcg_at_10,
+      input.goldenQuality.model_b.ndcg_at_10,
+      input.goldenQuality.labelled_query_count,
+      0.05,
+    ));
+  } else {
+    // recall: 5%+ higher
+    const recallA = reportA.scenarios.retrieval_quality.default_recall_at_10;
+    const recallB = reportB.scenarios.retrieval_quality.default_recall_at_10;
+    axes.push(recallAxis(recallA, recallB, 0.05));
+  }
 
   // diversity (no winner)
   axes.push({
@@ -419,6 +515,17 @@ function recallAxis(a: number, b: number, threshold: number): RecommendationAxis
   return diff >= threshold
     ? { axis: 'recall@10 (if labelled)', pick: winner, reason: `${winner === 'A' ? "A's" : "B's"} recall is ${(diff * 100).toFixed(1)}pp higher.` }
     : { axis: 'recall@10', pick: 'none', reason: `gap (${(diff * 100).toFixed(1)}pp) below threshold (${(threshold * 100).toFixed(0)}pp).` };
+}
+
+function qualityAxis(label: string, a: number, b: number, queryCount: number, threshold: number): RecommendationAxis {
+  if (queryCount === 0) return { axis: label, pick: 'none', reason: 'golden file had no scored positive labels.' };
+  const winner = a > b ? 'A' : 'B';
+  const winnerVal = Math.max(a, b);
+  const loserVal = Math.min(a, b);
+  const diff = winnerVal - loserVal;
+  return diff >= threshold
+    ? { axis: label, pick: winner, reason: `${winner === 'A' ? "A's" : "B's"} nDCG@10 is ${(diff * 100).toFixed(1)}pp higher across ${queryCount} labelled queries.` }
+    : { axis: label, pick: 'none', reason: `labelled gap (${(diff * 100).toFixed(1)}pp) below threshold (${(threshold * 100).toFixed(0)}pp).` };
 }
 
 function formatMeta(input: RenderInput): string {

--- a/benchmarks/compare/report-template.html
+++ b/benchmarks/compare/report-template.html
@@ -84,6 +84,9 @@
   </tbody>
 </table>
 
+<h2>Labelled quality</h2>
+{{QUALITY_SECTION}}
+
 <h2>Latency distribution (single + batch)</h2>
 <div class="charts">
   <div>
@@ -119,7 +122,7 @@
   <ul>
     <li>This report is your-KB selection guidance, NOT an MTEB leaderboard (RFC 013 §3.2 N10).</li>
     <li>Latency depends on hardware; rerun on the deployment target.</li>
-    <li>Recall@10 requires golden labels; absent them, only Jaccard / Spearman are shown.</li>
+    <li>Labelled quality metrics require <code>--golden</code>; absent them, only fixture recall and Jaccard / Spearman diagnostics are shown.</li>
     <li>Cost numbers reflect <code>src/cost-estimates.ts</code> <code>LAST_VERIFIED={{COST_LAST_VERIFIED}}</code>; verify if stale.</li>
     <li>One machine, one moment. Comparing across hardware = run the orchestrator on each and diff manually.</li>
   </ul>

--- a/benchmarks/compare/run.ts
+++ b/benchmarks/compare/run.ts
@@ -19,6 +19,7 @@ import type { BenchmarkReport } from '../types.js';
 import { installStubProvider } from '../stub.js';
 import { renderReport, type CrossModelAggregate, type CrossModelQueryResult } from './render.js';
 import { resolveModelCtx, safeChunkChars } from './model-ctx.js';
+import { loadGoldenFile, scoreGoldenQuality } from './golden.js';
 // Type duplicated locally rather than imported from src/ — tsconfig.bench.json's
 // rootDir scopes types to the benchmarks/ tree (src/ files are out of scope even
 // for type-only imports). All src-side runtime values are loaded via dynamic
@@ -99,6 +100,12 @@ async function main(): Promise<void> {
   if (modelA.id === modelB.id) {
     fatal(`models resolve to the same id "${modelA.id}". Pick two different models.`);
   }
+  const goldenLabels = flags.goldenPath
+    ? await loadGoldenFile(path.resolve(flags.goldenPath))
+    : undefined;
+  if (goldenLabels) {
+    process.stderr.write(`[bench:compare] golden labels: ${Object.keys(goldenLabels).length} labelled queries\n`);
+  }
 
   // Per-model workspace dirs so cross-model post-step can read both indexes.
   const orchestratorTmp = path.join(os.tmpdir(), `kb-bench-compare-${process.pid}-${Date.now()}`);
@@ -168,6 +175,17 @@ async function main(): Promise<void> {
     buildRoot,
     queries,
   });
+  const goldenQuality = goldenLabels
+    ? scoreGoldenQuality(goldenLabels, crossModel.per_query)
+    : undefined;
+  if (goldenQuality) {
+    process.stderr.write(
+      `[bench:compare] golden scoring: ${goldenQuality.labelled_query_count}/${goldenQuality.query_count} queries scored` +
+      (goldenQuality.missing_query_count > 0 ? `, ${goldenQuality.missing_query_count} missing labels` : '') +
+      (goldenQuality.no_positive_label_query_count > 0 ? `, ${goldenQuality.no_positive_label_query_count} without positive labels` : '') +
+      '\n',
+    );
+  }
 
   const cost = await computeCost(modelA, modelB, reportA, reportB, buildRoot);
 
@@ -179,6 +197,7 @@ async function main(): Promise<void> {
     modelB: { id: modelB.id, name: modelB.name },
     fixture: { profile: flags.fixture, chunks: reportA.scenarios.cold_index.chunks },
     crossModel,
+    goldenQuality,
     cost,
     generatedAt: new Date().toISOString(),
   });
@@ -197,6 +216,7 @@ async function main(): Promise<void> {
     reportA,
     reportB,
     crossModel,
+    goldenQuality,
     cost,
     generatedAt: new Date().toISOString(),
   }, null, 2) + '\n', 'utf-8');
@@ -322,19 +342,22 @@ async function crossModelAgreement(args: CrossModelArgs): Promise<CrossModelAggr
     const b = topKsB[i] ?? [];
     return {
       query: q,
-      jaccard: jaccard(a.map((r) => r.doc), b.map((r) => r.doc)),
+      jaccard: jaccard(a.slice(0, 10).map((r) => r.doc), b.slice(0, 10).map((r) => r.doc)),
       topK_a: a,
       topK_b: b,
     };
   });
 
   const jaccards = perQuery.map((q) => q.jaccard).sort((x, y) => x - y);
-  const spearmans = perQuery.map((q) => spearmanOnOverlap(q.topK_a.map((r) => r.doc), q.topK_b.map((r) => r.doc)));
+  const spearmans = perQuery.map((q) => spearmanOnOverlap(
+    q.topK_a.slice(0, 10).map((r) => r.doc),
+    q.topK_b.slice(0, 10).map((r) => r.doc),
+  ));
 
   const overlapDocs = new Set<string>();
   perQuery.forEach((q) => {
-    const seenA = new Set(q.topK_a.map((r) => r.doc));
-    q.topK_b.forEach((r) => { if (seenA.has(r.doc)) overlapDocs.add(r.doc); });
+    const seenA = new Set(q.topK_a.slice(0, 10).map((r) => r.doc));
+    q.topK_b.slice(0, 10).forEach((r) => { if (seenA.has(r.doc)) overlapDocs.add(r.doc); });
   });
 
   return {
@@ -383,7 +406,7 @@ async function runQueriesAgainstManager(
   const out: { doc: string; score: number }[][] = [];
   for (const q of queries) {
     try {
-      const results = await manager.similaritySearch(q, 10);
+      const results = await manager.similaritySearch(q, 20);
       out.push(results.map((r) => ({
         doc: String(r.metadata.source ?? r.metadata.relativePath ?? r.pageContent.slice(0, 40)),
         score: r.score ?? 0,
@@ -597,7 +620,8 @@ Optional:
   --fixture=small|medium|large|external   Default: medium.
   --queries=<path>                         File with one query per line (#-comments allowed).
   --concurrency=1,4,16                     Batch concurrency sweep (default 1,4,16).
-  --golden=<path>                          JSON {query: [doc_paths]} for recall@k.
+  --golden=<path>                          JSON {query: [{source,relevance}]} labels for quality scoring.
+                                            Legacy {query: [doc_paths]} arrays are treated as relevance=1.
   --output-dir=<path>                      Default: benchmarks/results/.
   --skip-add                               Reuse already-registered models (no re-embed).
   --yes                                    Non-interactive (skips paid-provider cost prompt).


### PR DESCRIPTION
Closes #300.

## Summary
- add bench:compare golden-label parsing and validation for query-to-source relevance labels
- score model result sets with nDCG@10, MRR@10, Recall@5/10/20, hit rate@10, MAP, and MAP@10
- surface labelled quality in merged JSON, HTML summary/recommendations, and per-query diagnostics

## Verification
- npm test -- /home/jean/git/knowledge-base-mcp-server-issue-300-bench-compare-golden/benchmarks/compare
- npx tsc -p /home/jean/git/knowledge-base-mcp-server-issue-300-bench-compare-golden/tsconfig.bench.json
- npm run build
- npm test

Note: an initial full npm test run had one transient KnowledgeBaseServer.test.ts timeout; rerunning that suite passed, and a subsequent full npm test passed.