### PR TITLE
Persist index refresh summaries

### DIFF
--- a/docs/cli-json-contracts.md
+++ b/docs/cli-json-contracts.md
@@ -448,9 +448,10 @@ Stable fields:
   `symlinked_checkout_path`.
 - `git`: either `null` or an object with `branch`, `head`, `origin_main`, and
   `relation`.
-- `last_index_update`: the latest in-process update summary. The object shape is
-  shared with stats/manager observability; agents should branch first on
-  `last_index_update.status`.
+- `last_index_update`: the latest update summary. Fresh processes use the
+  compact persisted summary for the active model when no update has run in the
+  current process. The object shape is shared with stats/manager observability;
+  agents should branch first on `last_index_update.status`.
 
 Stdout/stderr and exit codes:
 

--- a/docs/requirements/INDEX.md
+++ b/docs/requirements/INDEX.md
@@ -38,6 +38,22 @@
 **Linked Tests:** TS-OBS-237
 **Dependencies:** FR-SEARCH-192
 
+### FR-OBS-315: Persisted Last Index Update Summary
+**Status:** Implemented
+**Priority:** High
+
+**Requirement:** The system shall persist the latest `updateIndex` run summary under the active model directory and use that persisted summary for fresh-process stats and doctor reports when no in-process update has run.
+**Rationale:** Long refreshes can finish in a different CLI process from later diagnostics; persisting the compact sanitized summary preserves post-mortem evidence without requiring the original terminal output.
+
+**Acceptance Criteria:**
+- [x] Given an index update completes successfully, when the update finishes, then the active model directory contains the latest sanitized update summary.
+- [x] Given an index update fails or completes partially, when the update attempt finishes, then the active model directory contains the failed or partial summary with capped failure details.
+- [x] Given `kb stats` or `kb doctor` runs in a fresh process and the in-memory summary is `never_run`, when a persisted summary exists for the active model, then the report uses the persisted summary.
+- [x] Given the persisted summary is missing or malformed, when stats or doctor output is requested, then the report falls back to the in-memory `never_run` summary.
+
+**Linked Tests:** TS-OBS-315
+**Dependencies:** FR-OBS-237
+
 ## Search
 
 ### FR-SUPERSEDED-232: Superseded Memory Review

--- a/docs/testing/INDEX.md
+++ b/docs/testing/INDEX.md
@@ -26,6 +26,16 @@
 - `computeKbStats` shall include the manager's latest update summary in the payload.
 - `buildDoctorReport` and `formatDoctorMarkdown` shall include the latest update summary.
 
+### TS-OBS-315: Persisted Last Index Update Summary
+**Requirement:** FR-OBS-315
+
+**Test Cases:**
+- `FaissIndexManager.updateIndex` shall atomically persist the completed summary under the active model directory.
+- `FaissIndexManager.updateIndex` shall persist failed and partial summaries with capped sanitized failure details.
+- `computeKbStats` shall use the persisted summary when the manager summary is `never_run`.
+- `computeKbStats` shall ignore missing or malformed persisted summaries and keep the manager summary.
+- `buildDoctorReport` shall use the persisted summary for the active model when no explicit in-process summary is supplied.
+
 ## Search
 
 ### TS-SUPERSEDED-232: Superseded Memory Review

--- a/src/FaissIndexManager.test.ts
+++ b/src/FaissIndexManager.test.ts
@@ -19,6 +19,9 @@ function versionedIndexPathIn(faissPath: string, version = 'v0'): string {
 function modelNameFileIn(faissPath: string): string {
   return path.join(modelDirIn(faissPath), 'model_name.txt');
 }
+function lastIndexUpdatePathIn(faissPath: string): string {
+  return path.join(modelDirIn(faissPath), 'last-index-update.json');
+}
 
 const saveMock = jest.fn();
 const addDocumentsMock = jest.fn();
@@ -394,6 +397,21 @@ describe('FaissIndexManager permission handling', () => {
         }),
       ],
     });
+    const persistedSummary = JSON.parse(
+      await fsp.readFile(lastIndexUpdatePathIn(process.env.FAISS_INDEX_PATH!), 'utf-8'),
+    );
+    expect(persistedSummary).toMatchObject({
+      schema_version: 'kb.last-index-update.v1',
+      summary: {
+        status: 'failed',
+        scope: 'global',
+        model_id: DEFAULT_MODEL_ID,
+        files_scanned: 1,
+        files_changed: 1,
+        saved: false,
+        failure_count: 1,
+      },
+    });
     // RFC 014 — first save under v014 writes to index.v0/ via atomicSave.
     expect(saveMock).toHaveBeenCalledWith(versionedIndexPathIn(process.env.FAISS_INDEX_PATH!));
 
