### PR TITLE
feat(search): predicate-pushdown metadata sidecar

### DIFF
--- a/benchmarks/predicate-pushdown.bench.ts
+++ b/benchmarks/predicate-pushdown.bench.ts
@@ -1,0 +1,404 @@
+// benchmarks/predicate-pushdown.bench.ts — Issue #283.
+//
+// Standalone benchmark comparing the FAISS post-filter overfetch ladder
+// (the pre-#283 default for any metadata-filtered search) against the
+// new predicate-pushdown sidecar fast-path. Both paths run against an
+// in-memory simulator that mirrors the real `FaissIndexManager.similaritySearch`
+// orchestration: the simulator owns a synthetic distance map, applies
+// the same `createSimilaritySearchPostFilter`, and the same
+// `progressiveFetchSizes` ladder (loaded from the built `src/` modules
+// at runtime so this benchmark drifts with the real implementation).
+//
+// Run with:
+//   npm run build && tsc -p tsconfig.bench.json
+//   node build/benchmarks/predicate-pushdown.bench.js
+//
+// Or with a custom corpus / selectivity:
+//   BENCH_PUSHDOWN_NTOTAL=20000 BENCH_PUSHDOWN_SELECTIVITY=0.005 \
+//     node build/benchmarks/predicate-pushdown.bench.js
+//
+// Exits 0 on completion. The script does not assert a budget; the
+// `benchmark-harness` CI job does not invoke it. Operators reading the
+// PR body for #283 use the printed table to decide whether the fast-path
+// is worth keeping in their hot path.
+
+import * as fsp from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+
+interface SyntheticVector {
+  docstoreId: string;
+  metadata: Record<string, unknown>;
+  // baseline distance ranking in [0, 1]; smaller means more similar.
+  distance: number;
+}
+
+// Minimal structural type for the SimilaritySearchFilters surface we use.
+interface FiltersInput {
+  extensions?: readonly string[];
+  pathGlob?: string;
+  tags?: readonly string[];
+}
+
+interface PostFilterModule {
+  createSimilaritySearchPostFilter(opts: {
+    threshold: number;
+    knowledgeBasesRootDir: string;
+    knowledgeBaseName?: string;
+    filters?: FiltersInput;
+  }): {
+    requiresOverfetch: boolean;
+    apply(scored: ReadonlyArray<readonly [unknown, number]>): Array<readonly [unknown, number]>;
+  };
+}
+
+interface FaissModule {
+  progressiveFetchSizes(k: number, ntotal: number): number[];
+}
+
+interface SidecarModule {
+  writeMetadataSidecar(opts: {
+    sidecarPath: string;
+    modelId: string;
+    rows: ReadonlyArray<{
+      docstoreId: string;
+      knowledgeBase: string;
+      source: string;
+      relativePath: string;
+      extension: string;
+      tags: readonly string[];
+    }>;
+  }): Promise<void>;
+  readMetadataSidecar(opts: { sidecarPath: string; modelId: string }): Promise<{
+    candidateIds(filter: {
+      knowledgeBaseName?: string;
+      knowledgeBasesRootDir?: string;
+      extensions?: readonly string[];
+      pathGlob?: string;
+      tags?: readonly string[];
+    }): string[];
+    totalChunks: number;
+  } | null>;
+  toSidecarFilter(opts: {
+    knowledgeBaseName?: string;
+    knowledgeBasesRootDir: string;
+    filters?: FiltersInput;
+  }): {
+    knowledgeBaseName?: string;
+    knowledgeBasesRootDir?: string;
+    extensions?: readonly string[];
+    pathGlob?: string;
+    tags?: readonly string[];
+  };
+  recommendFastPathFetchK(opts: { k: number; candidates: number; ntotal: number }): number | null;
+}
+
+const repoRoot = process.cwd();
+const buildRoot = process.env.BENCH_BUILD_ROOT ?? path.join(repoRoot, 'build');
+
+async function loadModules(): Promise<{
+  filters: PostFilterModule;
+  faiss: FaissModule;
+  sidecar: SidecarModule;
+}> {
+  // Cache-bust the dynamic import so successive runs see the latest built JS.
+  const stamp = Date.now();
+  const filters = (await import(
+    new URL(`file://${path.join(buildRoot, 'search-filters.js')}?bench=pushdown-filters-${stamp}`).href,
+  )) as PostFilterModule;
+  const faiss = (await import(
+    new URL(`file://${path.join(buildRoot, 'FaissIndexManager.js')}?bench=pushdown-faiss-${stamp}`).href,
+  )) as FaissModule;
+  const sidecar = (await import(
+    new URL(`file://${path.join(buildRoot, 'metadata-sidecar.js')}?bench=pushdown-sidecar-${stamp}`).href,
+  )) as SidecarModule;
+  return { filters, faiss, sidecar };
+}
+
+function buildSyntheticCorpus(opts: {
+  ntotal: number;
+  selectivity: number;
+  seed: number;
+}): SyntheticVector[] {
+  const { ntotal, selectivity, seed } = opts;
+  const knowledgeBases = ['kb-alpha', 'kb-beta', 'kb-gamma', 'kb-delta'];
+  const extensions = ['.md', '.txt', '.pdf', '.json'];
+  const tags = ['ops', 'design', 'research', 'qa', 'misc'];
+  const candidateThreshold = Math.max(1, Math.round(ntotal * selectivity));
+
+  const random = mulberry32(seed);
+  const vectors: SyntheticVector[] = [];
+  for (let i = 0; i < ntotal; i += 1) {
+    const isCandidate = i < candidateThreshold;
+    const kb = isCandidate ? 'kb-alpha' : knowledgeBases[i % knowledgeBases.length];
+    const ext = isCandidate ? '.md' : extensions[(i + 1) % extensions.length];
+    const tag = isCandidate ? 'ops' : tags[i % tags.length];
+    vectors.push({
+      docstoreId: String(i),
+      distance: random(),
+      metadata: {
+        knowledgeBase: kb,
+        source: `/kb/${kb}/file-${i}${ext}`,
+        relativePath: `${kb}/file-${i}${ext}`,
+        extension: ext,
+        tags: [tag],
+        chunkIndex: 0,
+      },
+    });
+  }
+  return vectors;
+}
+
+class FaissSimulator {
+  private faissCalls = 0;
+  private readonly sorted: SyntheticVector[];
+
+  constructor(vectors: SyntheticVector[]) {
+    // Sort once; each search returns the top-k slice.
+    this.sorted = [...vectors].sort((a, b) => a.distance - b.distance);
+  }
+
+  similaritySearchWithScore(_query: string, k: number): Array<readonly [
+    { pageContent: string; metadata: Record<string, unknown> },
+    number,
+  ]> {
+    this.faissCalls += 1;
+    const slice = this.sorted.slice(0, Math.min(k, this.sorted.length));
+    return slice.map((v) => [
+      { pageContent: `c-${v.docstoreId}`, metadata: v.metadata },
+      v.distance,
+    ] as const);
+  }
+
+  totalVectors(): number { return this.sorted.length; }
+  getCallCount(): number { return this.faissCalls; }
+  resetCallCount(): void { this.faissCalls = 0; }
+}
+
+interface SearchPath {
+  label: string;
+  run(): { results: number; faissCalls: number; lastFetchK: number };
+}
+
+function buildBaselinePath(opts: {
+  simulator: FaissSimulator;
+  filters: FiltersInput;
+  knowledgeBaseName?: string;
+  knowledgeBasesRootDir: string;
+  k: number;
+  modules: { filters: PostFilterModule; faiss: FaissModule };
+}): SearchPath {
+  const postFilter = opts.modules.filters.createSimilaritySearchPostFilter({
+    threshold: 2,
+    knowledgeBasesRootDir: opts.knowledgeBasesRootDir,
+    knowledgeBaseName: opts.knowledgeBaseName,
+    filters: opts.filters,
+  });
+  return {
+    label: 'baseline (post-filter ladder)',
+    run() {
+      opts.simulator.resetCallCount();
+      const ntotal = opts.simulator.totalVectors();
+      const fetchSizes = opts.modules.faiss.progressiveFetchSizes(opts.k, ntotal);
+      let filtered: ReturnType<typeof postFilter.apply> = [];
+      let lastFetchK = opts.k;
+      for (const fetchK of fetchSizes) {
+        lastFetchK = fetchK;
+        const raw = opts.simulator.similaritySearchWithScore('q', fetchK);
+        filtered = postFilter.apply(raw);
+        if (filtered.length >= opts.k) break;
+        if (raw.length < fetchK) break;
+      }
+      return {
+        results: Math.min(filtered.length, opts.k),
+        faissCalls: opts.simulator.getCallCount(),
+        lastFetchK,
+      };
+    },
+  };
+}
+
+function buildFastPath(opts: {
+  simulator: FaissSimulator;
+  filters: FiltersInput;
+  knowledgeBaseName?: string;
+  knowledgeBasesRootDir: string;
+  k: number;
+  candidateCount: number;
+  modules: { filters: PostFilterModule; faiss: FaissModule; sidecar: SidecarModule };
+}): SearchPath {
+  const postFilter = opts.modules.filters.createSimilaritySearchPostFilter({
+    threshold: 2,
+    knowledgeBasesRootDir: opts.knowledgeBasesRootDir,
+    knowledgeBaseName: opts.knowledgeBaseName,
+    filters: opts.filters,
+  });
+  return {
+    label: 'fast-path (sidecar predicate-pushdown)',
+    run() {
+      opts.simulator.resetCallCount();
+      const ntotal = opts.simulator.totalVectors();
+      if (opts.candidateCount === 0) {
+        return { results: 0, faissCalls: 0, lastFetchK: 0 };
+      }
+      const recommended = opts.modules.sidecar.recommendFastPathFetchK({
+        k: opts.k,
+        candidates: opts.candidateCount,
+        ntotal,
+      });
+      let lastFetchK = opts.k;
+      let filtered: ReturnType<typeof postFilter.apply> = [];
+      if (recommended !== null) {
+        lastFetchK = recommended;
+        const raw = opts.simulator.similaritySearchWithScore('q', recommended);
+        filtered = postFilter.apply(raw);
+        const fastPathSatisfied = filtered.length >= opts.k || raw.length < recommended;
+        if (fastPathSatisfied) {
+          return {
+            results: Math.min(filtered.length, opts.k),
+            faissCalls: opts.simulator.getCallCount(),
+            lastFetchK,
+          };
+        }
+      }
+      const fetchSizes = opts.modules.faiss.progressiveFetchSizes(opts.k, ntotal);
+      for (const fetchK of fetchSizes) {
+        lastFetchK = fetchK;
+        const raw = opts.simulator.similaritySearchWithScore('q', fetchK);
+        filtered = postFilter.apply(raw);
+        if (filtered.length >= opts.k) break;
+        if (raw.length < fetchK) break;
+      }
+      return {
+        results: Math.min(filtered.length, opts.k),
+        faissCalls: opts.simulator.getCallCount(),
+        lastFetchK,
+      };
+    },
+  };
+}
+
+function timePath(searchPath: SearchPath, repetitions: number): {
+  median_ms: number;
+  faiss_calls: number;
+  last_fetch_k: number;
+  results: number;
+} {
+  const samples: number[] = [];
+  let lastResult = searchPath.run();
+  for (let i = 0; i < repetitions; i += 1) {
+    const start = process.hrtime.bigint();
+    lastResult = searchPath.run();
+    const end = process.hrtime.bigint();
+    samples.push(Number(end - start) / 1_000_000);
+  }
+  const sorted = [...samples].sort((a, b) => a - b);
+  const median = sorted[Math.floor(sorted.length / 2)];
+  return {
+    median_ms: Number(median.toFixed(3)),
+    faiss_calls: lastResult.faissCalls,
+    last_fetch_k: lastResult.lastFetchK,
+    results: lastResult.results,
+  };
+}
+
+async function main(): Promise<void> {
+  const ntotal = parsePositiveInt(process.env.BENCH_PUSHDOWN_NTOTAL) ?? 10_000;
+  const selectivity = parsePositiveFloat(process.env.BENCH_PUSHDOWN_SELECTIVITY) ?? 0.01;
+  const k = parsePositiveInt(process.env.BENCH_PUSHDOWN_K) ?? 10;
+  const repetitions = parsePositiveInt(process.env.BENCH_PUSHDOWN_REPETITIONS) ?? 50;
+
+  process.stdout.write(
+    `predicate-pushdown.bench: ntotal=${ntotal} selectivity=${selectivity} k=${k} repetitions=${repetitions}\n`,
+  );
+
+  const modules = await loadModules();
+  const vectors = buildSyntheticCorpus({ ntotal, selectivity, seed: 17 });
+  const simulator = new FaissSimulator(vectors);
+  const filters: FiltersInput = { extensions: ['.md'], tags: ['ops'] };
+  const knowledgeBaseName = 'kb-alpha';
+  const knowledgeBasesRootDir = '/kb';
+
+  // Round-trip the sidecar through disk so the candidate count we feed
+  // the fast-path matches what an operator's on-disk JSONL would produce.
+  const sidecarDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-sidecar-bench-'));
+  const sidecarPath = path.join(sidecarDir, 'metadata-sidecar.jsonl');
+  const sidecarRows = vectors.map((v) => ({
+    docstoreId: v.docstoreId,
+    knowledgeBase: v.metadata.knowledgeBase as string,
+    source: v.metadata.source as string,
+    relativePath: v.metadata.relativePath as string,
+    extension: v.metadata.extension as string,
+    tags: (v.metadata.tags as string[]) ?? [],
+  }));
+  await modules.sidecar.writeMetadataSidecar({
+    sidecarPath, modelId: 'bench-model', rows: sidecarRows,
+  });
+  const sidecar = await modules.sidecar.readMetadataSidecar({ sidecarPath, modelId: 'bench-model' });
+  if (sidecar === null) throw new Error('bench: failed to read back the sidecar we just wrote');
+  const sidecarFilter = modules.sidecar.toSidecarFilter({
+    knowledgeBaseName, knowledgeBasesRootDir, filters,
+  });
+  const candidateCount = sidecar.candidateIds(sidecarFilter).length;
+
+  const baseline = buildBaselinePath({
+    simulator, filters, knowledgeBaseName, knowledgeBasesRootDir, k, modules,
+  });
+  const fast = buildFastPath({
+    simulator, filters, knowledgeBaseName, knowledgeBasesRootDir, k, candidateCount, modules,
+  });
+  const baselineMetrics = timePath(baseline, repetitions);
+  const fastMetrics = timePath(fast, repetitions);
+
+  process.stdout.write('\n');
+  process.stdout.write(
+    `candidates from sidecar: ${candidateCount} ` +
+      `(selectivity = ${(candidateCount / ntotal * 100).toFixed(3)}%)\n\n`,
+  );
+  process.stdout.write(`${baseline.label.padEnd(48)}  ${formatMetrics(baselineMetrics)}\n`);
+  process.stdout.write(`${fast.label.padEnd(48)}  ${formatMetrics(fastMetrics)}\n\n`);
+  const delta = fastMetrics.median_ms === 0 ? 'inf'
+    : (((baselineMetrics.median_ms - fastMetrics.median_ms) / baselineMetrics.median_ms) * 100).toFixed(2);
+  const callDelta = fastMetrics.faiss_calls === 0 ? 'infx'
+    : `${(baselineMetrics.faiss_calls / Math.max(1, fastMetrics.faiss_calls)).toFixed(2)}x`;
+  process.stdout.write(`fast-path latency reduction: ${delta}% — fewer FAISS calls: ${callDelta}\n`);
+
+  await fsp.rm(sidecarDir, { recursive: true, force: true });
+}
+
+function formatMetrics(metrics: ReturnType<typeof timePath>): string {
+  return [
+    `median=${metrics.median_ms.toFixed(3)}ms`,
+    `faiss_calls=${metrics.faiss_calls}`,
+    `last_fetchK=${metrics.last_fetch_k}`,
+    `results=${metrics.results}`,
+  ].join('  ');
+}
+
+function parsePositiveInt(raw: string | undefined): number | null {
+  if (!raw) return null;
+  const parsed = parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}
+
+function parsePositiveFloat(raw: string | undefined): number | null {
+  if (!raw) return null;
+  const parsed = parseFloat(raw);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}
+
+function mulberry32(seed: number): () => number {
+  let current = seed >>> 0;
+  return () => {
+    current += 0x6d2b79f5;
+    let t = current;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4_294_967_296;
+  };
+}
+
+main().catch((err) => {
+  process.stderr.write(`${err instanceof Error ? err.stack ?? err.message : String(err)}\n`);
+  process.exit(1);
+});

