### PR TITLE
feat: add query embedding cache

### DIFF
--- a/docs/architecture/adr/0009-query-embedding-cache.md
+++ b/docs/architecture/adr/0009-query-embedding-cache.md
@@ -1,0 +1,42 @@
+# ADR 0009: Query Embedding Cache
+
+## Status
+
+Accepted.
+
+## Context
+
+`retrieve_knowledge` and `kb search` embed the query before FAISS lookup. For
+warm queries on small indexes, the provider call can dominate total latency and
+can incur paid-provider cost. The CLI and MCP server share `$FAISS_INDEX_PATH`,
+so a cache warmed by one process should be reusable by the other.
+
+## Decision
+
+Add a two-tier query-embedding cache keyed by:
+
+```text
+sha256("kb-query-cache.v1" + 0x1f + model_id + 0x1f + normalized_query)
+```
+
+`normalized_query` is NFKC, trimmed, and whitespace-collapsed. It remains
+case-preserving because not every embedding model is case-insensitive. The key
+does not include KB content state: the query vector is a function of model and
+query, while corpus changes affect only the FAISS candidate set.
+
+Tier 1 is an in-process LRU with `KB_QUERY_CACHE_LRU_MAX` defaulting to 256.
+Tier 2 stores vectors under
+`$FAISS_INDEX_PATH/cache/queries/<model_id>/<sha>.f32` with a
+`<sha>.meta.json` sidecar. Writes use a model-cache-directory lock plus
+tmp-and-rename so readers do not consume partial files. Corrupt or incomplete
+entries are unlinked and treated as misses.
+
+Operators can bypass the cache with `KB_QUERY_CACHE=off`, `kb search
+--no-cache`, and `kb compare --no-cache`.
+
+## Consequences
+
+Cache hits skip provider `embedQuery` calls but keep the FAISS query path
+unchanged. Disk entries contain query-derived vectors, so they inherit the same
+local trust boundary as the FAISS index directory. `kb_stats.query_cache`
+reports process hit/miss counters and current disk size for observability.

--- a/src/FaissIndexManager.ts
+++ b/src/FaissIndexManager.ts
@@ -40,6 +40,7 @@ import {
   type ScoredDocument,
   type SimilaritySearchFilters,
 } from './search-filters.js';
