### PR TITLE
feat(doctor): add reindex trigger diagnostics

### DIFF
--- a/src/cli-doctor.test.ts
+++ b/src/cli-doctor.test.ts
@@ -14,6 +14,9 @@ const originalEnv = {
   KB_AGE_BUDGET_HOURS: process.env.KB_AGE_BUDGET_HOURS,
   KB_AGE_BUDGET_HOURS_ALPHA: process.env.KB_AGE_BUDGET_HOURS_ALPHA,
   KB_AGE_BUDGET_HOURS_BETA: process.env.KB_AGE_BUDGET_HOURS_BETA,
+  REINDEX_TRIGGER_PATH: process.env.REINDEX_TRIGGER_PATH,
+  REINDEX_TRIGGER_POLL_MS: process.env.REINDEX_TRIGGER_POLL_MS,
+  KB_FS_WATCH: process.env.KB_FS_WATCH,
 };
 
 const MODEL_ID = 'huggingface__BAAI-bge-small-en-v1.5';
@@ -314,6 +317,90 @@ describe('kb doctor', () => {
     }
   });
 
+  it('reports reindex-trigger configuration, filesystem state, and freshness in markdown and JSON', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-doctor-trigger-'));
+    try {
+      const rootDir = path.join(tempDir, 'kbs');
+      const faissDir = path.join(tempDir, '.faiss');
+      await fsp.mkdir(rootDir, { recursive: true });
+      const modelDir = await seedRegisteredModel(faissDir);
+      const versionDir = await seedVersionedIndex(modelDir);
+      const binaryPath = path.join(versionDir, 'faiss.index');
+      const triggerPath = path.join(rootDir, '.reindex-trigger');
+      await fsp.writeFile(triggerPath, '');
+
+      const indexMs = 1_700_000_000_000;
+      const triggerMs = indexMs + 5_000;
+      await fsp.utimes(binaryPath, indexMs / 1000, indexMs / 1000);
+      await fsp.utimes(triggerPath, triggerMs / 1000, triggerMs / 1000);
+
+      const { buildDoctorReport, formatDoctorMarkdown } = await freshDoctor({
+        KNOWLEDGE_BASES_ROOT_DIR: rootDir,
+        FAISS_INDEX_PATH: faissDir,
+        EMBEDDING_PROVIDER: 'huggingface',
+        HUGGINGFACE_MODEL_NAME: MODEL_NAME,
+        HUGGINGFACE_API_KEY: 'test-key',
+        REINDEX_TRIGGER_PATH: triggerPath,
+        REINDEX_TRIGGER_POLL_MS: '2000',
+        KB_FS_WATCH: '1',
+      });
+
+      const report = await buildDoctorReport({
+        backendHealthCheck: async () => ({ healthy: true, detail: 'backend ok' }),
+        packageRoot: tempDir,
+        invokedPath: null,
+        packageVersion: '9.9.9',
+      });
+
+      expect(report.reindex_trigger).toMatchObject({
+        status: 'warn',
+        enabled: true,
+        poll_ms: 2000,
+        poll_ms_source: 'env',
+        path: triggerPath,
+        path_source: 'env',
+        kb_fs_watch_enabled: true,
+        trigger_file: {
+          exists: true,
+          kind: 'file',
+          mtime: new Date(triggerMs).toISOString(),
+        },
+        parent: {
+          path: rootDir,
+          exists: true,
+          writable: true,
+        },
+        freshness: {
+          index_mtime: new Date(indexMs).toISOString(),
+          trigger_mtime: new Date(triggerMs).toISOString(),
+          trigger_newer_than_index: true,
+        },
+      });
+      expect(report.reindex_trigger.warnings).toEqual([
+        'trigger file is newer than the active index; a refresh may be pending',
+      ]);
+      expect(report.checks).toContainEqual({
+        name: 'reindex_trigger',
+        status: 'warn',
+        detail: expect.stringContaining('reindex-trigger warning'),
+      });
+
+      const markdown = formatDoctorMarkdown(report);
+      expect(markdown).toContain('Reindex trigger:');
+      expect(markdown).toContain(`path: ${triggerPath} (env)`);
+      expect(markdown).toContain('poll: 2000ms (env)');
+      expect(markdown).toContain('freshness: trigger newer than active index');
+      expect(markdown).toContain('configuration and filesystem state only');
+      expect(markdown).not.toContain('actively watching: yes');
+
+      const json = JSON.parse(JSON.stringify(report)) as typeof report;
+      expect(json.reindex_trigger.freshness.trigger_newer_than_index).toBe(true);
+      expect(json.reindex_trigger.limitation).toContain('cannot prove');
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it('warns when a KB has quarantined ingest failures', async () => {
     const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-doctor-quarantine-'));
     try {
@@ -490,8 +577,13 @@ describe('kb doctor', () => {
 
   it('parses --format=json and rejects unsupported formats', async () => {
     const { parseDoctorArgs } = await freshDoctor({});
-    expect(parseDoctorArgs(['--format=json'])).toEqual({ format: 'json' });
-    expect(parseDoctorArgs([])).toEqual({ format: 'md' });
+    expect(parseDoctorArgs(['--format=json'])).toEqual({ format: 'json', reindexTrigger: false });
+    expect(parseDoctorArgs(['--reindex-trigger'])).toEqual({ format: 'md', reindexTrigger: true });
+    expect(parseDoctorArgs(['--reindex-trigger', '--format=json'])).toEqual({
+      format: 'json',
+      reindexTrigger: true,
+    });
+    expect(parseDoctorArgs([])).toEqual({ format: 'md', reindexTrigger: false });
     expect(() => parseDoctorArgs(['--format=yaml'])).toThrow(/invalid --format/);
   });
 

--- a/src/cli-doctor.ts
+++ b/src/cli-doctor.ts
@@ -22,8 +22,13 @@ import {
   HUGGINGFACE_ENDPOINT_URL_OVERRIDDEN,
   INGEST_EXCLUDE_PATHS,
   INGEST_EXTRA_EXTENSIONS,
+  KB_FS_WATCH,
   KNOWLEDGE_BASES_ROOT_DIR,
   OLLAMA_BASE_URL,
+  REINDEX_TRIGGER_PATH,
+  REINDEX_TRIGGER_POLL_MS,
+  resolveReindexTriggerPath,
+  resolveReindexTriggerPollMs,
 } from './config.js';
 import { enumerateIngestableKbFiles, listKnowledgeBases } from './kb-fs.js';
 import {
@@ -45,6 +50,7 @@ import {
   type ProviderCallSnapshot,
 } from './metrics.js';
 import { countIngestQuarantine } from './ingest-quarantine.js';
+import { inspectReindexTriggerFilesystem } from './triggerWatcher.js';
 
 /**
  * Issue #210 — error-rate threshold above which the doctor surfaces a
@@ -59,7 +65,7 @@ const execFileAsync = promisify(execFile);
 export const DOCTOR_HELP = `kb doctor — aggregate model / index / backend health report
 
 Usage:
-  kb doctor [--format=md|json]
+  kb doctor [--format=md|json] [--reindex-trigger]
 
 Composes existing read-only checks (env vars, registered models, active
 model, FAISS index presence + mtime, knowledge-base count, embedding
@@ -73,6 +79,8 @@ gate from a script.
 Options:
   --format=md|json      Output format (default: md). \`json\` emits the same
                         underlying report shape for agent shells.
+  --reindex-trigger     Include focused reindex-trigger diagnostics
+                        (also included in the aggregate report).
   --help, -h            Show this help.
 
 Examples:
@@ -83,6 +91,7 @@ Examples:
 
 export interface DoctorArgs {
   format: 'md' | 'json';
+  reindexTrigger: boolean;
 }
 
 export type HealthStatus = 'ok' | 'warn' | 'error';
@@ -187,6 +196,43 @@ export interface DoctorReport {
   } | null;
   last_index_update: IndexUpdateSummary;
   /**
+   * Reindex-trigger diagnostics for external ingest workflows. This is a
+   * read-only configuration and filesystem check; it cannot prove that a
+   * separate MCP server process is actively watching the trigger.
+   */
+  reindex_trigger: {
+    status: HealthStatus;
+    enabled: boolean;
+    poll_ms: number;
+    poll_ms_source: 'default' | 'env' | 'fallback';
+    poll_ms_raw: string | null;
+    path: string;
+    path_source: 'default' | 'env';
+    path_raw: string | null;
+    kb_fs_watch_enabled: boolean;
+    trigger_file: {
+      exists: boolean;
+      kind: 'file' | 'directory' | 'other' | 'missing';
+      mtime: string | null;
+      age_ms: number | null;
+      size_bytes: number | null;
+      stat_error: string | null;
+    };
+    parent: {
+      path: string;
+      exists: boolean;
+      writable: boolean | null;
+      access_error: string | null;
+    };
+    freshness: {
+      index_mtime: string | null;
+      trigger_mtime: string | null;
+      trigger_newer_than_index: boolean | null;
+    };
+    warnings: string[];
+    limitation: string;
+  };
+  /**
    * Issue #210 — per-`model_id` runtime telemetry for the active
    * embedding provider. Empty `{}` until the active provider has served
    * at least one call. The doctor row is WARN when
@@ -234,7 +280,7 @@ export async function runDoctor(rest: string[]): Promise<number> {
 }
 
 export function parseDoctorArgs(rest: string[]): DoctorArgs {
-  const out: DoctorArgs = { format: 'md' };
+  const out: DoctorArgs = { format: 'md', reindexTrigger: false };
   for (const raw of rest) {
     if (raw.startsWith('--format=')) {
       const value = raw.slice('--format='.length);
@@ -242,6 +288,10 @@ export function parseDoctorArgs(rest: string[]): DoctorArgs {
         throw new Error(`invalid --format: ${raw}`);
       }
       out.format = value;
+      continue;
+    }
+    if (raw === '--reindex-trigger') {
+      out.reindexTrigger = true;
       continue;
     }
     if (raw.startsWith('--')) throw new Error(`unknown flag: ${raw}`);
@@ -433,6 +483,12 @@ export async function buildDoctorReport(
   const lastIndexUpdate = options.lastIndexUpdateSummary
     ?? (await FaissIndexManager.readPersistedIndexUpdateSummary(activeModelId))
     ?? createNeverRunIndexUpdateSummary(activeModelId);
+  const reindexTrigger = await readReindexTriggerHealth(index.mtime);
+  checks.push({
+    name: 'reindex_trigger',
+    status: reindexTrigger.status,
+    detail: formatReindexTriggerCheckDetail(reindexTrigger),
+  });
 
   const status = summarizeStatus(checks);
   return {
@@ -454,8 +510,89 @@ export async function buildDoctorReport(
     cli,
     git,
     last_index_update: lastIndexUpdate,
+    reindex_trigger: reindexTrigger,
     provider_calls: providerCalls,
   };
+}
+
+async function readReindexTriggerHealth(
+  indexMtime: string | null,
+): Promise<DoctorReport['reindex_trigger']> {
+  const poll = resolveReindexTriggerPollMs(process.env.REINDEX_TRIGGER_POLL_MS);
+  const triggerPath = resolveReindexTriggerPath(
+    process.env.REINDEX_TRIGGER_PATH,
+    KNOWLEDGE_BASES_ROOT_DIR,
+  );
+  const fsState = await inspectReindexTriggerFilesystem(REINDEX_TRIGGER_PATH);
+  const warnings = [
+    ...triggerPath.warnings,
+    ...(poll.warning === null ? [] : [poll.warning]),
+    ...fsState.warnings,
+  ];
+
+  if (REINDEX_TRIGGER_POLL_MS <= 0) {
+    warnings.push('REINDEX_TRIGGER_POLL_MS=0 disables the reindex-trigger watcher');
+  }
+
+  const triggerMtimeMs = fsState.mtime === null ? null : Date.parse(fsState.mtime);
+  const indexMtimeMs = indexMtime === null ? null : Date.parse(indexMtime);
+  const triggerNewerThanIndex = triggerMtimeMs === null || indexMtimeMs === null
+    ? null
+    : triggerMtimeMs > indexMtimeMs;
+  if (triggerNewerThanIndex === true) {
+    warnings.push('trigger file is newer than the active index; a refresh may be pending');
+  }
+
+  const hasError = fsState.kind === 'directory'
+    || fsState.kind === 'other'
+    || !fsState.parent_exists
+    || fsState.parent_writable === false;
+  const status: HealthStatus = hasError ? 'error' : warnings.length > 0 ? 'warn' : 'ok';
+  const now = Date.now();
+  return {
+    status,
+    enabled: REINDEX_TRIGGER_POLL_MS > 0,
+    poll_ms: REINDEX_TRIGGER_POLL_MS,
+    poll_ms_source: poll.source,
+    poll_ms_raw: poll.raw_value,
+    path: REINDEX_TRIGGER_PATH,
+    path_source: triggerPath.source,
+    path_raw: triggerPath.raw_value,
+    kb_fs_watch_enabled: KB_FS_WATCH,
+    trigger_file: {
+      exists: fsState.exists,
+      kind: fsState.kind,
+      mtime: fsState.mtime,
+      age_ms: triggerMtimeMs === null ? null : Math.max(0, now - triggerMtimeMs),
+      size_bytes: fsState.size_bytes,
+      stat_error: fsState.stat_error,
+    },
+    parent: {
+      path: fsState.parent_path,
+      exists: fsState.parent_exists,
+      writable: fsState.parent_writable,
+      access_error: fsState.parent_access_error,
+    },
+    freshness: {
+      index_mtime: indexMtime,
+      trigger_mtime: fsState.mtime,
+      trigger_newer_than_index: triggerNewerThanIndex,
+    },
+    warnings,
+    limitation: 'configuration and filesystem state only; this CLI cannot prove another MCP server process is actively watching',
+  };
+}
+
+function formatReindexTriggerCheckDetail(
+  report: DoctorReport['reindex_trigger'],
+): string {
+  if (!report.enabled) {
+    return `disabled; path=${report.path}`;
+  }
+  if (report.warnings.length > 0) {
+    return `${report.warnings.length} reindex-trigger warning(s); path=${report.path}`;
+  }
+  return `enabled every ${report.poll_ms}ms; path=${report.path}`;
 }
 
 function formatErrorRate(errors: number, count: number): string {
@@ -901,6 +1038,39 @@ export function formatDoctorMarkdown(report: DoctorReport): string {
     lines.push('  ownership: skipped on this platform');
   }
   lines.push(`Last index update: ${formatLastIndexUpdate(report.last_index_update)}`);
+  lines.push('Reindex trigger:');
+  lines.push(
+    `  path: ${report.reindex_trigger.path} (${report.reindex_trigger.path_source})`,
+  );
+  lines.push(
+    `  poll: ${report.reindex_trigger.enabled ? `${report.reindex_trigger.poll_ms}ms` : 'disabled'} ` +
+    `(${report.reindex_trigger.poll_ms_source})`,
+  );
+  const triggerFile = report.reindex_trigger.trigger_file;
+  const triggerMtime = triggerFile.mtime ?? 'none';
+  const triggerAge = triggerFile.age_ms === null ? 'n/a' : `${Math.round(triggerFile.age_ms / 1000)}s`;
+  lines.push(
+    `  trigger file: ${triggerFile.exists ? triggerFile.kind : 'missing'}, ` +
+    `mtime=${triggerMtime}, age=${triggerAge}`,
+  );
+  lines.push(
+    `  parent: ${report.reindex_trigger.parent.path} ` +
+    `(exists=${report.reindex_trigger.parent.exists ? 'yes' : 'no'}, ` +
+    `writable=${formatNullableBoolean(report.reindex_trigger.parent.writable)})`,
+  );
+  lines.push(`  freshness: ${formatReindexTriggerFreshness(report.reindex_trigger)}`);
+  lines.push(
+    `  KB_FS_WATCH: ${report.reindex_trigger.kb_fs_watch_enabled ? 'on' : 'off'} ` +
+    '(independent per-file watcher)',
+  );
+  if (report.reindex_trigger.warnings.length === 0) {
+    lines.push('  warnings: (none)');
+  } else {
+    for (const warning of report.reindex_trigger.warnings) {
+      lines.push(`  WARN ${warning}`);
+    }
+  }
+  lines.push(`  note: ${report.reindex_trigger.limitation}`);
   lines.push(`Backend: ${report.backend.healthy ? 'ok' : 'error'} — ${report.backend.detail}`);
   lines.push(`kb version: ${report.cli.version}`);
   if (report.cli.symlinked_checkout_path !== null) {
@@ -1012,6 +1182,25 @@ function formatBytes(bytes: number | null): string {
   }
   if (unit === 0) return `${bytes} B`;
   return `${value.toFixed(1)} ${units[unit]}`;
+}
+
+function formatNullableBoolean(value: boolean | null): string {
+  if (value === null) return 'unknown';
+  return value ? 'yes' : 'no';
+}
+
+function formatReindexTriggerFreshness(
+  report: DoctorReport['reindex_trigger'],
+): string {
+  const indexMtime = report.freshness.index_mtime ?? 'none';
+  const triggerMtime = report.freshness.trigger_mtime ?? 'none';
+  if (report.freshness.trigger_newer_than_index === null) {
+    return `unknown (trigger=${triggerMtime}, index=${indexMtime})`;
+  }
+  if (report.freshness.trigger_newer_than_index) {
+    return `trigger newer than active index (trigger=${triggerMtime}, index=${indexMtime})`;
+  }
+  return `trigger not newer than active index (trigger=${triggerMtime}, index=${indexMtime})`;
 }
 
 function formatLastIndexUpdate(summary: IndexUpdateSummary): string {

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -11,6 +11,8 @@ import {
   parseKbMaxFileBytes,
   parseReindexTriggerPollMs,
   parseKBEditorUri,
+  resolveReindexTriggerPath,
+  resolveReindexTriggerPollMs,
   resolveChunkSize,
   resolveIndexingBatchSize,
   UnknownEmbeddingProviderError,
@@ -168,6 +170,68 @@ describe('parseReindexTriggerPollMs (RFC 011 §5.5)', () => {
   it('rounds fractional in-range values to an integer', () => {
     expect(parseReindexTriggerPollMs('1500.7')).toBe(1501);
     expect(parseReindexTriggerPollMs('59999.4')).toBe(59999);
+  });
+});
+
+describe('resolveReindexTriggerPollMs (#334 doctor diagnostics)', () => {
+  it('returns source metadata for defaults, disabled, and fallback values', () => {
+    expect(resolveReindexTriggerPollMs(undefined)).toMatchObject({
+      value: 5000,
+      source: 'default',
+      warning: null,
+    });
+    expect(resolveReindexTriggerPollMs('0')).toMatchObject({
+      value: 0,
+      source: 'env',
+      warning: null,
+    });
+    expect(resolveReindexTriggerPollMs('nope')).toMatchObject({
+      value: 5000,
+      source: 'fallback',
+      raw_value: 'nope',
+    });
+    expect(resolveReindexTriggerPollMs('nope').warning).toContain('REINDEX_TRIGGER_POLL_MS');
+  });
+
+  it('surfaces clamp and rounding warnings without changing parser semantics', () => {
+    expect(resolveReindexTriggerPollMs('500')).toMatchObject({
+      value: 1000,
+      source: 'env',
+    });
+    expect(resolveReindexTriggerPollMs('500').warning).toContain('clamped');
+
+    expect(resolveReindexTriggerPollMs('1500.7')).toMatchObject({
+      value: 1501,
+      source: 'env',
+    });
+    expect(resolveReindexTriggerPollMs('1500.7').warning).toContain('rounded');
+  });
+});
+
+describe('resolveReindexTriggerPath (#334 doctor diagnostics)', () => {
+  it('defaults to .reindex-trigger under the KB root when unset or blank', () => {
+    expect(resolveReindexTriggerPath(undefined, '/tmp/kbs')).toEqual({
+      path: '/tmp/kbs/.reindex-trigger',
+      source: 'default',
+      raw_value: null,
+      warnings: [],
+    });
+    expect(resolveReindexTriggerPath('   ', '/tmp/kbs')).toMatchObject({
+      path: '/tmp/kbs/.reindex-trigger',
+      source: 'default',
+    });
+  });
+
+  it('preserves explicit paths and warns when they are relative', () => {
+    expect(resolveReindexTriggerPath('/tmp/custom-trigger', '/tmp/kbs')).toEqual({
+      path: '/tmp/custom-trigger',
+      source: 'env',
+      raw_value: '/tmp/custom-trigger',
+      warnings: [],
+    });
+    const relative = resolveReindexTriggerPath('relative-trigger', '/tmp/kbs');
+    expect(relative.path).toBe('relative-trigger');
+    expect(relative.warnings).toEqual([expect.stringContaining('relative')]);
   });
 });
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -327,6 +327,50 @@ const DEFAULT_REINDEX_TRIGGER_POLL_MS = 5000;
 const MIN_REINDEX_TRIGGER_POLL_MS = 1000;
 const MAX_REINDEX_TRIGGER_POLL_MS = 60000;
 
+export type ReindexTriggerPollMsResolution = {
+  value: number;
+  source: 'default' | 'env' | 'fallback';
+  raw_value: string | null;
+  warning: string | null;
+};
+
+export function resolveReindexTriggerPollMs(
+  raw: string | undefined,
+): ReindexTriggerPollMsResolution {
+  if (raw === undefined || raw.trim() === '') {
+    return {
+      value: DEFAULT_REINDEX_TRIGGER_POLL_MS,
+      source: 'default',
+      raw_value: raw ?? null,
+      warning: null,
+    };
+  }
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return {
+      value: DEFAULT_REINDEX_TRIGGER_POLL_MS,
+      source: 'fallback',
+      raw_value: raw,
+      warning: `invalid REINDEX_TRIGGER_POLL_MS=${JSON.stringify(raw)}; using ${DEFAULT_REINDEX_TRIGGER_POLL_MS}`,
+    };
+  }
+  if (parsed === 0) {
+    return { value: 0, source: 'env', raw_value: raw, warning: null };
+  }
+  const rounded = Math.round(parsed);
+  const value = Math.max(
+    MIN_REINDEX_TRIGGER_POLL_MS,
+    Math.min(MAX_REINDEX_TRIGGER_POLL_MS, rounded),
+  );
+  let warning: string | null = null;
+  if (value !== rounded) {
+    warning = `REINDEX_TRIGGER_POLL_MS=${JSON.stringify(raw)} clamped to ${value}`;
+  } else if (rounded !== parsed) {
+    warning = `REINDEX_TRIGGER_POLL_MS=${JSON.stringify(raw)} rounded to ${value}`;
+  }
+  return { value, source: 'env', raw_value: raw, warning };
+}
+
 /**
  * @internal
  *
@@ -337,26 +381,41 @@ const MAX_REINDEX_TRIGGER_POLL_MS = 60000;
  * function.
  */
 export function parseReindexTriggerPollMs(raw: string | undefined): number {
-  if (raw === undefined || raw.trim() === '') {
-    return DEFAULT_REINDEX_TRIGGER_POLL_MS;
-  }
-  const parsed = Number(raw);
-  if (!Number.isFinite(parsed) || parsed < 0) {
-    return DEFAULT_REINDEX_TRIGGER_POLL_MS;
-  }
-  // `0` is the documented "disabled" sentinel — accepted unchanged.
-  if (parsed === 0) return 0;
-  // Otherwise clamp into [MIN, MAX] so operators can't set a 50ms spin-poll
-  // or a multi-hour interval that defeats the point of the watcher.
-  return Math.max(
-    MIN_REINDEX_TRIGGER_POLL_MS,
-    Math.min(MAX_REINDEX_TRIGGER_POLL_MS, Math.round(parsed)),
-  );
+  return resolveReindexTriggerPollMs(raw).value;
 }
 
 export const REINDEX_TRIGGER_POLL_MS: number = parseReindexTriggerPollMs(
   process.env.REINDEX_TRIGGER_POLL_MS,
 );
+
+export type ReindexTriggerPathResolution = {
+  path: string;
+  source: 'default' | 'env';
+  raw_value: string | null;
+  warnings: string[];
+};
+
+export function resolveReindexTriggerPath(
+  raw: string | undefined,
+  rootDir: string = KNOWLEDGE_BASES_ROOT_DIR,
+): ReindexTriggerPathResolution {
+  if (raw === undefined || raw.trim() === '') {
+    return {
+      path: path.join(rootDir, '.reindex-trigger'),
+      source: 'default',
+      raw_value: raw ?? null,
+      warnings: [],
+    };
+  }
+  return {
+    path: raw,
+    source: 'env',
+    raw_value: raw,
+    warnings: path.isAbsolute(raw)
+      ? []
+      : ['REINDEX_TRIGGER_PATH is relative; it is resolved against the server process working directory'],
+  };
+}
 
 /**
  * Path the reindex-trigger watcher polls. Defaults to a dotfile at the
@@ -364,8 +423,7 @@ export const REINDEX_TRIGGER_POLL_MS: number = parseReindexTriggerPollMs(
  * dot-prefixed entries at `src/file-utils.ts:25-29`).
  */
 export const REINDEX_TRIGGER_PATH: string =
-  process.env.REINDEX_TRIGGER_PATH
-  || path.join(KNOWLEDGE_BASES_ROOT_DIR, '.reindex-trigger');
+  resolveReindexTriggerPath(process.env.REINDEX_TRIGGER_PATH).path;
 
 // ---------------------------------------------------------------------------
 // Recursive fs.watch watcher (RFC 007 §6.6, issue #212).

--- a/src/triggerWatcher.test.ts
+++ b/src/triggerWatcher.test.ts
@@ -2,7 +2,10 @@ import * as fsp from 'fs/promises';
 import * as os from 'os';
 import * as path from 'path';
 
-import { ReindexTriggerWatcher } from './triggerWatcher.js';
+import {
+  ReindexTriggerWatcher,
+  inspectReindexTriggerFilesystem,
+} from './triggerWatcher.js';
 
 /**
  * The watcher runs off `setInterval`, which makes real-time testing flaky
@@ -219,5 +222,46 @@ describe('ReindexTriggerWatcher (RFC 011 §5.5)', () => {
     // (the previous bar) would let a regression that re-fired on every
     // tick after the bump pass silently.
     expect(onTrigger).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('inspectReindexTriggerFilesystem (#334 doctor diagnostics)', () => {
+  let tempDir: string;
+  let triggerPath: string;
+
+  beforeEach(async () => {
+    tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-trigger-state-'));
+    triggerPath = path.join(tempDir, '.reindex-trigger');
+  });
+
+  afterEach(async () => {
+    await fsp.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('reports a missing trigger file while validating the writable parent', async () => {
+    const state = await inspectReindexTriggerFilesystem(triggerPath);
+    expect(state).toMatchObject({
+      trigger_path: triggerPath,
+      parent_path: tempDir,
+      exists: false,
+      kind: 'missing',
+      mtime: null,
+      size_bytes: null,
+      parent_exists: true,
+      parent_writable: true,
+      stat_error: null,
+    });
+    expect(state.warnings).toEqual(['trigger file does not exist yet']);
+  });
+
+  it('reports file mtime and kind when the trigger exists', async () => {
+    await fsp.writeFile(triggerPath, 'touch\n');
+    const state = await inspectReindexTriggerFilesystem(triggerPath);
+    expect(state.exists).toBe(true);
+    expect(state.kind).toBe('file');
+    expect(state.size_bytes).toBe(Buffer.byteLength('touch\n'));
+    expect(state.mtime).toEqual(expect.any(String));
+    expect(state.parent_writable).toBe(true);
+    expect(state.warnings).toEqual([]);
   });
 });

--- a/src/triggerWatcher.ts
+++ b/src/triggerWatcher.ts
@@ -10,9 +10,102 @@
 // is the right surface for inline editing); the poller sees the root-level
 // dotfile that the walker and `fs.watch` both deliberately skip.
 import * as fsp from 'fs/promises';
+import { constants as fsConstants } from 'fs';
+import * as path from 'path';
 import { logger } from './logger.js';
 
 type FsError = NodeJS.ErrnoException & { code?: string };
+
+export type ReindexTriggerFileKind = 'file' | 'directory' | 'other' | 'missing';
+
+export interface ReindexTriggerFilesystemState {
+  trigger_path: string;
+  parent_path: string;
+  exists: boolean;
+  kind: ReindexTriggerFileKind;
+  mtime: string | null;
+  size_bytes: number | null;
+  parent_exists: boolean;
+  parent_writable: boolean | null;
+  stat_error: string | null;
+  parent_access_error: string | null;
+  warnings: string[];
+}
+
+export async function inspectReindexTriggerFilesystem(
+  triggerPath: string,
+): Promise<ReindexTriggerFilesystemState> {
+  const parentPath = path.dirname(triggerPath);
+  const warnings: string[] = [];
+  let exists = false;
+  let kind: ReindexTriggerFileKind = 'missing';
+  let mtime: string | null = null;
+  let sizeBytes: number | null = null;
+  let statError: string | null = null;
+
+  try {
+    const st = await fsp.stat(triggerPath);
+    exists = true;
+    kind = st.isFile() ? 'file' : st.isDirectory() ? 'directory' : 'other';
+    mtime = new Date(st.mtimeMs).toISOString();
+    sizeBytes = st.size;
+    if (kind !== 'file') {
+      warnings.push(`trigger path exists but is ${kind}, not a file`);
+    }
+  } catch (error) {
+    const code = (error as FsError | undefined)?.code;
+    if (code === 'ENOENT' || code === 'ENOTDIR') {
+      warnings.push('trigger file does not exist yet');
+    } else {
+      statError = (error as Error).message;
+      warnings.push(`trigger stat failed: ${statError}`);
+    }
+  }
+
+  let parentExists = false;
+  let parentWritable: boolean | null = null;
+  let parentAccessError: string | null = null;
+  try {
+    const parentStat = await fsp.stat(parentPath);
+    parentExists = parentStat.isDirectory();
+    if (!parentExists) {
+      warnings.push('trigger parent exists but is not a directory');
+      parentWritable = false;
+    } else {
+      try {
+        await fsp.access(parentPath, fsConstants.W_OK);
+        parentWritable = true;
+      } catch (error) {
+        parentWritable = false;
+        parentAccessError = (error as Error).message;
+        warnings.push(`trigger parent is not writable: ${parentAccessError}`);
+      }
+    }
+  } catch (error) {
+    const code = (error as FsError | undefined)?.code;
+    parentWritable = false;
+    parentAccessError = (error as Error).message;
+    if (code === 'ENOENT' || code === 'ENOTDIR') {
+      warnings.push('trigger parent directory does not exist');
+    } else {
+      warnings.push(`trigger parent stat failed: ${parentAccessError}`);
+    }
+  }
+
+  return {
+    trigger_path: triggerPath,
+    parent_path: parentPath,
+    exists,
+    kind,
+    mtime,
+    size_bytes: sizeBytes,
+    parent_exists: parentExists,
+    parent_writable: parentWritable,
+    stat_error: statError,
+    parent_access_error: parentAccessError,
+    warnings,
+  };
+}
 
 /**
  * Observes mtime on a single file and invokes `onTrigger` whenever it


### PR DESCRIPTION
Closes #334

## Summary
- add reindex-trigger config/filesystem diagnostics to `kb doctor` markdown and JSON output
- surface poll interval/path provenance, trigger mtime freshness versus the active index, parent writability, and the independent `KB_FS_WATCH` setting
- keep the v1 wording limited to configuration and filesystem state, without claiming another MCP server is actively watching

## Tests
- `npm test -- /home/jean/git/knowledge-base-mcp-server-issue-334-reindex-trigger-doctor/src/cli-doctor.test.ts /home/jean/git/knowledge-base-mcp-server-issue-334-reindex-trigger-doctor/src/config.test.ts /home/jean/git/knowledge-base-mcp-server-issue-334-reindex-trigger-doctor/src/triggerWatcher.test.ts --runInBand`
- `npm run build`
- `git diff --check`
- `npm test -- --runInBand`

## Pre-PR Review
- detected project type: npm
- type/build checks: passed (`npm run build`)
- tests: passed (focused suite and full `npm test -- --runInBand`)
- bug reproduction: skipped; feature PR, not a bug fix
- diff review: done; six expected source/test files only
- portability check: clean by manual changed-line scan; repo has no `scripts/check-portability.sh` helper
- reviewer specialists: skipped because this Codex session only permits subagent delegation when explicitly requested by the user
- OSS base-branch policy: skipped; same-repo PR
- gate file: created

Note: the prompt-specified absolute-path command using `/home/jean/git/knowledge-base-mcp-server/src/...` was attempted from the required feature worktree, but Jest reported no matching tests because those paths are outside the worktree root. The equivalent worktree-path focused suite passed.