### PR TITLE
Persist chunk manifests for refresh

### DIFF
--- a/src/FaissIndexManager.test.ts
+++ b/src/FaissIndexManager.test.ts
@@ -295,6 +295,8 @@ describe('FaissIndexManager permission handling', () => {
     KB_MAX_FILE_BYTES: process.env.KB_MAX_FILE_BYTES,
     KB_MAX_EXTRACTED_TEXT_BYTES: process.env.KB_MAX_EXTRACTED_TEXT_BYTES,
     KB_LARGE_FILE_POLICY: process.env.KB_LARGE_FILE_POLICY,
+    KB_CHUNK_SIZE: process.env.KB_CHUNK_SIZE,
+    KB_CHUNK_OVERLAP: process.env.KB_CHUNK_OVERLAP,
   };
 
 
@@ -711,6 +713,140 @@ describe('FaissIndexManager permission handling', () => {
       chunks_added: 3,
       index_mutated: true,
       saved: true,
+    });
+  });
+
+  it('persists chunk manifests and embeds only appended chunks when a changed file keeps its stable prefix', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-faiss-chunk-manifest-append-'));
+    const kbDir = path.join(tempDir, 'kb');
+    const defaultKb = path.join(kbDir, 'default');
+    await fsp.mkdir(defaultKb, { recursive: true });
+    const docPath = path.join(defaultKb, 'large.txt');
+    const paragraph = (label: string) => `${label} ${'stable words '.repeat(12)}`;
+    await fsp.writeFile(
+      docPath,
+      [paragraph('alpha'), paragraph('beta'), paragraph('gamma')].join('\n\n'),
+    );
+
+    process.env.KNOWLEDGE_BASES_ROOT_DIR = kbDir;
+    process.env.FAISS_INDEX_PATH = path.join(tempDir, '.faiss');
+    process.env.EMBEDDING_PROVIDER = 'huggingface';
+    process.env.HUGGINGFACE_API_KEY = 'test-key';
+    process.env.KB_CHUNK_SIZE = '80';
+    process.env.KB_CHUNK_OVERLAP = '0';
+
+    jest.resetModules();
+    const { FaissIndexManager } = await import('./FaissIndexManager.js');
+    const manager = new FaissIndexManager();
+    await manager.initialize();
+    await manager.updateIndex();
+
+    const manifestPath = path.join(defaultKb, '.index', 'large.txt.chunks.json');
+    const initialManifest = JSON.parse(await fsp.readFile(manifestPath, 'utf-8')) as {
+      chunks: unknown[];
+    };
+    expect(initialManifest.chunks.length).toBeGreaterThan(1);
+    const [initialTexts] = fromTextsMock.mock.calls[0] as [string[]];
+    expect(initialTexts).toHaveLength(initialManifest.chunks.length);
+
+    fromTextsMock.mockClear();
+    addDocumentsMock.mockClear();
+    embedDocumentsMock.mockClear();
+    saveMock.mockClear();
+
+    await fsp.writeFile(
+      docPath,
+      [
+        paragraph('alpha'),
+        paragraph('beta'),
+        paragraph('gamma'),
+        paragraph('delta appended'),
+      ].join('\n\n'),
+    );
+    await manager.updateIndex('default');
+
+    const updatedManifest = JSON.parse(await fsp.readFile(manifestPath, 'utf-8')) as {
+      source_sha256: string;
+      chunks: unknown[];
+    };
+    const appendedChunkCount = updatedManifest.chunks.length - initialManifest.chunks.length;
+    expect(appendedChunkCount).toBeGreaterThan(0);
+    expect(appendedChunkCount).toBeLessThan(updatedManifest.chunks.length);
+    expect(fromTextsMock).not.toHaveBeenCalled();
+    expect(addDocumentsMock).toHaveBeenCalledTimes(1);
+    const [[appendedDocs]] = addDocumentsMock.mock.calls as [[Array<{ pageContent: string }>]];
+    expect(appendedDocs).toHaveLength(appendedChunkCount);
+    const providerTexts = embedDocumentsMock.mock.calls.flatMap((call) => {
+      const [texts] = call as [string[]];
+      return texts;
+    });
+    expect(providerTexts).toHaveLength(appendedChunkCount);
+    expect(saveMock).toHaveBeenCalledTimes(1);
+    expect(manager.getLastIndexUpdateSummary()).toMatchObject({
+      status: 'success',
+      scope: 'default',
+      files_changed: 1,
+      chunks_added: appendedChunkCount,
+      index_mutated: true,
+      saved: true,
+      sidecars_written: true,
+    });
+    await expect(fsp.readFile(path.join(defaultKb, '.index', 'large.txt'), 'utf-8'))
+      .resolves.toBe(updatedManifest.source_sha256);
+  });
+
+  it('falls back to a full rebuild when a changed file removes chunks so stale content is compacted away', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-faiss-chunk-manifest-rebuild-'));
+    const kbDir = path.join(tempDir, 'kb');
+    const defaultKb = path.join(kbDir, 'default');
+    await fsp.mkdir(defaultKb, { recursive: true });
+    const docPath = path.join(defaultKb, 'large.txt');
+    const paragraph = (label: string) => `${label} ${'content words '.repeat(12)}`;
+    await fsp.writeFile(
+      docPath,
+      [
+        paragraph('keep alpha'),
+        paragraph('remove obsolete sentinel'),
+        paragraph('keep omega'),
+      ].join('\n\n'),
+    );
+
+    process.env.KNOWLEDGE_BASES_ROOT_DIR = kbDir;
+    process.env.FAISS_INDEX_PATH = path.join(tempDir, '.faiss');
+    process.env.EMBEDDING_PROVIDER = 'huggingface';
+    process.env.HUGGINGFACE_API_KEY = 'test-key';
+    process.env.KB_CHUNK_SIZE = '80';
+    process.env.KB_CHUNK_OVERLAP = '0';
+
+    jest.resetModules();
+    const { FaissIndexManager } = await import('./FaissIndexManager.js');
+    const manager = new FaissIndexManager();
+    await manager.initialize();
+    await manager.updateIndex();
+
+    fromTextsMock.mockClear();
+    addDocumentsMock.mockClear();
+    saveMock.mockClear();
+    embedDocumentsMock.mockClear();
+
+    await fsp.writeFile(
+      docPath,
+      [paragraph('keep alpha'), paragraph('keep omega')].join('\n\n'),
+    );
+    await manager.updateIndex('default');
+
+    expect(fromTextsMock).toHaveBeenCalledTimes(1);
+    expect(addDocumentsMock).not.toHaveBeenCalled();
+    const [rebuiltTexts] = fromTextsMock.mock.calls[0] as [string[]];
+    expect(rebuiltTexts.join('\n')).not.toContain('obsolete sentinel');
+    expect(saveMock).toHaveBeenCalledTimes(1);
+    expect(manager.getLastIndexUpdateSummary()).toMatchObject({
+      status: 'success',
+      scope: 'default',
+      files_changed: 1,
+      index_mutated: true,
+      saved: true,
+      sidecars_written: true,
     });
   });
 

