### PR TITLE
Add stable dogfood retrieval fixtures

### DIFF
--- a/docs/testing/fixtures/README.md
+++ b/docs/testing/fixtures/README.md
@@ -1,0 +1,21 @@
+# Retrieval Eval Fixtures
+
+This directory contains committed fixture packs for retrieval evaluation.
+
+The dogfood packs use the small corpus in `dogfood-corpus/` so schema and
+determinism checks can run in CI without a maintainer's private knowledge
+bases. The frozen core is intended for stable cases; the rotating arena is for
+new bug-derived or adversarial cases before they graduate.
+
+To run a real retrieval eval, index `docs/testing/fixtures/dogfood-corpus/` as a
+KB named `dogfood`, then run:
+
+```sh
+kb eval docs/testing/fixtures/dogfood-frozen-core.yml --mode=auto
+kb eval docs/testing/fixtures/dogfood-rotating-arena.yml --mode=auto
+```
+
+Both packs are warning-only for now (`gate: false`). Promote a case to gated use
+only after it is stable across the supported provider matrix and its
+source-of-truth comment still matches the committed corpus.
+

--- a/docs/testing/fixtures/dogfood-corpus/archive/old-rollback.md
+++ b/docs/testing/fixtures/dogfood-corpus/archive/old-rollback.md
@@ -1,0 +1,15 @@
+---
+fixture_owner: retrieval-eval
+status: archived
+topic: operations
+---
+
+# Archived Rollback Procedure
+
+This archived note advised deleting the docstore and rebuilding every vector
+from scratch during rollback. That advice is obsolete because it destroys
+stable document identifiers and makes post-incident retrieval traces harder to
+compare.
+
+Current rollback guidance lives in `current-rollback.md`.
+

--- a/docs/testing/fixtures/dogfood-corpus/atomic-faiss-save.md
+++ b/docs/testing/fixtures/dogfood-corpus/atomic-faiss-save.md
@@ -1,0 +1,15 @@
+---
+fixture_owner: retrieval-eval
+status: stable
+topic: storage
+---
+
+# Atomic FAISS Save
+
+FAISS persistence writes a replacement index to a temporary path, verifies that
+the write completed, and then renames it into place. The rename step keeps
+readers from observing a partially written index.
+
+The docstore metadata is saved alongside the vector index so a restored pair
+represents the same chunk set.
+

--- a/docs/testing/fixtures/dogfood-corpus/auth-and-errors.md
+++ b/docs/testing/fixtures/dogfood-corpus/auth-and-errors.md
@@ -1,0 +1,15 @@
+---
+fixture_owner: retrieval-eval
+status: stable
+topic: auth
+---
+
+# Authentication And Retrieval Errors
+
+The server accepts `MCP_AUTH_TOKEN` as the bearer token used by MCP clients.
+When an authenticated query reaches a knowledge base whose vector index has not
+been created, the retrieval layer reports `INDEX_NOT_INITIALIZED`.
+
+These exact tokens are intentionally present in this corpus so hybrid retrieval
+can be checked against dense-only behavior for out-of-vocabulary identifiers.
+

--- a/docs/testing/fixtures/dogfood-corpus/current-rollback.md
+++ b/docs/testing/fixtures/dogfood-corpus/current-rollback.md
@@ -1,0 +1,16 @@
+---
+fixture_owner: retrieval-eval
+status: current
+topic: operations
+---
+
+# Current Rollback Procedure
+
+Production rollback starts by freezing writers, checking the latest manifest,
+and restoring the most recent verified index snapshot. Operators then run the
+doctor command and a smoke retrieval query before reopening writes.
+
+The current procedure does not delete the docstore. It preserves canonical
+document identifiers so query traces and audit logs remain comparable before
+and after the rollback.
+

