### PR TITLE
fix(search): tolerate default timing sink

### DIFF
--- a/src/cli-search.test.ts
+++ b/src/cli-search.test.ts
@@ -11,10 +11,13 @@ import {
   formatRefreshProgressLine,
   parseSearchArgs,
   resolveAutoSearchMode,
+  runSearch,
   shouldUsePicker,
+  type RunSearchDeps,
   Staleness,
 } from './cli-search.js';
 import { compactTimingPayload, type TimingPayload } from './cli-timing.js';
+import type { FaissIndexManager, SimilaritySearchTiming } from './FaissIndexManager.js';
 import {
   classifyKbSearchError,
   formatKbSearchFailureJson,
@@ -235,6 +238,89 @@ describe('parseSearchArgs freshness', () => {
 
   it('accepts --no-freshness to omit freshness work and output', () => {
     expect(parseSearchArgs(['query', '--no-freshness'])).toMatchObject({ freshness: false });
+  });
+});
+
+describe('runSearch timing guard (#331)', () => {
+  function makeDeps(): {
+    deps: RunSearchDeps;
+    manager: FaissIndexManager & {
+      similaritySearch: jest.Mock;
+    };
+  } {
+    const manager = {
+      similaritySearch: jest.fn(async (...args: unknown[]) => {
+        const timing = args[5] as SimilaritySearchTiming | undefined;
+        // Mirrors FaissIndexManager's vector-search timing write. This used
+        // to throw for plain `kb search` because the CLI passed undefined.
+        timing!.faiss_search_ms = (timing!.faiss_search_ms ?? 0) + 7;
+        return [];
+      }),
+    } as unknown as FaissIndexManager & { similaritySearch: jest.Mock };
+
+    return {
+      manager,
+      deps: {
+        bootstrapLayout: jest.fn(async () => {}),
+        resolveActiveModel: jest.fn(async () => 'ollama__nomic-embed-text-latest'),
+        loadManagerForModel: jest.fn(async () => manager),
+        loadWithJsonRetry: jest.fn(async () => {}),
+      },
+    };
+  }
+
+  async function captureSearchOutput(
+    args: string[],
+    deps: RunSearchDeps,
+  ): Promise<{ code: number; stdout: string; stderr: string }> {
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const stdoutSpy = jest.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+      stdout.push(String(chunk));
+      return true;
+    });
+    const stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation((chunk) => {
+      stderr.push(String(chunk));
+      return true;
+    });
+
+    try {
+      const code = await runSearch(args, deps);
+      return { code, stdout: stdout.join(''), stderr: stderr.join('') };
+    } finally {
+      stdoutSpy.mockRestore();
+      stderrSpy.mockRestore();
+    }
+  }
+
+  it('keeps plain markdown search from dereferencing missing timing metrics', async () => {
+    const { deps, manager } = makeDeps();
+
+    const out = await captureSearchOutput(['query', '--no-freshness'], deps);
+
+    expect(out.code).toBe(0);
+    expect(out.stderr).toBe('');
+    expect(out.stdout).toContain('## Semantic Search Results');
+    expect(out.stdout).not.toContain('Timing');
+    expect(manager.similaritySearch).toHaveBeenCalledTimes(1);
+    expect(manager.similaritySearch.mock.calls[0][5]).toMatchObject({ faiss_search_ms: 7 });
+  });
+
+  it('keeps plain JSON search from dereferencing missing timing metrics', async () => {
+    const { deps, manager } = makeDeps();
+
+    const out = await captureSearchOutput(['query', '--format=json', '--no-freshness'], deps);
+
+    expect(out.code).toBe(0);
+    expect(out.stderr).toBe('');
+    expect(manager.similaritySearch).toHaveBeenCalledTimes(1);
+    expect(manager.similaritySearch.mock.calls[0][5]).toMatchObject({ faiss_search_ms: 7 });
+    const payload = JSON.parse(out.stdout);
+    expect(payload).toMatchObject({
+      results: [],
+      freshness_omitted: true,
+    });
+    expect(payload).not.toHaveProperty('timing');
   });
 });
 

--- a/src/cli-search.ts
+++ b/src/cli-search.ts
@@ -140,6 +140,20 @@ interface SearchArgs {
   neighborContext?: NeighborContextOptions;
 }
 