--- a/src/FaissIndexManager.test.ts
+++ b/src/FaissIndexManager.test.ts
@@ -3924,3 +3924,356 @@ describe('FaissIndexManager neighbor context expansion', () => {
     expect(expanded[0].contextTruncated).toBe(true);
   });
 });
+
+describe('FaissIndexManager predicate-pushdown sidecar (#283)', () => {
+  const originalEnv = {
+    KNOWLEDGE_BASES_ROOT_DIR: process.env.KNOWLEDGE_BASES_ROOT_DIR,
+    FAISS_INDEX_PATH: process.env.FAISS_INDEX_PATH,
+    EMBEDDING_PROVIDER: process.env.EMBEDDING_PROVIDER,
+    HUGGINGFACE_API_KEY: process.env.HUGGINGFACE_API_KEY,
+  };
+
+  beforeEach(() => {
+    saveMock.mockReset();
+    addDocumentsMock.mockReset();
+    fromTextsMock.mockReset();
+    loadMock.mockReset();
+    similaritySearchMock.mockReset();
+    embeddingConstructorMock.mockReset();
+  });
+
+  afterEach(() => {
+    const keys = Object.keys(originalEnv) as Array<keyof typeof originalEnv>;
+    for (const key of keys) {
+      const value = originalEnv[key];
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+    jest.restoreAllMocks();
+  });
+
+  // The progressive-overfetch suite above patches the loaded mock store's
+  // index to fake an arbitrary `ntotal`. We layer a sidecar on top of that
+  // by writing the JSONL file directly to the per-model directory; the
+  // manager's `loadMetadataSidecar` then sees a populated, non-stale
+  // sidecar and the fast-path can fire.
+  async function setupManagerWithSidecar(opts: {
+    ntotal: number;
+    rows: Array<{
+      docstoreId: string;
+      knowledgeBase: string;
+      source: string;
+      relativePath: string;
+      extension: string;
+      tags?: string[];
+      frontmatter?: Record<string, string>;
+    }>;
+  }) {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-sidecar-fast-path-'));
+    const kbDir = path.join(tempDir, 'kb');
+    const defaultKb = path.join(kbDir, 'default');
+    await fsp.mkdir(defaultKb, { recursive: true });
+    await fsp.writeFile(path.join(defaultKb, 'doc.md'), '# Title\n\nSidecar fast-path fixture.');
+
+    process.env.KNOWLEDGE_BASES_ROOT_DIR = kbDir;
+    process.env.FAISS_INDEX_PATH = path.join(tempDir, '.faiss');
+    process.env.EMBEDDING_PROVIDER = 'huggingface';
+    process.env.HUGGINGFACE_API_KEY = 'test-key';
+
+    jest.resetModules();
+    const { FaissIndexManager } = await import('./FaissIndexManager.js');
+    const { writeMetadataSidecar, METADATA_SIDECAR_FILENAME } = await import('./metadata-sidecar.js');
+
+    const manager = new FaissIndexManager();
+    await manager.initialize();
+    await manager.updateIndex();
+    loadedFaissStore(manager).index = {
+      ntotal: () => opts.ntotal,
+      getDimension: () => 2,
+    };
+
+    const sidecarPath = path.join(tempDir, '.faiss', 'models', DEFAULT_MODEL_ID, METADATA_SIDECAR_FILENAME);
+    await writeMetadataSidecar({
+      sidecarPath,
+      modelId: DEFAULT_MODEL_ID,
+      rows: opts.rows.map((row) => ({
+        docstoreId: row.docstoreId,
+        knowledgeBase: row.knowledgeBase,
+        source: row.source,
+        relativePath: row.relativePath,
+        extension: row.extension,
+        tags: row.tags ?? [],
+        frontmatter: row.frontmatter,
+      })),
+    });
+    (manager as { __resetMetadataSidecarCacheForTests?: () => void })
+      .__resetMetadataSidecarCacheForTests?.();
+    return { manager, tempDir, sidecarPath };
+  }
+
+  it('short-circuits to the empty result when no sidecar row matches the filter (no FAISS call)', async () => {
+    const { manager } = await setupManagerWithSidecar({
+      ntotal: 200,
+      rows: Array.from({ length: 200 }, (_, i) => ({
+        docstoreId: String(i),
+        knowledgeBase: 'docs',
+        source: `/kb/docs/file${i}.md`,
+        relativePath: `docs/file${i}.md`,
+        extension: '.md',
+      })),
+    });
+
+    const timing: Record<string, unknown> = {};
+    const results = await manager.similaritySearch(
+      'q',
+      10,
+      undefined,
+      undefined,
+      { extensions: ['.txt'] },
+      timing,
+    );
+
+    expect(results).toEqual([]);
+    expect(similaritySearchMock).not.toHaveBeenCalled();
+    expect(timing.sidecar_fast_path).toBe('short_circuit');
+    expect(timing.sidecar_candidates).toBe(0);
+  });
+
+  it('runs a single FAISS search at the targeted fetchK when the filter is highly selective', async () => {
+    // 100 .md+ops chunks out of 10_000 = 1% selectivity. The sidecar has
+    // a row per docstore vector so the header total matches the live
+    // ntotal; the fast-path picks a rung sized to the candidate count and
+    // returns as soon as it satisfies k.
+    const candidateCount = 100;
+    const { manager } = await setupManagerWithSidecar({
+      ntotal: 10_000,
+      rows: Array.from({ length: 10_000 }, (_, i) => {
+        const isCandidate = i < candidateCount;
+        return {
+          docstoreId: String(i),
+          knowledgeBase: 'docs',
+          source: isCandidate ? `/kb/docs/runbook${i}.md` : `/kb/docs/other${i}.pdf`,
+          relativePath: isCandidate ? `docs/runbooks/runbook${i}.md` : `docs/other${i}.pdf`,
+          extension: isCandidate ? '.md' : '.pdf',
+          tags: isCandidate ? ['ops'] : ['misc'],
+        };
+      }),
+    });
+
+    similaritySearchMock.mockImplementation(async (...args: unknown[]) => {
+      const fetchK = args[1] as number;
+      // Half the returned results match the filter so k=10 is satisfied.
+      const out: Array<[unknown, number]> = [];
+      for (let i = 0; i < fetchK; i += 1) {
+        out.push([
+          {
+            pageContent: `r${i}`,
+            metadata: i % 2 === 0
+              ? { extension: '.md', tags: ['ops'], relativePath: `docs/runbooks/r${i}.md` }
+              : { extension: '.pdf', tags: ['ops'], relativePath: `docs/r${i}.pdf` },
+          },
+          0.1 + i * 0.0001,
+        ]);
+      }
+      return out;
+    });
+
+    const timing: Record<string, unknown> = {};
+    const results = await manager.similaritySearch(
+      'q',
+      10,
+      undefined,
+      undefined,
+      { extensions: ['.md'], tags: ['ops'] },
+      timing,
+    );
+
+    expect(similaritySearchMock).toHaveBeenCalledTimes(1);
+    expect(results).toHaveLength(10);
+    expect(timing.sidecar_fast_path).toBe('hit');
+    expect(timing.sidecar_candidates).toBe(100);
+    // The fast-path requested far less than ntotal (which the post-filter
+    // ladder would walk up to in the worst case).
+    const callArgs = similaritySearchMock.mock.calls[0];
+    expect(callArgs[1]).toBeLessThan(10_000);
+  });
+
+  it('falls back to the progressive overfetch ladder when the filter is too broad', async () => {
+    // 800 of 1000 chunks match → selectivity 80%, above the SELECTIVITY_CEILING.
+    // fast-path declines (timing reports 'unused') and the existing #229 ladder
+    // runs unchanged. Rows total matches ntotal so the sidecar is not stale.
+    const { manager } = await setupManagerWithSidecar({
+      ntotal: 1000,
+      rows: [
+        ...Array.from({ length: 800 }, (_, i) => ({
+          docstoreId: String(i),
+          knowledgeBase: 'docs',
+          source: `/kb/docs/m${i}.md`,
+          relativePath: `docs/m${i}.md`,
+          extension: '.md',
+        })),
+        ...Array.from({ length: 200 }, (_, i) => ({
+          docstoreId: String(800 + i),
+          knowledgeBase: 'docs',
+          source: `/kb/docs/p${i}.pdf`,
+          relativePath: `docs/p${i}.pdf`,
+          extension: '.pdf',
+        })),
+      ],
+    });
+
+    const mdHits: Array<[unknown, number]> = Array.from({ length: 6 }, (_, i) => [
+      { pageContent: `m${i}`, metadata: { extension: '.md', relativePath: `docs/m${i}.md` } },
+      0.1 + i * 0.01,
+    ]);
+    const pdfPad: Array<[unknown, number]> = Array.from({ length: 14 }, (_, i) => [
+      { pageContent: `p${i}`, metadata: { extension: '.pdf', relativePath: `docs/p${i}.pdf` } },
+      0.2 + i * 0.01,
+    ]);
+    similaritySearchMock.mockResolvedValueOnce([...mdHits, ...pdfPad]);
+
+    const timing: Record<string, unknown> = {};
+    const results = await manager.similaritySearch(
+      'q',
+      5,
+      undefined,
+      undefined,
+      { extensions: ['.md'] },
+      timing,
+    );
+
+    expect(similaritySearchMock).toHaveBeenCalledTimes(1);
+    expect(similaritySearchMock).toHaveBeenCalledWith('q', 20);
+    expect(results).toHaveLength(5);
+    expect(timing.sidecar_fast_path).toBe('unused');
+  });
+
+  it('falls back to the post-filter ladder when the sidecar is missing entirely', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-sidecar-missing-'));
+    const kbDir = path.join(tempDir, 'kb');
+    const defaultKb = path.join(kbDir, 'default');
+    await fsp.mkdir(defaultKb, { recursive: true });
+    await fsp.writeFile(path.join(defaultKb, 'doc.md'), '# Title\n\nMissing sidecar fixture.');
+    process.env.KNOWLEDGE_BASES_ROOT_DIR = kbDir;
+    process.env.FAISS_INDEX_PATH = path.join(tempDir, '.faiss');
+    process.env.EMBEDDING_PROVIDER = 'huggingface';
+    process.env.HUGGINGFACE_API_KEY = 'test-key';
+
+    jest.resetModules();
+    const { FaissIndexManager } = await import('./FaissIndexManager.js');
+    const manager = new FaissIndexManager();
+    await manager.initialize();
+    await manager.updateIndex();
+    loadedFaissStore(manager).index = {
+      ntotal: () => 1000,
+      getDimension: () => 2,
+    };
+    // The mock store has no docstore, so refreshMetadataSidecar threw and
+    // no JSONL was persisted. This is exactly the on-disk "no sidecar" state.
+
+    const mdHits: Array<[unknown, number]> = Array.from({ length: 6 }, (_, i) => [
+      { pageContent: `m${i}`, metadata: { extension: '.md', relativePath: `kb/m${i}.md` } },
+      0.1 + i * 0.01,
+    ]);
+    const pad: Array<[unknown, number]> = Array.from({ length: 14 }, (_, i) => [
+      { pageContent: `p${i}`, metadata: { extension: '.pdf', relativePath: `kb/p${i}.pdf` } },
+      0.2 + i * 0.01,
+    ]);
+    similaritySearchMock.mockResolvedValueOnce([...mdHits, ...pad]);
+
+    const timing: Record<string, unknown> = {};
+    const results = await manager.similaritySearch(
+      'q',
+      5,
+      undefined,
+      undefined,
+      { extensions: ['.md'] },
+      timing,
+    );
+
+    expect(similaritySearchMock).toHaveBeenCalledTimes(1);
+    expect(similaritySearchMock).toHaveBeenCalledWith('q', 20);
+    expect(results).toHaveLength(5);
+    expect(timing.sidecar_fast_path).toBe('missing');
+  });
+
+  it('treats an ntotal mismatch as stale and falls through to the ladder for correctness', async () => {
+    // Sidecar header says 100 chunks but the live mock store reports 200.
+    // The stale signal must drop the fast-path even though the sidecar file
+    // is otherwise valid.
+    const { manager } = await setupManagerWithSidecar({
+      ntotal: 200,
+      rows: Array.from({ length: 100 }, (_, i) => ({
+        docstoreId: String(i),
+        knowledgeBase: 'docs',
+        source: `/kb/docs/file${i}.md`,
+        relativePath: `docs/file${i}.md`,
+        extension: '.md',
+      })),
+    });
+
+    const mdHits: Array<[unknown, number]> = Array.from({ length: 6 }, (_, i) => [
+      { pageContent: `m${i}`, metadata: { extension: '.md', relativePath: `docs/m${i}.md` } },
+      0.1 + i * 0.01,
+    ]);
+    const pad: Array<[unknown, number]> = Array.from({ length: 14 }, (_, i) => [
+      { pageContent: `p${i}`, metadata: { extension: '.pdf', relativePath: `docs/p${i}.pdf` } },
+      0.2 + i * 0.01,
+    ]);
+    similaritySearchMock.mockResolvedValueOnce([...mdHits, ...pad]);
+
+    const timing: Record<string, unknown> = {};
+    const results = await manager.similaritySearch(
+      'q',
+      5,
+      undefined,
+      undefined,
+      { extensions: ['.md'] },
+      timing,
+    );
+
+    expect(similaritySearchMock).toHaveBeenCalledTimes(1);
+    expect(similaritySearchMock).toHaveBeenCalledWith('q', 20);
+    expect(results).toHaveLength(5);
+    expect(timing.sidecar_fast_path).toBe('missing');
+  });
+
+  it('falls back to the ladder when the sidecar JSONL on disk is corrupt', async () => {
+    const { manager, sidecarPath } = await setupManagerWithSidecar({
+      ntotal: 100,
+      rows: Array.from({ length: 100 }, (_, i) => ({
+        docstoreId: String(i),
+        knowledgeBase: 'docs',
+        source: `/kb/docs/file${i}.md`,
+        relativePath: `docs/file${i}.md`,
+        extension: '.md',
+      })),
+    });
+    await fsp.writeFile(sidecarPath, '{not-valid-jsonl', 'utf-8');
+    (manager as { __resetMetadataSidecarCacheForTests?: () => void })
+      .__resetMetadataSidecarCacheForTests?.();
+
+    const items: Array<[unknown, number]> = Array.from({ length: 20 }, (_, i) => [
+      { pageContent: `m${i}`, metadata: { extension: '.md', relativePath: `docs/m${i}.md` } },
+      0.1 + i * 0.001,
+    ]);
+    similaritySearchMock.mockResolvedValueOnce(items);
+
+    const timing: Record<string, unknown> = {};
+    const results = await manager.similaritySearch(
+      'q',
+      5,
+      undefined,
+      undefined,
+      { extensions: ['.md'] },
+      timing,
+    );
+
+    expect(similaritySearchMock).toHaveBeenCalledWith('q', 20);
+    expect(results).toHaveLength(5);
+    expect(timing.sidecar_fast_path).toBe('missing');
+  });
+});