--- a/docs/testing/fixtures/dogfood-corpus/doctor-health.md
+++ b/docs/testing/fixtures/dogfood-corpus/doctor-health.md
@@ -1,0 +1,17 @@
+---
+fixture_owner: retrieval-eval
+status: stable
+topic: doctor
+---
+
+# Doctor Health Checks
+
+The doctor command verifies the local knowledge-base layout before retrieval.
+It checks that the index directory exists, that metadata manifests can be read,
+that the configured embedding provider is reachable, and that the active model
+matches the index metadata.
+
+The command reports stale files separately from structural failures. A stale
+file warning means the corpus can still answer queries, while a missing index
+or provider failure means retrieval should be treated as unavailable.
+

--- a/docs/testing/fixtures/dogfood-corpus/duplicate-canonical.md
+++ b/docs/testing/fixtures/dogfood-corpus/duplicate-canonical.md
@@ -1,0 +1,14 @@
+---
+fixture_owner: retrieval-eval
+status: canonical
+topic: duplicate-budget
+---
+
+# Duplicate Canonical Guidance
+
+Duplicate crowding is measured by counting repeated source groups in the top
+results. The canonical answer should appear once with adjacent support from
+different documents, not as many repeated chunks from the same source.
+
+This document is the intended source for duplicate-budget checks.
+

--- a/docs/testing/fixtures/dogfood-corpus/duplicate-shadow.md
+++ b/docs/testing/fixtures/dogfood-corpus/duplicate-shadow.md
@@ -1,0 +1,14 @@
+---
+fixture_owner: retrieval-eval
+status: shadow
+topic: duplicate-budget
+---
+
+# Duplicate Shadow Copy
+
+This shadow copy repeats the duplicate-crowding advice in similar words. It is
+kept in the corpus as an adversarial near miss so the fixture can budget how
+many repeated source groups are acceptable in the top results.
+
+The canonical source remains `duplicate-canonical.md`.
+

--- a/docs/testing/fixtures/dogfood-corpus/hybrid-tokens.md
+++ b/docs/testing/fixtures/dogfood-corpus/hybrid-tokens.md
@@ -1,0 +1,16 @@
+---
+fixture_owner: retrieval-eval
+status: stable
+topic: hybrid
+---
+
+# Hybrid Retrieval Tokens
+
+Hybrid retrieval should recover exact identifiers that natural language
+embeddings may blur. This fixture includes `ollama__nomic-embed-text-latest`,
+`pickleparser`, and `RFC 006` as literal terms that should remain findable.
+
+The same document also describes the natural-language intent: compare lexical
+matches with dense semantic matches and merge the rankings without losing
+high-confidence paraphrase results.
+

--- a/docs/testing/fixtures/dogfood-corpus/per-file-hash-sidecars.md
+++ b/docs/testing/fixtures/dogfood-corpus/per-file-hash-sidecars.md
@@ -1,0 +1,17 @@
+---
+fixture_owner: retrieval-eval
+status: stable
+topic: indexing
+---
+
+# Per-File Hash Sidecars
+
+The indexer decides whether to re-embed a file by comparing the stored content
+hash, parser version, and chunking settings against the current source file.
+Modification time alone is not the source of truth because copied files and
+checkout operations can preserve or rewrite timestamps without changing text.
+
+When the content hash and parser metadata match, the existing chunks can be
+reused. When either value changes, only that file's chunks are replaced in the
+docstore and vector index.
+

