### PR TITLE
Add retrieval diversity metrics

### DIFF
--- a/benchmarks/compare/golden.ts
+++ b/benchmarks/compare/golden.ts
@@ -5,6 +5,7 @@ export type GoldenRelevance = 0 | 1 | 2 | 3;
 export interface GoldenLabel {
   source: string;
   relevance: GoldenRelevance;
+  groups?: string[];
 }
 
 export type GoldenLabels = Record<string, GoldenLabel[]>;
@@ -24,6 +25,11 @@ export interface GoldenModelQueryMetrics {
   recall_at_10: number;
   recall_at_20: number;
   unique_retrieved_count: number;
+  unique_source_count_at_10: number;
+  max_source_share_at_10: number;
+  duplicate_source_groups_at_10: number;
+  intent_recall_at_10?: number;
+  alpha_ndcg_at_10?: number;
 }
 
 export interface GoldenAggregateMetrics {
@@ -35,6 +41,11 @@ export interface GoldenAggregateMetrics {
   recall_at_5: number;
   recall_at_10: number;
   recall_at_20: number;
+  unique_source_count_at_10: number;
+  max_source_share_at_10: number;
+  duplicate_source_groups_at_10: number;
+  intent_recall_at_10?: number;
+  alpha_ndcg_at_10?: number;
 }
 
 export interface GoldenQueryDiagnostics {
@@ -83,13 +94,13 @@ export function parseGoldenLabels(value: unknown, label = 'golden'): GoldenLabel
       throw new Error(`${label}: "${query}" must map to an array of labels`);
     }
 
-    const bySource = new Map<string, GoldenRelevance>();
+    const bySource = new Map<string, GoldenLabel>();
     labels.forEach((entry, i) => {
       const parsed = parseLabel(entry, `${label}: "${query}"[${i}]`);
       const existing = bySource.get(parsed.source);
-      bySource.set(parsed.source, existing === undefined ? parsed.relevance : maxRelevance(existing, parsed.relevance));
+      bySource.set(parsed.source, mergeLabel(existing, parsed));
     });
-    out[query] = Array.from(bySource.entries()).map(([source, relevance]) => ({ source, relevance }));
+    out[query] = Array.from(bySource.values());
   }
   return out;
 }
@@ -161,14 +172,21 @@ function parseLabel(entry: unknown, label: string): GoldenLabel {
   if (!isGoldenRelevance(relevance)) {
     throw new Error(`${label}: relevance must be one of 0, 1, 2, or 3`);
   }
-  return { source, relevance };
+  const groups = parseGroups(entry, label);
+  return {
+    source,
+    relevance,
+    ...(groups.length > 0 ? { groups } : {}),
+  };
 }
 
 function scoreRanking(labels: GoldenLabel[], ranking: RankedSource[]): GoldenModelQueryMetrics {
+  const sourceDiversity = scoreSourceDiversity(ranking, 10);
   const uniqueRanking = dedupeRanking(ranking).slice(0, 20);
   const relevanceBySource = new Map(labels.map((label) => [label.source, label.relevance]));
   const relevantSources = labels.filter((label) => label.relevance > 0).map((label) => label.source);
   const relevantSourceSet = new Set(relevantSources);
+  const intentDiversity = scoreIntentDiversity(labels, ranking, 10);
 
   return {
     hit_rate_at_10: hitRateAt(uniqueRanking, relevantSourceSet, 10),
@@ -180,6 +198,45 @@ function scoreRanking(labels: GoldenLabel[], ranking: RankedSource[]): GoldenMod
     recall_at_10: recallAt(uniqueRanking, relevantSourceSet, 10),
     recall_at_20: recallAt(uniqueRanking, relevantSourceSet, 20),
     unique_retrieved_count: uniqueRanking.length,
+    unique_source_count_at_10: sourceDiversity.unique_source_count_at_10,
+    max_source_share_at_10: sourceDiversity.max_source_share_at_10,
+    duplicate_source_groups_at_10: sourceDiversity.duplicate_source_groups_at_10,
+    ...(intentDiversity ?? {}),
+  };
+}
+
+function scoreSourceDiversity(ranking: RankedSource[], k: number): {
+  unique_source_count_at_10: number;
+  max_source_share_at_10: number;
+  duplicate_source_groups_at_10: number;
+} {
+  const topK = ranking.slice(0, k);
+  const counts = new Map<string, number>();
+  topK.forEach((item) => counts.set(item.doc, (counts.get(item.doc) ?? 0) + 1));
+  const maxCount = Math.max(0, ...Array.from(counts.values()));
+  return {
+    unique_source_count_at_10: counts.size,
+    max_source_share_at_10: topK.length === 0 ? 0 : roundMetric(maxCount / topK.length),
+    duplicate_source_groups_at_10: Array.from(counts.values()).filter((count) => count > 1).length,
+  };
+}
+
+function scoreIntentDiversity(
+  labels: GoldenLabel[],
+  ranking: RankedSource[],
+  k: number,
+): Pick<GoldenModelQueryMetrics, 'intent_recall_at_10' | 'alpha_ndcg_at_10'> | undefined {
+  const labelsWithGroups = labels.filter((label) => label.relevance > 0 && (label.groups?.length ?? 0) > 0);
+  if (labelsWithGroups.length === 0) return undefined;
+  const allGroups = new Set(labelsWithGroups.flatMap((label) => label.groups ?? []));
+  const retrievedGroups = new Set<string>();
+  ranking.slice(0, k).forEach((item) => {
+    groupsForRankedSource(item.doc, labelsWithGroups).forEach((group) => retrievedGroups.add(group));
+  });
+  const alphaNdcg = alphaNdcgAt(ranking, labelsWithGroups, k);
+  return {
+    intent_recall_at_10: allGroups.size === 0 ? 0 : roundMetric(retrievedGroups.size / allGroups.size),
+    alpha_ndcg_at_10: alphaNdcg,
   };
 }
 