+import { queryEmbeddingCache, type QueryCacheLookupStatus } from './query-cache.js';
 import { withSidecarLock } from './write-lock.js';
 import {
   recordIngestFailure,
@@ -185,6 +186,7 @@ export interface SimilaritySearchTiming {
   post_filter_ms?: number;
   total_ms?: number;
   fetch_k?: number;
+  query_cache?: QueryCacheLookupStatus | 'unavailable';
 }
 
 export const MAX_NEIGHBOR_CONTEXT_WINDOW = 5;
@@ -1209,6 +1211,7 @@ export class FaissIndexManager {
     knowledgeBaseName?: string,
     filters?: SimilaritySearchFilters,
     timing?: SimilaritySearchTiming,
+    opts: { noCache?: boolean } = {},
   ): Promise<SearchResultDocument[]> {
     const totalStartedAt = Date.now();
     if (!this.faissIndex) {
@@ -1225,9 +1228,10 @@ export class FaissIndexManager {
     // FaissStore.similaritySearchVectorWithScore accepts only (query, k) and
     // silently drops any filter argument, so threshold and KB scoping are both
     // applied as post-filters on the returned [doc, score] tuples. When the
-    // caller wants timing AND the wrapper exposes the vector-first entry
-    // point, embed once up front and reuse the embedding across every
-    // progressive-overfetch rung so the embed cost is paid exactly once.
+    // wrapper exposes the vector-first entry point, embed once up front and
+    // reuse the embedding across every progressive-overfetch rung so the
+    // embed cost is paid exactly once. Issue #214 adds the query-embedding
+    // cache at this boundary; document embedding remains untouched.
     const vectorSearch = (
       this.faissIndex as unknown as {
         similaritySearchVectorWithScore?: (
@@ -1236,12 +1240,23 @@ export class FaissIndexManager {
         ) => Promise<Array<[Document, number]>>;
       }
     ).similaritySearchVectorWithScore;
-    const useVectorPath = timing !== undefined && typeof vectorSearch === 'function';
+    const useVectorPath = typeof vectorSearch === 'function';
     let queryEmbedding: number[] | undefined;
     if (useVectorPath) {
       const embedStartedAt = Date.now();
-      queryEmbedding = await this.embeddings.embedQuery(query);
-      timing!.embed_query_ms = Date.now() - embedStartedAt;
+      const cached = await queryEmbeddingCache.getOrCompute({
+        modelId: this.modelId,
+        query,
+        bypass: opts.noCache === true,
+        embed: () => this.embeddings.embedQuery(query),
+      });
+      queryEmbedding = cached.embedding;
+      if (timing) {
+        timing.embed_query_ms = Date.now() - embedStartedAt;
+        timing.query_cache = cached.status;
+      }
+    } else if (timing) {
+      timing.query_cache = 'unavailable';
     }
 
     const runFaissSearch = async (

--- a/src/cli-compare.ts
+++ b/src/cli-compare.ts
@@ -8,7 +8,7 @@ import { loadManagerForModel, loadWithJsonRetry } from './cli-shared.js';
 export const COMPARE_HELP = `kb compare — side-by-side rank/score table for two embedding models
 
 Usage:
-  kb compare <query> <model_a> <model_b> [--k=<int>] [--kb=<name>]
+  kb compare <query> <model_a> <model_b> [--k=<int>] [--kb=<name>] [--no-cache]
 
 Runs the same query against two registered models' indexes and prints a
 joined table of \`rank_a / rank_b / score_a / score_b / in_both / source\`,
@@ -26,6 +26,7 @@ Arguments:
 Options:
   --k=<int>             Top-K results per model (default: 10).
   --kb=<name>           Scope to one knowledge base. Omit to search ALL KBs.
+  --no-cache            Bypass the query-embedding cache for both model legs.
   --help, -h            Show this help.
 
 Examples:
@@ -38,6 +39,7 @@ export async function runCompare(rest: string[]): Promise<number> {
   const positionals: string[] = [];
   let k = 10;
   let kb: string | undefined;
+  let noCache = false;
   for (const raw of rest) {
     if (raw.startsWith('--k=')) {
       const n = Number(raw.slice('--k='.length));
@@ -49,6 +51,7 @@ export async function runCompare(rest: string[]): Promise<number> {
       continue;
     }
     if (raw.startsWith('--kb=')) { kb = raw.slice('--kb='.length); continue; }
+    if (raw === '--no-cache') { noCache = true; continue; }
     if (raw.startsWith('--')) {
       process.stderr.write(`kb compare: unknown flag: ${raw}\n`);
       return 2;
@@ -91,11 +94,11 @@ export async function runCompare(rest: string[]): Promise<number> {
   try {
     const managerA = await loadManagerForModel(resolvedA);
     await loadWithJsonRetry(managerA);
-    resultsA = await managerA.similaritySearch(query, k, undefined, kb);
+    resultsA = await managerA.similaritySearch(query, k, undefined, kb, undefined, undefined, { noCache });
 
     const managerB = await loadManagerForModel(resolvedB);
     await loadWithJsonRetry(managerB);
-    resultsB = await managerB.similaritySearch(query, k, undefined, kb);
+    resultsB = await managerB.similaritySearch(query, k, undefined, kb, undefined, undefined, { noCache });
   } catch (err) {
     process.stderr.write(`kb compare: ${(err as Error).message}\n`);
     return 1;

--- a/src/cli-search.ts
+++ b/src/cli-search.ts
@@ -78,6 +78,7 @@ Result tuning:
   --context-after=<n>   Include up to n following chunks from the same source
                         around each dense semantic match (0-${MAX_NEIGHBOR_CONTEXT_WINDOW}).
   --context-window=<n>  Shorthand for --context-before=n --context-after=n.
+  --no-cache            Bypass the query-embedding cache for this search.
 
 Output:
   --format=md|json|vimgrep
@@ -124,6 +125,7 @@ interface SearchArgs {
   mode: SearchMode;
   timing: boolean;
   interactive: boolean;
+  noCache: boolean;
   neighborContext?: NeighborContextOptions;
 }
 
@@ -260,6 +262,7 @@ export async function runSearch(rest: string[]): Promise<number> {
         parsed.kb,
         undefined,
         timing ? denseTiming : undefined,
+        { noCache: parsed.noCache },
       );
       autoThresholdDecision = computeAutoThreshold(rawResults.map((r) => r.score));
       results = rawResults.slice(0, autoThresholdDecision.kept);
@@ -271,6 +274,7 @@ export async function runSearch(rest: string[]): Promise<number> {
         parsed.kb,
         undefined,
         timing ? denseTiming : undefined,
+        { noCache: parsed.noCache },
       );
     }
     if (parsed.neighborContext) {
@@ -392,12 +396,14 @@ export function parseSearchArgs(rest: string[]): SearchArgs {
     mode: 'dense',
     timing: false,
     interactive: false,
+    noCache: false,
   };
   for (const raw of rest) {
     if (raw === '--refresh') { out.refresh = true; continue; }
     if (raw === '--stdin')   { out.stdin = true; continue; }
     if (raw === '--group-by-source') { out.groupBySource = true; continue; }
     if (raw === '--timing') { out.timing = true; continue; }
+    if (raw === '--no-cache') { out.noCache = true; continue; }
     if (raw === '--interactive' || raw === '-i') { out.interactive = true; continue; }
     if (raw.startsWith('--context-before=')) {
       out.neighborContext = {
@@ -507,6 +513,7 @@ function mergeDenseTiming(target: TimingPayload, source: SimilaritySearchTiming)
   if (source.post_filter_ms !== undefined) target.post_filter_ms = source.post_filter_ms;
   if (source.total_ms !== undefined) target.dense_total_ms = source.total_ms;
   if (source.fetch_k !== undefined) target.fetch_k = source.fetch_k;
+  if (source.query_cache !== undefined) target.query_cache = source.query_cache;
 }
 
 export async function computeStaleness(modelId: string, scopedKb?: string): Promise<Staleness> {
@@ -1022,6 +1029,7 @@ async function runHybridSearch(
       parsed.kb,
       undefined,
       timing ? denseTiming : undefined,
+      { noCache: parsed.noCache },
     )
     .then((rs) => {
       if (timing) {

--- a/src/cli-stats.test.ts
+++ b/src/cli-stats.test.ts
@@ -57,6 +57,18 @@ function payload(): KbStatsPayload {
     // per-model provider call telemetry. Empty `{}` matches a fresh
     // process where the active provider has not been called yet.
     provider_calls: {},
+    query_cache: {
+      hits: 0,
+      misses: 0,
+      hit_ratio: 0,
+      l1_hits: 0,
+      disk_hits: 0,
+      bypasses: 0,
+      writes: 0,
+      corruptions: 0,
+      l1_size: 0,
+      disk_size_bytes: 0,
+    },
   };
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -213,6 +213,33 @@ export function resolveIndexingBatchSize(
 export const INDEXING_BATCH_SIZE: number = resolveIndexingBatchSize();
 
 // ---------------------------------------------------------------------------
+// Query embedding cache configuration (#214).
+// ---------------------------------------------------------------------------
+
+export function isQueryCacheEnabled(raw: string | undefined = process.env.KB_QUERY_CACHE): boolean {
+  const value = (raw ?? '').trim().toLowerCase();
+  return value !== 'off' && value !== 'false' && value !== '0' && value !== 'disabled';
+}
+
+export function resolveQueryCacheLruMax(raw: string | undefined = process.env.KB_QUERY_CACHE_LRU_MAX): number {
+  const parsed = raw === undefined || raw.trim() === '' ? NaN : Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) return 256;
+  return Math.floor(parsed);
+}
+
+export function resolveQueryCacheDiskMaxBytes(
+  raw: string | undefined = process.env.KB_QUERY_CACHE_DISK_MAX_MB,
+): number {
+  const parsed = raw === undefined || raw.trim() === '' ? NaN : Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) return 64 * 1024 * 1024;
+  return Math.floor(parsed * 1024 * 1024);
+}
+
+export const KB_QUERY_CACHE_ENABLED = isQueryCacheEnabled();
+export const KB_QUERY_CACHE_LRU_MAX = resolveQueryCacheLruMax();
+export const KB_QUERY_CACHE_DISK_MAX_BYTES = resolveQueryCacheDiskMaxBytes();
+
+// ---------------------------------------------------------------------------
 // Chunking configuration (#107 follow-up).
 // ---------------------------------------------------------------------------
 

--- a/src/kb-stats.ts
+++ b/src/kb-stats.ts
@@ -26,6 +26,7 @@ import {
   type ProviderCallSnapshot,
 } from './metrics.js';
 import { countIngestQuarantine } from './ingest-quarantine.js';
+import { queryEmbeddingCache, type QueryCacheStats } from './query-cache.js';
 
 export interface KbStatsRow {
   file_count: number;
@@ -49,6 +50,7 @@ export interface KbStatsPayload {
    * `provider_calls` keep working.
    */
   provider_calls: Record<string, ProviderCallSnapshot>;
+  query_cache: QueryCacheStats;
 }
 
 export interface ComputeKbStatsOptions {
@@ -153,6 +155,7 @@ export async function computeKbStats(
       uptime_ms: Date.now() - options.startedAt,
     },
     provider_calls: metricsSource.snapshot(),
+    query_cache: await queryEmbeddingCache.stats(),
   };
 }
 

--- a/src/query-cache.test.ts
+++ b/src/query-cache.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from '@jest/globals';
+import * as fsp from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  QueryEmbeddingCache,
+  normalizeQueryForCache,
+  queryCachePaths,
+} from './query-cache.js';
+import { isQueryCacheEnabled } from './config.js';
+
+async function tempIndexPath(prefix: string): Promise<string> {
+  const dir = await fsp.mkdtemp(path.join(os.tmpdir(), prefix));
+  return path.join(dir, '.faiss');
+}
+
+describe('query embedding cache (#214)', () => {
+  it('round-trips a query embedding through the disk tier across cache instances', async () => {
+    const indexPath = await tempIndexPath('kb-query-cache-roundtrip-');
+    try {
+      let calls = 0;
+      const first = new QueryEmbeddingCache({ indexPath, lruMax: 8 });
+      const miss = await first.getOrCompute({
+        modelId: 'fake__one',
+        query: '  hello   world  ',
+        embed: async () => {
+          calls += 1;
+          return [1.25, 2.5, 3.75];
+        },
+      });
+      expect(miss.status).toBe('miss');
+      expect(calls).toBe(1);
+
+      const second = new QueryEmbeddingCache({ indexPath, lruMax: 8 });
+      const hit = await second.getOrCompute({
+        modelId: 'fake__one',
+        query: 'hello world',
+        embed: async () => {
+          calls += 1;
+          return [9, 9, 9];
+        },
+      });
+      expect(hit.status).toBe('hit_disk');
+      expect(hit.embedding).toEqual([1.25, 2.5, 3.75]);
+      expect(calls).toBe(1);
+    } finally {
+      await fsp.rm(path.dirname(indexPath), { recursive: true, force: true });
+    }
+  });
+
+  it('isolates entries by model id', async () => {
+    const indexPath = await tempIndexPath('kb-query-cache-model-');
+    try {
+      const cache = new QueryEmbeddingCache({ indexPath, lruMax: 8 });
+      await cache.getOrCompute({
+        modelId: 'fake__one',
+        query: 'same query',
+        embed: async () => [1, 1],
+      });
+      const second = await cache.getOrCompute({
+        modelId: 'fake__two',
+        query: 'same query',
+        embed: async () => [2, 2],
+      });
+      expect(second.status).toBe('miss');
+      expect(second.embedding).toEqual([2, 2]);
+    } finally {
+      await fsp.rm(path.dirname(indexPath), { recursive: true, force: true });
+    }
+  });
+
+  it('evicts the least-recently-used in-memory entry and falls back to disk', async () => {
+    const indexPath = await tempIndexPath('kb-query-cache-lru-');
+    try {
+      const cache = new QueryEmbeddingCache({ indexPath, lruMax: 1 });
+      await cache.getOrCompute({ modelId: 'fake__one', query: 'a', embed: async () => [1] });
+      await cache.getOrCompute({ modelId: 'fake__one', query: 'b', embed: async () => [2] });
+      const again = await cache.getOrCompute({
+        modelId: 'fake__one',
+        query: 'a',
+        embed: async () => [9],
+      });
+      expect(again.status).toBe('hit_disk');
+      expect(again.embedding).toEqual([1]);
+      const stats = await cache.stats();
+      expect(stats.l1_size).toBe(1);
+      expect(stats.disk_hits).toBe(1);
+    } finally {
+      await fsp.rm(path.dirname(indexPath), { recursive: true, force: true });
+    }
+  });
+
+  it('treats corrupt disk entries as misses and overwrites them', async () => {
+    const indexPath = await tempIndexPath('kb-query-cache-corrupt-');
+    try {
+      const paths = queryCachePaths({ indexPath, modelId: 'fake__one', query: 'broken' });
+      await fsp.mkdir(paths.modelCacheDir, { recursive: true });
+      await fsp.writeFile(paths.vectorPath, Buffer.from([1, 2, 3]));
+      await fsp.writeFile(paths.metaPath, JSON.stringify({
+        schema_version: 'kb-query-cache.v1',
+        model_id: 'fake__one',
+        dim: 1,
+        created_at: new Date().toISOString(),
+      }));
+
+      const cache = new QueryEmbeddingCache({ indexPath, lruMax: 8 });
+      const result = await cache.getOrCompute({
+        modelId: 'fake__one',
+        query: 'broken',
+        embed: async () => [4],
+      });
+
+      expect(result.status).toBe('miss');
+      expect(result.embedding).toEqual([4]);
+      const stats = await cache.stats();
+      expect(stats.corruptions).toBe(1);
+      expect(await fsp.readFile(paths.vectorPath)).toHaveLength(4);
+    } finally {
+      await fsp.rm(path.dirname(indexPath), { recursive: true, force: true });
+    }
+  });
+
+  it('bypasses both tiers when disabled for a lookup', async () => {
+    const indexPath = await tempIndexPath('kb-query-cache-bypass-');
+    try {
+      let calls = 0;
+      const cache = new QueryEmbeddingCache({ indexPath, lruMax: 8 });
+      await cache.getOrCompute({
+        modelId: 'fake__one',
+        query: 'bypass me',
+        embed: async () => [1],
+      });
+      const bypassed = await cache.getOrCompute({
+        modelId: 'fake__one',
+        query: 'bypass me',
+        bypass: true,
+        embed: async () => {
+          calls += 1;
+          return [7];
+        },
+      });
+      expect(bypassed.status).toBe('bypass');
+      expect(bypassed.embedding).toEqual([7]);
+      expect(calls).toBe(1);
+      expect((await cache.stats()).bypasses).toBe(1);
+    } finally {
+      await fsp.rm(path.dirname(indexPath), { recursive: true, force: true });
+    }
+  });
+
+  it('parses KB_QUERY_CACHE=off aliases as disabled', () => {
+    expect(isQueryCacheEnabled('')).toBe(true);
+    expect(isQueryCacheEnabled('off')).toBe(false);
+    expect(isQueryCacheEnabled(' FALSE ')).toBe(false);
+    expect(isQueryCacheEnabled('0')).toBe(false);
+    expect(isQueryCacheEnabled('on')).toBe(true);
+  });
+
+  it('treats a disabled cache instance like KB_QUERY_CACHE=off', async () => {
+    const indexPath = await tempIndexPath('kb-query-cache-env-off-');
+    try {
+      let calls = 0;
+      const cache = new QueryEmbeddingCache({ indexPath, enabled: false, lruMax: 8 });
+      await cache.getOrCompute({
+        modelId: 'fake__one',
+        query: 'env off',
+        embed: async () => {
+          calls += 1;
+          return [1];
+        },
+      });
+      await cache.getOrCompute({
+        modelId: 'fake__one',
+        query: 'env off',
+        embed: async () => {
+          calls += 1;
+          return [2];
+        },
+      });
+      expect(calls).toBe(2);
+      const stats = await cache.stats();
+      expect(stats.bypasses).toBe(2);
+      expect(stats.hits).toBe(0);
+      expect(stats.disk_size_bytes).toBe(0);
+    } finally {
+      await fsp.rm(path.dirname(indexPath), { recursive: true, force: true });
+    }
+  });
+
+  it('normalizes queries with NFKC trim and whitespace collapse but preserves case', () => {
+    expect(normalizeQueryForCache('  A\u00a0B\nC  ')).toBe('A B C');
+    expect(normalizeQueryForCache('Case')).not.toBe(normalizeQueryForCache('case'));
+  });
+});

--- a/src/query-cache.ts
+++ b/src/query-cache.ts
@@ -1,0 +1,355 @@
+import * as crypto from 'crypto';
+import * as fsp from 'fs/promises';
+import * as path from 'path';
+import * as properLockfile from 'proper-lockfile';
+import {
+  FAISS_INDEX_PATH,
+  KB_QUERY_CACHE_DISK_MAX_BYTES,
+  KB_QUERY_CACHE_ENABLED,
+  KB_QUERY_CACHE_LRU_MAX,
+} from './config.js';
+import { pathExists } from './file-utils.js';
+import { logger } from './logger.js';
+import { isValidModelId } from './model-id.js';
+
+export const QUERY_CACHE_SCHEMA_VERSION = 'kb-query-cache.v1';
+
+export type QueryCacheLookupStatus = 'hit_l1' | 'hit_disk' | 'miss' | 'bypass';
+
+export interface QueryCacheStats {
+  hits: number;
+  misses: number;
+  hit_ratio: number;
+  l1_hits: number;
+  disk_hits: number;
+  bypasses: number;
+  writes: number;
+  corruptions: number;
+  l1_size: number;
+  disk_size_bytes: number;
+}
+
+interface QueryCacheRecord {
+  embedding: number[];
+  status: QueryCacheLookupStatus;
+}
+
+export interface QueryCacheOptions {
+  indexPath?: string;
+  enabled?: boolean;
+  lruMax?: number;
+  diskMaxBytes?: number;
+}
+
+interface CacheMeta {
+  schema_version: typeof QUERY_CACHE_SCHEMA_VERSION;
+  model_id: string;
+  dim: number;
+  created_at: string;
+}
+
+class LruVectorCache {
+  private readonly values = new Map<string, number[]>();
+  constructor(private readonly maxEntries: number) {}
+
+  get size(): number {
+    return this.values.size;
+  }
+
+  clear(): void {
+    this.values.clear();
+  }
+
+  get(key: string): number[] | null {
+    const value = this.values.get(key);
+    if (value === undefined) return null;
+    this.values.delete(key);
+    this.values.set(key, value);
+    return value.slice();
+  }
+
+  set(key: string, value: readonly number[]): void {
+    if (this.maxEntries <= 0) return;
+    if (this.values.has(key)) this.values.delete(key);
+    this.values.set(key, Array.from(value));
+    while (this.values.size > this.maxEntries) {
+      const oldest = this.values.keys().next().value as string | undefined;
+      if (oldest === undefined) break;
+      this.values.delete(oldest);
+    }
+  }
+}
+
+export class QueryEmbeddingCache {
+  private readonly indexPath: string;
+  private readonly enabled: boolean;
+  private readonly diskMaxBytes: number;
+  private readonly l1: LruVectorCache;
+  private hitsL1 = 0;
+  private hitsDisk = 0;
+  private misses = 0;
+  private bypasses = 0;
+  private writes = 0;
+  private corruptions = 0;
+
+  constructor(options: QueryCacheOptions = {}) {
+    this.indexPath = options.indexPath ?? FAISS_INDEX_PATH;
+    this.enabled = options.enabled ?? KB_QUERY_CACHE_ENABLED;
+    this.diskMaxBytes = options.diskMaxBytes ?? KB_QUERY_CACHE_DISK_MAX_BYTES;
+    this.l1 = new LruVectorCache(options.lruMax ?? KB_QUERY_CACHE_LRU_MAX);
+  }
+
+  clearMemory(): void {
+    this.l1.clear();
+  }
+
+  async getOrCompute(args: {
+    modelId: string;
+    query: string;
+    bypass?: boolean;
+    embed: () => Promise<number[]>;
+  }): Promise<QueryCacheRecord> {
+    if (args.bypass === true || !this.enabled) {
+      this.bypasses += 1;
+      return { embedding: await args.embed(), status: 'bypass' };
+    }
+
+    const paths = queryCachePaths({
+      indexPath: this.indexPath,
+      modelId: args.modelId,
+      query: args.query,
+    });
+
+    const memoryHit = this.l1.get(paths.cacheKey);
+    if (memoryHit !== null) {
+      this.hitsL1 += 1;
+      return { embedding: memoryHit, status: 'hit_l1' };
+    }
+
+    const diskHit = await this.readDisk(paths);
+    if (diskHit !== null) {
+      this.hitsDisk += 1;
+      this.l1.set(paths.cacheKey, diskHit);
+      return { embedding: diskHit.slice(), status: 'hit_disk' };
+    }
+
+    this.misses += 1;
+    const embedding = await args.embed();
+    const stableEmbedding = toFloat32Numbers(embedding);
+    this.l1.set(paths.cacheKey, stableEmbedding);
+    try {
+      await this.writeDisk(paths, stableEmbedding);
+      this.writes += 1;
+      await this.enforceDiskLimit();
+    } catch (err) {
+      logger.warn(`query embedding cache write skipped for ${args.modelId}: ${(err as Error).message}`);
+    }
+    return { embedding: stableEmbedding, status: 'miss' };
+  }
+
+  async stats(): Promise<QueryCacheStats> {
+    const hits = this.hitsL1 + this.hitsDisk;
+    const misses = this.misses;
+    const total = hits + misses;
+    return {
+      hits,
+      misses,
+      hit_ratio: total === 0 ? 0 : hits / total,
+      l1_hits: this.hitsL1,
+      disk_hits: this.hitsDisk,
+      bypasses: this.bypasses,
+      writes: this.writes,
+      corruptions: this.corruptions,
+      l1_size: this.l1.size,
+      disk_size_bytes: await queryCacheDiskSizeBytes(this.indexPath),
+    };
+  }
+
+  private async readDisk(paths: QueryCachePaths): Promise<number[] | null> {
+    let meta: CacheMeta;
+    try {
+      const raw = await fsp.readFile(paths.metaPath, 'utf-8');
+      meta = JSON.parse(raw) as CacheMeta;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null;
+      await this.recordCorrupt(paths);
+      return null;
+    }
+    if (
+      meta.schema_version !== QUERY_CACHE_SCHEMA_VERSION ||
+      meta.model_id !== paths.modelId ||
+      !Number.isInteger(meta.dim) ||
+      meta.dim <= 0
+    ) {
+      await this.recordCorrupt(paths);
+      return null;
+    }
+
+    let buffer: Buffer;
+    try {
+      buffer = await fsp.readFile(paths.vectorPath);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null;
+      await this.recordCorrupt(paths);
+      return null;
+    }
+    if (buffer.byteLength !== meta.dim * 4) {
+      await this.recordCorrupt(paths);
+      return null;
+    }
+    const out: number[] = [];
+    for (let offset = 0; offset < buffer.byteLength; offset += 4) {
+      out.push(buffer.readFloatLE(offset));
+    }
+    return out;
+  }
+
+  private async writeDisk(paths: QueryCachePaths, embedding: readonly number[]): Promise<void> {
+    await fsp.mkdir(paths.modelCacheDir, { recursive: true });
+    const release = await properLockfile.lock(paths.modelCacheDir, {
+      lockfilePath: path.join(paths.modelCacheDir, '.kb-query-cache.lock'),
+      stale: 30_000,
+      retries: { retries: 5, factor: 1.5, minTimeout: 25, maxTimeout: 250 },
+    });
+    const vectorTmp = `${paths.vectorPath}.${process.pid}.${Date.now()}.tmp`;
+    const metaTmp = `${paths.metaPath}.${process.pid}.${Date.now()}.tmp`;
+    try {
+      const buffer = Buffer.allocUnsafe(embedding.length * 4);
+      embedding.forEach((value, index) => buffer.writeFloatLE(value, index * 4));
+      const meta: CacheMeta = {
+        schema_version: QUERY_CACHE_SCHEMA_VERSION,
+        model_id: paths.modelId,
+        dim: embedding.length,
+        created_at: new Date().toISOString(),
+      };
+      await fsp.writeFile(vectorTmp, buffer);
+      await fsp.rename(vectorTmp, paths.vectorPath);
+      await fsp.writeFile(metaTmp, `${JSON.stringify(meta, null, 2)}\n`, 'utf-8');
+      await fsp.rename(metaTmp, paths.metaPath);
+    } finally {
+      await Promise.all([
+        fsp.unlink(vectorTmp).catch(() => undefined),
+        fsp.unlink(metaTmp).catch(() => undefined),
+      ]);
+      await release().catch((err) => {
+        logger.warn(`query embedding cache lock release failed: ${(err as Error).message}`);
+      });
+    }
+  }
+
+  private async recordCorrupt(paths: QueryCachePaths): Promise<void> {
+    this.corruptions += 1;
+    await Promise.all([
+      fsp.unlink(paths.vectorPath).catch(() => undefined),
+      fsp.unlink(paths.metaPath).catch(() => undefined),
+    ]);
+  }
+
+  private async enforceDiskLimit(): Promise<void> {
+    if (this.diskMaxBytes <= 0) return;
+    const root = queryCacheRoot(this.indexPath);
+    const files = await listCacheVectorFiles(root);
+    let total = files.reduce((sum, file) => sum + file.size, 0);
+    if (total <= this.diskMaxBytes) return;
+    files.sort((a, b) => a.mtimeMs - b.mtimeMs);
+    for (const file of files) {
+      if (total <= this.diskMaxBytes) break;
+      await fsp.unlink(file.path).catch(() => undefined);
+      await fsp.unlink(file.path.replace(/\.f32$/, '.meta.json')).catch(() => undefined);
+      total -= file.size;
+    }
+  }
+}
+
+interface QueryCachePaths {
+  indexPath: string;
+  modelId: string;
+  normalizedQuery: string;
+  cacheKey: string;
+  modelCacheDir: string;
+  vectorPath: string;
+  metaPath: string;
+}
+
+export function normalizeQueryForCache(query: string): string {
+  return query.normalize('NFKC').trim().replace(/\s+/g, ' ');
+}
+
+export function queryCachePaths(args: {
+  indexPath?: string;
+  modelId: string;
+  query: string;
+}): QueryCachePaths {
+  if (!isValidModelId(args.modelId)) {
+    throw new Error(`invalid query-cache model_id: ${args.modelId}`);
+  }
+  const indexPath = args.indexPath ?? FAISS_INDEX_PATH;
+  const normalizedQuery = normalizeQueryForCache(args.query);
+  const cacheKey = crypto
+    .createHash('sha256')
+    .update(QUERY_CACHE_SCHEMA_VERSION)
+    .update('\x1f')
+    .update(args.modelId)
+    .update('\x1f')
+    .update(normalizedQuery)
+    .digest('hex');
+  const modelCacheDir = path.join(queryCacheRoot(indexPath), args.modelId);
+  return {
+    indexPath,
+    modelId: args.modelId,
+    normalizedQuery,
+    cacheKey,
+    modelCacheDir,
+    vectorPath: path.join(modelCacheDir, `${cacheKey}.f32`),
+    metaPath: path.join(modelCacheDir, `${cacheKey}.meta.json`),
+  };
+}
+
+export async function queryCacheDiskSizeBytes(indexPath: string = FAISS_INDEX_PATH): Promise<number> {
+  const files = await listCacheVectorFiles(queryCacheRoot(indexPath));
+  return files.reduce((sum, file) => sum + file.size, 0);
+}
+
+export function __resetQueryEmbeddingCacheForTests(): void {
+  queryEmbeddingCache.clearMemory();
+}
+
+export const queryEmbeddingCache = new QueryEmbeddingCache();
+
+function queryCacheRoot(indexPath: string): string {
+  return path.join(indexPath, 'cache', 'queries');
+}
+
+function toFloat32Numbers(values: readonly number[]): number[] {
+  return Array.from(Float32Array.from(values));
+}
+
+async function listCacheVectorFiles(root: string): Promise<Array<{ path: string; size: number; mtimeMs: number }>> {
+  if (!(await pathExists(root))) return [];
+  const out: Array<{ path: string; size: number; mtimeMs: number }> = [];
+  async function walk(dir: string): Promise<void> {
+    let entries: Array<import('fs').Dirent>;
+    try {
+      entries = await fsp.readdir(dir, { withFileTypes: true });
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return;
+      throw err;
+    }
+    await Promise.all(entries.map(async (entry) => {
+      const child = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        await walk(child);
+        return;
+      }
+      if (!entry.isFile() || !entry.name.endsWith('.f32')) return;
+      try {
+        const st = await fsp.stat(child);
+        out.push({ path: child, size: st.size, mtimeMs: st.mtimeMs });
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+      }
+    }));
+  }
+  await walk(root);
+  return out;
+}


### PR DESCRIPTION
## Summary
- add a two-tier query embedding cache with in-process LRU and disk-backed `.f32` entries keyed by model id and normalized query
- route dense search and compare through the cache-aware vector path, with `--no-cache` and `KB_QUERY_CACHE=off` bypasses
- expose `kb_stats.query_cache` and document the decision in ADR 0009

Closes #214.

## Verification
- `npm test -- src/query-cache.test.ts`
- `npm run build`
- `npm test -- src/query-cache.test.ts src/cli-search.test.ts src/kb-stats.test.ts src/cli-stats.test.ts src/KnowledgeBaseServer.test.ts`
- `npm test`
- `git diff --check`
- manual portability scan of added diff lines; `scripts/check-portability.sh` is not present in this repo