--- a/docs/testing/fixtures/dogfood-frozen-core.yml
+++ b/docs/testing/fixtures/dogfood-frozen-core.yml
@@ -1,0 +1,92 @@
+# Stable dogfood retrieval fixture pack for issue #302.
+#
+# The committed corpus lives under docs/testing/fixtures/dogfood-corpus so a
+# fresh checkout can exercise schema parsing and provider-free determinism in CI.
+# Retrieval runs should index that directory as a KB named `dogfood`.
+#
+# This pack is warning-only while the corpus and provider matrix collect
+# baseline data. Promotion to a gated pack requires stable pass rates across
+# supported providers and agreement on thresholds.
+
+gate: false
+mode: auto
+
+cases:
+  # author: dogfood-fixture
+  # source-of-truth: docs/testing/fixtures/dogfood-corpus/doctor-health.md
+  # protects: smoke coverage for a fresh dogfood KB
+  - name: smoke - doctor health checks are discoverable
+    query: what health checks run when I invoke the doctor command
+    kb: dogfood
+    k: 5
+    required_sources:
+      - docs/testing/fixtures/dogfood-corpus/doctor-health.md
+    stale_policy: allow_stale
+
+  # author: dogfood-fixture
+  # source-of-truth: docs/testing/fixtures/dogfood-corpus/per-file-hash-sidecars.md
+  # judgment: content hash and parser metadata are the relevant recall target; mtime-only advice is intentionally absent from required sources.
+  # protects: recall floor for paraphrased indexing invalidation behavior
+  - name: recall floor - per-file invalidation remains findable
+    query: how does the index decide which files need to be re-embedded
+    kb: dogfood
+    k: 5
+    required_sources:
+      - docs/testing/fixtures/dogfood-corpus/per-file-hash-sidecars.md
+    max_duplicate_groups: 1
+    stale_policy: fresh
+
+  # author: dogfood-fixture
+  # source-of-truth: docs/testing/fixtures/dogfood-corpus/current-rollback.md
+  # judgment: archived rollback guidance is obsolete and should not appear above the current procedure.
+  # protects: precision floor against stale operational advice
+  - name: precision floor - archived rollback stays out
+    query: current production rollback procedure for a knowledge base index
+    kb: dogfood
+    k: 5
+    threshold: 2
+    required_sources:
+      - docs/testing/fixtures/dogfood-corpus/current-rollback.md
+    forbidden_sources:
+      - docs/testing/fixtures/dogfood-corpus/archive/old-rollback.md
+    stale_policy: fresh
+
+  # author: dogfood-fixture
+  # source-of-truth: docs/testing/fixtures/dogfood-corpus/duplicate-canonical.md
+  # judgment: one repeated source group is acceptable during early dogfood runs, but more would hide diverse supporting documents.
+  # protects: duplicate crowding budget in top-k retrieval
+  - name: duplicate budget - canonical duplicate guidance is not crowded out
+    query: how should duplicate source groups be budgeted in retrieval results
+    kb: dogfood
+    k: 5
+    required_sources:
+      - docs/testing/fixtures/dogfood-corpus/duplicate-canonical.md
+    max_duplicate_groups: 1
+    stale_policy: allow_stale
+
+  # author: dogfood-fixture
+  # source-of-truth: docs/testing/fixtures/dogfood-corpus/auth-and-errors.md
+  # protects: hybrid exact-token lift for error codes and env vars
+  - name: hybrid exact token - INDEX_NOT_INITIALIZED
+    query: INDEX_NOT_INITIALIZED MCP_AUTH_TOKEN
+    kb: dogfood
+    mode: auto
+    k: 5
+    required_sources:
+      - docs/testing/fixtures/dogfood-corpus/auth-and-errors.md
+    max_duplicate_groups: 1
+    stale_policy: allow_stale
+
+  # author: dogfood-fixture
+  # source-of-truth: docs/testing/fixtures/dogfood-corpus/atomic-faiss-save.md
+  # judgment: paraphrased storage-safety questions should still find the semantic answer when hybrid mode is selected.
+  # protects: hybrid/non-regression behavior for natural-language queries
+  - name: hybrid non-regression - paraphrased atomic save
+    query: how does the vector index avoid readers seeing a partially written save
+    kb: dogfood
+    mode: hybrid
+    k: 5
+    required_sources:
+      - docs/testing/fixtures/dogfood-corpus/atomic-faiss-save.md
+    max_duplicate_groups: 1
+    stale_policy: fresh

