### PR TITLE
feat(benchmarks): add large corpus compare fixture

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -171,6 +171,12 @@ Real-provider modes (`ollama`, `huggingface`, `openai`) keep the repository logi
 
 The benchmark fixtures are generated at bench start from a seeded `mulberry32` PRNG. This keeps the corpus stable across runs while avoiding checked-in FAISS binaries that can break across platforms. The generator lives in `benchmarks/fixtures/generator.ts`.
 
+The default `small` and `medium` compare fixtures are CI-safe synthetic corpora. They are intentionally compact and do not write persistent corpus caches.
+
+`--fixture=large` is maintainer-local. It builds a realistic arxiv-style technical corpus under `benchmarks/.cache/large-corpus/<cache-key>/` by default, verifies every cached markdown file plus `queries.json` and `golden.json` with SHA-256 hashes from `MANIFEST.json`, then copies that verified corpus into each temporary benchmark workspace. Set `BENCH_LARGE_CORPUS_CACHE_DIR=/path/to/cache` to keep the cache outside the repository checkout. If the cache cannot be created or verified, the runner fails with setup instructions instead of silently falling back to a smaller fixture.
+
+The large fixture includes labelled judgments for single-hop, multi-hop, exact-token, paraphrase, and near-duplicate queries. When `--fixture=large` is used without `--queries` or `--golden`, `bench:compare` automatically uses the fixture's query set and golden labels so the report includes ranked quality metrics in addition to indexing time, storage, warm query latency, and batch throughput.
+
 ## Comparing two embedding models — `bench:compare` (RFC 013 M5)
 
 The `bench:compare` orchestrator drives two back-to-back per-model bench runs against a shared corpus and emits a self-contained HTML comparison report (inline CSS + SVG; no CDN, no JS framework). Use it to pick between two embedding models on **your hardware** without wiring up MTEB.
@@ -192,10 +198,10 @@ Flags (all post `--`):
 | Flag | Default | Meaning |
 |------|---------|---------|
 | `--models=<id_a>,<id_b>` | required | Two `<provider>__<slug>` ids (or `<provider>:<modelName>`). |
-| `--fixture=small\|medium\|external` | `medium` | Synthetic profile; `external` honors `KNOWLEDGE_BASES_ROOT_DIR`. (`large`/arxiv corpus is a follow-up.) |
-| `--queries=<path>` | bundled `queries-default.txt` for prose corpora; fixture-derived for synthetic | One query per line; `#`-comments allowed. |
+| `--fixture=small\|medium\|large\|external` | `medium` | `small`/`medium` use CI-safe synthetic fixtures; `large` uses the cached maintainer-local corpus; `external` honors `KNOWLEDGE_BASES_ROOT_DIR`. |
+| `--queries=<path>` | fixture-derived for small/medium; large-corpus queries for large; bundled `queries-default.txt` for external prose corpora | One query per line; `#`-comments allowed. |
 | `--concurrency=1,4,16` | `1,4,16` | Concurrency sweep for the batch-query phase. |
-| `--golden=<path>` | none | Reserved — JSON `{query: [doc_paths]}` for recall@k. (Not yet wired into the report; follow-up.) |
+| `--golden=<path>` | large fixture labels when `--fixture=large`, otherwise none | JSON `{query: [{source,relevance}]}` for ranked IR metrics. Legacy `{query: [doc_paths]}` arrays are treated as binary labels. |
 | `--output-dir=<path>` | `benchmarks/results` | Where the HTML + JSON pair lands. |
 | `--skip-add` | off | Reuse already-registered models (no re-embed). |
 | `--yes` | off | Non-interactive; skips paid-provider cost prompt. |
@@ -252,6 +258,19 @@ BENCH_FIXTURE_CHUNK_CHARS=1000 npm run bench:compare -- --models=…
 `BENCH_FIXTURE_FILES=N` and `BENCH_FIXTURE_CHUNKS_PER_FILE=N` are also
 honored as scope knobs that override each scenario's hardcoded defaults.
 
+For a maintainer-local large run:
+
+```bash
+BENCH_LARGE_CORPUS_CACHE_DIR=/tmp/kb-bench-large-cache \
+  npm run bench:compare -- \
+  --models=ollama__nomic-embed-text-latest,huggingface__BAAI-bge-small-en-v1.5 \
+  --fixture=large \
+  --concurrency=1,4,16 \
+  --yes
+```
+
+The first run populates the deterministic cache; later runs reuse it after integrity verification. Do not commit generated cache contents or compare results unless you are deliberately updating benchmark artifacts.
+
 Concurrency invariants (RFC 013 §4.13.9):
 
 - Both per-model bench legs run **back-to-back, never in parallel** — avoids CPU/network confounding.
@@ -260,8 +279,6 @@ Concurrency invariants (RFC 013 §4.13.9):
 
 Follow-ups not in M5 v1:
 
-- `--fixture=large` with the ~3000-chunk arxiv (`cs.IR + cs.CL`) corpus and sha256-keyed cache (`benchmarks/.cache/`) — RFC 013 §4.13.4. Today the orchestrator runs against the existing seeded synthetic generator at the bench's hardcoded sizes (~600 chunks for cold-index).
-- `--golden` recall@k integration into the report.
 - `workflow_dispatch` GitHub workflow for maintainer-triggered real-provider runs (RFC 013 §4.13.7).
 
 ## Jest mocking strategy note

