### PR TITLE
feat(doctor): warn on unsafe FAISS permissions

### DIFF
--- a/docs/architecture/threat-model.md
+++ b/docs/architecture/threat-model.md
@@ -28,6 +28,7 @@ Sections below go one level deeper on each.
 - Do **not** restore `$FAISS_INDEX_PATH` (or any `models/<id>/`) from an untrusted backup, container image, or package.
 - Do **not** mount `$FAISS_INDEX_PATH` on a shared filesystem with write access for untrusted peers.
 - Do **not** point `$FAISS_INDEX_PATH` at a directory another tool writes to.
+- Do run `kb doctor` after changing storage locations or restoring index files; it warns when the FAISS root, `active.txt`, the active model directory, or the active index version directory are group/world writable or owned by a different local user. These checks are best-effort and ownership is skipped on platforms that do not expose POSIX user IDs.
 - **Do** treat deletion as safe: `kb models remove <id>` (or `rm -rf ${FAISS_INDEX_PATH}/models/<id>/`) forces a rebuild on the next `kb models add`. The in-memory FaissStore in a running MCP server keeps working until process exit — verified empirically (RFC 013 §10 E6), `faiss-node` reads the index into memory at `.load()` time and does not mmap.
 
 The surface is permanent until upstream swaps the docstore format away from pickle. ADR [`0001-faiss-over-qdrant.md`](./adr/0001-faiss-over-qdrant.md) explains why we stay with FAISS despite this cost; a future RFC may migrate the docstore to a JSON-only format.

--- a/src/cli-doctor.test.ts
+++ b/src/cli-doctor.test.ts
@@ -40,6 +40,14 @@ async function seedRegisteredModel(faissDir: string): Promise<string> {
   return modelDir;
 }
 
