### PR TITLE
feat(search): expose freshness scan timing

### DIFF
--- a/src/cli-search-staleness.test.ts
+++ b/src/cli-search-staleness.test.ts
@@ -79,11 +79,26 @@ describe('computeStaleness', () => {
         newFiles: 1,
         scope: { kb: 'alpha', modifiedFiles: 1, newFiles: 1 },
         global: { modifiedFiles: 2, newFiles: 2 },
+        scan: {
+          scope: 'scoped',
+          source: 'filesystem',
+          filesScanned: 2,
+          globalFiles: 3,
+          scopedFiles: 2,
+          kbsScanned: 2,
+        },
       });
 
       await expect(computeStaleness(modelId)).resolves.toMatchObject({
         modifiedFiles: 2,
         newFiles: 2,
+        scan: {
+          scope: 'global',
+          source: 'filesystem',
+          filesScanned: 3,
+          globalFiles: 3,
+          kbsScanned: 2,
+        },
       });
     } finally {
       await fsp.rm(tempDir, { recursive: true, force: true });
@@ -137,6 +152,14 @@ describe('computeStaleness', () => {
         newFiles: 1,
         scope: { kb: 'alpha', modifiedFiles: 1, newFiles: 1 },
         global: { modifiedFiles: 1, newFiles: 2 },
+        scan: {
+          scope: 'scoped',
+          source: 'manifest',
+          filesScanned: 1,
+          globalFiles: 2,
+          scopedFiles: 1,
+          kbsScanned: 1,
+        },
       });
     } finally {
       await fsp.rm(tempDir, { recursive: true, force: true });

--- a/src/cli-search.test.ts
+++ b/src/cli-search.test.ts
@@ -445,6 +445,42 @@ describe('dense freshness output (#332)', () => {
     expect(payload).not.toHaveProperty('freshness_omitted');
   });
 
+  it('includes freshness scan metadata in JSON timing only when timing is requested', () => {
+    const staleness: Staleness = {
+      indexMtime: MTIME,
+      modifiedFiles: 1,
+      newFiles: 2,
+    };
+    const payload = buildDenseSearchJsonPayload({
+      results: [],
+      requestedMode: 'dense',
+      effectiveMode: 'dense',
+      autoModeDecision: null,
+      groupBySource: false,
+      refreshed: false,
+      scopedKb: undefined,
+      staleness,
+      autoThresholdDecision: null,
+      timing: {
+        freshness_scan_ms: 4,
+        freshness_scan_files: 3,
+        freshness_scan_scope: 'global',
+        freshness_scan_source: 'filesystem',
+      },
+    });
+
+    expect(payload).toMatchObject({
+      timing: {
+        freshness_scan_ms: 4,
+        freshness_scan_files: 3,
+        freshness_scan_scope: 'global',
+        freshness_scan_source: 'filesystem',
+      },
+    });
+    expect(payload).not.toHaveProperty('freshness_scan_ms');
+    expect(payload).not.toHaveProperty('freshness_scan_files');
+  });
+
   it('keeps the default markdown freshness footer when freshness is present', () => {
     const output = formatDenseSearchMarkdownOutput({
       results: [],
@@ -457,6 +493,26 @@ describe('dense freshness output (#332)', () => {
     });
 
     expect(output).toContain(`> _Index up-to-date as of ${MTIME}._`);
+  });
+
+  it('includes freshness scan metadata in the markdown timing footer', () => {
+    const output = formatDenseSearchMarkdownOutput({
+      results: [],
+      groupBySource: false,
+      staleness: { indexMtime: MTIME, modifiedFiles: 0, newFiles: 0 },
+      refreshed: false,
+      autoModeDecision: null,
+      autoThresholdDecision: null,
+      timing: {
+        freshness_scan_ms: 5,
+        freshness_scan_files: 8,
+        freshness_scan_scope: 'scoped',
+      },
+    });
+
+    expect(output).toContain(
+      '> _Timing: freshness_scan_ms=5ms, freshness_scan_files=8, freshness_scan_scope=scoped._',
+    );
   });
 });
 

--- a/src/cli-search.ts
+++ b/src/cli-search.ts
@@ -42,7 +42,10 @@ import {
   elapsedMs,
   formatTimingFooter,
   nowMs,
+  recordFreshnessScanTiming,
   recordRefreshProgressTiming,
+  type FreshnessScanSource,
+  type FreshnessScanScope,
   type TimingPayload,
 } from './cli-timing.js';
 import { LexicalIndex, type LexicalSearchResult } from './lexical-index.js';
@@ -160,6 +163,7 @@ export interface Staleness {
   newFiles: number;
   scope?: StalenessScope;
   global?: StalenessCounts;
+  scan?: StalenessScanStats;
 }
 
 export interface StalenessCounts {
@@ -169,6 +173,15 @@ export interface StalenessCounts {
 
 export interface StalenessScope extends StalenessCounts {
   kb: string;
+}
+
+export interface StalenessScanStats {
+  scope: FreshnessScanScope;
+  source: FreshnessScanSource;
+  filesScanned: number;
+  globalFiles: number;
+  scopedFiles?: number;
+  kbsScanned: number;
 }
 
 export interface AutoThresholdDecision {
@@ -599,19 +612,45 @@ export async function computeStaleness(modelId: string, scopedKb?: string): Prom
 
   const enumerations = await enumerateIngestableKbFiles(KNOWLEDGE_BASES_ROOT_DIR, kbs);
   const global = await countStaleness(enumerations, indexMtimeMs);
+  const globalFiles = countEnumeratedFiles(enumerations);
   if (!scopedKb) {
-    return { indexMtime, modifiedFiles: global.modifiedFiles, newFiles: global.newFiles };
+    return {
+      indexMtime,
+      modifiedFiles: global.modifiedFiles,
+      newFiles: global.newFiles,
+      scan: buildStalenessScanStats({
+        scopedKb,
+        source: 'filesystem',
+        globalFiles,
+        scopedFiles: undefined,
+        kbsScanned: enumerations.length,
+      }),
+    };
   }
 
   const scopedEnumeration = enumerations.filter((entry) => entry.kbName === scopedKb);
   const scopeCounts = await countStaleness(scopedEnumeration, indexMtimeMs);
+  const scopedFiles = countEnumeratedFiles(scopedEnumeration);
   return {
     indexMtime,
     modifiedFiles: scopeCounts.modifiedFiles,
     newFiles: scopeCounts.newFiles,
     scope: { kb: scopedKb, ...scopeCounts },
     global,
+    scan: buildStalenessScanStats({
+      scopedKb,
+      source: 'filesystem',
+      globalFiles,
+      scopedFiles,
+      kbsScanned: enumerations.length,
+    }),
   };
+}
+
+function countEnumeratedFiles(
+  enumerations: Awaited<ReturnType<typeof enumerateIngestableKbFiles>>,
+): number {
+  return enumerations.reduce((sum, entry) => sum + entry.filePaths.length, 0);
 }
 
 async function countStaleness(
@@ -662,13 +701,21 @@ async function countSidecarFiles(dir: string): Promise<number> {
 }
 
 function emptyStaleness(indexMtime: string | null, scopedKb?: string): Staleness {
-  if (!scopedKb) return { indexMtime, modifiedFiles: 0, newFiles: 0 };
+  const scan = buildStalenessScanStats({
+    scopedKb,
+    source: 'none',
+    globalFiles: 0,
+    scopedFiles: scopedKb ? 0 : undefined,
+    kbsScanned: 0,
+  });
+  if (!scopedKb) return { indexMtime, modifiedFiles: 0, newFiles: 0, scan };
   return {
     indexMtime,
     modifiedFiles: 0,
     newFiles: 0,
     scope: { kb: scopedKb, modifiedFiles: 0, newFiles: 0 },
     global: { modifiedFiles: 0, newFiles: 0 },
+    scan,
   };
 }
 
@@ -686,10 +733,25 @@ function stalenessFromManifest(
     { modifiedFiles: 0, newFiles: 0 },
   );
   if (!scopedKb) {
-    return { indexMtime, modifiedFiles: global.modifiedFiles, newFiles: global.newFiles };
+    const globalFiles = Object.values(manifest.kbs)
+      .reduce((sum, entry) => sum + entry.file_count, 0);
+    return {
+      indexMtime,
+      modifiedFiles: global.modifiedFiles,
+      newFiles: global.newFiles,
+      scan: buildStalenessScanStats({
+        scopedKb,
+        source: 'manifest',
+        globalFiles,
+        scopedFiles: undefined,
+        kbsScanned: Object.keys(manifest.kbs).length,
+      }),
+    };
   }
   const scopedEntry = manifest.kbs[scopedKb];
   if (scopedEntry === undefined) return null;
+  const globalFiles = Object.values(manifest.kbs)
+    .reduce((sum, entry) => sum + entry.file_count, 0);
   const scopeCounts = {
     modifiedFiles: scopedEntry.modified_files,
     newFiles: scopedEntry.new_files,
@@ -700,6 +762,34 @@ function stalenessFromManifest(
     newFiles: scopeCounts.newFiles,
     scope: { kb: scopedKb, ...scopeCounts },
     global,
+    scan: buildStalenessScanStats({
+      scopedKb,
+      source: 'manifest',
+      globalFiles,
+      scopedFiles: scopedEntry.file_count,
+      kbsScanned: 1,
+    }),
+  };
+}
+
+function buildStalenessScanStats(input: {
+  scopedKb: string | undefined;
+  source: FreshnessScanSource;
+  globalFiles: number;
+  scopedFiles: number | undefined;
+  kbsScanned: number;
+}): StalenessScanStats {
+  const scope: FreshnessScanScope = input.scopedKb ? 'scoped' : 'global';
+  const filesScanned = scope === 'scoped'
+    ? input.scopedFiles ?? 0
+    : input.globalFiles;
+  return {
+    scope,
+    source: input.source,
+    filesScanned,
+    globalFiles: input.globalFiles,
+    ...(input.scopedFiles !== undefined ? { scopedFiles: input.scopedFiles } : {}),
+    kbsScanned: input.kbsScanned,
   };
 }
 
@@ -710,7 +800,18 @@ async function computeStalenessWithTiming(
 ): Promise<Staleness> {
   const stalenessStartedAt = nowMs();
   const staleness = await computeStaleness(activeModelId, scopedKb);
-  if (timing) timing.staleness_ms = elapsedMs(stalenessStartedAt);
+  if (timing) {
+    recordFreshnessScanTiming(timing, {
+      elapsedMs: elapsedMs(stalenessStartedAt),
+      ...(staleness.scan ?? buildStalenessScanStats({
+        scopedKb,
+        source: 'none',
+        globalFiles: 0,
+        scopedFiles: scopedKb ? 0 : undefined,
+        kbsScanned: 0,
+      })),
+    });
+  }
   return staleness;
 }
 

--- a/src/cli-timing.test.ts
+++ b/src/cli-timing.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from '@jest/globals';
 import {
   compactTimingPayload,
   formatTimingFooter,
+  recordFreshnessScanTiming,
   recordRefreshProgressTiming,
 } from './cli-timing.js';
 
@@ -16,6 +17,33 @@ describe('compactTimingPayload', () => {
       total_ms: 13,
       fetch_k: 4,
       llm_first_token_ms: null,
+    });
+  });
+});
+
+describe('recordFreshnessScanTiming', () => {
+  it('records freshness scan cost, counts, scope, and source as flat timing fields', () => {
+    const timing = {};
+
+    recordFreshnessScanTiming(timing, {
+      elapsedMs: 12.6,
+      scope: 'scoped',
+      source: 'manifest',
+      filesScanned: 7,
+      globalFiles: 23,
+      scopedFiles: 7,
+      kbsScanned: 1,
+    });
+
+    expect(compactTimingPayload(timing)).toEqual({
+      staleness_ms: 13,
+      freshness_scan_ms: 13,
+      freshness_scan_scope: 'scoped',
+      freshness_scan_source: 'manifest',
+      freshness_scan_files: 7,
+      freshness_scan_global_files: 23,
+      freshness_scan_scoped_files: 7,
+      freshness_scan_kbs: 1,
     });
   });
 });

