### PR TITLE
feat(search): inline empty-result staleness guidance (#335)

### DIFF
--- a/src/cli-search-staleness.test.ts
+++ b/src/cli-search-staleness.test.ts
@@ -6,6 +6,7 @@ import {
   REFRESH_PREFLIGHT_BYTE_THRESHOLD,
   REFRESH_PREFLIGHT_FILE_THRESHOLD,
   buildAgeBudgetFooter,
+  buildEmptyResultGuidance,
   buildRefreshPreflightEstimate,
   formatRefreshPreflightEstimate,
   maybeWriteRefreshPreflight,
@@ -332,6 +333,198 @@ describe('refresh preflight estimate (issue #318)', () => {
 
     expect(stderr.join('')).toContain('kb search refresh preflight');
     expect(JSON.parse(stdout.join(''))).toEqual({ results: [] });
+  });
+});
+
+describe('buildEmptyResultGuidance (issue #335)', () => {
+  const MTIME = '2026-05-13T15:30:00.000Z';
+
+  it('returns null markdown and null JSON when freshness was skipped (--no-freshness)', () => {
+    const result = buildEmptyResultGuidance({
+      query: 'rollback procedure',
+      scopedKb: undefined,
+      refreshed: false,
+      staleness: null,
+    });
+    expect(result.markdown).toBeNull();
+    expect(result.json).toBeNull();
+  });
+
+  it('returns null markdown when global scope is fresh (no inline guidance to add)', () => {
+    const result = buildEmptyResultGuidance({
+      query: 'rollback procedure',
+      scopedKb: undefined,
+      refreshed: false,
+      staleness: {
+        indexMtime: MTIME,
+        scoped: { modifiedFiles: 0, newFiles: 0 },
+        global: null,
+      },
+    });
+    expect(result.markdown).toBeNull();
+    expect(result.json).toMatchObject({
+      refresh_command: 'kb search "rollback procedure" --refresh',
+      scope: 'global',
+      index_mtime: MTIME,
+      index_built: true,
+      refreshed: false,
+      scoped_stale: false,
+      global_stale: false,
+    });
+    expect(result.json).not.toHaveProperty('scope_kb');
+  });
+
+  it('emits an inline tip when the unscoped global index is stale', () => {
+    const result = buildEmptyResultGuidance({
+      query: 'rollback procedure',
+      scopedKb: undefined,
+      refreshed: false,
+      staleness: {
+        indexMtime: MTIME,
+        scoped: { modifiedFiles: 3, newFiles: 1 },
+        global: null,
+      },
+    });
+    expect(result.markdown).toBe(
+      `> **Tip:** No results found, and the index is stale ` +
+        `(3 modified, 1 new file(s) since ${MTIME}). ` +
+        'Try `kb search "rollback procedure" --refresh` to update the index and re-run.',
+    );
+    expect(result.json).toMatchObject({
+      refresh_command: 'kb search "rollback procedure" --refresh',
+      scope: 'global',
+      scoped_stale: true,
+      scoped_modified_files: 3,
+      scoped_new_files: 1,
+      global_stale: true,
+      global_modified_files: 3,
+      global_new_files: 1,
+    });
+  });
+
+  it('emits a scoped tip with the --kb=<name> refresh command when the scoped KB is stale', () => {
+    const result = buildEmptyResultGuidance({
+      query: 'auth flow',
+      scopedKb: 'work',
+      refreshed: false,
+      staleness: {
+        indexMtime: MTIME,
+        scoped: { modifiedFiles: 2, newFiles: 5 },
+        global: { modifiedFiles: 4, newFiles: 7 },
+      },
+    });
+    expect(result.markdown).toBe(
+      `> **Tip:** No results found, and the "work" KB scope is stale ` +
+        `(2 modified, 5 new file(s) since ${MTIME}). ` +
+        'Try `kb search "auth flow" --kb=work --refresh` to update the index and re-run.',
+    );
+    expect(result.json).toMatchObject({
+      refresh_command: 'kb search "auth flow" --kb=work --refresh',
+      scope: 'scoped',
+      scope_kb: 'work',
+      scoped_stale: true,
+      scoped_modified_files: 2,
+      scoped_new_files: 5,
+      global_stale: true,
+      global_modified_files: 4,
+      global_new_files: 7,
+    });
+  });
+
+  it('points to the global index when the scoped KB is fresh but global drift exists', () => {
+    const result = buildEmptyResultGuidance({
+      query: 'auth flow',
+      scopedKb: 'work',
+      refreshed: false,
+      staleness: {
+        indexMtime: MTIME,
+        scoped: { modifiedFiles: 0, newFiles: 0 },
+        global: { modifiedFiles: 4, newFiles: 7 },
+      },
+    });
+    expect(result.markdown).not.toBeNull();
+    expect(result.markdown).toContain('"work" KB scope is up-to-date');
+    expect(result.markdown).toContain('drop `--kb=work`');
+    expect(result.markdown).toContain('`kb search "auth flow" --refresh`');
+    expect(result.json).toMatchObject({
+      scope: 'scoped',
+      scope_kb: 'work',
+      scoped_stale: false,
+      global_stale: true,
+    });
+  });
+
+  it('returns null markdown when the scoped KB is fresh and global is fresh', () => {
+    const result = buildEmptyResultGuidance({
+      query: 'auth flow',
+      scopedKb: 'work',
+      refreshed: false,
+      staleness: {
+        indexMtime: MTIME,
+        scoped: { modifiedFiles: 0, newFiles: 0 },
+        global: { modifiedFiles: 0, newFiles: 0 },
+      },
+    });
+    expect(result.markdown).toBeNull();
+    expect(result.json).toMatchObject({
+      scope: 'scoped',
+      scope_kb: 'work',
+      scoped_stale: false,
+      global_stale: false,
+    });
+  });
+
+  it('returns null markdown when the run already refreshed the index', () => {
+    const result = buildEmptyResultGuidance({
+      query: 'auth flow',
+      scopedKb: 'work',
+      refreshed: true,
+      staleness: {
+        indexMtime: MTIME,
+        scoped: { modifiedFiles: 0, newFiles: 0 },
+        global: { modifiedFiles: 0, newFiles: 0 },
+      },
+    });
+    expect(result.markdown).toBeNull();
+    expect(result.json).toMatchObject({ refreshed: true });
+  });
+
+  it('suggests creating the index when it has never been built', () => {
+    const result = buildEmptyResultGuidance({
+      query: 'rollback procedure',
+      scopedKb: undefined,
+      refreshed: false,
+      staleness: {
+        indexMtime: null,
+        scoped: { modifiedFiles: 0, newFiles: 0 },
+        global: null,
+      },
+    });
+    expect(result.markdown).toBe(
+      '> **Tip:** No results found, and the index has not been built yet. ' +
+        'Run `kb search "rollback procedure" --refresh` to create it, then re-run the query.',
+    );
+    expect(result.json).toMatchObject({
+      index_built: false,
+      index_mtime: null,
+    });
+  });
+
+  it('escapes embedded quotes in the refresh command so the suggestion stays copy-pasteable', () => {
+    const result = buildEmptyResultGuidance({
+      query: 'error "oops" $HOME',
+      scopedKb: undefined,
+      refreshed: false,
+      staleness: {
+        indexMtime: MTIME,
+        scoped: { modifiedFiles: 1, newFiles: 0 },
+        global: null,
+      },
+    });
+    expect(result.json?.refresh_command).toBe(
+      'kb search "error \\"oops\\" \\$HOME" --refresh',
+    );
+    expect(result.markdown).toContain('kb search "error \\"oops\\" \\$HOME" --refresh');
   });
 });
 