--- a/benchmarks/compare/large-fixture.test.ts
+++ b/benchmarks/compare/large-fixture.test.ts
@@ -1,0 +1,118 @@
+import * as fsp from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { generateKnowledgeBaseFixture } from '../fixtures/generator.js';
+import {
+  ensureLargeCorpusCache,
+  getDefaultLargeCorpusSpec,
+  largeCorpusGoldenLabels,
+  largeCorpusQueryLines,
+  materializeLargeCorpusFixture,
+  validateLargeCorpusCache,
+} from '../fixtures/large-corpus.js';
+
+describe('large corpus fixture', () => {
+  let tmpdir: string;
+  let originalProfile: string | undefined;
+  let originalCacheDir: string | undefined;
+
+  beforeEach(async () => {
+    tmpdir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-large-fixture-test-'));
+    originalProfile = process.env.BENCH_FIXTURE_PROFILE;
+    originalCacheDir = process.env.BENCH_LARGE_CORPUS_CACHE_DIR;
+  });
+
+  afterEach(async () => {
+    if (originalProfile === undefined) delete process.env.BENCH_FIXTURE_PROFILE;
+    else process.env.BENCH_FIXTURE_PROFILE = originalProfile;
+    if (originalCacheDir === undefined) delete process.env.BENCH_LARGE_CORPUS_CACHE_DIR;
+    else process.env.BENCH_LARGE_CORPUS_CACHE_DIR = originalCacheDir;
+    await fsp.rm(tmpdir, { recursive: true, force: true });
+  });
+
+  it('creates a deterministic cache with query judgments for every required case', async () => {
+    const cacheRoot = path.join(tmpdir, 'cache');
+    const spec = getDefaultLargeCorpusSpec({ documentCount: 16, targetChunksPerFile: 3 });
+
+    const first = await ensureLargeCorpusCache({ cacheRoot, spec });
+    const second = await ensureLargeCorpusCache({ cacheRoot, spec });
+
+    expect(second.cacheKey).toBe(first.cacheKey);
+    expect(second.manifest.content_sha256).toBe(first.manifest.content_sha256);
+    expect(first.manifest.files).toHaveLength(16);
+
+    const kinds = new Set(first.queries.map((query) => query.kind));
+    expect(kinds).toEqual(new Set([
+      'exact-token',
+      'multi-hop',
+      'near-duplicate',
+      'paraphrase',
+      'single-hop',
+    ]));
+
+    const queryLines = await largeCorpusQueryLines(first);
+    expect(queryLines).toHaveLength(first.queries.length);
+    expect(queryLines.every((line) => line.length > 0)).toBe(true);
+
+    const golden = await largeCorpusGoldenLabels(first);
+    expect(new Set(Object.keys(golden))).toEqual(new Set(queryLines));
+    expect(Object.values(golden).every((labels) => labels.some((label) => label.relevance > 0))).toBe(true);
+  });
+
+  it('rejects a cache when an integrity-checked file is modified', async () => {
+    const cacheRoot = path.join(tmpdir, 'cache');
+    const spec = getDefaultLargeCorpusSpec({ documentCount: 8, targetChunksPerFile: 2 });
+    const cache = await ensureLargeCorpusCache({ cacheRoot, spec });
+    const firstFile = cache.manifest.files[0];
+    expect(firstFile).toBeDefined();
+
+    await fsp.appendFile(path.join(cache.cachePath, firstFile!.path), '\ncorrupting the cache\n', 'utf-8');
+
+    await expect(validateLargeCorpusCache(cache.cachePath, spec))
+      .rejects
+      .toThrow('sha256 mismatch');
+  });
+
+  it('materializes cached documents and labels using KB-relative sources', async () => {
+    const cacheRoot = path.join(tmpdir, 'cache');
+    const rootDir = path.join(tmpdir, 'knowledge-bases');
+    const spec = getDefaultLargeCorpusSpec({ documentCount: 10, targetChunksPerFile: 2 });
+
+    const fixture = await materializeLargeCorpusFixture({
+      cacheRoot,
+      knowledgeBaseName: 'large-kb',
+      rootDir,
+      spec,
+    });
+
+    expect(fixture.files).toBe(10);
+    expect(fixture.chunkCount).toBeGreaterThan(10);
+    expect(fixture.query.toLowerCase()).toContain('retrieval');
+
+    const materialized = await fsp.readdir(path.join(rootDir, 'large-kb'));
+    expect(materialized.filter((name) => name.endsWith('.md'))).toHaveLength(10);
+    expect(fixture.goldenLabels[fixture.query]?.[0]?.source).toMatch(/^large-kb\/paper-/);
+  });
+
+  it('routes generateKnowledgeBaseFixture through the large profile when requested', async () => {
+    const cacheRoot = path.join(tmpdir, 'cache');
+    const rootDir = path.join(tmpdir, 'knowledge-bases');
+    process.env.BENCH_FIXTURE_PROFILE = 'large';
+    process.env.BENCH_LARGE_CORPUS_CACHE_DIR = cacheRoot;
+
+    const fixture = await generateKnowledgeBaseFixture({
+      files: 9,
+      knowledgeBaseName: 'default',
+      rootDir,
+      seed: 7,
+      targetChunksPerFile: 2,
+    });
+
+    expect(fixture.files).toBe(9);
+    expect(fixture.chunkCount).toBeGreaterThan(9);
+    expect(fixture.query.toLowerCase()).toContain('retrieval');
+    await expect(fsp.stat(path.join(rootDir, 'default', 'paper-0001-hybrid-retrieval.md')))
+      .resolves
+      .toBeDefined();
+  });
+});

--- a/benchmarks/compare/run.ts
+++ b/benchmarks/compare/run.ts
@@ -20,6 +20,13 @@ import { installStubProvider } from '../stub.js';
 import { renderReport, type CrossModelAggregate, type CrossModelQueryResult } from './render.js';
 import { resolveModelCtx, safeChunkChars } from './model-ctx.js';
 import { loadGoldenFile, scoreGoldenQuality } from './golden.js';
+import {
+  ensureLargeCorpusCache,
+  getDefaultLargeCorpusSpec,
+  largeCorpusGoldenLabels,
+  largeCorpusQueryLines,
+  type LargeCorpusCache,
+} from '../fixtures/large-corpus.js';
 // Type duplicated locally rather than imported from src/ — tsconfig.bench.json's
 // rootDir scopes types to the benchmarks/ tree (src/ files are out of scope even
 // for type-only imports). All src-side runtime values are loaded via dynamic