@@ -242,7 +299,7 @@ function dcgGain(relevance: GoldenRelevance, rank: number): number {
 
 function aggregate(metrics: Array<GoldenModelQueryMetrics | undefined>): GoldenAggregateMetrics {
   const present = metrics.filter((metric): metric is GoldenModelQueryMetrics => metric !== undefined);
-  return {
+  const out: GoldenAggregateMetrics = {
     hit_rate_at_10: meanMetric(present, 'hit_rate_at_10'),
     map: meanMetric(present, 'map'),
     map_at_10: meanMetric(present, 'map_at_10'),
@@ -251,12 +308,109 @@ function aggregate(metrics: Array<GoldenModelQueryMetrics | undefined>): GoldenA
     recall_at_5: meanMetric(present, 'recall_at_5'),
     recall_at_10: meanMetric(present, 'recall_at_10'),
     recall_at_20: meanMetric(present, 'recall_at_20'),
+    unique_source_count_at_10: meanMetric(present, 'unique_source_count_at_10'),
+    max_source_share_at_10: meanMetric(present, 'max_source_share_at_10'),
+    duplicate_source_groups_at_10: meanMetric(present, 'duplicate_source_groups_at_10'),
   };
+  const withIntent = present.filter((metric) => metric.intent_recall_at_10 !== undefined && metric.alpha_ndcg_at_10 !== undefined);
+  if (withIntent.length > 0) {
+    out.intent_recall_at_10 = meanOptionalMetric(withIntent, 'intent_recall_at_10');
+    out.alpha_ndcg_at_10 = meanOptionalMetric(withIntent, 'alpha_ndcg_at_10');
+  }
+  return out;
 }
 
 function meanMetric(metrics: GoldenModelQueryMetrics[], key: keyof GoldenAggregateMetrics): number {
   if (metrics.length === 0) return 0;
-  return roundMetric(metrics.reduce((sum, metric) => sum + metric[key], 0) / metrics.length);
+  return roundMetric(metrics.reduce((sum, metric) => sum + Number(metric[key] ?? 0), 0) / metrics.length);
+}
+
+function meanOptionalMetric(
+  metrics: GoldenModelQueryMetrics[],
+  key: 'intent_recall_at_10' | 'alpha_ndcg_at_10',
+): number {
+  if (metrics.length === 0) return 0;
+  return roundMetric(metrics.reduce((sum, metric) => sum + (metric[key] ?? 0), 0) / metrics.length);
+}
+
+function parseGroups(entry: Record<string, unknown>, label: string): string[] {
+  const raw = entry.groups ?? entry.group ?? entry.intents ?? entry.intent;
+  if (raw === undefined) return [];
+  const values = typeof raw === 'string' ? [raw] : raw;
+  if (
+    !Array.isArray(values) ||
+    values.some((value) => typeof value !== 'string' || value.trim() === '')
+  ) {
+    throw new Error(`${label}: groups/intents must be a non-empty string or string array`);
+  }
+  return Array.from(new Set(values));
+}
+
+function mergeLabel(existing: GoldenLabel | undefined, incoming: GoldenLabel): GoldenLabel {
+  if (existing === undefined) return incoming;
+  const groups = Array.from(new Set([...(existing.groups ?? []), ...(incoming.groups ?? [])]));
+  return {
+    source: incoming.source,
+    relevance: maxRelevance(existing.relevance, incoming.relevance),
+    ...(groups.length > 0 ? { groups } : {}),
+  };
+}
+
+function groupsForRankedSource(doc: string, labels: GoldenLabel[]): string[] {
+  const groups = new Set<string>();
+  for (const label of labels) {
+    if (label.source !== doc) continue;
+    for (const group of label.groups ?? []) groups.add(group);
+  }
+  return Array.from(groups);
+}
+
+function alphaNdcgAt(ranking: RankedSource[], labels: GoldenLabel[], k: number, alpha = 0.5): number {
+  const dcg = alphaDcg(ranking.map((item) => groupsForRankedSource(item.doc, labels)), k, alpha);
+  const ideal = idealAlphaDcg(labels, k, alpha);
+  return ideal === 0 ? 0 : roundMetric(dcg / ideal);
+}
+
+function alphaDcg(groupSets: string[][], k: number, alpha: number): number {
+  const seenByGroup = new Map<string, number>();
+  let dcg = 0;
+  for (let idx = 0; idx < Math.min(groupSets.length, k); idx += 1) {
+    let gain = 0;
+    for (const group of groupSets[idx]) {
+      gain += (1 - alpha) ** (seenByGroup.get(group) ?? 0);
+    }
+    for (const group of groupSets[idx]) {
+      seenByGroup.set(group, (seenByGroup.get(group) ?? 0) + 1);
+    }
+    dcg += gain / Math.log2(idx + 2);
+  }
+  return dcg;
+}
+
+function idealAlphaDcg(labels: GoldenLabel[], k: number, alpha: number): number {
+  const remaining = labels
+    .filter((label) => label.relevance > 0)
+    .map((label) => Array.from(new Set(label.groups ?? [])))
+    .filter((groups) => groups.length > 0);
+  const chosen: string[][] = [];
+  const seenByGroup = new Map<string, number>();
+  while (chosen.length < k && remaining.length > 0) {
+    let bestIdx = 0;
+    let bestGain = Number.NEGATIVE_INFINITY;
+    remaining.forEach((groups, idx) => {
+      const gain = groups.reduce((sum, group) => sum + ((1 - alpha) ** (seenByGroup.get(group) ?? 0)), 0);
+      if (gain > bestGain) {
+        bestGain = gain;
+        bestIdx = idx;
+      }
+    });
+    const [next] = remaining.splice(bestIdx, 1);
+    chosen.push(next);
+    for (const group of next) {
+      seenByGroup.set(group, (seenByGroup.get(group) ?? 0) + 1);
+    }
+  }
+  return alphaDcg(chosen, k, alpha);
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/benchmarks/compare/model-quality.test.ts
+++ b/benchmarks/compare/model-quality.test.ts
@@ -105,8 +105,44 @@ describe('golden model quality scoring', () => {
     expect(scored.per_query[0]?.model_a?.unique_retrieved_count).toBe(2);
     expect(scored.model_a.recall_at_10).toBe(1);
     expect(scored.model_a.map_at_10).toBe(1);
+    expect(scored.per_query[0]?.model_a?.unique_source_count_at_10).toBe(2);
+    expect(scored.per_query[0]?.model_b?.max_source_share_at_10).toBe(1);
     expect(scored.model_b.recall_at_10).toBe(0.5);
     expect(scored.model_b.map_at_10).toBe(0.5);
+  });
+
+  it('scores intent-aware diversity when golden labels define groups', () => {
+    const labels = parseGoldenLabels({
+      'multi intent': [
+        { source: 'procedure.md', relevance: 3, intent: 'procedure' },
+        { source: 'checklist.md', relevance: 2, group: 'checklist' },
+        { source: 'rollback.md', relevance: 2, intents: ['rollback'] },
+      ],
+    });
+
+    const scored = scoreGoldenQuality(labels, [{
+      query: 'multi intent',
+      topK_a: [
+        { doc: 'procedure.md', score: 0.9 },
+        { doc: 'checklist.md', score: 0.8 },
+        { doc: 'rollback.md', score: 0.7 },
+      ],
+      topK_b: [
+        { doc: 'procedure.md', score: 0.9 },
+        { doc: 'procedure.md', score: 0.8 },
+        { doc: 'checklist.md', score: 0.7 },
+      ],
+    }]);
+
+    expect(labels['multi intent']).toEqual([
+      { source: 'procedure.md', relevance: 3, groups: ['procedure'] },
+      { source: 'checklist.md', relevance: 2, groups: ['checklist'] },
+      { source: 'rollback.md', relevance: 2, groups: ['rollback'] },
+    ]);
+    expect(scored.model_a.intent_recall_at_10).toBe(1);
+    expect(scored.model_a.alpha_ndcg_at_10).toBe(1);
+    expect(scored.model_b.intent_recall_at_10).toBeCloseTo(2 / 3, 6);
+    expect(scored.model_b.alpha_ndcg_at_10).toBeLessThan(scored.model_a.alpha_ndcg_at_10 ?? 0);
   });
 
   it('fails invalid golden labels with a clear error', () => {

--- a/benchmarks/compare/render.ts
+++ b/benchmarks/compare/render.ts
@@ -10,11 +10,19 @@ import type { BenchmarkReport } from '../types.js';
 import { renderBarChart, renderLegend, renderLineChart, renderStackedBar } from './chart.js';
 import type { GoldenQualityReport } from './golden.js';
 
+export interface SourceDiversityDiagnostics {
+  unique_source_count_at_10: number;
+  duplicate_source_groups_at_10: number;
+  max_source_share_at_10: number;
+}
+
 export interface CrossModelQueryResult {
   query: string;
   jaccard: number;
   topK_a: { doc: string; score: number }[];
   topK_b: { doc: string; score: number }[];
+  diversity_a?: SourceDiversityDiagnostics;
+  diversity_b?: SourceDiversityDiagnostics;
 }
 
 export interface CrossModelAggregate {
@@ -212,6 +220,41 @@ function buildSummaryRows(input: RenderInput): SummaryRow[] {
       b: input.goldenQuality.model_b.recall_at_20.toFixed(3),
       winner: higherIsBetter(input.goldenQuality.model_a.recall_at_20, input.goldenQuality.model_b.recall_at_20),
     });
+    rows.push({
+      metric: 'golden_unique_source@10',
+      a: input.goldenQuality.model_a.unique_source_count_at_10.toFixed(2),
+      b: input.goldenQuality.model_b.unique_source_count_at_10.toFixed(2),
+      winner: higherIsBetter(
+        input.goldenQuality.model_a.unique_source_count_at_10,
+        input.goldenQuality.model_b.unique_source_count_at_10,
+      ),
+      detail: 'higher = less crowding',
+    });
+    rows.push({
+      metric: 'golden_max_source_share@10',
+      a: input.goldenQuality.model_a.max_source_share_at_10.toFixed(3),
+      b: input.goldenQuality.model_b.max_source_share_at_10.toFixed(3),
+      winner: lowerIsBetter(
+        input.goldenQuality.model_a.max_source_share_at_10,
+        input.goldenQuality.model_b.max_source_share_at_10,
+      ),
+      detail: 'lower = less crowding',
+    });
+    if (
+      input.goldenQuality.model_a.alpha_ndcg_at_10 !== undefined &&
+      input.goldenQuality.model_b.alpha_ndcg_at_10 !== undefined
+    ) {
+      rows.push({
+        metric: 'golden_alpha_nDCG@10',
+        a: input.goldenQuality.model_a.alpha_ndcg_at_10.toFixed(3),
+        b: input.goldenQuality.model_b.alpha_ndcg_at_10.toFixed(3),
+        winner: higherIsBetter(
+          input.goldenQuality.model_a.alpha_ndcg_at_10,
+          input.goldenQuality.model_b.alpha_ndcg_at_10,
+        ),
+        detail: 'intent-aware',
+      });
+    }
   }
 
   rows.push({
@@ -314,6 +357,14 @@ function buildQualitySection(input: RenderInput): string {
   if (!quality) {
     return '<p class="meta">No golden label file was provided; quality rows use only the benchmark fixture recall proxy.</p>';
   }
+  const intentMetricRows =
+    quality.model_a.intent_recall_at_10 !== undefined &&
+    quality.model_b.intent_recall_at_10 !== undefined
+      ? [
+          qualityMetricRow('Intent recall@10', quality.model_a.intent_recall_at_10, quality.model_b.intent_recall_at_10),
+          qualityMetricRow('alpha-nDCG@10', quality.model_a.alpha_ndcg_at_10 ?? 0, quality.model_b.alpha_ndcg_at_10 ?? 0),
+        ]
+      : [];
 
   const metricRows = [
     qualityMetricRow('nDCG@10', quality.model_a.ndcg_at_10, quality.model_b.ndcg_at_10),
@@ -324,11 +375,15 @@ function buildQualitySection(input: RenderInput): string {
     qualityMetricRow('Hit rate@10', quality.model_a.hit_rate_at_10, quality.model_b.hit_rate_at_10),
     qualityMetricRow('MAP', quality.model_a.map, quality.model_b.map),
     qualityMetricRow('MAP@10', quality.model_a.map_at_10, quality.model_b.map_at_10),
+    qualityMetricRow('Unique source@10', quality.model_a.unique_source_count_at_10, quality.model_b.unique_source_count_at_10),
+    qualityMetricRow('Duplicate groups@10', quality.model_a.duplicate_source_groups_at_10, quality.model_b.duplicate_source_groups_at_10, 'lower'),
+    qualityMetricRow('Max source share@10', quality.model_a.max_source_share_at_10, quality.model_b.max_source_share_at_10, 'lower'),
+    ...intentMetricRows,
   ].join('');
 
   const diagnosticRows = quality.per_query.slice(0, 50).map((q) => {
     if (q.status !== 'scored') {
-      return `<tr><td>${escHtml(q.query)}</td><td>${escHtml(q.status)}</td><td colspan="6" class="tie">not scored</td></tr>`;
+      return `<tr><td>${escHtml(q.query)}</td><td>${escHtml(q.status)}</td><td colspan="10" class="tie">not scored</td></tr>`;
     }
     return `<tr><td>${escHtml(q.query)}</td><td>${q.relevant_source_count}</td>` +
       qualityDiagnosticCells(q.model_a) +
@@ -346,25 +401,25 @@ function buildQualitySection(input: RenderInput): string {
 </table>
 <h3>Per-query quality diagnostics</h3>
 <table>
-  <thead><tr><th>Query</th><th>Labels</th><th>A nDCG@10</th><th>A MRR@10</th><th>A R@10</th><th>B nDCG@10</th><th>B MRR@10</th><th>B R@10</th></tr></thead>
+  <thead><tr><th>Query</th><th>Labels</th><th>A nDCG@10</th><th>A MRR@10</th><th>A R@10</th><th>A uniq@10</th><th>A max share</th><th>B nDCG@10</th><th>B MRR@10</th><th>B R@10</th><th>B uniq@10</th><th>B max share</th></tr></thead>
   <tbody>${diagnosticRows}</tbody>
 </table>`;
 }
 
-function qualityMetricRow(metric: string, a: number, b: number): string {
+function qualityMetricRow(metric: string, a: number, b: number, direction: 'higher' | 'lower' = 'higher'): string {
   return rowHtml({
     metric,
     a: a.toFixed(3),
     b: b.toFixed(3),
-    winner: higherIsBetter(a, b),
+    winner: direction === 'higher' ? higherIsBetter(a, b) : lowerIsBetter(a, b),
   });
 }
 
 function qualityDiagnosticCells(metrics: GoldenQueryMetricsLike | undefined): string {
   if (!metrics) {
-    return '<td class="tie">N/A</td><td class="tie">N/A</td><td class="tie">N/A</td>';
+    return '<td class="tie">N/A</td><td class="tie">N/A</td><td class="tie">N/A</td><td class="tie">N/A</td><td class="tie">N/A</td>';
   }
-  return `<td>${metrics.ndcg_at_10.toFixed(3)}</td><td>${metrics.mrr_at_10.toFixed(3)}</td><td>${metrics.recall_at_10.toFixed(3)}</td>`;
+  return `<td>${metrics.ndcg_at_10.toFixed(3)}</td><td>${metrics.mrr_at_10.toFixed(3)}</td><td>${metrics.recall_at_10.toFixed(3)}</td><td>${metrics.unique_source_count_at_10.toFixed(0)}</td><td>${metrics.max_source_share_at_10.toFixed(3)}</td>`;
 }
 
 type GoldenQueryMetricsLike = GoldenQualityReport['per_query'][number]['model_a'];
@@ -385,12 +440,20 @@ function buildQueryDetails(input: RenderInput): string {
     }).join('');
     return `<details class="query-detail">
 <summary>j=${q.jaccard.toFixed(2)} • ${escHtml(q.query.slice(0, 80))}${q.query.length > 80 ? '…' : ''}</summary>
+<p class="meta">A diversity: ${formatSourceDiversity(q.diversity_a)} • B diversity: ${formatSourceDiversity(q.diversity_b)}</p>
 <div class="results">
   <div><strong>A</strong>${list(q.topK_a)}</div>
   <div><strong>B</strong>${list(q.topK_b)}</div>
 </div>
 </details>`;
   }).join('');
+}
+
+function formatSourceDiversity(diversity: SourceDiversityDiagnostics | undefined): string {
+  if (!diversity) return 'N/A';
+  return `unique-source@10=${diversity.unique_source_count_at_10}, ` +
+    `max-source-share@10=${diversity.max_source_share_at_10.toFixed(3)}, ` +
+    `duplicate-groups@10=${diversity.duplicate_source_groups_at_10}`;
 }
 
 interface RecommendationAxis {

--- a/benchmarks/compare/run.ts
+++ b/benchmarks/compare/run.ts
@@ -17,7 +17,7 @@ import { spawn } from 'child_process';
 import { fileURLToPath } from 'url';
 import type { BenchmarkReport } from '../types.js';
 import { installStubProvider } from '../stub.js';
-import { renderReport, type CrossModelAggregate, type CrossModelQueryResult } from './render.js';
+import { renderReport, type CrossModelAggregate, type CrossModelQueryResult, type SourceDiversityDiagnostics } from './render.js';
 import { resolveModelCtx, safeChunkChars } from './model-ctx.js';
 import { loadGoldenFile, scoreGoldenQuality } from './golden.js';
 import {
@@ -371,6 +371,8 @@ async function crossModelAgreement(args: CrossModelArgs): Promise<CrossModelAggr
       jaccard: jaccard(a.slice(0, 10).map((r) => r.doc), b.slice(0, 10).map((r) => r.doc)),
       topK_a: a,
       topK_b: b,
+      diversity_a: sourceDiversityAt10(a.map((r) => r.doc)),
+      diversity_b: sourceDiversityAt10(b.map((r) => r.doc)),
     };
   });
 
@@ -442,6 +444,18 @@ async function runQueriesAgainstManager(
     }
   }
   return out;
+}
+
+function sourceDiversityAt10(docs: string[]): SourceDiversityDiagnostics {
+  const topK = docs.slice(0, 10);
+  const counts = new Map<string, number>();
+  topK.forEach((doc) => counts.set(doc, (counts.get(doc) ?? 0) + 1));
+  const maxCount = Math.max(0, ...Array.from(counts.values()));
+  return {
+    unique_source_count_at_10: counts.size,
+    duplicate_source_groups_at_10: Array.from(counts.values()).filter((count) => count > 1).length,
+    max_source_share_at_10: topK.length === 0 ? 0 : Number((maxCount / topK.length).toFixed(6)),
+  };
 }
 
 function jaccard(a: string[], b: string[]): number {

--- a/docs/testing/retrieval-eval-methodology.md
+++ b/docs/testing/retrieval-eval-methodology.md
@@ -8,8 +8,9 @@ smallest schema knob that would catch that failure again.
 Use this guide when creating or reviewing fixtures for `kb eval`. The schema is
 deliberately small: top-level `gate`, and per-case `name`, `query`, `kb`, `k`,
 `threshold`, `gate`, `required_sources`, `forbidden_sources`,
-`expected_metadata`, `relevant_sources`/`judgments`,
-`max_duplicate_groups`, and `stale_policy`.
+`expected_metadata`, `relevant_sources`/`judgments`, optional judgement
+`group`/`groups`/`intent`/`intents`, `max_duplicate_groups`, and
+`stale_policy`.
 
 ## Why Fixtures Miss Regressions
 
@@ -54,22 +55,36 @@ themselves. Keep `required_sources`, `forbidden_sources`, and `gate` for CI
 floors. Use ranked metrics to compare retrieval modes, embedding models, and
 fixture packs without turning every rank movement into a hard failure.
 
+Source diversity metrics are emitted for every case. `unique-source@k` counts
+distinct source documents in the top-k results, `duplicate-groups@k` counts
+sources that appear more than once in that top-k, and `max-source-share@k`
+reports the largest single-source share of the returned top-k. These are useful
+diagnostics for crowding even when a fixture has no relevance judgments.
+`max_duplicate_groups` keeps its existing pass/fail behavior and remains the
+hard gate knob for duplicate crowding.
+
 `relevant_sources` is the readable form:
 
 ```yaml
 relevant_sources:
   - source: runbooks/deploy.md
     relevance: 3
+    intent: procedure
   - source: runbooks/fallback.md
     relevance: 1
+    groups: [fallback]
 ```
 
 `judgments` is the compact equivalent:
 
 ```yaml
 judgments:
-  runbooks/deploy.md: 3
-  runbooks/fallback.md: 1
+  runbooks/deploy.md:
+    relevance: 3
+    intent: procedure
+  runbooks/fallback.md:
+    relevance: 1
+    groups: [fallback]
 ```
 
 Relevance is a non-negative grade. Use `1` for ordinary relevant sources, `2`
@@ -78,6 +93,14 @@ for explicit non-relevant qrels if you need to keep a compact object aligned
 with another benchmark. The metric denominator includes only positive grades.
 `nDCG@10` uses the graded values; `MRR@10`, recall, precision, MAP, and hit
 rate treat every positive grade as relevant.
+
+Use `group`, `groups`, `intent`, or `intents` when a query has multiple valid
+subtopics or source clusters. When any positive judgment carries one of these
+labels, eval output also includes intent recall@k and alpha-nDCG@k. These
+metrics reward covering multiple labelled groups and penalize repeated hits
+from the same intent. They are informational diagnostics; use
+`required_sources`, `forbidden_sources`, or `max_duplicate_groups` when a
+diversity condition should fail CI.
 
 ## Four Fixture Archetypes
 
@@ -143,10 +166,13 @@ rank 2 swap.
   relevant_sources:
     - source: runbooks/deploy.md
       relevance: 3
+      intent: procedure
     - source: runbooks/post-incident-checklist.md
       relevance: 2
+      intent: checklist
     - source: runbooks/service-owner-escalation.md
       relevance: 1
+      intent: escalation
   gate: false
 ```
 
@@ -216,12 +242,12 @@ answer key.
 |---|---|---|
 | Canonical answer disappears | `required_sources` | Keep `query` close to the user wording that failed. |
 | Wrong legacy answer returns | `forbidden_sources` | Use only once-bad or clearly obsolete sources. |
-| Duplicate chunks crowd the result set | `max_duplicate_groups` | Set a loose budget first; tighten after observing stable output. |
+| Duplicate chunks crowd the result set | `max_duplicate_groups` | Watch unique-source@k and max-source-share@k first; set a loose budget, then tighten after observing stable output. |
 | Search crosses KB boundaries | `kb` plus `forbidden_sources` | Forbid a representative source from the wrong KB. |
 | Stale index hides fresh edits | `stale_policy: fresh` | Use this only in environments that refresh before eval. |
 | Stale-warning path regresses | `stale_policy: stale` | Reserve for tests that intentionally create stale state. |
 | Authored metadata stops flowing | `expected_metadata` | Prefer whitelisted frontmatter fields. |
-| Model or mode change shifts quality | `relevant_sources` or `judgments` | Compare aggregate nDCG@10, MRR@10, Recall@k, Precision@k, MAP/MAP@k, and hit rate. |
+| Model or mode change shifts quality | `relevant_sources` or `judgments` | Compare aggregate nDCG@10, MRR@10, Recall@k, Precision@k, MAP/MAP@k, hit rate, source diversity, and group/intent metrics when labels exist. |
 | Threshold or top-k change cuts too hard | `k` and `threshold` | Pin only when the budget itself is part of the contract. |
 
 ## Worked Example

--- a/docs/testing/retrieval-eval.md
+++ b/docs/testing/retrieval-eval.md
@@ -15,6 +15,10 @@ The unit tests in `src/retrieval-eval.test.ts` cover:
 - Optional ranked relevance judgments via `relevant_sources` and `judgments`.
 - Ranked IR metrics for perfect ranking, relevant-but-low-ranked sources,
   missing judged sources, graded relevance, and aggregate reporting.
+- Source diversity diagnostics for every case, including unique-source@k,
+  duplicate-groups@k, and max-source-share@k.
+- Intent-aware diversity diagnostics when relevant source labels include
+  `group`, `groups`, `intent`, or `intents`.
 - Parse coverage for the worked example in `docs/testing/fixtures/methodology-starter.yml`.
 
 `kb eval` defaults to dense retrieval to preserve the original evaluator behavior.
@@ -24,10 +28,16 @@ its default, and individual cases can override it with case-level `mode`.
 JSON output records `requested_mode`, `effective_mode`, and `auto_mode` when
 auto selection is used.
 
+Every case emits `diversity_metrics` in JSON and a diversity summary in
+markdown. Source-level diagnostics include unique-source@k, duplicate-groups@k,
+and max-source-share@k, with aggregate means across cases.
+
 Cases with `relevant_sources` or `judgments` also emit `ranked_metrics` in both
 markdown and JSON. The evaluator reports per-case `nDCG@10`, `MRR@10`,
 `Recall@k`, `Precision@k`, `MAP`, `MAP@k`, and hit rate, then reports aggregate
-means across judged cases. Cases without judgments preserve the original
-binary pass/fail output shape.
+means across judged cases. When positive judgments carry `group`, `groups`,
+`intent`, or `intents`, `diversity_metrics.intent` adds intent recall@k and
+alpha-nDCG@k. Cases without judgments preserve the original binary pass/fail
+output shape, plus the source diversity diagnostics.
 
 For authoring guidance, see [Retrieval eval fixture methodology](retrieval-eval-methodology.md).

--- a/src/cli-eval.ts
+++ b/src/cli-eval.ts
@@ -15,6 +15,8 @@ import {
   retrievalEvalExitCode,
   summarizeRetrievalEval,
   type RetrievalEvalAggregateRankedMetrics,
+  type RetrievalEvalAggregateDiversityMetrics,
+  type RetrievalEvalDiversityMetrics,
   type RetrievalEvalFixture,
   type RetrievalEvalRankedMetrics,
 } from './retrieval-eval.js';
@@ -40,7 +42,8 @@ Usage:
 Reads cases from a YAML or JSON fixture and runs each query against the
 active model's index. Each case can set \`query\`, optional \`kb\`,
 \`required_sources\`, \`forbidden_sources\`, \`expected_metadata\`,
-\`relevant_sources\`/\`judgments\`, \`max_duplicate_groups\`, \`stale_policy\`, and \`gate\`.
+\`relevant_sources\`/\`judgments\`, optional judgement \`groups\`/\`intents\`,
+\`max_duplicate_groups\`, \`stale_policy\`, and \`gate\`.
 
 Failing ungated cases print warnings and exit 0; failing GATED cases
 exit 1, suitable for CI gates.
@@ -73,6 +76,7 @@ Fixture example (YAML):
       relevant_sources:
         - source: runbooks/deploy.md
           relevance: 3
+          intent: procedure
       max_duplicate_groups: 1
       stale_policy: fresh
 `;
@@ -220,6 +224,7 @@ export function toJsonReport(report: ReturnType<typeof summarizeRetrievalEval>):
     passed: report.passed,
     failed: report.failed,
     gate_failed: report.gateFailed,
+    diversity_metrics: toJsonAggregateDiversityMetrics(report.diversityMetrics),
     ...(report.rankedMetrics !== undefined ? {
       ranked_metrics: toJsonAggregateRankedMetrics(report.rankedMetrics),
     } : {}),
@@ -236,10 +241,32 @@ export function toJsonReport(report: ReturnType<typeof summarizeRetrievalEval>):
       warnings: result.warnings,
       result_count: result.resultCount,
       duplicate_groups: result.duplicateGroups,
+      diversity_metrics: toJsonDiversityMetrics(result.diversityMetrics),
       ...(result.rankedMetrics !== undefined ? {
         ranked_metrics: toJsonRankedMetrics(result.rankedMetrics),
       } : {}),
     })),
+  };
+}
+
+function toJsonDiversityMetrics(metrics: RetrievalEvalDiversityMetrics): unknown {
+  return {
+    source: {
+      k: metrics.source.k,
+      result_count: metrics.source.resultCount,
+      unique_source_count_at_k: metrics.source.uniqueSourceCountAtK,
+      duplicate_source_groups_at_k: metrics.source.duplicateSourceGroupsAtK,
+      max_source_share_at_k: metrics.source.maxSourceShareAtK,
+    },
+    ...(metrics.intent !== undefined ? {
+      intent: {
+        k: metrics.intent.k,
+        group_count: metrics.intent.groupCount,
+        retrieved_group_count_at_k: metrics.intent.retrievedGroupCountAtK,
+        intent_recall_at_k: metrics.intent.intentRecallAtK,
+        alpha_ndcg_at_k: metrics.intent.alphaNdcgAtK,
+      },
+    } : {}),
   };
 }
 
@@ -255,6 +282,24 @@ function toJsonRankedMetrics(metrics: RetrievalEvalRankedMetrics): unknown {
     map: metrics.map,
     map_at_k: metrics.mapAtK,
     hit_rate: metrics.hitRate,
+  };
+}
+
+function toJsonAggregateDiversityMetrics(metrics: RetrievalEvalAggregateDiversityMetrics): unknown {
+  return {
+    source: {
+      case_count: metrics.source.caseCount,
+      unique_source_count_at_k: metrics.source.uniqueSourceCountAtK,
+      duplicate_source_groups_at_k: metrics.source.duplicateSourceGroupsAtK,
+      max_source_share_at_k: metrics.source.maxSourceShareAtK,
+    },
+    ...(metrics.intent !== undefined ? {
+      intent: {
+        case_count: metrics.intent.caseCount,
+        intent_recall_at_k: metrics.intent.intentRecallAtK,
+        alpha_ndcg_at_k: metrics.intent.alphaNdcgAtK,
+      },
+    } : {}),
   };
 }
 

--- a/src/retrieval-eval.test.ts
+++ b/src/retrieval-eval.test.ts
@@ -323,6 +323,111 @@ describe('evaluateRetrievalCase', () => {
     });
   });
 
+  it('reports source crowding metrics for duplicate chunks from one source', () => {
+    const result = evaluateRetrievalCase(
+      fixtureCase({ k: 4, maxDuplicateGroups: 1 }),
+      [
+        doc('runbooks/deploy.md'),
+        doc('runbooks/deploy.md'),
+        doc('runbooks/deploy.md'),
+        doc('runbooks/fallback.md'),
+      ],
+      FRESH,
+    );
+
+    expect(result.passed).toBe(true);
+    expect(result.duplicateGroups).toBe(1);
+    expect(result.diversityMetrics.source).toEqual({
+      k: 4,
+      resultCount: 4,
+      uniqueSourceCountAtK: 2,
+      duplicateSourceGroupsAtK: 1,
+      maxSourceShareAtK: 0.75,
+    });
+  });
+
+  it('rewards diversified relevant sources in source diversity metrics', () => {
+    const result = evaluateRetrievalCase(
+      fixtureCase({
+        k: 4,
+        relevanceJudgments: [
+          { source: 'runbooks/deploy.md', relevance: 1 },
+          { source: 'runbooks/fallback.md', relevance: 1 },
+          { source: 'runbooks/checklist.md', relevance: 1 },
+        ],
+      }),
+      [
+        doc('runbooks/deploy.md'),
+        doc('runbooks/fallback.md'),
+        doc('runbooks/checklist.md'),
+        doc('notes/other.md'),
+      ],
+      FRESH,
+    );
+
+    expect(result.diversityMetrics.source.uniqueSourceCountAtK).toBe(4);
+    expect(result.diversityMetrics.source.maxSourceShareAtK).toBe(0.25);
+    expect(result.rankedMetrics?.recallAtK).toBe(1);
+  });
+
+  it('computes intent-aware diversity when judgments define groups', () => {
+    const fixture = normalizeRetrievalEvalFixture({
+      cases: [{
+        query: 'deployment readiness',
+        k: 4,
+        relevant_sources: [
+          { source: 'runbooks/deploy.md', relevance: 3, intent: 'procedure' },
+          { source: 'runbooks/checklist.md', relevance: 2, groups: ['checklist'] },
+          { source: 'runbooks/rollback.md', relevance: 2, intents: ['rollback'] },
+        ],
+      }],
+    });
+    const fixtureCaseWithGroups = fixture.cases[0];
+
+    const crowded = evaluateRetrievalCase(
+      fixtureCaseWithGroups,
+      [
+        doc('runbooks/deploy.md'),
+        doc('runbooks/deploy.md'),
+        doc('runbooks/deploy.md'),
+        doc('runbooks/checklist.md'),
+      ],
+      FRESH,
+    );
+    const diverse = evaluateRetrievalCase(
+      fixtureCaseWithGroups,
+      [
+        doc('runbooks/deploy.md'),
+        doc('runbooks/checklist.md'),
+        doc('runbooks/rollback.md'),
+        doc('notes/other.md'),
+      ],
+      FRESH,
+    );
+
+    expect(fixtureCaseWithGroups.relevanceJudgments).toEqual([
+      { source: 'runbooks/deploy.md', relevance: 3, groups: ['procedure'] },
+      { source: 'runbooks/checklist.md', relevance: 2, groups: ['checklist'] },
+      { source: 'runbooks/rollback.md', relevance: 2, groups: ['rollback'] },
+    ]);
+    expect(crowded.diversityMetrics.intent).toMatchObject({
+      k: 4,
+      groupCount: 3,
+      retrievedGroupCountAtK: 2,
+      intentRecallAtK: 2 / 3,
+    });
+    expect(diverse.diversityMetrics.intent).toMatchObject({
+      k: 4,
+      groupCount: 3,
+      retrievedGroupCountAtK: 3,
+      intentRecallAtK: 1,
+      alphaNdcgAtK: 1,
+    });
+    expect(crowded.diversityMetrics.intent?.alphaNdcgAtK).toBeLessThan(
+      diverse.diversityMetrics.intent?.alphaNdcgAtK ?? 0,
+    );
+  });
+
   it('penalizes a relevant source that is retrieved at a low rank', () => {
     const result = evaluateRetrievalCase(
       fixtureCase({
@@ -426,10 +531,16 @@ describe('summarizeRetrievalEval', () => {
       mapAtK: 1,
       hitRate: 1,
     });
+    expect(report.diversityMetrics.source).toEqual({
+      caseCount: 2,
+      uniqueSourceCountAtK: 1.5,
+      duplicateSourceGroupsAtK: 0,
+      maxSourceShareAtK: 0.75,
+    });
     expect(report.cases[1].rankedMetrics).toBeUndefined();
   });
 
-  it('prints ranked metrics in markdown when judgments are present', () => {
+  it('prints ranked and diversity metrics in markdown when judgments are present', () => {
     const result = evaluateRetrievalCase(
       fixtureCase({
         k: 2,
@@ -442,10 +553,12 @@ describe('summarizeRetrievalEval', () => {
     const markdown = formatRetrievalEvalMarkdown(summarizeRetrievalEval([result]));
 
     expect(markdown).toContain('ranked: nDCG@10=1.000');
+    expect(markdown).toContain('diversity: unique-source@2=2');
     expect(markdown).toContain('Ranked metrics: nDCG@10=1.000');
+    expect(markdown).toContain('Diversity metrics: unique-source@k=2.000');
   });
 
-  it('includes ranked metrics in JSON output when judgments are present', () => {
+  it('includes ranked and diversity metrics in JSON output when judgments are present', () => {
     const result = evaluateRetrievalCase(
       fixtureCase({
         k: 2,
@@ -456,6 +569,14 @@ describe('summarizeRetrievalEval', () => {
     );
 
     expect(toJsonReport(summarizeRetrievalEval([result]))).toMatchObject({
+      diversity_metrics: {
+        source: {
+          case_count: 1,
+          unique_source_count_at_k: 2,
+          duplicate_source_groups_at_k: 0,
+          max_source_share_at_k: 0.5,
+        },
+      },
       ranked_metrics: {
         judged_case_count: 1,
         ndcg_at_10: 1,
@@ -478,6 +599,15 @@ describe('summarizeRetrievalEval', () => {
           map: 1,
           map_at_k: 1,
           hit_rate: 1,
+        },
+        diversity_metrics: {
+          source: {
+            k: 2,
+            result_count: 2,
+            unique_source_count_at_k: 2,
+            duplicate_source_groups_at_k: 0,
+            max_source_share_at_k: 0.5,
+          },
         },
       }],
     });

--- a/src/retrieval-eval.ts
+++ b/src/retrieval-eval.ts
@@ -27,6 +27,7 @@ export interface ExpectedMetadataRule {
 export interface RelevanceJudgment {
   source: string;
   relevance: number;
+  groups?: string[];
 }
 
 export interface RetrievalEvalRankedMetrics {
@@ -42,6 +43,27 @@ export interface RetrievalEvalRankedMetrics {
   hitRate: number;
 }
 
+export interface RetrievalEvalSourceDiversityMetrics {
+  k: number;
+  resultCount: number;
+  uniqueSourceCountAtK: number;
+  duplicateSourceGroupsAtK: number;
+  maxSourceShareAtK: number;
+}
+
+export interface RetrievalEvalIntentDiversityMetrics {
+  k: number;
+  groupCount: number;
+  retrievedGroupCountAtK: number;
+  intentRecallAtK: number;
+  alphaNdcgAtK: number;
+}
+
+export interface RetrievalEvalDiversityMetrics {
+  source: RetrievalEvalSourceDiversityMetrics;
+  intent?: RetrievalEvalIntentDiversityMetrics;
+}
+
 export interface RetrievalEvalAggregateRankedMetrics {
   judgedCaseCount: number;
   ndcgAt10: number;
@@ -51,6 +73,20 @@ export interface RetrievalEvalAggregateRankedMetrics {
   map: number;
   mapAtK: number;
   hitRate: number;
+}
+
+export interface RetrievalEvalAggregateDiversityMetrics {
+  source: {
+    caseCount: number;
+    uniqueSourceCountAtK: number;
+    duplicateSourceGroupsAtK: number;
+    maxSourceShareAtK: number;
+  };
+  intent?: {
+    caseCount: number;
+    intentRecallAtK: number;
+    alphaNdcgAtK: number;
+  };
 }
 
 export interface RetrievalEvalCase {
@@ -105,6 +141,7 @@ export interface RetrievalEvalCaseResult {
   warnings: string[];
   resultCount: number;
   duplicateGroups: number;
+  diversityMetrics: RetrievalEvalDiversityMetrics;
   rankedMetrics?: RetrievalEvalRankedMetrics;
 }
 
@@ -114,6 +151,7 @@ export interface RetrievalEvalReport {
   passed: number;
   failed: number;
   gateFailed: number;
+  diversityMetrics: RetrievalEvalAggregateDiversityMetrics;
   rankedMetrics?: RetrievalEvalAggregateRankedMetrics;
 }
 
@@ -231,6 +269,7 @@ export function evaluateRetrievalCase(
 
   const gate = fixtureCase.gate ?? fixtureGate;
   const rankedMetrics = computeRankedMetrics(fixtureCase, results);
+  const diversityMetrics = computeDiversityMetrics(fixtureCase, results);
   return {
     name: fixtureCase.name,
     query: fixtureCase.query,
@@ -244,6 +283,7 @@ export function evaluateRetrievalCase(
     warnings,
     resultCount: results.length,
     duplicateGroups,
+    diversityMetrics,
     ...(rankedMetrics !== undefined ? { rankedMetrics } : {}),
   };
 }
@@ -251,12 +291,14 @@ export function evaluateRetrievalCase(
 export function summarizeRetrievalEval(results: RetrievalEvalCaseResult[]): RetrievalEvalReport {
   const failed = results.filter((r) => !r.passed).length;
   const rankedMetrics = summarizeRankedMetrics(results);
+  const diversityMetrics = summarizeDiversityMetrics(results);
   return {
     cases: results,
     total: results.length,
     passed: results.length - failed,
     failed,
     gateFailed: results.filter((r) => r.gate && !r.passed).length,
+    diversityMetrics,
     ...(rankedMetrics !== undefined ? { rankedMetrics } : {}),
   };
 }
@@ -276,8 +318,9 @@ export function formatRetrievalEvalMarkdown(report: RetrievalEvalReport): string
     const ranked = result.rankedMetrics === undefined
       ? ''
       : `, ranked: ${formatRankedMetrics(result.rankedMetrics)}`;
+    const diversity = `, diversity: ${formatDiversityMetrics(result.diversityMetrics)}`;
     lines.push(
-      `- ${status} ${result.name} (${scope}, mode: ${mode}, ${result.resultCount} result(s), duplicate groups: ${result.duplicateGroups}${ranked})`,
+      `- ${status} ${result.name} (${scope}, mode: ${mode}, ${result.resultCount} result(s), duplicate groups: ${result.duplicateGroups}${ranked}${diversity})`,
     );
     for (const failure of result.failures) {
       lines.push(`  - ${failure}`);
@@ -293,6 +336,7 @@ export function formatRetrievalEvalMarkdown(report: RetrievalEvalReport): string
   if (report.rankedMetrics !== undefined) {
     lines.push(`Ranked metrics: ${formatAggregateRankedMetrics(report.rankedMetrics)}.`);
   }
+  lines.push(`Diversity metrics: ${formatAggregateDiversityMetrics(report.diversityMetrics)}.`);
   return `${lines.join('\n')}\n`;
 }
 
@@ -443,11 +487,8 @@ function normalizeRelevanceJudgments(
   }
   if (judgments !== undefined) {
     if (isRecord(judgments)) {
-      for (const [source, relevance] of Object.entries(judgments)) {
-        entries.push({
-          source: validateJudgmentSource(source, caseNumber, 'judgments'),
-          relevance: validateJudgmentRelevance(relevance, caseNumber, `judgments.${source}`),
-        });
+      for (const [source, rawJudgment] of Object.entries(judgments)) {
+        entries.push(normalizeJudgmentObjectEntry(source, rawJudgment, caseNumber));
       }
     } else {
       entries.push(...normalizeJudgmentArray(judgments, caseNumber, 'judgments'));
@@ -458,10 +499,36 @@ function normalizeRelevanceJudgments(
   for (const entry of entries) {
     const existing = deduped.get(entry.source);
     if (existing === undefined || entry.relevance > existing.relevance) {
-      deduped.set(entry.source, entry);
+      deduped.set(entry.source, mergeJudgments(existing, entry));
+    } else if (existing !== undefined) {
+      deduped.set(entry.source, mergeJudgments(existing, entry));
     }
   }
   return Array.from(deduped.values());
+}
+
+function normalizeJudgmentObjectEntry(
+  source: string,
+  rawJudgment: unknown,
+  caseNumber: number,
+): RelevanceJudgment {
+  const baseSource = validateJudgmentSource(source, caseNumber, 'judgments');
+  if (!isRecord(rawJudgment)) {
+    return {
+      source: baseSource,
+      relevance: validateJudgmentRelevance(rawJudgment, caseNumber, `judgments.${source}`),
+    };
+  }
+  const groups = normalizeJudgmentGroups(rawJudgment, caseNumber, `judgments.${source}`);
+  return {
+    source: baseSource,
+    relevance: validateJudgmentRelevance(
+      rawJudgment.relevance ?? 1,
+      caseNumber,
+      `judgments.${source}.relevance`,
+    ),
+    ...(groups.length > 0 ? { groups } : {}),
+  };
 }
 
 function normalizeJudgmentArray(
@@ -489,8 +556,26 @@ function normalizeJudgmentArray(
         caseNumber,
         `${key}[${idx}].relevance`,
       ),
+      ...(() => {
+        const groups = normalizeJudgmentGroups(entry, caseNumber, `${key}[${idx}]`);
+        return groups.length > 0 ? { groups } : {};
+      })(),
     };
   });
+}
+
+function mergeJudgments(
+  existing: RelevanceJudgment | undefined,
+  incoming: RelevanceJudgment,
+): RelevanceJudgment {
+  if (existing === undefined) return incoming;
+  const relevance = Math.max(existing.relevance, incoming.relevance);
+  const groups = Array.from(new Set([...(existing.groups ?? []), ...(incoming.groups ?? [])]));
+  return {
+    source: incoming.source,
+    relevance,
+    ...(groups.length > 0 ? { groups } : {}),
+  };
 }
 
 function validateJudgmentSource(value: unknown, caseNumber: number, key: string): string {
@@ -505,6 +590,23 @@ function validateJudgmentRelevance(value: unknown, caseNumber: number, key: stri
     throw new Error(`case ${caseNumber} ${key} must be a non-negative finite relevance number`);
   }
   return value;
+}
+
+function normalizeJudgmentGroups(
+  input: Record<string, unknown>,
+  caseNumber: number,
+  key: string,
+): string[] {
+  const raw = input.groups ?? input.group ?? input.intents ?? input.intent;
+  if (raw === undefined) return [];
+  const values = typeof raw === 'string' ? [raw] : raw;
+  if (
+    !Array.isArray(values) ||
+    values.some((entry) => typeof entry !== 'string' || entry.trim() === '')
+  ) {
+    throw new Error(`case ${caseNumber} ${key} groups/intents must be a non-empty string or string array`);
+  }
+  return Array.from(new Set(values));
 }
 
 function computeRankedMetrics(
@@ -529,6 +631,85 @@ function computeRankedMetrics(
     map: averagePrecisionAt(results, positiveJudgments, results.length, positiveJudgments.length),
     mapAtK: averagePrecisionAt(topK, positiveJudgments, k, Math.min(positiveJudgments.length, k)),
     hitRate: retrievedAtK.size > 0 ? 1 : 0,
+  };
+}
+
+function computeDiversityMetrics(
+  fixtureCase: RetrievalEvalCase,
+  results: readonly ScoredDocument[],
+): RetrievalEvalDiversityMetrics {
+  const k = fixtureCase.k ?? 10;
+  return {
+    source: computeSourceDiversityMetrics(results, k),
+    ...(() => {
+      const intent = computeIntentDiversityMetrics(fixtureCase, results, k);
+      return intent === undefined ? {} : { intent };
+    })(),
+  };
+}
+
+function computeSourceDiversityMetrics(
+  results: readonly ScoredDocument[],
+  k: number,
+): RetrievalEvalSourceDiversityMetrics {
+  const topK = results.slice(0, k);
+  const counts = countSources(topK);
+  const maxCount = Math.max(0, ...Array.from(counts.values()));
+  return {
+    k,
+    resultCount: topK.length,
+    uniqueSourceCountAtK: counts.size,
+    duplicateSourceGroupsAtK: Array.from(counts.values()).filter((count) => count > 1).length,
+    maxSourceShareAtK: topK.length === 0 ? 0 : maxCount / topK.length,
+  };
+}
+
+function computeIntentDiversityMetrics(
+  fixtureCase: RetrievalEvalCase,
+  results: readonly ScoredDocument[],
+  k: number,
+): RetrievalEvalIntentDiversityMetrics | undefined {
+  const judgments = (fixtureCase.relevanceJudgments ?? [])
+    .filter((judgment) => judgment.relevance > 0 && (judgment.groups?.length ?? 0) > 0);
+  if (judgments.length === 0) return undefined;
+
+  const allGroups = new Set(judgments.flatMap((judgment) => judgment.groups ?? []));
+  const topK = results.slice(0, k);
+  const retrievedGroups = new Set<string>();
+  for (const doc of topK) {
+    for (const group of groupsForDocument(doc, judgments)) retrievedGroups.add(group);
+  }
+
+  return {
+    k,
+    groupCount: allGroups.size,
+    retrievedGroupCountAtK: retrievedGroups.size,
+    intentRecallAtK: allGroups.size === 0 ? 0 : retrievedGroups.size / allGroups.size,
+    alphaNdcgAtK: alphaNdcgAt(topK, judgments, k),
+  };
+}
+
+function summarizeDiversityMetrics(
+  results: readonly RetrievalEvalCaseResult[],
+): RetrievalEvalAggregateDiversityMetrics {
+  const sourceMetrics = results.map((result) => result.diversityMetrics.source);
+  const intentMetrics = results
+    .map((result) => result.diversityMetrics.intent)
+    .filter((metrics): metrics is RetrievalEvalIntentDiversityMetrics => metrics !== undefined);
+  return {
+    source: {
+      caseCount: sourceMetrics.length,
+      uniqueSourceCountAtK: meanOrZero(sourceMetrics.map((m) => m.uniqueSourceCountAtK)),
+      duplicateSourceGroupsAtK: meanOrZero(sourceMetrics.map((m) => m.duplicateSourceGroupsAtK)),
+      maxSourceShareAtK: meanOrZero(sourceMetrics.map((m) => m.maxSourceShareAtK)),
+    },
+    ...(intentMetrics.length > 0 ? {
+      intent: {
+        caseCount: intentMetrics.length,
+        intentRecallAtK: mean(intentMetrics.map((m) => m.intentRecallAtK)),
+        alphaNdcgAtK: mean(intentMetrics.map((m) => m.alphaNdcgAtK)),
+      },
+    } : {}),
   };
 }
 
@@ -561,6 +742,82 @@ function matchedJudgmentIndexes(
     if (index !== undefined) matched.add(index);
   }
   return matched;
+}
+
+function groupsForDocument(
+  doc: ScoredDocument,
+  judgments: readonly RelevanceJudgment[],
+): string[] {
+  const groups = new Set<string>();
+  for (const judgment of judgments) {
+    if (!documentMatchesSource(doc, judgment.source)) continue;
+    for (const group of judgment.groups ?? []) groups.add(group);
+  }
+  return Array.from(groups);
+}
+
+function alphaNdcgAt(
+  results: readonly ScoredDocument[],
+  judgments: readonly RelevanceJudgment[],
+  cutoff: number,
+  alpha = 0.5,
+): number {
+  const dcg = alphaDcg(results.map((doc) => groupsForDocument(doc, judgments)), cutoff, alpha);
+  const ideal = idealAlphaDcg(judgments, cutoff, alpha);
+  return ideal === 0 ? 0 : dcg / ideal;
+}
+
+function alphaDcg(
+  groupSets: readonly string[][],
+  cutoff: number,
+  alpha: number,
+): number {
+  const seenByGroup = new Map<string, number>();
+  let dcg = 0;
+  for (let idx = 0; idx < Math.min(groupSets.length, cutoff); idx += 1) {
+    let gain = 0;
+    for (const group of groupSets[idx]) {
+      const seen = seenByGroup.get(group) ?? 0;
+      gain += (1 - alpha) ** seen;
+    }
+    for (const group of groupSets[idx]) {
+      seenByGroup.set(group, (seenByGroup.get(group) ?? 0) + 1);
+    }
+    dcg += gain / Math.log2(idx + 2);
+  }
+  return dcg;
+}
+
+function idealAlphaDcg(
+  judgments: readonly RelevanceJudgment[],
+  cutoff: number,
+  alpha: number,
+): number {
+  const remaining = judgments
+    .map((judgment) => Array.from(new Set(judgment.groups ?? [])))
+    .filter((groups) => groups.length > 0);
+  const chosen: string[][] = [];
+  const seenByGroup = new Map<string, number>();
+  while (chosen.length < cutoff && remaining.length > 0) {
+    let bestIdx = 0;
+    let bestGain = Number.NEGATIVE_INFINITY;
+    remaining.forEach((groups, idx) => {
+      const gain = groups.reduce((sum, group) => {
+        const seen = seenByGroup.get(group) ?? 0;
+        return sum + ((1 - alpha) ** seen);
+      }, 0);
+      if (gain > bestGain) {
+        bestGain = gain;
+        bestIdx = idx;
+      }
+    });
+    const [next] = remaining.splice(bestIdx, 1);
+    chosen.push(next);
+    for (const group of next) {
+      seenByGroup.set(group, (seenByGroup.get(group) ?? 0) + 1);
+    }
+  }
+  return alphaDcg(chosen, cutoff, alpha);
 }
 
 function reciprocalRankAt(
@@ -643,6 +900,10 @@ function mean(values: readonly number[]): number {
   return values.reduce((sum, value) => sum + value, 0) / values.length;
 }
 
+function meanOrZero(values: readonly number[]): number {
+  return values.length === 0 ? 0 : mean(values);
+}
+
 function formatRankedMetrics(metrics: RetrievalEvalRankedMetrics): string {
   return [
     `nDCG@10=${formatMetric(metrics.ndcgAt10)}`,
@@ -652,6 +913,18 @@ function formatRankedMetrics(metrics: RetrievalEvalRankedMetrics): string {
     `MAP=${formatMetric(metrics.map)}`,
     `MAP@${metrics.k}=${formatMetric(metrics.mapAtK)}`,
     `HitRate@${metrics.k}=${formatMetric(metrics.hitRate)}`,
+  ].join(', ');
+}
+
+function formatDiversityMetrics(metrics: RetrievalEvalDiversityMetrics): string {
+  return [
+    `unique-source@${metrics.source.k}=${metrics.source.uniqueSourceCountAtK}`,
+    `max-source-share@${metrics.source.k}=${formatMetric(metrics.source.maxSourceShareAtK)}`,
+    `duplicate-groups@${metrics.source.k}=${metrics.source.duplicateSourceGroupsAtK}`,
+    ...(metrics.intent === undefined ? [] : [
+      `intent-recall@${metrics.intent.k}=${formatMetric(metrics.intent.intentRecallAtK)}`,
+      `alpha-nDCG@${metrics.intent.k}=${formatMetric(metrics.intent.alphaNdcgAtK)}`,
+    ]),
   ].join(', ');
 }
 
@@ -665,6 +938,20 @@ function formatAggregateRankedMetrics(metrics: RetrievalEvalAggregateRankedMetri
     `MAP@k=${formatMetric(metrics.mapAtK)}`,
     `HitRate=${formatMetric(metrics.hitRate)}`,
     `judged cases=${metrics.judgedCaseCount}`,
+  ].join(', ');
+}
+
+function formatAggregateDiversityMetrics(metrics: RetrievalEvalAggregateDiversityMetrics): string {
+  return [
+    `unique-source@k=${formatMetric(metrics.source.uniqueSourceCountAtK)}`,
+    `max-source-share@k=${formatMetric(metrics.source.maxSourceShareAtK)}`,
+    `duplicate-groups@k=${formatMetric(metrics.source.duplicateSourceGroupsAtK)}`,
+    `cases=${metrics.source.caseCount}`,
+    ...(metrics.intent === undefined ? [] : [
+      `intent-recall@k=${formatMetric(metrics.intent.intentRecallAtK)}`,
+      `alpha-nDCG@k=${formatMetric(metrics.intent.alphaNdcgAtK)}`,
+      `intent cases=${metrics.intent.caseCount}`,
+    ]),
   ].join(', ');
 }
 
@@ -714,12 +1001,16 @@ function sourceMatches(source: string, pattern: string): boolean {
 }
 
 function countDuplicateSourceGroups(results: readonly ScoredDocument[]): number {
+  return Array.from(countSources(results).values()).filter((count) => count > 1).length;
+}
+
+function countSources(results: readonly ScoredDocument[]): Map<string, number> {
   const counts = new Map<string, number>();
   results.forEach((doc, idx) => {
     const key = sourceIdentities(doc)[0] ?? `(unknown source ${idx + 1})`;
     counts.set(key, (counts.get(key) ?? 0) + 1);
   });
-  return Array.from(counts.values()).filter((count) => count > 1).length;
+  return counts;
 }
 
 function metadataMatchesRule(metadata: unknown, rule: ExpectedMetadataRule): boolean {


### PR DESCRIPTION
## Summary
- add source diversity diagnostics to kb eval reports and JSON output
- support optional group/intent labels with intent recall and alpha-nDCG diagnostics
- surface diversity diagnostics in bench compare golden scoring and per-query comparison output
- document fixture authoring guidance for diversity metrics

Closes #305.

## Verification
- npx jest src/retrieval-eval.test.ts benchmarks/compare/model-quality.test.ts --runInBand
- npm run build
- npx tsc -p tsconfig.bench.json
- npm test -- --runInBand
- BENCH_PROVIDER=stub BENCH_RESULTS_PREFIX=ci-local npm run bench
- npm run docs:check-anchors (warning mode, existing stale anchors reported)

## Pre-PR review
- detected project type: npm
- type/build checks: passed (`npm run build`, `npx tsc -p tsconfig.bench.json`)
- tests: passed (`npm test -- --runInBand`; focused Jest; stub benchmark harness)
- bug reproduction: skipped, feature PR
- diff review: done
- portability check: clean via manual added-line scan; repo helper script absent
- reviewer specialists: skipped; current Codex tool policy does not allow spawning reviewer subagents without explicit user delegation
- OSS base-branch policy: skipped, same-repo PR
- gate file: created