+export interface RunSearchDeps {
+  bootstrapLayout: typeof FaissIndexManager.bootstrapLayout;
+  resolveActiveModel: typeof resolveActiveModel;
+  loadManagerForModel: typeof loadManagerForModel;
+  loadWithJsonRetry: typeof loadWithJsonRetry;
+}
+
+const DEFAULT_RUN_SEARCH_DEPS: RunSearchDeps = {
+  bootstrapLayout: FaissIndexManager.bootstrapLayout,
+  resolveActiveModel,
+  loadManagerForModel,
+  loadWithJsonRetry,
+};
+
 export interface Staleness {
   indexMtime: string | null;
   modifiedFiles: number;
@@ -168,7 +182,10 @@ export interface AutoSearchModeDecision {
   reason: string;
 }
 
-export async function runSearch(rest: string[]): Promise<number> {
+export async function runSearch(
+  rest: string[],
+  deps: RunSearchDeps = DEFAULT_RUN_SEARCH_DEPS,
+): Promise<number> {
   const totalStartedAt = nowMs();
   let parsed: SearchArgs;
   try {
@@ -221,7 +238,7 @@ export async function runSearch(rest: string[]): Promise<number> {
 
   try {
     const startedAt = nowMs();
-    await FaissIndexManager.bootstrapLayout();
+    await deps.bootstrapLayout();
     if (timing) timing.bootstrap_ms = elapsedMs(startedAt);
   } catch (err) {
     return reportFailure(classifyKbSearchError(err), parsed.format);
@@ -230,7 +247,7 @@ export async function runSearch(rest: string[]): Promise<number> {
   let activeModelId: string;
   try {
     const startedAt = nowMs();
-    activeModelId = await resolveActiveModel({ explicitOverride: parsed.model });
+    activeModelId = await deps.resolveActiveModel({ explicitOverride: parsed.model });
     if (timing) timing.model_resolution_ms = elapsedMs(startedAt);
   } catch (err) {
     return reportFailure(classifyKbSearchError(err), parsed.format);
@@ -239,7 +256,7 @@ export async function runSearch(rest: string[]): Promise<number> {
   let manager: FaissIndexManager;
   try {
     const startedAt = nowMs();
-    manager = await loadManagerForModel(activeModelId);
+    manager = await deps.loadManagerForModel(activeModelId);
     if (timing) timing.manager_load_ms = elapsedMs(startedAt);
   } catch (err) {
     return reportFailure(classifyKbSearchError(err), parsed.format);
@@ -256,7 +273,7 @@ export async function runSearch(rest: string[]): Promise<number> {
         });
       });
     } else {
-      await loadWithJsonRetry(manager);
+      await deps.loadWithJsonRetry(manager);
     }
     if (timing) timing.index_load_ms = elapsedMs(startedAt);
   } catch (err) {
@@ -275,7 +292,7 @@ export async function runSearch(rest: string[]): Promise<number> {
         Number.POSITIVE_INFINITY,
         parsed.kb,
         undefined,
-        timing ? denseTiming : undefined,
+        denseTiming,
         { noCache: parsed.noCache },
       );
       autoThresholdDecision = computeAutoThreshold(rawResults.map((r) => r.score));
@@ -287,7 +304,7 @@ export async function runSearch(rest: string[]): Promise<number> {
         parsed.threshold,
         parsed.kb,
         undefined,
-        timing ? denseTiming : undefined,
+        denseTiming,
         { noCache: parsed.noCache },
       );
     }
@@ -1219,7 +1236,7 @@ async function runHybridSearch(
       Number.POSITIVE_INFINITY,
       parsed.kb,
       undefined,
-      timing ? denseTiming : undefined,
+      denseTiming,
       { noCache: parsed.noCache },
     )
     .then((rs) => {


### PR DESCRIPTION
## Summary
- keep the dense FAISS timing sink initialized for CLI search calls even when --timing output is disabled
- preserve default markdown/JSON output by omitting timing unless --timing is requested
- add focused markdown and JSON regressions for the no---timing path

## Tests
- npm test -- /home/jean/git/knowledge-base-mcp-server/src/cli-search.test.ts --runInBand (no tests found from feature worktree because the requested absolute path points at the main checkout)
- npm test -- /home/jean/git/knowledge-base-mcp-server-issue-331-timing-guard/src/cli-search.test.ts --runInBand
- npm run build
- git diff --check

Closes #331