### PR TITLE
refactor(faiss): isolate store internals behind adapter

### DIFF
--- a/src/FaissIndexManager.test.ts
+++ b/src/FaissIndexManager.test.ts
@@ -118,6 +118,22 @@ jest.mock('@langchain/community/vectorstores/faiss', () => ({
   FaissStore: MockFaissStore,
 }));
 
+function loadedFaissStore(manager: unknown): Record<string, unknown> {
+  const internal = manager as {
+    faissIndex?: { getStoreForPersistence?: () => unknown } | null;
+  };
+  const store = internal.faissIndex?.getStoreForPersistence?.();
+  if (store === undefined || store === null || typeof store !== 'object') {
+    throw new Error('manager has no loaded FAISS store');
+  }
+  return store as Record<string, unknown>;
+}
+
+async function setLoadedFaissStore(manager: unknown, store: Record<string, unknown>): Promise<void> {
+  const { FaissStoreAdapter } = await import('./faiss-store-adapter.js');
+  (manager as { faissIndex?: unknown }).faissIndex = FaissStoreAdapter.fromStore(store as never);
+}
+
 function createPermissionError(message: string): NodeJS.ErrnoException {
   const error = new Error(message) as NodeJS.ErrnoException;
   error.code = 'EACCES';
@@ -3292,10 +3308,10 @@ describe('FaissIndexManager similaritySearch metadata filters (#53)', () => {
     // Provide ntotal() so the over-fetch branch (scoped or filtered) doesn't
     // crash on undefined.index. The real FaissStore exposes this; the mock
     // does not, so wire the minimum surface the implementation reads.
-    interface IndexHandle { index: { ntotal: () => number } }
-    (manager as unknown as IndexHandle).index = { ntotal: () => 100 };
-    const internal = manager as unknown as { faissIndex: { index: { ntotal: () => number } } };
-    internal.faissIndex.index = { ntotal: () => 100 };
+    loadedFaissStore(manager).index = {
+      ntotal: () => 100,
+      getDimension: () => 2,
+    };
     return manager;
   }
 
@@ -3512,8 +3528,10 @@ describe('FaissIndexManager similaritySearch metadata filters (#53)', () => {
     const manager = new FaissIndexManager();
     await manager.initialize();
     await manager.updateIndex();
-    const internal = manager as unknown as { faissIndex: { index: { ntotal: () => number } } };
-    internal.faissIndex.index = { ntotal: () => 100 };
+    loadedFaissStore(manager).index = {
+      ntotal: () => 100,
+      getDimension: () => 2,
+    };
 
     // Capture the metadata that ingest stamped on the chunks for both files;
     // feed those exact objects back via the FAISS mock so the post-filter
@@ -3648,10 +3666,10 @@ describe('FaissIndexManager progressive overfetch (#229)', () => {
     const manager = new FaissIndexManager();
     await manager.initialize();
     await manager.updateIndex();
-    const internal = manager as unknown as {
-      faissIndex: { index: { ntotal: () => number } };
+    loadedFaissStore(manager).index = {
+      ntotal: () => ntotal,
+      getDimension: () => 2,
     };
-    internal.faissIndex.index = { ntotal: () => ntotal };
     return manager;
   }
 
@@ -3819,7 +3837,7 @@ describe('FaissIndexManager neighbor context expansion', () => {
       ['2', { pageContent: 'after', metadata: { knowledgeBase: 'kb', source: '/kb/doc.md', chunkIndex: 2 } }],
       ['other', { pageContent: 'wrong source', metadata: { knowledgeBase: 'kb', source: '/kb/other.md', chunkIndex: 0 } }],
     ]);
-    (manager as any).faissIndex = { docstore: { _docs: docs } };
+    await setLoadedFaissStore(manager, { docstore: { _docs: docs } });
 
     const expanded = manager.expandWithNeighborContext([
       {
@@ -3860,7 +3878,7 @@ describe('FaissIndexManager neighbor context expansion', () => {
       ['2', { pageContent: 'two', metadata: { knowledgeBase: 'kb', source: '/kb/doc.md', chunkIndex: 2 } }],
       ['3', { pageContent: 'three', metadata: { knowledgeBase: 'kb', source: '/kb/doc.md', chunkIndex: 3 } }],
     ]);
-    (manager as any).faissIndex = { docstore: { _docs: docs } };
+    await setLoadedFaissStore(manager, { docstore: { _docs: docs } });
 
     const expanded = manager.expandWithNeighborContext([
       {
@@ -3892,7 +3910,7 @@ describe('FaissIndexManager neighbor context expansion', () => {
       ['1', { pageContent: 'one', metadata: { knowledgeBase: 'kb', source: '/kb/doc.md', chunkIndex: 1 } }],
       ['2', { pageContent: 'two', metadata: { knowledgeBase: 'kb', source: '/kb/doc.md', chunkIndex: 2 } }],
     ]);
-    (manager as any).faissIndex = { docstore: { _docs: docs } };
+    await setLoadedFaissStore(manager, { docstore: { _docs: docs } });
 
     const expanded = manager.expandWithNeighborContext([
       {

--- a/src/FaissIndexManager.ts
+++ b/src/FaissIndexManager.ts
@@ -1,7 +1,6 @@
 // FaissIndexManager.ts — RFC 013 M1+M2 (multi-model layout).
 import * as fsp from 'fs/promises';
 import * as path from 'path';
-import { FaissStore } from "@langchain/community/vectorstores/faiss";
 import type { EmbeddingsInterface } from '@langchain/core/embeddings';
 import { Document } from "@langchain/core/documents";
 import { createEmbeddingsClient, type EmbeddingsClient } from './embedding-provider.js';
@@ -54,6 +53,7 @@ import {
 } from './search-filters.js';
 import { queryEmbeddingCache, type QueryCacheLookupStatus } from './query-cache.js';
 import { withSidecarLock } from './write-lock.js';
+import { FaissStoreAdapter } from './faiss-store-adapter.js';
 import {
   recordIngestFailure,
   recordIngestSuccess,
@@ -440,7 +440,7 @@ function parsePersistedIndexUpdateSummary(value: unknown): IndexUpdateSummary | 
 }
 
 export class FaissIndexManager {
-  private faissIndex: FaissStore | null = null;
+  private faissIndex: FaissStoreAdapter | null = null;
   // Issue #59 — populated by initialize() via dynamic import of the active
   // provider's @langchain module. Definite-assignment-asserted because the
   // class invariant is "every method that touches embeddings runs after
@@ -789,14 +789,15 @@ export class FaissIndexManager {
    * `list_models` (active-model.ts:detectDowngradeHazard), so no marker
    * file is required — the filesystem is the single source of truth.
    */
-  private async loadAtomic(opts: { repairCorrupt?: boolean } = {}): Promise<FaissStore | null> {
-    return loadFaissStoreAtomic({
+  private async loadAtomic(opts: { repairCorrupt?: boolean } = {}): Promise<FaissStoreAdapter | null> {
+    const store = await loadFaissStoreAtomic({
       modelDir: this.modelDir,
       modelId: this.modelId,
       embeddings: this.embeddings,
       handleFsOperationError,
       repairCorrupt: opts.repairCorrupt,
     });
+    return store === null ? null : FaissStoreAdapter.fromStore(store);
   }
 
   /**
@@ -830,12 +831,22 @@ export class FaissIndexManager {
 
     this.swapCounter += 1;
     await saveFaissStoreAtomic({
-      store: this.faissIndex,
+      store: this.faissStoreForPersistence(),
       modelDir: this.modelDir,
       modelId: this.modelId,
       swapCounter: this.swapCounter,
       casRoot: casRootForIndexPath(FAISS_INDEX_PATH),
     });
+  }
+
+  private faissStoreForPersistence(): ReturnType<FaissStoreAdapter['getStoreForPersistence']> {
+    const candidate = this.faissIndex as
+      | FaissStoreAdapter
+      | ReturnType<FaissStoreAdapter['getStoreForPersistence']>;
+    if (candidate instanceof FaissStoreAdapter) {
+      return candidate.getStoreForPersistence();
+    }
+    return candidate;
   }
 
   private async addDocumentsToIndex(
@@ -863,22 +874,15 @@ export class FaissIndexManager {
       batchIndex += 1;
       if (this.faissIndex === null) {
         logger.info(`Creating new FAISS index from ${batch.length} text(s)...`);
-        this.faissIndex = await FaissStore.fromTexts(
-          batch.map((doc) => doc.pageContent),
-          batch.map((doc) => doc.metadata),
+        this.faissIndex = await FaissStoreAdapter.fromDocuments(
+          batch,
           indexingEmbeddings,
         );
         // The store must keep the real client for query embeddings and later
         // operations; the deduper is only an insertion-time wrapper.
-        this.faissIndex.embeddings = this.embeddings;
+        this.faissIndex.restoreEmbeddings(this.embeddings);
       } else {
-        const previousEmbeddings = this.faissIndex.embeddings;
-        this.faissIndex.embeddings = indexingEmbeddings;
-        try {
-          await this.faissIndex.addDocuments(batch);
-        } finally {
-          this.faissIndex.embeddings = previousEmbeddings;
-        }
+        await this.faissIndex.addDocumentsWithEmbeddings(batch, indexingEmbeddings);
       }
       processedChunks += batch.length;
       if (opts?.onProgress) {
@@ -1824,48 +1828,26 @@ export class FaissIndexManager {
     // reuse the embedding across every progressive-overfetch rung so the
     // embed cost is paid exactly once. Issue #214 adds the query-embedding
     // cache at this boundary; document embedding remains untouched.
-    const vectorSearch = (
-      this.faissIndex as unknown as {
-        similaritySearchVectorWithScore?: (
-          queryEmbedding: number[],
-          k: number,
-        ) => Promise<Array<[Document, number]>>;
-      }
-    ).similaritySearchVectorWithScore;
-    const useVectorPath = typeof vectorSearch === 'function';
-    let queryEmbedding: number[] | undefined;
-    if (useVectorPath) {
-      const embedStartedAt = Date.now();
-      const cached = await queryEmbeddingCache.getOrCompute({
+    let queryEmbeddingLookup: ReturnType<typeof queryEmbeddingCache.getOrCompute> | null = null;
+    const getQueryEmbedding = (): ReturnType<typeof queryEmbeddingCache.getOrCompute> => {
+      queryEmbeddingLookup ??= queryEmbeddingCache.getOrCompute({
         modelId: this.modelId,
         query,
         bypass: opts.noCache === true,
         embed: () => this.embeddings.embedQuery(query),
       });
-      queryEmbedding = cached.embedding;
-      if (timing) {
-        timing.embed_query_ms = Date.now() - embedStartedAt;
-        timing.query_cache = cached.status;
-      }
-    } else if (timing) {
-      timing.query_cache = 'unavailable';
-    }
+      return queryEmbeddingLookup;
+    };
 
     const runFaissSearch = async (
       fetchK: number,
     ): Promise<Array<[Document, number]>> => {
-      if (useVectorPath) {
-        const faissStartedAt = Date.now();
-        const out = await vectorSearch!.call(this.faissIndex, queryEmbedding!, fetchK);
-        timing!.faiss_search_ms = (timing!.faiss_search_ms ?? 0) + (Date.now() - faissStartedAt);
-        return out;
-      }
-      const queryStartedAt = Date.now();
-      const out = await this.faissIndex!.similaritySearchWithScore(query, fetchK);
-      if (timing) {
-        timing.query_search_ms = (timing.query_search_ms ?? 0) + (Date.now() - queryStartedAt);
-      }
-      return out;
+      return this.faissIndex!.similaritySearchUsingBestPath({
+        query,
+        k: fetchK,
+        timing,
+        getQueryEmbedding,
+      });
     };
 
     if (!postFilter.requiresOverfetch) {
@@ -1887,7 +1869,7 @@ export class FaissIndexManager {
     // already returned its entire docstore (raw length below the requested
     // window ⇒ ntotal exhausted). Worst case ends at `ntotal` and matches
     // the pre-#229 cost; common filtered queries terminate at the first rung.
-    const ntotal = this.faissIndex.index.ntotal();
+    const ntotal = this.faissIndex.totalVectors();
     const fetchSizes = progressiveFetchSizes(k, ntotal);
     let filtered: ScoredDocument[] = [];
     let lastFetchK = k;
@@ -2007,35 +1989,14 @@ export class FaissIndexManager {
     if (!this.faissIndex) {
       return { totalChunks: 0, chunkCountsByKb: {}, dim: null };
     }
-    const totalChunks = this.faissIndex.index.ntotal();
-    const dim = this.faissIndex.index.getDimension();
-    const chunkCountsByKb: Record<string, number> = {};
-    // SynchronousInMemoryDocstore exposes `_docs: Map<string, Document>`
-    // (langchain 0.3 internal — verified against the bundled
-    // node_modules/langchain/dist/stores/doc/in_memory.js). The cast
-    // surfaces only the fields we touch.
-    const docs = (
-      this.faissIndex.docstore as unknown as {
-        _docs: Map<string, { metadata?: { knowledgeBase?: unknown } }>;
-      }
-    )._docs;
-    for (const doc of docs.values()) {
-      const kb = doc.metadata?.knowledgeBase;
-      if (typeof kb === 'string') {
-        chunkCountsByKb[kb] = (chunkCountsByKb[kb] ?? 0) + 1;
-      }
-    }
+    const totalChunks = this.faissIndex.totalVectors();
+    const dim = this.faissIndex.vectorDimension();
+    const chunkCountsByKb = this.faissIndex.chunkCountsByKnowledgeBase();
     return { totalChunks, chunkCountsByKb, dim };
   }
 
   private getDocstoreDocuments(): Document[] {
-    const docs = (
-      this.faissIndex?.docstore as unknown as {
-        _docs?: Map<string, Document>;
-      } | undefined
-    )?._docs;
-    if (!(docs instanceof Map)) return [];
-    return Array.from(docs.values());
+    return this.faissIndex?.docstoreDocuments() ?? [];
   }
 
   /**

--- a/src/faiss-store-adapter.test.ts
+++ b/src/faiss-store-adapter.test.ts
@@ -1,0 +1,137 @@
+import { FaissStoreAdapter, type FaissSearchTimingSink } from './faiss-store-adapter.js';
+
+function adapterFor(store: Record<string, unknown>): FaissStoreAdapter {
+  return FaissStoreAdapter.fromStore(store as never);
+}
+
+describe('FaissStoreAdapter', () => {
+  it('guards raw index access before reading totals', () => {
+    expect(() => adapterFor({}).totalVectors()).toThrow(
+      'FAISS store index must be an object; got undefined',
+    );
+    expect(() => adapterFor({ index: {} }).totalVectors()).toThrow(
+      'FAISS store index is missing ntotal()',
+    );
+    expect(() => adapterFor({ index: { ntotal: () => 3 } }).vectorDimension()).toThrow(
+      'FAISS store index is missing getDimension()',
+    );
+  });
+
+  it('reads vector totals and dimensions from a guarded index handle', () => {
+    const adapter = adapterFor({
+      index: {
+        ntotal: () => 7,
+        getDimension: () => 384,
+      },
+    });
+
+    expect(adapter.totalVectors()).toBe(7);
+    expect(adapter.vectorDimension()).toBe(384);
+  });
+
+  it('guards docstore internals before reading documents', () => {
+    expect(() => adapterFor({ docstore: {} }).docstoreDocuments()).toThrow(
+      'FAISS store docstore is missing _docs Map',
+    );
+  });
+
+  it('derives per-KB counts from docstore documents', () => {
+    const docs = new Map([
+      ['a', { pageContent: 'a', metadata: { knowledgeBase: 'alpha' } }],
+      ['b', { pageContent: 'b', metadata: { knowledgeBase: 'alpha' } }],
+      ['c', { pageContent: 'c', metadata: { knowledgeBase: 'beta' } }],
+      ['d', { pageContent: 'd', metadata: { knowledgeBase: 42 } }],
+    ]);
+
+    expect(adapterFor({ docstore: { _docs: docs } }).chunkCountsByKnowledgeBase()).toEqual({
+      alpha: 2,
+      beta: 1,
+    });
+  });
+
+  it('temporarily swaps embeddings for addDocuments and restores the original client', async () => {
+    const originalEmbeddings = { embedDocuments: jest.fn(), embedQuery: jest.fn() };
+    const indexingEmbeddings = { embedDocuments: jest.fn(), embedQuery: jest.fn() };
+    const addDocuments = jest.fn(async function add(this: { embeddings: unknown }) {
+      expect(this.embeddings).toBe(indexingEmbeddings);
+    });
+    const store = {
+      embeddings: originalEmbeddings,
+      addDocuments,
+    };
+
+    await adapterFor(store).addDocumentsWithEmbeddings(
+      [{ pageContent: 'doc', metadata: {} }] as never,
+      indexingEmbeddings as never,
+    );
+
+    expect(addDocuments).toHaveBeenCalledWith([{ pageContent: 'doc', metadata: {} }]);
+    expect(store.embeddings).toBe(originalEmbeddings);
+  });
+
+  it('restores embeddings when addDocuments throws', async () => {
+    const originalEmbeddings = { embedDocuments: jest.fn(), embedQuery: jest.fn() };
+    const indexingEmbeddings = { embedDocuments: jest.fn(), embedQuery: jest.fn() };
+    const store = {
+      embeddings: originalEmbeddings,
+      addDocuments: jest.fn(async () => {
+        throw new Error('provider failed');
+      }),
+    };
+
+    await expect(
+      adapterFor(store).addDocumentsWithEmbeddings(
+        [{ pageContent: 'doc', metadata: {} }] as never,
+        indexingEmbeddings as never,
+      ),
+    ).rejects.toThrow('provider failed');
+    expect(store.embeddings).toBe(originalEmbeddings);
+  });
+
+  it('uses vector-first search when LangChain exposes it', async () => {
+    const vectorSearch = jest.fn(async () => [[{ pageContent: 'hit', metadata: {} }, 0.1]]);
+    const getQueryEmbedding = jest.fn(async () => ({
+      embedding: [1, 2, 3],
+      status: 'miss' as const,
+    }));
+    const timing: FaissSearchTimingSink = {};
+
+    const results = await adapterFor({
+      similaritySearchVectorWithScore: vectorSearch,
+      similaritySearchWithScore: jest.fn(),
+    }).similaritySearchUsingBestPath({
+      query: 'q',
+      k: 5,
+      timing,
+      getQueryEmbedding,
+    });
+
+    expect(getQueryEmbedding).toHaveBeenCalledTimes(1);
+    expect(vectorSearch).toHaveBeenCalledWith([1, 2, 3], 5);
+    expect(results[0][0].pageContent).toBe('hit');
+    expect(timing.query_cache).toBe('miss');
+    expect(typeof timing.embed_query_ms).toBe('number');
+    expect(typeof timing.faiss_search_ms).toBe('number');
+  });
+
+  it('falls back to query search and marks query cache unavailable', async () => {
+    const querySearch = jest.fn(async () => [[{ pageContent: 'hit', metadata: {} }, 0.1]]);
+    const getQueryEmbedding = jest.fn();
+    const timing: FaissSearchTimingSink = {};
+
+    const results = await adapterFor({
+      similaritySearchWithScore: querySearch,
+    }).similaritySearchUsingBestPath({
+      query: 'q',
+      k: 3,
+      timing,
+      getQueryEmbedding,
+    });
+
+    expect(getQueryEmbedding).not.toHaveBeenCalled();
+    expect(querySearch).toHaveBeenCalledWith('q', 3);
+    expect(results[0][0].pageContent).toBe('hit');
+    expect(timing.query_cache).toBe('unavailable');
+    expect(typeof timing.query_search_ms).toBe('number');
+  });
+});

--- a/src/faiss-store-adapter.ts
+++ b/src/faiss-store-adapter.ts
@@ -1,0 +1,206 @@
+import { FaissStore } from '@langchain/community/vectorstores/faiss';
+import type { EmbeddingsInterface } from '@langchain/core/embeddings';
+import type { Document } from '@langchain/core/documents';
+import type { QueryCacheLookupStatus } from './query-cache.js';
+
+type ScoredFaissDocument = [Document, number];
+
+type FaissStoreWithEmbeddings = FaissStore & {
+  embeddings: EmbeddingsInterface;
+};
+
+type FaissStoreWithVectorSearch = FaissStore & {
+  similaritySearchVectorWithScore: (
+    queryEmbedding: number[],
+    k: number,
+  ) => Promise<ScoredFaissDocument[]>;
+};
+
+type FaissIndexHandle = {
+  ntotal: () => number;
+  getDimension: () => number;
+};
+
+function describeShape(value: unknown): string {
+  if (value === null) return 'null';
+  if (Array.isArray(value)) return 'array';
+  return typeof value;
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function assertObject(value: unknown, label: string): asserts value is Record<string, unknown> {
+  if (!isObject(value)) {
+    throw new Error(`${label} must be an object; got ${describeShape(value)}`);
+  }
+}
+
+function assertEmbeddingsSlot(store: FaissStore): asserts store is FaissStoreWithEmbeddings {
+  assertObject(store, 'FAISS store');
+  const candidate = store as Record<string, unknown>;
+  if (!isObject(candidate.embeddings)) {
+    throw new Error('FAISS store is missing an embeddings client');
+  }
+}
+
+function getIndexHandle(store: FaissStore): FaissIndexHandle {
+  assertObject(store, 'FAISS store');
+  const index = (store as Record<string, unknown>).index;
+  assertObject(index, 'FAISS store index');
+  if (typeof index.ntotal !== 'function') {
+    throw new Error('FAISS store index is missing ntotal()');
+  }
+  if (typeof index.getDimension !== 'function') {
+    throw new Error('FAISS store index is missing getDimension()');
+  }
+  return index as FaissIndexHandle;
+}
+
+function getDocstoreMap(store: FaissStore): Map<string, Document> {
+  assertObject(store, 'FAISS store');
+  const docstore = (store as Record<string, unknown>).docstore;
+  assertObject(docstore, 'FAISS store docstore');
+  const docs = docstore._docs;
+  if (!(docs instanceof Map)) {
+    throw new Error('FAISS store docstore is missing _docs Map');
+  }
+  return docs as Map<string, Document>;
+}
+
+function getVectorSearch(store: FaissStore): FaissStoreWithVectorSearch['similaritySearchVectorWithScore'] | null {
+  assertObject(store, 'FAISS store');
+  const vectorSearch = (store as Record<string, unknown>).similaritySearchVectorWithScore;
+  return typeof vectorSearch === 'function'
+    ? vectorSearch as FaissStoreWithVectorSearch['similaritySearchVectorWithScore']
+    : null;
+}
+
+export interface FaissSearchTimingSink {
+  embed_query_ms?: number;
+  query_cache?: QueryCacheLookupStatus | 'unavailable';
+  faiss_search_ms?: number;
+  query_search_ms?: number;
+}
+
+export interface QueryEmbeddingLookup {
+  embedding: number[];
+  status: QueryCacheLookupStatus;
+}
+
+/**
+ * Small boundary around @langchain/community's FaissStore.
+ *
+ * FaissStore exposes several public-looking fields that are effectively
+ * runtime internals for this project: `embeddings`, `index`, `docstore._docs`,
+ * and the optional vector-first search method. Keep those assumptions here so
+ * FaissIndexManager remains the public orchestration facade.
+ */
+export class FaissStoreAdapter {
+  private constructor(private readonly store: FaissStore) {}
+
+  static fromStore(store: FaissStore): FaissStoreAdapter {
+    return new FaissStoreAdapter(store);
+  }
+
+  static async fromDocuments(
+    documents: readonly Document[],
+    embeddings: EmbeddingsInterface,
+  ): Promise<FaissStoreAdapter> {
+    const store = await FaissStore.fromTexts(
+      documents.map((doc) => doc.pageContent),
+      documents.map((doc) => doc.metadata),
+      embeddings,
+    );
+    return new FaissStoreAdapter(store);
+  }
+
+  /**
+   * Persistence is still implemented by faiss-store-layout.ts; this is the
+   * only intentional raw-store handoff left outside the adapter.
+   */
+  getStoreForPersistence(): FaissStore {
+    return this.store;
+  }
+
+  restoreEmbeddings(embeddings: EmbeddingsInterface): void {
+    assertEmbeddingsSlot(this.store);
+    this.store.embeddings = embeddings;
+  }
+
+  async addDocumentsWithEmbeddings(
+    documents: readonly Document[],
+    embeddings: EmbeddingsInterface,
+  ): Promise<void> {
+    assertEmbeddingsSlot(this.store);
+    const previousEmbeddings = this.store.embeddings;
+    this.store.embeddings = embeddings;
+    try {
+      await this.store.addDocuments([...documents]);
+    } finally {
+      this.store.embeddings = previousEmbeddings;
+    }
+  }
+
+  async similaritySearchUsingBestPath(options: {
+    query: string;
+    k: number;
+    timing?: FaissSearchTimingSink;
+    getQueryEmbedding: () => Promise<QueryEmbeddingLookup>;
+  }): Promise<ScoredFaissDocument[]> {
+    const vectorSearch = getVectorSearch(this.store);
+    if (vectorSearch === null) {
+      const queryStartedAt = Date.now();
+      const out = await this.store.similaritySearchWithScore(options.query, options.k);
+      if (options.timing) {
+        options.timing.query_cache = 'unavailable';
+        options.timing.query_search_ms =
+          (options.timing.query_search_ms ?? 0) + (Date.now() - queryStartedAt);
+      }
+      return out;
+    }
+
+    const embedStartedAt = Date.now();
+    const cached = await options.getQueryEmbedding();
+    if (options.timing) {
+      if (options.timing.embed_query_ms === undefined) {
+        options.timing.embed_query_ms = Date.now() - embedStartedAt;
+      }
+      if (options.timing.query_cache === undefined) {
+        options.timing.query_cache = cached.status;
+      }
+    }
+
+    const faissStartedAt = Date.now();
+    const out = await vectorSearch.call(this.store, cached.embedding, options.k);
+    if (options.timing) {
+      options.timing.faiss_search_ms =
+        (options.timing.faiss_search_ms ?? 0) + (Date.now() - faissStartedAt);
+    }
+    return out;
+  }
+
+  totalVectors(): number {
+    return getIndexHandle(this.store).ntotal();
+  }
+
+  vectorDimension(): number {
+    return getIndexHandle(this.store).getDimension();
+  }
+
+  docstoreDocuments(): Document[] {
+    return Array.from(getDocstoreMap(this.store).values());
+  }
+
+  chunkCountsByKnowledgeBase(): Record<string, number> {
+    const counts: Record<string, number> = {};
+    for (const doc of getDocstoreMap(this.store).values()) {
+      const kb = doc.metadata?.knowledgeBase;
+      if (typeof kb === 'string') {
+        counts[kb] = (counts[kb] ?? 0) + 1;
+      }
+    }
+    return counts;
+  }
+}


### PR DESCRIPTION
## Summary
- add a FAISS store adapter to own LangChain/FAISS internal access and runtime shape guards
- route manager indexing, search, stats, and docstore reads through the adapter
- add focused adapter guard tests and update manager tests to preserve existing behavior

Closes #338.

## Tests
- npm test -- /home/jean/git/knowledge-base-mcp-server/src/FaissIndexManager.test.ts src/faiss-store-adapter.test.ts --runInBand
- npm test -- src/FaissIndexManager.test.ts src/faiss-store-adapter.test.ts --runInBand
- npm test -- src/atomic-save.test.ts src/FaissIndexManager.test.ts src/faiss-store-adapter.test.ts --runInBand
- npm run build
- npm test -- --runInBand
- npm test -- src/KnowledgeBaseServer.test.ts --runInBand