--- a/src/FaissIndexManager.ts
+++ b/src/FaissIndexManager.ts
@@ -8,8 +8,13 @@ import { createEmbeddingsClient, type EmbeddingsClient } from './embedding-provi
 import { handleFsOperationError, toError } from './error-utils.js';
 import { calculateSHA256, pathExists } from './file-utils.js';
 import {
+  buildChunkManifest,
   buildChunkDocuments,
+  countStableChunkPrefix,
+  readChunkManifest,
+  type ChunkManifest,
   normalizeChunkTextForEmbedding,
+  writeChunkManifests,
   writeSidecarHashes,
 } from './file-ingest.js';
 import { loadFile } from './loaders.js';
@@ -1012,6 +1017,7 @@ export class FaissIndexManager {
         Math.floor(opts.progressIntervalFiles ?? DEFAULT_REBUILD_PROGRESS_INTERVAL_FILES),
       );
       const pendingHashWrites: { path: string; hash: string }[] = [];
+      const pendingChunkManifestWrites: { path: string; manifest: ChunkManifest }[] = [];
       const loaderFailurePaths = new Set<string>();
 
       // First enumerate every candidate path so progress notifications can
@@ -1126,9 +1132,30 @@ export class FaissIndexManager {
         relativePath: string;
         filePath: string;
         indexFilePath: string;
+        chunkManifestPath: string;
         fileHash: string;
         documents: Document[];
+        manifest: ChunkManifest;
       }> = [];
