### PR TITLE
feat: dedupe chunk embeddings during indexing

### DIFF
--- a/docs/requirements/INDEX.md
+++ b/docs/requirements/INDEX.md
@@ -21,6 +21,21 @@
 **Linked Tests:** TS-INDEX-236
 **Dependencies:** RFC007
 
+### NFR-INDEX-281: Duplicate Chunk Embedding Compaction
+**Status:** Implemented
+**Priority:** High
+
+**Requirement:** The system shall embed each unique normalized changed-file chunk text at most once per `updateIndex` operation while preserving one FAISS/docstore entry for every source chunk.
+**Rationale:** Knowledge bases often contain repeated boilerplate, mirrored notes, or duplicated generated sections. Exact normalized-text compaction reduces provider embedding work without changing citation or retrieval metadata.
+
+**Acceptance Criteria:**
+- [x] Given changed chunks with identical normalized text across files or knowledge bases, when `updateIndex` embeds them in one operation, then the embedding provider receives that normalized text once.
+- [x] Given duplicate chunk text is compacted for provider calls, then the FAISS insertion path still receives every source chunk and its source-specific metadata.
+- [x] Given a query embedding is requested, then document-indexing compaction shall not alter query embedding behavior.
+
+**Linked Tests:** TS-INDEX-281
+**Dependencies:** NFR-INDEX-236
+
 ## Observability
 
 ### FR-OBS-237: Last Index Update Summary

--- a/docs/testing/INDEX.md
+++ b/docs/testing/INDEX.md
@@ -14,6 +14,13 @@
 - `FaissIndexManager.updateIndex` shall keep the one-save-at-end invariant and write sidecar hashes only after a successful save.
 - `FaissIndexManager` shall resolve unset batch defaults from an explicitly configured manager provider.
 
+### TS-INDEX-281: Duplicate Chunk Embedding Compaction
+**Requirement:** NFR-INDEX-281
+
+**Test Cases:**
+- `normalizeChunkTextForEmbedding` shall collapse insignificant Unicode and whitespace differences before indexing dedupe.
+- `FaissIndexManager.updateIndex` shall call the embedding provider with unique normalized changed-file chunk text while preserving every duplicate source metadata entry in the FAISS insertion path.
+
 ## Observability
 
 ### TS-OBS-237: Last Index Update Summary

--- a/src/FaissIndexManager.test.ts
+++ b/src/FaissIndexManager.test.ts
@@ -28,12 +28,26 @@ const addDocumentsMock = jest.fn();
 const fromTextsMock = jest.fn();
 const loadMock = jest.fn();
 const similaritySearchMock = jest.fn();
+const embedDocumentsMock = jest.fn(async (texts: string[]) => texts.map(mockVectorForText));
+const embedQueryMock = jest.fn(async (text: string) => mockVectorForText(text));
 const embeddingConstructorMock = jest.fn();
 const ollamaEmbeddingConstructorMock = jest.fn();
 const openAIEmbeddingConstructorMock = jest.fn();
 
+function mockVectorForText(text: string): number[] {
+  let hash = 0;
+  for (let i = 0; i < text.length; i += 1) {
+    hash = Math.imul(hash ^ text.charCodeAt(i), 16777619);
+  }
+  return [text.length, hash >>> 0];
+}
+
 class MockFaissStore {
+  constructor(public embeddings: { embedDocuments: (texts: string[]) => Promise<number[][]> }) {}
+
   async addDocuments(...args: unknown[]) {
+    const [documents] = args as [Array<{ pageContent: string }>];
+    await this.embeddings.embedDocuments(documents.map((doc) => doc.pageContent));
     return addDocumentsMock(...args);
   }
 
@@ -47,12 +61,22 @@ class MockFaissStore {
 
   static async fromTexts(...args: unknown[]) {
     fromTextsMock(...args);
-    return new MockFaissStore();
+    const [texts, , embeddings] = args as [
+      string[],
+      unknown,
+      { embedDocuments: (texts: string[]) => Promise<number[][]> },
+    ];
+    await embeddings.embedDocuments(texts);
+    return new MockFaissStore(embeddings);
   }
 
   static async load(...args: unknown[]) {
     loadMock(...args);
-    return new MockFaissStore();
+    const [, embeddings] = args as [
+      unknown,
+      { embedDocuments: (texts: string[]) => Promise<number[][]> },
+    ];
+    return new MockFaissStore(embeddings);
   }
 }
 
@@ -62,6 +86,8 @@ jest.mock('@langchain/community/embeddings/hf', () => ({
     constructor(public _config: unknown) {
       embeddingConstructorMock(_config);
     }
+    embedDocuments = embedDocumentsMock;
+    embedQuery = embedQueryMock;
   },
 }));
 