@@ -641,6 +659,22 @@ describe('FaissIndexManager permission handling', () => {
     expect(changedSummary.started_at).toEqual(expect.any(String));
     expect(changedSummary.finished_at).toEqual(expect.any(String));
     expect(changedSummary.duration_ms).toEqual(expect.any(Number));
+    const persistedChangedSummary = JSON.parse(
+      await fsp.readFile(lastIndexUpdatePathIn(process.env.FAISS_INDEX_PATH!), 'utf-8'),
+    );
+    expect(persistedChangedSummary).toMatchObject({
+      schema_version: 'kb.last-index-update.v1',
+      summary: {
+        status: 'success',
+        scope: 'default',
+        model_id: DEFAULT_MODEL_ID,
+        files_scanned: 1,
+        files_changed: 1,
+        chunks_added: 1,
+        saved: true,
+        sidecars_written: true,
+      },
+    });
 
     saveMock.mockClear();
     fromTextsMock.mockClear();
@@ -662,6 +696,16 @@ describe('FaissIndexManager permission handling', () => {
       saved: false,
       sidecars_written: false,
       failure_count: 0,
+    });
+    const persistedUnchangedSummary = JSON.parse(
+      await fsp.readFile(lastIndexUpdatePathIn(process.env.FAISS_INDEX_PATH!), 'utf-8'),
+    );
+    expect(persistedUnchangedSummary.summary).toMatchObject({
+      status: 'success',
+      scope: 'default',
+      files_changed: 0,
+      files_unchanged: 1,
+      saved: false,
     });
   });
 