+      const metadataOnlyFileUpdates: Array<{
+        knowledgeBasePath: string;
+        relativePath: string;
+        filePath: string;
+        indexFilePath: string;
+        chunkManifestPath: string;
+        fileHash: string;
+        manifest: ChunkManifest;
+      }> = [];
+      const indexableScans: Array<{
+        knowledgeBaseName: string;
+        knowledgeBasePath: string;
+        filePath: string;
+        relativePath: string;
+        indexFilePath: string;
+        chunkManifestPath: string;
+        fileHash: string;
+      }> = [];
+      let requiresFullRebuild = false;
       const successfulIndexedFiles: Array<{ knowledgeBasePath: string; relativePath: string }> = [];
       const fsConcurrency = resolveFsConcurrency();
       const fileScanJobs = knowledgeBaseFiles.flatMap(
@@ -1146,6 +1173,7 @@ export class FaissIndexManager {
             filePath,
             relativePath,
             indexFilePath,
+            chunkManifestPath: `${indexFilePath}.chunks.json`,
           };
         }),
       );
@@ -1204,6 +1232,15 @@ export class FaissIndexManager {
           await reportLoadProgress(scan.filePath);
           continue;
         }
+        indexableScans.push({
+          knowledgeBaseName: scan.knowledgeBaseName,
+          knowledgeBasePath: scan.knowledgeBasePath,
+          filePath: scan.filePath,
+          relativePath: scan.relativePath,
+          indexFilePath: scan.indexFilePath,
+          chunkManifestPath: scan.chunkManifestPath,
+          fileHash: scan.fileHash,
+        });
 
         // If the file is new/changed, or the index itself is absent,
         // process it. The missing-index case must ignore matching sidecars:
