### PR TITLE
refactor(search): centralize hybrid retrieval policy

### DIFF
--- a/src/KnowledgeBaseServer.ts
+++ b/src/KnowledgeBaseServer.ts
@@ -69,8 +69,12 @@ import { SseHost } from './transport/sse.js';
 import { ReindexTriggerWatcher } from './triggerWatcher.js';
 import { RecursiveKbWatcher } from './recursive-fs-watch.js';
 import { KBError, type KBErrorCode } from './errors.js';
-import { LexicalIndex, type LexicalSearchResult } from './lexical-index.js';
-import { chunkIdFromMetadata, reciprocalRankFusion, type RankedList } from './rrf.js';
+import {
+  HYBRID_RRF_C,
+  fuseHybridResults,
+  hybridFetchK,
+  runLexicalLeg,
+} from './hybrid-retrieval.js';
 import {
   canonicalErrorFromToolResult,
   classifyCanonicalError,
@@ -634,9 +638,8 @@ export class KnowledgeBaseServer {
     canonical?: Partial<CanonicalLogInput>;
   }): Promise<CallToolResult> {
     const { query, knowledgeBaseName, modelNameOverride, filters, canonical } = input;
-    const HYBRID_FETCH_K = 40;
     const HYBRID_TOP_K = 10;
-    const HYBRID_RRF_C = 60;
+    const fetchK = hybridFetchK(HYBRID_TOP_K);
 
     try {
       let activeModelId: string;
@@ -655,36 +658,26 @@ export class KnowledgeBaseServer {
       // Dense leg — over-fetch to give RRF room.
       const denseTiming: SimilaritySearchTiming = {};
       const densePromise = manager
-        .similaritySearch(query, HYBRID_FETCH_K, Number.POSITIVE_INFINITY, knowledgeBaseName, filters, denseTiming)
+        .similaritySearch(query, fetchK, Number.POSITIVE_INFINITY, knowledgeBaseName, filters, denseTiming)
         .then((rs) => rs.map((r) => ({ pageContent: r.pageContent, metadata: r.metadata, score: r.score })));
 
       // Lexical leg — BM25 over the same chunks the FAISS path embeds, but
       // managed independently (the lexical index is model-agnostic and lives
       // under `${FAISS_INDEX_PATH}/lexical/<kb>/`). Auto-refresh on first use
       // per KB; explicit refresh is the CLI's job (`kb search --refresh`).
-      const lexicalPromise: Promise<LexicalSearchResult[]> = (async () => {
-        const all: LexicalSearchResult[] = [];
-        const kbNames = knowledgeBaseName
-          ? [knowledgeBaseName]
-          : await listKnowledgeBases(KNOWLEDGE_BASES_ROOT_DIR);
-        for (const kbName of kbNames) {
-          const kbPath = path.join(KNOWLEDGE_BASES_ROOT_DIR, kbName);
-          try {
-            const idx = await LexicalIndex.load(kbName, kbPath);
-            if (idx.numFiles() === 0) {
-              await idx.refresh();
-              await idx.save();
-            }
-            const hits = await idx.query(query, HYBRID_FETCH_K);
-            for (const h of hits) all.push(h);
-          } catch (err) {
-            // Per-KB lexical failure is non-fatal; the dense leg still runs.
-            logger.warn(`hybrid: lexical leg failed for KB "${kbName}": ${(err as Error).message}`);
-          }
-        }
-        all.sort((a, b) => b.score - a.score);
-        return all.slice(0, HYBRID_FETCH_K);
-      })();
+      const kbNames = knowledgeBaseName
+        ? [knowledgeBaseName]
+        : await listKnowledgeBases(KNOWLEDGE_BASES_ROOT_DIR);
+      const kbs = kbNames.map((kbName) => ({ kbName, kbPath: path.join(KNOWLEDGE_BASES_ROOT_DIR, kbName) }));
+      const lexicalPromise = runLexicalLeg({
+        kbs,
+        query,
+        fetchK,
+        refresh: 'when-empty',
+        onError: (kbName, err) => {
+          logger.warn(`hybrid: lexical leg failed for KB "${kbName}": ${err.message}`);
+        },
+      }).then((res) => res.hits);
 
       const [denseResults, lexicalResults] = await Promise.all([densePromise, lexicalPromise]);
       if (canonical) {
@@ -692,24 +685,11 @@ export class KnowledgeBaseServer {
         canonical.faiss_ms = denseTiming.faiss_search_ms ?? denseTiming.query_search_ms;
       }
 
-      const denseList: RankedList = {
-        retriever: 'dense',
-        results: denseResults.map((r, i) => ({ id: chunkIdFromMetadata(r.metadata), rank: i + 1 })),
-      };
-      const lexicalList: RankedList = {
-        retriever: 'lexical',
-        results: lexicalResults.map((r, i) => ({ id: chunkIdFromMetadata(r.metadata), rank: i + 1 })),
-      };
-      const fused = reciprocalRankFusion([denseList, lexicalList], { c: HYBRID_RRF_C });
-
-      const byId = new Map<string, { pageContent: string; metadata: Record<string, unknown>; score: number }>();
-      for (const r of lexicalResults) byId.set(chunkIdFromMetadata(r.metadata), { pageContent: r.pageContent, metadata: r.metadata, score: r.score });
-      for (const r of denseResults) byId.set(chunkIdFromMetadata(r.metadata), { pageContent: r.pageContent, metadata: r.metadata, score: r.score });
-
-      const ranked = fused.slice(0, HYBRID_TOP_K).map((f) => {
-        const chunk = byId.get(f.id);
-        return chunk ? { ...chunk, score: f.fusedScore } : null;
-      }).filter((x): x is { pageContent: string; metadata: Record<string, unknown>; score: number } => x !== null);
+      const ranked = fuseHybridResults({
+        denseResults,
+        lexicalResults,
+        k: HYBRID_TOP_K,
+      });
 
       const formatStartedAt = Date.now();
       let responseText = formatRetrievalAsMarkdown(ranked as never, FRONTMATTER_EXTRAS_WIRE_VISIBLE);

--- a/src/cli-search.ts
+++ b/src/cli-search.ts
@@ -49,7 +49,14 @@ import {
   type TimingPayload,
 } from './cli-timing.js';
 import { LexicalIndex, type LexicalSearchResult } from './lexical-index.js';
-import { chunkIdFromMetadata, reciprocalRankFusion, type RankedList } from './rrf.js';
+import {
+  HYBRID_RRF_C,
+  fuseHybridResults,
+  hybridFetchK,
+  listLexicalKbs,
+  runLexicalLeg,
+  type HybridChunk,
+} from './hybrid-retrieval.js';
 import {
   buildRefreshPreflightEstimate,
   maybeWriteRefreshPreflight,
@@ -1097,15 +1104,6 @@ interface LexicalKbResult {
   error?: Error;
 }
 
-async function listLexicalKbs(scoped?: string): Promise<Array<{ kbName: string; kbPath: string }>> {
-  const all = await listKnowledgeBases(KNOWLEDGE_BASES_ROOT_DIR);
-  const filtered = scoped ? all.filter((n) => n === scoped) : all;
-  return filtered.map((kbName) => ({
-    kbName,
-    kbPath: path.join(KNOWLEDGE_BASES_ROOT_DIR, kbName),
-  }));
-}
-
 async function runLexicalSearch(
   parsed: SearchArgs,
   timing: TimingPayload | null = null,
@@ -1264,15 +1262,6 @@ async function runLexicalSearch(
 
 // -- #206 stage 2 — hybrid (RRF) dispatch ----------------------------------
 
-const HYBRID_FETCH_MULTIPLIER = 4;
-const HYBRID_RRF_C = 60;
-
-interface HybridChunk {
-  pageContent: string;
-  metadata: Record<string, unknown>;
-  score: number;
-}
-
 async function runHybridSearch(
   parsed: SearchArgs,
   timing: TimingPayload | null = null,
@@ -1287,7 +1276,7 @@ async function runHybridSearch(
   }
 
   const query = parsed.query as string;
-  const fetchK = Math.max(parsed.k * HYBRID_FETCH_MULTIPLIER, parsed.k);
+  const fetchK = hybridFetchK(parsed.k);
 
   // -- dense leg -----------------------------------------------------------
   let densePromise: Promise<HybridChunk[]>;
@@ -1364,33 +1353,15 @@ async function runHybridSearch(
   }
 
   const lexicalStartedAt = nowMs();
-  const lexicalPromise: Promise<{ hits: HybridChunk[]; refreshed: number; failed: number }> = (async () => {
-    let refreshed = 0;
-    let failed = 0;
-    const all: LexicalSearchResult[] = [];
-    for (const { kbName, kbPath } of lexicalKbs) {
-      try {
-        const idx = await LexicalIndex.load(kbName, kbPath);
-        if (parsed.refresh || idx.numFiles() === 0) {
-          await idx.refresh();
-          await idx.save();
-          refreshed += 1;
-        }
-        const hits = await idx.query(query, fetchK);
-        for (const h of hits) all.push(h);
-      } catch (err) {
-        failed += 1;
-        process.stderr.write(`kb search (hybrid lexical leg): ${kbName} — ${(err as Error).message}\n`);
-      }
-    }
-    all.sort((a, b) => b.score - a.score);
-    const top = all.slice(0, fetchK);
-    return {
-      hits: top.map((h) => ({ pageContent: h.pageContent, metadata: h.metadata, score: h.score })),
-      refreshed,
-      failed,
-    };
-  })().then((row) => {
+  const lexicalPromise = runLexicalLeg({
+    kbs: lexicalKbs,
+    query,
+    fetchK,
+    refresh: parsed.refresh ? 'always' : 'when-empty',
+    onError: (kbName, err) => {
+      process.stderr.write(`kb search (hybrid lexical leg): ${kbName} — ${err.message}\n`);
+    },
+  }).then((row) => {
     if (timing) timing.lexical_search_ms = elapsedMs(lexicalStartedAt);
     return row;
   });
@@ -1403,26 +1374,11 @@ async function runHybridSearch(
 
   // -- fuse ----------------------------------------------------------------
   const fusionStartedAt = nowMs();
-  const denseList: RankedList = {
-    retriever: 'dense',
-    results: denseResults.map((r, i) => ({ id: chunkIdFromMetadata(r.metadata), rank: i + 1 })),
-  };
-  const lexicalList: RankedList = {
-    retriever: 'lexical',
-    results: lexicalResults.map((r, i) => ({ id: chunkIdFromMetadata(r.metadata), rank: i + 1 })),
-  };
-  const fused = reciprocalRankFusion([denseList, lexicalList], { c: HYBRID_RRF_C });
-
-  // Index chunks by id for output. When both legs return the same id, prefer
-  // the dense entry (more complete metadata typically), but read from
-  // whichever exists.
-  const byId = new Map<string, HybridChunk>();
-  for (const r of lexicalResults) byId.set(chunkIdFromMetadata(r.metadata), r);
-  for (const r of denseResults) byId.set(chunkIdFromMetadata(r.metadata), r);
-  const ranked = fused.slice(0, parsed.k).map((f) => {
-    const chunk = byId.get(f.id);
-    return chunk ? { ...chunk, score: f.fusedScore } : null;
-  }).filter((x): x is HybridChunk => x !== null);
+  const ranked = fuseHybridResults({
+    denseResults,
+    lexicalResults,
+    k: parsed.k,
+  });
   if (timing) {
     timing.fusion_ms = elapsedMs(fusionStartedAt);
     timing.total_ms = elapsedMs(totalStartedAt);

--- a/src/hybrid-retrieval.test.ts
+++ b/src/hybrid-retrieval.test.ts
@@ -1,0 +1,301 @@
+// Issue #339 — unit tests for src/hybrid-retrieval.ts.
+//
+// Coverage targets called out in the issue:
+//
+//   - Fetch sizing across small/medium/large k.
+//   - RRF fusion with overlapping and disjoint dense/lexical inputs.
+//   - Identity mapping when the same id appears in both lists.
+//   - Result assembly preserving the documented (fused) order.
+//
+// We also cover the lexical-leg orchestrator's policy knobs (refresh
+// always vs when-empty) and its per-KB error semantics, since those are
+// the only behaviours the adapters had to reimplement consistently.
+
+import { describe, expect, it, jest } from '@jest/globals';
+
+import {
+  HYBRID_FETCH_CAP,
+  HYBRID_FETCH_MULTIPLIER,
+  HYBRID_RRF_C,
+  fuseHybridResults,
+  hybridFetchK,
+  runLexicalLeg,
+  type HybridChunk,
+  type LexicalKb,
+} from './hybrid-retrieval.js';
+import type { LexicalIndex, LexicalSearchResult } from './lexical-index.js';
+import { DEFAULT_C } from './rrf.js';
+
+function chunk(source: string, chunkIndex: number, score: number, body = `c${chunkIndex}`): HybridChunk {
+  return {
+    pageContent: `${source}::${body}`,
+    metadata: { source, chunkIndex },
+    score,
+  };
+}
+
+describe('hybridFetchK', () => {
+  it('returns k * HYBRID_FETCH_MULTIPLIER for small k (matches the prior CLI/eval formula)', () => {
+    expect(hybridFetchK(1)).toBe(1 * HYBRID_FETCH_MULTIPLIER);
+    expect(hybridFetchK(5)).toBe(5 * HYBRID_FETCH_MULTIPLIER);
+    expect(hybridFetchK(10)).toBe(40); // pinned: matches the prior MCP HYBRID_FETCH_K
+    expect(hybridFetchK(25)).toBe(25 * HYBRID_FETCH_MULTIPLIER);
+  });
+
+  it('clamps fetch to HYBRID_FETCH_CAP for medium k', () => {
+    // The cap kicks in once k * 4 > 200, i.e. k > 50.
+    expect(hybridFetchK(50)).toBe(200);
+    expect(hybridFetchK(51)).toBe(HYBRID_FETCH_CAP);
+    expect(hybridFetchK(100)).toBe(HYBRID_FETCH_CAP);
+  });
+
+  it('falls back to k itself for very large k so we never fetch fewer than the requested top-k', () => {
+    // For k > HYBRID_FETCH_CAP the cap would otherwise lower us below k. The
+    // `Math.max(..., k)` guard prevents that.
+    expect(hybridFetchK(HYBRID_FETCH_CAP)).toBe(HYBRID_FETCH_CAP);
+    expect(hybridFetchK(HYBRID_FETCH_CAP + 1)).toBe(HYBRID_FETCH_CAP + 1);
+    expect(hybridFetchK(1000)).toBe(1000);
+  });
+
+  it('rejects non-positive, non-integer, and non-finite k', () => {
+    expect(() => hybridFetchK(0)).toThrow(/positive integer/);
+    expect(() => hybridFetchK(-3)).toThrow(/positive integer/);
+    expect(() => hybridFetchK(1.5)).toThrow(/positive integer/);
+    expect(() => hybridFetchK(Number.NaN)).toThrow(/positive integer/);
+    expect(() => hybridFetchK(Number.POSITIVE_INFINITY)).toThrow(/positive integer/);
+  });
+});
+
+describe('fuseHybridResults', () => {
+  it('returns disjoint lists in fused-score order, preserving rank within each leg', () => {
+    // Dense: A (rank 1), B (rank 2). Lexical: C (rank 1), D (rank 2).
+    // No overlap, so fused score for each id is exactly the single-leg
+    // contribution. With c=60: A,C tie at 1/61, B,D tie at 1/62. The tie
+    // breaks on insertion order across lists (dense first, then lexical),
+    // so the fused order is [A, C, B, D].
+    const dense = [chunk('a.md', 0, 0.9), chunk('b.md', 0, 0.8)];
+    const lexical = [chunk('c.md', 0, 0.7), chunk('d.md', 0, 0.6)];
+    const out = fuseHybridResults({ denseResults: dense, lexicalResults: lexical, k: 4 });
+    expect(out.map((r) => r.metadata.source)).toEqual(['a.md', 'c.md', 'b.md', 'd.md']);
+    // The first two are tied at 1/(60+1).
+    expect(out[0].score).toBeCloseTo(1 / (DEFAULT_C + 1), 12);
+    expect(out[1].score).toBeCloseTo(1 / (DEFAULT_C + 1), 12);
+    expect(out[2].score).toBeCloseTo(1 / (DEFAULT_C + 2), 12);
+    expect(out[3].score).toBeCloseTo(1 / (DEFAULT_C + 2), 12);
+  });
+
+  it('sums contributions when the same chunk appears in both legs (overlapping inputs)', () => {
+    // Y appears at rank 2 dense and rank 1 lexical → wins.
+    // X appears at rank 1 dense and rank 5 lexical → strong dense, weak lexical.
+    const dense = [chunk('x.md', 0, 0.9), chunk('y.md', 0, 0.85)];
+    const lexical = [
+      chunk('y.md', 0, 0.7),
+      chunk('w.md', 0, 0.6),
+      chunk('v.md', 0, 0.55),
+      chunk('u.md', 0, 0.5),
+      chunk('x.md', 0, 0.45),
+    ];
+    const out = fuseHybridResults({ denseResults: dense, lexicalResults: lexical, k: 5 });
+
+    const yScore = 1 / (DEFAULT_C + 2) + 1 / (DEFAULT_C + 1);
+    const xScore = 1 / (DEFAULT_C + 1) + 1 / (DEFAULT_C + 5);
+    expect(out[0].metadata.source).toBe('y.md');
+    expect(out[0].score).toBeCloseTo(yScore, 12);
+    expect(out[1].metadata.source).toBe('x.md');
+    expect(out[1].score).toBeCloseTo(xScore, 12);
+
+    // The remaining lexical-only ids fill the rest in their lexical-rank order.
+    expect(out.slice(2).map((r) => r.metadata.source)).toEqual(['w.md', 'v.md', 'u.md']);
+  });
+
+  it('prefers the dense entry when both legs return the same chunk id (identity mapping)', () => {
+    // The two legs return the SAME chunk id but with different pageContent.
+    // The dense pageContent should win (writes happen lexical-first then dense).
+    const dense = [chunk('shared.md', 7, 0.9, 'DENSE-BODY')];
+    const lexical = [chunk('shared.md', 7, 0.6, 'LEXICAL-BODY')];
+    const out = fuseHybridResults({ denseResults: dense, lexicalResults: lexical, k: 1 });
+    expect(out).toHaveLength(1);
+    expect(out[0].pageContent).toBe('shared.md::DENSE-BODY');
+    // Score is replaced by the fused score, NOT carried from either leg.
+    const expected = 1 / (DEFAULT_C + 1) + 1 / (DEFAULT_C + 1);
+    expect(out[0].score).toBeCloseTo(expected, 12);
+  });
+
+  it('clips to k while preserving fused order', () => {
+    const dense = [chunk('a.md', 0, 0.9), chunk('b.md', 0, 0.8), chunk('c.md', 0, 0.7)];
+    const lexical = [chunk('a.md', 0, 0.5), chunk('d.md', 0, 0.4)];
+    const top1 = fuseHybridResults({ denseResults: dense, lexicalResults: lexical, k: 1 });
+    expect(top1).toHaveLength(1);
+    expect(top1[0].metadata.source).toBe('a.md');
+    const top3 = fuseHybridResults({ denseResults: dense, lexicalResults: lexical, k: 3 });
+    expect(top3.map((r) => r.metadata.source)).toEqual(['a.md', 'b.md', 'd.md']);
+  });
+
+  it('returns [] when both legs are empty', () => {
+    expect(fuseHybridResults({ denseResults: [], lexicalResults: [], k: 10 })).toEqual([]);
+  });
+
+  it('handles a single-leg-only query (the other leg returned nothing)', () => {
+    const dense = [chunk('a.md', 0, 0.9), chunk('b.md', 0, 0.8)];
+    const out = fuseHybridResults({ denseResults: dense, lexicalResults: [], k: 5 });
+    expect(out.map((r) => r.metadata.source)).toEqual(['a.md', 'b.md']);
+    expect(out[0].score).toBeCloseTo(1 / (DEFAULT_C + 1), 12);
+  });
+
+  it('uses HYBRID_RRF_C by default and accepts an override', () => {
+    // Sanity: HYBRID_RRF_C is the rrf module's DEFAULT_C.
+    expect(HYBRID_RRF_C).toBe(DEFAULT_C);
+    const dense = [chunk('a.md', 0, 0.9)];
+    const out = fuseHybridResults({ denseResults: dense, lexicalResults: [], k: 1, c: 1 });
+    expect(out[0].score).toBeCloseTo(1 / (1 + 1), 12);
+  });
+
+  it('rejects non-positive k', () => {
+    expect(() =>
+      fuseHybridResults({ denseResults: [], lexicalResults: [], k: 0 }),
+    ).toThrow(/positive integer/);
+  });
+});
+
+// -- runLexicalLeg --------------------------------------------------------
+
+interface FakeIndexOptions {
+  numFiles: number;
+  hits: LexicalSearchResult[];
+  /** When set, the next `query` rejects with this error. */
+  failQuery?: Error;
+  /** When set, the next `refresh` rejects with this error. */
+  failRefresh?: Error;
+}
+
+function makeFakeIndex(opts: FakeIndexOptions) {
+  let files = opts.numFiles;
+  const refresh = jest.fn(async () => {
+    if (opts.failRefresh) throw opts.failRefresh;
+    files = Math.max(files, 1);
+    return { added: 1, updated: 0, removed: 0, failed: 0, totalFiles: files, totalChunks: 1 };
+  });
+  const save = jest.fn(async () => {});
+  const query = jest.fn(async (_q: string, _k: number) => {
+    if (opts.failQuery) throw opts.failQuery;
+    return opts.hits;
+  });
+  const numFiles = jest.fn(() => files);
+  const idx = { refresh, save, query, numFiles } as unknown as LexicalIndex;
+  return { idx, refresh, save, query, numFiles };
+}
+
+const KB_LIST: LexicalKb[] = [
+  { kbName: 'kb-a', kbPath: '/tmp/fake/kb-a' },
+  { kbName: 'kb-b', kbPath: '/tmp/fake/kb-b' },
+];
+
+function lexicalHit(source: string, score: number): LexicalSearchResult {
+  return { pageContent: `${source}::body`, metadata: { source, chunkIndex: 0 }, score };
+}
+
+describe('runLexicalLeg', () => {
+  it('refreshes only when the index is empty under refresh="when-empty"', async () => {
+    const empty = makeFakeIndex({ numFiles: 0, hits: [lexicalHit('a.md', 0.9)] });
+    const populated = makeFakeIndex({ numFiles: 5, hits: [lexicalHit('b.md', 0.8)] });
+    const loadIndex = jest.fn(async (kbName: string) =>
+      kbName === 'kb-a' ? empty.idx : populated.idx,
+    );
+
+    const result = await runLexicalLeg({
+      kbs: KB_LIST,
+      query: 'q',
+      fetchK: 10,
+      refresh: 'when-empty',
+      loadIndex,
+    });
+
+    expect(empty.refresh).toHaveBeenCalledTimes(1);
+    expect(empty.save).toHaveBeenCalledTimes(1);
+    expect(populated.refresh).not.toHaveBeenCalled();
+    expect(populated.save).not.toHaveBeenCalled();
+    expect(result.refreshed).toBe(1);
+    expect(result.failed).toBe(0);
+    // Hits are sorted descending by score: a.md (0.9) before b.md (0.8).
+    expect(result.hits.map((h) => h.metadata.source)).toEqual(['a.md', 'b.md']);
+  });
+
+  it('always refreshes under refresh="always" even when the index is populated', async () => {
+    const populated = makeFakeIndex({ numFiles: 5, hits: [lexicalHit('a.md', 0.9)] });
+    const loadIndex = jest.fn(async () => populated.idx);
+    const result = await runLexicalLeg({
+      kbs: [{ kbName: 'kb-a', kbPath: '/tmp/fake/kb-a' }],
+      query: 'q',
+      fetchK: 10,
+      refresh: 'always',
+      loadIndex,
+    });
+    expect(populated.refresh).toHaveBeenCalledTimes(1);
+    expect(populated.save).toHaveBeenCalledTimes(1);
+    expect(result.refreshed).toBe(1);
+  });
+
+  it('survives per-KB load/query failures, counts them in failed, and notifies onError', async () => {
+    const ok = makeFakeIndex({ numFiles: 5, hits: [lexicalHit('a.md', 0.9)] });
+    const failingQuery = makeFakeIndex({
+      numFiles: 5,
+      hits: [],
+      failQuery: new Error('boom-query'),
+    });
+    const loadIndex = jest.fn(async (kbName: string) => {
+      if (kbName === 'kb-a') return ok.idx;
+      if (kbName === 'kb-b') return failingQuery.idx;
+      throw new Error('boom-load');
+    });
+    const onError = jest.fn();
+    const kbs: LexicalKb[] = [
+      { kbName: 'kb-a', kbPath: '/tmp/a' },
+      { kbName: 'kb-b', kbPath: '/tmp/b' },
+      { kbName: 'kb-c', kbPath: '/tmp/c' },
+    ];
+    const result = await runLexicalLeg({
+      kbs,
+      query: 'q',
+      fetchK: 10,
+      refresh: 'when-empty',
+      loadIndex,
+      onError,
+    });
+    expect(result.failed).toBe(2);
+    expect(result.refreshed).toBe(0);
+    expect(result.hits.map((h) => h.metadata.source)).toEqual(['a.md']);
+    expect(onError).toHaveBeenCalledTimes(2);
+    expect(onError.mock.calls.map(([kbName]) => kbName).sort()).toEqual(['kb-b', 'kb-c']);
+  });
+
+  it('clips merged hits to fetchK after sorting by score', async () => {
+    const a = makeFakeIndex({
+      numFiles: 5,
+      hits: [lexicalHit('a1', 0.9), lexicalHit('a2', 0.5)],
+    });
+    const b = makeFakeIndex({
+      numFiles: 5,
+      hits: [lexicalHit('b1', 0.95), lexicalHit('b2', 0.4)],
+    });
+    const loadIndex = jest.fn(async (kbName: string) => (kbName === 'kb-a' ? a.idx : b.idx));
+    const result = await runLexicalLeg({
+      kbs: KB_LIST,
+      query: 'q',
+      fetchK: 2,
+      refresh: 'when-empty',
+      loadIndex,
+    });
+    // After sort: b1 (0.95), a1 (0.9), a2 (0.5), b2 (0.4) → top-2 = [b1, a1].
+    expect(result.hits.map((h) => h.metadata.source)).toEqual(['b1', 'a1']);
+  });
+
+  it('returns an empty result for an empty KB list', async () => {
+    const result = await runLexicalLeg({
+      kbs: [],
+      query: 'q',
+      fetchK: 10,
+      refresh: 'when-empty',
+    });
+    expect(result).toEqual({ hits: [], refreshed: 0, failed: 0 });
+  });
+});

--- a/src/hybrid-retrieval.ts
+++ b/src/hybrid-retrieval.ts
@@ -1,0 +1,259 @@
+// Issue #339 — shared hybrid (dense ⨁ lexical via RRF) retrieval policy.
+//
+// Why this module exists. Before this extraction, hybrid retrieval lived in
+// three places: the MCP `retrieve_knowledge` handler, the CLI
+// `kb search --mode=hybrid` command, and the offline `retrieval-eval` runner.
+// Each owned its own copies of the fetch-sizing constants, the RRF wiring,
+// the identity-mapping pass, and the final assembly. The MCP copy already
+// drifted from the other two: MCP fetched a fixed `HYBRID_FETCH_K = 40`
+// regardless of the requested top-k, while CLI/eval scaled fetch as
+// `k * HYBRID_FETCH_MULTIPLIER`. That divergence makes ranking changes hard
+// to validate — a fix landed against the eval runner does not necessarily
+// land against the MCP surface, and vice versa.
+//
+// Scope. This module owns:
+//
+//   1. The fetch-sizing policy (`hybridFetchK`). One formula across surfaces.
+//   2. The RRF fusion + identity mapping + final result assembly
+//      (`fuseHybridResults`). Pure function — no I/O, no clock.
+//   3. The per-KB lexical leg orchestration (`runLexicalLeg`). Iterates a
+//      caller-supplied KB list, runs `LexicalIndex.load → (refresh? →) query`,
+//      surfaces per-KB failures through an `onError` hook, and returns the
+//      merged + score-sorted top-`fetchK`. The lexical index itself is still
+//      owned by `lexical-index.ts`; this module just removes the boilerplate.
+//
+// Out of scope (kept in the adapters):
+//
+//   - The dense leg invocation. Each surface calls
+//     `FaissIndexManager.similaritySearch` with surface-specific filters,
+//     timing sinks, and cache options. Centralizing that signature would
+//     leak adapter detail back into this module without removing duplication.
+//   - Telemetry capture (canonical-log fields, `TimingPayload`). Adapters
+//     own those.
+//   - Output formatting (markdown header, JSON envelope, ScoredDocument
+//     reshaping). Adapters own those too — that is the whole point of the
+//     "policy outside adapter" framing in #339.
+//
+// Unified fetch policy. `fetchK = max(min(k * HYBRID_FETCH_MULTIPLIER, HYBRID_FETCH_CAP), k)`
+// with `HYBRID_FETCH_MULTIPLIER = 4` and `HYBRID_FETCH_CAP = 200`.
+//
+//   - `× 4` matches the CLI/eval formula byte-for-byte at the typical
+//     `k ≤ 25` operating point. It also keeps MCP's behaviour at its
+//     hard-coded `k = 10`: 10 × 4 = 40, the same as the prior fixed
+//     `HYBRID_FETCH_K = 40`. So there is no behavioural change for any
+//     existing caller against today's defaults.
+//   - The `200` cap protects against pathological `k` (e.g. an eval fixture
+//     bumping `k` to 1000 would otherwise issue a 4000-fetch FAISS call and
+//     materialize 4000 BM25 hits per KB). It sits well above any production
+//     `k` we have observed (`kb search` defaults `k = 10`; the MCP surface
+//     is fixed at `k = 10`; eval fixtures top out around `k = 25`). When a
+//     caller asks for `k > HYBRID_FETCH_CAP / HYBRID_FETCH_MULTIPLIER = 50`,
+//     we still return at least `k` items by clamping fetch to `k` — the
+//     guard is `Math.max(..., k)` — so a `k = 100` caller gets `fetchK = 100`
+//     rather than `200`, which keeps the post-fusion slice well-formed.
+//
+// RRF constant. `c = 60` per Cormack 2009; same value the standalone `rrf.ts`
+// module uses as its default and the same value the prior duplicated copies
+// hard-coded. Centralizing here means one place to change if the constant
+// ever moves.
+
+import * as path from 'path';
+import { LexicalIndex, type LexicalSearchResult } from './lexical-index.js';
+import { KNOWLEDGE_BASES_ROOT_DIR } from './config.js';
+import { listKnowledgeBases } from './kb-fs.js';
+import { chunkIdFromMetadata, reciprocalRankFusion, type RankedList } from './rrf.js';
+
+export const HYBRID_FETCH_MULTIPLIER = 4;
+export const HYBRID_FETCH_CAP = 200;
+export const HYBRID_RRF_C = 60;
+
+/**
+ * Compute the per-leg fetch size for a given requested output `k`.
+ *
+ * Returns `max(min(k * HYBRID_FETCH_MULTIPLIER, HYBRID_FETCH_CAP), k)` so that
+ * the fetch always overshoots the output (giving RRF room to re-order),
+ * never exceeds `HYBRID_FETCH_CAP` for moderate `k`, but also never drops
+ * below `k` itself for `k > HYBRID_FETCH_CAP`. The outer `max(..., k)`
+ * guarantees the post-fusion `slice(0, k)` is always well-formed. See the
+ * module-level comment for the policy justification.
+ *
+ * Throws on non-finite or non-positive `k` — these are caller bugs.
+ */
+export function hybridFetchK(k: number): number {
+  if (!Number.isFinite(k) || k < 1 || !Number.isInteger(k)) {
+    throw new Error(`hybridFetchK: invalid k=${k}; expected a positive integer`);
+  }
+  return Math.max(Math.min(k * HYBRID_FETCH_MULTIPLIER, HYBRID_FETCH_CAP), k);
+}
+
+/**
+ * Generic score-bearing chunk shape suitable for fusion. `score` is optional
+ * because fusion only consumes the position of each chunk in its input list
+ * (RRF math is rank-based) and overwrites the field on output with the fused
+ * RRF score. Accepting an optional score lets the dense leg pass
+ * `ScoredDocument`-shaped objects (whose `score` is also optional) through
+ * without a coercion at the adapter boundary.
+ */
+export interface HybridChunk {
+  pageContent: string;
+  metadata: Record<string, unknown>;
+  score?: number;
+}
+
+export interface FuseHybridResultsArgs {
+  denseResults: ReadonlyArray<HybridChunk>;
+  lexicalResults: ReadonlyArray<HybridChunk>;
+  /** Number of fused results to return. Must be ≥ 1. */
+  k: number;
+  /** Override the RRF smoothing constant. Defaults to `HYBRID_RRF_C` (60). */
+  c?: number;
+}
+
+/**
+ * Pure fusion + identity mapping + result assembly.
+ *
+ *   1. Build per-leg `RankedList` views over `(id, rank)` pairs using the
+ *      stable `chunkIdFromMetadata` identity from `rrf.ts`.
+ *   2. Fuse with Reciprocal Rank Fusion at `c = HYBRID_RRF_C` (or the caller
+ *      override). All fusion math is delegated to `reciprocalRankFusion`.
+ *   3. Build a `byId` map keyed on the same chunk id. Lexical entries are
+ *      written first, dense entries second — when both legs return the same
+ *      chunk, the dense entry wins, mirroring the prior CLI/MCP/eval
+ *      precedence (dense metadata is generally more complete after
+ *      similarity-search shaping).
+ *   4. Walk the fused list in fused order, look the chunk up in `byId`, and
+ *      replace `score` with the RRF `fusedScore`. Chunks the fusion produced
+ *      that do not exist in either input map (impossible given the construct,
+ *      but guarded for caller safety) are filtered out.
+ *
+ * Returns a fresh array of length ≤ `k`. Inputs are not mutated.
+ */
+export function fuseHybridResults(args: FuseHybridResultsArgs): HybridChunk[] {
+  const { denseResults, lexicalResults, k } = args;
+  if (!Number.isFinite(k) || k < 1 || !Number.isInteger(k)) {
+    throw new Error(`fuseHybridResults: invalid k=${k}; expected a positive integer`);
+  }
+  const c = args.c ?? HYBRID_RRF_C;
+
+  const denseList: RankedList = {
+    retriever: 'dense',
+    results: denseResults.map((r, i) => ({ id: chunkIdFromMetadata(r.metadata), rank: i + 1 })),
+  };
+  const lexicalList: RankedList = {
+    retriever: 'lexical',
+    results: lexicalResults.map((r, i) => ({ id: chunkIdFromMetadata(r.metadata), rank: i + 1 })),
+  };
+  const fused = reciprocalRankFusion([denseList, lexicalList], { c });
+
+  const byId = new Map<string, HybridChunk>();
+  for (const r of lexicalResults) byId.set(chunkIdFromMetadata(r.metadata), r);
+  for (const r of denseResults) byId.set(chunkIdFromMetadata(r.metadata), r);
+
+  const out: HybridChunk[] = [];
+  for (const f of fused.slice(0, k)) {
+    const chunk = byId.get(f.id);
+    if (chunk) out.push({ ...chunk, score: f.fusedScore });
+  }
+  return out;
+}
+
+export interface LexicalKb {
+  kbName: string;
+  kbPath: string;
+}
+
+/**
+ * List the lexical KBs to scan for a hybrid query.
+ *
+ * Enumerate every KB under `KNOWLEDGE_BASES_ROOT_DIR`, optionally filter to
+ * `scopedKb`, and hand back `(kbName, kbPath)` pairs. The pre-extraction
+ * copies of this helper disagreed on the missing-KB policy: the CLI returned
+ * an empty array silently, the eval runner threw `KB not found`. We
+ * centralize the silent-empty behaviour here — it matches the more
+ * permissive surface (CLI, MCP) — and let strict callers (the eval runner)
+ * do their own existence check before calling. Concretely, `listLexicalKbs`
+ * never throws for a missing scope: callers see `[]` and can decide.
+ */
+export async function listLexicalKbs(scopedKb?: string): Promise<LexicalKb[]> {
+  const all = await listKnowledgeBases(KNOWLEDGE_BASES_ROOT_DIR);
+  const filtered = scopedKb ? all.filter((name) => name === scopedKb) : all;
+  return filtered.map((kbName) => ({
+    kbName,
+    kbPath: path.join(KNOWLEDGE_BASES_ROOT_DIR, kbName),
+  }));
+}
+
+export type LexicalRefreshPolicy = 'always' | 'when-empty';
+
+export interface LexicalLegOptions {
+  kbs: ReadonlyArray<LexicalKb>;
+  query: string;
+  /** Per-KB top-k handed to `LexicalIndex.query`, then merged + clipped. */
+  fetchK: number;
+  /**
+   * `'always'` mirrors `kb search --refresh` — refresh + save before every
+   * query. `'when-empty'` matches MCP and eval — refresh only when the index
+   * has zero files (first-use bootstrap). Either way, refreshes are counted
+   * in the returned `refreshed`.
+   */
+  refresh: LexicalRefreshPolicy;
+  /**
+   * Called when a per-KB load/refresh/query throws. Per-KB failures are not
+   * fatal — the leg continues with the remaining KBs. The hook lets each
+   * surface log to its preferred channel (logger.warn for MCP, stderr for
+   * CLI, throw for eval).
+   */
+  onError?: (kbName: string, err: Error) => void;
+  /**
+   * Optional injection point for tests so they can avoid touching disk. The
+   * default loads via `LexicalIndex.load`.
+   */
+  loadIndex?: (kbName: string, kbPath: string) => Promise<LexicalIndex>;
+}
+
+export interface LexicalLegResult {
+  hits: LexicalSearchResult[];
+  /** Number of KBs whose index was refreshed during this call. */
+  refreshed: number;
+  /** Number of KBs whose load/refresh/query failed (and were swallowed). */
+  failed: number;
+}
+
+/**
+ * Run the lexical leg of a hybrid query over a KB list.
+ *
+ * For each `LexicalKb`:
+ *
+ *   1. Load the per-KB index.
+ *   2. Refresh + save when policy says so (always, or when the index is empty).
+ *   3. Query the top-`fetchK` hits and accumulate them.
+ *
+ * After the iteration, the merged hits are score-sorted descending and
+ * clipped to `fetchK`. Per-KB failures are routed to `onError` (if provided)
+ * and counted in the returned `failed`; the leg never throws on a per-KB
+ * error.
+ */
+export async function runLexicalLeg(opts: LexicalLegOptions): Promise<LexicalLegResult> {
+  const load = opts.loadIndex ?? LexicalIndex.load.bind(LexicalIndex);
+  let refreshed = 0;
+  let failed = 0;
+  const all: LexicalSearchResult[] = [];
+  for (const { kbName, kbPath } of opts.kbs) {
+    try {
+      const idx = await load(kbName, kbPath);
+      const shouldRefresh = opts.refresh === 'always' || idx.numFiles() === 0;
+      if (shouldRefresh) {
+        await idx.refresh();
+        await idx.save();
+        refreshed += 1;
+      }
+      const hits = await idx.query(opts.query, opts.fetchK);
+      for (const h of hits) all.push(h);
+    } catch (err) {
+      failed += 1;
+      opts.onError?.(kbName, err as Error);
+    }
+  }
+  all.sort((a, b) => b.score - a.score);
+  return { hits: all.slice(0, opts.fetchK), refreshed, failed };
+}

--- a/src/retrieval-eval.ts
+++ b/src/retrieval-eval.ts
@@ -1,4 +1,3 @@
-import * as path from 'path';
 import { minimatch } from 'minimatch';
 import type { FaissIndexManager } from './FaissIndexManager.js';
 import type { ScoredDocument } from './formatter.js';
@@ -9,15 +8,14 @@ import {
   type SearchMode,
   type Staleness,
 } from './cli-search.js';
-import { KNOWLEDGE_BASES_ROOT_DIR } from './config.js';
-import { listKnowledgeBases } from './kb-fs.js';
 import { LexicalIndex, type LexicalSearchResult } from './lexical-index.js';
-import { chunkIdFromMetadata, reciprocalRankFusion, type RankedList } from './rrf.js';
+import {
+  fuseHybridResults,
+  hybridFetchK,
+  listLexicalKbs,
+} from './hybrid-retrieval.js';
 
 export type StalePolicy = 'allow_stale' | 'fresh' | 'stale';
-
-const HYBRID_FETCH_MULTIPLIER = 4;
-const HYBRID_RRF_C = 60;
 
 export interface ExpectedMetadataRule {
   path: string;
@@ -451,6 +449,13 @@ async function retrieveLexical(
   scopedKb?: string,
 ): Promise<ScoredDocument[]> {
   const kbs = await listLexicalKbs(scopedKb);
+  // The eval runner is strict about scope: a missing scoped KB is a fixture
+  // bug worth surfacing, not silent dense-only fallback. The shared
+  // `listLexicalKbs` returns `[]` for an unknown name (matching CLI/MCP), so
+  // we replicate the prior eval-specific check here.
+  if (scopedKb !== undefined && kbs.length === 0) {
+    throw new Error(`KB not found: ${scopedKb}`);
+  }
   const merged: LexicalSearchResult[] = [];
   for (const { kbName, kbPath } of kbs) {
     const index = await LexicalIndex.load(kbName, kbPath);
@@ -469,7 +474,7 @@ async function retrieveHybrid(
   context: RetrievalEvalSearchContext,
 ): Promise<ScoredDocument[]> {
   const k = fixtureCase.k ?? context.defaultK;
-  const fetchK = Math.max(k * HYBRID_FETCH_MULTIPLIER, k);
+  const fetchK = hybridFetchK(k);
   const [denseResults, lexicalResults] = await Promise.all([
     context.manager.similaritySearch(
       fixtureCase.query,
@@ -479,36 +484,11 @@ async function retrieveHybrid(
     ),
     retrieveLexical(fixtureCase.query, fetchK, fixtureCase.kb),
   ]);
-  const denseList: RankedList = {
-    retriever: 'dense',
-    results: denseResults.map((r, i) => ({ id: chunkIdFromMetadata(r.metadata), rank: i + 1 })),
-  };
-  const lexicalList: RankedList = {
-    retriever: 'lexical',
-    results: lexicalResults.map((r, i) => ({ id: chunkIdFromMetadata(r.metadata), rank: i + 1 })),
-  };
-  const fused = reciprocalRankFusion([denseList, lexicalList], { c: HYBRID_RRF_C });
-  const byId = new Map<string, ScoredDocument>();
-  for (const result of lexicalResults) byId.set(chunkIdFromMetadata(result.metadata), result);
-  for (const result of denseResults) byId.set(chunkIdFromMetadata(result.metadata), result);
-  const ranked: ScoredDocument[] = [];
-  for (const entry of fused.slice(0, k)) {
-    const result = byId.get(entry.id);
-    if (result) ranked.push({ ...result, score: entry.fusedScore });
-  }
-  return ranked;
-}
-
-async function listLexicalKbs(scopedKb?: string): Promise<Array<{ kbName: string; kbPath: string }>> {
-  const all = await listKnowledgeBases(KNOWLEDGE_BASES_ROOT_DIR);
-  const filtered = scopedKb ? all.filter((name) => name === scopedKb) : all;
-  if (scopedKb !== undefined && filtered.length === 0) {
-    throw new Error(`KB not found: ${scopedKb}`);
-  }
-  return filtered.map((kbName) => ({
-    kbName,
-    kbPath: path.join(KNOWLEDGE_BASES_ROOT_DIR, kbName),
-  }));
+  return fuseHybridResults({
+    denseResults,
+    lexicalResults,
+    k,
+  });
 }
 
 function toScoredDocument(result: LexicalSearchResult): ScoredDocument {


### PR DESCRIPTION
Closes #339.

## Summary

Extract the dense+lexical fusion path into a new `src/hybrid-retrieval.ts` so the three duplicated implementations all route through one module.

**Call sites deduplicated:**
- `src/KnowledgeBaseServer.ts` → `handleRetrieveKnowledgeHybrid` (the MCP `retrieve_knowledge` `search_mode=hybrid` path).
- `src/cli-search.ts` → `runHybridSearch` (the `kb search --mode=hybrid` CLI command). Also drops the now-redundant local `listLexicalKbs` helper in favour of the shared one.
- `src/retrieval-eval.ts` → `retrieveHybrid` (offline eval-runner hybrid mode).

The shared module exposes:
- `hybridFetchK(k)` — pure fetch-sizing.
- `fuseHybridResults({ denseResults, lexicalResults, k, c? })` — pure RRF fusion + identity mapping + result assembly.
- `runLexicalLeg({ kbs, query, fetchK, refresh, onError, loadIndex? })` — per-KB lexical orchestration with a refresh-policy switch (`always` for `kb search --refresh`, `when-empty` for MCP/eval auto-bootstrap) and an `onError` hook so each surface logs to its preferred channel.
- `listLexicalKbs(scopedKb?)` — the shared KB enumerator (silent-empty on missing scope; eval-runner does its own existence check before calling).

Adapter-specific concerns (telemetry / canonical-log fields, `TimingPayload`, MCP markdown header, CLI JSON envelope + retriever counts, `ScoredDocument` reshaping for eval scoring) stay in the adapters.

## Unified fetch policy

`fetchK = max(min(k * HYBRID_FETCH_MULTIPLIER, HYBRID_FETCH_CAP), k)` with `HYBRID_FETCH_MULTIPLIER = 4` and `HYBRID_FETCH_CAP = 200`.

- The `× 4` matches the prior CLI/eval formula byte-for-byte at the typical `k ≤ 25` operating point. It also keeps MCP at `k=10 → fetchK=40`, identical to the old hard-coded `HYBRID_FETCH_K = 40` — no behaviour change at default.
- The `200` cap protects against pathological `k` (e.g. an eval fixture bumping `k` to 1000 would otherwise issue a 4000-fetch FAISS call and materialize 4000 BM25 hits per KB) without affecting any production `k` we have observed (`kb search` defaults `k=10`; MCP is fixed at `k=10`; eval fixtures top out around `k=25`).
- The outer `max(..., k)` ensures `fetchK ≥ k` even when `k > HYBRID_FETCH_CAP / HYBRID_FETCH_MULTIPLIER = 50`, so the post-fusion `slice(0, k)` is always well-formed.

## Tests

New `src/hybrid-retrieval.test.ts` (17 cases) covers fetch sizing across small/medium/large `k`, RRF fusion with overlapping and disjoint dense/lexical inputs, identity mapping when both legs return the same chunk id (with the dense entry winning), result assembly preserving the documented fused order, and the lexical-leg refresh-policy + per-KB error semantics.

Local verification (Node 20):
- `npm run build` — clean.
- `npx jest src/hybrid-retrieval.test.ts src/KnowledgeBaseServer.test.ts --runInBand` — 84 tests passed.
- `npm test -- --runInBand` — 78 suites, 1290 passed, 4 skipped, 1 todo.
- `git diff --check` — clean.

## Scope cuts

- **`./cli-search.js` import in `src/retrieval-eval.ts`**: the issue called out this CLI dependency. The hybrid path no longer imports anything from cli-search, but `resolveAutoSearchMode` and the `SearchMode` / `EffectiveSearchMode` / `AutoSearchModeDecision` / `Staleness` types still live in `cli-search.ts` and are imported by retrieval-eval for the auto-mode resolver and case schemas. Lifting those to a separate module is a follow-up that should land alongside (or after) the planned config / KB-list cleanups in #340 / #341, so this PR leaves that import in place.
- **MCP "KB not found" semantics**: when `knowledgeBaseName` was supplied to the MCP hybrid handler before this change and the KB did not exist, the lexical leg attempted to load a nonexistent path and logged a per-KB warning. Routing through the shared `listLexicalKbs` now silently returns an empty KB list in that case (no warning); the dense leg still runs. This matches the existing CLI behaviour and is a small, intentional consistency upgrade — no test depended on the old log-line.