### PR TITLE
feat(eval): add ranked IR metrics

### DIFF
--- a/docs/testing/retrieval-eval-methodology.md
+++ b/docs/testing/retrieval-eval-methodology.md
@@ -8,7 +8,8 @@ smallest schema knob that would catch that failure again.
 Use this guide when creating or reviewing fixtures for `kb eval`. The schema is
 deliberately small: top-level `gate`, and per-case `name`, `query`, `kb`, `k`,
 `threshold`, `gate`, `required_sources`, `forbidden_sources`,
-`expected_metadata`, `max_duplicate_groups`, and `stale_policy`.
+`expected_metadata`, `relevant_sources`/`judgments`,
+`max_duplicate_groups`, and `stale_policy`.
 
 ## Why Fixtures Miss Regressions
 
@@ -32,8 +33,9 @@ details unless the bug is specifically about those fields.
 
 Local prior art uses `R` for retrieved documents and `G` for the verified gold
 evidence set. Precision asks how much of `R` belongs in `G`; recall asks how
-much of `G` was recovered. `kb eval` does not compute a full metric suite, but
-its knobs let you encode floors that catch the same classes of regression.
+much of `G` was recovered. Binary knobs encode hard floors. Ranked judgments
+add source-level quality measurements when the order of the returned evidence
+matters.
 
 | Concept | Fixture knob | Default use |
 |---|---|---|
@@ -42,9 +44,40 @@ its knobs let you encode floors that catch the same classes of regression.
 | Output tidiness | `max_duplicate_groups` | One source should not crowd out the result set. |
 | Freshness contract | `stale_policy` | Use `fresh` for release gates, `allow_stale` for local packs, `stale` only when testing stale detection. |
 | Metadata pin | `expected_metadata` | At least one result must carry an authored metadata value. |
+| Ranked quality | `relevant_sources` or `judgments` | Verified relevant sources should appear early, with optional graded relevance. |
 | CI behavior | top-level or per-case `gate` | Gated failures exit nonzero; ungated failures warn. |
 | Scope | `kb` | The query should search only the named KB. |
 | Search shape | `query`, `k`, `threshold` | The user wording and retrieval budget being protected. |
+
+Ranked metrics are observational: they do not make a case pass or fail by
+themselves. Keep `required_sources`, `forbidden_sources`, and `gate` for CI
+floors. Use ranked metrics to compare retrieval modes, embedding models, and
+fixture packs without turning every rank movement into a hard failure.
+
+`relevant_sources` is the readable form:
+
+```yaml
+relevant_sources:
+  - source: runbooks/deploy.md
+    relevance: 3
+  - source: runbooks/fallback.md
+    relevance: 1
+```
+
+`judgments` is the compact equivalent:
+
+```yaml
+judgments:
+  runbooks/deploy.md: 3
+  runbooks/fallback.md: 1
+```
+
+Relevance is a non-negative grade. Use `1` for ordinary relevant sources, `2`
+or `3` for sources that are more complete or authoritative, and reserve `0`
+for explicit non-relevant qrels if you need to keep a compact object aligned
+with another benchmark. The metric denominator includes only positive grades.
+`nDCG@10` uses the graded values; `MRR@10`, recall, precision, MAP, and hit
+rate treat every positive grade as relevant.
 
 ## Four Fixture Archetypes
 