@@ -1264,15 +1301,68 @@ export class FaissIndexManager {
           runSummary.chunks_attempted += documentsToAdd.length;
 
           if (documentsToAdd.length > 0) {
-            changedFileDocuments.push({
-              knowledgeBasePath: scan.knowledgeBasePath,
-              relativePath: scan.relativePath,
-              filePath: scan.filePath,
-              indexFilePath: scan.indexFilePath,
-              fileHash: scan.fileHash,
-              documents: documentsToAdd,
-            });
+            const nextManifest = buildChunkManifest(documentsToAdd, scan.fileHash);
+            let documentsForIndex = documentsToAdd;
+            if (!rebuildFromEmptyIndex && !forceReindex) {
+              const previousManifest = await readChunkManifest(scan.chunkManifestPath);
+              if (previousManifest === null) {
+                requiresFullRebuild = true;
+                logger.info(
+                  `Chunk manifest missing for changed file ${scan.filePath}; ` +
+                    `falling back to a full rebuild to avoid stale vectors.`,
+                );
+              } else {
+                const stablePrefix = countStableChunkPrefix(previousManifest, nextManifest);
+                if (
+                  stablePrefix === previousManifest.chunks.length &&
+                  nextManifest.chunks.length >= previousManifest.chunks.length
+                ) {
+                  documentsForIndex = documentsToAdd.slice(stablePrefix);
+                } else {
+                  requiresFullRebuild = true;
+                  logger.info(
+                    `Chunk manifest for ${scan.filePath} changed outside a stable append; ` +
+                      `falling back to a full rebuild because FAISS vector deletion is unsupported.`,
+                  );
+                }
+              }
+            }
+
+            if (!requiresFullRebuild) {
+              if (documentsForIndex.length > 0) {
+                changedFileDocuments.push({
+                  knowledgeBasePath: scan.knowledgeBasePath,
+                  relativePath: scan.relativePath,
+                  filePath: scan.filePath,
+                  indexFilePath: scan.indexFilePath,
+                  chunkManifestPath: scan.chunkManifestPath,
+                  fileHash: scan.fileHash,
+                  documents: documentsForIndex,
+                  manifest: nextManifest,
+                });
+              } else {
+                metadataOnlyFileUpdates.push({
+                  knowledgeBasePath: scan.knowledgeBasePath,
+                  relativePath: scan.relativePath,
+                  filePath: scan.filePath,
+                  indexFilePath: scan.indexFilePath,
+                  chunkManifestPath: scan.chunkManifestPath,
+                  fileHash: scan.fileHash,
+                  manifest: nextManifest,
+                });
+              }
+            }
           } else {
+            if (!rebuildFromEmptyIndex && !forceReindex) {
+              const previousManifest = await readChunkManifest(scan.chunkManifestPath);
+              if (previousManifest !== null && previousManifest.chunks.length > 0) {
+                requiresFullRebuild = true;
+                logger.info(
+                  `Changed file ${scan.filePath} now emits no chunks; ` +
+                    `falling back to a full rebuild to remove stale vectors.`,
+                );
+              }
+            }
             logger.debug(`No documents generated from ${scan.filePath}. Skipping index update.`);
           }
         } else {
@@ -1281,6 +1371,72 @@ export class FaissIndexManager {
           logger.debug(`File ${scan.filePath} unchanged, skipping.`);
         }
         await reportLoadProgress(scan.filePath);
+      }
+      if (requiresFullRebuild) {
+        this.faissIndex = null;
+        changedFileDocuments.length = 0;
+        metadataOnlyFileUpdates.length = 0;
+        runSummary.chunks_attempted = 0;
+        logger.info(
+          'Rebuilding the full FAISS index because at least one changed file ' +
+            'could not be updated incrementally without leaving stale vectors.',
+        );
+        for (const scan of indexableScans) {
+          let content = '';
+          try {
+            content = await loadFile(scan.filePath);
+          } catch (error: unknown) {
+            logger.warn(`Quarantining rebuild load failure for ${scan.filePath}:`, toError(error));
+            runSummary.files_skipped += 1;
+            loaderFailurePaths.add(scan.filePath);
+            recordFailure(scan.relativePath, 'load', error);
+            await recordQuarantineFailure(
+              scan.knowledgeBasePath,
+              scan.relativePath,
+              scan.fileHash,
+              error,
+            );
+            continue;
+          }
+
+          let documents: Document[];
+          try {
+            documents = await buildChunkDocuments(
+              scan.filePath,
+              content,
+              scan.knowledgeBaseName,
+            );
+          } catch (error: unknown) {
+            logger.warn(`Quarantining rebuild chunking failure for ${scan.filePath}:`, toError(error));
+            runSummary.files_skipped += 1;
+            loaderFailurePaths.add(scan.filePath);
+            recordFailure(scan.relativePath, 'indexing', error);
+            await recordQuarantineFailure(
+              scan.knowledgeBasePath,
+              scan.relativePath,
+              scan.fileHash,
+              error,
+            );
+            continue;
+          }
+
+          runSummary.chunks_attempted += documents.length;
+          if (documents.length === 0) {
+            logger.debug(`No documents generated from ${scan.filePath}. Skipping rebuild entry.`);
+            continue;
+          }
+
+          changedFileDocuments.push({
+            knowledgeBasePath: scan.knowledgeBasePath,
+            relativePath: scan.relativePath,
+            filePath: scan.filePath,
+            indexFilePath: scan.indexFilePath,
+            chunkManifestPath: scan.chunkManifestPath,
+            fileHash: scan.fileHash,
+            documents,
+            manifest: buildChunkManifest(documents, scan.fileHash),
+          });
+        }
       }
       const documentsToAdd = changedFileDocuments.flatMap((entry) => entry.documents);
       let addedChangedDocuments = false;