+async function seedVersionedIndex(modelDir: string): Promise<string> {
+  const versionDir = path.join(modelDir, 'index.v1');
+  await fsp.mkdir(versionDir, { recursive: true });
+  await fsp.writeFile(path.join(versionDir, 'faiss.index'), 'fake-index');
+  await fsp.symlink('index.v1', path.join(modelDir, 'index'), 'dir');
+  return versionDir;
+}
+
 function persistedSuccessSummary() {
   return {
     status: 'success',
@@ -63,6 +71,128 @@ function persistedSuccessSummary() {
 }
 
 describe('kb doctor', () => {
+  const itOnPosix = process.platform === 'win32' ? it.skip : it;
+
+  itOnPosix('reports safe FAISS index permissions without warnings', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-doctor-perms-safe-'));
+    try {
+      const rootDir = path.join(tempDir, 'kbs');
+      const faissDir = path.join(tempDir, '.faiss');
+      await fsp.mkdir(rootDir, { recursive: true });
+      const modelDir = await seedRegisteredModel(faissDir);
+      const versionDir = await seedVersionedIndex(modelDir);
+      await fsp.chmod(faissDir, 0o700);
+      await fsp.chmod(path.join(faissDir, 'active.txt'), 0o600);
+      await fsp.chmod(modelDir, 0o700);
+      await fsp.chmod(versionDir, 0o700);
+
+      const { buildDoctorReport, formatDoctorMarkdown } = await freshDoctor({
+        KNOWLEDGE_BASES_ROOT_DIR: rootDir,
+        FAISS_INDEX_PATH: faissDir,
+        EMBEDDING_PROVIDER: 'huggingface',
+        HUGGINGFACE_MODEL_NAME: MODEL_NAME,
+        HUGGINGFACE_API_KEY: 'test-key',
+      });
+
+      const report = await buildDoctorReport({
+        backendHealthCheck: async () => ({ healthy: true, detail: 'backend ok' }),
+        packageRoot: tempDir,
+        invokedPath: null,
+        packageVersion: '9.9.9',
+      });
+
+      expect(report.index_security.ownership_check).toBe('checked');
+      expect(report.index_security.entries).toEqual([
+        expect.objectContaining({ name: 'faiss_root', mode_octal: '0700', warnings: [] }),
+        expect.objectContaining({ name: 'active_file', mode_octal: '0600', warnings: [] }),
+        expect.objectContaining({ name: 'active_model_dir', mode_octal: '0700', warnings: [] }),
+        expect.objectContaining({ name: 'active_index_version_dir', mode_octal: '0700', warnings: [] }),
+      ]);
+      expect(report.checks).toContainEqual({
+        name: 'index_security',
+        status: 'ok',
+        detail: 'FAISS index boundary permissions look safe',
+      });
+      const md = formatDoctorMarkdown(report);
+      expect(md).toContain('FAISS index security:');
+      expect(md).toContain('active_index_version_dir:');
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  itOnPosix('warns when FAISS index boundary paths are group or world writable', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-doctor-perms-unsafe-'));
+    try {
+      const rootDir = path.join(tempDir, 'kbs');
+      const faissDir = path.join(tempDir, '.faiss');
+      await fsp.mkdir(rootDir, { recursive: true });
+      const modelDir = await seedRegisteredModel(faissDir);
+      const versionDir = await seedVersionedIndex(modelDir);
+      await fsp.chmod(faissDir, 0o777);
+      await fsp.chmod(path.join(faissDir, 'active.txt'), 0o666);
+      await fsp.chmod(modelDir, 0o770);
+      await fsp.chmod(versionDir, 0o772);
+
+      const { buildDoctorReport, formatDoctorMarkdown } = await freshDoctor({
+        KNOWLEDGE_BASES_ROOT_DIR: rootDir,
+        FAISS_INDEX_PATH: faissDir,
+        EMBEDDING_PROVIDER: 'huggingface',
+        HUGGINGFACE_MODEL_NAME: MODEL_NAME,
+        HUGGINGFACE_API_KEY: 'test-key',
+      });
+
+      const report = await buildDoctorReport({
+        backendHealthCheck: async () => ({ healthy: true, detail: 'backend ok' }),
+        packageRoot: tempDir,
+        invokedPath: null,
+        packageVersion: '9.9.9',
+      });
+
+      expect(report.status).toBe('warn');
+      const check = report.checks.find((c) => c.name === 'index_security');
+      expect(check?.status).toBe('warn');
+      expect(check?.detail).toContain('FAISS index boundary permission warning');
+      expect(report.index_security.entries).toEqual([
+        expect.objectContaining({
+          name: 'faiss_root',
+          permission_status: 'warn',
+          warnings: expect.arrayContaining([
+            'group_writable: mode 0777',
+            'world_writable: mode 0777',
+          ]),
+        }),
+        expect.objectContaining({
+          name: 'active_file',
+          permission_status: 'warn',
+          warnings: expect.arrayContaining([
+            'group_writable: mode 0666',
+            'world_writable: mode 0666',
+          ]),
+        }),
+        expect.objectContaining({
+          name: 'active_model_dir',
+          permission_status: 'warn',
+          warnings: expect.arrayContaining(['group_writable: mode 0770']),
+        }),
+        expect.objectContaining({
+          name: 'active_index_version_dir',
+          permission_status: 'warn',
+          warnings: expect.arrayContaining([
+            'group_writable: mode 0772',
+            'world_writable: mode 0772',
+          ]),
+        }),
+      ]);
+      const md = formatDoctorMarkdown(report);
+      expect(md).toMatch(/WARN\s+index_security:/);
+      expect(md).toContain('faiss_root:');
+      expect(md).toContain('world_writable: mode 0777');
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it('reports active model, index version/mtime, backend health, and stale counts by KB', async () => {
     const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-doctor-'));
     try {

--- a/src/cli-doctor.ts
+++ b/src/cli-doctor.ts
@@ -87,6 +87,19 @@ export interface DoctorArgs {
 
 export type HealthStatus = 'ok' | 'warn' | 'error';
 
+export interface DoctorIndexSecurityEntry {
+  name: 'faiss_root' | 'active_file' | 'active_model_dir' | 'active_index_version_dir';
+  path: string;
+  exists: boolean;
+  kind: 'directory' | 'file' | 'other' | 'missing';
+  mode_octal: string | null;
+  uid: number | null;
+  expected_uid: number | null;
+  permission_status: 'ok' | 'warn' | 'skipped';
+  ownership_status: 'ok' | 'warn' | 'skipped';
+  warnings: string[];
+}
+
 export interface DoctorReport {
   status: HealthStatus;
   checks: Array<{ name: string; status: HealthStatus; detail: string }>;
@@ -107,6 +120,16 @@ export interface DoctorReport {
       total_version_bytes: number;
       retention_previous_versions: number;
     };
+  };
+  /**
+   * Best-effort filesystem security checks for the FAISS trust boundary.
+   * Ownership is skipped on platforms without `process.getuid`; permission
+   * warnings are derived from POSIX group/world write bits where available.
+   */
+  index_security: {
+    permission_check: 'checked' | 'skipped';
+    ownership_check: 'checked' | 'skipped';
+    entries: DoctorIndexSecurityEntry[];
   };
   stale_counts_by_kb: Record<string, { modified_files: number; new_files: number }>;
   quarantine_counts_by_kb: Record<string, number>;
@@ -262,6 +285,16 @@ export async function buildDoctorReport(
       ? 'active model index is not built'
       : `${index.version ?? 'unknown'} at ${index.mtime ?? 'unknown mtime'}`,
   });
+  const indexSecurity = await readIndexSecurity(activeModelId, index.binary_path);
+  const indexSecurityWarningCount = indexSecurity.entries
+    .reduce((sum, entry) => sum + entry.warnings.length, 0);
+  checks.push({
+    name: 'index_security',
+    status: indexSecurityWarningCount > 0 ? 'warn' : 'ok',
+    detail: indexSecurityWarningCount === 0
+      ? 'FAISS index boundary permissions look safe'
+      : `${indexSecurityWarningCount} FAISS index boundary permission warning(s)`,
+  });
 
   const staleCounts = await computeStaleCountsByKb(
     activeModelId,
@@ -411,6 +444,7 @@ export async function buildDoctorReport(
       model_name: activeModelName,
     },
     index,
+    index_security: indexSecurity,
     stale_counts_by_kb: staleCounts,
     quarantine_counts_by_kb: quarantineCounts,
     age_budgets: ageBudgetResult.byKb,
@@ -465,6 +499,101 @@ async function readIndexHealth(activeModelId: string | null): Promise<DoctorRepo
   } catch {
     return { path: FAISS_INDEX_PATH, binary_path: null, version: null, mtime: null, storage: storageSummary };
   }
+}
+
+async function readIndexSecurity(
+  activeModelId: string | null,
+  binaryPath: string | null,
+): Promise<DoctorReport['index_security']> {
+  const expectedUid = typeof process.getuid === 'function' ? process.getuid() : null;
+  const canCheckPosixMode = process.platform !== 'win32';
+  const candidates: Array<Pick<DoctorIndexSecurityEntry, 'name' | 'path'>> = [
+    { name: 'faiss_root', path: FAISS_INDEX_PATH },
+    { name: 'active_file', path: path.join(FAISS_INDEX_PATH, 'active.txt') },
+  ];
+  if (activeModelId !== null) {
+    const activeModelDir = path.join(FAISS_INDEX_PATH, 'models', activeModelId);
+    candidates.push({ name: 'active_model_dir', path: activeModelDir });
+  }
+  if (binaryPath !== null) {
+    candidates.push({ name: 'active_index_version_dir', path: path.dirname(binaryPath) });
+  }
+
+  const entries: DoctorIndexSecurityEntry[] = [];
+  const seen = new Set<string>();
+  for (const candidate of candidates) {
+    if (seen.has(`${candidate.name}:${candidate.path}`)) continue;
+    seen.add(`${candidate.name}:${candidate.path}`);
+    entries.push(await statIndexSecurityEntry(candidate, expectedUid, canCheckPosixMode));
+  }
+  return {
+    permission_check: canCheckPosixMode ? 'checked' : 'skipped',
+    ownership_check: expectedUid === null ? 'skipped' : 'checked',
+    entries,
+  };
+}
+
+async function statIndexSecurityEntry(
+  candidate: Pick<DoctorIndexSecurityEntry, 'name' | 'path'>,
+  expectedUid: number | null,
+  canCheckPosixMode: boolean,
+): Promise<DoctorIndexSecurityEntry> {
+  let st: import('fs').Stats;
+  try {
+    st = await fsp.stat(candidate.path);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT' || code === 'ENOTDIR') {
+      return {
+        ...candidate,
+        exists: false,
+        kind: 'missing',
+        mode_octal: null,
+        uid: null,
+        expected_uid: expectedUid,
+        permission_status: 'skipped',
+        ownership_status: expectedUid === null ? 'skipped' : 'ok',
+        warnings: [],
+      };
+    }
+    return {
+      ...candidate,
+      exists: false,
+      kind: 'missing',
+      mode_octal: null,
+      uid: null,
+      expected_uid: expectedUid,
+      permission_status: 'skipped',
+      ownership_status: expectedUid === null ? 'skipped' : 'ok',
+      warnings: [`stat_failed: ${(err as Error).message}`],
+    };
+  }
+
+  const kind = st.isDirectory() ? 'directory' : st.isFile() ? 'file' : 'other';
+  const mode = st.mode & 0o777;
+  const modeDisplay = formatMode(mode);
+  const permissionWarning = canCheckPosixMode && (mode & 0o022) !== 0;
+  const warnings: string[] = [];
+  if (canCheckPosixMode && (mode & 0o020) !== 0) warnings.push(`group_writable: mode ${modeDisplay}`);
+  if (canCheckPosixMode && (mode & 0o002) !== 0) warnings.push(`world_writable: mode ${modeDisplay}`);
+  if (expectedUid !== null && st.uid !== expectedUid) {
+    warnings.push(`unexpected_owner: uid ${st.uid}, expected ${expectedUid}`);
+  }
+  return {
+    ...candidate,
+    exists: true,
+    kind,
+    mode_octal: modeDisplay,
+    uid: typeof st.uid === 'number' ? st.uid : null,
+    expected_uid: expectedUid,
+    permission_status: canCheckPosixMode ? (permissionWarning ? 'warn' : 'ok') : 'skipped',
+    ownership_status: expectedUid === null ? 'skipped' : (st.uid === expectedUid ? 'ok' : 'warn'),
+    warnings,
+  };
+}
+
+function formatMode(mode: number): string {
+  return `0${mode.toString(8).padStart(3, '0')}`;
 }
 
 async function computeStaleCountsByKb(
@@ -758,6 +887,19 @@ export function formatDoctorMarkdown(report: DoctorReport): string {
       `${report.index.storage.inactive_version_count} retained inactive version(s); ` +
       `retention=${report.index.storage.retention_previous_versions})`,
   );
+  lines.push('FAISS index security:');
+  for (const entry of report.index_security.entries) {
+    const mode = entry.mode_octal === null ? 'mode=n/a' : `mode=${entry.mode_octal}`;
+    const uid = entry.uid === null ? 'uid=n/a' : `uid=${entry.uid}`;
+    const marker = entry.warnings.length === 0 ? 'ok' : `WARN ${entry.warnings.join('; ')}`;
+    lines.push(`  ${entry.name}: ${entry.path} (${mode}, ${uid}) ${marker}`);
+  }
+  if (report.index_security.permission_check === 'skipped') {
+    lines.push('  permissions: skipped on this platform');
+  }
+  if (report.index_security.ownership_check === 'skipped') {
+    lines.push('  ownership: skipped on this platform');
+  }
   lines.push(`Last index update: ${formatLastIndexUpdate(report.last_index_update)}`);
   lines.push(`Backend: ${report.backend.healthy ? 'ok' : 'error'} — ${report.backend.detail}`);
   lines.push(`kb version: ${report.cli.version}`);


### PR DESCRIPTION
## Summary
- add a kb doctor index_security report for FAISS trust-boundary permissions and owner checks
- warn on group/world writable FAISS root, active.txt, active model dir, and active index version dir
- document the doctor check in the threat model

Closes #336

## Tests
- npm run build
- npx jest src/cli-doctor.test.ts --runInBand
- npx jest /home/jean/git/knowledge-base-mcp-server-issue-336-faiss-permissions/src/cli-doctor.test.ts --runInBand
- git diff --check
- npx jest src/KnowledgeBaseServer.test.ts --runInBand

Note: npm test -- --runInBand ran 73/74 suites successfully, then timed out one unrelated KnowledgeBaseServer test under full-suite load; the isolated KnowledgeBaseServer rerun passed.