--- a/src/FaissIndexManager.ts
+++ b/src/FaissIndexManager.ts
@@ -51,6 +51,18 @@ import {
   type ScoredDocument,
   type SimilaritySearchFilters,
 } from './search-filters.js';
+import {
+  METADATA_SIDECAR_FILENAME,
+  buildSidecarRowFromDocument,
+  deleteMetadataSidecar,
+  isSidecarStale,
+  readMetadataSidecar,
+  recommendFastPathFetchK,
+  toSidecarFilter,
+  writeMetadataSidecar,
+  type MetadataSidecar,
+  type MetadataSidecarRow,
+} from './metadata-sidecar.js';
 import { queryEmbeddingCache, type QueryCacheLookupStatus } from './query-cache.js';
 import { withSidecarLock } from './write-lock.js';
 import { FaissStoreAdapter } from './faiss-store-adapter.js';
@@ -263,6 +275,17 @@ export interface SimilaritySearchTiming {
   total_ms?: number;
   fetch_k?: number;
   query_cache?: QueryCacheLookupStatus | 'unavailable';
+  /**
+   * Issue #283 — outcome of the metadata-sidecar predicate-pushdown
+   * fast-path. `unused` means the active filter did not benefit from the
+   * sidecar; `missing`/`stale` mean the sidecar did not exist or did not
+   * match `ntotal` (post-filter ladder ran). `hit` means the fast-path
+   * served the query without falling back. `miss_underflow` means we
+   * tried the fast-path but the targeted fetchK did not yield enough
+   * filtered hits and we fell through to the ladder.
+   */
+  sidecar_fast_path?: 'hit' | 'unused' | 'missing' | 'stale' | 'miss_underflow' | 'short_circuit';
+  sidecar_candidates?: number;
 }
 
 export const MAX_NEIGHBOR_CONTEXT_WINDOW = 5;