@@ -1309,6 +1465,10 @@ export class FaissIndexManager {
         runSummary.chunks_added += documentsToAdd.length;
         for (const entry of changedFileDocuments) {
           pendingHashWrites.push({ path: entry.indexFilePath, hash: entry.fileHash });
+          pendingChunkManifestWrites.push({
+            path: entry.chunkManifestPath,
+            manifest: entry.manifest,
+          });
           successfulIndexedFiles.push({
             knowledgeBasePath: entry.knowledgeBasePath,
             relativePath: entry.relativePath,
@@ -1317,6 +1477,17 @@ export class FaissIndexManager {
           processedFiles += 1;
           await reportProgress(entry.filePath);
         }
+      }
+      for (const entry of metadataOnlyFileUpdates) {
+        pendingHashWrites.push({ path: entry.indexFilePath, hash: entry.fileHash });
+        pendingChunkManifestWrites.push({
+          path: entry.chunkManifestPath,
+          manifest: entry.manifest,
+        });
+        successfulIndexedFiles.push({
+          knowledgeBasePath: entry.knowledgeBasePath,
+          relativePath: entry.relativePath,
+        });
       }
 
       // If at least one file was processed but no changes triggered index creation,
@@ -1327,8 +1498,11 @@ export class FaissIndexManager {
           knowledgeBasePath: string;
           relativePath: string;
           filePath: string;
+          indexFilePath: string;
+          chunkManifestPath: string;
           fileHash: string | null;
           documents: Document[];
+          manifest: ChunkManifest;
         }> = [];
         for (const { knowledgeBaseName, knowledgeBasePath, filePaths } of knowledgeBaseFiles) {
           for (const filePath of filePaths) {
@@ -1387,12 +1561,21 @@ export class FaissIndexManager {
             }
             runSummary.chunks_attempted += documents.length;
             if (documents.length > 0) {
+              const indexFilePath = path.join(
+                knowledgeBasePath,
+                '.index',
+                path.dirname(relativePath),
+                path.basename(filePath),
+              );
               fallbackDocuments.push({
                 knowledgeBasePath,
                 relativePath,
                 filePath,
+                indexFilePath,
+                chunkManifestPath: `${indexFilePath}.chunks.json`,
                 fileHash,
                 documents,
+                manifest: buildChunkManifest(documents, fileHash ?? '0'.repeat(64)),
               });
             }
           }
@@ -1428,6 +1611,13 @@ export class FaissIndexManager {
             0,
           );
           for (const entry of fallbackDocuments) {
+            if (entry.fileHash !== null) {
+              pendingHashWrites.push({ path: entry.indexFilePath, hash: entry.fileHash });
+              pendingChunkManifestWrites.push({
+                path: entry.chunkManifestPath,
+                manifest: entry.manifest,
+              });
+            }
             successfulIndexedFiles.push({
               knowledgeBasePath: entry.knowledgeBasePath,
               relativePath: entry.relativePath,
@@ -1438,42 +1628,49 @@ export class FaissIndexManager {
         }
       }
 
-      if (indexMutated && this.faissIndex !== null) {
+      if (
+        (indexMutated && this.faissIndex !== null) ||
+        pendingHashWrites.length > 0 ||
+        pendingChunkManifestWrites.length > 0
+      ) {
         // RFC 014 — atomicSave writes to a versioned `index.vN/` and swaps
         // the `index` symlink atomically. The legacy `faiss.index/` directory
         // (if present from a pre-RFC-014 install) is intentionally NOT
         // updated; first save under v014 effectively migrates the model to
         // versioned layout.
-        try {
-          const saveStartedAtMs = Date.now();
-          await emitProgress({
-            processedFiles,
-            totalFiles,
-            currentFile: '',
-            phase: 'save',
-            phaseStatus: 'started',
-          });
-          await this.atomicSave();
-          runSummary.saved = true;
-          await emitProgress({
-            processedFiles,
-            totalFiles,
-            currentFile: '',
-            phase: 'save',
-            phaseStatus: 'completed',
-            phaseElapsedMs: Date.now() - saveStartedAtMs,
-            saved: true,
-          });
-        } catch (saveError: unknown) {
-          recordFailure(null, 'save', saveError);
-          handleFsOperationError(
-            'save FAISS index for model',
-            this.modelId,
-            saveError,
-          );
+        if (indexMutated) {
+          try {
+            const saveStartedAtMs = Date.now();
+            await emitProgress({
+              processedFiles,
+              totalFiles,
+              currentFile: '',
+              phase: 'save',
+              phaseStatus: 'started',
+            });
+            await this.atomicSave();
+            runSummary.saved = true;
+            await emitProgress({
+              processedFiles,
+              totalFiles,
+              currentFile: '',
+              phase: 'save',
+              phaseStatus: 'completed',
+              phaseElapsedMs: Date.now() - saveStartedAtMs,
+              saved: true,
+            });
+          } catch (saveError: unknown) {
+            recordFailure(null, 'save', saveError);
+            handleFsOperationError(
+              'save FAISS index for model',
+              this.modelId,
+              saveError,
+            );
+          }
         }
-        // Sidecar hashes are written only after the index has persisted so
-        // we never claim a hash for vectors that never landed on disk.
+        // Sidecars are written only after any needed index save has
+        // completed. Metadata-only updates (same chunks, different file
+        // bytes) do not need a FAISS save, but can still advance sidecars.
         // `writeSidecarHashes` runs the batch under `withSidecarLock` so a
         // concurrent model's `purgeStaleSidecars` cannot rmrf
         // `<kb>/.index/` between our pre-loop `mkdir` and `rename` (issue
@@ -1489,10 +1686,12 @@ export class FaissIndexManager {
             currentFile: '',
             phase: 'sidecar',
             phaseStatus: 'started',
-            sidecarsWritten: pendingHashWrites.length,
+            sidecarsWritten: pendingHashWrites.length + pendingChunkManifestWrites.length,
           });
           await writeSidecarHashes(pendingHashWrites);
-          runSummary.sidecars_written = pendingHashWrites.length > 0;
+          await writeChunkManifests(pendingChunkManifestWrites);
+          runSummary.sidecars_written =
+            pendingHashWrites.length > 0 || pendingChunkManifestWrites.length > 0;
           await emitProgress({
             processedFiles,
             totalFiles,
@@ -1500,7 +1699,7 @@ export class FaissIndexManager {
             phase: 'sidecar',
             phaseStatus: 'completed',
             phaseElapsedMs: Date.now() - sidecarStartedAtMs,
-            sidecarsWritten: pendingHashWrites.length,
+            sidecarsWritten: pendingHashWrites.length + pendingChunkManifestWrites.length,
           });
           for (const entry of successfulIndexedFiles) {
             await recordQuarantineSuccess(entry.knowledgeBasePath, entry.relativePath);

--- a/src/file-ingest.test.ts
+++ b/src/file-ingest.test.ts
@@ -1,7 +1,55 @@
-import { normalizeChunkTextForEmbedding } from './file-ingest.js';
+import { Document } from '@langchain/core/documents';
+import {
+  buildChunkManifest,
+  countStableChunkPrefix,
+  normalizeChunkTextForEmbedding,
+} from './file-ingest.js';
 
 describe('normalizeChunkTextForEmbedding', () => {
   it('collapses insignificant text differences before indexing dedupe', () => {
     expect(normalizeChunkTextForEmbedding('  Cafe\u0301\t\nrunbook   section  ')).toBe('Caf\u00e9 runbook section');
+  });
+});
+
+describe('buildChunkManifest', () => {
+  it('hashes normalized chunk text and stable metadata for prefix comparison', () => {
+    const first = buildChunkManifest(
+      [
+        new Document({
+          pageContent: '  Cafe\u0301\t\nrunbook   section  ',
+          metadata: { source: '/kb/doc.md', chunkIndex: 0, tags: ['ops'] },
+        }),
+        new Document({
+          pageContent: 'next section',
+          metadata: { tags: ['ops'], chunkIndex: 1, source: '/kb/doc.md' },
+        }),
+      ],
+      'a'.repeat(64),
+    );
+    const second = buildChunkManifest(
+      [
+        new Document({
+          pageContent: 'Caf\u00e9 runbook section',
+          metadata: { tags: ['ops'], chunkIndex: 0, source: '/kb/doc.md' },
+        }),
+        new Document({
+          pageContent: 'changed section',
+          metadata: { source: '/kb/doc.md', chunkIndex: 1, tags: ['ops'] },
+        }),
+      ],
+      'b'.repeat(64),
+    );
+
+    expect(first.schema_version).toBe('kb.chunk-manifest.v1');
+    expect(first.chunks).toHaveLength(2);
+    expect(first.chunks[0]).toEqual(expect.objectContaining({
+      chunkIndex: 0,
+      textHash: expect.stringMatching(/^[0-9a-f]{64}$/),
+      metadataHash: expect.stringMatching(/^[0-9a-f]{64}$/),
+      vectorDocstoreId: expect.stringMatching(/^[0-9a-f]{64}$/),
+    }));
+    expect(first.chunks[0].textHash).toBe(second.chunks[0].textHash);
+    expect(first.chunks[0].metadataHash).toBe(second.chunks[0].metadataHash);
+    expect(countStableChunkPrefix(first, second)).toBe(1);
   });
 });

--- a/src/file-ingest.ts
+++ b/src/file-ingest.ts
@@ -20,6 +20,7 @@
 // so they're testable on their own and don't carry per-instance state.
 
 import * as fsp from 'fs/promises';
+import * as crypto from 'crypto';
 import * as path from 'path';
 import { Document } from '@langchain/core/documents';
 import { MarkdownTextSplitter, RecursiveCharacterTextSplitter } from 'langchain/text_splitter';
@@ -37,8 +38,150 @@ export interface PendingSidecarWrite {
   hash: string;
 }
 
+export const CHUNK_MANIFEST_SCHEMA_VERSION = 'kb.chunk-manifest.v1';
+
+export interface ChunkManifestEntry {
+  chunkIndex: number;
+  textHash: string;
+  metadataHash: string;
+  vectorDocstoreId: string;
+}
+
+export interface ChunkManifest {
+  schema_version: typeof CHUNK_MANIFEST_SCHEMA_VERSION;
+  source_sha256: string;
+  chunks: ChunkManifestEntry[];
+}
+
+export interface PendingChunkManifestWrite {
+  /** Absolute path of the chunk manifest sidecar under `<kb>/.index/`. */
+  path: string;
+  manifest: ChunkManifest;
+}
+
 export function normalizeChunkTextForEmbedding(text: string): string {
   return text.normalize('NFC').replace(/\s+/g, ' ').trim();
+}
+
+function sha256Hex(value: string): string {
+  return crypto.createHash('sha256').update(value).digest('hex');
+}
+
+function isJsonObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function normalizeJsonValue(value: unknown): unknown {
+  if (value === null) return null;
+  if (Array.isArray(value)) {
+    return value.map(normalizeJsonValue);
+  }
+  if (isJsonObject(value)) {
+    const sorted: Record<string, unknown> = {};
+    for (const key of Object.keys(value).sort()) {
+      sorted[key] = normalizeJsonValue(value[key]);
+    }
+    return sorted;
+  }
+  if (
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean'
+  ) {
+    return value;
+  }
+  return null;
+}
+
+function stableJsonStringify(value: unknown): string {
+  return JSON.stringify(normalizeJsonValue(value));
+}
+
+export function buildChunkManifest(
+  documents: ReadonlyArray<Document>,
+  sourceHash: string,
+): ChunkManifest {
+  return {
+    schema_version: CHUNK_MANIFEST_SCHEMA_VERSION,
+    source_sha256: sourceHash,
+    chunks: documents.map((document, index) => {
+      const chunkIndex = typeof document.metadata?.chunkIndex === 'number'
+        ? document.metadata.chunkIndex
+        : index;
+      const textHash = sha256Hex(normalizeChunkTextForEmbedding(document.pageContent));
+      const metadataHash = sha256Hex(stableJsonStringify(document.metadata ?? {}));
+      return {
+        chunkIndex,
+        textHash,
+        metadataHash,
+        vectorDocstoreId: sha256Hex(`${chunkIndex}\0${textHash}\0${metadataHash}`),
+      };
+    }),
+  };
+}
+
+function isChunkManifestEntry(value: unknown): value is ChunkManifestEntry {
+  if (!isJsonObject(value)) return false;
+  return (
+    typeof value.chunkIndex === 'number' &&
+    Number.isSafeInteger(value.chunkIndex) &&
+    value.chunkIndex >= 0 &&
+    typeof value.textHash === 'string' &&
+    /^[0-9a-f]{64}$/.test(value.textHash) &&
+    typeof value.metadataHash === 'string' &&
+    /^[0-9a-f]{64}$/.test(value.metadataHash) &&
+    typeof value.vectorDocstoreId === 'string' &&
+    /^[0-9a-f]{64}$/.test(value.vectorDocstoreId)
+  );
+}
+
+function isChunkManifest(value: unknown): value is ChunkManifest {
+  if (!isJsonObject(value)) return false;
+  return (
+    value.schema_version === CHUNK_MANIFEST_SCHEMA_VERSION &&
+    typeof value.source_sha256 === 'string' &&
+    /^[0-9a-f]{64}$/.test(value.source_sha256) &&
+    Array.isArray(value.chunks) &&
+    value.chunks.every(isChunkManifestEntry)
+  );
+}
+
+export async function readChunkManifest(manifestPath: string): Promise<ChunkManifest | null> {
+  let raw: string;
+  try {
+    raw = await fsp.readFile(manifestPath, 'utf-8');
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT' || code === 'ENOTDIR') return null;
+    throw error;
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return isChunkManifest(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+export function countStableChunkPrefix(
+  previous: ChunkManifest,
+  next: ChunkManifest,
+): number {
+  const limit = Math.min(previous.chunks.length, next.chunks.length);
+  let stablePrefix = 0;
+  for (; stablePrefix < limit; stablePrefix += 1) {
+    const previousChunk = previous.chunks[stablePrefix];
+    const nextChunk = next.chunks[stablePrefix];
+    if (
+      previousChunk.chunkIndex !== nextChunk.chunkIndex ||
+      previousChunk.textHash !== nextChunk.textHash ||
+      previousChunk.metadataHash !== nextChunk.metadataHash
+    ) {
+      break;
+    }
+  }
+  return stablePrefix;
 }
 
 /**
@@ -145,6 +288,34 @@ export async function writeSidecarHashes(
             // best-effort cleanup; original error is what matters
           }
           handleFsOperationError('write file hash metadata to', target, error);
+        }
+      }),
+    );
+  });
+}
+
+export async function writeChunkManifests(
+  pendingManifestWrites: ReadonlyArray<PendingChunkManifestWrite>,
+): Promise<void> {
+  if (pendingManifestWrites.length === 0) return;
+  await withSidecarLock(async () => {
+    await Promise.all(
+      pendingManifestWrites.map(async ({ path: target, manifest }) => {
+        const tmpPath = `${target}.tmp`;
+        try {
+          await fsp.mkdir(path.dirname(target), { recursive: true });
+          await fsp.writeFile(tmpPath, JSON.stringify(manifest), {
+            encoding: 'utf-8',
+            mode: 0o600,
+          });
+          await fsp.rename(tmpPath, target);
+        } catch (error) {
+          try {
+            await fsp.unlink(tmpPath);
+          } catch {
+            // best-effort cleanup; original error is what matters
+          }
+          handleFsOperationError('write chunk manifest to', target, error);
         }
       }),
     );


### PR DESCRIPTION
## Summary
- persist per-source chunk manifests with normalized text and metadata hashes
- skip re-embedding stable prefix chunks for append-only changed files
- fall back to a full rebuild when chunks are removed or reordered so stale content is compacted away

Closes #280

## Verification
- npx jest src/file-ingest.test.ts src/FaissIndexManager.test.ts --runInBand
- npm run build
- npm test -- --runInBand

## Pre-PR review
- detected project type: npm
- type/build checks: passed
- tests: passed
- bug reproduction: skipped; feature PR with focused before/after tests for append-only reuse and removal rebuild
- diff review: done
- portability check: clean (manual scan; repo helper not present)
- reviewer specialists: skipped (subagent spawning not authorized in this Codex session)
- OSS base-branch policy: skipped (same-repo PR)
- gate file: created