--- a/docs/testing/fixtures/dogfood-rotating-arena.yml
+++ b/docs/testing/fixtures/dogfood-rotating-arena.yml
@@ -1,0 +1,62 @@
+# Rotating dogfood retrieval arena for issue #302.
+#
+# Add bug-derived or adversarial cases here first. Cases that stay stable across
+# providers can later graduate into dogfood-frozen-core.yml.
+
+gate: false
+mode: auto
+
+cases:
+  # author: dogfood-fixture
+  # source-of-truth: docs/testing/fixtures/dogfood-corpus/current-rollback.md
+  # judgment: the archived note deliberately contains similar rollback terms and is a precision near miss.
+  # protects: adversarial stale-document precision
+  - name: arena precision - current rollback beats archived note
+    query: should rollback delete the docstore and rebuild vectors from scratch
+    kb: dogfood
+    k: 5
+    threshold: 2
+    required_sources:
+      - docs/testing/fixtures/dogfood-corpus/current-rollback.md
+    forbidden_sources:
+      - docs/testing/fixtures/dogfood-corpus/archive/old-rollback.md
+    stale_policy: fresh
+
+  # author: dogfood-fixture
+  # source-of-truth: docs/testing/fixtures/dogfood-corpus/hybrid-tokens.md
+  # protects: exact-token retrieval for model ids
+  - name: arena hybrid - exact model id remains findable
+    query: ollama__nomic-embed-text-latest
+    kb: dogfood
+    mode: auto
+    k: 5
+    required_sources:
+      - docs/testing/fixtures/dogfood-corpus/hybrid-tokens.md
+    max_duplicate_groups: 1
+    stale_policy: allow_stale
+
+  # author: dogfood-fixture
+  # source-of-truth: docs/testing/fixtures/dogfood-corpus/hybrid-tokens.md
+  # protects: exact-token retrieval for parser dependency names
+  - name: arena hybrid - exact parser token remains findable
+    query: pickleparser RFC 006
+    kb: dogfood
+    mode: auto
+    k: 5
+    required_sources:
+      - docs/testing/fixtures/dogfood-corpus/hybrid-tokens.md
+    max_duplicate_groups: 1
+    stale_policy: allow_stale
+
+  # author: dogfood-fixture
+  # source-of-truth: docs/testing/fixtures/dogfood-corpus/duplicate-canonical.md
+  # judgment: the shadow copy is included as a near miss but should not displace the canonical source.
+  # protects: duplicate and near-duplicate crowding behavior
+  - name: arena duplicate - canonical source survives shadow copy
+    query: duplicate crowding repeated chunks from the same source
+    kb: dogfood
+    k: 5
+    required_sources:
+      - docs/testing/fixtures/dogfood-corpus/duplicate-canonical.md
+    max_duplicate_groups: 1
+    stale_policy: allow_stale

