### PR TITLE
feat: emit refresh progress heartbeats

### DIFF
--- a/docs/cli-json-contracts.md
+++ b/docs/cli-json-contracts.md
@@ -89,6 +89,11 @@ Optional stable fields:
   `{"threshold": number, "knee_index": number|null, "kept": number}`.
 - `timing`: present with `--timing`; keys are elapsed millisecond counters and
   mode labels. Treat the object as diagnostic, not a compatibility contract.
+  For dense and hybrid `--refresh` runs, the same diagnostic object may include
+  refresh counters such as `refresh_embed_batches`,
+  `refresh_embed_batches_total`, `refresh_embed_chunks`,
+  `refresh_embed_chunks_total`, `refresh_embed_ms`, `refresh_save_ms`,
+  `refresh_sidecar_ms`, and `refresh_manifest_ms`.
 
 Refresh preflight:
 
@@ -98,6 +103,10 @@ Refresh preflight:
   cheap-to-stat stale bytes.
 - The preflight is always stderr text. JSON stdout remains the success envelope
   above, and agents must not expect a JSON field for the preflight.
+- Refresh progress heartbeats are also stderr text. Embedding heartbeats include
+  the current bounded batch, embedded chunk count, provider/model, elapsed time,
+  and rolling throughput when available; save, sidecar, and manifest phases
+  emit start/completion lines. These lines never appear in JSON stdout.
 - TTY and non-TTY runs continue without prompting by default; there is no
   confirmation gate or required `--yes` for `kb search --refresh`.
 - The stderr text includes changed/new file counts by KB, estimated stale bytes,

--- a/docs/requirements/INDEX.md
+++ b/docs/requirements/INDEX.md
@@ -54,6 +54,21 @@
 **Linked Tests:** TS-OBS-315
 **Dependencies:** FR-OBS-237
 
+### FR-OBS-316: Refresh Progress Heartbeats
+**Status:** Implemented
+**Priority:** High
+
+**Requirement:** The system shall emit phase-aware `kb search --refresh` progress heartbeats to stderr during dense index refresh work without writing progress text to JSON stdout.
+**Rationale:** Long refreshes spend most of their wall time embedding and saving after file discovery has already logged changes; operators need bounded-batch progress without breaking machine-readable search output.
+
+**Acceptance Criteria:**
+- [x] Given changed-file chunks exceeding the configured indexing batch size, when `updateIndex` embeds them, then progress events identify each bounded embedding batch.
+- [x] Given `kb search --refresh --format=json`, when refresh progress is emitted, then progress lines are written to stderr and the JSON success payload remains parseable on stdout.
+- [x] Given `kb search --refresh --format=json --timing`, when refresh progress is emitted, then the timing payload includes refresh embedding batch counters and phase elapsed counters.
+
+**Linked Tests:** TS-OBS-316
+**Dependencies:** NFR-INDEX-236
+
 ## Search
 
 ### FR-SUPERSEDED-232: Superseded Memory Review

--- a/docs/testing/INDEX.md
+++ b/docs/testing/INDEX.md
@@ -36,6 +36,15 @@
 - `computeKbStats` shall ignore missing or malformed persisted summaries and keep the manager summary.
 - `buildDoctorReport` shall use the persisted summary for the active model when no explicit in-process summary is supplied.
 
+### TS-OBS-316: Refresh Progress Heartbeats
+**Requirement:** FR-OBS-316
+
+**Test Cases:**
+- `FaissIndexManager.updateIndex` shall emit one `embed` progress event for each bounded embedding batch.
+- `formatRefreshProgressLine` shall format embedding batch progress as concise operator-facing stderr text.
+- `createRefreshProgressReporter` shall write progress through the stderr writer and shall not write to stdout.
+- `recordRefreshProgressTiming` shall copy refresh batch counters and completed phase elapsed times into the flat timing payload.
+
 ## Search
 
 ### TS-SUPERSEDED-232: Superseded Memory Review

