### PR TITLE
feat(search): add refresh preflight estimates

### DIFF
--- a/docs/cli-json-contracts.md
+++ b/docs/cli-json-contracts.md
@@ -20,6 +20,7 @@ Invocation:
 
 ```bash
 kb search "<query>" --format=json [--kb=<name>] [--model=<id>] [--k=<int>]
+kb search "<query>" --format=json --refresh [--kb=<name>]
 kb search --stdin --format=json
 kb search "<query>" --format=json --mode=dense|lexical|hybrid|auto
 KB_EDITOR_URI=cursor kb search "<query>" --format=json
@@ -88,6 +89,21 @@ Optional stable fields:
   `{"threshold": number, "knee_index": number|null, "kept": number}`.
 - `timing`: present with `--timing`; keys are elapsed millisecond counters and
   mode labels. Treat the object as diagnostic, not a compatibility contract.
+
+Refresh preflight:
+
+- Dense and hybrid `kb search --refresh` compute a nonblocking stale-delta
+  preflight before embedding starts when the selected scope exceeds either
+  documented threshold: more than 100 changed/new files or more than 100 MiB of
+  cheap-to-stat stale bytes.
+- The preflight is always stderr text. JSON stdout remains the success envelope
+  above, and agents must not expect a JSON field for the preflight.
+- TTY and non-TTY runs continue without prompting by default; there is no
+  confirmation gate or required `--yes` for `kb search --refresh`.
+- The stderr text includes changed/new file counts by KB, estimated stale bytes,
+  top KBs by stale bytes/files, the active provider/model, provider class
+  (`local` or `paid`), `--kb=<name>` scoping suggestions, and PDF exclusion
+  guidance when stale PDFs are present.
 - `mode`, `requested_mode`, `auto_mode`: present when `--mode=auto` is used.
   `mode` is the selected effective mode; `auto_mode` has `mode` and `reason`.
 

--- a/src/cli-search-staleness.test.ts
+++ b/src/cli-search-staleness.test.ts
@@ -2,7 +2,14 @@ import { afterEach, describe, expect, it, jest } from '@jest/globals';
 import * as fsp from 'fs/promises';
 import * as os from 'os';
 import * as path from 'path';
-import { buildAgeBudgetFooter } from './cli-search-staleness.js';
+import {
+  REFRESH_PREFLIGHT_BYTE_THRESHOLD,
+  REFRESH_PREFLIGHT_FILE_THRESHOLD,
+  buildAgeBudgetFooter,
+  buildRefreshPreflightEstimate,
+  formatRefreshPreflightEstimate,
+  maybeWriteRefreshPreflight,
+} from './cli-search-staleness.js';
 import { writeFreshnessManifest } from './freshness-manifest.js';
 
 const ORIGINAL_ENV = {
@@ -134,6 +141,174 @@ describe('computeStaleness', () => {
     } finally {
       await fsp.rm(tempDir, { recursive: true, force: true });
     }
+  });
+});
+
+describe('refresh preflight estimate (issue #318)', () => {
+  it('does not print below the documented stale-delta thresholds', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-refresh-preflight-small-'));
+    try {
+      const kbRoot = path.join(tempDir, 'kbs');
+      const alpha = path.join(kbRoot, 'alpha');
+      await fsp.mkdir(path.join(alpha, '.index'), { recursive: true });
+      const doc = path.join(alpha, 'small.md');
+      await fsp.writeFile(doc, 'small\n', 'utf-8');
+      await fsp.writeFile(path.join(alpha, '.index', 'small.md'), 'old-hash', 'utf-8');
+      const indexMtimeMs = Date.parse('2026-05-12T10:00:00.000Z');
+      await fsp.utimes(doc, new Date(indexMtimeMs + 60_000), new Date(indexMtimeMs + 60_000));
+
+      const estimate = await buildRefreshPreflightEstimate({
+        kbRootDir: kbRoot,
+        indexMtimeMs,
+        scopedKb: undefined,
+        activeModel: {
+          modelId: 'ollama__nomic-embed-text-latest',
+          provider: 'ollama',
+          modelName: 'nomic-embed-text:latest',
+        },
+      });
+      const writes: string[] = [];
+
+      expect(estimate).toMatchObject({
+        totalModifiedFiles: 1,
+        totalNewFiles: 0,
+      });
+      expect(maybeWriteRefreshPreflight(estimate, { write: (text) => writes.push(text) })).toBe(false);
+      expect(writes).toEqual([]);
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('prints a large stale-delta estimate with by-KB counts, bytes, model, provider class, and scoped suggestions', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-refresh-preflight-large-'));
+    try {
+      const kbRoot = path.join(tempDir, 'kbs');
+      const alpha = path.join(kbRoot, 'alpha');
+      const beta = path.join(kbRoot, 'beta');
+      await fsp.mkdir(path.join(alpha, '.index'), { recursive: true });
+      await fsp.mkdir(beta, { recursive: true });
+
+      const alphaModified = path.join(alpha, 'modified.md');
+      const alphaPdf = path.join(alpha, 'new.pdf');
+      const betaNew = path.join(beta, 'new.md');
+      await fsp.writeFile(alphaModified, 'x'.repeat(64), 'utf-8');
+      await fsp.writeFile(alphaPdf, 'p'.repeat(REFRESH_PREFLIGHT_BYTE_THRESHOLD + 1), 'utf-8');
+      await fsp.writeFile(betaNew, 'b'.repeat(32), 'utf-8');
+      await fsp.writeFile(path.join(alpha, '.index', 'modified.md'), 'old-hash', 'utf-8');
+      const indexMtimeMs = Date.parse('2026-05-12T10:00:00.000Z');
+      await fsp.utimes(alphaModified, new Date(indexMtimeMs + 60_000), new Date(indexMtimeMs + 60_000));
+
+      const estimate = await buildRefreshPreflightEstimate({
+        kbRootDir: kbRoot,
+        indexMtimeMs,
+        activeModel: {
+          modelId: 'openai__text-embedding-3-small',
+          provider: 'openai',
+          modelName: 'text-embedding-3-small',
+        },
+      });
+      const text = formatRefreshPreflightEstimate(estimate);
+
+      expect(estimate.exceedsThreshold).toBe(true);
+      expect(text).toContain(`thresholds: ${REFRESH_PREFLIGHT_FILE_THRESHOLD} files or 100 MiB`);
+      expect(text).toContain('Active model: openai__text-embedding-3-small');
+      expect(text).toContain('provider=openai');
+      expect(text).toContain('provider_class=paid');
+      expect(text).toContain('Estimated chunks: unknown until extraction');
+      expect(text).toContain('- alpha: 1 modified, 1 new');
+      expect(text).toContain('- beta: 0 modified, 1 new');
+      expect(text).toContain('Top stale KBs:');
+      expect(text).toContain('kb search "<query>" --refresh --kb=alpha');
+      expect(text).toContain('INGEST_EXCLUDE_PATHS=pdfs/**');
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('scopes estimates to --kb and does not suggest narrowing to another KB', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-refresh-preflight-scoped-'));
+    try {
+      const kbRoot = path.join(tempDir, 'kbs');
+      const alpha = path.join(kbRoot, 'alpha');
+      const beta = path.join(kbRoot, 'beta');
+      await fsp.mkdir(alpha, { recursive: true });
+      await fsp.mkdir(beta, { recursive: true });
+      for (let i = 0; i < REFRESH_PREFLIGHT_FILE_THRESHOLD + 1; i += 1) {
+        await fsp.writeFile(path.join(alpha, `alpha-${i}.md`), 'alpha\n', 'utf-8');
+        await fsp.writeFile(path.join(beta, `beta-${i}.md`), 'beta\n', 'utf-8');
+      }
+
+      const estimate = await buildRefreshPreflightEstimate({
+        kbRootDir: kbRoot,
+        indexMtimeMs: null,
+        scopedKb: 'alpha',
+        activeModel: {
+          modelId: 'ollama__nomic-embed-text-latest',
+          provider: 'ollama',
+          modelName: 'nomic-embed-text:latest',
+        },
+      });
+      const text = formatRefreshPreflightEstimate(estimate);
+
+      expect(estimate.totalNewFiles).toBe(REFRESH_PREFLIGHT_FILE_THRESHOLD + 1);
+      expect(estimate.kbs).toHaveLength(1);
+      expect(estimate.kbs[0].kb).toBe('alpha');
+      expect(text).toContain('Scope: --kb=alpha');
+      expect(text).toContain('provider_class=local');
+      expect(text).toContain('Already scoped to `--kb=alpha`');
+      expect(text).not.toContain('--kb=beta');
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('writes preflight text to stderr even for JSON output mode', async () => {
+    const estimate = {
+      activeModel: {
+        modelId: 'ollama__nomic-embed-text-latest',
+        provider: 'ollama',
+        modelName: 'nomic-embed-text:latest',
+        providerClass: 'local' as const,
+      },
+      scopedKb: undefined,
+      thresholdFiles: REFRESH_PREFLIGHT_FILE_THRESHOLD,
+      thresholdBytes: REFRESH_PREFLIGHT_BYTE_THRESHOLD,
+      exceedsThreshold: true,
+      totalModifiedFiles: 0,
+      totalNewFiles: REFRESH_PREFLIGHT_FILE_THRESHOLD + 1,
+      totalStaleFiles: REFRESH_PREFLIGHT_FILE_THRESHOLD + 1,
+      estimatedBytes: 1,
+      estimatedChunks: null,
+      stalePdfFiles: 0,
+      kbs: [{
+        kb: 'alpha',
+        modifiedFiles: 0,
+        newFiles: REFRESH_PREFLIGHT_FILE_THRESHOLD + 1,
+        staleFiles: REFRESH_PREFLIGHT_FILE_THRESHOLD + 1,
+        estimatedBytes: 1,
+        stalePdfFiles: 0,
+      }],
+      topKbs: [{
+        kb: 'alpha',
+        modifiedFiles: 0,
+        newFiles: REFRESH_PREFLIGHT_FILE_THRESHOLD + 1,
+        staleFiles: REFRESH_PREFLIGHT_FILE_THRESHOLD + 1,
+        estimatedBytes: 1,
+        stalePdfFiles: 0,
+      }],
+    };
+    const stderr: string[] = [];
+    const stdout: string[] = [];
+
+    expect(maybeWriteRefreshPreflight(estimate, {
+      format: 'json',
+      write: (text) => stderr.push(text),
+    })).toBe(true);
+    stdout.push(JSON.stringify({ results: [] }));
+
+    expect(stderr.join('')).toContain('kb search refresh preflight');
+    expect(JSON.parse(stdout.join(''))).toEqual({ results: [] });
   });
 });
 

--- a/src/cli-search-staleness.ts
+++ b/src/cli-search-staleness.ts
@@ -8,12 +8,25 @@
 // is configured. The two layers compose: a KB can be content-fresh
 // but age-budget-stale, or vice versa.
 
+import * as fsp from 'fs/promises';
+import * as path from 'path';
 import {
   AgeBudgetConfigError,
   computeAgeBudgetStatus,
   formatAgeHours,
   type AgeBudgetStatus,
 } from './age-budget.js';
+import {
+  INGEST_EXCLUDE_PATHS,
+  INGEST_EXTRA_EXTENSIONS,
+  KNOWLEDGE_BASES_ROOT_DIR,
+} from './config.js';
+import { mapBounded, resolveFsConcurrency } from './bounded-concurrency.js';
+import { enumerateIngestableKbFiles, listKnowledgeBases } from './kb-fs.js';
+
+export const REFRESH_PREFLIGHT_FILE_THRESHOLD = 100;
+export const REFRESH_PREFLIGHT_BYTE_THRESHOLD = 100 * 1024 * 1024;
+export const REFRESH_PREFLIGHT_TOP_K = 5;
 
 export interface AgeBudgetFooterInput {
   /** KB name scoped by the search. The footer is per-KB, so callers
@@ -40,6 +53,240 @@ export interface AgeBudgetFooterResult {
    *  Callers can surface this as a warning footer line. The
    *  underlying `status` falls back to "no budget configured". */
   configError: AgeBudgetConfigError | null;
+}
+
+export type RefreshPreflightProviderClass = 'local' | 'paid';
+
+export interface RefreshPreflightActiveModel {
+  modelId: string;
+  provider: string;
+  modelName: string;
+}
+
+export interface RefreshPreflightKbEstimate {
+  kb: string;
+  modifiedFiles: number;
+  newFiles: number;
+  staleFiles: number;
+  estimatedBytes: number;
+  stalePdfFiles: number;
+}
+
+export interface RefreshPreflightEstimate {
+  activeModel: RefreshPreflightActiveModel & {
+    providerClass: RefreshPreflightProviderClass;
+  };
+  scopedKb?: string;
+  thresholdFiles: number;
+  thresholdBytes: number;
+  exceedsThreshold: boolean;
+  totalModifiedFiles: number;
+  totalNewFiles: number;
+  totalStaleFiles: number;
+  estimatedBytes: number;
+  estimatedChunks: null;
+  stalePdfFiles: number;
+  kbs: RefreshPreflightKbEstimate[];
+  topKbs: RefreshPreflightKbEstimate[];
+}
+
+export interface BuildRefreshPreflightEstimateInput {
+  activeModel: RefreshPreflightActiveModel;
+  indexMtimeMs: number | null;
+  scopedKb?: string;
+  kbRootDir?: string;
+  thresholdFiles?: number;
+  thresholdBytes?: number;
+  topK?: number;
+}
+
+export async function buildRefreshPreflightEstimate(
+  input: BuildRefreshPreflightEstimateInput,
+): Promise<RefreshPreflightEstimate> {
+  const kbRootDir = input.kbRootDir ?? KNOWLEDGE_BASES_ROOT_DIR;
+  const thresholdFiles = input.thresholdFiles ?? REFRESH_PREFLIGHT_FILE_THRESHOLD;
+  const thresholdBytes = input.thresholdBytes ?? REFRESH_PREFLIGHT_BYTE_THRESHOLD;
+  const topK = input.topK ?? REFRESH_PREFLIGHT_TOP_K;
+  const kbNames = input.scopedKb
+    ? [input.scopedKb]
+    : await listKnowledgeBases(kbRootDir);
+  const enumerations = await enumerateIngestableKbFiles(kbRootDir, kbNames, {
+    extraExtensions: INGEST_EXTRA_EXTENSIONS,
+    excludePaths: INGEST_EXCLUDE_PATHS,
+  });
+
+  const kbs: RefreshPreflightKbEstimate[] = [];
+  for (const { kbName, kbPath, filePaths } of enumerations) {
+    const fileEstimates = await mapBounded(
+      filePaths,
+      resolveFsConcurrency(),
+      async (filePath) => classifyRefreshPreflightFile(kbPath, filePath, input.indexMtimeMs),
+    );
+    const row = fileEstimates.reduce<RefreshPreflightKbEstimate>(
+      (acc, file) => ({
+        kb: acc.kb,
+        modifiedFiles: acc.modifiedFiles + (file.kind === 'modified' ? 1 : 0),
+        newFiles: acc.newFiles + (file.kind === 'new' ? 1 : 0),
+        staleFiles: acc.staleFiles + (file.kind === 'fresh' ? 0 : 1),
+        estimatedBytes: acc.estimatedBytes + file.estimatedBytes,
+        stalePdfFiles: acc.stalePdfFiles + (file.isPdf && file.kind !== 'fresh' ? 1 : 0),
+      }),
+      {
+        kb: kbName,
+        modifiedFiles: 0,
+        newFiles: 0,
+        staleFiles: 0,
+        estimatedBytes: 0,
+        stalePdfFiles: 0,
+      },
+    );
+    if (row.staleFiles > 0) kbs.push(row);
+  }
+
+  kbs.sort((a, b) => a.kb.localeCompare(b.kb));
+  const topKbs = [...kbs]
+    .sort((a, b) =>
+      (b.estimatedBytes - a.estimatedBytes) ||
+      (b.staleFiles - a.staleFiles) ||
+      a.kb.localeCompare(b.kb))
+    .slice(0, topK);
+  const totals = kbs.reduce(
+    (acc, row) => ({
+      modifiedFiles: acc.modifiedFiles + row.modifiedFiles,
+      newFiles: acc.newFiles + row.newFiles,
+      staleFiles: acc.staleFiles + row.staleFiles,
+      estimatedBytes: acc.estimatedBytes + row.estimatedBytes,
+      stalePdfFiles: acc.stalePdfFiles + row.stalePdfFiles,
+    }),
+    { modifiedFiles: 0, newFiles: 0, staleFiles: 0, estimatedBytes: 0, stalePdfFiles: 0 },
+  );
+
+  return {
+    activeModel: {
+      ...input.activeModel,
+      providerClass: classifyRefreshProvider(input.activeModel.provider),
+    },
+    ...(input.scopedKb ? { scopedKb: input.scopedKb } : {}),
+    thresholdFiles,
+    thresholdBytes,
+    exceedsThreshold:
+      totals.staleFiles > thresholdFiles ||
+      totals.estimatedBytes > thresholdBytes,
+    totalModifiedFiles: totals.modifiedFiles,
+    totalNewFiles: totals.newFiles,
+    totalStaleFiles: totals.staleFiles,
+    estimatedBytes: totals.estimatedBytes,
+    estimatedChunks: null,
+    stalePdfFiles: totals.stalePdfFiles,
+    kbs,
+    topKbs,
+  };
+}
+
+export function maybeWriteRefreshPreflight(
+  estimate: RefreshPreflightEstimate,
+  options: {
+    format?: 'md' | 'json' | 'vimgrep';
+    write?: (text: string) => void;
+  } = {},
+): boolean {
+  if (!estimate.exceedsThreshold) return false;
+  const write = options.write ?? ((text: string) => process.stderr.write(text));
+  write(formatRefreshPreflightEstimate(estimate));
+  return true;
+}
+
+export function formatRefreshPreflightEstimate(
+  estimate: RefreshPreflightEstimate,
+): string {
+  const lines = [
+    `kb search refresh preflight: ${estimate.totalModifiedFiles} modified, ` +
+      `${estimate.totalNewFiles} new file(s), ${formatBytes(estimate.estimatedBytes)} ` +
+      `estimated stale bytes; thresholds: ${estimate.thresholdFiles} files or ` +
+      `${formatBytes(estimate.thresholdBytes)}.`,
+    `Active model: ${estimate.activeModel.modelId} ` +
+      `(provider=${estimate.activeModel.provider}, model=${estimate.activeModel.modelName}, ` +
+      `provider_class=${estimate.activeModel.providerClass})`,
+    `Scope: ${estimate.scopedKb ? `--kb=${estimate.scopedKb}` : 'all KBs'}`,
+    'Estimated chunks: unknown until extraction',
+    'Changed/new files by KB:',
+  ];
+
+  for (const row of estimate.kbs) {
+    lines.push(
+      `- ${row.kb}: ${row.modifiedFiles} modified, ${row.newFiles} new, ` +
+        `${formatBytes(row.estimatedBytes)} estimated stale bytes`,
+    );
+  }
+
+  lines.push('Top stale KBs:');
+  for (const row of estimate.topKbs) {
+    lines.push(`- ${row.kb}: ${formatBytes(row.estimatedBytes)} across ${row.staleFiles} file(s)`);
+  }
+
+  lines.push('Suggestions:');
+  if (estimate.scopedKb) {
+    lines.push(`- Already scoped to \`--kb=${estimate.scopedKb}\`; omit --kb only when a full refresh is intentional.`);
+  } else if (estimate.topKbs.length > 0) {
+    lines.push(`- Start with \`kb search "<query>" --refresh --kb=${estimate.topKbs[0].kb}\` to refresh the largest stale KB first.`);
+  }
+  if (estimate.stalePdfFiles > 0) {
+    lines.push('- Exclude bulky PDFs with `INGEST_EXCLUDE_PATHS=pdfs/**` when they are not needed for this run.');
+  }
+  lines.push('- This preflight is informational: TTY and non-TTY runs continue without prompting.');
+  return `${lines.join('\n')}\n`;
+}
+
+function classifyRefreshProvider(provider: string): RefreshPreflightProviderClass {
+  return provider === 'ollama' || provider === 'fake' ? 'local' : 'paid';
+}
+
+async function classifyRefreshPreflightFile(
+  kbPath: string,
+  filePath: string,
+  indexMtimeMs: number | null,
+): Promise<{ kind: 'fresh' | 'modified' | 'new'; estimatedBytes: number; isPdf: boolean }> {
+  let stat;
+  try {
+    stat = await fsp.stat(filePath);
+  } catch {
+    return { kind: 'fresh', estimatedBytes: 0, isPdf: false };
+  }
+  const relativePath = path.relative(kbPath, filePath);
+  const sidecarPath = path.join(kbPath, '.index', path.dirname(relativePath), path.basename(filePath));
+  const hasSidecar = indexMtimeMs !== null && await sidecarExists(sidecarPath);
+  const kind = !hasSidecar
+    ? 'new'
+    : stat.mtimeMs > indexMtimeMs
+      ? 'modified'
+      : 'fresh';
+  return {
+    kind,
+    estimatedBytes: kind === 'fresh' ? 0 : stat.size,
+    isPdf: path.extname(filePath).toLowerCase() === '.pdf',
+  };
+}
+
+async function sidecarExists(sidecarPath: string): Promise<boolean> {
+  try {
+    const stat = await fsp.stat(sidecarPath);
+    return stat.isFile();
+  } catch {
+    return false;
+  }
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  const units = ['KiB', 'MiB', 'GiB', 'TiB'];
+  let value = bytes / 1024;
+  let unit = units[0];
+  for (let i = 1; i < units.length && value >= 1024; i += 1) {
+    value /= 1024;
+    unit = units[i];
+  }
+  const rounded = value >= 10 ? value.toFixed(0) : value.toFixed(1);
+  return `${rounded.replace(/\.0$/, '')} ${unit}`;
 }
 
 /**

--- a/src/cli-search.ts
+++ b/src/cli-search.ts
@@ -45,6 +45,10 @@ import {
 } from './cli-timing.js';
 import { LexicalIndex, type LexicalSearchResult } from './lexical-index.js';
 import { chunkIdFromMetadata, reciprocalRankFusion, type RankedList } from './rrf.js';
+import {
+  buildRefreshPreflightEstimate,
+  maybeWriteRefreshPreflight,
+} from './cli-search-staleness.js';
 
 export const SEARCH_HELP = `kb search — semantic search across knowledge bases
 
@@ -91,6 +95,9 @@ Output:
 
 Indexing:
   --refresh             Re-scan KB files; acquires the per-model write lock.
+                        If the stale delta is larger than 100 files or
+                        100 MiB, prints a nonblocking refresh preflight to
+                        stderr before embedding starts.
 
 Input:
   --stdin               Read query from stdin (multi-line safe).
@@ -238,6 +245,7 @@ export async function runSearch(rest: string[]): Promise<number> {
     const startedAt = nowMs();
     if (parsed.refresh) {
       await withWriteLock(manager.modelDir, async () => {
+        await printRefreshPreflightIfLarge(activeModelId, manager, parsed.kb, parsed.format);
         await manager.initialize();
         await manager.updateIndex(parsed.kb);
       });
@@ -713,6 +721,33 @@ function reportFailure(failure: SearchFailure, format: SearchFormat): number {
   return exitCodeForFailure(failure);
 }
 
+async function printRefreshPreflightIfLarge(
+  activeModelId: string,
+  manager: FaissIndexManager,
+  scopedKb: string | undefined,
+  format: SearchFormat,
+): Promise<void> {
+  const binaryPath = await resolveFaissIndexBinaryPath(activeModelId);
+  let indexMtimeMs: number | null = null;
+  if (binaryPath !== null) {
+    try {
+      indexMtimeMs = (await fsp.stat(binaryPath)).mtimeMs;
+    } catch {
+      indexMtimeMs = null;
+    }
+  }
+  const estimate = await buildRefreshPreflightEstimate({
+    activeModel: {
+      modelId: activeModelId,
+      provider: manager.embeddingProvider,
+      modelName: manager.modelName,
+    },
+    indexMtimeMs,
+    scopedKb,
+  });
+  maybeWriteRefreshPreflight(estimate, { format });
+}
+
 async function readAllStdin(): Promise<string> {
   const chunks: Buffer[] = [];
   return new Promise((resolve, reject) => {
@@ -1009,6 +1044,7 @@ async function runHybridSearch(
     const startedAt = nowMs();
     if (parsed.refresh) {
       await withWriteLock(manager.modelDir, async () => {
+        await printRefreshPreflightIfLarge(activeModelId, manager, parsed.kb, parsed.format);
         await manager.initialize();
         await manager.updateIndex(parsed.kb);
       });


### PR DESCRIPTION
## Summary
- add a nonblocking stderr refresh preflight for large dense/hybrid `kb search --refresh` stale deltas
- report changed/new counts by KB, cheap stale byte estimates, top stale KBs, active model/provider class, and scoped/PDF suggestions
- document the 100 file / 100 MiB thresholds and JSON stdout behavior

Closes #318

## Verification
- `npm test -- --runTestsByPath src/cli-search-staleness.test.ts`
- `npm test -- --runTestsByPath src/cli-search.test.ts`
- `npm run build`
- `npm test`
- `npm run docs:check-anchors` (exits 0; reports pre-existing stale anchors outside `docs/cli-json-contracts.md`)

## Pre-PR checklist
- project type: npm
- build: passed
- tests: passed
- diff review: done
- portability: manual changed-line scan clean; repo has no `scripts/check-portability.sh`
- reviewer specialists: skipped due session tool policy requiring explicit user authorization for subagents