@@ -97,6 +130,26 @@ manual failure. Start it ungated, keep the exact bad source in
   gate: false
 ```
 
+**Ranked arena.** A non-gated case with several independently verified
+relevant sources. This is best for comparing modes or model candidates because
+it rewards putting the best source first without failing CI when rank 1 and
+rank 2 swap.
+
+```yaml
+- name: ranked - rollback evidence order
+  query: current rollback procedure
+  kb: ops
+  k: 10
+  relevant_sources:
+    - source: runbooks/deploy.md
+      relevance: 3
+    - source: runbooks/post-incident-checklist.md
+      relevance: 2
+    - source: runbooks/service-owner-escalation.md
+      relevance: 1
+  gate: false
+```
+
 ## Gating Ladder
 
 Start with roughly 80 percent warning cases and 20 percent gated cases. Gate the
@@ -135,9 +188,10 @@ fixture-set provenance is hard to interpret.
 
 ## Contamination Guardrails
 
-Never write `required_sources` by copying the current top-k. Read the target
-document, decide whether it is truly required, then run `kb search` to see
-whether the system finds it.
+Never write `required_sources`, `relevant_sources`, or `judgments` by copying
+the current top-k. Read the target documents, decide whether each one is truly
+required or relevant, assign grades before looking at today's rank order, then
+run `kb search` to see whether the system finds them.
 
 Keep metadata assertions on authored fields. `frontmatter.status: approved` is
 a contract; `chunkIndex: 7` is an implementation accident.
@@ -167,7 +221,7 @@ answer key.
 | Stale index hides fresh edits | `stale_policy: fresh` | Use this only in environments that refresh before eval. |
 | Stale-warning path regresses | `stale_policy: stale` | Reserve for tests that intentionally create stale state. |
 | Authored metadata stops flowing | `expected_metadata` | Prefer whitelisted frontmatter fields. |
-| Model or mode change shifts quality | `required_sources` and `forbidden_sources` | Run the same fixture under both candidates and compare failures. |
+| Model or mode change shifts quality | `relevant_sources` or `judgments` | Compare aggregate nDCG@10, MRR@10, Recall@k, Precision@k, MAP/MAP@k, and hit rate. |
 | Threshold or top-k change cuts too hard | `k` and `threshold` | Pin only when the budget itself is part of the contract. |
 
 ## Worked Example

--- a/docs/testing/retrieval-eval.md
+++ b/docs/testing/retrieval-eval.md
@@ -12,6 +12,9 @@ The unit tests in `src/retrieval-eval.test.ts` cover:
 - Retrieval mode parsing for `dense`, `lexical`, `hybrid`, and `auto`.
 - Fixture-level and case-level retrieval mode normalization.
 - Per-case requested/effective retrieval mode reporting.
+- Optional ranked relevance judgments via `relevant_sources` and `judgments`.
+- Ranked IR metrics for perfect ranking, relevant-but-low-ranked sources,
+  missing judged sources, graded relevance, and aggregate reporting.
 - Parse coverage for the worked example in `docs/testing/fixtures/methodology-starter.yml`.
 
 `kb eval` defaults to dense retrieval to preserve the original evaluator behavior.
@@ -20,5 +23,11 @@ mode choices exposed by `kb search`. A fixture can also set top-level `mode` as
 its default, and individual cases can override it with case-level `mode`.
 JSON output records `requested_mode`, `effective_mode`, and `auto_mode` when
 auto selection is used.
+
+Cases with `relevant_sources` or `judgments` also emit `ranked_metrics` in both
+markdown and JSON. The evaluator reports per-case `nDCG@10`, `MRR@10`,
+`Recall@k`, `Precision@k`, `MAP`, `MAP@k`, and hit rate, then reports aggregate
+means across judged cases. Cases without judgments preserve the original
+binary pass/fail output shape.
 
 For authoring guidance, see [Retrieval eval fixture methodology](retrieval-eval-methodology.md).

--- a/src/cli-eval.ts
+++ b/src/cli-eval.ts
@@ -14,7 +14,9 @@ import {
   retrieveForRetrievalEvalCase,
   retrievalEvalExitCode,
   summarizeRetrievalEval,
+  type RetrievalEvalAggregateRankedMetrics,
   type RetrievalEvalFixture,
+  type RetrievalEvalRankedMetrics,
 } from './retrieval-eval.js';
 
 interface EvalArgs {
@@ -38,7 +40,7 @@ Usage:
 Reads cases from a YAML or JSON fixture and runs each query against the
 active model's index. Each case can set \`query\`, optional \`kb\`,
 \`required_sources\`, \`forbidden_sources\`, \`expected_metadata\`,
-\`max_duplicate_groups\`, \`stale_policy\`, and \`gate\`.
+\`relevant_sources\`/\`judgments\`, \`max_duplicate_groups\`, \`stale_policy\`, and \`gate\`.
 
 Failing ungated cases print warnings and exit 0; failing GATED cases
 exit 1, suitable for CI gates.
@@ -68,6 +70,9 @@ Fixture example (YAML):
       forbidden_sources: [archive/old-deploy.md]
       expected_metadata:
         frontmatter.status: approved
+      relevant_sources:
+        - source: runbooks/deploy.md
+          relevance: 3
       max_duplicate_groups: 1
       stale_policy: fresh
 `;
@@ -209,12 +214,15 @@ async function loadEvalFixture(fixturePath: string): Promise<RetrievalEvalFixtur
   return normalizeRetrievalEvalFixture(parsed);
 }
 