@@ -691,6 +735,21 @@ describe('FaissIndexManager permission handling', () => {
       status: 'partial',
       files_scanned: 1,
       files_changed: 1,
+      files_skipped: 1,
+      failure_count: 1,
+      failures: [expect.objectContaining({
+        relative_path: 'bad.md',
+        phase: 'load',
+        code: 'KB_LARGE_FILE_TOO_LARGE',
+      })],
+    });
+    const persistedPartialSummary = JSON.parse(
+      await fsp.readFile(lastIndexUpdatePathIn(process.env.FAISS_INDEX_PATH!), 'utf-8'),
+    );
+    expect(persistedPartialSummary.summary).toMatchObject({
+      status: 'partial',
+      scope: 'default',
+      files_scanned: 1,
       files_skipped: 1,
       failure_count: 1,
       failures: [expect.objectContaining({

--- a/src/FaissIndexManager.ts
+++ b/src/FaissIndexManager.ts
@@ -214,6 +214,8 @@ export interface SearchResultDocument extends Document {
 }
 
 const MAX_INDEX_UPDATE_FAILURES = 10;
+const LAST_INDEX_UPDATE_SUMMARY_FILE = 'last-index-update.json';
+const LAST_INDEX_UPDATE_SUMMARY_SCHEMA_VERSION = 'kb.last-index-update.v1';
 
 export function createNeverRunIndexUpdateSummary(modelId: string | null = null): IndexUpdateSummary {
   return {
@@ -234,6 +236,13 @@ export function createNeverRunIndexUpdateSummary(modelId: string | null = null):
     sidecars_written: false,
     failure_count: 0,
     failures: [],
+  };
+}
+
+function cloneIndexUpdateSummary(summary: IndexUpdateSummary): IndexUpdateSummary {
+  return {
+    ...summary,
+    failures: summary.failures.map((failure) => ({ ...failure })),
   };
 }
 
@@ -263,6 +272,95 @@ function sanitizeFailureMessage(
   }
   const replacement = relativePath ?? '<path>';
   return message.split(rawPath).join(replacement);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function stringOrNull(value: unknown): string | null {
+  return typeof value === 'string' ? value : null;
+}
+
+function numberOrDefault(value: unknown, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback;
+}
+
+function numberOrNull(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function booleanOrDefault(value: unknown, fallback: boolean): boolean {
+  return typeof value === 'boolean' ? value : fallback;
+}
+
+function parseSummaryStatus(value: unknown): IndexUpdateSummaryStatus | null {
+  if (
+    value === 'success' ||
+    value === 'partial' ||
+    value === 'failed' ||
+    value === 'never_run'
+  ) {
+    return value;
+  }
+  return null;
+}
+
+function parseFailurePhase(value: unknown): IndexUpdateFailureSummary['phase'] {
+  if (
+    value === 'load' ||
+    value === 'indexing' ||
+    value === 'save' ||
+    value === 'sidecar' ||
+    value === 'unknown'
+  ) {
+    return value;
+  }
+  return 'unknown';
+}
+
+function parsePersistedIndexUpdateSummary(value: unknown): IndexUpdateSummary | null {
+  const candidate = isRecord(value) && isRecord(value.summary)
+    ? value.summary
+    : value;
+  if (!isRecord(candidate)) return null;
+
+  const status = parseSummaryStatus(candidate.status);
+  if (status === null) return null;
+
+  const modelId = stringOrNull(candidate.model_id);
+  const base = createNeverRunIndexUpdateSummary(modelId);
+  const failures = Array.isArray(candidate.failures)
+    ? candidate.failures
+        .filter(isRecord)
+        .slice(0, MAX_INDEX_UPDATE_FAILURES)
+        .map((failure): IndexUpdateFailureSummary => ({
+          relative_path: stringOrNull(failure.relative_path),
+          phase: parseFailurePhase(failure.phase),
+          code: stringOrNull(failure.code),
+          message: typeof failure.message === 'string' ? failure.message : '',
+        }))
+    : [];
+
+  return {
+    ...base,
+    status,
+    scope: stringOrNull(candidate.scope),
+    started_at: stringOrNull(candidate.started_at),
+    finished_at: stringOrNull(candidate.finished_at),
+    duration_ms: numberOrNull(candidate.duration_ms),
+    files_scanned: numberOrDefault(candidate.files_scanned, base.files_scanned),
+    files_changed: numberOrDefault(candidate.files_changed, base.files_changed),
+    files_unchanged: numberOrDefault(candidate.files_unchanged, base.files_unchanged),
+    files_skipped: numberOrDefault(candidate.files_skipped, base.files_skipped),
+    chunks_attempted: numberOrDefault(candidate.chunks_attempted, base.chunks_attempted),
+    chunks_added: numberOrDefault(candidate.chunks_added, base.chunks_added),
+    index_mutated: booleanOrDefault(candidate.index_mutated, base.index_mutated),
+    saved: booleanOrDefault(candidate.saved, base.saved),
+    sidecars_written: booleanOrDefault(candidate.sidecars_written, base.sidecars_written),
+    failure_count: numberOrDefault(candidate.failure_count, failures.length),
+    failures,
+  };
 }
 
 export class FaissIndexManager {
@@ -326,10 +424,54 @@ export class FaissIndexManager {
   }
 
   getLastIndexUpdateSummary(): IndexUpdateSummary {
-    return {
-      ...this.lastIndexUpdateSummary,
-      failures: this.lastIndexUpdateSummary.failures.map((failure) => ({ ...failure })),
+    return cloneIndexUpdateSummary(this.lastIndexUpdateSummary);
+  }
+
+  static async readPersistedIndexUpdateSummary(
+    modelId: string | null,
+  ): Promise<IndexUpdateSummary | null> {
+    if (modelId === null) return null;
+    const summaryPath = path.join(modelDir(modelId), LAST_INDEX_UPDATE_SUMMARY_FILE);
+    let raw: string;
+    try {
+      raw = await fsp.readFile(summaryPath, 'utf-8');
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === 'ENOENT' || code === 'ENOTDIR') return null;
+      logger.warn(
+        `Could not read persisted index update summary for ${modelId}: ${toError(err).message}`,
+      );
+      return null;
+    }
+
+    try {
+      return parsePersistedIndexUpdateSummary(JSON.parse(raw));
+    } catch (err) {
+      logger.warn(
+        `Ignoring malformed persisted index update summary for ${modelId}: ${toError(err).message}`,
+      );
+      return null;
+    }
+  }
+
+  private async persistIndexUpdateSummary(summary: IndexUpdateSummary): Promise<void> {
+    await fsp.mkdir(this.modelDir, { recursive: true });
+    const summaryPath = path.join(this.modelDir, LAST_INDEX_UPDATE_SUMMARY_FILE);
+    const tmpPath = path.join(
+      this.modelDir,
+      `.${LAST_INDEX_UPDATE_SUMMARY_FILE}.${process.pid}.${process.hrtime.bigint()}.tmp`,
+    );
+    const payload = {
+      schema_version: LAST_INDEX_UPDATE_SUMMARY_SCHEMA_VERSION,
+      summary: cloneIndexUpdateSummary(summary),
     };
+    try {
+      await fsp.writeFile(tmpPath, JSON.stringify(payload), { encoding: 'utf-8', mode: 0o600 });
+      await fsp.rename(tmpPath, summaryPath);
+    } catch (err) {
+      await fsp.rm(tmpPath, { force: true }).catch(() => undefined);
+      throw err;
+    }
   }
 
   /** RFC 013 §4.8 — process-global, idempotent layout bootstrap. */
@@ -1171,10 +1313,14 @@ export class FaissIndexManager {
       const finishedAtMs = Date.now();
       runSummary.finished_at = new Date(finishedAtMs).toISOString();
       runSummary.duration_ms = finishedAtMs - startedAtMs;
-      this.lastIndexUpdateSummary = {
-        ...runSummary,
-        failures: runSummary.failures.map((failure) => ({ ...failure })),
-      };
+      this.lastIndexUpdateSummary = cloneIndexUpdateSummary(runSummary);
+      try {
+        await this.persistIndexUpdateSummary(this.lastIndexUpdateSummary);
+      } catch (persistError: unknown) {
+        logger.warn(
+          `Could not persist index update summary for ${this.modelId}: ${toError(persistError).message}`,
+        );
+      }
     }
   }
 

--- a/src/cli-doctor.test.ts
+++ b/src/cli-doctor.test.ts
@@ -40,6 +40,28 @@ async function seedRegisteredModel(faissDir: string): Promise<string> {
   return modelDir;
 }
 
+function persistedSuccessSummary() {
+  return {
+    status: 'success',
+    scope: 'global',
+    model_id: MODEL_ID,
+    started_at: '2026-05-12T10:00:00.000Z',
+    finished_at: '2026-05-12T10:00:05.000Z',
+    duration_ms: 5000,
+    files_scanned: 4,
+    files_changed: 2,
+    files_unchanged: 2,
+    files_skipped: 0,
+    chunks_attempted: 5,
+    chunks_added: 5,
+    index_mutated: true,
+    saved: true,
+    sidecars_written: true,
+    failure_count: 0,
+    failures: [],
+  };
+}
+
 describe('kb doctor', () => {
   it('reports active model, index version/mtime, backend health, and stale counts by KB', async () => {
     const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-doctor-'));
@@ -200,6 +222,53 @@ describe('kb doctor', () => {
         detail: '1 quarantined ingest file(s) detected',
       });
       expect(formatDoctorMarkdown(report)).toContain('Ingest quarantine by KB:\n  alpha: 1 quarantined');
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('uses the persisted update summary for a fresh-process doctor report', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-doctor-persisted-summary-'));
+    try {
+      const rootDir = path.join(tempDir, 'kbs');
+      const faissDir = path.join(tempDir, '.faiss');
+      await fsp.mkdir(path.join(rootDir, 'alpha'), { recursive: true });
+      await fsp.writeFile(path.join(rootDir, 'alpha', 'a.md'), 'alpha');
+      const modelDir = await seedRegisteredModel(faissDir);
+      await fsp.writeFile(
+        path.join(modelDir, 'last-index-update.json'),
+        JSON.stringify({
+          schema_version: 'kb.last-index-update.v1',
+          summary: persistedSuccessSummary(),
+        }),
+      );
+
+      const { buildDoctorReport, formatDoctorMarkdown } = await freshDoctor({
+        KNOWLEDGE_BASES_ROOT_DIR: rootDir,
+        FAISS_INDEX_PATH: faissDir,
+        EMBEDDING_PROVIDER: 'huggingface',
+        HUGGINGFACE_MODEL_NAME: MODEL_NAME,
+        HUGGINGFACE_API_KEY: 'test-key',
+      });
+
+      const report = await buildDoctorReport({
+        backendHealthCheck: async () => ({ healthy: true, detail: 'backend ok' }),
+        packageRoot: tempDir,
+        invokedPath: null,
+        packageVersion: '9.9.9',
+      });
+
+      expect(report.last_index_update).toMatchObject({
+        status: 'success',
+        scope: 'global',
+        model_id: MODEL_ID,
+        duration_ms: 5000,
+        files_changed: 2,
+        files_unchanged: 2,
+      });
+      expect(formatDoctorMarkdown(report)).toContain(
+        'Last index update: success (global, 5000ms, 2 changed, 2 unchanged, 0 skipped)',
+      );
     } finally {
       await fsp.rm(tempDir, { recursive: true, force: true });
     }

--- a/src/cli-doctor.ts
+++ b/src/cli-doctor.ts
@@ -398,6 +398,7 @@ export async function buildDoctorReport(
   };
   const git = await readGitState(packageRoot);
   const lastIndexUpdate = options.lastIndexUpdateSummary
+    ?? (await FaissIndexManager.readPersistedIndexUpdateSummary(activeModelId))
     ?? createNeverRunIndexUpdateSummary(activeModelId);
 
   const status = summarizeStatus(checks);

--- a/src/kb-stats.test.ts
+++ b/src/kb-stats.test.ts
@@ -11,6 +11,7 @@ import * as path from 'path';
 interface FakeManager {
   embeddingProvider: string;
   modelName: string;
+  modelId: string;
   getStats(): {
     totalChunks: number;
     chunkCountsByKb: Record<string, number>;
@@ -22,21 +23,25 @@ interface FakeManager {
 function makeManager(opts: {
   provider?: string;
   modelName?: string;
+  modelId?: string;
   chunkCountsByKb?: Record<string, number>;
   dim?: number | null;
+  lastIndexUpdateSummary?: unknown;
 }): FakeManager {
+  const modelId = opts.modelId ?? 'huggingface__BAAI-bge-small-en-v1.5';
   return {
     embeddingProvider: opts.provider ?? 'huggingface',
     modelName: opts.modelName ?? 'BAAI/bge-small-en-v1.5',
+    modelId,
     getStats: () => ({
       totalChunks: Object.values(opts.chunkCountsByKb ?? {}).reduce((s, n) => s + n, 0),
       chunkCountsByKb: opts.chunkCountsByKb ?? {},
       dim: opts.dim ?? null,
     }),
-    getLastIndexUpdateSummary: () => ({
+    getLastIndexUpdateSummary: () => opts.lastIndexUpdateSummary ?? ({
       status: 'never_run',
       scope: null,
-      model_id: 'huggingface__BAAI-bge-small-en-v1.5',
+      model_id: modelId,
       started_at: null,
       finished_at: null,
       duration_ms: null,
@@ -52,6 +57,28 @@ function makeManager(opts: {
       failure_count: 0,
       failures: [],
     }),
+  };
+}
+
+function successfulSummary(modelId = 'huggingface__BAAI-bge-small-en-v1.5') {
+  return {
+    status: 'success',
+    scope: 'global',
+    model_id: modelId,
+    started_at: '2026-05-12T10:00:00.000Z',
+    finished_at: '2026-05-12T10:00:05.000Z',
+    duration_ms: 5000,
+    files_scanned: 3,
+    files_changed: 2,
+    files_unchanged: 1,
+    files_skipped: 0,
+    chunks_attempted: 4,
+    chunks_added: 4,
+    index_mutated: true,
+    saved: true,
+    sidecars_written: true,
+    failure_count: 0,
+    failures: [],
   };
 }
 
@@ -217,6 +244,87 @@ describe('computeKbStats', () => {
     expect(payload.knowledge_bases.alpha.last_updated_at).toBe(new Date(fixedMs).toISOString());
 
     await fsp.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('uses a persisted update summary when the fresh manager summary is never_run', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-stats-persisted-summary-'));
+    try {
+      const kbRoot = path.join(tempDir, 'kbs');
+      const faissDir = path.join(tempDir, '.faiss');
+      const modelId = 'huggingface__BAAI-bge-small-en-v1.5';
+      await fsp.mkdir(path.join(kbRoot, 'alpha'), { recursive: true });
+      await fsp.writeFile(path.join(kbRoot, 'alpha', 'a.md'), 'alpha');
+      await fsp.mkdir(path.join(faissDir, 'models', modelId), { recursive: true });
+      await fsp.writeFile(
+        path.join(faissDir, 'models', modelId, 'last-index-update.json'),
+        JSON.stringify({
+          schema_version: 'kb.last-index-update.v1',
+          summary: successfulSummary(modelId),
+        }),
+      );
+
+      const { computeKbStats } = await freshKbStats({
+        KNOWLEDGE_BASES_ROOT_DIR: kbRoot,
+        FAISS_INDEX_PATH: faissDir,
+      });
+
+      const payload = await computeKbStats(makeManager({ modelId }) as any, {
+        serverVersion: '0.0.0',
+        startedAt: Date.now(),
+      });
+
+      expect(payload.last_index_update).toMatchObject({
+        status: 'success',
+        scope: 'global',
+        model_id: modelId,
+        duration_ms: 5000,
+        files_changed: 2,
+      });
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back to the fresh manager summary when the persisted summary is missing or malformed', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-stats-persisted-summary-fallback-'));
+    try {
+      const kbRoot = path.join(tempDir, 'kbs');
+      const faissDir = path.join(tempDir, '.faiss');
+      const modelId = 'huggingface__BAAI-bge-small-en-v1.5';
+      await fsp.mkdir(path.join(kbRoot, 'alpha'), { recursive: true });
+      await fsp.writeFile(path.join(kbRoot, 'alpha', 'a.md'), 'alpha');
+
+      const { computeKbStats } = await freshKbStats({
+        KNOWLEDGE_BASES_ROOT_DIR: kbRoot,
+        FAISS_INDEX_PATH: faissDir,
+      });
+
+      const missing = await computeKbStats(makeManager({ modelId }) as any, {
+        serverVersion: '0.0.0',
+        startedAt: Date.now(),
+      });
+      expect(missing.last_index_update).toMatchObject({
+        status: 'never_run',
+        model_id: modelId,
+      });
+
+      await fsp.mkdir(path.join(faissDir, 'models', modelId), { recursive: true });
+      await fsp.writeFile(
+        path.join(faissDir, 'models', modelId, 'last-index-update.json'),
+        '{not-json',
+      );
+
+      const malformed = await computeKbStats(makeManager({ modelId }) as any, {
+        serverVersion: '0.0.0',
+        startedAt: Date.now(),
+      });
+      expect(malformed.last_index_update).toMatchObject({
+        status: 'never_run',
+        model_id: modelId,
+      });
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
   });
 
   it('returns an empty provider_calls map by default and a populated one after telemetry is recorded (issue #210)', async () => {

--- a/src/kb-stats.ts
+++ b/src/kb-stats.ts
@@ -9,7 +9,7 @@
 
 import * as fsp from 'fs/promises';
 import * as path from 'path';
-import type { FaissIndexManager, IndexUpdateSummary } from './FaissIndexManager.js';
+import { FaissIndexManager, type IndexUpdateSummary } from './FaissIndexManager.js';
 import {
   FAISS_INDEX_PATH,
   INGEST_EXCLUDE_PATHS,
@@ -140,6 +140,15 @@ export async function computeKbStats(
   }
 
   const metricsSource = options.metrics ?? providerCallMetrics;
+  const managerSummary = manager.getLastIndexUpdateSummary();
+  const readPersistedSummary = FaissIndexManager.readPersistedIndexUpdateSummary;
+  const lastIndexUpdate = managerSummary.status === 'never_run'
+    ? (
+        typeof readPersistedSummary === 'function'
+          ? await readPersistedSummary(manager.modelId)
+          : null
+      ) ?? managerSummary
+    : managerSummary;
   return {
     knowledge_bases,
     quarantined,
@@ -149,7 +158,7 @@ export async function computeKbStats(
       dim: indexStats.dim,
     },
     index_path: FAISS_INDEX_PATH,
-    last_index_update: manager.getLastIndexUpdateSummary(),
+    last_index_update: lastIndexUpdate,
     server: {
       version: options.serverVersion,
       uptime_ms: Date.now() - options.startedAt,


### PR DESCRIPTION
## Summary
- persist the latest updateIndex summary as last-index-update.json under each active model directory
- make fresh-process stats and doctor use the persisted summary when the live summary is still never_run
- document and test success, partial, failed, missing, and malformed summary behavior

Closes #315.

## Tests
- npm test -- --runTestsByPath src/FaissIndexManager.test.ts src/kb-stats.test.ts src/cli-doctor.test.ts --runInBand
- npm run build
- npm test -- --runInBand
- npm run docs:check-anchors (exits 0; reports pre-existing stale anchors outside this change)
- git diff --check