### PR TITLE
Prune old atomic FAISS index versions

### DIFF
--- a/docs/architecture/data-model.md
+++ b/docs/architecture/data-model.md
@@ -78,7 +78,9 @@ models/<model_id>/
     docstore.json
 ```
 
-`saveFaissStoreAtomic` writes the next `index.vN/`, creates a temporary symlink, atomically renames it to `index`, and keeps the newest three version directories (`src/faiss-store-layout.ts:150-179`). `loadFaissStoreAtomic` pins reads by resolving the `index` symlink once before calling `FaissStore.load`, so `faiss.index` and `docstore.json` come from the same version directory even if another writer swaps the symlink later (`src/faiss-store-layout.ts:58-120`).
+`saveFaissStoreAtomic` writes the next `index.vN/`, creates a temporary symlink, atomically renames it to `index`, and then prunes inactive version directories (`src/faiss-store-layout.ts`). The default retention policy keeps the active version plus two inactive retained versions. Operators can set `KB_INDEX_VERSION_RETENTION=<non-negative integer>` to change the inactive-version count; `0` keeps only the active version after a successful save. Pruning reads the active `index` symlink before deleting anything and never removes that target, even if it is outside the newest retained versions. `kb doctor` reports active, inactive, and total version-directory storage so retained-version cost is visible during health checks.
+
+`loadFaissStoreAtomic` pins reads by resolving the `index` symlink once before calling `FaissStore.load`, so `faiss.index` and `docstore.json` come from the same version directory even if another writer swaps the symlink later (`src/faiss-store-layout.ts:58-120`).
 
 `faiss.index` is the binary vector index in `faiss-node`'s native format. `docstore.json` is the LangChain docstore sibling emitted by `FaissStore.save`; it is part of the `$FAISS_INDEX_PATH` code-exec trust boundary because loading attacker-controlled serialized data is unsafe. See [`threat-model.md`](./threat-model.md).
 
@@ -138,7 +140,7 @@ This page is verified against the following source files. If one of these files 
 
 - Chunk metadata wire shape: `src/file-ingest.ts:37-104`.
 - Frontmatter whitelist + sanitisation: `src/frontmatter-lift.ts:19-218`, `src/formatter.ts:34-90`.
-- Atomic FAISS save / pinned load: `src/faiss-store-layout.ts:58-179`.
+- Atomic FAISS save / pinned load / version retention: `src/faiss-store-layout.ts`.
 - Sidecar write path: `src/file-ingest.ts:118-144`, `src/FaissIndexManager.ts:782-793`.
 - Active-model resolution: `src/active-model.ts:5-26`, `:259-330`.
 - Per-model directory and `model_name.txt`: `src/active-model.ts:107-127`, `src/FaissIndexManager.ts:327-334`.

--- a/src/active-model.ts
+++ b/src/active-model.ts
@@ -22,6 +22,10 @@ import {
 import { pathExists } from './file-utils.js';
 import { deriveModelId, EmbeddingProvider, isValidModelId, parseModelId } from './model-id.js';
 import { logger } from './logger.js';
+import {
+  parseIndexVersionDirName,
+  resolveIndexVersionRetention,
+} from './faiss-store-layout.js';
 
 const ACTIVE_FILE = path.join(FAISS_INDEX_PATH, 'active.txt');
 const MODELS_DIR = path.join(FAISS_INDEX_PATH, 'models');
@@ -80,6 +84,96 @@ export async function resolveFaissIndexBinaryPath(modelId: string): Promise<stri
   }
   const legacy = path.join(dir, 'faiss.index', 'faiss.index');
   return (await pathExists(legacy)) ? legacy : null;
+}
+
+export interface ModelIndexVersionStorage {
+  version: string;
+  bytes: number;
+  active: boolean;
+}
+
+export interface ModelIndexStorageSummary {
+  active_version: string | null;
+  retention_previous_versions: number;
+  version_count: number;
+  total_version_bytes: number;
+  active_version_bytes: number | null;
+  inactive_version_count: number;
+  inactive_version_bytes: number;
+  versions: ModelIndexVersionStorage[];
+}
+
+export async function readModelIndexStorage(
+  modelId: string,
+): Promise<ModelIndexStorageSummary> {
+  const dir = modelDir(modelId);
+  let activeVersion: string | null = null;
+  try {
+    const st = await fsp.lstat(path.join(dir, 'index'));
+    if (st.isSymbolicLink()) {
+      activeVersion = await fsp.readlink(path.join(dir, 'index'));
+      if (parseIndexVersionDirName(activeVersion) === null) activeVersion = null;
+    }
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+  }
+
+  let entries: string[];
+  try {
+    entries = await fsp.readdir(dir);
+  } catch {
+    entries = [];
+  }
+  const versions: ModelIndexVersionStorage[] = [];
+  for (const entry of entries) {
+    if (parseIndexVersionDirName(entry) === null) continue;
+    versions.push({
+      version: entry,
+      bytes: await directorySizeBytes(path.join(dir, entry)),
+      active: entry === activeVersion,
+    });
+  }
+  versions.sort((a, b) => a.version.localeCompare(b.version, undefined, { numeric: true }));
+  const totalVersionBytes = versions.reduce((sum, v) => sum + v.bytes, 0);
+  const activeVersionBytes = versions.find((v) => v.active)?.bytes ?? null;
+  const inactiveVersionBytes = versions
+    .filter((v) => !v.active)
+    .reduce((sum, v) => sum + v.bytes, 0);
+  return {
+    active_version: activeVersion,
+    retention_previous_versions: resolveIndexVersionRetention(),
+    version_count: versions.length,
+    total_version_bytes: totalVersionBytes,
+    active_version_bytes: activeVersionBytes,
+    inactive_version_count: versions.filter((v) => !v.active).length,
+    inactive_version_bytes: inactiveVersionBytes,
+    versions,
+  };
+}
+
+async function directorySizeBytes(dir: string): Promise<number> {
+  let total = 0;
+  let entries: Array<import('fs').Dirent>;
+  try {
+    entries = await fsp.readdir(dir, { withFileTypes: true });
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT' || code === 'ENOTDIR') return 0;
+    throw err;
+  }
+  for (const entry of entries) {
+    const child = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      total += await directorySizeBytes(child);
+    } else if (entry.isFile()) {
+      try {
+        total += (await fsp.stat(child)).size;
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+      }
+    }
+  }
+  return total;
 }
 
 export function modelNameFilePath(modelId: string): string {

--- a/src/atomic-save.test.ts
+++ b/src/atomic-save.test.ts
@@ -152,10 +152,12 @@ async function holdWriteLock<T>(modelDir: string, fn: () => Promise<T>): Promise
 
 describe('RFC 014 atomic save — layout helpers', () => {
   let nextVersionAfter: (s: string | null) => string;
+  let resolveIndexVersionRetention: (raw?: string) => number;
 
   beforeAll(async () => {
     const mod = await import('./faiss-store-layout.js');
     nextVersionAfter = mod.nextVersionAfter;
+    resolveIndexVersionRetention = mod.resolveIndexVersionRetention;
   });
 
   test('nextVersionAfter(null) returns index.v0', () => {
@@ -177,6 +179,15 @@ describe('RFC 014 atomic save — layout helpers', () => {
     // Empty string is falsy and equivalent to null — both indicate no
     // current versioned layout exists yet (fresh install).
     expect(nextVersionAfter('')).toBe('index.v0');
+  });
+
+  test('retention config defaults to two inactive versions and accepts zero', () => {
+    expect(resolveIndexVersionRetention(undefined)).toBe(2);
+    expect(resolveIndexVersionRetention('')).toBe(2);
+    expect(resolveIndexVersionRetention('0')).toBe(0);
+    expect(resolveIndexVersionRetention(' 4 ')).toBe(4);
+    expect(resolveIndexVersionRetention('-1')).toBe(2);
+    expect(resolveIndexVersionRetention('abc')).toBe(2);
   });
 });
 
@@ -294,11 +305,12 @@ describe('RFC 014 atomic save — F1 invariant (reader-during-writer)', () => {
   }, 30_000);
 });
 
-describe('RFC 014 atomic save — GC retention (N=3)', () => {
+describe('RFC 014 atomic save — index version pruning', () => {
   let tmpDir: string;
 
   beforeEach(async () => {
     resetMockState();
+    delete process.env.KB_INDEX_VERSION_RETENTION;
     tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'rfc014-gc-'));
   });
 
@@ -306,7 +318,7 @@ describe('RFC 014 atomic save — GC retention (N=3)', () => {
     await fsp.rm(tmpDir, { recursive: true, force: true });
   });
 
-  test('after 6 saves, only index.v3, v4, v5 remain', async () => {
+  test('default retention keeps active version plus two inactive versions', async () => {
     const mgr = await makeManager(tmpDir);
     const modelDir = modelDirIn(tmpDir);
     await fsp.mkdir(modelDir, { recursive: true });
@@ -321,6 +333,47 @@ describe('RFC 014 atomic save — GC retention (N=3)', () => {
     const versions = entries.filter((e) => /^index\.v\d+$/.test(e)).sort();
     expect(versions).toEqual(['index.v3', 'index.v4', 'index.v5']);
     expect(await fsp.readlink(path.join(modelDir, 'index'))).toBe('index.v5');
+  });
+
+  test('KB_INDEX_VERSION_RETENTION=0 keeps only the active version after save', async () => {
+    process.env.KB_INDEX_VERSION_RETENTION = '0';
+    const mgr = await makeManager(tmpDir);
+    const modelDir = modelDirIn(tmpDir);
+    await fsp.mkdir(modelDir, { recursive: true });
+    await mgr.initialize({ readOnly: true });
+    (mgr as any).faissIndex = new MockFaissStore();
+
+    for (let i = 0; i < 4; i += 1) {
+      await holdWriteLock(modelDir, () => (mgr as any).atomicSave());
+    }
+
+    const entries = await fsp.readdir(modelDir);
+    const versions = entries.filter((e) => /^index\.v\d+$/.test(e)).sort();
+    expect(versions).toEqual(['index.v3']);
+    expect(await fsp.readlink(path.join(modelDir, 'index'))).toBe('index.v3');
+  });
+
+  test('pruning never removes the active symlink target', async () => {
+    const modelDir = modelDirIn(tmpDir);
+    await fsp.mkdir(modelDir, { recursive: true });
+    for (let i = 0; i < 6; i += 1) {
+      const dir = path.join(modelDir, `index.v${i}`);
+      await fsp.mkdir(dir);
+      await fsp.writeFile(path.join(dir, 'faiss.index'), `v${i}`);
+    }
+    await fsp.symlink('index.v1', path.join(modelDir, 'index'));
+
+    const { pruneInactiveIndexVersions } = await import('./faiss-store-layout.js');
+    const result = await pruneInactiveIndexVersions(modelDir, { retention: 1 });
+
+    expect(result.active).toBe('index.v1');
+    expect(result.removed).not.toContain('index.v1');
+    expect(await fsp.readlink(path.join(modelDir, 'index'))).toBe('index.v1');
+    await expect(fsp.stat(path.join(modelDir, 'index.v1'))).resolves.toBeDefined();
+    const versions = (await fsp.readdir(modelDir))
+      .filter((e) => /^index\.v\d+$/.test(e))
+      .sort();
+    expect(versions).toEqual(['index.v1', 'index.v5']);
   });
 });
 

--- a/src/cli-doctor.test.ts
+++ b/src/cli-doctor.test.ts
@@ -10,6 +10,7 @@ const originalEnv = {
   HUGGINGFACE_MODEL_NAME: process.env.HUGGINGFACE_MODEL_NAME,
   HUGGINGFACE_API_KEY: process.env.HUGGINGFACE_API_KEY,
   KB_ACTIVE_MODEL: process.env.KB_ACTIVE_MODEL,
+  KB_INDEX_VERSION_RETENTION: process.env.KB_INDEX_VERSION_RETENTION,
   KB_AGE_BUDGET_HOURS: process.env.KB_AGE_BUDGET_HOURS,
   KB_AGE_BUDGET_HOURS_ALPHA: process.env.KB_AGE_BUDGET_HOURS_ALPHA,
   KB_AGE_BUDGET_HOURS_BETA: process.env.KB_AGE_BUDGET_HOURS_BETA,
@@ -57,6 +58,9 @@ describe('kb doctor', () => {
       await fsp.writeFile(path.join(rootDir, 'alpha', '.index', 'newer.md'), 'hash');
 
       const modelDir = await seedRegisteredModel(faissDir);
+      const inactiveVersionDir = path.join(modelDir, 'index.v2');
+      await fsp.mkdir(inactiveVersionDir, { recursive: true });
+      await fsp.writeFile(path.join(inactiveVersionDir, 'faiss.index'), 'old-index');
       const versionDir = path.join(modelDir, 'index.v3');
       await fsp.mkdir(versionDir, { recursive: true });
       const binaryPath = path.join(versionDir, 'faiss.index');
@@ -81,6 +85,7 @@ describe('kb doctor', () => {
         EMBEDDING_PROVIDER: 'huggingface',
         HUGGINGFACE_MODEL_NAME: MODEL_NAME,
         HUGGINGFACE_API_KEY: 'test-key',
+        KB_INDEX_VERSION_RETENTION: '2',
       });
 
       const report = await buildDoctorReport({
@@ -117,6 +122,13 @@ describe('kb doctor', () => {
       });
       expect(report.index.version).toBe('index.v3');
       expect(report.index.mtime).toBe(new Date(indexMs).toISOString());
+      expect(report.index.storage).toMatchObject({
+        active_version_bytes: Buffer.byteLength('fake-index'),
+        inactive_version_count: 1,
+        inactive_version_bytes: Buffer.byteLength('old-index'),
+        total_version_bytes: Buffer.byteLength('fake-index') + Buffer.byteLength('old-index'),
+        retention_previous_versions: 2,
+      });
       expect(report.backend).toMatchObject({ healthy: true, detail: 'backend ok' });
       expect(report.last_index_update).toMatchObject({
         status: 'success',
@@ -134,6 +146,8 @@ describe('kb doctor', () => {
       expect(markdown).toContain('Status: WARN');
       expect(markdown).toContain(`Active model: ${MODEL_ID}`);
       expect(markdown).toContain('Last index update: success (global, 1000ms, 1 changed, 1 unchanged, 0 skipped)');
+      expect(markdown).toContain('Index storage:');
+      expect(markdown).toContain('inactive across 1 retained inactive version(s); retention=2');
       expect(markdown).toContain('alpha: 1 modified, 0 new');
       expect(markdown).toContain('beta: 0 modified, 1 new');
       expect(markdown).toContain('Ingest quarantine by KB:\n  alpha: 0 quarantined\n  beta: 0 quarantined');

--- a/src/cli-doctor.ts
+++ b/src/cli-doctor.ts
@@ -13,6 +13,7 @@ import {
   listIncompleteModelStates,
   listRegisteredModels,
   parseModelId,
+  readModelIndexStorage,
   resolveActiveModel,
   resolveFaissIndexBinaryPath,
 } from './active-model.js';
@@ -99,6 +100,13 @@ export interface DoctorReport {
     binary_path: string | null;
     version: string | null;
     mtime: string | null;
+    storage: {
+      active_version_bytes: number | null;
+      inactive_version_count: number;
+      inactive_version_bytes: number;
+      total_version_bytes: number;
+      retention_previous_versions: number;
+    };
   };
   stale_counts_by_kb: Record<string, { modified_files: number; new_files: number }>;
   quarantine_counts_by_kb: Record<string, number>;
@@ -422,12 +430,27 @@ function formatErrorRate(errors: number, count: number): string {
 }
 
 async function readIndexHealth(activeModelId: string | null): Promise<DoctorReport['index']> {
+  const emptyStorage: DoctorReport['index']['storage'] = {
+    active_version_bytes: null,
+    inactive_version_count: 0,
+    inactive_version_bytes: 0,
+    total_version_bytes: 0,
+    retention_previous_versions: 0,
+  };
   if (activeModelId === null) {
-    return { path: FAISS_INDEX_PATH, binary_path: null, version: null, mtime: null };
+    return { path: FAISS_INDEX_PATH, binary_path: null, version: null, mtime: null, storage: emptyStorage };
   }
+  const storage = await readModelIndexStorage(activeModelId);
+  const storageSummary: DoctorReport['index']['storage'] = {
+    active_version_bytes: storage.active_version_bytes,
+    inactive_version_count: storage.inactive_version_count,
+    inactive_version_bytes: storage.inactive_version_bytes,
+    total_version_bytes: storage.total_version_bytes,
+    retention_previous_versions: storage.retention_previous_versions,
+  };
   const binaryPath = await resolveFaissIndexBinaryPath(activeModelId);
   if (binaryPath === null) {
-    return { path: FAISS_INDEX_PATH, binary_path: null, version: null, mtime: null };
+    return { path: FAISS_INDEX_PATH, binary_path: null, version: null, mtime: null, storage: storageSummary };
   }
   try {
     const st = await fsp.stat(binaryPath);
@@ -436,9 +459,10 @@ async function readIndexHealth(activeModelId: string | null): Promise<DoctorRepo
       binary_path: binaryPath,
       version: indexVersionFromPath(binaryPath),
       mtime: new Date(st.mtimeMs).toISOString(),
+      storage: storageSummary,
     };
   } catch {
-    return { path: FAISS_INDEX_PATH, binary_path: null, version: null, mtime: null };
+    return { path: FAISS_INDEX_PATH, binary_path: null, version: null, mtime: null, storage: storageSummary };
   }
 }
 
@@ -726,6 +750,13 @@ export function formatDoctorMarkdown(report: DoctorReport): string {
   lines.push(`Index: ${report.index.binary_path ?? '<not built>'}`);
   lines.push(`Index version: ${report.index.version ?? '<unknown>'}`);
   lines.push(`Index mtime: ${report.index.mtime ?? '<none>'}`);
+  lines.push(
+    `Index storage: ${formatBytes(report.index.storage.total_version_bytes)} total ` +
+      `(${formatBytes(report.index.storage.active_version_bytes)} active, ` +
+      `${formatBytes(report.index.storage.inactive_version_bytes)} inactive across ` +
+      `${report.index.storage.inactive_version_count} retained inactive version(s); ` +
+      `retention=${report.index.storage.retention_previous_versions})`,
+  );
   lines.push(`Last index update: ${formatLastIndexUpdate(report.last_index_update)}`);
   lines.push(`Backend: ${report.backend.healthy ? 'ok' : 'error'} — ${report.backend.detail}`);
   lines.push(`kb version: ${report.cli.version}`);
@@ -825,6 +856,19 @@ export function formatDoctorMarkdown(report: DoctorReport): string {
     lines.push(`  ${check.status.toUpperCase().padEnd(5)} ${check.name}: ${check.detail}`);
   }
   return lines.join('\n') + '\n';
+}
+
+function formatBytes(bytes: number | null): string {
+  if (bytes === null) return 'n/a';
+  const units = ['B', 'KiB', 'MiB', 'GiB', 'TiB'];
+  let value = bytes;
+  let unit = 0;
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit += 1;
+  }
+  if (unit === 0) return `${bytes} B`;
+  return `${value.toFixed(1)} ${units[unit]}`;
 }
 
 function formatLastIndexUpdate(summary: IndexUpdateSummary): string {

--- a/src/faiss-store-layout.ts
+++ b/src/faiss-store-layout.ts
@@ -5,9 +5,51 @@ import { FaissStore } from '@langchain/community/vectorstores/faiss';
 import { pathExists } from './file-utils.js';
 import { logger } from './logger.js';
 
+export const INDEX_VERSION_RETENTION_ENV = 'KB_INDEX_VERSION_RETENTION';
+export const DEFAULT_PREVIOUS_INDEX_VERSION_RETENTION = 2;
 const VERSION_DIR_PATTERN = /^index\.v(\d+)$/;
 const SYMLINK_NAME = 'index';
 const LEGACY_INDEX_NAME = 'faiss.index';
+
+export interface IndexVersionPruneResult {
+  active: string | null;
+  retention: number;
+  kept: string[];
+  removed: string[];
+  skipped: string | null;
+}
+
+export function parseIndexVersionDirName(name: string): number | null {
+  const match = name.match(VERSION_DIR_PATTERN);
+  if (!match) return null;
+  const n = parseInt(match[1], 10);
+  return Number.isFinite(n) ? n : null;
+}
+
+export function resolveIndexVersionRetention(
+  raw: string | undefined = process.env[INDEX_VERSION_RETENTION_ENV],
+): number {
+  const trimmed = raw?.trim();
+  if (trimmed === undefined || trimmed === '') {
+    return DEFAULT_PREVIOUS_INDEX_VERSION_RETENTION;
+  }
+  if (!/^\d+$/.test(trimmed)) {
+    logger.warn(
+      `${INDEX_VERSION_RETENTION_ENV}=${JSON.stringify(raw)} is not a non-negative integer; ` +
+        `using default ${DEFAULT_PREVIOUS_INDEX_VERSION_RETENTION}`,
+    );
+    return DEFAULT_PREVIOUS_INDEX_VERSION_RETENTION;
+  }
+  const parsed = Number(trimmed);
+  if (!Number.isSafeInteger(parsed)) {
+    logger.warn(
+      `${INDEX_VERSION_RETENTION_ENV}=${JSON.stringify(raw)} is too large; ` +
+        `using default ${DEFAULT_PREVIOUS_INDEX_VERSION_RETENTION}`,
+    );
+    return DEFAULT_PREVIOUS_INDEX_VERSION_RETENTION;
+  }
+  return parsed;
+}
 
 async function readSymlinkOrNull(p: string): Promise<string | null> {
   try {
@@ -22,35 +64,77 @@ async function readSymlinkOrNull(p: string): Promise<string | null> {
 /** Pure: derive the next versioned directory name from the current target. */
 export function nextVersionAfter(currentTarget: string | null): string {
   if (!currentTarget) return 'index.v0';
-  const m = currentTarget.match(VERSION_DIR_PATTERN);
-  if (!m) throw new Error(`atomicSave: unrecognized symlink target "${currentTarget}"`);
-  return `index.v${parseInt(m[1], 10) + 1}`;
+  const n = parseIndexVersionDirName(currentTarget);
+  if (n === null) throw new Error(`atomicSave: unrecognized symlink target "${currentTarget}"`);
+  return `index.v${n + 1}`;
 }
 
-async function gcOldVersions(
+export async function pruneInactiveIndexVersions(
   modelDirPath: string,
-  opts: { keep: number; current: string },
-): Promise<void> {
+  opts: { retention?: number } = {},
+): Promise<IndexVersionPruneResult> {
+  const rawRetention = opts.retention ?? resolveIndexVersionRetention();
+  const retention = Number.isSafeInteger(rawRetention) && rawRetention > 0 ? rawRetention : 0;
   let entries: string[];
   try {
     entries = await fsp.readdir(modelDirPath);
   } catch {
-    return;
+    return { active: null, retention, kept: [], removed: [], skipped: 'model directory unreadable' };
   }
 
   const versions = entries
-    .map((e) => ({ name: e, n: parseInt(e.match(VERSION_DIR_PATTERN)?.[1] ?? '', 10) }))
-    .filter((v) => Number.isFinite(v.n))
+    .map((e) => ({ name: e, n: parseIndexVersionDirName(e) }))
+    .filter((v): v is { name: string; n: number } => v.n !== null)
     .sort((a, b) => b.n - a.n);
+  const active = await readSymlinkOrNull(path.join(modelDirPath, SYMLINK_NAME));
+  if (active === null) {
+    return {
+      active,
+      retention,
+      kept: versions.map((v) => v.name),
+      removed: [],
+      skipped: 'active index symlink is missing or not a symlink',
+    };
+  }
+  if (parseIndexVersionDirName(active) === null) {
+    logger.warn(
+      `gc: skipping index version pruning in ${modelDirPath}; active symlink target ` +
+        `${JSON.stringify(active)} is not an index.vN directory`,
+    );
+    return {
+      active,
+      retention,
+      kept: versions.map((v) => v.name),
+      removed: [],
+      skipped: 'active index symlink target is not an index.vN directory',
+    };
+  }
 
-  for (const v of versions.slice(opts.keep)) {
-    if (v.name === opts.current) continue;
+  const kept = new Set<string>([active]);
+  for (const v of versions) {
+    if (v.name === active) continue;
+    if (kept.size >= retention + 1) break;
+    kept.add(v.name);
+  }
+
+  const removed: string[] = [];
+  for (const v of versions) {
+    if (kept.has(v.name)) continue;
     await fsp
       .rm(path.join(modelDirPath, v.name), { recursive: true, force: true })
-      .catch((err) =>
-        logger.warn(`gc: failed to remove ${v.name} in ${modelDirPath}: ${(err as Error).message}`),
-      );
+      .then(() => removed.push(v.name))
+      .catch((err) => {
+        kept.add(v.name);
+        logger.warn(`gc: failed to remove ${v.name} in ${modelDirPath}: ${(err as Error).message}`);
+      });
   }
+  if (removed.length > 0) {
+    logger.info(
+      `gc: pruned ${removed.length} inactive index version(s) in ${modelDirPath}; ` +
+        `kept active ${active} plus ${Math.max(0, kept.size - 1)} inactive version(s)`,
+    );
+  }
+  return { active, retention, kept: [...kept].sort(), removed, skipped: null };
 }
 
 type FsOperationErrorHandler = (action: string, targetPath: string, error: unknown) => never;
@@ -194,7 +278,9 @@ export async function saveFaissStoreAtomic(options: {
     `atomicSave: ${modelId} ${currentTarget ?? '(none)'} -> ${nextVersion}`,
   );
 
-  await gcOldVersions(modelDir, { keep: 3, current: nextVersion });
+  await pruneInactiveIndexVersions(modelDir, {
+    retention: resolveIndexVersionRetention(),
+  });
 }
 
 export async function resolveActiveIndexFilePath(modelDir: string): Promise<string | null> {


### PR DESCRIPTION
Closes #317.

## Summary
- prune inactive atomic FAISS `index.vN/` directories after successful saves with a documented default retention policy
- add `KB_INDEX_VERSION_RETENTION` for retained inactive versions while preserving the active symlink target
- surface active/inactive retained-version storage in `kb doctor`

## Verification
- Default retention: six atomic saves leave active `index.v5` plus `index.v4` and `index.v3`
- Configured retention: `KB_INDEX_VERSION_RETENTION=0` leaves only the active version after save
- Active-target safety: direct pruning keeps an older active symlink target even when outside the newest retained set

## Tests
- `npm test -- --runTestsByPath src/atomic-save.test.ts src/cli-doctor.test.ts`
- `npm run build`
- `npm test`
- after final retention-helper edge adjustment: `npm test -- --runTestsByPath src/atomic-save.test.ts src/cli-doctor.test.ts && npm run build`