-function toJsonReport(report: ReturnType<typeof summarizeRetrievalEval>): unknown {
+export function toJsonReport(report: ReturnType<typeof summarizeRetrievalEval>): unknown {
   return {
     total: report.total,
     passed: report.passed,
     failed: report.failed,
     gate_failed: report.gateFailed,
+    ...(report.rankedMetrics !== undefined ? {
+      ranked_metrics: toJsonAggregateRankedMetrics(report.rankedMetrics),
+    } : {}),
     cases: report.cases.map((result) => ({
       name: result.name,
       query: result.query,
@@ -228,6 +236,37 @@ function toJsonReport(report: ReturnType<typeof summarizeRetrievalEval>): unknow
       warnings: result.warnings,
       result_count: result.resultCount,
       duplicate_groups: result.duplicateGroups,
+      ...(result.rankedMetrics !== undefined ? {
+        ranked_metrics: toJsonRankedMetrics(result.rankedMetrics),
+      } : {}),
     })),
+  };
+}
+
+function toJsonRankedMetrics(metrics: RetrievalEvalRankedMetrics): unknown {
+  return {
+    k: metrics.k,
+    judged_relevant_count: metrics.judgedRelevantCount,
+    retrieved_relevant_count: metrics.retrievedRelevantCount,
+    ndcg_at_10: metrics.ndcgAt10,
+    mrr_at_10: metrics.mrrAt10,
+    recall_at_k: metrics.recallAtK,
+    precision_at_k: metrics.precisionAtK,
+    map: metrics.map,
+    map_at_k: metrics.mapAtK,
+    hit_rate: metrics.hitRate,
+  };
+}
+
+function toJsonAggregateRankedMetrics(metrics: RetrievalEvalAggregateRankedMetrics): unknown {
+  return {
+    judged_case_count: metrics.judgedCaseCount,
+    ndcg_at_10: metrics.ndcgAt10,
+    mrr_at_10: metrics.mrrAt10,
+    recall_at_k: metrics.recallAtK,
+    precision_at_k: metrics.precisionAtK,
+    map: metrics.map,
+    map_at_k: metrics.mapAtK,
+    hit_rate: metrics.hitRate,
   };
 }

--- a/src/retrieval-eval.test.ts
+++ b/src/retrieval-eval.test.ts
@@ -2,11 +2,12 @@ import { describe, expect, it } from '@jest/globals';
 import * as fsp from 'fs/promises';
 import * as path from 'path';
 import yaml from 'js-yaml';
-import { parseEvalArgs } from './cli-eval.js';
+import { parseEvalArgs, toJsonReport } from './cli-eval.js';
 import type { ScoredDocument } from './formatter.js';
 import type { Staleness } from './cli-search.js';
 import {
   evaluateRetrievalCase,
+  formatRetrievalEvalMarkdown,
   normalizeRetrievalEvalFixture,
   retrievalEvalExitCode,
   resolveRetrievalEvalMode,
@@ -35,6 +36,7 @@ function fixtureCase(overrides: Partial<RetrievalEvalCase> = {}): RetrievalEvalC
     requiredSources: [],
     forbiddenSources: [],
     expectedMetadata: [],
+    relevanceJudgments: [],
     stalePolicy: 'fresh',
     ...overrides,
   };
@@ -63,7 +65,7 @@ describe('normalizeRetrievalEvalFixture', () => {
     })).toThrow('fixture mode must be "dense", "lexical", "hybrid", or "auto"');
   });
 