@@ -100,8 +107,23 @@ async function main(): Promise<void> {
   if (modelA.id === modelB.id) {
     fatal(`models resolve to the same id "${modelA.id}". Pick two different models.`);
   }
+  const largeCorpusCache = flags.fixture === 'large'
+    ? await ensureLargeCorpusCache({
+        spec: getDefaultLargeCorpusSpec({
+          documentCount: fixtureFileCount(flags.fixture),
+          targetChunksPerFile: fixtureChunksPerFile(flags.fixture),
+        }),
+      })
+    : undefined;
+  if (largeCorpusCache) {
+    process.stderr.write(
+      `[bench:compare] large fixture cache: ${largeCorpusCache.cachePath} (${largeCorpusCache.manifest.files.length} files)\n`,
+    );
+  }
   const goldenLabels = flags.goldenPath
     ? await loadGoldenFile(path.resolve(flags.goldenPath))
+    : largeCorpusCache
+      ? await largeCorpusGoldenLabels(largeCorpusCache, 'default')
     : undefined;
   if (goldenLabels) {
     process.stderr.write(`[bench:compare] golden labels: ${Object.keys(goldenLabels).length} labelled queries\n`);
@@ -140,6 +162,7 @@ async function main(): Promise<void> {
     buildRoot,
     isFirst: true,
     fixtureChunkChars,
+    largeCorpusCache,
   });
 
   process.stderr.write(`[bench:compare] running model B bench…\n`);
@@ -152,6 +175,7 @@ async function main(): Promise<void> {
     buildRoot,
     isFirst: false,
     fixtureChunkChars,
+    largeCorpusCache,
   });
 
   process.stderr.write(`[bench:compare] cross-model agreement…\n`);
