### PR TITLE
feat(benchmarks): add budget regression summary

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -3,10 +3,16 @@ name: Benchmarks
 on:
   pull_request:
   workflow_dispatch:
+    inputs:
+      enforce_budgets:
+        description: Fail the benchmark job when budget diff rows are FAIL.
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   benchmark-harness:
-    continue-on-error: true
+    continue-on-error: ${{ !(github.event_name == 'workflow_dispatch' && inputs.enforce_budgets) }}
     runs-on: ubuntu-latest
 
     steps:
@@ -27,6 +33,23 @@ jobs:
           BENCH_PROVIDER: stub
           BENCH_RESULTS_PREFIX: ci
         run: npm run bench
+
+      - name: Summarize benchmark budget diff
+        if: always()
+        env:
+          BENCH_BUDGET_FAIL: ${{ github.event_name == 'workflow_dispatch' && inputs.enforce_budgets && '1' || '0' }}
+        run: |
+          current="$(find benchmarks/results -maxdepth 1 -name 'ci-*.json' -print -quit)"
+          if [ -z "$current" ]; then
+            {
+              echo "## Benchmark regression summary"
+              echo
+              echo "No current benchmark result was produced, so no budget diff could be computed."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          node build/benchmarks/budget-diff.js --current "$current"
 
       - name: Upload benchmark artifact
         if: always()

--- a/benchmarks/budget-diff.test.ts
+++ b/benchmarks/budget-diff.test.ts
@@ -1,0 +1,215 @@
+import type { BenchmarkReport } from './types.js';
+import {
+  buildBudgetRows,
+  defaultBaselinePath,
+  renderBudgetMarkdown,
+  summarizeBudgetRows,
+} from './budget-diff.js';
+
+const baseReport: BenchmarkReport = {
+  arch: 'x64',
+  git_sha: 'base123',
+  node_version: 'v24.11.1',
+  os: 'linux',
+  provider: 'stub',
+  scenarios: {
+    cold_index: {
+      chunks: 600,
+      files: 100,
+      ms: 10_000,
+    },
+    cold_start: {
+      fixture_documents: 120,
+      ms: 40,
+      rss_bytes: 100 * 1024 * 1024,
+    },
+    memory_peak: {
+      chunk_count: 600,
+      files: 100,
+      heap_used_bytes: 40 * 1024 * 1024,
+      rss_bytes: 120 * 1024 * 1024,
+    },
+    retrieval_quality: {
+      default_fanout_factor: 3,
+      default_loaded_kbs: 5,
+      default_recall_at_10: 0.98,
+      query_count: 50,
+      sweep: [],
+    },
+    warm_query: {
+      p50_ms: 80,
+      p95_ms: 100,
+      p99_ms: 120,
+      repetitions: 30,
+    },
+    batch_query: {
+      runs: [
+        {
+          concurrency: 16,
+          latency_p50_ms: 80,
+          latency_p95_ms: 100,
+          latency_p99_ms: 120,
+          qps_p50: 20,
+          qps_p95: 18,
+          total_queries: 64,
+        },
+      ],
+    },
+    index_storage: {
+      bytes_per_vector: 320,
+      docstore_bytes: 8 * 1024 * 1024,
+      total_bytes: 20 * 1024 * 1024,
+      vector_binary_bytes: 12 * 1024 * 1024,
+      vectors: 600,
+    },
+  },
+  version: 1,
+};
+
+describe('budget diff rows', () => {
+  it('classifies meaningful latency and quality regressions', () => {
+    const current = reportWith({
+      coldIndexMs: 12_600,
+      retrievalRecall: 0.92,
+      warmP50Ms: 83,
+    });
+
+    const rows = buildBudgetRows(baseReport, current);
+
+    expect(row(rows, 'cold-index-ms')).toMatchObject({
+      status: 'fail',
+      baseline: 10_000,
+      current: 12_600,
+    });
+    expect(row(rows, 'retrieval-recall-at-10')).toMatchObject({
+      status: 'fail',
+      delta: -0.06,
+    });
+    expect(row(rows, 'warm-query-p50-ms')).toMatchObject({
+      status: 'pass',
+    });
+    expect(summarizeBudgetRows(rows)).toEqual({
+      fail: 2,
+      pass: 7,
+      skip: 0,
+      warn: 0,
+      worstStatus: 'fail',
+    });
+  });
+
+  it('warns before failing for moderate memory and throughput regressions', () => {
+    const current = reportWith({
+      batchQpsP50: 17,
+      memoryRssBytes: 138 * 1024 * 1024,
+    });
+
+    const rows = buildBudgetRows(baseReport, current);
+
+    expect(row(rows, 'memory-peak-rss-bytes')).toMatchObject({
+      status: 'warn',
+    });
+    expect(row(rows, 'batch-query-qps-p50')).toMatchObject({
+      status: 'warn',
+      delta: -3,
+    });
+  });
+
+  it('skips optional batch and storage rows when a baseline lacks those scenarios', () => {
+    const baseline = reportWith({
+      batchQuery: undefined,
+      indexStorage: undefined,
+    });
+
+    const rows = buildBudgetRows(baseline, baseReport);
+
+    expect(row(rows, 'batch-query-qps-p50')).toMatchObject({
+      status: 'skip',
+      note: 'No common batch-query concurrency in baseline and current report.',
+    });
+    expect(row(rows, 'index-storage-total-bytes')).toMatchObject({
+      status: 'skip',
+    });
+    expect(row(rows, 'index-storage-bytes-per-vector')).toMatchObject({
+      status: 'skip',
+    });
+  });
+
+  it('renders a GitHub step-summary friendly table', () => {
+    const rows = buildBudgetRows(baseReport, reportWith({ warmP95Ms: 118 }));
+    const markdown = renderBudgetMarkdown({
+      baselineLabel: 'baseline-stub-node24-linux-x64.json',
+      currentLabel: 'ci-stub-node24-linux-x64.json',
+      enforceFailures: false,
+      rows,
+    });
+
+    expect(markdown).toContain('## Benchmark regression summary');
+    expect(markdown).toContain('| Status | Budget | Baseline | Current | Delta | Threshold |');
+    expect(markdown).toContain('| WARN | Warm query p95 | 100.0 ms | 118.0 ms | +18.0 ms (+18.0%) | warn >= +10.0% and +10.0 ms; fail >= +25.0% and +25.0 ms |');
+    expect(markdown).toContain('Mode: advisory');
+  });
+
+  it('derives the matching committed baseline path from the current report identity', () => {
+    expect(defaultBaselinePath('/repo', baseReport)).toBe(
+      '/repo/benchmarks/results/baseline-stub-node24-linux-x64.json',
+    );
+  });
+});
+
+function reportWith(overrides: {
+  batchQpsP50?: number;
+  batchQuery?: BenchmarkReport['scenarios']['batch_query'];
+  coldIndexMs?: number;
+  indexStorage?: BenchmarkReport['scenarios']['index_storage'];
+  memoryRssBytes?: number;
+  retrievalRecall?: number;
+  warmP50Ms?: number;
+  warmP95Ms?: number;
+}): BenchmarkReport {
+  return {
+    ...baseReport,
+    git_sha: 'current123',
+    scenarios: {
+      ...baseReport.scenarios,
+      cold_index: {
+        ...baseReport.scenarios.cold_index,
+        ms: overrides.coldIndexMs ?? baseReport.scenarios.cold_index.ms,
+      },
+      memory_peak: {
+        ...baseReport.scenarios.memory_peak,
+        rss_bytes: overrides.memoryRssBytes ?? baseReport.scenarios.memory_peak.rss_bytes,
+      },
+      retrieval_quality: {
+        ...baseReport.scenarios.retrieval_quality,
+        default_recall_at_10: overrides.retrievalRecall
+          ?? baseReport.scenarios.retrieval_quality.default_recall_at_10,
+      },
+      warm_query: {
+        ...baseReport.scenarios.warm_query,
+        p50_ms: overrides.warmP50Ms ?? baseReport.scenarios.warm_query.p50_ms,
+        p95_ms: overrides.warmP95Ms ?? baseReport.scenarios.warm_query.p95_ms,
+      },
+      batch_query: overrides.batchQuery === undefined && 'batchQuery' in overrides
+        ? undefined
+        : {
+            runs: [
+              {
+                ...baseReport.scenarios.batch_query!.runs[0],
+                qps_p50: overrides.batchQpsP50 ?? baseReport.scenarios.batch_query!.runs[0].qps_p50,
+              },
+            ],
+          },
+      index_storage: overrides.indexStorage === undefined && 'indexStorage' in overrides
+        ? undefined
+        : baseReport.scenarios.index_storage,
+    },
+  };
+}
+
+function row(rows: ReturnType<typeof buildBudgetRows>, id: string) {
+  const found = rows.find((candidate) => candidate.id === id);
+  if (!found) {
+    throw new Error(`Missing row ${id}`);
+  }
+  return found;
+}

--- a/benchmarks/budget-diff.ts
+++ b/benchmarks/budget-diff.ts
@@ -1,0 +1,483 @@
+import * as fsp from 'fs/promises';
+import * as path from 'path';
+import type { BenchmarkReport, BatchQueryRunResult } from './types.js';
+
+type BudgetDirection = 'higher' | 'lower';
+export type BudgetStatus = 'pass' | 'warn' | 'fail' | 'skip';
+
+interface BudgetThreshold {
+  failAbsolute?: number;
+  failRelative?: number;
+  warnAbsolute?: number;
+  warnRelative?: number;
+}
+
+interface BudgetMetric {
+  id: string;
+  direction: BudgetDirection;
+  label: string;
+  read: (report: BenchmarkReport) => number | undefined;
+  threshold: BudgetThreshold;
+  unit: 'bytes' | 'bytes-per-vector' | 'ms' | 'qps' | 'score';
+}
+
+export interface BudgetRow {
+  baseline?: number;
+  current?: number;
+  delta?: number;
+  deltaRelative?: number;
+  direction: BudgetDirection;
+  id: string;
+  label: string;
+  note?: string;
+  status: BudgetStatus;
+  thresholdLabel: string;
+  unit: BudgetMetric['unit'];
+}
+
+interface RenderOptions {
+  baselineLabel: string;
+  currentLabel: string;
+  enforceFailures: boolean;
+  rows: BudgetRow[];
+}
+
+interface CliOptions {
+  baselinePath?: string;
+  currentPath?: string;
+  enforceFailures: boolean;
+  repoRoot: string;
+  summaryPath?: string;
+}
+
+const BYTE = 1;
+const MIB = 1024 * 1024;
+
+const BASE_METRICS: BudgetMetric[] = [
+  {
+    id: 'cold-index-ms',
+    direction: 'lower',
+    label: 'Cold index',
+    read: (report) => report.scenarios.cold_index.ms,
+    threshold: { warnAbsolute: 1_000, warnRelative: 0.1, failAbsolute: 2_000, failRelative: 0.2 },
+    unit: 'ms',
+  },
+  {
+    id: 'warm-query-p50-ms',
+    direction: 'lower',
+    label: 'Warm query p50',
+    read: (report) => report.scenarios.warm_query.p50_ms,
+    threshold: { warnAbsolute: 10, warnRelative: 0.1, failAbsolute: 25, failRelative: 0.25 },
+    unit: 'ms',
+  },
+  {
+    id: 'warm-query-p95-ms',
+    direction: 'lower',
+    label: 'Warm query p95',
+    read: (report) => report.scenarios.warm_query.p95_ms,
+    threshold: { warnAbsolute: 10, warnRelative: 0.1, failAbsolute: 25, failRelative: 0.25 },
+    unit: 'ms',
+  },
+  {
+    id: 'warm-query-p99-ms',
+    direction: 'lower',
+    label: 'Warm query p99',
+    read: (report) => report.scenarios.warm_query.p99_ms,
+    threshold: { warnAbsolute: 15, warnRelative: 0.1, failAbsolute: 30, failRelative: 0.25 },
+    unit: 'ms',
+  },
+  {
+    id: 'memory-peak-rss-bytes',
+    direction: 'lower',
+    label: 'Peak RSS',
+    read: (report) => report.scenarios.memory_peak.rss_bytes,
+    threshold: { warnAbsolute: 16 * MIB, warnRelative: 0.1, failAbsolute: 32 * MIB, failRelative: 0.25 },
+    unit: 'bytes',
+  },
+  {
+    id: 'retrieval-recall-at-10',
+    direction: 'higher',
+    label: 'Retrieval recall@10',
+    read: (report) => report.scenarios.retrieval_quality.default_recall_at_10,
+    threshold: { warnAbsolute: 0.01, failAbsolute: 0.03 },
+    unit: 'score',
+  },
+];
+
+export function buildBudgetRows(baseline: BenchmarkReport, current: BenchmarkReport): BudgetRow[] {
+  const metrics = [...BASE_METRICS];
+
+  metrics.push({
+    id: 'index-storage-total-bytes',
+    direction: 'lower',
+    label: 'Index storage total',
+    read: (report) => report.scenarios.index_storage?.total_bytes,
+    threshold: { warnAbsolute: 1 * MIB, warnRelative: 0.05, failAbsolute: 5 * MIB, failRelative: 0.15 },
+    unit: 'bytes',
+  });
+  metrics.push({
+    id: 'index-storage-bytes-per-vector',
+    direction: 'lower',
+    label: 'Index bytes/vector',
+    read: (report) => report.scenarios.index_storage?.bytes_per_vector,
+    threshold: { warnAbsolute: 16 * BYTE, warnRelative: 0.05, failAbsolute: 48 * BYTE, failRelative: 0.15 },
+    unit: 'bytes-per-vector',
+  });
+
+  const batchConcurrency = highestCommonBatchConcurrency(baseline, current);
+  metrics.push({
+    id: 'batch-query-qps-p50',
+    direction: 'higher',
+    label: batchConcurrency === undefined ? 'Batch throughput p50' : `Batch throughput p50 (c=${batchConcurrency})`,
+    read: (report) => {
+      if (batchConcurrency === undefined) return undefined;
+      return report.scenarios.batch_query?.runs.find((run) => run.concurrency === batchConcurrency)?.qps_p50;
+    },
+    threshold: { warnRelative: 0.1, failRelative: 0.2 },
+    unit: 'qps',
+  });
+
+  return metrics.map((metric) => buildBudgetRow(metric, baseline, current));
+}
+
+export function summarizeBudgetRows(rows: BudgetRow[]): {
+  fail: number;
+  pass: number;
+  skip: number;
+  warn: number;
+  worstStatus: BudgetStatus;
+} {
+  const counts = {
+    fail: rows.filter((row) => row.status === 'fail').length,
+    pass: rows.filter((row) => row.status === 'pass').length,
+    skip: rows.filter((row) => row.status === 'skip').length,
+    warn: rows.filter((row) => row.status === 'warn').length,
+  };
+
+  return {
+    ...counts,
+    worstStatus: counts.fail > 0 ? 'fail' : counts.warn > 0 ? 'warn' : counts.skip === rows.length ? 'skip' : 'pass',
+  };
+}
+
+export function renderBudgetMarkdown(options: RenderOptions): string {
+  const summary = summarizeBudgetRows(options.rows);
+  const lines = [
+    '## Benchmark regression summary',
+    '',
+    `Current: \`${options.currentLabel}\``,
+    `Baseline: \`${options.baselineLabel}\``,
+    `Mode: ${options.enforceFailures ? 'enforcing FAIL rows' : 'advisory'}`,
+    `Overall: ${summary.worstStatus.toUpperCase()} (${summary.fail} fail, ${summary.warn} warn, ${summary.pass} pass, ${summary.skip} skipped)`,
+    '',
+    '| Status | Budget | Baseline | Current | Delta | Threshold |',
+    '| --- | --- | ---: | ---: | ---: | --- |',
+  ];
+
+  for (const row of options.rows) {
+    lines.push([
+      row.status.toUpperCase(),
+      row.label,
+      formatMaybeValue(row.baseline, row.unit),
+      formatMaybeValue(row.current, row.unit),
+      formatDelta(row),
+      row.status === 'skip' && row.note ? row.note : row.thresholdLabel,
+    ].join(' | ').replace(/^/, '| ').replace(/$/, ' |'));
+  }
+
+  lines.push('', 'FAIL rows only fail the job when `BENCH_BUDGET_FAIL=1` or the workflow input enables budget enforcement.');
+  return `${lines.join('\n')}\n`;
+}
+
+export function defaultBaselinePath(repoRoot: string, report: BenchmarkReport): string {
+  const nodeLabel = nodeMajorLabel(report.node_version);
+  return path.join(
+    repoRoot,
+    'benchmarks',
+    'results',
+    `baseline-${report.provider}-${nodeLabel}-${report.os}-${report.arch}.json`,
+  );
+}
+
+async function runCli(): Promise<void> {
+  const options = parseArgs(process.argv.slice(2), process.env);
+  if (!options.currentPath) {
+    throw new Error('Missing --current <path> argument.');
+  }
+
+  const current = await readBenchmarkReport(options.currentPath);
+  const baselinePath = options.baselinePath ?? defaultBaselinePath(options.repoRoot, current);
+  let markdown: string;
+  let hasFailRows = false;
+
+  try {
+    const baseline = await readBenchmarkReport(baselinePath);
+    const rows = buildBudgetRows(baseline, current);
+    hasFailRows = summarizeBudgetRows(rows).fail > 0;
+    markdown = renderBudgetMarkdown({
+      baselineLabel: path.relative(options.repoRoot, baselinePath),
+      currentLabel: path.relative(options.repoRoot, options.currentPath),
+      enforceFailures: options.enforceFailures,
+      rows,
+    });
+  } catch (error) {
+    if (!isMissingFileError(error)) {
+      throw error;
+    }
+    markdown = [
+      '## Benchmark regression summary',
+      '',
+      `Current: \`${path.relative(options.repoRoot, options.currentPath)}\``,
+      `Baseline: \`${path.relative(options.repoRoot, baselinePath)}\``,
+      'Overall: SKIP (matching baseline not found)',
+      '',
+      'Add or refresh the committed baseline for this provider/node/os/arch before interpreting regression budgets.',
+      '',
+    ].join('\n');
+  }
+
+  process.stdout.write(markdown);
+  if (options.summaryPath) {
+    await fsp.appendFile(options.summaryPath, markdown, 'utf-8');
+  }
+
+  if (options.enforceFailures && hasFailRows) {
+    process.exitCode = 1;
+  }
+}
+
+function buildBudgetRow(metric: BudgetMetric, baselineReport: BenchmarkReport, currentReport: BenchmarkReport): BudgetRow {
+  const baseline = metric.read(baselineReport);
+  const current = metric.read(currentReport);
+  const thresholdLabel = formatThreshold(metric.threshold, metric.unit, metric.direction);
+
+  if (baseline === undefined || current === undefined) {
+    return {
+      baseline,
+      current,
+      direction: metric.direction,
+      id: metric.id,
+      label: metric.label,
+      note: skipNote(metric.id),
+      status: 'skip',
+      thresholdLabel,
+      unit: metric.unit,
+    };
+  }
+
+  const delta = Number((current - baseline).toFixed(6));
+  const deltaRelative = baseline === 0 ? undefined : delta / baseline;
+  const regression = metric.direction === 'lower' ? current - baseline : baseline - current;
+  const regressionRelative = baseline === 0 ? undefined : regression / baseline;
+  const status = regression <= 0
+    ? 'pass'
+    : thresholdReached(metric.threshold, regression, regressionRelative, 'fail')
+      ? 'fail'
+      : thresholdReached(metric.threshold, regression, regressionRelative, 'warn')
+        ? 'warn'
+        : 'pass';
+
+  return {
+    baseline,
+    current,
+    delta,
+    deltaRelative,
+    direction: metric.direction,
+    id: metric.id,
+    label: metric.label,
+    status,
+    thresholdLabel,
+    unit: metric.unit,
+  };
+}
+
+function thresholdReached(
+  threshold: BudgetThreshold,
+  absoluteRegression: number,
+  relativeRegression: number | undefined,
+  severity: 'fail' | 'warn',
+): boolean {
+  const absolute = severity === 'fail' ? threshold.failAbsolute : threshold.warnAbsolute;
+  const relative = severity === 'fail' ? threshold.failRelative : threshold.warnRelative;
+
+  if (absolute !== undefined && relative !== undefined) {
+    return absoluteRegression >= absolute && relativeRegression !== undefined && relativeRegression >= relative;
+  }
+  if (absolute !== undefined) {
+    return absoluteRegression >= absolute;
+  }
+  if (relative !== undefined) {
+    return relativeRegression !== undefined && relativeRegression >= relative;
+  }
+  return false;
+}
+
+function highestCommonBatchConcurrency(
+  baseline: BenchmarkReport,
+  current: BenchmarkReport,
+): number | undefined {
+  const baselineRuns = baseline.scenarios.batch_query?.runs ?? [];
+  const currentRuns = current.scenarios.batch_query?.runs ?? [];
+  const currentConcurrencies = new Set(currentRuns.map((run) => run.concurrency));
+  const common = baselineRuns
+    .filter((run): run is BatchQueryRunResult => currentConcurrencies.has(run.concurrency))
+    .map((run) => run.concurrency)
+    .sort((left, right) => right - left);
+  return common[0];
+}
+
+function formatMaybeValue(value: number | undefined, unit: BudgetMetric['unit']): string {
+  if (value === undefined) return '-';
+  return formatValue(value, unit);
+}
+
+function formatValue(value: number, unit: BudgetMetric['unit']): string {
+  switch (unit) {
+    case 'bytes':
+      return `${(value / MIB).toFixed(1)} MiB`;
+    case 'bytes-per-vector':
+      return `${value.toFixed(1)} B/vector`;
+    case 'ms':
+      return `${value.toFixed(1)} ms`;
+    case 'qps':
+      return `${value.toFixed(2)} qps`;
+    case 'score':
+      return value.toFixed(3);
+  }
+}
+
+function formatDelta(row: BudgetRow): string {
+  if (row.delta === undefined) return '-';
+  const sign = row.delta > 0 ? '+' : '';
+  const relative = row.deltaRelative === undefined
+    ? ''
+    : ` (${row.deltaRelative > 0 ? '+' : ''}${(row.deltaRelative * 100).toFixed(1)}%)`;
+  return `${sign}${formatValue(row.delta, row.unit)}${relative}`;
+}
+
+function formatThreshold(
+  threshold: BudgetThreshold,
+  unit: BudgetMetric['unit'],
+  direction: BudgetDirection,
+): string {
+  return [
+    formatSeverityThreshold('warn', threshold.warnRelative, threshold.warnAbsolute, unit, direction),
+    formatSeverityThreshold('fail', threshold.failRelative, threshold.failAbsolute, unit, direction),
+  ].filter(Boolean).join('; ');
+}
+
+function formatSeverityThreshold(
+  severity: 'fail' | 'warn',
+  relative: number | undefined,
+  absolute: number | undefined,
+  unit: BudgetMetric['unit'],
+  direction: BudgetDirection,
+): string | undefined {
+  if (relative === undefined && absolute === undefined) return undefined;
+  const parts = [];
+  if (relative !== undefined) {
+    parts.push(direction === 'lower' ? `+${(relative * 100).toFixed(1)}%` : `${(relative * 100).toFixed(1)}% lower`);
+  }
+  if (absolute !== undefined) {
+    parts.push(formatThresholdValue(absolute, unit, direction));
+  }
+  return `${severity} >= ${parts.join(' and ')}`;
+}
+
+function formatThresholdValue(value: number, unit: BudgetMetric['unit'], direction: BudgetDirection): string {
+  const formatted = formatValue(value, unit).replace('-', '');
+  if (direction === 'higher') {
+    return `${formatted} lower`;
+  }
+  return unit === 'score' ? formatted : `+${formatted}`;
+}
+
+function skipNote(id: string): string {
+  if (id === 'batch-query-qps-p50') {
+    return 'No common batch-query concurrency in baseline and current report.';
+  }
+  return 'Metric is missing from the baseline or current report.';
+}
+
+function nodeMajorLabel(nodeVersion: string): string {
+  const match = /^v?(\d+)/.exec(nodeVersion);
+  return `node${match?.[1] ?? 'unknown'}`;
+}
+
+async function readBenchmarkReport(filePath: string): Promise<BenchmarkReport> {
+  const raw = await fsp.readFile(filePath, 'utf-8');
+  const parsed = JSON.parse(raw) as Partial<BenchmarkReport>;
+  if (parsed.version !== 1 || !parsed.provider || !parsed.node_version || !parsed.os || !parsed.arch || !parsed.scenarios) {
+    throw new Error(`Invalid benchmark report: ${filePath}`);
+  }
+  return parsed as BenchmarkReport;
+}
+
+function parseArgs(args: string[], env: NodeJS.ProcessEnv): CliOptions {
+  const options: CliOptions = {
+    currentPath: env.BENCH_CURRENT_PATH,
+    enforceFailures: parseBool(env.BENCH_BUDGET_FAIL),
+    repoRoot: process.cwd(),
+    summaryPath: env.GITHUB_STEP_SUMMARY,
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === '--baseline') {
+      options.baselinePath = requireValue(args, ++index, arg);
+    } else if (arg === '--current') {
+      options.currentPath = requireValue(args, ++index, arg);
+    } else if (arg === '--fail-on-regression') {
+      options.enforceFailures = true;
+    } else if (arg === '--repo-root') {
+      options.repoRoot = requireValue(args, ++index, arg);
+    } else if (arg === '--summary') {
+      options.summaryPath = requireValue(args, ++index, arg);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (options.currentPath) {
+    options.currentPath = path.resolve(options.repoRoot, options.currentPath);
+  }
+  if (options.baselinePath) {
+    options.baselinePath = path.resolve(options.repoRoot, options.baselinePath);
+  }
+  if (options.summaryPath) {
+    options.summaryPath = path.resolve(options.repoRoot, options.summaryPath);
+  }
+  return options;
+}
+
+function requireValue(args: string[], index: number, flag: string): string {
+  const value = args[index];
+  if (!value) {
+    throw new Error(`Missing value for ${flag}`);
+  }
+  return value;
+}
+
+function parseBool(value: string | undefined): boolean {
+  if (!value) return false;
+  return value === '1' || value.toLowerCase() === 'true' || value.toLowerCase() === 'yes';
+}
+
+function isMissingFileError(error: unknown): boolean {
+  return typeof error === 'object'
+    && error !== null
+    && 'code' in error
+    && (error as { code?: string }).code === 'ENOENT';
+}
+
+function isDirectRun(argvPath: string | undefined): boolean {
+  if (!argvPath) return false;
+  return path.basename(argvPath) === 'budget-diff.js';
+}
+
+if (isDirectRun(process.argv[1])) {
+  runCli().catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.stack ?? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/docs/architecture/qa-budgets.md
+++ b/docs/architecture/qa-budgets.md
@@ -69,6 +69,34 @@ BENCH_PROVIDER=openai npm run bench    # real provider (requires OPENAI_API_KEY)
 
 Baselines in `benchmarks/results/` are keyed by `{provider}-{node_version}-{os}-{arch}`; compare apples to apples.
 
+## CI regression summary
+
+The benchmark workflow runs the stub provider on pull requests and appends a budget diff to the GitHub job summary. The diff compares the current `ci-{provider}-{node}-{os}-{arch}.json` report against the matching committed `baseline-{provider}-{node}-{os}-{arch}.json` report.
+
+Rows are advisory by default. A manual `workflow_dispatch` run can enable `enforce_budgets`; that sets `BENCH_BUDGET_FAIL=1` and makes FAIL rows fail the job without rewriting the workflow.
+
+| Metric | WARN threshold | FAIL threshold |
+| ------ | -------------- | -------------- |
+| Cold index wall time | >= 10% and >= 1,000 ms slower | >= 20% and >= 2,000 ms slower |
+| Warm query p50/p95 | >= 10% and >= 10 ms slower | >= 25% and >= 25 ms slower |
+| Warm query p99 | >= 10% and >= 15 ms slower | >= 25% and >= 30 ms slower |
+| Peak RSS | >= 10% and >= 16 MiB higher | >= 25% and >= 32 MiB higher |
+| Index storage total | >= 5% and >= 1 MiB higher | >= 15% and >= 5 MiB higher |
+| Index bytes/vector | >= 5% and >= 16 B higher | >= 15% and >= 48 B higher |
+| Batch throughput p50 | >= 10% lower | >= 20% lower |
+| Retrieval recall@10 | >= 0.010 lower | >= 0.030 lower |
+
+Optional scenarios such as batch throughput and storage are marked SKIP when either the current report or the committed baseline lacks that metric. They start producing deltas as soon as both sides contain the same JSON keys.
+
+To update a baseline intentionally:
+
+```bash
+BENCH_PROVIDER=stub BENCH_RESULTS_PREFIX=baseline npm run bench
+git diff -- benchmarks/results/
+```
+
+Commit the changed baseline with the code change that justifies the new budget. Do not refresh baselines to hide unrelated regressions; include the job-summary diff in the PR discussion when a threshold moves.
+
 ## Runtime budget enforcement (issue #210)
 
 The bench harness above measures budgets offline. **At runtime**, the same wall-clock numbers are surfaced live in `kb_stats.provider_calls` (per-`model_id` count, errors, p50/p95/p99 latency, token-in sum) and rolled up in `kb doctor`'s `provider_calls` check. The doctor flips the row to `WARN` when `errors / count > 5%` for any active model_id, so an operator can observe both:


### PR DESCRIPTION
## Summary

Adds a benchmark budget-diff script and wires the benchmark workflow to append an actionable PASS/WARN/FAIL regression summary against the matching committed baseline. Budget enforcement remains advisory by default and can be enabled through the manual workflow input.

Closes #306

## Testing

- [x] `npm test -- benchmarks/budget-diff.test.ts`
- [x] `npx tsc -p /home/jean/git/knowledge-base-mcp-server-issue-306-benchmark-regression-signals/tsconfig.bench.json`
- [x] `npx tsc -p /home/jean/git/knowledge-base-mcp-server/tsconfig.bench.json`
- [x] `BENCH_PROVIDER=stub BENCH_RESULTS_PREFIX=ci npm run bench`
- [x] `node build/benchmarks/budget-diff.js --current benchmarks/results/ci-stub-node24-linux-x64.json --summary /tmp/kb-budget-ci-summary.md`
- [x] `npm run build`
- [x] `npm test` (rerun passed: 67 suites, 1110 passing, 4 skipped; first run had one load-related timeout in `src/KnowledgeBaseServer.test.ts`, and that suite passed in isolation before the full rerun)

## Changelog

Not added per issue scope; this is CI/tooling documentation rather than a release-note entry.

## Follow-ups

None.