-  it('normalizes fixture cases with source, metadata, duplicate, gate, and stale policy fields', () => {
+  it('normalizes fixture cases with source, metadata, duplicate, judgment, gate, and stale policy fields', () => {
     const fixture = normalizeRetrievalEvalFixture({
       gate: true,
       cases: [{
@@ -75,6 +77,10 @@ describe('normalizeRetrievalEvalFixture', () => {
         gate: false,
         required_sources: ['runbooks/routing.md'],
         forbidden_sources: ['archive/old-routing.md'],
+        relevant_sources: [
+          { source: 'runbooks/routing.md', relevance: 3 },
+          'runbooks/fallback.md',
+        ],
         expected_metadata: { 'frontmatter.status': 'approved' },
         max_duplicate_groups: 1,
         stale_policy: { expect: 'fresh' },
@@ -91,12 +97,41 @@ describe('normalizeRetrievalEvalFixture', () => {
       gate: false,
       requiredSources: ['runbooks/routing.md'],
       forbiddenSources: ['archive/old-routing.md'],
+      relevanceJudgments: [
+        { source: 'runbooks/routing.md', relevance: 3 },
+        { source: 'runbooks/fallback.md', relevance: 1 },
+      ],
       maxDuplicateGroups: 1,
       stalePolicy: 'fresh',
     });
     expect(fixture.cases[0].expectedMetadata).toEqual([
       { path: 'frontmatter.status', equals: 'approved' },
     ]);
+  });
+
+  it('normalizes compact judgment objects', () => {
+    const fixture = normalizeRetrievalEvalFixture({
+      cases: [{
+        query: 'deployment notes',
+        judgments: {
+          'runbooks/deploy.md': 2,
+          'runbooks/fallback.md': 1,
+        },
+      }],
+    });
+
+    expect(fixture.cases[0].relevanceJudgments).toEqual([
+      { source: 'runbooks/deploy.md', relevance: 2 },
+      { source: 'runbooks/fallback.md', relevance: 1 },
+    ]);
+  });
+
+  it('preserves the normalized fixture shape when judgments are absent', () => {
+    const fixture = normalizeRetrievalEvalFixture({
+      cases: [{ query: 'deployment notes' }],
+    });
+
+    expect(fixture.cases[0].relevanceJudgments).toBeUndefined();
   });
 
   it('parses the methodology starter fixture against the eval schema', async () => {
@@ -255,5 +290,196 @@ describe('evaluateRetrievalCase', () => {
 
     expect(retrievalEvalExitCode(summarizeRetrievalEval([warning]))).toBe(0);
     expect(retrievalEvalExitCode(summarizeRetrievalEval([gated]))).toBe(1);
+  });
+
+  it('computes perfect ranked metrics for a perfect ranking', () => {
+    const result = evaluateRetrievalCase(
+      fixtureCase({
+        k: 3,
+        relevanceJudgments: [
+          { source: 'runbooks/deploy.md', relevance: 1 },
+          { source: 'runbooks/fallback.md', relevance: 1 },
+        ],
+      }),
+      [
+        doc('runbooks/deploy.md'),
+        doc('runbooks/fallback.md'),
+        doc('notes/other.md'),
+      ],
+      FRESH,
+    );
+
+    expect(result.rankedMetrics).toEqual({
+      k: 3,
+      judgedRelevantCount: 2,
+      retrievedRelevantCount: 2,
+      ndcgAt10: 1,
+      mrrAt10: 1,
+      recallAtK: 1,
+      precisionAtK: 2 / 3,
+      map: 1,
+      mapAtK: 1,
+      hitRate: 1,
+    });
+  });
+
+  it('penalizes a relevant source that is retrieved at a low rank', () => {
+    const result = evaluateRetrievalCase(
+      fixtureCase({
+        k: 10,
+        relevanceJudgments: [{ source: 'runbooks/deploy.md', relevance: 1 }],
+      }),
+      [
+        doc('noise/1.md'),
+        doc('noise/2.md'),
+        doc('noise/3.md'),
+        doc('noise/4.md'),
+        doc('noise/5.md'),
+        doc('noise/6.md'),
+        doc('noise/7.md'),
+        doc('noise/8.md'),
+        doc('noise/9.md'),
+        doc('runbooks/deploy.md'),
+      ],
+      FRESH,
+    );
+
+    expect(result.rankedMetrics?.hitRate).toBe(1);
+    expect(result.rankedMetrics?.mrrAt10).toBeCloseTo(0.1, 6);
+    expect(result.rankedMetrics?.recallAtK).toBe(1);
+    expect(result.rankedMetrics?.precisionAtK).toBeCloseTo(0.1, 6);
+    expect(result.rankedMetrics?.map).toBeCloseTo(0.1, 6);
+    expect(result.rankedMetrics?.mapAtK).toBeCloseTo(0.1, 6);
+    expect(result.rankedMetrics?.ndcgAt10).toBeCloseTo(1 / Math.log2(11), 6);
+  });
+
+  it('reports zero ranked metrics for a missing judged source without failing the binary case', () => {
+    const result = evaluateRetrievalCase(
+      fixtureCase({
+        k: 5,
+        relevanceJudgments: [{ source: 'runbooks/deploy.md', relevance: 1 }],
+      }),
+      [doc('notes/other.md')],
+      FRESH,
+    );
+
+    expect(result.passed).toBe(true);
+    expect(result.rankedMetrics).toMatchObject({
+      retrievedRelevantCount: 0,
+      ndcgAt10: 0,
+      mrrAt10: 0,
+      recallAtK: 0,
+      precisionAtK: 0,
+      map: 0,
+      mapAtK: 0,
+      hitRate: 0,
+    });
+  });
+
+  it('uses graded relevance for nDCG and binary relevance for AP-style metrics', () => {
+    const result = evaluateRetrievalCase(
+      fixtureCase({
+        k: 3,
+        relevanceJudgments: [
+          { source: 'runbooks/deploy.md', relevance: 3 },
+          { source: 'runbooks/fallback.md', relevance: 2 },
+          { source: 'runbooks/checklist.md', relevance: 1 },
+        ],
+      }),
+      [
+        doc('runbooks/fallback.md'),
+        doc('runbooks/deploy.md'),
+        doc('runbooks/checklist.md'),
+      ],
+      FRESH,
+    );
+
+    const dcg = 3 + (7 / Math.log2(3)) + (1 / Math.log2(4));
+    const idealDcg = 7 + (3 / Math.log2(3)) + (1 / Math.log2(4));
+    expect(result.rankedMetrics?.ndcgAt10).toBeCloseTo(dcg / idealDcg, 6);
+    expect(result.rankedMetrics?.mrrAt10).toBe(1);
+    expect(result.rankedMetrics?.map).toBe(1);
+  });
+});
+
+describe('summarizeRetrievalEval', () => {
+  it('aggregates ranked metrics across judged cases and omits them when absent', () => {
+    const judged = evaluateRetrievalCase(
+      fixtureCase({
+        k: 2,
+        relevanceJudgments: [{ source: 'runbooks/deploy.md', relevance: 1 }],
+      }),
+      [doc('runbooks/deploy.md'), doc('notes/other.md')],
+      FRESH,
+    );
+    const unjudged = evaluateRetrievalCase(fixtureCase(), [doc('notes/other.md')], FRESH);
+
+    const report = summarizeRetrievalEval([judged, unjudged]);
+
+    expect(report.rankedMetrics).toEqual({
+      judgedCaseCount: 1,
+      ndcgAt10: 1,
+      mrrAt10: 1,
+      recallAtK: 1,
+      precisionAtK: 0.5,
+      map: 1,
+      mapAtK: 1,
+      hitRate: 1,
+    });
+    expect(report.cases[1].rankedMetrics).toBeUndefined();
+  });
+
+  it('prints ranked metrics in markdown when judgments are present', () => {
+    const result = evaluateRetrievalCase(
+      fixtureCase({
+        k: 2,
+        relevanceJudgments: [{ source: 'runbooks/deploy.md', relevance: 1 }],
+      }),
+      [doc('runbooks/deploy.md'), doc('notes/other.md')],
+      FRESH,
+    );
+
+    const markdown = formatRetrievalEvalMarkdown(summarizeRetrievalEval([result]));
+
+    expect(markdown).toContain('ranked: nDCG@10=1.000');
+    expect(markdown).toContain('Ranked metrics: nDCG@10=1.000');
+  });
+
+  it('includes ranked metrics in JSON output when judgments are present', () => {
+    const result = evaluateRetrievalCase(
+      fixtureCase({
+        k: 2,
+        relevanceJudgments: [{ source: 'runbooks/deploy.md', relevance: 1 }],
+      }),
+      [doc('runbooks/deploy.md'), doc('notes/other.md')],
+      FRESH,
+    );
+
+    expect(toJsonReport(summarizeRetrievalEval([result]))).toMatchObject({
+      ranked_metrics: {
+        judged_case_count: 1,
+        ndcg_at_10: 1,
+        mrr_at_10: 1,
+        recall_at_k: 1,
+        precision_at_k: 0.5,
+        map: 1,
+        map_at_k: 1,
+        hit_rate: 1,
+      },
+      cases: [{
+        ranked_metrics: {
+          k: 2,
+          judged_relevant_count: 1,
+          retrieved_relevant_count: 1,
+          ndcg_at_10: 1,
+          mrr_at_10: 1,
+          recall_at_k: 1,
+          precision_at_k: 0.5,
+          map: 1,
+          map_at_k: 1,
+          hit_rate: 1,
+        },
+      }],
+    });
   });
 });

--- a/src/retrieval-eval.ts
+++ b/src/retrieval-eval.ts
@@ -24,6 +24,35 @@ export interface ExpectedMetadataRule {
   equals: unknown;
 }
 
+export interface RelevanceJudgment {
+  source: string;
+  relevance: number;
+}
+
+export interface RetrievalEvalRankedMetrics {
+  k: number;
+  judgedRelevantCount: number;
+  retrievedRelevantCount: number;
+  ndcgAt10: number;
+  mrrAt10: number;
+  recallAtK: number;
+  precisionAtK: number;
+  map: number;
+  mapAtK: number;
+  hitRate: number;
+}
+
+export interface RetrievalEvalAggregateRankedMetrics {
+  judgedCaseCount: number;
+  ndcgAt10: number;
+  mrrAt10: number;
+  recallAtK: number;
+  precisionAtK: number;
+  map: number;
+  mapAtK: number;
+  hitRate: number;
+}
+
 export interface RetrievalEvalCase {
   name: string;
   query: string;
@@ -35,6 +64,7 @@ export interface RetrievalEvalCase {
   requiredSources: string[];
   forbiddenSources: string[];
   expectedMetadata: ExpectedMetadataRule[];
+  relevanceJudgments?: RelevanceJudgment[];
   maxDuplicateGroups?: number;
   stalePolicy: StalePolicy;
 }
@@ -49,6 +79,8 @@ export interface RetrievalEvalCaseInput {
   gate?: boolean;
   required_sources?: string[];
   forbidden_sources?: string[];
+  relevant_sources?: Array<string | { source?: unknown; relevance?: unknown }>;
+  judgments?: Record<string, unknown> | Array<string | { source?: unknown; relevance?: unknown }>;
   expected_metadata?: Record<string, unknown> | Array<Record<string, unknown>>;
   max_duplicate_groups?: number;
   stale_policy?: StalePolicy | { expect?: StalePolicy };
@@ -73,6 +105,7 @@ export interface RetrievalEvalCaseResult {
   warnings: string[];
   resultCount: number;
   duplicateGroups: number;
+  rankedMetrics?: RetrievalEvalRankedMetrics;
 }
 
 export interface RetrievalEvalReport {
@@ -81,6 +114,7 @@ export interface RetrievalEvalReport {
   passed: number;
   failed: number;
   gateFailed: number;
+  rankedMetrics?: RetrievalEvalAggregateRankedMetrics;
 }
 
 export interface RetrievalEvalSearchContext {
@@ -196,6 +230,7 @@ export function evaluateRetrievalCase(
   }
 
   const gate = fixtureCase.gate ?? fixtureGate;
+  const rankedMetrics = computeRankedMetrics(fixtureCase, results);
   return {
     name: fixtureCase.name,
     query: fixtureCase.query,
@@ -209,17 +244,20 @@ export function evaluateRetrievalCase(
     warnings,
     resultCount: results.length,
     duplicateGroups,
+    ...(rankedMetrics !== undefined ? { rankedMetrics } : {}),
   };
 }
 
 export function summarizeRetrievalEval(results: RetrievalEvalCaseResult[]): RetrievalEvalReport {
   const failed = results.filter((r) => !r.passed).length;
+  const rankedMetrics = summarizeRankedMetrics(results);
   return {
     cases: results,
     total: results.length,
     passed: results.length - failed,
     failed,
     gateFailed: results.filter((r) => r.gate && !r.passed).length,
+    ...(rankedMetrics !== undefined ? { rankedMetrics } : {}),
   };
 }
 
@@ -235,8 +273,11 @@ export function formatRetrievalEvalMarkdown(report: RetrievalEvalReport): string
     const mode = result.requestedMode === result.effectiveMode
       ? result.effectiveMode
       : `${result.requestedMode} -> ${result.effectiveMode}`;
+    const ranked = result.rankedMetrics === undefined
+      ? ''
+      : `, ranked: ${formatRankedMetrics(result.rankedMetrics)}`;
     lines.push(
-      `- ${status} ${result.name} (${scope}, mode: ${mode}, ${result.resultCount} result(s), duplicate groups: ${result.duplicateGroups})`,
+      `- ${status} ${result.name} (${scope}, mode: ${mode}, ${result.resultCount} result(s), duplicate groups: ${result.duplicateGroups}${ranked})`,
     );
     for (const failure of result.failures) {
       lines.push(`  - ${failure}`);
@@ -249,6 +290,9 @@ export function formatRetrievalEvalMarkdown(report: RetrievalEvalReport): string
   lines.push(
     `Summary: ${report.passed}/${report.total} passed; ${report.failed} failed; ${report.gateFailed} gate failure(s).`,
   );
+  if (report.rankedMetrics !== undefined) {
+    lines.push(`Ranked metrics: ${formatAggregateRankedMetrics(report.rankedMetrics)}.`);
+  }
   return `${lines.join('\n')}\n`;
 }
 
@@ -262,6 +306,7 @@ function normalizeCase(raw: unknown, caseNumber: number): RetrievalEvalCase {
   const threshold = readOptionalPositiveNumber(raw, 'threshold');
   const gate = readOptionalBoolean(raw, 'gate');
   const maxDuplicateGroups = readOptionalNonNegativeInteger(raw, 'max_duplicate_groups');
+  const relevanceJudgments = normalizeRelevanceJudgments(raw, caseNumber);
   return {
     name: readOptionalString(raw, 'name') ?? `case ${caseNumber}`,
     query,
@@ -273,6 +318,7 @@ function normalizeCase(raw: unknown, caseNumber: number): RetrievalEvalCase {
     requiredSources: readOptionalStringArray(raw, 'required_sources') ?? [],
     forbiddenSources: readOptionalStringArray(raw, 'forbidden_sources') ?? [],
     expectedMetadata: normalizeExpectedMetadata(raw.expected_metadata, caseNumber),
+    ...(relevanceJudgments.length > 0 ? { relevanceJudgments } : {}),
     ...(maxDuplicateGroups !== undefined ? { maxDuplicateGroups } : {}),
     stalePolicy: normalizeStalePolicy(raw.stale_policy, caseNumber),
   };
@@ -382,6 +428,248 @@ function normalizeExpectedMetadata(raw: unknown, caseNumber: number): ExpectedMe
     return rules;
   }
   throw new Error(`case ${caseNumber} expected_metadata must be an object or array of objects`);
+}
+
+function normalizeRelevanceJudgments(
+  raw: Record<string, unknown>,
+  caseNumber: number,
+): RelevanceJudgment[] {
+  const entries: RelevanceJudgment[] = [];
+  const relevantSources = raw.relevant_sources;
+  const judgments = raw.judgments;
+
+  if (relevantSources !== undefined) {
+    entries.push(...normalizeJudgmentArray(relevantSources, caseNumber, 'relevant_sources'));
+  }
+  if (judgments !== undefined) {
+    if (isRecord(judgments)) {
+      for (const [source, relevance] of Object.entries(judgments)) {
+        entries.push({
+          source: validateJudgmentSource(source, caseNumber, 'judgments'),
+          relevance: validateJudgmentRelevance(relevance, caseNumber, `judgments.${source}`),
+        });
+      }
+    } else {
+      entries.push(...normalizeJudgmentArray(judgments, caseNumber, 'judgments'));
+    }
+  }
+
+  const deduped = new Map<string, RelevanceJudgment>();
+  for (const entry of entries) {
+    const existing = deduped.get(entry.source);
+    if (existing === undefined || entry.relevance > existing.relevance) {
+      deduped.set(entry.source, entry);
+    }
+  }
+  return Array.from(deduped.values());
+}
+
+function normalizeJudgmentArray(
+  raw: unknown,
+  caseNumber: number,
+  key: string,
+): RelevanceJudgment[] {
+  if (!Array.isArray(raw)) {
+    throw new Error(`case ${caseNumber} ${key} must be an array or object`);
+  }
+  return raw.map((entry, idx) => {
+    if (typeof entry === 'string') {
+      return {
+        source: validateJudgmentSource(entry, caseNumber, `${key}[${idx}]`),
+        relevance: 1,
+      };
+    }
+    if (!isRecord(entry)) {
+      throw new Error(`case ${caseNumber} ${key}[${idx}] must be a source string or object`);
+    }
+    return {
+      source: validateJudgmentSource(entry.source, caseNumber, `${key}[${idx}].source`),
+      relevance: validateJudgmentRelevance(
+        entry.relevance ?? 1,
+        caseNumber,
+        `${key}[${idx}].relevance`,
+      ),
+    };
+  });
+}
+
+function validateJudgmentSource(value: unknown, caseNumber: number, key: string): string {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new Error(`case ${caseNumber} ${key} must be a non-empty source string`);
+  }
+  return value;
+}
+
+function validateJudgmentRelevance(value: unknown, caseNumber: number, key: string): number {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
+    throw new Error(`case ${caseNumber} ${key} must be a non-negative finite relevance number`);
+  }
+  return value;
+}
+
+function computeRankedMetrics(
+  fixtureCase: RetrievalEvalCase,
+  results: readonly ScoredDocument[],
+): RetrievalEvalRankedMetrics | undefined {
+  const positiveJudgments = (fixtureCase.relevanceJudgments ?? []).filter((j) => j.relevance > 0);
+  if (positiveJudgments.length === 0) return undefined;
+
+  const k = fixtureCase.k ?? 10;
+  const topK = results.slice(0, k);
+  const retrievedAtK = matchedJudgmentIndexes(topK, positiveJudgments);
+
+  return {
+    k,
+    judgedRelevantCount: positiveJudgments.length,
+    retrievedRelevantCount: retrievedAtK.size,
+    ndcgAt10: ndcgAt(results, positiveJudgments, 10),
+    mrrAt10: reciprocalRankAt(results, positiveJudgments, 10),
+    recallAtK: retrievedAtK.size / positiveJudgments.length,
+    precisionAtK: retrievedAtK.size / k,
+    map: averagePrecisionAt(results, positiveJudgments, results.length, positiveJudgments.length),
+    mapAtK: averagePrecisionAt(topK, positiveJudgments, k, Math.min(positiveJudgments.length, k)),
+    hitRate: retrievedAtK.size > 0 ? 1 : 0,
+  };
+}
+
+function summarizeRankedMetrics(
+  results: readonly RetrievalEvalCaseResult[],
+): RetrievalEvalAggregateRankedMetrics | undefined {
+  const judged = results
+    .map((result) => result.rankedMetrics)
+    .filter((metrics): metrics is RetrievalEvalRankedMetrics => metrics !== undefined);
+  if (judged.length === 0) return undefined;
+  return {
+    judgedCaseCount: judged.length,
+    ndcgAt10: mean(judged.map((m) => m.ndcgAt10)),
+    mrrAt10: mean(judged.map((m) => m.mrrAt10)),
+    recallAtK: mean(judged.map((m) => m.recallAtK)),
+    precisionAtK: mean(judged.map((m) => m.precisionAtK)),
+    map: mean(judged.map((m) => m.map)),
+    mapAtK: mean(judged.map((m) => m.mapAtK)),
+    hitRate: mean(judged.map((m) => m.hitRate)),
+  };
+}
+
+function matchedJudgmentIndexes(
+  results: readonly ScoredDocument[],
+  judgments: readonly RelevanceJudgment[],
+): Set<number> {
+  const matched = new Set<number>();
+  for (const doc of results) {
+    const index = bestMatchingJudgmentIndex(doc, judgments);
+    if (index !== undefined) matched.add(index);
+  }
+  return matched;
+}
+
+function reciprocalRankAt(
+  results: readonly ScoredDocument[],
+  judgments: readonly RelevanceJudgment[],
+  cutoff: number,
+): number {
+  const seen = new Set<number>();
+  for (let idx = 0; idx < Math.min(results.length, cutoff); idx += 1) {
+    const match = bestMatchingJudgmentIndex(results[idx], judgments, seen);
+    if (match !== undefined) return 1 / (idx + 1);
+  }
+  return 0;
+}
+
+function averagePrecisionAt(
+  results: readonly ScoredDocument[],
+  judgments: readonly RelevanceJudgment[],
+  cutoff: number,
+  denominator: number,
+): number {
+  if (denominator === 0) return 0;
+  const seen = new Set<number>();
+  let retrievedRelevant = 0;
+  let precisionSum = 0;
+  for (let idx = 0; idx < Math.min(results.length, cutoff); idx += 1) {
+    const match = bestMatchingJudgmentIndex(results[idx], judgments, seen);
+    if (match === undefined) continue;
+    seen.add(match);
+    retrievedRelevant += 1;
+    precisionSum += retrievedRelevant / (idx + 1);
+  }
+  return precisionSum / denominator;
+}
+
+function ndcgAt(
+  results: readonly ScoredDocument[],
+  judgments: readonly RelevanceJudgment[],
+  cutoff: number,
+): number {
+  const seen = new Set<number>();
+  let dcg = 0;
+  for (let idx = 0; idx < Math.min(results.length, cutoff); idx += 1) {
+    const match = bestMatchingJudgmentIndex(results[idx], judgments, seen);
+    if (match === undefined) continue;
+    seen.add(match);
+    dcg += gradedGain(judgments[match].relevance) / Math.log2(idx + 2);
+  }
+
+  const ideal = judgments
+    .map((judgment) => judgment.relevance)
+    .sort((a, b) => b - a)
+    .slice(0, cutoff)
+    .reduce((sum, relevance, idx) => sum + (gradedGain(relevance) / Math.log2(idx + 2)), 0);
+  return ideal === 0 ? 0 : dcg / ideal;
+}
+
+function bestMatchingJudgmentIndex(
+  doc: ScoredDocument,
+  judgments: readonly RelevanceJudgment[],
+  exclude: ReadonlySet<number> = new Set(),
+): number | undefined {
+  let bestIndex: number | undefined;
+  let bestRelevance = Number.NEGATIVE_INFINITY;
+  judgments.forEach((judgment, idx) => {
+    if (exclude.has(idx) || !documentMatchesSource(doc, judgment.source)) return;
+    if (judgment.relevance > bestRelevance) {
+      bestIndex = idx;
+      bestRelevance = judgment.relevance;
+    }
+  });
+  return bestIndex;
+}
+
+function gradedGain(relevance: number): number {
+  return (2 ** relevance) - 1;
+}
+
+function mean(values: readonly number[]): number {
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+function formatRankedMetrics(metrics: RetrievalEvalRankedMetrics): string {
+  return [
+    `nDCG@10=${formatMetric(metrics.ndcgAt10)}`,
+    `MRR@10=${formatMetric(metrics.mrrAt10)}`,
+    `Recall@${metrics.k}=${formatMetric(metrics.recallAtK)}`,
+    `Precision@${metrics.k}=${formatMetric(metrics.precisionAtK)}`,
+    `MAP=${formatMetric(metrics.map)}`,
+    `MAP@${metrics.k}=${formatMetric(metrics.mapAtK)}`,
+    `HitRate@${metrics.k}=${formatMetric(metrics.hitRate)}`,
+  ].join(', ');
+}
+
+function formatAggregateRankedMetrics(metrics: RetrievalEvalAggregateRankedMetrics): string {
+  return [
+    `nDCG@10=${formatMetric(metrics.ndcgAt10)}`,
+    `MRR@10=${formatMetric(metrics.mrrAt10)}`,
+    `Recall@k=${formatMetric(metrics.recallAtK)}`,
+    `Precision@k=${formatMetric(metrics.precisionAtK)}`,
+    `MAP=${formatMetric(metrics.map)}`,
+    `MAP@k=${formatMetric(metrics.mapAtK)}`,
+    `HitRate=${formatMetric(metrics.hitRate)}`,
+    `judged cases=${metrics.judgedCaseCount}`,
+  ].join(', ');
+}
+
+function formatMetric(value: number): string {
+  return value.toFixed(3);
 }
 
 function readOptionalSearchMode(


### PR DESCRIPTION
Closes #299

## Summary
- add optional source-level relevance judgments to kb eval fixtures via `relevant_sources` or `judgments`
- compute per-case and aggregate ranked IR metrics in markdown and JSON output
- document judgment authoring guidance and contamination guardrails

## Verification
- `npm test -- src/retrieval-eval.test.ts`
- `npm test -- /home/jean/git/knowledge-base-mcp-server-issue-299-ranked-ir-metrics/src/retrieval-eval.test.ts`
- `npm run build`
- `npm test`
- `git diff --check`

Note: the literal prompt command `npm test -- /home/jean/git/knowledge-base-mcp-server/src/retrieval-eval.test.ts` was attempted from the issue worktree, but Jest does not match tests outside the worktree root and returned `No tests found`. The same absolute-path command against the issue worktree test file passes.