@@ -165,7 +189,7 @@ async function main(): Promise<void> {
   if (isStubRun) {
     await installStubProvider();
   }
-  const queries = await resolveQueries(flags, sharedKbRoot);
+  const queries = await resolveQueries(flags, sharedKbRoot, largeCorpusCache);
   const crossModel = await crossModelAgreement({
     workspaceA,
     workspaceB,
@@ -245,6 +269,7 @@ interface RunOnceArgs {
   // to the bench leg via BENCH_FIXTURE_CHUNK_CHARS. undefined = leg uses its
   // default (1000).
   fixtureChunkChars?: number;
+  largeCorpusCache?: LargeCorpusCache;
 }
 
 async function runOnce(args: RunOnceArgs): Promise<BenchmarkReport> {
@@ -264,6 +289,7 @@ async function runOnce(args: RunOnceArgs): Promise<BenchmarkReport> {
     // comparison JSON next to the HTML report is what survives.
     BENCH_RESULTS_DIR: args.workspace,
     BENCH_BATCH_CONCURRENCIES: args.flags.concurrencies.join(','),
+    ...fixtureProfileEnv(args.flags, args.largeCorpusCache),
     ...(args.flags.queriesPath ? { BENCH_QUERIES: path.resolve(args.flags.queriesPath) } : {}),
     ...(args.fixtureChunkChars !== undefined
       ? {
@@ -408,7 +434,7 @@ async function runQueriesAgainstManager(
     try {
       const results = await manager.similaritySearch(q, 20);
       out.push(results.map((r) => ({
-        doc: String(r.metadata.source ?? r.metadata.relativePath ?? r.pageContent.slice(0, 40)),
+        doc: String(r.metadata.relativePath ?? r.metadata.source ?? r.pageContent.slice(0, 40)),
         score: r.score ?? 0,
       })));
     } catch {
@@ -477,10 +503,17 @@ async function computeCost(
   };
 }
 
-async function resolveQueries(flags: CliFlags, kbRoot: string): Promise<string[]> {
+async function resolveQueries(
+  flags: CliFlags,
+  kbRoot: string,
+  largeCorpusCache?: LargeCorpusCache,
+): Promise<string[]> {
   if (flags.queriesPath) {
     const raw = await fsp.readFile(flags.queriesPath, 'utf-8');
     return raw.split('\n').map((l) => l.trim()).filter((l) => l && !l.startsWith('#'));
+  }
+  if (flags.fixture === 'large' && largeCorpusCache) {
+    return largeCorpusQueryLines(largeCorpusCache);
   }
   // Default: pull queries-default.txt OR derive from synthetic fixture.
   // For the synthetic small/medium fixtures, prose queries return nothing
@@ -505,6 +538,43 @@ async function resolveQueries(flags: CliFlags, kbRoot: string): Promise<string[]
     }
   }
   return [];
+}
+
+function fixtureProfileEnv(
+  flags: CliFlags,
+  largeCorpusCache?: LargeCorpusCache,
+): NodeJS.ProcessEnv {
+  if (flags.fixture === 'external') {
+    return {};
+  }
+
+  const env: NodeJS.ProcessEnv = {
+    BENCH_FIXTURE_CHUNKS_PER_FILE: String(fixtureChunksPerFile(flags.fixture)),
+    BENCH_FIXTURE_FILES: String(fixtureFileCount(flags.fixture)),
+    BENCH_FIXTURE_PROFILE: flags.fixture === 'large' ? 'large' : '',
+  };
+
+  if (flags.fixture === 'large' && largeCorpusCache) {
+    env.BENCH_LARGE_CORPUS_CACHE_DIR = path.dirname(largeCorpusCache.cachePath);
+  }
+
+  return env;
+}
+
+function fixtureFileCount(fixture: Exclude<CliFlags['fixture'], 'external'>): number {
+  return positiveIntEnv('BENCH_FIXTURE_FILES') ?? FIXTURE_FILES[fixture];
+}
+
+function fixtureChunksPerFile(fixture: Exclude<CliFlags['fixture'], 'external'>): number {
+  return positiveIntEnv('BENCH_FIXTURE_CHUNKS_PER_FILE') ?? FIXTURE_CHUNKS_PER_FILE[fixture];
+}
+
+function positiveIntEnv(name: string): number | undefined {
+  const value = process.env[name];
+  if (!value) return undefined;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) return undefined;
+  return Math.floor(parsed);
 }
 
 async function deriveQueriesFromFixture(kbRoot: string, max: number): Promise<string[]> {

--- a/benchmarks/fixtures/generator.ts
+++ b/benchmarks/fixtures/generator.ts
@@ -1,6 +1,7 @@
 import * as fsp from 'fs/promises';
 import * as path from 'path';
 import { MarkdownTextSplitter } from 'langchain/text_splitter';
+import { getDefaultLargeCorpusSpec, materializeLargeCorpusFixture } from './large-corpus.js';
 
 interface KnowledgeBaseFixtureOptions {
   // Optional override for MarkdownTextSplitter chunkSize. Default 1000 chars.
@@ -48,6 +49,25 @@ const VOCABULARY = Array.from({ length: 2_000 }, (_, index) => `token-${index.to
 export async function generateKnowledgeBaseFixture(
   options: KnowledgeBaseFixtureOptions,
 ): Promise<KnowledgeBaseFixture> {
+  if (process.env.BENCH_FIXTURE_PROFILE === 'large') {
+    const fixture = await materializeLargeCorpusFixture({
+      chunkSize: options.chunkSize,
+      knowledgeBaseName: options.knowledgeBaseName,
+      rootDir: options.rootDir,
+      spec: getDefaultLargeCorpusSpec({
+        documentCount: options.files,
+        seed: options.seed,
+        targetChunksPerFile: options.targetChunksPerFile,
+      }),
+    });
+    return {
+      chunkCount: fixture.chunkCount,
+      files: fixture.files,
+      knowledgeBaseName: fixture.knowledgeBaseName,
+      query: fixture.query,
+    };
+  }
+
   const knowledgeBasePath = path.join(options.rootDir, options.knowledgeBaseName);
   await fsp.mkdir(knowledgeBasePath, { recursive: true });
 

--- a/benchmarks/fixtures/large-corpus.ts
+++ b/benchmarks/fixtures/large-corpus.ts
@@ -1,0 +1,629 @@
+import * as crypto from 'crypto';
+import * as fsp from 'fs/promises';
+import * as path from 'path';
+import { MarkdownTextSplitter } from 'langchain/text_splitter';
+import type { GoldenLabel, GoldenLabels } from '../compare/golden.js';
+
+export type LargeCorpusQueryKind =
+  | 'single-hop'
+  | 'multi-hop'
+  | 'exact-token'
+  | 'paraphrase'
+  | 'near-duplicate';
+
+export interface LargeCorpusSpec {
+  schema_version: 'large-corpus-spec.v1';
+  document_count: number;
+  seed: number;
+  target_chunks_per_file: number;
+  topic_set: 'retrieval-systems-v1';
+}
+
+export interface LargeCorpusQueryJudgment {
+  id: string;
+  kind: LargeCorpusQueryKind;
+  query: string;
+  labels: GoldenLabel[];
+}
+
+export interface LargeCorpusManifest {
+  schema_version: 'large-corpus-cache.v1';
+  cache_key: string;
+  content_sha256: string;
+  spec: LargeCorpusSpec;
+  files: Array<{
+    path: string;
+    bytes: number;
+    sha256: string;
+  }>;
+  queries_sha256: string;
+  golden_sha256: string;
+}
+
+export interface LargeCorpusCache {
+  cacheKey: string;
+  cachePath: string;
+  documentsPath: string;
+  goldenPath: string;
+  manifest: LargeCorpusManifest;
+  queries: LargeCorpusQueryJudgment[];
+  queriesPath: string;
+}
+
+export interface LargeCorpusFixture {
+  cache: LargeCorpusCache;
+  chunkCount: number;
+  files: number;
+  goldenLabels: GoldenLabels;
+  knowledgeBaseName: string;
+  query: string;
+  queries: LargeCorpusQueryJudgment[];
+  queriesPath: string;
+  goldenPath: string;
+}
+
+interface EnsureLargeCorpusCacheOptions {
+  cacheRoot?: string;
+  spec?: LargeCorpusSpec;
+}
+
+interface MaterializeLargeCorpusFixtureOptions extends EnsureLargeCorpusCacheOptions {
+  chunkSize?: number;
+  knowledgeBaseName: string;
+  rootDir: string;
+}
+
+interface Topic {
+  slug: string;
+  title: string;
+  domain: string;
+  method: string;
+  metric: string;
+  risk: string;
+  artifact: string;
+}
+
+const CACHE_SCHEMA_VERSION = 'large-corpus-cache.v1';
+const SPEC_SCHEMA_VERSION = 'large-corpus-spec.v1';
+const DEFAULT_DOCUMENT_COUNT = 600;
+const DEFAULT_SEED = 304;
+const DEFAULT_TARGET_CHUNKS_PER_FILE = 5;
+const DEFAULT_CHUNK_SIZE = 1000;
+
+const TOPICS: Topic[] = [
+  {
+    slug: 'hybrid-retrieval',
+    title: 'Hybrid Retrieval',
+    domain: 'knowledge base search',
+    method: 'reciprocal rank fusion over dense and lexical candidates',
+    metric: 'nDCG@10',
+    risk: 'lexical drift under paraphrased questions',
+    artifact: 'RRF_ALPHA_42',
+  },
+  {
+    slug: 'chunk-boundaries',
+    title: 'Chunk Boundary Planning',
+    domain: 'markdown ingestion',
+    method: 'heading-aware splitting with overlap budgets',
+    metric: 'answer-bearing chunk recall',
+    risk: 'facts split across adjacent sections',
+    artifact: 'CHUNK_SENTINEL_17',
+  },
+  {
+    slug: 'cache-integrity',
+    title: 'Cache Integrity',
+    domain: 'benchmark reproducibility',
+    method: 'sha256 manifests for corpus files and labels',
+    metric: 'cache hit reuse rate',
+    risk: 'silent fixture drift after local edits',
+    artifact: 'CACHE_PROOF_91',
+  },
+  {
+    slug: 'query-paraphrase',
+    title: 'Paraphrase Query Robustness',
+    domain: 'semantic retrieval evaluation',
+    method: 'paired literal and rewritten information needs',
+    metric: 'MRR@10',
+    risk: 'model-specific synonym gaps',
+    artifact: 'PARA_BRIDGE_23',
+  },
+  {
+    slug: 'duplicate-crowding',
+    title: 'Near Duplicate Crowding',
+    domain: 'ranking diagnostics',
+    method: 'duplicate-aware judgments with graded relevance',
+    metric: 'unique relevant source count',
+    risk: 'one source family crowding the top-k window',
+    artifact: 'DUP_CLUSTER_08',
+  },
+  {
+    slug: 'batch-throughput',
+    title: 'Batch Throughput',
+    domain: 'embedding service operations',
+    method: 'concurrency sweeps with warm indexes',
+    metric: 'queries per second p95',
+    risk: 'tail latency amplification',
+    artifact: 'BATCH_TRACE_64',
+  },
+  {
+    slug: 'index-storage',
+    title: 'Index Storage Footprint',
+    domain: 'FAISS docstore accounting',
+    method: 'vector binary and docstore byte measurement',
+    metric: 'bytes per vector',
+    risk: 'metadata growth masking vector cost',
+    artifact: 'STORE_BYTES_12',
+  },
+  {
+    slug: 'citation-grounding',
+    title: 'Citation Grounding',
+    domain: 'answer synthesis',
+    method: 'source-preserving retrieval diagnostics',
+    metric: 'source precision at five',
+    risk: 'citation paths detached from ranked chunks',
+    artifact: 'CITE_KEY_55',
+  },
+];
+
+export function getDefaultLargeCorpusSpec(
+  overrides: Partial<Pick<LargeCorpusSpec, 'document_count' | 'seed' | 'target_chunks_per_file'>>
+    & { documentCount?: number; targetChunksPerFile?: number } = {},
+): LargeCorpusSpec {
+  return {
+    schema_version: SPEC_SCHEMA_VERSION,
+    document_count: positiveInt(
+      overrides.document_count ?? overrides.documentCount,
+      DEFAULT_DOCUMENT_COUNT,
+    ),
+    seed: positiveInt(overrides.seed, DEFAULT_SEED),
+    target_chunks_per_file: positiveInt(
+      overrides.target_chunks_per_file ?? overrides.targetChunksPerFile,
+      DEFAULT_TARGET_CHUNKS_PER_FILE,
+    ),
+    topic_set: 'retrieval-systems-v1',
+  };
+}
+
+export function defaultLargeCorpusCacheRoot(repoRoot = process.cwd()): string {
+  return process.env.BENCH_LARGE_CORPUS_CACHE_DIR
+    ? path.resolve(process.env.BENCH_LARGE_CORPUS_CACHE_DIR)
+    : path.join(repoRoot, 'benchmarks', '.cache', 'large-corpus');
+}
+
+export function largeCorpusCacheKey(spec: LargeCorpusSpec): string {
+  return `large-corpus-${sha256(canonicalJson(spec)).slice(0, 16)}`;
+}
+
+export async function ensureLargeCorpusCache(
+  options: EnsureLargeCorpusCacheOptions = {},
+): Promise<LargeCorpusCache> {
+  const spec = options.spec ?? getDefaultLargeCorpusSpec();
+  const cacheRoot = path.resolve(options.cacheRoot ?? defaultLargeCorpusCacheRoot());
+  const cacheKey = largeCorpusCacheKey(spec);
+  const cachePath = path.join(cacheRoot, cacheKey);
+
+  try {
+    return await validateLargeCorpusCache(cachePath, spec);
+  } catch (error) {
+    await fsp.rm(cachePath, { recursive: true, force: true });
+    try {
+      return await createLargeCorpusCache(cacheRoot, spec);
+    } catch (createError) {
+      const reason = createError instanceof Error ? createError.message : String(createError);
+      throw new Error([
+        `Large benchmark fixture cache could not be prepared at ${cacheRoot}: ${reason}`,
+        'Setup: create a writable cache directory or set BENCH_LARGE_CORPUS_CACHE_DIR=/path/to/cache, then retry',
+        '`npm run bench:compare -- --fixture=large --models=<a>,<b> --yes`.',
+      ].join('\n'));
+    }
+  }
+}
+
+export async function validateLargeCorpusCache(
+  cachePath: string,
+  expectedSpec?: LargeCorpusSpec,
+): Promise<LargeCorpusCache> {
+  const manifestPath = path.join(cachePath, 'MANIFEST.json');
+  const manifest = JSON.parse(await fsp.readFile(manifestPath, 'utf-8')) as LargeCorpusManifest;
+  if (manifest.schema_version !== CACHE_SCHEMA_VERSION) {
+    throw new Error(`large corpus cache schema mismatch: ${manifest.schema_version}`);
+  }
+  if (expectedSpec && canonicalJson(manifest.spec) !== canonicalJson(expectedSpec)) {
+    throw new Error('large corpus cache spec mismatch');
+  }
+  if (manifest.cache_key !== largeCorpusCacheKey(manifest.spec)) {
+    throw new Error('large corpus cache key mismatch');
+  }
+
+  const queriesPath = path.join(cachePath, 'queries.json');
+  const goldenPath = path.join(cachePath, 'golden.json');
+  await assertFileHash(queriesPath, manifest.queries_sha256);
+  await assertFileHash(goldenPath, manifest.golden_sha256);
+
+  const fileHashes: string[] = [];
+  for (const file of manifest.files) {
+    await assertFileHash(path.join(cachePath, file.path), file.sha256);
+    fileHashes.push(file.sha256);
+  }
+  const contentSha = sha256(fileHashes.join('\n'));
+  if (contentSha !== manifest.content_sha256) {
+    throw new Error(`large corpus cache content sha256 mismatch: expected ${manifest.content_sha256}, got ${contentSha}`);
+  }
+
+  const queries = JSON.parse(await fsp.readFile(queriesPath, 'utf-8')) as LargeCorpusQueryJudgment[];
+  return {
+    cacheKey: manifest.cache_key,
+    cachePath,
+    documentsPath: path.join(cachePath, 'documents'),
+    goldenPath,
+    manifest,
+    queries,
+    queriesPath,
+  };
+}
+
+export async function materializeLargeCorpusFixture(
+  options: MaterializeLargeCorpusFixtureOptions,
+): Promise<LargeCorpusFixture> {
+  const cache = await ensureLargeCorpusCache({
+    cacheRoot: options.cacheRoot,
+    spec: options.spec,
+  });
+  const knowledgeBasePath = path.join(options.rootDir, options.knowledgeBaseName);
+  await fsp.rm(knowledgeBasePath, { recursive: true, force: true });
+  await fsp.mkdir(knowledgeBasePath, { recursive: true });
+
+  for (const file of cache.manifest.files) {
+    const relativeDocumentPath = path.relative('documents', file.path);
+    const target = path.join(knowledgeBasePath, relativeDocumentPath);
+    await fsp.mkdir(path.dirname(target), { recursive: true });
+    await fsp.copyFile(path.join(cache.cachePath, file.path), target);
+  }
+
+  const chunkCount = await countChunks(knowledgeBasePath, options.chunkSize);
+  const queries = rewriteQueriesForKnowledgeBase(cache.queries, options.knowledgeBaseName);
+  const goldenLabels = queriesToGoldenLabels(queries);
+  const firstQuery = queries.find((query) => query.id === 'single-hop-hybrid-retrieval')?.query
+    ?? queries.find((query) => query.kind === 'single-hop')?.query
+    ?? queries[0]?.query
+    ?? 'hybrid retrieval cache integrity benchmark';
+
+  return {
+    cache,
+    chunkCount,
+    files: cache.manifest.files.length,
+    goldenLabels,
+    knowledgeBaseName: options.knowledgeBaseName,
+    query: firstQuery,
+    queries,
+    queriesPath: cache.queriesPath,
+    goldenPath: cache.goldenPath,
+  };
+}
+
+export async function largeCorpusQueryLines(cache: LargeCorpusCache): Promise<string[]> {
+  const queries = JSON.parse(await fsp.readFile(cache.queriesPath, 'utf-8')) as LargeCorpusQueryJudgment[];
+  return queries.map((query) => query.query);
+}
+
+export async function largeCorpusGoldenLabels(
+  cache: LargeCorpusCache,
+  knowledgeBaseName?: string,
+): Promise<GoldenLabels> {
+  const labels = JSON.parse(await fsp.readFile(cache.goldenPath, 'utf-8')) as GoldenLabels;
+  if (!knowledgeBaseName) return labels;
+
+  return Object.fromEntries(
+    Object.entries(labels).map(([query, queryLabels]) => [
+      query,
+      queryLabels.map((label) => ({
+        ...label,
+        source: path.posix.join(knowledgeBaseName, label.source),
+      })),
+    ]),
+  );
+}
+
+async function createLargeCorpusCache(
+  cacheRoot: string,
+  spec: LargeCorpusSpec,
+): Promise<LargeCorpusCache> {
+  const cacheKey = largeCorpusCacheKey(spec);
+  const cachePath = path.join(cacheRoot, cacheKey);
+  const documentsPath = path.join(cachePath, 'documents');
+  await fsp.mkdir(documentsPath, { recursive: true });
+
+  const docs = buildDocuments(spec);
+  const files: LargeCorpusManifest['files'] = [];
+  for (const doc of docs) {
+    const filePath = path.join(documentsPath, doc.fileName);
+    await fsp.writeFile(filePath, doc.content, 'utf-8');
+    const bytes = Buffer.byteLength(doc.content, 'utf-8');
+    files.push({
+      path: path.posix.join('documents', doc.fileName),
+      bytes,
+      sha256: sha256(doc.content),
+    });
+  }
+
+  const queries = buildQueryJudgments(docs);
+  const golden = queriesToGoldenLabels(queries);
+  const queriesJson = stableJson(queries);
+  const goldenJson = stableJson(golden);
+  await fsp.writeFile(path.join(cachePath, 'queries.json'), queriesJson, 'utf-8');
+  await fsp.writeFile(path.join(cachePath, 'golden.json'), goldenJson, 'utf-8');
+
+  const manifest: LargeCorpusManifest = {
+    schema_version: CACHE_SCHEMA_VERSION,
+    cache_key: cacheKey,
+    content_sha256: sha256(files.map((file) => file.sha256).join('\n')),
+    spec,
+    files,
+    queries_sha256: sha256(queriesJson),
+    golden_sha256: sha256(goldenJson),
+  };
+  await fsp.writeFile(path.join(cachePath, 'MANIFEST.json'), stableJson(manifest), 'utf-8');
+  return validateLargeCorpusCache(cachePath, spec);
+}
+
+interface BuiltDocument {
+  content: string;
+  exactToken: string;
+  fileName: string;
+  relativeSource: string;
+  topic: Topic;
+  variant: number;
+}
+
+function buildDocuments(spec: LargeCorpusSpec): BuiltDocument[] {
+  const docs: BuiltDocument[] = [];
+  const duplicateStride = Math.max(6, TOPICS.length);
+  for (let index = 0; index < spec.document_count; index += 1) {
+    const topic = TOPICS[index % TOPICS.length];
+    const variant = Math.floor(index / TOPICS.length) + 1;
+    const nearDuplicateOf = index >= duplicateStride && index % duplicateStride === 1
+      ? docs[index - 1]
+      : undefined;
+    const fileName = `paper-${String(index + 1).padStart(4, '0')}-${topic.slug}.md`;
+    const exactToken = `${topic.artifact}_${String(index + spec.seed).padStart(4, '0')}`;
+    const content = nearDuplicateOf
+      ? buildNearDuplicateDocument(topic, variant, exactToken, nearDuplicateOf)
+      : buildTopicDocument(topic, variant, exactToken, spec.target_chunks_per_file);
+    docs.push({
+      content,
+      exactToken,
+      fileName,
+      relativeSource: fileName,
+      topic,
+      variant,
+    });
+  }
+  return docs;
+}
+
+function buildTopicDocument(
+  topic: Topic,
+  variant: number,
+  exactToken: string,
+  targetChunksPerFile: number,
+): string {
+  const repeatedSections = Array.from({ length: Math.max(1, targetChunksPerFile) }, (_, sectionIndex) => {
+    const sectionNumber = sectionIndex + 1;
+    return [
+      `## Experiment ${sectionNumber}: ${topic.title}`,
+      `${topic.title} study ${variant}.${sectionNumber} evaluates ${topic.method} for ${topic.domain}. The primary measurement is ${topic.metric}, while operators watch ${topic.risk}.`,
+      `The controlled marker ${exactToken} appears in the audit table so exact-token retrieval can distinguish this paper from adjacent papers in the same topic family.`,
+      `Ablation notes compare baseline keyword retrieval, dense embedding retrieval, and hybrid retrieval. The result narrative keeps ${topic.domain}, ${topic.method}, ${topic.metric}, and ${topic.risk} close enough for realistic chunk-level matching.`,
+      `Operational guidance records cache warmup, index storage, warm query latency, batch throughput, and labelled quality checks for maintainers running the benchmark locally.`,
+    ].join('\n\n');
+  });
+
+  return [
+    '---',
+    `title: ${topic.title} Study ${variant}`,
+    `tags: benchmark,large-corpus,${topic.slug}`,
+    '---',
+    '',
+    `# ${topic.title} Study ${variant}`,
+    '',
+    `Abstract: This technical note studies ${topic.domain} with ${topic.method}. It reports ${topic.metric} and documents ${topic.risk}.`,
+    '',
+    ...repeatedSections,
+    '',
+  ].join('\n');
+}
+
+function buildNearDuplicateDocument(
+  topic: Topic,
+  variant: number,
+  exactToken: string,
+  base: BuiltDocument,
+): string {
+  return [
+    '---',
+    `title: ${topic.title} Replication ${variant}`,
+    `tags: benchmark,large-corpus,near-duplicate,${topic.slug}`,
+    '---',
+    '',
+    `# ${topic.title} Replication ${variant}`,
+    '',
+    `Abstract: This replication intentionally mirrors ${base.fileName} with small wording changes. It measures ${topic.metric} for ${topic.domain} and preserves the same retrieval intent.`,
+    '',
+    `## Replication Notes`,
+    `The source family repeats the method ${topic.method}, the risk ${topic.risk}, and the diagnostic marker ${base.exactToken}.`,
+    `This near duplicate adds its own marker ${exactToken} so exact-token queries still have a single best answer while near-duplicate queries have two strong labels.`,
+    `Maintainers use this pair to see whether a model crowds top-k results with copies or keeps diverse relevant sources.`,
+    '',
+    `## Local Benchmark Interpretation`,
+    `Warm query latency, index storage, batch throughput, and nDCG@10 should be inspected together because duplicate-heavy corpora can make one metric look healthy while ranked quality regresses.`,
+    '',
+  ].join('\n');
+}
+
+function buildQueryJudgments(docs: BuiltDocument[]): LargeCorpusQueryJudgment[] {
+  const queries: LargeCorpusQueryJudgment[] = [];
+  const bySlug = new Map<string, BuiltDocument[]>();
+  docs.forEach((doc) => {
+    const current = bySlug.get(doc.topic.slug) ?? [];
+    current.push(doc);
+    bySlug.set(doc.topic.slug, current);
+  });
+
+  TOPICS.slice(0, 5).forEach((topic, offset) => {
+    const family = bySlug.get(topic.slug) ?? [];
+    const primary = family[offset % Math.max(1, family.length)];
+    if (!primary) return;
+    queries.push({
+      id: `single-hop-${topic.slug}`,
+      kind: 'single-hop',
+      query: `${topic.domain} retrieval ${topic.metric} ${topic.method}`,
+      labels: labels([primary]),
+    });
+  });
+
+  for (let i = 0; i < Math.min(5, TOPICS.length - 1); i += 1) {
+    const first = firstDoc(bySlug, TOPICS[i].slug);
+    const second = firstDoc(bySlug, TOPICS[i + 1].slug);
+    if (!first || !second) continue;
+    queries.push({
+      id: `multi-hop-${TOPICS[i].slug}-${TOPICS[i + 1].slug}`,
+      kind: 'multi-hop',
+      query: `${TOPICS[i].risk} together with ${TOPICS[i + 1].metric} benchmark evidence`,
+      labels: labels([first, second], [3, 2]),
+    });
+  }
+
+  docs.slice(0, 5).forEach((doc) => {
+    queries.push({
+      id: `exact-token-${doc.topic.slug}-${doc.variant}`,
+      kind: 'exact-token',
+      query: doc.exactToken,
+      labels: labels([doc]),
+    });
+  });
+
+  TOPICS.slice(0, 5).forEach((topic) => {
+    const primary = firstDoc(bySlug, topic.slug);
+    if (!primary) return;
+    queries.push({
+      id: `paraphrase-${topic.slug}`,
+      kind: 'paraphrase',
+      query: paraphraseFor(topic),
+      labels: labels([primary]),
+    });
+  });
+
+  const duplicatePairs = findDuplicatePairs(docs).slice(0, 5);
+  duplicatePairs.forEach(([base, duplicate]) => {
+    queries.push({
+      id: `near-duplicate-${base.topic.slug}-${base.variant}`,
+      kind: 'near-duplicate',
+      query: `${base.topic.title} replication ${base.topic.method} ${base.topic.risk}`,
+      labels: labels([base, duplicate], [3, 2]),
+    });
+  });
+
+  return queries.sort((left, right) => left.id.localeCompare(right.id));
+}
+
+function firstDoc(bySlug: Map<string, BuiltDocument[]>, slug: string): BuiltDocument | undefined {
+  return bySlug.get(slug)?.[0];
+}
+
+function findDuplicatePairs(docs: BuiltDocument[]): Array<[BuiltDocument, BuiltDocument]> {
+  const pairs: Array<[BuiltDocument, BuiltDocument]> = [];
+  for (const doc of docs) {
+    const base = docs.find((candidate) => candidate !== doc && doc.content.includes(candidate.exactToken));
+    if (base) {
+      pairs.push([base, doc]);
+    }
+  }
+  return pairs;
+}
+
+function labels(docs: BuiltDocument[], relevance = docs.map(() => 3)): GoldenLabel[] {
+  return docs.map((doc, index) => ({
+    source: doc.relativeSource,
+    relevance: relevance[index] === 2 ? 2 : 3,
+  }));
+}
+
+function paraphraseFor(topic: Topic): string {
+  return `Which paper explains how to judge ${topic.domain} when wording changes but the answer should still match ${topic.metric}?`;
+}
+
+function queriesToGoldenLabels(queries: LargeCorpusQueryJudgment[]): GoldenLabels {
+  const golden: GoldenLabels = {};
+  for (const query of queries) {
+    golden[query.query] = query.labels;
+  }
+  return golden;
+}
+
+function rewriteQueriesForKnowledgeBase(
+  queries: LargeCorpusQueryJudgment[],
+  knowledgeBaseName: string,
+): LargeCorpusQueryJudgment[] {
+  return queries.map((query) => ({
+    ...query,
+    labels: query.labels.map((label) => ({
+      ...label,
+      source: path.posix.join(knowledgeBaseName, label.source),
+    })),
+  }));
+}
+
+async function countChunks(knowledgeBasePath: string, chunkSize?: number): Promise<number> {
+  const splitter = new MarkdownTextSplitter({
+    chunkOverlap: Math.floor((chunkSize ?? DEFAULT_CHUNK_SIZE) / 5),
+    chunkSize: chunkSize ?? DEFAULT_CHUNK_SIZE,
+    keepSeparator: false,
+  });
+  const files = await fsp.readdir(knowledgeBasePath);
+  let total = 0;
+  for (const file of files) {
+    if (!file.endsWith('.md')) continue;
+    const filePath = path.join(knowledgeBasePath, file);
+    const content = await fsp.readFile(filePath, 'utf-8');
+    const docs = await splitter.createDocuments([content], [{ source: filePath }]);
+    total += docs.length;
+  }
+  return total;
+}
+
+async function assertFileHash(filePath: string, expected: string): Promise<void> {
+  const raw = await fsp.readFile(filePath);
+  const actual = sha256(raw);
+  if (actual !== expected) {
+    throw new Error(`large corpus cache sha256 mismatch for ${filePath}: expected ${expected}, got ${actual}`);
+  }
+}
+
+function positiveInt(value: number | undefined, fallback: number): number {
+  if (!Number.isFinite(value) || value === undefined || value <= 0) return fallback;
+  return Math.floor(value);
+}
+
+function stableJson(value: unknown): string {
+  return `${canonicalJson(value)}\n`;
+}
+
+function canonicalJson(value: unknown): string {
+  return JSON.stringify(sortForJson(value));
+}
+
+function sortForJson(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortForJson);
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, child]) => [key, sortForJson(child)]),
+    );
+  }
+  return value;
+}
+
+function sha256(input: crypto.BinaryLike): string {
+  return crypto.createHash('sha256').update(input).digest('hex');
+}