--- a/src/FaissIndexManager.test.ts
+++ b/src/FaissIndexManager.test.ts
@@ -541,11 +541,52 @@ describe('FaissIndexManager permission handling', () => {
     const { FaissIndexManager } = await import('./FaissIndexManager.js');
     const manager = new FaissIndexManager();
     await manager.initialize();
-    await manager.updateIndex();
+    const progressEvents: Array<{
+      phase?: string;
+      batchIndex?: number;
+      batchCount?: number;
+      batchSize?: number;
+      processedChunks?: number;
+      totalChunks?: number;
+      provider?: string;
+      modelName?: string;
+      throughputChunksPerSecond?: number;
+    }> = [];
+    await manager.updateIndex(undefined, {
+      onProgress: (progress) => {
+        progressEvents.push(progress);
+      },
+    });
 
     expect(saveMock).toHaveBeenCalledTimes(1);
     expect(fromTextsMock).toHaveBeenCalledTimes(1);
     expect(addDocumentsMock).toHaveBeenCalledTimes(2);
+    const embedEvents = progressEvents.filter((event) => event.phase === 'embed');
+    expect(embedEvents).toEqual([
+      expect.objectContaining({
+        batchIndex: 1,
+        batchCount: 3,
+        batchSize: 2,
+        processedChunks: 2,
+        totalChunks: 5,
+        provider: 'huggingface',
+        modelName: 'BAAI/bge-small-en-v1.5',
+      }),
+      expect.objectContaining({
+        batchIndex: 2,
+        batchCount: 3,
+        batchSize: 2,
+        processedChunks: 4,
+        totalChunks: 5,
+      }),
+      expect.objectContaining({
+        batchIndex: 3,
+        batchCount: 3,
+        batchSize: 1,
+        processedChunks: 5,
+        totalChunks: 5,
+      }),
+    ]);
     expect(manager.getLastIndexUpdateSummary()).toMatchObject({
       chunks_added: 5,
       index_mutated: true,

--- a/src/FaissIndexManager.ts
+++ b/src/FaissIndexManager.ts
@@ -137,6 +137,24 @@ export interface IndexUpdateProgress {
   totalFiles: number;
   currentFile: string;
   modelId: string;
+  phase?: 'scan' | 'load' | 'embed' | 'save' | 'sidecar' | 'manifest';
+  phaseStatus?: 'started' | 'progress' | 'completed';
+  filesScanned?: number;
+  filesChanged?: number;
+  filesSkipped?: number;
+  chunksDiscovered?: number;
+  processedChunks?: number;
+  totalChunks?: number;
+  batchIndex?: number;
+  batchCount?: number;
+  batchSize?: number;
+  provider?: EmbeddingProvider;
+  modelName?: string;
+  elapsedMs?: number;
+  phaseElapsedMs?: number;
+  throughputChunksPerSecond?: number;
+  saved?: boolean;
+  sidecarsWritten?: number;
 }
 
 export interface UpdateIndexOptions {
@@ -761,13 +779,26 @@ export class FaissIndexManager {
     });
   }
 
-  private async addDocumentsToIndex(documentsToAdd: Document[]): Promise<boolean> {
+  private async addDocumentsToIndex(
+    documentsToAdd: Document[],
+    opts: {
+      onProgress?: (progress: IndexUpdateProgress) => void | Promise<void>;
+      processedFiles: () => number;
+      totalFiles: number;
+      updateStartedAtMs: number;
+    } | null = null,
+  ): Promise<boolean> {
     if (documentsToAdd.length === 0) {
       return false;
     }
 
+    const batchCount = Math.ceil(documentsToAdd.length / this.indexingBatchSize);
+    const embedStartedAtMs = Date.now();
+    let processedChunks = 0;
+    let batchIndex = 0;
     for (let offset = 0; offset < documentsToAdd.length; offset += this.indexingBatchSize) {
       const batch = documentsToAdd.slice(offset, offset + this.indexingBatchSize);
+      batchIndex += 1;
       if (this.faissIndex === null) {
         logger.info(`Creating new FAISS index from ${batch.length} text(s)...`);
         this.faissIndex = await FaissStore.fromTexts(
@@ -777,6 +808,32 @@ export class FaissIndexManager {
         );
       } else {
         await this.faissIndex.addDocuments(batch);
+      }
+      processedChunks += batch.length;
+      if (opts?.onProgress) {
+        const phaseElapsedMs = Date.now() - embedStartedAtMs;
+        const throughputChunksPerSecond = phaseElapsedMs > 0
+          ? processedChunks / (phaseElapsedMs / 1000)
+          : null;
+        const lastSource = batch[batch.length - 1]?.metadata?.source;
+        await opts.onProgress({
+          processedFiles: opts.processedFiles(),
+          totalFiles: opts.totalFiles,
+          currentFile: typeof lastSource === 'string' ? lastSource : '',
+          modelId: this.modelId,
+          phase: 'embed',
+          phaseStatus: 'progress',
+          processedChunks,
+          totalChunks: documentsToAdd.length,
+          batchIndex,
+          batchCount,
+          batchSize: batch.length,
+          provider: this.embeddingProvider,
+          modelName: this.modelName,
+          elapsedMs: Date.now() - opts.updateStartedAtMs,
+          phaseElapsedMs,
+          throughputChunksPerSecond: throughputChunksPerSecond ?? undefined,
+        });
       }
     }
     return true;
@@ -917,6 +974,64 @@ export class FaissIndexManager {
       }));
 
       const totalFiles = totalFileCount(knowledgeBaseFiles);
+      const emitProgress = async (
+        progress: Omit<IndexUpdateProgress, 'modelId' | 'provider' | 'modelName' | 'elapsedMs'>,
+      ): Promise<void> => {
+        if (!opts.onProgress) return;
+        await opts.onProgress({
+          ...progress,
+          modelId: this.modelId,
+          provider: this.embeddingProvider,
+          modelName: this.modelName,
+          elapsedMs: Date.now() - startedAtMs,
+        });
+      };
+      let scannedFilesForProgress = 0;
+      let lastScanProgressFileCount = 0;
+      const reportScanProgress = async (currentFile: string): Promise<void> => {
+        if (!opts.onProgress || scannedFilesForProgress === lastScanProgressFileCount) {
+          return;
+        }
+        if (
+          scannedFilesForProgress % progressIntervalFiles !== 0 &&
+          scannedFilesForProgress !== totalFiles
+        ) {
+          return;
+        }
+        lastScanProgressFileCount = scannedFilesForProgress;
+        await emitProgress({
+          processedFiles,
+          totalFiles,
+          currentFile,
+          phase: 'scan',
+          phaseStatus: 'progress',
+          filesScanned: scannedFilesForProgress,
+        });
+      };
+      let lastLoadProgressFileCount = 0;
+      const reportLoadProgress = async (currentFile: string): Promise<void> => {
+        if (!opts.onProgress || runSummary.files_scanned === lastLoadProgressFileCount) {
+          return;
+        }
+        if (
+          runSummary.files_scanned % progressIntervalFiles !== 0 &&
+          runSummary.files_scanned !== totalFiles
+        ) {
+          return;
+        }
+        lastLoadProgressFileCount = runSummary.files_scanned;
+        await emitProgress({
+          processedFiles,
+          totalFiles,
+          currentFile,
+          phase: 'load',
+          phaseStatus: 'progress',
+          filesScanned: runSummary.files_scanned,
+          filesChanged: runSummary.files_changed,
+          filesSkipped: runSummary.files_skipped,
+          chunksDiscovered: runSummary.chunks_attempted,
+        });
+      };
       const reportProgress = async (currentFile: string): Promise<void> => {
         if (!opts.onProgress || processedFiles === lastProgressFileCount) {
           return;
@@ -933,6 +1048,9 @@ export class FaissIndexManager {
           totalFiles,
           currentFile,
           modelId: this.modelId,
+          provider: this.embeddingProvider,
+          modelName: this.modelName,
+          elapsedMs: Date.now() - startedAtMs,
         });
       };
 
@@ -981,6 +1099,9 @@ export class FaissIndexManager {
             return { ...job, success: true as const, fileHash, storedHash };
           } catch (error: unknown) {
             return { ...job, success: false as const, error };
+          } finally {
+            scannedFilesForProgress += 1;
+            await reportScanProgress(job.filePath);
           }
         },
       );
@@ -999,6 +1120,7 @@ export class FaissIndexManager {
             null,
             scan.error,
           );
+          await reportLoadProgress(scan.filePath);
           continue;
         }
 
@@ -1013,6 +1135,7 @@ export class FaissIndexManager {
             `Skipping quarantined file ${scan.filePath} ` +
               `(${retryDecision.reason}; next_retry_at=${retryDecision.record?.next_retry_at ?? '<unknown>'})`,
           );
+          await reportLoadProgress(scan.filePath);
           continue;
         }
 