@@ -71,6 +97,8 @@ jest.mock('@langchain/ollama', () => ({
     constructor(public _config: unknown) {
       ollamaEmbeddingConstructorMock(_config);
     }
+    embedDocuments = embedDocumentsMock;
+    embedQuery = embedQueryMock;
   },
 }));
 
@@ -80,6 +108,8 @@ jest.mock('@langchain/openai', () => ({
     constructor(public _config: unknown) {
       openAIEmbeddingConstructorMock(_config);
     }
+    embedDocuments = embedDocumentsMock;
+    embedQuery = embedQueryMock;
   },
 }));
 
@@ -614,6 +644,108 @@ describe('FaissIndexManager permission handling', () => {
       const sidecarPath = path.join(defaultKb, '.index', path.basename(docPath));
       await expect(fsp.readFile(sidecarPath, 'utf-8')).resolves.toMatch(/^[0-9a-f]{64}$/);
     }
+  });
+
+  it('embeds duplicate normalized chunk text once per indexing operation while preserving every source', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-faiss-dedupe-embeddings-'));
+    const kbDir = path.join(tempDir, 'kb');
+    const alphaKb = path.join(kbDir, 'alpha');
+    const betaKb = path.join(kbDir, 'beta');
+    await fsp.mkdir(alphaKb, { recursive: true });
+    await fsp.mkdir(betaKb, { recursive: true });
+
+    const alphaDuplicate = path.join(alphaKb, 'shared-a.md');
+    const alphaUnique = path.join(alphaKb, 'unique.md');
+    const betaDuplicate = path.join(betaKb, 'shared-b.md');
+    await fsp.writeFile(alphaDuplicate, '# Shared\n\nRepeated boilerplate chunk.');
+    await fsp.writeFile(alphaUnique, '# Unique\n\nOnly this source has this chunk.');
+    await fsp.writeFile(betaDuplicate, '# Shared\n\nRepeated boilerplate chunk.');
+
+    process.env.KNOWLEDGE_BASES_ROOT_DIR = kbDir;
+    process.env.FAISS_INDEX_PATH = path.join(tempDir, '.faiss');
+    process.env.EMBEDDING_PROVIDER = 'huggingface';
+    process.env.HUGGINGFACE_API_KEY = 'test-key';
+    process.env.INDEXING_BATCH_SIZE = '2';
+
+    jest.resetModules();
+    const { FaissIndexManager } = await import('./FaissIndexManager.js');
+    const { normalizeChunkTextForEmbedding } = await import('./file-ingest.js');
+    const manager = new FaissIndexManager();
+    await manager.initialize();
+    embedDocumentsMock.mockClear();
+
+    await manager.updateIndex();
+
+    const [seedTexts, seedMetadatas] = fromTextsMock.mock.calls[0] as [
+      string[],
+      Array<{ source: string }>,
+    ];
+    const appendedDocs = addDocumentsMock.mock.calls.flatMap((call) => {
+      const [docs] = call as [Array<{ pageContent: string; metadata: { source: string } }>];
+      return docs;
+    });
+    const indexedTexts = [
+      ...seedTexts,
+      ...appendedDocs.map((doc) => doc.pageContent),
+    ];
+    const indexedSources = [
+      ...seedMetadatas.map((metadata) => metadata.source),
+      ...appendedDocs.map((doc) => doc.metadata.source),
+    ];
+
+    expect(indexedSources.sort()).toEqual([
+      alphaDuplicate,
+      alphaUnique,
+      betaDuplicate,
+    ].sort());
+    expect(indexedTexts).toHaveLength(3);
+
+    const providerTexts = embedDocumentsMock.mock.calls.flatMap((call) => {
+      const [texts] = call as [string[]];
+      return texts;
+    });
+    expect(providerTexts).toEqual([...new Set(indexedTexts.map(normalizeChunkTextForEmbedding))]);
+    expect(providerTexts).toHaveLength(2);
+    expect(providerTexts).toContain(normalizeChunkTextForEmbedding(seedTexts[0]));
+    expect(manager.getLastIndexUpdateSummary()).toMatchObject({
+      chunks_added: 3,
+      index_mutated: true,
+      saved: true,
+    });
+  });
+
+  it('propagates an indexing error when the provider returns the wrong vector count', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-faiss-dedupe-vector-count-'));
+    const kbDir = path.join(tempDir, 'kb');
+    const defaultKb = path.join(kbDir, 'default');
+    await fsp.mkdir(defaultKb, { recursive: true });
+    await fsp.writeFile(path.join(defaultKb, 'doc.md'), '# Doc\n\nContent that needs one embedding.');
+
+    process.env.KNOWLEDGE_BASES_ROOT_DIR = kbDir;
+    process.env.FAISS_INDEX_PATH = path.join(tempDir, '.faiss');
+    process.env.EMBEDDING_PROVIDER = 'huggingface';
+    process.env.HUGGINGFACE_API_KEY = 'test-key';
+
+    jest.resetModules();
+    const { FaissIndexManager } = await import('./FaissIndexManager.js');
+    const manager = new FaissIndexManager();
+    await manager.initialize();
+    embedDocumentsMock.mockResolvedValueOnce([]);
+
+    await expect(manager.updateIndex()).rejects.toThrow(
+      'Embedding provider returned 0 vector(s) for 1 document(s)',
+    );
+    expect(manager.getLastIndexUpdateSummary()).toMatchObject({
+      status: 'failed',
+      files_changed: 1,
+      failure_count: 1,
+      failures: [
+        expect.objectContaining({
+          phase: 'indexing',
+          message: 'Embedding provider returned 0 vector(s) for 1 document(s)',
+        }),
+      ],
+    });
   });
 
   it('resolves default batch size from an explicit manager provider', async () => {

--- a/src/FaissIndexManager.ts
+++ b/src/FaissIndexManager.ts
@@ -2,11 +2,16 @@
 import * as fsp from 'fs/promises';
 import * as path from 'path';
 import { FaissStore } from "@langchain/community/vectorstores/faiss";
+import type { EmbeddingsInterface } from '@langchain/core/embeddings';
 import { Document } from "@langchain/core/documents";
 import { createEmbeddingsClient, type EmbeddingsClient } from './embedding-provider.js';
 import { handleFsOperationError, toError } from './error-utils.js';
 import { calculateSHA256, pathExists } from './file-utils.js';
-import { buildChunkDocuments, writeSidecarHashes } from './file-ingest.js';
+import {
+  buildChunkDocuments,
+  normalizeChunkTextForEmbedding,
+  writeSidecarHashes,
+} from './file-ingest.js';
 import { loadFile } from './loaders.js';
 import {
   KNOWLEDGE_BASES_ROOT_DIR,
@@ -119,6 +124,52 @@ export function progressiveFetchSizes(k: number, ntotal: number): number[] {
   }
   sizes.push(ntotal);
   return sizes;
+}
+
+class IndexingEmbeddingDeduper implements EmbeddingsInterface {
+  private readonly vectorsByNormalizedText = new Map<string, number[]>();
+
+  constructor(private readonly delegate: EmbeddingsInterface) {}
+
+  async embedDocuments(texts: string[]): Promise<number[][]> {
+    const normalizedTexts = texts.map(normalizeChunkTextForEmbedding);
+    const missingTexts: string[] = [];
+    const missingSet = new Set<string>();
+
+    for (const normalizedText of normalizedTexts) {
+      if (
+        !this.vectorsByNormalizedText.has(normalizedText) &&
+        !missingSet.has(normalizedText)
+      ) {
+        missingSet.add(normalizedText);
+        missingTexts.push(normalizedText);
+      }
+    }
+
+    if (missingTexts.length > 0) {
+      const vectors = await this.delegate.embedDocuments(missingTexts);
+      if (vectors.length !== missingTexts.length) {
+        throw new Error(
+          `Embedding provider returned ${vectors.length} vector(s) for ${missingTexts.length} document(s)`,
+        );
+      }
+      for (let i = 0; i < missingTexts.length; i += 1) {
+        this.vectorsByNormalizedText.set(missingTexts[i], vectors[i]);
+      }
+    }
+
+    return normalizedTexts.map((normalizedText) => {
+      const vector = this.vectorsByNormalizedText.get(normalizedText);
+      if (vector === undefined) {
+        throw new Error('Missing cached vector for normalized chunk text');
+      }
+      return vector;
+    });
+  }
+
+  async embedQuery(text: string): Promise<number[]> {
+    return this.delegate.embedQuery(text);
+  }
 }
 
 function totalFileCount(
@@ -796,6 +847,9 @@ export class FaissIndexManager {
     const embedStartedAtMs = Date.now();
     let processedChunks = 0;
     let batchIndex = 0;
+    // Scope duplicate-compaction to this indexing operation. FAISS still
+    // receives every document; only provider embedDocuments calls are deduped.
+    const indexingEmbeddings = new IndexingEmbeddingDeduper(this.embeddings);
     for (let offset = 0; offset < documentsToAdd.length; offset += this.indexingBatchSize) {
       const batch = documentsToAdd.slice(offset, offset + this.indexingBatchSize);
       batchIndex += 1;
@@ -804,10 +858,19 @@ export class FaissIndexManager {
         this.faissIndex = await FaissStore.fromTexts(
           batch.map((doc) => doc.pageContent),
           batch.map((doc) => doc.metadata),
-          this.embeddings
+          indexingEmbeddings,
         );
+        // The store must keep the real client for query embeddings and later
+        // operations; the deduper is only an insertion-time wrapper.
+        this.faissIndex.embeddings = this.embeddings;
       } else {
-        await this.faissIndex.addDocuments(batch);
+        const previousEmbeddings = this.faissIndex.embeddings;
+        this.faissIndex.embeddings = indexingEmbeddings;
+        try {
+          await this.faissIndex.addDocuments(batch);
+        } finally {
+          this.faissIndex.embeddings = previousEmbeddings;
+        }
       }
       processedChunks += batch.length;
       if (opts?.onProgress) {

--- a/src/file-ingest.test.ts
+++ b/src/file-ingest.test.ts
@@ -1,0 +1,7 @@
+import { normalizeChunkTextForEmbedding } from './file-ingest.js';
+
+describe('normalizeChunkTextForEmbedding', () => {
+  it('collapses insignificant text differences before indexing dedupe', () => {
+    expect(normalizeChunkTextForEmbedding('  Cafe\u0301\t\nrunbook   section  ')).toBe('Caf\u00e9 runbook section');
+  });
+});

--- a/src/file-ingest.ts
+++ b/src/file-ingest.ts
@@ -1,7 +1,7 @@
 // src/file-ingest.ts
 //
 // Issue #179 — per-file embedding helpers extracted out of the
-// `FaissIndexManager.updateIndex` loop. Two pieces live here:
+// `FaissIndexManager.updateIndex` loop. Three pieces live here:
 //
 //   1. `buildChunkDocuments(filePath, content, knowledgeBaseName)` —
 //      run the markdown / recursive splitter, attach the wire-shape
@@ -12,6 +12,8 @@
 //      lock. Recreates the parent dir if a peer's `purgeStaleSidecars`
 //      raced and rmrf'd it between the loop's pre-pass `mkdir` and
 //      this write.
+//   3. `normalizeChunkTextForEmbedding(text)` — canonicalize chunk text
+//      for exact duplicate embedding compaction during indexing.
 //
 // The class still owns the loop orchestration and `addDocumentsToIndex`
 // (which mutates `this.faissIndex`); these helpers are pure / I/O-only
@@ -33,6 +35,10 @@ export interface PendingSidecarWrite {
   path: string;
   /** SHA-256 hex digest of the embedded source file. */
   hash: string;
+}
+
+export function normalizeChunkTextForEmbedding(text: string): string {
+  return text.normalize('NFC').replace(/\s+/g, ' ').trim();
 }
 
 /**


### PR DESCRIPTION
## Summary

- Add indexing-scoped embedding dedupe for duplicate normalized chunk text.
- Preserve one FAISS/docstore insertion per source chunk so duplicate files remain independently citeable.
- Document requirement/test coverage for NFR-INDEX-281 / TS-INDEX-281.

Closes #281

## Verification

- `npx jest src/file-ingest.test.ts src/FaissIndexManager.test.ts --runInBand`
- `npm run build`
- `npm test` (72 suites passed, 1172 tests passed, 4 skipped)
- `npm run docs:check-anchors` (exited 0 in warning mode; reported pre-existing stale anchors outside this PR)
- `git diff --check`
- manual portability scan of added diff lines (repo has no `scripts/check-portability.sh`)

## Pre-PR Gate

- detected project type: npm
- type/build checks: passed (`npm run build`)
- tests: passed (`npm test`)
- bug reproduction: skipped; feature PR, covered by new focused indexing test
- diff review: done
- portability check: clean by manual added-line scan; helper absent in this repo
- reviewer specialists: run (conventions, correctness, deadcode, test); no blocking findings
- OSS base-branch policy: skipped; same-repo PR
- gate file: created