--- a/src/retrieval-eval-dogfood.test.ts
+++ b/src/retrieval-eval-dogfood.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from '@jest/globals';
+import { createHash } from 'crypto';
+import * as fsp from 'fs/promises';
+import * as path from 'path';
+import yaml from 'js-yaml';
+import { normalizeRetrievalEvalFixture } from './retrieval-eval.js';
+
+const FIXTURE_DIR = path.join(process.cwd(), 'docs/testing/fixtures');
+const CORPUS_DIR = path.join(FIXTURE_DIR, 'dogfood-corpus');
+const DOGFOOD_FIXTURES = [
+  {
+    file: 'dogfood-frozen-core.yml',
+    expectedCases: [
+      'smoke - doctor health checks are discoverable',
+      'recall floor - per-file invalidation remains findable',
+      'precision floor - archived rollback stays out',
+      'duplicate budget - canonical duplicate guidance is not crowded out',
+      'hybrid exact token - INDEX_NOT_INITIALIZED',
+      'hybrid non-regression - paraphrased atomic save',
+    ],
+  },
+  {
+    file: 'dogfood-rotating-arena.yml',
+    expectedCases: [
+      'arena precision - current rollback beats archived note',
+      'arena hybrid - exact model id remains findable',
+      'arena hybrid - exact parser token remains findable',
+      'arena duplicate - canonical source survives shadow copy',
+    ],
+  },
+] as const;
+
+async function readFixture(file: string) {
+  const raw = await fsp.readFile(path.join(FIXTURE_DIR, file), 'utf-8');
+  return {
+    raw,
+    fixture: normalizeRetrievalEvalFixture(yaml.load(raw)),
+  };
+}
+
+function referencedSources(fixture: ReturnType<typeof normalizeRetrievalEvalFixture>): string[] {
+  return fixture.cases.flatMap((fixtureCase) => [
+    ...fixtureCase.requiredSources,
+    ...fixtureCase.forbiddenSources,
+  ]);
+}
+
+function stableDigest(value: unknown): string {
+  return createHash('sha256').update(JSON.stringify(value)).digest('hex');
+}
+
+describe('dogfood retrieval eval fixtures', () => {
+  it.each(DOGFOOD_FIXTURES)('parses $file with stable warning-only cases', async ({ file, expectedCases }) => {
+    const { raw, fixture } = await readFixture(file);
+
+    expect(fixture.gate).toBe(false);
+    expect(fixture.mode).toBe('auto');
+    expect(fixture.cases.map((fixtureCase) => fixtureCase.name)).toEqual(expectedCases);
+    expect(fixture.cases.every((fixtureCase) => fixtureCase.kb === 'dogfood')).toBe(true);
+    expect(new Set(fixture.cases.map((fixtureCase) => fixtureCase.query)).size).toBe(fixture.cases.length);
+    expect(raw.match(/source-of-truth:/g)).toHaveLength(fixture.cases.length);
+  });
+
+  it('keeps every dogfood source judgment inside the committed corpus', async () => {
+    for (const { file } of DOGFOOD_FIXTURES) {
+      const { fixture } = await readFixture(file);
+
+      for (const source of referencedSources(fixture)) {
+        expect(source.startsWith('docs/testing/fixtures/dogfood-corpus/')).toBe(true);
+        expect((await fsp.stat(path.join(process.cwd(), source))).isFile()).toBe(true);
+      }
+    }
+  });
+
+  it('covers smoke, recall, precision, duplicate-budget, and hybrid/non-regression cases', async () => {
+    const { fixture } = await readFixture('dogfood-frozen-core.yml');
+    const names = fixture.cases.map((fixtureCase) => fixtureCase.name);
+
+    expect(names.some((name) => name.startsWith('smoke -'))).toBe(true);
+    expect(names.some((name) => name.startsWith('recall floor -'))).toBe(true);
+    expect(names.some((name) => name.startsWith('precision floor -'))).toBe(true);
+    expect(fixture.cases.some((fixtureCase) => fixtureCase.maxDuplicateGroups === 1)).toBe(true);
+    expect(fixture.cases).toEqual(expect.arrayContaining([
+      expect.objectContaining({ name: 'hybrid exact token - INDEX_NOT_INITIALIZED', mode: 'auto' }),
+      expect.objectContaining({ name: 'hybrid non-regression - paraphrased atomic save', mode: 'hybrid' }),
+    ]));
+  });
+
+  it('has a deterministic provider-free fixture and corpus digest for CI', async () => {
+    const normalizedFixtures = [];
+    for (const { file } of DOGFOOD_FIXTURES) {
+      normalizedFixtures.push((await readFixture(file)).fixture);
+    }
+
+    const corpusFiles = (await fsp.readdir(CORPUS_DIR, { recursive: true }))
+      .filter((entry) => entry.endsWith('.md'))
+      .sort();
+    const corpus = await Promise.all(corpusFiles.map(async (file) => [
+      file,
+      await fsp.readFile(path.join(CORPUS_DIR, file), 'utf-8'),
+    ]));
+
+    expect(stableDigest({ normalizedFixtures, corpus })).toBe(
+      'efc9f96676f70fe4ac4185ae304ae3719d05f636848e7586ab3f180b38baeaed',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add a committed dogfood retrieval corpus under docs/testing/fixtures/dogfood-corpus
- add warning-only frozen-core and rotating-arena fixture packs covering smoke, recall, precision, duplicate-budget, and hybrid/non-regression cases
- add provider-free CI test coverage that parses the packs, verifies source judgments, and locks a deterministic fixture/corpus digest

Closes #302

## Verification
- npm test -- src/retrieval-eval-dogfood.test.ts
- npm test -- src/retrieval-eval.test.ts
- npm run build
- npm test
- scripts/check-portability.sh origin/main