@@ -1047,6 +1170,7 @@ export class FaissIndexManager {
               scan.fileHash,
               error,
             );
+            await reportLoadProgress(scan.filePath);
             continue;
           }
 
@@ -1068,6 +1192,7 @@ export class FaissIndexManager {
               scan.fileHash,
               error,
             );
+            await reportLoadProgress(scan.filePath);
             continue;
           }
           runSummary.chunks_attempted += documentsToAdd.length;
@@ -1089,11 +1214,17 @@ export class FaissIndexManager {
           runSummary.files_unchanged += 1;
           logger.debug(`File ${scan.filePath} unchanged, skipping.`);
         }
+        await reportLoadProgress(scan.filePath);
       }
       const documentsToAdd = changedFileDocuments.flatMap((entry) => entry.documents);
       let addedChangedDocuments = false;
       try {
-        addedChangedDocuments = await this.addDocumentsToIndex(documentsToAdd);
+        addedChangedDocuments = await this.addDocumentsToIndex(documentsToAdd, {
+          onProgress: opts.onProgress,
+          processedFiles: () => processedFiles,
+          totalFiles,
+          updateStartedAtMs: startedAtMs,
+        });
       } catch (error: unknown) {
         for (const entry of changedFileDocuments) {
           recordFailure(entry.relativePath, 'indexing', error);
@@ -1204,6 +1335,12 @@ export class FaissIndexManager {
         try {
           addedFallbackDocuments = await this.addDocumentsToIndex(
             fallbackDocuments.flatMap((entry) => entry.documents),
+            {
+              onProgress: opts.onProgress,
+              processedFiles: () => processedFiles,
+              totalFiles,
+              updateStartedAtMs: startedAtMs,
+            },
           );
         } catch (error: unknown) {
           for (const entry of fallbackDocuments) {
@@ -1242,8 +1379,25 @@ export class FaissIndexManager {
         // updated; first save under v014 effectively migrates the model to
         // versioned layout.
         try {
+          const saveStartedAtMs = Date.now();
+          await emitProgress({
+            processedFiles,
+            totalFiles,
+            currentFile: '',
+            phase: 'save',
+            phaseStatus: 'started',
+          });
           await this.atomicSave();
           runSummary.saved = true;
+          await emitProgress({
+            processedFiles,
+            totalFiles,
+            currentFile: '',
+            phase: 'save',
+            phaseStatus: 'completed',
+            phaseElapsedMs: Date.now() - saveStartedAtMs,
+            saved: true,
+          });
         } catch (saveError: unknown) {
           recordFailure(null, 'save', saveError);
           handleFsOperationError(
@@ -1262,8 +1416,26 @@ export class FaissIndexManager {
         // duplicating their vectors until RFC 007 PR 2.1 lands the
         // pending-manifest protocol.
         try {
+          const sidecarStartedAtMs = Date.now();
+          await emitProgress({
+            processedFiles,
+            totalFiles,
+            currentFile: '',
+            phase: 'sidecar',
+            phaseStatus: 'started',
+            sidecarsWritten: pendingHashWrites.length,
+          });
           await writeSidecarHashes(pendingHashWrites);
           runSummary.sidecars_written = pendingHashWrites.length > 0;
+          await emitProgress({
+            processedFiles,
+            totalFiles,
+            currentFile: '',
+            phase: 'sidecar',
+            phaseStatus: 'completed',
+            phaseElapsedMs: Date.now() - sidecarStartedAtMs,
+            sidecarsWritten: pendingHashWrites.length,
+          });
           for (const entry of successfulIndexedFiles) {
             await recordQuarantineSuccess(entry.knowledgeBasePath, entry.relativePath);
           }
@@ -1273,6 +1445,7 @@ export class FaissIndexManager {
         }
       }
       try {
+        const manifestStartedAtMs = Date.now();
         const activeIndexFilePath = await this.resolveActiveIndexFilePath();
         if (activeIndexFilePath !== null) {
           const indexStat = await fsp.stat(activeIndexFilePath);
@@ -1282,6 +1455,14 @@ export class FaissIndexManager {
             indexMtimeMs: indexStat.mtimeMs,
           });
         }
+        await emitProgress({
+          processedFiles,
+          totalFiles,
+          currentFile: '',
+          phase: 'manifest',
+          phaseStatus: 'completed',
+          phaseElapsedMs: Date.now() - manifestStartedAtMs,
+        });
       } catch (manifestError: unknown) {
         logger.warn(
           `Could not write freshness manifest for ${this.modelId}: ${toError(manifestError).message}`,

--- a/src/cli-search.test.ts
+++ b/src/cli-search.test.ts
@@ -1,15 +1,18 @@
-import { describe, expect, it } from '@jest/globals';
+import { describe, expect, it, jest } from '@jest/globals';
 import {
   AutoThresholdDecision,
   computeAutoThreshold,
+  createRefreshProgressReporter,
   formatAutoModeHeader,
   formatAutoThresholdHeader,
   formatFreshnessFooter,
+  formatRefreshProgressLine,
   parseSearchArgs,
   resolveAutoSearchMode,
   shouldUsePicker,
   Staleness,
 } from './cli-search.js';
+import { compactTimingPayload, type TimingPayload } from './cli-timing.js';
 import {
   classifyKbSearchError,
   formatKbSearchFailureJson,
@@ -134,6 +137,79 @@ describe('lock contention output (issue #181 + #199 unified shape)', () => {
     expect(out).toContain('category: lock');
     expect(out).toContain('Retry in a few seconds');
     expect(out).toContain('/tmp/model/.kb-write.lock');
+  });
+});
+
+describe('refresh progress output (#316)', () => {
+  it('formats bounded embedding batches as concise stderr progress lines', () => {
+    expect(formatRefreshProgressLine({
+      processedFiles: 0,
+      totalFiles: 5,
+      currentFile: '/kb/default/doc-1.md',
+      modelId: 'huggingface__BAAI-bge-small-en-v1.5',
+      phase: 'embed',
+      phaseStatus: 'progress',
+      batchIndex: 2,
+      batchCount: 3,
+      processedChunks: 4,
+      totalChunks: 5,
+      throughputChunksPerSecond: 12.4,
+      provider: 'huggingface',
+      modelName: 'BAAI/bge-small-en-v1.5',
+      elapsedMs: 1250,
+    })).toBe(
+      'kb search refresh: embed batch 2/3, 4/5 chunks, 12 chunks/s, ' +
+      'model=huggingface/BAAI/bge-small-en-v1.5, elapsed=1.3s',
+    );
+  });
+
+  it('writes refresh progress to stderr while preserving JSON stdout', () => {
+    const timing: TimingPayload = {};
+    const stderr: string[] = [];
+    const stdoutSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    try {
+      const reporter = createRefreshProgressReporter(timing, (line) => {
+        stderr.push(line);
+      });
+      reporter({
+        processedFiles: 0,
+        totalFiles: 5,
+        currentFile: '/kb/default/doc-0.md',
+        modelId: 'huggingface__BAAI-bge-small-en-v1.5',
+        phase: 'embed',
+        phaseStatus: 'progress',
+        batchIndex: 1,
+        batchCount: 3,
+        batchSize: 2,
+        processedChunks: 2,
+        totalChunks: 5,
+        phaseElapsedMs: 500,
+        elapsedMs: 500,
+      });
+
+      expect(stderr).toEqual([
+        'kb search refresh: embed batch 1/3, 2/5 chunks, elapsed=500ms\n',
+      ]);
+      expect(stdoutSpy).not.toHaveBeenCalled();
+      const stdoutPayload = JSON.stringify({
+        results: [],
+        timing: compactTimingPayload(timing),
+      });
+      expect(JSON.parse(stdoutPayload)).toEqual({
+        results: [],
+        timing: {
+          refresh_embed_chunks: 2,
+          refresh_embed_chunks_total: 5,
+          refresh_embed_batches: 1,
+          refresh_embed_batches_total: 3,
+          refresh_embed_batch_size: 2,
+          refresh_embed_ms: 500,
+        },
+      });
+    } finally {
+      stdoutSpy.mockRestore();
+    }
   });
 });
 

--- a/src/cli-search.ts
+++ b/src/cli-search.ts
@@ -2,6 +2,7 @@ import * as fsp from 'fs/promises';
 import * as path from 'path';
 import {
   FaissIndexManager,
+  type IndexUpdateProgress,
   MAX_NEIGHBOR_CONTEXT_WINDOW,
   type NeighborContextOptions,
   type SimilaritySearchTiming,
@@ -41,6 +42,7 @@ import {
   elapsedMs,
   formatTimingFooter,
   nowMs,
+  recordRefreshProgressTiming,
   type TimingPayload,
 } from './cli-timing.js';
 import { LexicalIndex, type LexicalSearchResult } from './lexical-index.js';
@@ -247,7 +249,9 @@ export async function runSearch(rest: string[]): Promise<number> {
       await withWriteLock(manager.modelDir, async () => {
         await printRefreshPreflightIfLarge(activeModelId, manager, parsed.kb, parsed.format);
         await manager.initialize();
-        await manager.updateIndex(parsed.kb);
+        await manager.updateIndex(parsed.kb, {
+          onProgress: createRefreshProgressReporter(timing),
+        });
       });
     } else {
       await loadWithJsonRetry(manager);
@@ -512,6 +516,79 @@ export function resolveAutoSearchMode(query: string): AutoSearchModeDecision {
 
 export function formatAutoModeHeader(decision: AutoSearchModeDecision): string {
   return `> _Mode: auto -> ${decision.mode} (${decision.reason})._`;
+}
+
+export function createRefreshProgressReporter(
+  timing: TimingPayload | null,
+  writeStderr: (line: string) => void = (line) => process.stderr.write(line),
+): (progress: IndexUpdateProgress) => void {
+  return (progress) => {
+    if (timing) recordRefreshProgressTiming(timing, progress);
+    const line = formatRefreshProgressLine(progress);
+    if (line !== null) writeStderr(`${line}\n`);
+  };
+}
+
+export function formatRefreshProgressLine(progress: IndexUpdateProgress): string | null {
+  const elapsed = formatElapsed(progress.elapsedMs);
+  if (progress.phase === 'embed') {
+    const batch = progress.batchIndex !== undefined && progress.batchCount !== undefined
+      ? ` batch ${progress.batchIndex}/${progress.batchCount}`
+      : '';
+    const chunks = progress.processedChunks !== undefined && progress.totalChunks !== undefined
+      ? `, ${progress.processedChunks}/${progress.totalChunks} chunks`
+      : '';
+    const rate = progress.throughputChunksPerSecond !== undefined
+      ? `, ${formatRate(progress.throughputChunksPerSecond)} chunks/s`
+      : '';
+    return `kb search refresh: embed${batch}${chunks}${rate}${formatModel(progress)}${elapsed}`;
+  }
+  if (progress.phase === 'save') {
+    const status = progress.phaseStatus === 'completed' ? 'completed' : 'started';
+    return `kb search refresh: save ${status}${elapsed}`;
+  }
+  if (progress.phase === 'sidecar') {
+    const status = progress.phaseStatus === 'completed' ? 'completed' : 'started';
+    const count = progress.sidecarsWritten !== undefined
+      ? ` (${progress.sidecarsWritten} hash sidecar${progress.sidecarsWritten === 1 ? '' : 's'})`
+      : '';
+    return `kb search refresh: sidecar ${status}${count}${elapsed}`;
+  }
+  if (progress.phase === 'manifest') {
+    return `kb search refresh: manifest ${progress.phaseStatus ?? 'progress'}${elapsed}`;
+  }
+  if (progress.phase === 'scan') {
+    const files = progress.filesScanned !== undefined
+      ? `${progress.filesScanned}/${progress.totalFiles} files`
+      : `${progress.processedFiles}/${progress.totalFiles} files`;
+    return `kb search refresh: scan ${files}${elapsed}`;
+  }
+  if (progress.phase === 'load') {
+    const files = progress.filesScanned !== undefined
+      ? `${progress.filesScanned}/${progress.totalFiles} files`
+      : `${progress.processedFiles}/${progress.totalFiles} files`;
+    const chunks = progress.chunksDiscovered !== undefined
+      ? `, ${progress.chunksDiscovered} chunks discovered`
+      : '';
+    return `kb search refresh: load ${files}${chunks}${elapsed}`;
+  }
+  return null;
+}
+
+function formatModel(progress: IndexUpdateProgress): string {
+  if (!progress.provider || !progress.modelName) return '';
+  return `, model=${progress.provider}/${progress.modelName}`;
+}
+
+function formatElapsed(ms: number | undefined): string {
+  if (ms === undefined) return '';
+  if (ms < 1000) return `, elapsed=${Math.round(ms)}ms`;
+  return `, elapsed=${(ms / 1000).toFixed(1)}s`;
+}
+
+function formatRate(value: number): string {
+  if (value >= 10) return value.toFixed(0);
+  return value.toFixed(1);
 }
 
 function mergeDenseTiming(target: TimingPayload, source: SimilaritySearchTiming): void {
@@ -1046,7 +1123,9 @@ async function runHybridSearch(
       await withWriteLock(manager.modelDir, async () => {
         await printRefreshPreflightIfLarge(activeModelId, manager, parsed.kb, parsed.format);
         await manager.initialize();
-        await manager.updateIndex(parsed.kb);
+        await manager.updateIndex(parsed.kb, {
+          onProgress: createRefreshProgressReporter(timing),
+        });
       });
     } else {
       await loadWithJsonRetry(manager);

--- a/src/cli-timing.test.ts
+++ b/src/cli-timing.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from '@jest/globals';
-import { compactTimingPayload, formatTimingFooter } from './cli-timing.js';
+import {
+  compactTimingPayload,
+  formatTimingFooter,
+  recordRefreshProgressTiming,
+} from './cli-timing.js';
 
 describe('compactTimingPayload', () => {
   it('drops undefined values and rounds numeric measurements', () => {
@@ -12,6 +16,39 @@ describe('compactTimingPayload', () => {
       total_ms: 13,
       fetch_k: 4,
       llm_first_token_ms: null,
+    });
+  });
+});
+
+describe('recordRefreshProgressTiming', () => {
+  it('records refresh phase counters as flat timing fields', () => {
+    const timing = {};
+    recordRefreshProgressTiming(timing, {
+      phase: 'embed',
+      phaseStatus: 'progress',
+      batchIndex: 3,
+      batchCount: 4,
+      batchSize: 8,
+      processedChunks: 24,
+      totalChunks: 31,
+      phaseElapsedMs: 1250,
+    });
+    recordRefreshProgressTiming(timing, {
+      phase: 'save',
+      phaseStatus: 'completed',
+      phaseElapsedMs: 80,
+      saved: true,
+    });
+
+    expect(compactTimingPayload(timing)).toEqual({
+      refresh_embed_chunks: 24,
+      refresh_embed_chunks_total: 31,
+      refresh_embed_batches: 3,
+      refresh_embed_batches_total: 4,
+      refresh_embed_batch_size: 8,
+      refresh_embed_ms: 1250,
+      refresh_save_ms: 80,
+      refresh_saved: true,
     });
   });
 });

--- a/src/cli-timing.ts
+++ b/src/cli-timing.ts
@@ -1,6 +1,24 @@
 export type TimingValue = number | string | boolean | null;
 
 export type TimingPayload = Record<string, TimingValue | undefined>;
+export type RefreshTimingPhase = 'embed' | 'save' | 'sidecar' | 'manifest';
+
+export interface RefreshProgressTimingInput {
+  phase?: string;
+  phaseStatus?: string;
+  phaseElapsedMs?: number;
+  processedChunks?: number;
+  totalChunks?: number;
+  batchIndex?: number;
+  batchCount?: number;
+  batchSize?: number;
+  filesScanned?: number;
+  filesChanged?: number;
+  filesSkipped?: number;
+  chunksDiscovered?: number;
+  saved?: boolean;
+  sidecarsWritten?: number;
+}
 
 export function nowMs(): number {
   return Date.now();
@@ -30,6 +48,56 @@ export function formatTimingFooter(label: string, timing: TimingPayload): string
   const modeText = formatModeText(timing);
   const body = entries.length > 0 ? entries.join(', ') : 'no timing data';
   return `> _${label}${modeText}: ${body}._`;
+}
+
+export function recordRefreshProgressTiming(
+  timing: TimingPayload,
+  progress: RefreshProgressTimingInput,
+): void {
+  if (progress.filesScanned !== undefined) timing.refresh_files_scanned = progress.filesScanned;
+  if (progress.filesChanged !== undefined) timing.refresh_files_changed = progress.filesChanged;
+  if (progress.filesSkipped !== undefined) timing.refresh_files_skipped = progress.filesSkipped;
+  if (progress.chunksDiscovered !== undefined) {
+    timing.refresh_chunks_discovered = progress.chunksDiscovered;
+  }
+
+  if (progress.phase === 'embed') {
+    if (progress.processedChunks !== undefined) {
+      timing.refresh_embed_chunks = progress.processedChunks;
+    }
+    if (progress.totalChunks !== undefined) {
+      timing.refresh_embed_chunks_total = progress.totalChunks;
+    }
+    if (progress.batchIndex !== undefined) {
+      timing.refresh_embed_batches = progress.batchIndex;
+    }
+    if (progress.batchCount !== undefined) {
+      timing.refresh_embed_batches_total = progress.batchCount;
+    }
+    if (progress.batchSize !== undefined) {
+      timing.refresh_embed_batch_size = progress.batchSize;
+    }
+    if (progress.phaseElapsedMs !== undefined) {
+      timing.refresh_embed_ms = progress.phaseElapsedMs;
+    }
+  }
+
+  if (
+    progress.phaseStatus === 'completed' &&
+    progress.phaseElapsedMs !== undefined &&
+    isRefreshTimingPhase(progress.phase)
+  ) {
+    timing[`refresh_${progress.phase}_ms`] = progress.phaseElapsedMs;
+  }
+
+  if (progress.saved !== undefined) timing.refresh_saved = progress.saved;
+  if (progress.sidecarsWritten !== undefined) {
+    timing.refresh_sidecars_written = progress.sidecarsWritten;
+  }
+}
+
+function isRefreshTimingPhase(phase: string | undefined): phase is RefreshTimingPhase {
+  return phase === 'embed' || phase === 'save' || phase === 'sidecar' || phase === 'manifest';
 }
 
 function formatModeText(timing: TimingPayload): string {


### PR DESCRIPTION
## Summary
- add phase-aware refresh progress events for scan/load/embed/save/sidecar/manifest work
- emit concise `kb search --refresh` progress lines to stderr without writing progress text to JSON stdout
- record refresh embedding and phase timing counters in `--format=json --timing`
- document the JSON timing/stderr contract and link focused requirements/testing entries

Closes #316

## Verification
- `npm test -- --runTestsByPath src/FaissIndexManager.test.ts src/cli-search.test.ts src/cli-timing.test.ts`
- `npm run build`
- `npm test`
- `git diff --check`
- manual changed-line portability scan for `/home/<user>`, `/Users/<user>`, and `C:\\Users\\` patterns

## Pre-PR Gate
- detected project type: npm
- type/build checks: passed (`npm run build`)
- tests: passed (focused tests and full `npm test`)
- bug reproduction: verified by focused tests for bounded embedding progress and stderr/stdout separation
- diff review: done
- portability check: clean (manual scan; repo helper absent)
- reviewer specialists: skipped because this Codex session disallows spawning subagents unless explicitly requested
- OSS base-branch policy: skipped (same-repo PR)
- gate file: created