### PR TITLE
feat(eval): scaffold retrieval fixtures from live search

### DIFF
--- a/docs/testing/retrieval-eval.md
+++ b/docs/testing/retrieval-eval.md
@@ -28,6 +28,18 @@ its default, and individual cases can override it with case-level `mode`.
 JSON output records `requested_mode`, `effective_mode`, and `auto_mode` when
 auto selection is used.
 
+Use `kb eval scaffold "<query>"` to turn a live retrieval query into starter
+fixture YAML on stdout:
+
+```bash
+kb eval scaffold "rollback procedure" --kb=work --mode=hybrid --k=5
+```
+
+The scaffold output is intentionally not written to disk. It seeds one ungated
+case with top unique result sources as `required_sources`, simple metadata
+expectations when the retrieved chunks already expose them, and a stale policy
+that validates through `normalizeRetrievalEvalFixture`.
+
 Every case emits `diversity_metrics` in JSON and a diversity summary in
 markdown. Source-level diagnostics include unique-source@k, duplicate-groups@k,
 and max-source-share@k, with aggregate means across cases.

--- a/src/cli-eval.ts
+++ b/src/cli-eval.ts
@@ -8,6 +8,7 @@ import {
 import { computeStaleness, type SearchMode } from './cli-search.js';
 import { loadManagerForModel, loadWithJsonRetry } from './cli-shared.js';
 import {
+  buildRetrievalEvalScaffoldFixture,
   evaluateRetrievalCase,
   formatRetrievalEvalMarkdown,
   normalizeRetrievalEvalFixture,
@@ -21,23 +22,41 @@ import {
   type RetrievalEvalRankedMetrics,
 } from './retrieval-eval.js';
 
-interface EvalArgs {
-  fixturePath: string | null;
+type EvalArgs = EvalRunArgs | EvalScaffoldArgs;
+
+interface EvalBaseArgs {
   model?: string;
-  format: 'md' | 'json';
   k: number;
   threshold: number;
+  thresholdExplicit: boolean;
   mode?: SearchMode;
+}
+
+interface EvalRunArgs extends EvalBaseArgs {
+  action: 'run';
+  fixturePath: string | null;
+  format: 'md' | 'json';
+}
+
+interface EvalScaffoldArgs extends EvalBaseArgs {
+  action: 'scaffold';
+  query: string | null;
+  kb?: string;
+  requiredSources: number;
 }
 
 const DEFAULT_K = 10;
 const DEFAULT_THRESHOLD = 2;
+const DEFAULT_SCAFFOLD_REQUIRED_SOURCES = 3;
 
 export const EVAL_HELP = `kb eval — run fixture-driven retrieval checks
 
 Usage:
   kb eval <fixture.yml|json> [--model=<id>] [--k=<int>] [--threshold=<float>]
                               [--mode=dense|lexical|hybrid|auto] [--format=md|json]
+  kb eval scaffold <query> [--model=<id>] [--kb=<name>] [--k=<int>]
+                            [--threshold=<float>] [--mode=dense|lexical|hybrid|auto]
+                            [--required-sources=<int>]
 
 Reads cases from a YAML or JSON fixture and runs each query against the
 active model's index. Each case can set \`query\`, optional \`kb\`,
@@ -48,8 +67,14 @@ active model's index. Each case can set \`query\`, optional \`kb\`,
 Failing ungated cases print warnings and exit 0; failing GATED cases
 exit 1, suitable for CI gates.
 
+\`kb eval scaffold <query>\` runs a live retrieval query and prints starter
+retrieval-eval YAML to stdout. The generated case uses top unique result
+sources as \`required_sources\`, includes simple metadata expectations when
+available, and records a stale policy. It never writes files.
+
 Arguments:
   <fixture.yml|json>    Path to fixture file. Format inferred from extension.
+  scaffold <query>      Emit a starter retrieval-eval fixture for query.
 
 Options:
   --model=<id>          Override the active model for the run (RFC 013).
@@ -60,6 +85,10 @@ Options:
                         Retrieval mode (default: dense). Fixture-level mode
                         sets a default; case-level mode overrides both.
   --format=md|json      Output format (default: md).
+  --kb=<name>           Scope scaffold retrieval to one knowledge base.
+  --required-sources=<int>
+                        Max unique result sources to seed in scaffold YAML
+                        (default: ${DEFAULT_SCAFFOLD_REQUIRED_SOURCES}).
   --help, -h            Show this help.
 
 Fixture example (YAML):
@@ -88,6 +117,10 @@ export async function runEval(rest: string[]): Promise<number> {
   } catch (err) {
     process.stderr.write(`kb eval: ${(err as Error).message}\n`);
     return 2;
+  }
+
+  if (parsed.action === 'scaffold') {
+    return runEvalScaffold(parsed);
   }
 
   if (parsed.fixturePath === null) {
@@ -158,15 +191,27 @@ export async function runEval(rest: string[]): Promise<number> {
 }
 
 export function parseEvalArgs(rest: string[]): EvalArgs {
-  const out: EvalArgs = {
+  const action = rest[0] === 'scaffold' ? 'scaffold' : 'run';
+  const args = action === 'scaffold' ? rest.slice(1) : rest;
+  const out: EvalArgs = action === 'scaffold' ? {
+    action: 'scaffold',
+    query: null,
+    k: DEFAULT_K,
+    threshold: DEFAULT_THRESHOLD,
+    thresholdExplicit: false,
+    requiredSources: DEFAULT_SCAFFOLD_REQUIRED_SOURCES,
+  } : {
+    action: 'run',
     fixturePath: null,
     format: 'md',
     k: DEFAULT_K,
     threshold: DEFAULT_THRESHOLD,
+    thresholdExplicit: false,
   };
 
-  for (const raw of rest) {
+  for (const raw of args) {
     if (raw.startsWith('--fixture=')) {
+      if (out.action === 'scaffold') throw new Error('--fixture=<path> is not supported for scaffold');
       const value = raw.slice('--fixture='.length);
       if (value.length === 0) throw new Error('--fixture=<path> requires a non-empty value');
       out.fixturePath = value;
@@ -177,6 +222,7 @@ export function parseEvalArgs(rest: string[]): EvalArgs {
       continue;
     }
     if (raw.startsWith('--format=')) {
+      if (out.action === 'scaffold') throw new Error('--format is not supported for scaffold');
       const value = raw.slice('--format='.length);
       if (value !== 'md' && value !== 'json') throw new Error(`invalid --format: ${raw}`);
       out.format = value;
@@ -200,14 +246,106 @@ export function parseEvalArgs(rest: string[]): EvalArgs {
       const value = Number(raw.slice('--threshold='.length));
       if (!Number.isFinite(value) || value <= 0) throw new Error(`invalid --threshold: ${raw}`);
       out.threshold = value;
+      out.thresholdExplicit = true;
+      continue;
+    }
+    if (raw.startsWith('--kb=')) {
+      if (out.action !== 'scaffold') throw new Error('--kb=<name> is only supported for scaffold');
+      const value = raw.slice('--kb='.length);
+      if (value.length === 0) throw new Error('--kb=<name> requires a non-empty value');
+      out.kb = value;
+      continue;
+    }
+    if (raw.startsWith('--required-sources=')) {
+      if (out.action !== 'scaffold') throw new Error('--required-sources=<int> is only supported for scaffold');
+      const value = Number(raw.slice('--required-sources='.length));
+      if (!Number.isInteger(value) || value < 0) throw new Error(`invalid --required-sources: ${raw}`);
+      out.requiredSources = value;
       continue;
     }
     if (raw.startsWith('--')) throw new Error(`unknown flag: ${raw}`);
-    if (out.fixturePath !== null) throw new Error(`unexpected argument: ${JSON.stringify(raw)}`);
-    out.fixturePath = raw;
+    if (out.action === 'scaffold') {
+      if (out.query !== null) throw new Error(`unexpected argument: ${JSON.stringify(raw)}`);
+      out.query = raw;
+    } else {
+      if (out.fixturePath !== null) throw new Error(`unexpected argument: ${JSON.stringify(raw)}`);
+      out.fixturePath = raw;
+    }
   }
 
   return out;
+}
+
+async function runEvalScaffold(parsed: EvalScaffoldArgs): Promise<number> {
+  if (parsed.query === null) {
+    process.stderr.write('kb eval: missing scaffold <query>\n');
+    return 2;
+  }
+
+  try {
+    await FaissIndexManager.bootstrapLayout();
+  } catch (err) {
+    process.stderr.write(`kb eval: layout bootstrap failed: ${(err as Error).message}\n`);
+    return 1;
+  }
+
+  let activeModelId: string;
+  try {
+    activeModelId = await resolveActiveModel({ explicitOverride: parsed.model });
+  } catch (err) {
+    if (err instanceof ActiveModelResolutionError) {
+      process.stderr.write(`kb eval: ${err.message}\n`);
+      return 2;
+    }
+    process.stderr.write(`kb eval: ${(err as Error).message}\n`);
+    return 1;
+  }
+
+  let manager: FaissIndexManager;
+  try {
+    manager = await loadManagerForModel(activeModelId);
+    await loadWithJsonRetry(manager);
+  } catch (err) {
+    process.stderr.write(`kb eval: ${(err as Error).message}\n`);
+    return 1;
+  }
+
+  try {
+    const searchCase = normalizeRetrievalEvalFixture({
+      cases: [{
+        name: 'scaffold',
+        query: parsed.query,
+        ...(parsed.kb !== undefined ? { kb: parsed.kb } : {}),
+        k: parsed.k,
+        ...(parsed.thresholdExplicit ? { threshold: parsed.threshold } : {}),
+        ...(parsed.mode !== undefined ? { mode: parsed.mode } : {}),
+        stale_policy: 'allow_stale',
+      }],
+    }).cases[0];
+    const requestedMode = parsed.mode ?? 'dense';
+    const [search, staleness] = await Promise.all([
+      retrieveForRetrievalEvalCase(searchCase, {
+        manager,
+        defaultK: parsed.k,
+        defaultThreshold: parsed.threshold,
+      }, requestedMode),
+      computeStaleness(activeModelId, parsed.kb),
+    ]);
+    const scaffold = buildRetrievalEvalScaffoldFixture(search.results, {
+      query: parsed.query,
+      ...(parsed.kb !== undefined ? { kb: parsed.kb } : {}),
+      k: parsed.k,
+      ...(parsed.thresholdExplicit ? { threshold: parsed.threshold } : {}),
+      ...(parsed.mode !== undefined ? { mode: parsed.mode } : {}),
+      maxRequiredSources: parsed.requiredSources,
+      staleness,
+    });
+    process.stdout.write(yaml.dump(scaffold, { lineWidth: -1, noRefs: true, sortKeys: false }));
+    return 0;
+  } catch (err) {
+    process.stderr.write(`kb eval: scaffold: ${(err as Error).message}\n`);
+    return 1;
+  }
 }
 
 async function loadEvalFixture(fixturePath: string): Promise<RetrievalEvalFixture> {

--- a/src/retrieval-eval.test.ts
+++ b/src/retrieval-eval.test.ts
@@ -6,6 +6,7 @@ import { parseEvalArgs, toJsonReport } from './cli-eval.js';
 import type { ScoredDocument } from './formatter.js';
 import type { Staleness } from './cli-search.js';
 import {
+  buildRetrievalEvalScaffoldFixture,
   evaluateRetrievalCase,
   formatRetrievalEvalMarkdown,
   normalizeRetrievalEvalFixture,
@@ -16,6 +17,7 @@ import {
 } from './retrieval-eval.js';
 
 const FRESH: Staleness = { indexMtime: '2026-05-09T08:00:00.000Z', modifiedFiles: 0, newFiles: 0 };
+const STALE: Staleness = { indexMtime: '2026-05-09T08:00:00.000Z', modifiedFiles: 1, newFiles: 0 };
 
 function doc(source: string, score = 0.5, metadata: Record<string, unknown> = {}): ScoredDocument {
   return {
@@ -164,10 +166,103 @@ describe('parseEvalArgs', () => {
     expect(parseEvalArgs(['fixture.yml']).mode).toBeUndefined();
   });
 
+  it('parses scaffold query and narrow scaffold options', () => {
+    expect(parseEvalArgs([
+      'scaffold',
+      'rollback procedure',
+      '--kb=ops',
+      '--k=5',
+      '--mode=hybrid',
+      '--required-sources=2',
+    ])).toMatchObject({
+      action: 'scaffold',
+      query: 'rollback procedure',
+      kb: 'ops',
+      k: 5,
+      mode: 'hybrid',
+      requiredSources: 2,
+    });
+  });
+
   it('rejects invalid retrieval modes', () => {
     expect(() => parseEvalArgs(['fixture.yml', '--mode=sparse'])).toThrow(
       "invalid --mode: --mode=sparse (expected 'dense', 'lexical', 'hybrid', or 'auto')",
     );
+  });
+
+  it('keeps scaffold-only flags out of fixture runner mode', () => {
+    expect(() => parseEvalArgs(['fixture.yml', '--kb=ops'])).toThrow(
+      '--kb=<name> is only supported for scaffold',
+    );
+    expect(() => parseEvalArgs(['scaffold', 'query', '--format=json'])).toThrow(
+      '--format is not supported for scaffold',
+    );
+  });
+});
+
+describe('buildRetrievalEvalScaffoldFixture', () => {
+  it('emits starter YAML that normalizes as a retrieval eval fixture', () => {
+    const scaffold = buildRetrievalEvalScaffoldFixture([
+      doc('/tmp/kbs/ops/runbooks/deploy.md', 0.1, {
+        relativePath: 'runbooks/deploy.md',
+        frontmatter: { status: 'approved', owner: 'search-platform' },
+      }),
+      doc('/tmp/kbs/ops/runbooks/deploy.md', 0.2, {
+        relativePath: 'runbooks/deploy.md',
+      }),
+      doc('/tmp/kbs/ops/runbooks/rollback.md', 0.3, {
+        relativePath: 'runbooks/rollback.md',
+        frontmatter: { status: 'draft' },
+      }),
+    ], {
+      query: 'rollback procedure',
+      kb: 'ops',
+      k: 5,
+      mode: 'hybrid',
+      maxRequiredSources: 2,
+      staleness: FRESH,
+    });
+    const rawYaml = yaml.dump(scaffold, { lineWidth: -1, noRefs: true, sortKeys: false });
+    const normalized = normalizeRetrievalEvalFixture(yaml.load(rawYaml));
+
+    expect(scaffold).toEqual({
+      gate: false,
+      cases: [{
+        name: 'scaffold - rollback procedure',
+        query: 'rollback procedure',
+        kb: 'ops',
+        k: 5,
+        mode: 'hybrid',
+        required_sources: [
+          'runbooks/deploy.md',
+          'runbooks/rollback.md',
+        ],
+        expected_metadata: {
+          'frontmatter.status': 'approved',
+          'frontmatter.owner': 'search-platform',
+        },
+        stale_policy: 'fresh',
+      }],
+    });
+    expect(normalized.cases[0]).toMatchObject({
+      query: 'rollback procedure',
+      requiredSources: ['runbooks/deploy.md', 'runbooks/rollback.md'],
+      expectedMetadata: [
+        { path: 'frontmatter.status', equals: 'approved' },
+        { path: 'frontmatter.owner', equals: 'search-platform' },
+      ],
+      stalePolicy: 'fresh',
+    });
+  });
+
+  it('uses allow_stale for scaffold output when the live index is stale', () => {
+    const scaffold = buildRetrievalEvalScaffoldFixture([doc('notes/drift.md')], {
+      query: 'drift',
+      k: 10,
+      staleness: STALE,
+    });
+
+    expect(scaffold.cases[0].stale_policy).toBe('allow_stale');
   });
 });
 

--- a/src/retrieval-eval.ts
+++ b/src/retrieval-eval.ts
@@ -168,6 +168,44 @@ export interface RetrievalEvalSearchResult {
   autoMode?: AutoSearchModeDecision;
 }
 
+export interface RetrievalEvalScaffoldOptions {
+  query: string;
+  kb?: string;
+  k: number;
+  threshold?: number;
+  mode?: SearchMode;
+  maxRequiredSources?: number;
+  staleness?: Staleness;
+}
+
+export interface RetrievalEvalScaffoldFixtureInput {
+  gate: false;
+  cases: RetrievalEvalScaffoldCaseInput[];
+}
+
+export interface RetrievalEvalScaffoldCaseInput {
+  name: string;
+  query: string;
+  kb?: string;
+  k: number;
+  threshold?: number;
+  mode?: SearchMode;
+  required_sources: string[];
+  expected_metadata?: Record<string, unknown>;
+  stale_policy: StalePolicy;
+}
+
+const DEFAULT_SCAFFOLD_REQUIRED_SOURCES = 3;
+const SCAFFOLD_METADATA_PATHS = [
+  'frontmatter.status',
+  'frontmatter.owner',
+  'frontmatter.review_status',
+  'frontmatter.review.status',
+  'frontmatter.type',
+  'frontmatter.category',
+  'frontmatter.topic',
+] as const;
+
 export function normalizeRetrievalEvalFixture(input: unknown): RetrievalEvalFixture {
   if (!isRecord(input)) {
     throw new Error('fixture must be an object with a cases array');
@@ -182,6 +220,33 @@ export function normalizeRetrievalEvalFixture(input: unknown): RetrievalEvalFixt
     ...readOptionalSearchMode(input, 'mode', 'fixture'),
     cases: rawCases.map((raw, idx) => normalizeCase(raw, idx + 1)),
   };
+}
+
+export function buildRetrievalEvalScaffoldFixture(
+  results: readonly ScoredDocument[],
+  options: RetrievalEvalScaffoldOptions,
+): RetrievalEvalScaffoldFixtureInput {
+  const requiredSources = selectRequiredSources(
+    results,
+    options.maxRequiredSources ?? DEFAULT_SCAFFOLD_REQUIRED_SOURCES,
+  );
+  const expectedMetadata = selectExpectedMetadata(results, new Set(requiredSources));
+  const fixture: RetrievalEvalScaffoldFixtureInput = {
+    gate: false,
+    cases: [{
+      name: scaffoldCaseName(options.query),
+      query: options.query,
+      ...(options.kb !== undefined ? { kb: options.kb } : {}),
+      k: options.k,
+      ...(options.threshold !== undefined ? { threshold: options.threshold } : {}),
+      ...(options.mode !== undefined ? { mode: options.mode } : {}),
+      required_sources: requiredSources,
+      ...(Object.keys(expectedMetadata).length > 0 ? { expected_metadata: expectedMetadata } : {}),
+      stale_policy: scaffoldStalePolicy(options.staleness),
+    }],
+  };
+  normalizeRetrievalEvalFixture(fixture);
+  return fixture;
 }
 
 export async function retrieveForRetrievalEvalCase(
@@ -1011,6 +1076,67 @@ function countSources(results: readonly ScoredDocument[]): Map<string, number> {
     counts.set(key, (counts.get(key) ?? 0) + 1);
   });
   return counts;
+}
+
+function selectRequiredSources(
+  results: readonly ScoredDocument[],
+  maxRequiredSources: number,
+): string[] {
+  if (maxRequiredSources <= 0) return [];
+  const selected: string[] = [];
+  const seen = new Set<string>();
+  for (const doc of results) {
+    const source = portableSourceIdentity(doc);
+    if (source === undefined || seen.has(source)) continue;
+    selected.push(source);
+    seen.add(source);
+    if (selected.length >= maxRequiredSources) break;
+  }
+  return selected;
+}
+
+function portableSourceIdentity(doc: ScoredDocument): string | undefined {
+  const metadata = doc.metadata as Record<string, unknown>;
+  const relativePath = metadata.relativePath;
+  if (typeof relativePath === 'string' && relativePath.trim() !== '') {
+    return relativePath;
+  }
+  return sourceIdentities(doc)[0];
+}
+
+function selectExpectedMetadata(
+  results: readonly ScoredDocument[],
+  requiredSources: ReadonlySet<string>,
+): Record<string, unknown> {
+  const expected: Record<string, unknown> = {};
+  for (const doc of results) {
+    const source = portableSourceIdentity(doc);
+    if (source === undefined || !requiredSources.has(source)) continue;
+    for (const dotPath of SCAFFOLD_METADATA_PATHS) {
+      if (dotPath in expected) continue;
+      const value = readPath(doc.metadata, dotPath);
+      if (isMetadataScaffoldValue(value)) expected[dotPath] = value;
+    }
+  }
+  return expected;
+}
+
+function isMetadataScaffoldValue(value: unknown): boolean {
+  return (
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean'
+  );
+}
+
+function scaffoldStalePolicy(staleness: Staleness | undefined): StalePolicy {
+  if (staleness === undefined) return 'allow_stale';
+  return isStale(staleness) ? 'allow_stale' : 'fresh';
+}
+
+function scaffoldCaseName(query: string): string {
+  const compact = query.trim().replace(/\s+/g, ' ');
+  return `scaffold - ${compact.slice(0, 60)}`;
 }
 
 function metadataMatchesRule(metadata: unknown, rule: ExpectedMetadataRule): boolean {


### PR DESCRIPTION
Closes #329

## Summary
- add `kb eval scaffold <query>` to emit starter retrieval-eval YAML to stdout
- seed required sources, stable metadata expectations, and stale policy from live retrieval results
- cover parser behavior and YAML normalization round-trip

## Tests
- `npx jest /home/jean/git/knowledge-base-mcp-server-issue-329-eval-scaffold/src/retrieval-eval.test.ts --runInBand`
- `npx jest /home/jean/git/knowledge-base-mcp-server/src/retrieval-eval.test.ts --runInBand`
- `npm run build`
- `git diff --check`
- `npm test -- --runInBand --silent`

Note: running the literal main-checkout retrieval-eval test from the feature worktree does not match Jest paths, so the worktree-path command above is the branch validation; the literal command passes from the main checkout.