### PR DESCRIPTION
## Summary
- add a deterministic cached large corpus fixture with SHA-256 manifest verification
- wire `bench:compare -- --fixture=large` to use generated large queries and golden labels by default
- document CI-safe synthetic fixtures separately from maintainer-local large runs

Closes #304

## Verification
- `npm test -- benchmarks/compare/large-fixture.test.ts`
- `npx tsc -p /home/jean/git/knowledge-base-mcp-server/tsconfig.bench.json`
- `npx tsc -p tsconfig.bench.json`
- `npm run build`
- `npm test`
- `BENCH_PROVIDER=stub BENCH_STUB_EMBED_MS_PER_INPUT=0 BENCH_FIXTURE_FILES=12 BENCH_FIXTURE_CHUNKS_PER_FILE=2 BENCH_LARGE_CORPUS_CACHE_DIR=/tmp/kb-issue304-large-cache npm run bench:compare -- --models=stub:bench-stub-A,stub:bench-stub-B --fixture=large --concurrency=1 --output-dir=/tmp/kb-issue304-large-results --yes`

## Pre-PR review
- detected project type: npm
- type/build checks: passed
- tests: passed
- bug reproduction: skipped (feature PR)
- diff review: done
- portability check: skipped (scripts/check-portability.sh not present)
- reviewer specialists: skipped (session policy permits subagents only when explicitly requested)
- OSS base-branch policy: skipped (same-repo PR)
- gate file: created