--- a/src/cli-search-staleness.ts
+++ b/src/cli-search-staleness.ts
@@ -289,6 +289,194 @@ function formatBytes(bytes: number): string {
   return `${rounded.replace(/\.0$/, '')} ${unit}`;
 }
 
+// -- Empty-result inline guidance (issue #335) -------------------------------
+//
+// When `kb search` returns zero results, the legacy CLI markdown body was just
+// `_No similar results found._` and any stale-scope hint lived only in the
+// trailing freshness footer. Operators reading top-down missed the footer and
+// re-ran the query without refreshing. This helper renders an inline tip block
+// (and a parallel JSON shape) that lands directly under the empty body when
+// the scoped or global index is stale.
+//
+// Markdown form is a single blockquote line so it composes with the existing
+// "Disclaimer" blockquote without nested-fence rendering quirks.
+//
+// JSON form is additive: callers splice it into the dense search JSON payload
+// under `empty_result_guidance` without touching the existing freshness fields.
+
+export interface EmptyResultStalenessSnapshot {
+  /** ISO-8601 mtime of the FAISS index, or null when the index has never been built. */
+  indexMtime: string | null;
+  /** Counts for the active scope — either the selected KB or the global index. */
+  scoped: {
+    modifiedFiles: number;
+    newFiles: number;
+  };
+  /** Global counts when a KB scope is active; null for unscoped runs (scoped already === global). */
+  global: {
+    modifiedFiles: number;
+    newFiles: number;
+  } | null;
+}
+
+export interface BuildEmptyResultGuidanceInput {
+  /** User-typed search query; embedded into the suggested refresh command. */
+  query: string;
+  /** KB scope selected via `--kb=<name>`; `undefined` for global searches. */
+  scopedKb: string | undefined;
+  /** True when this CLI invocation already passed `--refresh`. */
+  refreshed: boolean;
+  /** Compact staleness snapshot. `null` when freshness was skipped (`--no-freshness`). */
+  staleness: EmptyResultStalenessSnapshot | null;
+}
+
+export interface EmptyResultGuidanceJson {
+  refresh_command: string;
+  scope: 'global' | 'scoped';
+  scope_kb?: string;
+  index_mtime: string | null;
+  index_built: boolean;
+  refreshed: boolean;
+  scoped_stale: boolean;
+  scoped_modified_files: number;
+  scoped_new_files: number;
+  global_stale: boolean;
+  global_modified_files: number;
+  global_new_files: number;
+}
+
+export interface EmptyResultGuidance {
+  /** Markdown blockquote tip to inline under `_No similar results found._`, or null when nothing actionable to surface. */
+  markdown: string | null;
+  /** Additive JSON fragment for the dense search payload, or null when freshness was skipped. */
+  json: EmptyResultGuidanceJson | null;
+}
+
+/**
+ * Compute the inline empty-result guidance block (markdown + JSON) for a
+ * `kb search` run that returned zero matches.
+ *
+ * Returns `markdown: null` when there is nothing actionable to say — i.e.
+ * the run was already refreshed, or both scope and global are fresh. In those
+ * cases the CLI falls back to the plain "no similar results found" body and
+ * the existing freshness footer (which itself becomes "_Index up-to-date_"
+ * or "_Index refreshed_"); no behaviour change for fresh runs.
+ *
+ * Returns `json: null` only when freshness was skipped entirely (`--no-freshness`).
+ */
+export function buildEmptyResultGuidance(
+  input: BuildEmptyResultGuidanceInput,
+): EmptyResultGuidance {
+  if (input.staleness === null) {
+    return { markdown: null, json: null };
+  }
+  const refreshCommand = buildRefreshCommand(input.query, input.scopedKb);
+  const indexBuilt = input.staleness.indexMtime !== null;
+  const scopedCounts = input.staleness.scoped;
+  const globalCounts = input.staleness.global ?? input.staleness.scoped;
+  const scopedStale = scopedCounts.modifiedFiles + scopedCounts.newFiles > 0;
+  const globalStale = globalCounts.modifiedFiles + globalCounts.newFiles > 0;
+  const scope: 'global' | 'scoped' = input.scopedKb ? 'scoped' : 'global';
+  const json: EmptyResultGuidanceJson = {
+    refresh_command: refreshCommand,
+    scope,
+    ...(input.scopedKb ? { scope_kb: input.scopedKb } : {}),
+    index_mtime: input.staleness.indexMtime,
+    index_built: indexBuilt,
+    refreshed: input.refreshed,
+    scoped_stale: scopedStale,
+    scoped_modified_files: scopedCounts.modifiedFiles,
+    scoped_new_files: scopedCounts.newFiles,
+    global_stale: globalStale,
+    global_modified_files: globalCounts.modifiedFiles,
+    global_new_files: globalCounts.newFiles,
+  };
+  const markdown = renderEmptyGuidanceMarkdown({
+    indexBuilt,
+    refreshed: input.refreshed,
+    scopedKb: input.scopedKb,
+    query: input.query,
+    scopedCounts,
+    globalCounts,
+    scopedStale,
+    globalStale,
+    refreshCommand,
+    indexMtime: input.staleness.indexMtime,
+  });
+  return { markdown, json };
+}
+
+function renderEmptyGuidanceMarkdown(input: {
+  indexBuilt: boolean;
+  refreshed: boolean;
+  scopedKb: string | undefined;
+  query: string;
+  scopedCounts: { modifiedFiles: number; newFiles: number };
+  globalCounts: { modifiedFiles: number; newFiles: number };
+  scopedStale: boolean;
+  globalStale: boolean;
+  refreshCommand: string;
+  indexMtime: string | null;
+}): string | null {
+  if (!input.indexBuilt) {
+    return (
+      `> **Tip:** No results found, and the index has not been built yet. ` +
+      `Run \`${input.refreshCommand}\` to create it, then re-run the query.`
+    );
+  }
+  if (input.refreshed) {
+    // The user already paid the refresh cost on this invocation; emitting
+    // another "run --refresh" tip would just be noise.
+    return null;
+  }
+  if (input.scopedKb) {
+    if (input.scopedStale) {
+      const stamp = input.indexMtime ?? 'index mtime unknown';
+      return (
+        `> **Tip:** No results found, and the "${input.scopedKb}" KB scope is stale ` +
+        `(${input.scopedCounts.modifiedFiles} modified, ${input.scopedCounts.newFiles} new file(s) since ${stamp}). ` +
+        `Try \`${input.refreshCommand}\` to update the index and re-run.`
+      );
+    }
+    if (input.globalStale) {
+      const globalRefresh = buildRefreshCommand(input.query, undefined);
+      return (
+        `> **Tip:** No results found. The "${input.scopedKb}" KB scope is up-to-date, but the global ` +
+        `index has drift outside this scope (${input.globalCounts.modifiedFiles} modified, ` +
+        `${input.globalCounts.newFiles} new file(s)). If the answer might live in another KB, drop ` +
+        `\`--kb=${input.scopedKb}\` and run \`${globalRefresh}\` to refresh and search the full index.`
+      );
+    }
+    return null;
+  }
+  if (input.scopedStale) {
+    const stamp = input.indexMtime ?? 'index mtime unknown';
+    return (
+      `> **Tip:** No results found, and the index is stale ` +
+      `(${input.scopedCounts.modifiedFiles} modified, ${input.scopedCounts.newFiles} new file(s) since ${stamp}). ` +
+      `Try \`${input.refreshCommand}\` to update the index and re-run.`
+    );
+  }
+  return null;
+}
+
+function buildRefreshCommand(query: string, scopedKb: string | undefined): string {
+  const kbFlag = scopedKb ? ` --kb=${scopedKb}` : '';
+  if (query === '') {
+    return `kb search${kbFlag} --refresh`;
+  }
+  return `kb search ${shellQuoteQuery(query)}${kbFlag} --refresh`;
+}
+
+function shellQuoteQuery(query: string): string {
+  // The suggested refresh command lands in markdown blockquotes / JSON
+  // payloads, so we need a deterministic, copy-pasteable representation that
+  // round-trips through `sh -c`. Double-quote and escape internal `"` / `\` /
+  // `$` / backticks — the same set bash would interpret inside double quotes.
+  const escaped = query.replace(/(["\\$`])/g, '\\$1');
+  return `"${escaped}"`;
+}
+
 /**
  * Compute the age-budget footer line for a scoped `kb search` run.
  *

--- a/src/cli-search.test.ts
+++ b/src/cli-search.test.ts
@@ -17,6 +17,7 @@ import {
   Staleness,
 } from './cli-search.js';
 import { compactTimingPayload, type TimingPayload } from './cli-timing.js';
+import type { ScoredDocument } from './formatter.js';
 import type { FaissIndexManager, SimilaritySearchTiming } from './FaissIndexManager.js';
 import {
   classifyKbSearchError,
@@ -513,6 +514,209 @@ describe('dense freshness output (#332)', () => {
     expect(output).toContain(
       '> _Timing: freshness_scan_ms=5ms, freshness_scan_files=8, freshness_scan_scope=scoped._',
     );
+  });
+});
+
+describe('empty-result inline staleness guidance (issue #335)', () => {
+  it('does not change the markdown body when results are non-empty', () => {
+    const doc = {
+      pageContent: 'hit',
+      metadata: { source: 'kb/doc.md' },
+      score: 0.5,
+    } as unknown as ScoredDocument;
+    const output = formatDenseSearchMarkdownOutput({
+      results: [doc],
+      groupBySource: false,
+      staleness: {
+        indexMtime: MTIME,
+        modifiedFiles: 4,
+        newFiles: 1,
+        scope: { kb: 'work', modifiedFiles: 4, newFiles: 1 },
+        global: { modifiedFiles: 7, newFiles: 9 },
+      },
+      refreshed: false,
+      scopedKb: 'work',
+      query: 'auth flow',
+      autoModeDecision: null,
+      autoThresholdDecision: null,
+      timing: null,
+    });
+    expect(output).toContain('**Result 1:**');
+    expect(output).not.toContain('**Tip:**');
+    expect(output).toContain('Index may be stale for KB "work"');
+  });
+
+  it('inlines the staleness tip and suppresses the duplicate freshness footer on empty scoped-stale runs', () => {
+    const output = formatDenseSearchMarkdownOutput({
+      results: [],
+      groupBySource: false,
+      staleness: {
+        indexMtime: MTIME,
+        modifiedFiles: 2,
+        newFiles: 5,
+        scope: { kb: 'work', modifiedFiles: 2, newFiles: 5 },
+        global: { modifiedFiles: 4, newFiles: 7 },
+      },
+      refreshed: false,
+      scopedKb: 'work',
+      query: 'auth flow',
+      autoModeDecision: null,
+      autoThresholdDecision: null,
+      timing: null,
+    });
+    expect(output).toContain('_No similar results found._');
+    expect(output).toContain('**Tip:** No results found, and the "work" KB scope is stale');
+    expect(output).toContain('kb search "auth flow" --kb=work --refresh');
+    expect(output).not.toContain('Run `kb search --kb=work --refresh` to update this scope');
+  });
+
+  it('inlines the staleness tip on empty global-stale runs and suppresses the footer', () => {
+    const output = formatDenseSearchMarkdownOutput({
+      results: [],
+      groupBySource: false,
+      staleness: {
+        indexMtime: MTIME,
+        modifiedFiles: 3,
+        newFiles: 1,
+      },
+      refreshed: false,
+      scopedKb: undefined,
+      query: 'auth flow',
+      autoModeDecision: null,
+      autoThresholdDecision: null,
+      timing: null,
+    });
+    expect(output).toContain('**Tip:** No results found, and the index is stale');
+    expect(output).toContain('kb search "auth flow" --refresh');
+    expect(output).not.toContain('Index may be stale: ');
+  });
+
+  it('keeps the existing "up-to-date" footer on empty fresh runs (no inline tip)', () => {
+    const output = formatDenseSearchMarkdownOutput({
+      results: [],
+      groupBySource: false,
+      staleness: {
+        indexMtime: MTIME,
+        modifiedFiles: 0,
+        newFiles: 0,
+      },
+      refreshed: false,
+      scopedKb: undefined,
+      query: 'auth flow',
+      autoModeDecision: null,
+      autoThresholdDecision: null,
+      timing: null,
+    });
+    expect(output).toContain('_No similar results found._');
+    expect(output).not.toContain('**Tip:**');
+    expect(output).toContain(`> _Index up-to-date as of ${MTIME}._`);
+  });
+
+  it('keeps the existing "refreshed" footer on empty refreshed runs (no inline tip)', () => {
+    const output = formatDenseSearchMarkdownOutput({
+      results: [],
+      groupBySource: false,
+      staleness: {
+        indexMtime: MTIME,
+        modifiedFiles: 0,
+        newFiles: 0,
+      },
+      refreshed: true,
+      scopedKb: undefined,
+      query: 'auth flow',
+      autoModeDecision: null,
+      autoThresholdDecision: null,
+      timing: null,
+    });
+    expect(output).not.toContain('**Tip:**');
+    expect(output).toContain(`> _Index refreshed at ${MTIME}._`);
+  });
+
+  it('JSON payload exposes empty_result_guidance on stale empty scoped runs', () => {
+    const payload = buildDenseSearchJsonPayload({
+      results: [],
+      requestedMode: 'dense',
+      effectiveMode: 'dense',
+      autoModeDecision: null,
+      groupBySource: false,
+      refreshed: false,
+      scopedKb: 'work',
+      query: 'auth flow',
+      staleness: {
+        indexMtime: MTIME,
+        modifiedFiles: 2,
+        newFiles: 5,
+        scope: { kb: 'work', modifiedFiles: 2, newFiles: 5 },
+        global: { modifiedFiles: 4, newFiles: 7 },
+      },
+      autoThresholdDecision: null,
+      timing: null,
+    });
+    expect(payload).toMatchObject({
+      results: [],
+      empty_result_guidance: {
+        refresh_command: 'kb search "auth flow" --kb=work --refresh',
+        scope: 'scoped',
+        scope_kb: 'work',
+        index_built: true,
+        refreshed: false,
+        scoped_stale: true,
+        scoped_modified_files: 2,
+        scoped_new_files: 5,
+        global_stale: true,
+        global_modified_files: 4,
+        global_new_files: 7,
+      },
+    });
+    expect(payload).toMatchObject({
+      stale: true,
+      modified_files: 2,
+      new_files: 5,
+    });
+  });
+
+  it('JSON payload omits empty_result_guidance when results are non-empty', () => {
+    const doc = {
+      pageContent: 'hit',
+      metadata: { source: 'kb/doc.md' },
+      score: 0.1,
+    } as unknown as ScoredDocument;
+    const payload = buildDenseSearchJsonPayload({
+      results: [doc],
+      requestedMode: 'dense',
+      effectiveMode: 'dense',
+      autoModeDecision: null,
+      groupBySource: false,
+      refreshed: false,
+      scopedKb: undefined,
+      query: 'auth flow',
+      staleness: {
+        indexMtime: MTIME,
+        modifiedFiles: 3,
+        newFiles: 1,
+      },
+      autoThresholdDecision: null,
+      timing: null,
+    });
+    expect(payload).not.toHaveProperty('empty_result_guidance');
+  });
+
+  it('JSON payload omits empty_result_guidance when freshness was skipped', () => {
+    const payload = buildDenseSearchJsonPayload({
+      results: [],
+      requestedMode: 'dense',
+      effectiveMode: 'dense',
+      autoModeDecision: null,
+      groupBySource: false,
+      refreshed: false,
+      scopedKb: undefined,
+      query: 'auth flow',
+      staleness: null,
+      autoThresholdDecision: null,
+      timing: null,
+    });
+    expect(payload).toMatchObject({ freshness_omitted: true });
+    expect(payload).not.toHaveProperty('empty_result_guidance');
   });
 });
 

--- a/src/cli-search.ts
+++ b/src/cli-search.ts
@@ -27,6 +27,7 @@ import {
   formatRetrievalAsJson,
   formatRetrievalAsMarkdown,
   formatRetrievalAsVimgrep,
+  formatRetrievalEmptyAsMarkdown,
   formatRetrievalGroupedBySourceAsMarkdown,
   groupRetrievalBySource,
   type ScoredDocument,
@@ -58,8 +59,10 @@ import {
   type HybridChunk,
 } from './hybrid-retrieval.js';
 import {
+  buildEmptyResultGuidance,
   buildRefreshPreflightEstimate,
   maybeWriteRefreshPreflight,
+  type EmptyResultGuidance,
 } from './cli-search-staleness.js';
 
 export const SEARCH_HELP = `kb search — semantic search across knowledge bases
@@ -357,6 +360,7 @@ export async function runSearch(
       groupBySource: parsed.groupBySource,
       refreshed: parsed.refresh,
       scopedKb: parsed.kb,
+      query: parsed.query ?? undefined,
       staleness,
       autoThresholdDecision,
       timing,
@@ -371,6 +375,8 @@ export async function runSearch(
       groupBySource: parsed.groupBySource,
       staleness,
       refreshed: parsed.refresh,
+      scopedKb: parsed.kb,
+      query: parsed.query ?? undefined,
       autoModeDecision,
       autoThresholdDecision,
       timing,
@@ -830,6 +836,8 @@ export interface DenseSearchJsonPayloadInput {
   groupBySource: boolean;
   refreshed: boolean;
   scopedKb: string | undefined;
+  /** Original user query; embedded in the issue #335 empty-result refresh-command suggestion. */
+  query?: string;
   staleness: Staleness | null;
   autoThresholdDecision: AutoThresholdDecision | null;
   timing: TimingPayload | null;
@@ -852,6 +860,10 @@ export function buildDenseSearchJsonPayload(input: DenseSearchJsonPayloadInput):
     );
   }
   Object.assign(payload, buildFreshnessJsonFields(input));
+  const emptyGuidance = computeEmptyResultGuidance(input);
+  if (emptyGuidance?.json) {
+    payload.empty_result_guidance = emptyGuidance.json;
+  }
   if (input.autoThresholdDecision !== null) {
     payload.auto_threshold = {
       threshold: input.autoThresholdDecision.threshold,
@@ -863,6 +875,35 @@ export function buildDenseSearchJsonPayload(input: DenseSearchJsonPayloadInput):
     payload.timing = compactTimingPayload(input.timing);
   }
   return payload;
+}
+
+function computeEmptyResultGuidance(input: {
+  results: ScoredDocument[];
+  refreshed: boolean;
+  scopedKb: string | undefined;
+  query?: string;
+  staleness: Staleness | null;
+}): EmptyResultGuidance | null {
+  if (input.results.length > 0) return null;
+  if (input.staleness === null) return null;
+  return buildEmptyResultGuidance({
+    query: input.query ?? '',
+    scopedKb: input.scopedKb,
+    refreshed: input.refreshed,
+    staleness: {
+      indexMtime: input.staleness.indexMtime,
+      scoped: {
+        modifiedFiles: input.staleness.scope?.modifiedFiles ?? input.staleness.modifiedFiles,
+        newFiles: input.staleness.scope?.newFiles ?? input.staleness.newFiles,
+      },
+      global: input.staleness.scope
+        ? {
+            modifiedFiles: input.staleness.global?.modifiedFiles ?? 0,
+            newFiles: input.staleness.global?.newFiles ?? 0,
+          }
+        : null,
+    },
+  });
 }
 
 function buildFreshnessJsonFields(input: DenseSearchJsonPayloadInput): Record<string, unknown> {
@@ -912,6 +953,9 @@ export interface DenseSearchMarkdownOutputInput {
   groupBySource: boolean;
   staleness: Staleness | null;
   refreshed: boolean;
+  scopedKb?: string;
+  /** Original user query; embedded in the issue #335 empty-result refresh-command suggestion. */
+  query?: string;
   autoModeDecision: AutoSearchModeDecision | null;
   autoThresholdDecision: AutoThresholdDecision | null;
   timing: TimingPayload | null;
@@ -925,11 +969,27 @@ export function formatDenseSearchMarkdownOutput(input: DenseSearchMarkdownOutput
   if (input.autoThresholdDecision !== null) {
     output += `${formatAutoThresholdHeader(input.autoThresholdDecision)}\n\n`;
   }
-  const md = input.groupBySource
-    ? formatRetrievalGroupedBySourceAsMarkdown(input.results, FRONTMATTER_EXTRAS_WIRE_VISIBLE, KB_EDITOR_URI)
-    : formatRetrievalAsMarkdown(input.results, FRONTMATTER_EXTRAS_WIRE_VISIBLE, KB_EDITOR_URI);
+  const emptyGuidance = computeEmptyResultGuidance({
+    results: input.results,
+    refreshed: input.refreshed,
+    scopedKb: input.scopedKb,
+    query: input.query,
+    staleness: input.staleness,
+  });
+  const inlineEmptyGuidance = emptyGuidance?.markdown ?? null;
+  let md: string;
+  if (input.results.length === 0 && inlineEmptyGuidance !== null) {
+    md = formatRetrievalEmptyAsMarkdown(inlineEmptyGuidance);
+  } else if (input.groupBySource) {
+    md = formatRetrievalGroupedBySourceAsMarkdown(input.results, FRONTMATTER_EXTRAS_WIRE_VISIBLE, KB_EDITOR_URI);
+  } else {
+    md = formatRetrievalAsMarkdown(input.results, FRONTMATTER_EXTRAS_WIRE_VISIBLE, KB_EDITOR_URI);
+  }
   output += `${md}\n\n`;
-  if (input.staleness !== null) {
+  if (input.staleness !== null && inlineEmptyGuidance === null) {
+    // Suppress the trailing footer when the inline empty-result block already
+    // includes the refresh command + stale counts — operators shouldn't see
+    // the same suggestion twice (issue #335).
     output += `${formatFreshnessFooter(input.staleness, input.refreshed)}\n`;
   }
   if (input.timing) {

--- a/src/formatter.test.ts
+++ b/src/formatter.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
 import {
   formatRetrievalAsJson,
   formatRetrievalAsVimgrep,
+  formatRetrievalEmptyAsMarkdown,
   formatRetrievalGroupedBySourceAsMarkdown,
   formatRetrievalAsMarkdown,
   groupRetrievalBySource,
@@ -198,6 +199,31 @@ describe('formatRetrievalAsMarkdown', () => {
     expect(out).toContain('**Context chunks:**');
     expect(out).toContain('**Context (before, distance 1):**');
     expect(out).toContain('previous chunk');
+  });
+});
+
+describe('formatRetrievalEmptyAsMarkdown (issue #335)', () => {
+  it('matches the legacy "no similar results" body when no inline guidance is passed', () => {
+    const out = formatRetrievalEmptyAsMarkdown();
+    expect(out).toContain('## Semantic Search Results');
+    expect(out).toContain('_No similar results found._');
+    expect(out).toContain('Disclaimer');
+    expect(out).toBe(formatRetrievalAsMarkdown([], false));
+  });
+
+  it('injects the inline guidance block between the "no results" line and the disclaimer', () => {
+    const tip = '> **Tip:** No results, the index is stale. Run `kb search --refresh` to update.';
+    const out = formatRetrievalEmptyAsMarkdown(tip);
+    expect(out).toContain('_No similar results found._');
+    expect(out).toContain(tip);
+    expect(out.indexOf('_No similar results found._'))
+      .toBeLessThan(out.indexOf(tip));
+    expect(out.indexOf(tip)).toBeLessThan(out.indexOf('Disclaimer'));
+  });
+
+  it('does not change the empty body when the inline guidance is an empty string', () => {
+    const out = formatRetrievalEmptyAsMarkdown('');
+    expect(out).toBe(formatRetrievalEmptyAsMarkdown());
   });
 });
 

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -102,6 +102,26 @@ export function sanitizeMetadataForWire(
   };
 }
 
+const SEMANTIC_SEARCH_HEADER = '## Semantic Search Results';
+const SEMANTIC_SEARCH_DISCLAIMER =
+  '\n\n> **Disclaimer:** The provided results might not all be relevant. Please cross-check the relevance of the information.';
+const NO_RESULTS_LINE = '_No similar results found._';
+
+/**
+ * Renders the empty-result body for `kb search` / `retrieve_knowledge`. With no
+ * argument it matches the legacy `_No similar results found._` block; with an
+ * `inlineGuidance` markdown fragment it injects that block between the
+ * "no results" line and the disclaimer (issue #335).
+ *
+ * Issue #335 — CLI-only callers pass a staleness-derived inline tip so the
+ * refresh command lands at the empty result, not just in the trailing footer.
+ * MCP callers stay on the no-argument path and keep byte-equal output.
+ */
+export function formatRetrievalEmptyAsMarkdown(inlineGuidance?: string): string {
+  const guidance = inlineGuidance ? `\n\n${inlineGuidance}` : '';
+  return `${SEMANTIC_SEARCH_HEADER}\n\n${NO_RESULTS_LINE}${guidance}${SEMANTIC_SEARCH_DISCLAIMER}`;
+}
+
 /**
  * Produces the markdown body of a `retrieve_knowledge` / `kb search` response.
  * Byte-equal to the previous inline KnowledgeBaseServer formatting. Adding a
@@ -113,35 +133,32 @@ export function formatRetrievalAsMarkdown(
   extrasVisible: boolean,
   editorUriMode: KBEditorUriMode = KB_EDITOR_URI,
 ): string {
-  let formattedResults = '';
-  if (results && results.length > 0) {
-    const guardOptions = resolveInjectionGuardOptions();
-    formattedResults = results
-      .map((doc, idx) => {
-        const hasContextAnnotation = hasNeighborContextAnnotation(doc);
-        const resultHeader = hasContextAnnotation
-          ? `**Result ${idx + 1} (semantic match):**`
-          : `**Result ${idx + 1}:**`;
-        const sanitizedMetadata = sanitizeMetadataForWire(
-          doc.metadata as Record<string, unknown>,
-          extrasVisible,
-        );
-        const guarded = guardRetrievalChunk(doc.pageContent, sanitizedMetadata, guardOptions);
-        const content = guarded.content.trim();
-        const citation = buildChunkCitation(guarded.metadata, editorUriMode);
-        const metadata = JSON.stringify(guarded.metadata, null, 2);
-        const scoreText = doc.score !== undefined ? `**Score:** ${doc.score.toFixed(2)}\n\n` : '';
-        const signals = getShieldSignals(doc.pageContent, sanitizedMetadata, guardOptions);
-        const shieldFooter = formatInjectionMarkdown(signals);
-        const contextText = formatContextChunksAsMarkdown(doc, extrasVisible, editorUriMode);
-        return `${resultHeader}\n\n${scoreText}${content}\n\n${shieldFooter}${formatSourceBlock(metadata, citation)}${contextText}`;
-      })
-      .join('\n\n---\n\n');
-  } else {
-    formattedResults = '_No similar results found._';
+  if (!results || results.length === 0) {
+    return formatRetrievalEmptyAsMarkdown();
   }
-  const disclaimer = '\n\n> **Disclaimer:** The provided results might not all be relevant. Please cross-check the relevance of the information.';
-  return `## Semantic Search Results\n\n${formattedResults}${disclaimer}`;
+  const guardOptions = resolveInjectionGuardOptions();
+  const formattedResults = results
+    .map((doc, idx) => {
+      const hasContextAnnotation = hasNeighborContextAnnotation(doc);
+      const resultHeader = hasContextAnnotation
+        ? `**Result ${idx + 1} (semantic match):**`
+        : `**Result ${idx + 1}:**`;
+      const sanitizedMetadata = sanitizeMetadataForWire(
+        doc.metadata as Record<string, unknown>,
+        extrasVisible,
+      );
+      const guarded = guardRetrievalChunk(doc.pageContent, sanitizedMetadata, guardOptions);
+      const content = guarded.content.trim();
+      const citation = buildChunkCitation(guarded.metadata, editorUriMode);
+      const metadata = JSON.stringify(guarded.metadata, null, 2);
+      const scoreText = doc.score !== undefined ? `**Score:** ${doc.score.toFixed(2)}\n\n` : '';
+      const signals = getShieldSignals(doc.pageContent, sanitizedMetadata, guardOptions);
+      const shieldFooter = formatInjectionMarkdown(signals);
+      const contextText = formatContextChunksAsMarkdown(doc, extrasVisible, editorUriMode);
+      return `${resultHeader}\n\n${scoreText}${content}\n\n${shieldFooter}${formatSourceBlock(metadata, citation)}${contextText}`;
+    })
+    .join('\n\n---\n\n');
+  return `${SEMANTIC_SEARCH_HEADER}\n\n${formattedResults}${SEMANTIC_SEARCH_DISCLAIMER}`;
 }
 
 export function formatRetrievalGroupedBySourceAsMarkdown(
@@ -150,34 +167,31 @@ export function formatRetrievalGroupedBySourceAsMarkdown(
   editorUriMode: KBEditorUriMode = KB_EDITOR_URI,
 ): string {
   const grouped = groupRetrievalBySource(results, extrasVisible, editorUriMode);
-  let formattedResults = '';
-  if (grouped.length > 0) {
-    formattedResults = grouped
-      .map((group, idx) => {
-        const chunks = group.chunks
-          .map((chunk, chunkIdx) => {
-            const scoreText = formatScore(chunk.score);
-            const locationText = formatLocation(chunk.location);
-            const openText = chunk.editor_uri ? `\n   **Open:** ${chunk.editor_uri}` : '';
-            const shieldText = formatInjectionGrouped(chunk.injection_signals);
-            const typeText = chunk.match_type ? `\n   **Type:** ${chunk.match_type}` : '';
-            const contextText = formatJsonContextChunksForGroupedMarkdown(chunk.context_chunks);
-            return `${chunkIdx + 1}. **Score:** ${scoreText}${typeText}\n   **Location:** ${locationText}${openText}\n\n   ${indentChunkContent(chunk.content.trim())}${shieldText}${contextText}`;
-          })
-          .join('\n\n');
-        return (
-          `**Source ${idx + 1}:** \`${group.source}\`\n\n` +
-          `**Best score:** ${formatScore(group.best_score)}\n\n` +
-          `**Chunk count:** ${group.chunk_count}\n\n` +
-          `**Matching chunks:**\n\n${chunks}`
-        );
-      })
-      .join('\n\n---\n\n');
-  } else {
-    formattedResults = '_No similar results found._';
+  if (grouped.length === 0) {
+    return formatRetrievalEmptyAsMarkdown();
   }
-  const disclaimer = '\n\n> **Disclaimer:** The provided results might not all be relevant. Please cross-check the relevance of the information.';
-  return `## Semantic Search Results\n\n${formattedResults}${disclaimer}`;
+  const formattedResults = grouped
+    .map((group, idx) => {
+      const chunks = group.chunks
+        .map((chunk, chunkIdx) => {
+          const scoreText = formatScore(chunk.score);
+          const locationText = formatLocation(chunk.location);
+          const openText = chunk.editor_uri ? `\n   **Open:** ${chunk.editor_uri}` : '';
+          const shieldText = formatInjectionGrouped(chunk.injection_signals);
+          const typeText = chunk.match_type ? `\n   **Type:** ${chunk.match_type}` : '';
+          const contextText = formatJsonContextChunksForGroupedMarkdown(chunk.context_chunks);
+          return `${chunkIdx + 1}. **Score:** ${scoreText}${typeText}\n   **Location:** ${locationText}${openText}\n\n   ${indentChunkContent(chunk.content.trim())}${shieldText}${contextText}`;
+        })
+        .join('\n\n');
+      return (
+        `**Source ${idx + 1}:** \`${group.source}\`\n\n` +
+        `**Best score:** ${formatScore(group.best_score)}\n\n` +
+        `**Chunk count:** ${group.chunk_count}\n\n` +
+        `**Matching chunks:**\n\n${chunks}`
+      );
+    })
+    .join('\n\n---\n\n');
+  return `${SEMANTIC_SEARCH_HEADER}\n\n${formattedResults}${SEMANTIC_SEARCH_DISCLAIMER}`;
 }
 
 /**


### PR DESCRIPTION
Closes #335.

## Summary

When `kb search` returns zero results and the selected scope (single-KB or global) is stale, the refresh command and stale counts now appear directly under the empty body, not only as a trailing footer. Operators reading top-down were missing the footer and re-running the same query without refreshing.

- `formatter.ts` — new `formatRetrievalEmptyAsMarkdown(inlineGuidance?)` helper; the existing markdown/JSON formatters and MCP output are unchanged.
- `cli-search-staleness.ts` — new `buildEmptyResultGuidance({ query, scopedKb, refreshed, staleness })` returns a markdown blockquote tip and an additive JSON fragment. Stays null when there is nothing actionable (fresh, refreshed, or `--no-freshness`).
- `cli-search.ts` — wires the helper into `formatDenseSearchMarkdownOutput` and `buildDenseSearchJsonPayload`; the duplicate freshness footer is suppressed when the inline tip already shows the refresh command. JSON gains an additive `empty_result_guidance` field; existing freshness keys are preserved.
- MCP retrieval output is intentionally unchanged — only the dense CLI path plumbs `query`/`scopedKb` into the formatter.

## Before / after

### Before — empty scoped-stale run (guidance hidden in the footer)

```
## Semantic Search Results

_No similar results found._

> **Disclaimer:** The provided results might not all be relevant.

> _Index may be stale for KB "work": 2 modified, 5 new file(s) since 2026-05-13T15:30:00.000Z. Run `kb search --kb=work --refresh` to update this scope. Global index drift: 4 modified, 7 new file(s)._
```

### After — empty scoped-stale run (inline tip, no duplicate footer)

```
## Semantic Search Results

_No similar results found._

> **Tip:** No results found, and the "work" KB scope is stale (2 modified, 5 new file(s) since 2026-05-13T15:30:00.000Z). Try `kb search "auth flow" --kb=work --refresh` to update the index and re-run.

> **Disclaimer:** The provided results might not all be relevant.
```

### After — empty global-stale run (unscoped)

```
## Semantic Search Results

_No similar results found._

> **Tip:** No results found, and the index is stale (3 modified, 1 new file(s) since 2026-05-13T15:30:00.000Z). Try `kb search "auth flow" --refresh` to update the index and re-run.

> **Disclaimer:** The provided results might not all be relevant.
```

### After — empty fresh run (legacy footer preserved, no inline tip)

```
## Semantic Search Results

_No similar results found._

> **Disclaimer:** The provided results might not all be relevant.

> _Index up-to-date as of 2026-05-13T15:30:00.000Z._
```

### After — JSON additive shape

```json
{
  "results": [],
  "index_mtime": "2026-05-13T15:30:00.000Z",
  "stale": true,
  "modified_files": 2,
  "new_files": 5,
  "global_stale": true,
  "global_modified_files": 4,
  "global_new_files": 7,
  "scope": { "kb": "work", "stale": true, "modified_files": 2, "new_files": 5 },
  "empty_result_guidance": {
    "refresh_command": "kb search \"auth flow\" --kb=work --refresh",
    "scope": "scoped",
    "scope_kb": "work",
    "index_mtime": "2026-05-13T15:30:00.000Z",
    "index_built": true,
    "refreshed": false,
    "scoped_stale": true,
    "scoped_modified_files": 2,
    "scoped_new_files": 5,
    "global_stale": true,
    "global_modified_files": 4,
    "global_new_files": 7
  }
}
```

## Test plan

- [x] `npx jest src/cli-search.test.ts src/cli-search-staleness.test.ts src/formatter.test.ts --runInBand` — 122 tests, all green
- [x] `npm run build` — clean
- [x] `npm test -- --runInBand` — 78 suites, 1310 passed, 4 skipped, 1 todo
- [x] `git diff --check` — clean
- [x] Cases covered: index not built, scoped stale, global stale, scoped fresh + global stale, fresh, refreshed, `--no-freshness`, embedded shell quotes in query
- [x] Footer suppression verified for both scoped and global stale empty runs; legacy footer preserved on fresh and non-empty runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)