--- a/src/cli-timing.ts
+++ b/src/cli-timing.ts
@@ -2,6 +2,18 @@ export type TimingValue = number | string | boolean | null;
 
 export type TimingPayload = Record<string, TimingValue | undefined>;
 export type RefreshTimingPhase = 'embed' | 'save' | 'sidecar' | 'manifest';
+export type FreshnessScanScope = 'global' | 'scoped';
+export type FreshnessScanSource = 'filesystem' | 'manifest' | 'none';
+
+export interface FreshnessScanTimingInput {
+  elapsedMs: number;
+  scope: FreshnessScanScope;
+  source: FreshnessScanSource;
+  filesScanned: number;
+  globalFiles: number;
+  scopedFiles?: number;
+  kbsScanned: number;
+}
 
 export interface RefreshProgressTimingInput {
   phase?: string;
@@ -48,6 +60,23 @@ export function formatTimingFooter(label: string, timing: TimingPayload): string
   const modeText = formatModeText(timing);
   const body = entries.length > 0 ? entries.join(', ') : 'no timing data';
   return `> _${label}${modeText}: ${body}._`;
+}
+
+export function recordFreshnessScanTiming(
+  timing: TimingPayload,
+  scan: FreshnessScanTimingInput,
+): void {
+  const elapsed = roundedMs(scan.elapsedMs);
+  timing.staleness_ms = elapsed;
+  timing.freshness_scan_ms = elapsed;
+  timing.freshness_scan_scope = scan.scope;
+  timing.freshness_scan_source = scan.source;
+  timing.freshness_scan_files = scan.filesScanned;
+  timing.freshness_scan_global_files = scan.globalFiles;
+  if (scan.scopedFiles !== undefined) {
+    timing.freshness_scan_scoped_files = scan.scopedFiles;
+  }
+  timing.freshness_scan_kbs = scan.kbsScanned;
 }
 
 export function recordRefreshProgressTiming(


### PR DESCRIPTION
Closes #333.

## Summary
- add freshness scan timing fields to `kb search --timing` output
- include scan scope, source, scanned file counts, global/scoped file counts, and KB count in timing payloads
- preserve existing `staleness_ms` while adding `freshness_scan_*` fields

## Verification
- `npx jest src/cli-search.test.ts src/cli-timing.test.ts src/cli-search-staleness.test.ts --runInBand`
- `npm run build`
- `npm test -- --runInBand`
- `git diff --check`