@@ -459,6 +482,11 @@ export class FaissIndexManager {
   readonly modelNameFile: string;
   private readonly indexingBatchSize: number;
   private lastIndexUpdateSummary: IndexUpdateSummary;
+  // Issue #283 — cached metadata sidecar so we don't re-parse the JSONL
+  // file on every query. Invalidated whenever updateIndex rewrites it,
+  // and re-checked for staleness on every search via `isSidecarStale`.
+  private metadataSidecarCache: { sidecar: MetadataSidecar; loadedAt: number } | null = null;
+  private metadataSidecarMissingLogged = false;
 
   /**
    * RFC 013 §4.9 file table — preferred form: `new FaissIndexManager({provider, modelName})`
@@ -761,6 +789,12 @@ export class FaissIndexManager {
           `crash mid-rebuild, or model switch with the prior model's store moved aside.`,
       );
     }
+    // Issue #283 — drop the metadata sidecar too; it indexes the same
+    // (now absent) docstore and would otherwise return stale candidate
+    // ids to the predicate-pushdown fast-path.
+    await deleteMetadataSidecar(this.metadataSidecarPath());
+    this.metadataSidecarCache = null;
+    this.metadataSidecarMissingLogged = false;
     if (skippedSymlinks.length > 0) {
       logger.warn(
         `Issue #90 sidecar purge: skipped ${skippedSymlinks.length} symlinked KB entry(ies) ` +
@@ -768,6 +802,92 @@ export class FaissIndexManager {
           `If those KBs need their sidecars cleared, run \`find <kb-target> -type d -name .index -exec rm -rf {} +\` manually.`,
       );
     }
+  }
+
+  /**
+   * Issue #283 — absolute path of this model's predicate-pushdown sidecar.
+   * Lives next to `last-index-update.json` and `model_name.txt` under the
+   * per-model directory so a model swap can never confuse two sidecars.
+   */
+  private metadataSidecarPath(): string {
+    return path.join(this.modelDir, METADATA_SIDECAR_FILENAME);
+  }
+
+  /**
+   * Issue #283 — rebuild the sidecar from the current in-memory docstore
+   * after a successful index save. Held under `withSidecarLock` so a
+   * concurrent `purgeStaleSidecars` cross-model can't rmrf the directory
+   * (the sidecar lives under `<modelDir>`, not under `<kb>/.index/`, but
+   * the lock keeps both write paths in a single serial domain).
+   */
+  private async refreshMetadataSidecar(): Promise<void> {
+    if (!this.faissIndex) return;
+    const entries = this.faissIndex.docstoreEntries();
+    const rows: MetadataSidecarRow[] = [];
+    for (const [docstoreId, document] of entries) {
+      const row = buildSidecarRowFromDocument(docstoreId, document);
+      if (row !== null) rows.push(row);
+    }
+    const sidecarPath = this.metadataSidecarPath();
+    await withSidecarLock(() =>
+      writeMetadataSidecar({ sidecarPath, modelId: this.modelId, rows }),
+    );
+    this.metadataSidecarCache = null;
+    this.metadataSidecarMissingLogged = false;
+  }
+
+  /**
+   * Issue #283 — read-time sidecar accessor. Caches the parsed sidecar
+   * for this process and re-validates on every call against the live
+   * `ntotal`. Returns null whenever the sidecar is missing, stale, or
+   * corrupt — the caller must then fall through to the post-filter
+   * ladder for correctness. The first miss in a process logs ONE
+   * canonical warn to keep operator logs clean under repeated queries.
+   */
+  private async loadMetadataSidecar(): Promise<MetadataSidecar | null> {
+    if (!this.faissIndex) return null;
+    const ntotal = this.faissIndex.totalVectors();
+    if (this.metadataSidecarCache !== null) {
+      if (!isSidecarStale(this.metadataSidecarCache.sidecar, ntotal)) {
+        return this.metadataSidecarCache.sidecar;
+      }
+      this.metadataSidecarCache = null;
+    }
+    const sidecarPath = this.metadataSidecarPath();
+    const sidecar = await readMetadataSidecar({ sidecarPath, modelId: this.modelId });
+    if (sidecar === null) {
+      if (!this.metadataSidecarMissingLogged) {
+        logger.warn(
+          `Issue #283 metadata sidecar absent or unreadable for model ${this.modelId}; ` +
+            `metadata-filtered queries will use the post-filter overfetch ladder. ` +
+            `Run \`npm run build && node build/index.js\` (or any updateIndex) to regenerate.`,
+        );
+        this.metadataSidecarMissingLogged = true;
+      }
+      return null;
+    }
+    if (isSidecarStale(sidecar, ntotal)) {
+      logger.warn(
+        `Issue #283 metadata sidecar for ${this.modelId} reports ${sidecar.totalChunks} chunks ` +
+          `but the live FAISS docstore has ${ntotal}; falling back to post-filter overfetch.`,
+      );
+      this.metadataSidecarCache = null;
+      return null;
+    }
+    this.metadataSidecarCache = { sidecar, loadedAt: Date.now() };
+    this.metadataSidecarMissingLogged = false;
+    return sidecar;
+  }
+
+  /**
+   * Test seam — drops the in-memory sidecar cache so a test that mutates
+   * the on-disk JSONL directly (without going through `refreshMetadataSidecar`)
+   * sees the new bytes on the next search.
+   */
+  /** @internal */
+  __resetMetadataSidecarCacheForTests(): void {
+    this.metadataSidecarCache = null;
+    this.metadataSidecarMissingLogged = false;
   }
 
   /**
@@ -1694,6 +1814,21 @@ export class FaissIndexManager {
           });
           await writeSidecarHashes(pendingHashWrites);
           await writeChunkManifests(pendingChunkManifestWrites);
+          if (indexMutated && this.faissIndex !== null) {
+            // Issue #283 — keep the predicate-pushdown sidecar in sync
+            // with the FAISS docstore. Best-effort: a write failure here
+            // logs and falls through; the next query simply picks the
+            // post-filter ladder until the next successful refresh.
+            try {
+              await this.refreshMetadataSidecar();
+            } catch (sidecarRefreshError: unknown) {
+              logger.warn(
+                `Issue #283 metadata sidecar refresh failed for ${this.modelId}: ` +
+                  `${toError(sidecarRefreshError).message}. Queries will use the ` +
+                  `post-filter overfetch ladder until the next successful refresh.`,
+              );
+            }
+          }
           runSummary.sidecars_written =
             pendingHashWrites.length > 0 || pendingChunkManifestWrites.length > 0;
           await emitProgress({
@@ -1864,16 +1999,76 @@ export class FaissIndexManager {
       return filtered.slice(0, k).map(([doc, score]) => ({ ...doc, score }));
     }
 
+    const ntotal = this.faissIndex.totalVectors();
+
+    // Issue #283 — predicate-pushdown fast-path. When a metadata-aware
+    // filter is active and the per-model sidecar matches the live docstore
+    // we use it to:
+    //   (a) short-circuit to an empty result when no row matches (no FAISS
+    //       call at all),
+    //   (b) pick a single FAISS fetchK targeted at the filter selectivity
+    //       so common 1%-class filters terminate in one search instead of
+    //       walking the [20, 4k, 16k, ntotal] ladder.
+    // The post-filter still runs on the FAISS results for correctness:
+    // sidecar candidates only narrow how MANY vectors we ask FAISS for,
+    // they do not bypass the post-filter.
+    const sidecarFilter = toSidecarFilter({
+      knowledgeBaseName,
+      knowledgeBasesRootDir: KNOWLEDGE_BASES_ROOT_DIR,
+      filters,
+    });
+    const sidecar = await this.loadMetadataSidecar();
+    let cumulativePostFilterMs = 0;
+    let filtered: ScoredDocument[] = [];
+
+    if (sidecar !== null && sidecar.hasFilter(sidecarFilter)) {
+      const candidates = sidecar.candidateIds(sidecarFilter);
+      if (timing) timing.sidecar_candidates = candidates.length;
+      if (candidates.length === 0) {
+        if (timing) {
+          timing.sidecar_fast_path = 'short_circuit';
+          timing.fetch_k = 0;
+          timing.post_filter_ms = 0;
+          timing.total_ms = Date.now() - totalStartedAt;
+        }
+        return [];
+      }
+      const fastFetchK = recommendFastPathFetchK({
+        k,
+        candidates: candidates.length,
+        ntotal,
+      });
+      if (fastFetchK !== null) {
+        const resultsWithScore = await runFaissSearch(fastFetchK);
+        const postFilterStartedAt = Date.now();
+        filtered = postFilter.apply(resultsWithScore);
+        cumulativePostFilterMs += Date.now() - postFilterStartedAt;
+        const fastPathSatisfied =
+          filtered.length >= k || resultsWithScore.length < fastFetchK;
+        if (fastPathSatisfied) {
+          if (timing) {
+            timing.fetch_k = fastFetchK;
+            timing.post_filter_ms = cumulativePostFilterMs;
+            timing.sidecar_fast_path = 'hit';
+            timing.total_ms = Date.now() - totalStartedAt;
+          }
+          return filtered.slice(0, k).map(([doc, score]) => ({ ...doc, score }));
+        }
+        if (timing) timing.sidecar_fast_path = 'miss_underflow';
+      } else if (timing) {
+        timing.sidecar_fast_path = 'unused';
+      }
+    } else if (timing) {
+      timing.sidecar_fast_path = sidecar === null ? 'missing' : 'unused';
+    }
+
     // Issue #229 — progressive overfetch. Walk increasing fetch windows and
     // stop as soon as the post-filter yields at least `k` hits, or FAISS has
     // already returned its entire docstore (raw length below the requested
     // window ⇒ ntotal exhausted). Worst case ends at `ntotal` and matches
     // the pre-#229 cost; common filtered queries terminate at the first rung.
-    const ntotal = this.faissIndex.totalVectors();
     const fetchSizes = progressiveFetchSizes(k, ntotal);
-    let filtered: ScoredDocument[] = [];
     let lastFetchK = k;
-    let cumulativePostFilterMs = 0;
     for (const fetchK of fetchSizes) {
       lastFetchK = fetchK;
       const resultsWithScore = await runFaissSearch(fetchK);

--- a/src/faiss-store-adapter.ts
+++ b/src/faiss-store-adapter.ts
@@ -193,6 +193,15 @@ export class FaissStoreAdapter {
     return Array.from(getDocstoreMap(this.store).values());
   }
 
+  /**
+   * Issue #283 — emit `[docstoreId, Document]` pairs in insertion order so
+   * the metadata sidecar can persist a stable id keyed by exactly what the
+   * langchain docstore uses internally.
+   */
+  docstoreEntries(): Array<[string, Document]> {
+    return Array.from(getDocstoreMap(this.store).entries());
+  }
+
   chunkCountsByKnowledgeBase(): Record<string, number> {
     const counts: Record<string, number> = {};
     for (const doc of getDocstoreMap(this.store).values()) {

--- a/src/file-ingest.test.ts
+++ b/src/file-ingest.test.ts
@@ -1,9 +1,14 @@
+import * as fsp from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
 import { Document } from '@langchain/core/documents';
 import {
+  buildChunkDocuments,
   buildChunkManifest,
   countStableChunkPrefix,
   normalizeChunkTextForEmbedding,
 } from './file-ingest.js';
+import { buildSidecarRowFromDocument } from './metadata-sidecar.js';
 
 describe('normalizeChunkTextForEmbedding', () => {
   it('collapses insignificant text differences before indexing dedupe', () => {
@@ -51,5 +56,110 @@ describe('buildChunkManifest', () => {
     expect(first.chunks[0].textHash).toBe(second.chunks[0].textHash);
     expect(first.chunks[0].metadataHash).toBe(second.chunks[0].metadataHash);
     expect(countStableChunkPrefix(first, second)).toBe(1);
+  });
+});
+
+describe('buildChunkDocuments → metadata-sidecar contract (#283)', () => {
+  // Issue #283: the ingest path must emit every metadata field the
+  // predicate-pushdown sidecar relies on. If buildChunkDocuments ever
+  // stops attaching `knowledgeBase`, `relativePath`, `extension`, or the
+  // tags array, the sidecar row will be null and the fast-path silently
+  // disappears. Lock that contract here.
+  //
+  // KNOWLEDGE_BASES_ROOT_DIR is read by `config.ts` at module load, so
+  // tests build their fixture under a directory that is itself under the
+  // active KB root and assert the relativePath is the path RELATIVE to
+  // that root (rather than guessing it).
+  let kbRoot: string | undefined;
+  let workspaceUnderRoot: string | undefined;
+
+  beforeAll(async () => {
+    const { KNOWLEDGE_BASES_ROOT_DIR } = await import('./config.js');
+    kbRoot = KNOWLEDGE_BASES_ROOT_DIR;
+    workspaceUnderRoot = await fsp.mkdtemp(path.join(kbRoot, 'kb-ingest-sidecar-'));
+  });
+
+  afterAll(async () => {
+    if (workspaceUnderRoot !== undefined) {
+      await fsp.rm(workspaceUnderRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('produces documents whose metadata maps cleanly to a sidecar row', async () => {
+    const kbName = 'docs';
+    const kbDir = path.join(workspaceUnderRoot as string, kbName, 'runbooks');
+    await fsp.mkdir(kbDir, { recursive: true });
+    const filePath = path.join(kbDir, 'oncall.md');
+    const content = [
+      '---',
+      'tags:',
+      '  - ops',
+      '  - oncall',
+      'title: On-call runbook',
+      'status: active',
+      '---',
+      '',
+      '# On-call runbook',
+      '',
+      'Restart the queue worker if the lag exceeds five minutes.',
+    ].join('\n');
+    await fsp.writeFile(filePath, content, 'utf-8');
+
+    const documents = await buildChunkDocuments(filePath, content, kbName);
+    expect(documents.length).toBeGreaterThan(0);
+
+    const first = documents[0];
+    const expectedRelativePath = path
+      .relative(kbRoot as string, filePath)
+      .split(path.sep)
+      .join('/');
+
+    expect(first.metadata).toEqual(expect.objectContaining({
+      knowledgeBase: kbName,
+      source: filePath,
+      relativePath: expectedRelativePath,
+      extension: '.md',
+      tags: expect.arrayContaining(['ops', 'oncall']),
+      frontmatter: expect.objectContaining({ title: 'On-call runbook', status: 'active' }),
+    }));
+
+    const row = buildSidecarRowFromDocument('vec-0', first);
+    expect(row).not.toBeNull();
+    expect(row).toEqual(expect.objectContaining({
+      docstoreId: 'vec-0',
+      knowledgeBase: kbName,
+      source: filePath,
+      relativePath: expectedRelativePath,
+      extension: '.md',
+      tags: expect.arrayContaining(['ops', 'oncall']),
+      frontmatter: expect.objectContaining({ title: 'On-call runbook', status: 'active' }),
+    }));
+  });
+
+  it('refresh re-ingest of the same file regenerates documents that map to fresh rows', async () => {
+    const kbName = 'docs';
+    const kbDir = path.join(workspaceUnderRoot as string, 'refresh', kbName);
+    await fsp.mkdir(kbDir, { recursive: true });
+    const filePath = path.join(kbDir, 'changing.md');
+    const expectedRelativePath = path
+      .relative(kbRoot as string, filePath)
+      .split(path.sep)
+      .join('/');
+
+    await fsp.writeFile(filePath, '# Initial title\n\nFirst body.\n', 'utf-8');
+    const initial = await buildChunkDocuments(filePath, await fsp.readFile(filePath, 'utf-8'), kbName);
+    const initialRow = buildSidecarRowFromDocument('vec-0', initial[0]);
+    expect(initialRow?.relativePath).toBe(expectedRelativePath);
+
+    await fsp.writeFile(filePath, '# Updated title\n\nNew body.\n', 'utf-8');
+    const updated = await buildChunkDocuments(filePath, await fsp.readFile(filePath, 'utf-8'), kbName);
+    const updatedRow = buildSidecarRowFromDocument('vec-0', updated[0]);
+    expect(updatedRow?.relativePath).toBe(expectedRelativePath);
+    // Same docstore id, same metadata fields → sidecar refresh stays
+    // structurally identical even when the underlying chunk text changed.
+    expect(updatedRow).toEqual(expect.objectContaining({
+      knowledgeBase: kbName,
+      extension: '.md',
+    }));
   });
 });

--- a/src/metadata-sidecar.test.ts
+++ b/src/metadata-sidecar.test.ts
@@ -1,0 +1,371 @@
+import * as fsp from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { Document } from '@langchain/core/documents';
+import {
+  METADATA_SIDECAR_FILENAME,
+  METADATA_SIDECAR_SCHEMA_VERSION,
+  buildSidecarRowFromDocument,
+  deleteMetadataSidecar,
+  isSidecarStale,
+  readMetadataSidecar,
+  recommendFastPathFetchK,
+  toSidecarFilter,
+  writeMetadataSidecar,
+  type MetadataSidecarRow,
+} from './metadata-sidecar.js';
+
+async function makeTempDir(): Promise<string> {
+  return fsp.mkdtemp(path.join(os.tmpdir(), 'kb-sidecar-test-'));
+}
+
+function row(overrides: Partial<MetadataSidecarRow>): MetadataSidecarRow {
+  return {
+    docstoreId: overrides.docstoreId ?? '0',
+    knowledgeBase: overrides.knowledgeBase ?? 'kb-default',
+    source: overrides.source ?? '/kbs/kb-default/notes/file.md',
+    relativePath: overrides.relativePath ?? 'kb-default/notes/file.md',
+    extension: overrides.extension ?? '.md',
+    tags: overrides.tags ?? [],
+    frontmatter: overrides.frontmatter,
+  };
+}
+
+describe('metadata-sidecar', () => {
+  describe('buildSidecarRowFromDocument', () => {
+    it('extracts the search-relevant metadata fields and lower-cases the extension', () => {
+      const document = new Document({
+        pageContent: 'irrelevant',
+        metadata: {
+          knowledgeBase: 'docs',
+          source: '/kbs/docs/runbooks/payments.MD',
+          relativePath: 'docs/runbooks/payments.MD',
+          extension: '.MD',
+          tags: ['ops', 'oncall', ''],
+          frontmatter: {
+            title: 'Payments runbook',
+            status: 'active',
+            extras: { ignored: 'because non-whitelisted' },
+            non_string: 42,
+          },
+        },
+      });
+      const result = buildSidecarRowFromDocument('vec-7', document);
+      expect(result).not.toBeNull();
+      expect(result).toEqual({
+        docstoreId: 'vec-7',
+        knowledgeBase: 'docs',
+        source: '/kbs/docs/runbooks/payments.MD',
+        relativePath: 'docs/runbooks/payments.MD',
+        extension: '.md',
+        tags: ['ops', 'oncall'],
+        frontmatter: { title: 'Payments runbook', status: 'active' },
+      });
+    });
+
+    it('returns null when required fields are missing rather than indexing a broken row', () => {
+      const document = new Document({
+        pageContent: 'irrelevant',
+        metadata: { source: '/kbs/docs/file.md' },
+      });
+      expect(buildSidecarRowFromDocument('1', document)).toBeNull();
+    });
+
+    it('omits frontmatter when no whitelisted scalars survive', () => {
+      const document = new Document({
+        pageContent: 'irrelevant',
+        metadata: {
+          knowledgeBase: 'docs',
+          source: '/kbs/docs/file.md',
+          relativePath: 'docs/file.md',
+          extension: '.md',
+          frontmatter: { extras: { x: 'y' }, non_string: 42 },
+        },
+      });
+      const result = buildSidecarRowFromDocument('id', document);
+      expect(result).not.toBeNull();
+      expect(result?.frontmatter).toBeUndefined();
+    });
+  });
+
+  describe('round-trip persistence', () => {
+    it('writes a JSONL header + one line per row and reads them back with stable buckets', async () => {
+      const dir = await makeTempDir();
+      try {
+        const sidecarPath = path.join(dir, METADATA_SIDECAR_FILENAME);
+        const rows: MetadataSidecarRow[] = [
+          row({ docstoreId: '0', knowledgeBase: 'docs', extension: '.md', tags: ['ops'] }),
+          row({ docstoreId: '1', knowledgeBase: 'docs', extension: '.txt' }),
+          row({ docstoreId: '2', knowledgeBase: 'design', extension: '.md', tags: ['oncall'] }),
+        ];
+        await writeMetadataSidecar({ sidecarPath, modelId: 'model-x', rows });
+
+        const raw = await fsp.readFile(sidecarPath, 'utf-8');
+        const lines = raw.trim().split('\n');
+        expect(lines).toHaveLength(rows.length + 1);
+        expect(JSON.parse(lines[0])).toEqual({
+          schema_version: METADATA_SIDECAR_SCHEMA_VERSION,
+          model_id: 'model-x',
+          total_chunks: rows.length,
+        });
+
+        const sidecar = await readMetadataSidecar({ sidecarPath, modelId: 'model-x' });
+        expect(sidecar).not.toBeNull();
+        if (!sidecar) throw new Error('sidecar read returned null');
+        expect(sidecar.totalChunks).toBe(rows.length);
+        const docsCandidates = sidecar.candidateIds({ knowledgeBaseName: 'docs' });
+        expect(docsCandidates.sort()).toEqual(['0', '1']);
+        const opsCandidates = sidecar.candidateIds({ tags: ['ops'] });
+        expect(opsCandidates).toEqual(['0']);
+      } finally {
+        await fsp.rm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('refresh re-ingest replaces rows so the candidate set reflects the new file', async () => {
+      const dir = await makeTempDir();
+      try {
+        const sidecarPath = path.join(dir, METADATA_SIDECAR_FILENAME);
+        await writeMetadataSidecar({
+          sidecarPath,
+          modelId: 'model-x',
+          rows: [row({ docstoreId: '0', extension: '.md' })],
+        });
+        // Same model, fresh ingest with a different file shape — sidecar
+        // is rewritten in place; the old row must not survive.
+        await writeMetadataSidecar({
+          sidecarPath,
+          modelId: 'model-x',
+          rows: [
+            row({ docstoreId: '0', extension: '.md' }),
+            row({ docstoreId: '1', extension: '.txt' }),
+          ],
+        });
+
+        const sidecar = await readMetadataSidecar({ sidecarPath, modelId: 'model-x' });
+        if (!sidecar) throw new Error('sidecar read returned null');
+        expect(sidecar.totalChunks).toBe(2);
+        expect(sidecar.candidateIds({ extensions: ['.txt'] })).toEqual(['1']);
+      } finally {
+        await fsp.rm(dir, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe('candidate id selection', () => {
+    function buildSidecarFromRows(rows: MetadataSidecarRow[]): Promise<NonNullable<Awaited<ReturnType<typeof readMetadataSidecar>>>> {
+      return (async () => {
+        const dir = await makeTempDir();
+        const sidecarPath = path.join(dir, METADATA_SIDECAR_FILENAME);
+        await writeMetadataSidecar({ sidecarPath, modelId: 'mid', rows });
+        const sidecar = await readMetadataSidecar({ sidecarPath, modelId: 'mid' });
+        if (!sidecar) throw new Error('failed to build sidecar fixture');
+        return sidecar;
+      })();
+    }
+
+    it('intersects KB + extension + tag predicates so the candidate set is the AND of all', async () => {
+      const sidecar = await buildSidecarFromRows([
+        row({ docstoreId: '0', knowledgeBase: 'docs', extension: '.md', tags: ['ops'] }),
+        row({ docstoreId: '1', knowledgeBase: 'docs', extension: '.txt', tags: ['ops'] }),
+        row({ docstoreId: '2', knowledgeBase: 'design', extension: '.md', tags: ['ops'] }),
+        row({ docstoreId: '3', knowledgeBase: 'docs', extension: '.md', tags: [] }),
+      ]);
+
+      expect(
+        sidecar
+          .candidateIds({ knowledgeBaseName: 'docs', extensions: ['.md'], tags: ['ops'] })
+          .sort(),
+      ).toEqual(['0']);
+    });
+
+    it('returns the empty array when no row satisfies the filter (so the caller can short-circuit FAISS)', async () => {
+      const sidecar = await buildSidecarFromRows([
+        row({ docstoreId: '0', knowledgeBase: 'docs', extension: '.md' }),
+      ]);
+      expect(sidecar.candidateIds({ knowledgeBaseName: 'design' })).toEqual([]);
+    });
+
+    it('applies the path glob against either the KB-prefixed path or the in-KB suffix', async () => {
+      const sidecar = await buildSidecarFromRows([
+        row({ docstoreId: 'a', knowledgeBase: 'docs', relativePath: 'docs/runbooks/foo.md' }),
+        row({ docstoreId: 'b', knowledgeBase: 'docs', relativePath: 'docs/notes/bar.md' }),
+      ]);
+      expect(sidecar.candidateIds({ pathGlob: 'runbooks/**' })).toEqual(['a']);
+      expect(sidecar.candidateIds({ pathGlob: 'docs/notes/**' })).toEqual(['b']);
+    });
+
+    it('matches whitelisted frontmatter keys by exact equality', async () => {
+      const sidecar = await buildSidecarFromRows([
+        row({ docstoreId: 'p', frontmatter: { status: 'active', tier: 'platinum' } }),
+        row({ docstoreId: 'g', frontmatter: { status: 'active', tier: 'gold' } }),
+        row({ docstoreId: 's', frontmatter: { status: 'archived', tier: 'platinum' } }),
+      ]);
+      expect(
+        sidecar.candidateIds({ frontmatter: { status: 'active', tier: 'platinum' } }),
+      ).toEqual(['p']);
+    });
+  });
+
+  describe('staleness and corruption fallback', () => {
+    it('returns null and logs a single warning when the sidecar file is missing', async () => {
+      const dir = await makeTempDir();
+      try {
+        const sidecar = await readMetadataSidecar({
+          sidecarPath: path.join(dir, METADATA_SIDECAR_FILENAME),
+          modelId: 'mid',
+        });
+        expect(sidecar).toBeNull();
+      } finally {
+        await fsp.rm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('returns null when the header schema version is wrong', async () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+      const dir = await makeTempDir();
+      try {
+        const sidecarPath = path.join(dir, METADATA_SIDECAR_FILENAME);
+        await fsp.writeFile(
+          sidecarPath,
+          `${JSON.stringify({ schema_version: 'kb.metadata-sidecar.v999', model_id: 'mid', total_chunks: 0 })}\n`,
+          'utf-8',
+        );
+        const sidecar = await readMetadataSidecar({ sidecarPath, modelId: 'mid' });
+        expect(sidecar).toBeNull();
+      } finally {
+        warnSpy.mockRestore();
+        await fsp.rm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('returns null when the model id stored in the header does not match the active model', async () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+      const dir = await makeTempDir();
+      try {
+        const sidecarPath = path.join(dir, METADATA_SIDECAR_FILENAME);
+        await writeMetadataSidecar({
+          sidecarPath,
+          modelId: 'other-model',
+          rows: [row({ docstoreId: '0' })],
+        });
+        const sidecar = await readMetadataSidecar({ sidecarPath, modelId: 'mid' });
+        expect(sidecar).toBeNull();
+      } finally {
+        warnSpy.mockRestore();
+        await fsp.rm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('returns null when a body row is malformed JSON', async () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+      const dir = await makeTempDir();
+      try {
+        const sidecarPath = path.join(dir, METADATA_SIDECAR_FILENAME);
+        const header = JSON.stringify({
+          schema_version: METADATA_SIDECAR_SCHEMA_VERSION,
+          model_id: 'mid',
+          total_chunks: 1,
+        });
+        await fsp.writeFile(sidecarPath, `${header}\n{not-json\n`, 'utf-8');
+        const sidecar = await readMetadataSidecar({ sidecarPath, modelId: 'mid' });
+        expect(sidecar).toBeNull();
+      } finally {
+        warnSpy.mockRestore();
+        await fsp.rm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('returns null when row count disagrees with the header total', async () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+      const dir = await makeTempDir();
+      try {
+        const sidecarPath = path.join(dir, METADATA_SIDECAR_FILENAME);
+        const header = JSON.stringify({
+          schema_version: METADATA_SIDECAR_SCHEMA_VERSION,
+          model_id: 'mid',
+          total_chunks: 5,
+        });
+        await fsp.writeFile(
+          sidecarPath,
+          `${header}\n${JSON.stringify(row({ docstoreId: '0' }))}\n`,
+          'utf-8',
+        );
+        const sidecar = await readMetadataSidecar({ sidecarPath, modelId: 'mid' });
+        expect(sidecar).toBeNull();
+      } finally {
+        warnSpy.mockRestore();
+        await fsp.rm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('detects ntotal mismatch via isSidecarStale so the caller can fall through', async () => {
+      const dir = await makeTempDir();
+      try {
+        const sidecarPath = path.join(dir, METADATA_SIDECAR_FILENAME);
+        await writeMetadataSidecar({
+          sidecarPath,
+          modelId: 'mid',
+          rows: [row({ docstoreId: '0' }), row({ docstoreId: '1' })],
+        });
+        const sidecar = await readMetadataSidecar({ sidecarPath, modelId: 'mid' });
+        if (!sidecar) throw new Error('sidecar read returned null');
+        expect(isSidecarStale(sidecar, 2)).toBe(false);
+        expect(isSidecarStale(sidecar, 3)).toBe(true);
+      } finally {
+        await fsp.rm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('deleteMetadataSidecar succeeds when the file is absent', async () => {
+      const dir = await makeTempDir();
+      try {
+        await deleteMetadataSidecar(path.join(dir, 'never-existed.jsonl'));
+      } finally {
+        await fsp.rm(dir, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe('toSidecarFilter', () => {
+    it('passes through the post-filter inputs unchanged', () => {
+      const result = toSidecarFilter({
+        knowledgeBaseName: 'docs',
+        knowledgeBasesRootDir: '/kbs',
+        filters: { extensions: ['.md'], pathGlob: 'runbooks/**', tags: ['ops'] },
+        frontmatter: { status: 'active' },
+      });
+      expect(result).toEqual({
+        knowledgeBaseName: 'docs',
+        knowledgeBasesRootDir: '/kbs',
+        extensions: ['.md'],
+        pathGlob: 'runbooks/**',
+        tags: ['ops'],
+        frontmatter: { status: 'active' },
+      });
+    });
+  });
+
+  describe('recommendFastPathFetchK', () => {
+    it('returns null when the filter is too broad to benefit', () => {
+      expect(recommendFastPathFetchK({ k: 10, candidates: 80, ntotal: 100 })).toBeNull();
+    });
+
+    it('returns the targeted window when the filter is selective', () => {
+      // selectivity = 100/10000 = 1%. Naive ceil(k / sel) * 2 = ceil(10 / 0.01) * 2 = 2000.
+      const fetchK = recommendFastPathFetchK({ k: 10, candidates: 100, ntotal: 10_000 });
+      expect(fetchK).not.toBeNull();
+      expect(fetchK).toBeGreaterThanOrEqual(40); // at least k * 4
+      expect(fetchK).toBeLessThanOrEqual(10_000); // capped at ntotal
+    });
+
+    it('caps the fetchK at ntotal even when the targeted window is larger', () => {
+      const fetchK = recommendFastPathFetchK({ k: 1000, candidates: 10, ntotal: 200 });
+      expect(fetchK).toBe(200);
+    });
+
+    it('returns null when ntotal is zero', () => {
+      expect(recommendFastPathFetchK({ k: 10, candidates: 0, ntotal: 0 })).toBeNull();
+    });
+  });
+});

--- a/src/metadata-sidecar.ts
+++ b/src/metadata-sidecar.ts
@@ -1,0 +1,575 @@
+// src/metadata-sidecar.ts
+//
+// Issue #283 — predicate-pushdown sidecar for metadata-filtered search.
+//
+// Companion to the FAISS docstore: a flat per-model JSONL file that lets
+// `similaritySearch` resolve the candidate id set for a high-selectivity
+// metadata filter (KB / extension / path glob / tags / whitelisted
+// frontmatter) BEFORE asking FAISS for a top-k. The post-filter path
+// (progressive overfetch in `FaissIndexManager.similaritySearch`) is the
+// correctness fallback whenever the sidecar is missing, stale, corrupt,
+// or the filter is too broad to benefit.
+//
+// Layout
+//   `${modelDir}/metadata-sidecar.jsonl`
+//   Line 0  — header `{ schema_version, model_id, total_chunks }`
+//   Line 1+ — one row per docstore entry, recording the metadata fields
+//             the post-filter consults today: `knowledgeBase`, `source`,
+//             `relativePath`, `extension`, `tags[]`, `frontmatter` (the
+//             RFC 011 §5.4.2 whitelist).
+//
+// The sidecar is rewritten atomically (tmp + rename) at the end of every
+// successful `updateIndex` save. Staleness is detected by comparing the
+// header `total_chunks` against the live FAISS docstore size: a mismatch
+// or any read/parse failure logs ONE canonical warning per call site and
+// the caller falls through to the existing post-filter ladder.
+
+import * as fsp from 'fs/promises';
+import * as path from 'path';
+import { minimatch } from 'minimatch';
+import type { Document } from '@langchain/core/documents';
+import { handleFsOperationError } from './error-utils.js';
+import { logger } from './logger.js';
+import type { SimilaritySearchFilters } from './search-filters.js';
+
+export const METADATA_SIDECAR_FILENAME = 'metadata-sidecar.jsonl';
+export const METADATA_SIDECAR_SCHEMA_VERSION = 'kb.metadata-sidecar.v1';
+
+/** Header line written first; carries the integrity fields we rely on. */
+export interface MetadataSidecarHeader {
+  schema_version: typeof METADATA_SIDECAR_SCHEMA_VERSION;
+  model_id: string;
+  total_chunks: number;
+}
+
+/**
+ * One sidecar row per docstore entry. Mirrors the metadata fields the
+ * `createSimilaritySearchPostFilter` path consults — anything else (e.g.
+ * `pdf_path`, the lifted `extras`) does not influence search and stays
+ * out of the sidecar to keep the file small.
+ */
+export interface MetadataSidecarRow {
+  docstoreId: string;
+  knowledgeBase: string;
+  source: string;
+  relativePath: string;
+  extension: string;
+  tags: readonly string[];
+  /** RFC 011 §5.4 lifted frontmatter scalars only (workspace-trusted strings). */
+  frontmatter?: Readonly<Record<string, string>>;
+}
+
+/** Predicate selecting candidate docstore ids from the sidecar. */
+export interface MetadataSidecarFilter {
+  knowledgeBaseName?: string;
+  knowledgeBasesRootDir?: string;
+  extensions?: readonly string[];
+  pathGlob?: string;
+  tags?: readonly string[];
+  /** Equality-only frontmatter predicate, evaluated against lifted scalars. */
+  frontmatter?: Readonly<Record<string, string>>;
+}
+
+export interface MetadataSidecar {
+  readonly modelId: string;
+  readonly totalChunks: number;
+  /** True when at least one filter dimension narrows the candidate set. */
+  hasFilter(filter: MetadataSidecarFilter): boolean;
+  /** Returns the docstore ids that match `filter` (deduplicated, no order guarantee). */
+  candidateIds(filter: MetadataSidecarFilter): string[];
+  /** Iterate every row — used by tests and the bench harness. */
+  rows(): IterableIterator<MetadataSidecarRow>;
+}
+
+const MINIMATCH_OPTS = { dot: true, nonegate: true } as const;
+
+class MetadataSidecarImpl implements MetadataSidecar {
+  readonly modelId: string;
+  readonly totalChunks: number;
+  private readonly rowsById = new Map<string, MetadataSidecarRow>();
+  private readonly idsByKb = new Map<string, Set<string>>();
+  private readonly idsByExtension = new Map<string, Set<string>>();
+  private readonly idsByTag = new Map<string, Set<string>>();
+
+  constructor(header: MetadataSidecarHeader, rows: ReadonlyArray<MetadataSidecarRow>) {
+    this.modelId = header.model_id;
+    this.totalChunks = header.total_chunks;
+    for (const row of rows) {
+      this.rowsById.set(row.docstoreId, row);
+      addToBucket(this.idsByKb, row.knowledgeBase, row.docstoreId);
+      addToBucket(this.idsByExtension, row.extension.toLowerCase(), row.docstoreId);
+      for (const tag of row.tags) {
+        if (typeof tag === 'string' && tag.length > 0) {
+          addToBucket(this.idsByTag, tag, row.docstoreId);
+        }
+      }
+    }
+  }
+
+  hasFilter(filter: MetadataSidecarFilter): boolean {
+    return (
+      typeof filter.knowledgeBaseName === 'string' && filter.knowledgeBaseName.length > 0
+    ) ||
+      normalizeExtensions(filter.extensions) !== undefined ||
+      (typeof filter.pathGlob === 'string' && filter.pathGlob.length > 0) ||
+      requiredTagsOf(filter.tags).length > 0 ||
+      Object.keys(filter.frontmatter ?? {}).length > 0;
+  }
+
+  candidateIds(filter: MetadataSidecarFilter): string[] {
+    if (this.totalChunks === 0) return [];
+
+    const buckets: Set<string>[] = [];
+    if (typeof filter.knowledgeBaseName === 'string' && filter.knowledgeBaseName.length > 0) {
+      buckets.push(this.idsByKb.get(filter.knowledgeBaseName) ?? new Set<string>());
+    }
+    const normalizedExtensions = normalizeExtensions(filter.extensions);
+    if (normalizedExtensions !== undefined) {
+      const union = new Set<string>();
+      for (const ext of normalizedExtensions) {
+        const bucket = this.idsByExtension.get(ext);
+        if (bucket) for (const id of bucket) union.add(id);
+      }
+      buckets.push(union);
+    }
+    const requiredTags = requiredTagsOf(filter.tags);
+    for (const tag of requiredTags) {
+      buckets.push(this.idsByTag.get(tag) ?? new Set<string>());
+    }
+
+    const candidateIds = buckets.length === 0
+      ? new Set<string>(this.rowsById.keys())
+      : intersectSets(buckets);
+
+    if (candidateIds.size === 0) return [];
+
+    const pathGlob = typeof filter.pathGlob === 'string' && filter.pathGlob.length > 0
+      ? filter.pathGlob
+      : undefined;
+    const frontmatter = filter.frontmatter && Object.keys(filter.frontmatter).length > 0
+      ? filter.frontmatter
+      : undefined;
+
+    if (pathGlob === undefined && frontmatter === undefined) {
+      return [...candidateIds];
+    }
+
+    const out: string[] = [];
+    for (const id of candidateIds) {
+      const row = this.rowsById.get(id);
+      if (row === undefined) continue;
+      if (pathGlob !== undefined && !matchesPathGlob(row.relativePath, pathGlob)) continue;
+      if (frontmatter !== undefined && !rowMatchesFrontmatter(row, frontmatter)) continue;
+      out.push(id);
+    }
+    return out;
+  }
+
+  *rows(): IterableIterator<MetadataSidecarRow> {
+    yield* this.rowsById.values();
+  }
+}
+
+function addToBucket(bucket: Map<string, Set<string>>, key: string, id: string): void {
+  let set = bucket.get(key);
+  if (!set) {
+    set = new Set<string>();
+    bucket.set(key, set);
+  }
+  set.add(id);
+}
+
+function intersectSets(buckets: ReadonlyArray<Set<string>>): Set<string> {
+  if (buckets.length === 0) return new Set<string>();
+  let smallestIndex = 0;
+  for (let i = 1; i < buckets.length; i += 1) {
+    if (buckets[i].size < buckets[smallestIndex].size) smallestIndex = i;
+  }
+  const out = new Set<string>();
+  for (const id of buckets[smallestIndex]) {
+    let inAll = true;
+    for (let i = 0; i < buckets.length; i += 1) {
+      if (i === smallestIndex) continue;
+      if (!buckets[i].has(id)) {
+        inAll = false;
+        break;
+      }
+    }
+    if (inAll) out.add(id);
+  }
+  return out;
+}
+
+function normalizeExtensions(raw: readonly string[] | undefined): Set<string> | undefined {
+  if (!raw || raw.length === 0) return undefined;
+  const out = new Set<string>();
+  for (const entry of raw) {
+    if (typeof entry !== 'string') continue;
+    const trimmed = entry.trim().toLowerCase();
+    if (trimmed.length === 0) continue;
+    out.add(trimmed.startsWith('.') ? trimmed : `.${trimmed}`);
+  }
+  return out.size > 0 ? out : undefined;
+}
+
+function requiredTagsOf(raw: readonly string[] | undefined): string[] {
+  if (!raw) return [];
+  return raw.filter((tag): tag is string => typeof tag === 'string' && tag.length > 0);
+}
+
+function matchesPathGlob(relativePath: string, pattern: string): boolean {
+  if (minimatch(relativePath, pattern, MINIMATCH_OPTS)) return true;
+  const firstSep = relativePath.indexOf('/');
+  if (firstSep > 0) {
+    const inKb = relativePath.slice(firstSep + 1);
+    if (minimatch(inKb, pattern, MINIMATCH_OPTS)) return true;
+  }
+  return false;
+}
+
+function rowMatchesFrontmatter(
+  row: MetadataSidecarRow,
+  required: Readonly<Record<string, string>>,
+): boolean {
+  if (!row.frontmatter) return false;
+  for (const [key, expected] of Object.entries(required)) {
+    if (typeof expected !== 'string' || expected.length === 0) continue;
+    if (row.frontmatter[key] !== expected) return false;
+  }
+  return true;
+}
+
+/**
+ * Translate a `Document.metadata` record into a sidecar row.
+ *
+ * Returns null when the metadata is missing the fields the sidecar relies
+ * on (`knowledgeBase`, `source`, `extension`, `relativePath`) — those rows
+ * stay out of the sidecar instead of being indexed under empty buckets and
+ * silently masking valid documents at query time.
+ */
+export function buildSidecarRowFromDocument(
+  docstoreId: string,
+  document: Document,
+): MetadataSidecarRow | null {
+  const metadata = document.metadata as Record<string, unknown> | undefined;
+  if (!metadata) return null;
+
+  const knowledgeBase = stringOrNull(metadata.knowledgeBase);
+  const source = stringOrNull(metadata.source);
+  const relativePath = stringOrNull(metadata.relativePath);
+  const extension = stringOrNull(metadata.extension);
+  if (knowledgeBase === null || source === null || relativePath === null || extension === null) {
+    return null;
+  }
+
+  return {
+    docstoreId,
+    knowledgeBase,
+    source,
+    relativePath,
+    extension: extension.toLowerCase(),
+    tags: extractStringArray(metadata.tags),
+    frontmatter: extractFrontmatterScalars(metadata.frontmatter),
+  };
+}
+
+function stringOrNull(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+function extractStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  const out: string[] = [];
+  for (const entry of value) {
+    if (typeof entry === 'string' && entry.length > 0) out.push(entry);
+  }
+  return out;
+}
+
+function extractFrontmatterScalars(value: unknown): Record<string, string> | undefined {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return undefined;
+  const out: Record<string, string> = {};
+  for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+    if (key === 'extras') continue;
+    if (typeof entry === 'string' && entry.length > 0) {
+      out[key] = entry;
+    }
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+/**
+ * Atomic JSONL write: header line followed by one row per line. Caller
+ * holds the per-model write lock (and ideally the cross-model sidecar
+ * lock for symmetry with `writeSidecarHashes`); this helper does not
+ * lock on its own.
+ */
+export async function writeMetadataSidecar(opts: {
+  sidecarPath: string;
+  modelId: string;
+  rows: ReadonlyArray<MetadataSidecarRow>;
+}): Promise<void> {
+  const { sidecarPath, modelId, rows } = opts;
+  const header: MetadataSidecarHeader = {
+    schema_version: METADATA_SIDECAR_SCHEMA_VERSION,
+    model_id: modelId,
+    total_chunks: rows.length,
+  };
+
+  const tmpPath = `${sidecarPath}.${process.pid}.${process.hrtime.bigint()}.tmp`;
+  const lines: string[] = [JSON.stringify(header)];
+  for (const row of rows) {
+    lines.push(JSON.stringify(row));
+  }
+  const payload = `${lines.join('\n')}\n`;
+
+  try {
+    await fsp.mkdir(path.dirname(sidecarPath), { recursive: true });
+    await fsp.writeFile(tmpPath, payload, { encoding: 'utf-8', mode: 0o600 });
+    await fsp.rename(tmpPath, sidecarPath);
+  } catch (err) {
+    try {
+      await fsp.unlink(tmpPath);
+    } catch {
+      // best-effort cleanup; original error is what matters
+    }
+    handleFsOperationError('write metadata sidecar to', sidecarPath, err);
+  }
+}
+
+/**
+ * Best-effort sidecar removal — used by the few places that rebuild the
+ * docstore from scratch. Missing file is success.
+ */
+export async function deleteMetadataSidecar(sidecarPath: string): Promise<void> {
+  try {
+    await fsp.unlink(sidecarPath);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT' || code === 'ENOTDIR') return;
+    logger.warn(
+      `Could not remove metadata sidecar ${sidecarPath}: ${(err as Error).message}`,
+    );
+  }
+}
+
+/**
+ * Read the sidecar at `sidecarPath`, validate the header, and return a
+ * `MetadataSidecar` ready for `candidateIds()`. Returns null on:
+ *
+ *   - missing file (ENOENT/ENOTDIR) — first-run indexers, sidecar yet to
+ *     be written, or operator-removed.
+ *   - header schema/model mismatch — the docstore was written by a
+ *     different model or an older schema; fast-path would be wrong.
+ *   - parse error or truncated row — we surface a single canonical warn
+ *     so operators see ONE log per failure regardless of how many queries
+ *     hit the missing/corrupt sidecar in the same process.
+ *
+ * Stale-by-count (header `total_chunks` ≠ live ntotal) is checked by the
+ * caller via `isSidecarStale`, since the live count comes from FAISS.
+ */
+export async function readMetadataSidecar(opts: {
+  sidecarPath: string;
+  modelId: string;
+}): Promise<MetadataSidecar | null> {
+  const { sidecarPath, modelId } = opts;
+  let raw: string;
+  try {
+    raw = await fsp.readFile(sidecarPath, 'utf-8');
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT' || code === 'ENOTDIR') return null;
+    logger.warn(
+      `Issue #283 metadata sidecar: could not read ${sidecarPath}: ${(err as Error).message}. ` +
+        `Falling back to post-filter overfetch.`,
+    );
+    return null;
+  }
+
+  const lines = raw.split('\n').filter((line) => line.length > 0);
+  if (lines.length === 0) {
+    logger.warn(
+      `Issue #283 metadata sidecar at ${sidecarPath} is empty; falling back to post-filter overfetch.`,
+    );
+    return null;
+  }
+
+  let header: MetadataSidecarHeader | null = null;
+  try {
+    header = parseHeader(JSON.parse(lines[0]));
+  } catch {
+    header = null;
+  }
+  if (header === null) {
+    logger.warn(
+      `Issue #283 metadata sidecar header at ${sidecarPath} is malformed; falling back to post-filter overfetch.`,
+    );
+    return null;
+  }
+  if (header.model_id !== modelId) {
+    logger.warn(
+      `Issue #283 metadata sidecar at ${sidecarPath} was written for model ${header.model_id}, ` +
+        `not ${modelId}; falling back to post-filter overfetch.`,
+    );
+    return null;
+  }
+
+  const rows: MetadataSidecarRow[] = [];
+  for (let i = 1; i < lines.length; i += 1) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(lines[i]);
+    } catch {
+      logger.warn(
+        `Issue #283 metadata sidecar at ${sidecarPath} has malformed row ${i}; ` +
+          `falling back to post-filter overfetch.`,
+      );
+      return null;
+    }
+    const row = parseRow(parsed);
+    if (row === null) {
+      logger.warn(
+        `Issue #283 metadata sidecar at ${sidecarPath} has invalid row ${i}; ` +
+          `falling back to post-filter overfetch.`,
+      );
+      return null;
+    }
+    rows.push(row);
+  }
+
+  if (rows.length !== header.total_chunks) {
+    logger.warn(
+      `Issue #283 metadata sidecar at ${sidecarPath} has ${rows.length} rows but header claims ` +
+        `${header.total_chunks}; falling back to post-filter overfetch.`,
+    );
+    return null;
+  }
+
+  return new MetadataSidecarImpl(header, rows);
+}
+
+/**
+ * `total_chunks` must match the live FAISS docstore size, otherwise the
+ * sidecar predates the most recent ingest and could omit (or include)
+ * chunks that have since been removed (or added). The caller logs ONE
+ * canonical warning and falls through.
+ */
+export function isSidecarStale(sidecar: MetadataSidecar, ntotal: number): boolean {
+  return sidecar.totalChunks !== ntotal;
+}
+
+function parseHeader(value: unknown): MetadataSidecarHeader | null {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return null;
+  const candidate = value as Record<string, unknown>;
+  if (candidate.schema_version !== METADATA_SIDECAR_SCHEMA_VERSION) return null;
+  if (typeof candidate.model_id !== 'string' || candidate.model_id.length === 0) return null;
+  if (typeof candidate.total_chunks !== 'number' || !Number.isFinite(candidate.total_chunks)) {
+    return null;
+  }
+  if (candidate.total_chunks < 0 || !Number.isSafeInteger(candidate.total_chunks)) return null;
+  return {
+    schema_version: METADATA_SIDECAR_SCHEMA_VERSION,
+    model_id: candidate.model_id,
+    total_chunks: candidate.total_chunks,
+  };
+}
+
+function parseRow(value: unknown): MetadataSidecarRow | null {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return null;
+  const candidate = value as Record<string, unknown>;
+  const docstoreId = candidate.docstoreId;
+  const knowledgeBase = candidate.knowledgeBase;
+  const source = candidate.source;
+  const relativePath = candidate.relativePath;
+  const extension = candidate.extension;
+  if (typeof docstoreId !== 'string' || docstoreId.length === 0) return null;
+  if (typeof knowledgeBase !== 'string' || knowledgeBase.length === 0) return null;
+  if (typeof source !== 'string' || source.length === 0) return null;
+  if (typeof relativePath !== 'string' || relativePath.length === 0) return null;
+  if (typeof extension !== 'string' || extension.length === 0) return null;
+
+  const tags: string[] = [];
+  if (Array.isArray(candidate.tags)) {
+    for (const entry of candidate.tags) {
+      if (typeof entry === 'string' && entry.length > 0) tags.push(entry);
+    }
+  }
+
+  let frontmatter: Record<string, string> | undefined;
+  if (
+    typeof candidate.frontmatter === 'object' &&
+    candidate.frontmatter !== null &&
+    !Array.isArray(candidate.frontmatter)
+  ) {
+    const collected: Record<string, string> = {};
+    for (const [key, entry] of Object.entries(candidate.frontmatter as Record<string, unknown>)) {
+      if (typeof entry === 'string' && entry.length > 0) collected[key] = entry;
+    }
+    if (Object.keys(collected).length > 0) frontmatter = collected;
+  }
+
+  return {
+    docstoreId,
+    knowledgeBase,
+    source,
+    relativePath,
+    extension: extension.toLowerCase(),
+    tags,
+    frontmatter,
+  };
+}
+
+/**
+ * Translate the `SimilaritySearchFilters` shape (post-filter input) plus
+ * KB scope into the pure-data `MetadataSidecarFilter`. Helper kept here
+ * so callers don't reimplement the field-name bridge.
+ */
+export function toSidecarFilter(opts: {
+  knowledgeBaseName?: string;
+  knowledgeBasesRootDir: string;
+  filters?: SimilaritySearchFilters;
+  frontmatter?: Readonly<Record<string, string>>;
+}): MetadataSidecarFilter {
+  return {
+    knowledgeBaseName: opts.knowledgeBaseName,
+    knowledgeBasesRootDir: opts.knowledgeBasesRootDir,
+    extensions: opts.filters?.extensions,
+    pathGlob: opts.filters?.pathGlob,
+    tags: opts.filters?.tags,
+    frontmatter: opts.frontmatter,
+  };
+}
+
+/**
+ * Pick the FAISS `fetchK` for a sidecar-narrowed query. We know:
+ *   - `k`:           how many filtered hits the caller wants.
+ *   - `candidates`:  how many docs satisfy the metadata filter.
+ *   - `ntotal`:      total vectors in the docstore.
+ *
+ * If candidates ≥ ntotal/2 the filter is too broad for the fast-path to
+ * help; the caller stays on the existing ladder. Otherwise we estimate
+ * the FAISS window needed to surface `k` filtered hits at the candidate
+ * selectivity, with a 2× safety multiplier and a hard cap at `ntotal`.
+ *
+ * Returns null when the fast-path doesn't apply (broad filter, empty
+ * candidate set is the caller's concern — it should short-circuit before
+ * calling this).
+ */
+export function recommendFastPathFetchK(opts: {
+  k: number;
+  candidates: number;
+  ntotal: number;
+}): number | null {
+  const { k, candidates, ntotal } = opts;
+  if (ntotal <= 0 || candidates <= 0 || k <= 0) return null;
+  // Fast-path is only worth it when the filter is selective enough that
+  // the targeted fetchK is meaningfully smaller than ntotal.
+  const SELECTIVITY_CEILING = 0.5;
+  if (candidates / ntotal >= SELECTIVITY_CEILING) return null;
+
+  const selectivity = candidates / ntotal;
+  const targeted = Math.ceil((k / Math.max(selectivity, Number.EPSILON)) * 2);
+  const minimumWindow = Math.max(k * 4, 20);
+  const fetchK = Math.max(minimumWindow, targeted);
+  return Math.min(ntotal, fetchK);
+}


### PR DESCRIPTION
Closes #283.

## Summary

Adds a per-model JSONL sidecar (`<modelDir>/metadata-sidecar.jsonl`) that resolves the candidate id set for any metadata-aware similarity search BEFORE asking FAISS for a top-k. When the filter is high-selectivity, the fast-path either short-circuits to `[]` (no FAISS call) or runs a single FAISS search sized for the candidate count, instead of walking the `[max(k,20), 4k, 16k, ntotal]` post-filter ladder. The post-filter remains the correctness fallback whenever the sidecar is missing, stale, corrupt, or the filter is too broad.

## Sidecar schema

`<modelDir>/metadata-sidecar.jsonl` (next to `last-index-update.json`):

```
Line 0  — header { schema_version: "kb.metadata-sidecar.v1", model_id, total_chunks }
Line 1+ — { docstoreId, knowledgeBase, source, relativePath, extension, tags[], frontmatter? }
```

Per row, `frontmatter` carries only the RFC 011 §5.4.2 lifted scalars (workspace-trusted strings); `extras` and non-string keys are dropped at row build time. The sidecar is rewritten atomically (tmp + `rename`) under `withSidecarLock` after every successful `updateIndex` save that mutates the FAISS docstore.

## Fast-path conditions

The fast-path is taken when ALL of these hold:

1. The filter has at least one sidecar-backed dimension (KB scope, extensions, pathGlob, tags, or frontmatter equality).
2. The on-disk sidecar header matches the active model id and the live FAISS `ntotal` (`isSidecarStale === false`).
3. The candidate count is below 50% of `ntotal` (otherwise the targeted fetchK is no smaller than the existing ladder rungs).

Outcomes (recorded on `SimilaritySearchTiming.sidecar_fast_path`):
- `short_circuit` — zero candidates → `[]` returned, no FAISS call.
- `hit` — single FAISS call at the targeted fetchK satisfied `k`.
- `miss_underflow` — fast-path call did not produce enough hits, fell through to the ladder for correctness.
- `unused` — filter too broad to benefit, ladder ran unchanged.
- `missing` — sidecar absent / stale / corrupt; ladder ran unchanged.

`fetchK` selection (`recommendFastPathFetchK`):

```
selectivity = candidates / ntotal
fetchK = min(ntotal, max(k * 4, 20, ceil(k / max(selectivity, EPS)) * 2))
```

The 2× safety multiplier covers ranking uncertainty (top-k by score is not necessarily the top-k by filter-passing-score). When the underflow path triggers we fall back to the existing ladder rather than chasing the candidates ourselves — FAISS in this repo does not expose id-restricted search (`faiss-node` only ships `Index.search(x, k)`), so an in-memory candidate mask is the only correct refinement available, and the ladder already implements it.

## Fallback conditions

The pre-#283 progressive overfetch ladder runs unchanged when:

- the search has no metadata-aware filter (`requiresOverfetch === false`);
- the sidecar file is missing (first run, manual rm, model swap, post-init purge — `purgeStaleSidecars` now also unlinks the metadata sidecar);
- the sidecar header schema version or model id does not match;
- a row line is malformed JSON or missing required fields;
- the sidecar header `total_chunks` does not match the live FAISS `ntotal` (any incremental ingest invalidates the cache; the next successful `updateIndex` rewrites it);
- the filter is too broad (selectivity ≥ 50%);
- the targeted fetchK underflows (insufficient filtered hits in the first FAISS call).

A single canonical warning per process is logged on the first `missing` or `corrupt` outcome so operators see one signal regardless of how many filtered queries hit the gap.

## Benchmark numbers

`benchmarks/predicate-pushdown.bench.ts` is a standalone harness (not wired into `npm run bench`; run with `node build/benchmarks/predicate-pushdown.bench.js` after `npm run build && tsc -p tsconfig.bench.json`). It builds an in-memory simulator that reuses the real `createSimilaritySearchPostFilter` and `progressiveFetchSizes`, round-trips the sidecar through disk, and times both paths over 50 repetitions.

| Scenario | ntotal | candidates | baseline median | fast-path median | latency reduction | FAISS call count |
| --- | --- | --- | --- | --- | --- | --- |
| 1% selectivity, k=10 | 10 000 | 100 | 2.83 ms | 0.30 ms | **89%** | 4 → 1 |
| 0.2% selectivity, k=10 | 50 000 | 100 | 43.31 ms | 10.77 ms | **75%** | 4 → 1 |

## What I did NOT touch

- `cli-search.ts` and friends, `cli-search-staleness.ts`, `formatter.ts`, and their tests are owned by the parallel #335 branch. I added a new optional field to `SimilaritySearchTiming` (`sidecar_fast_path`, `sidecar_candidates`) but did not surface it in any CLI code path; downstream readers can pick it up in a follow-up.
- `config.ts`, `hybrid-retrieval.ts`, `retrieval-eval.ts`, the MCP server entrypoints, and the docs/lockfile/changelog files are unchanged.
- The sidecar is per-model, kept under the same per-model directory the FAISS index uses; no changes to KB-side `<kb>/.index/` layouts.

## Test plan

- [x] `npx jest src/metadata-sidecar.test.ts src/FaissIndexManager.test.ts src/file-ingest.test.ts --runInBand` (130 tests pass, including 21 new sidecar tests, 6 new fast-path/fallback tests on the manager, and 2 new ingest→sidecar contract tests).
- [x] `npm run build` (clean).
- [x] `npm test -- --runInBand` (79 suites, 1319 passed, 4 skipped, 1 todo).
- [x] `git diff --check` (clean).
- [x] `node build/benchmarks/predicate-pushdown.bench.js` at default and `BENCH_PUSHDOWN_NTOTAL=50000 BENCH_PUSHDOWN_SELECTIVITY=0.002`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)