### PR TITLE
fix(watcher): catch up on pending trigger at startup (#356)

### DIFF
--- a/src/KnowledgeBaseServer.ts
+++ b/src/KnowledgeBaseServer.ts
@@ -1,4 +1,5 @@
 // KnowledgeBaseServer.ts
+import * as fsp from 'fs/promises';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { z } from 'zod';
@@ -19,6 +20,7 @@ import {
   listRegisteredModels,
   modelDir,
   resolveActiveModel,
+  resolveFaissIndexBinaryPath,
 } from './active-model.js';
 import { ManagerRegistry } from './manager-registry.js';
 import {
@@ -952,8 +954,27 @@ export class KnowledgeBaseServer {
         }
       },
       REINDEX_TRIGGER_POLL_MS,
+      // Issue #356 — let the watcher catch up on a pending trigger at
+      // startup. Returns the active model's FAISS index mtime in ms,
+      // or null if the active model / index can't be resolved (e.g.
+      // no model is registered, or the index hasn't been built yet).
+      // The watcher fires once if the trigger is newer than this.
+      async () => {
+        try {
+          const activeId = await resolveActiveModel();
+          const binaryPath = await resolveFaissIndexBinaryPath(activeId);
+          if (binaryPath === null) return null;
+          const st = await fsp.stat(binaryPath);
+          return st.mtimeMs;
+        } catch {
+          // Active model unresolved, index missing, or stat failed —
+          // skip the catch-up. The watcher's normal poll loop still
+          // covers any post-startup trigger touches.
+          return null;
+        }
+      },
     );
-    this.triggerWatcher.start();
+    void this.triggerWatcher.start();
   }
 
   private installHttpShutdown(): void {

--- a/src/triggerWatcher.test.ts
+++ b/src/triggerWatcher.test.ts
@@ -201,6 +201,166 @@ describe('ReindexTriggerWatcher (RFC 011 §5.5)', () => {
     expect(onTrigger).not.toHaveBeenCalled();
   });
 
+  describe('startup catch-up (#356) — pending trigger newer than active index', () => {
+    // `start()` reads `mtime(triggerPath)` ONCE and compares it against
+    // the active-index mtime returned by the injected lookup callback.
+    // Tests control the comparison by writing the trigger file with a
+    // known mtime and returning a smaller (or larger, or null) index
+    // mtime from the lookup.
+    async function setMtime(filePath: string, mtimeMs: number): Promise<void> {
+      const sec = mtimeMs / 1000;
+      await fsp.utimes(filePath, sec, sec);
+    }
+
+    it('fires the catch-up trigger once when trigger mtime > active index mtime', async () => {
+      await fsp.writeFile(triggerPath, '');
+      // Trigger is 5s newer than the (synthetic) active index mtime.
+      const indexMtimeMs = Date.now() - 10_000;
+      const triggerMtimeMs = indexMtimeMs + 5_000;
+      await setMtime(triggerPath, triggerMtimeMs);
+
+      const onTrigger = jest.fn().mockResolvedValue(undefined);
+      const getActiveIndexMtimeMs = jest.fn().mockResolvedValue(indexMtimeMs);
+      // pollMs large so the real interval timer never fires during the test.
+      const watcher = new ReindexTriggerWatcher(
+        triggerPath,
+        onTrigger,
+        60_000,
+        getActiveIndexMtimeMs,
+      );
+
+      await watcher.start();
+      // Drain the in-flight onTrigger scheduled inside catchUpAtStart.
+      await watcher.stop();
+
+      expect(getActiveIndexMtimeMs).toHaveBeenCalledTimes(1);
+      expect(onTrigger).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT fire catch-up when trigger mtime is older than the active index', async () => {
+      await fsp.writeFile(triggerPath, '');
+      // Trigger predates the index (the workflow ran, was indexed, and
+      // nothing has touched the trigger since). No refresh pending.
+      const indexMtimeMs = Date.now();
+      const triggerMtimeMs = indexMtimeMs - 5_000;
+      await setMtime(triggerPath, triggerMtimeMs);
+
+      const onTrigger = jest.fn().mockResolvedValue(undefined);
+      const getActiveIndexMtimeMs = jest.fn().mockResolvedValue(indexMtimeMs);
+      const watcher = new ReindexTriggerWatcher(
+        triggerPath,
+        onTrigger,
+        60_000,
+        getActiveIndexMtimeMs,
+      );
+
+      await watcher.start();
+      await watcher.stop();
+
+      expect(getActiveIndexMtimeMs).toHaveBeenCalledTimes(1);
+      expect(onTrigger).not.toHaveBeenCalled();
+    });
+
+    it('does NOT fire catch-up when trigger mtime equals the active index mtime', async () => {
+      // Tie-breaking belongs to "no fire" — RFC 011 §5.5 and `kb doctor`
+      // both treat strict `>` as the refresh-pending signal.
+      await fsp.writeFile(triggerPath, '');
+      const sameMtimeMs = Date.now() - 1_000;
+      await setMtime(triggerPath, sameMtimeMs);
+
+      const onTrigger = jest.fn().mockResolvedValue(undefined);
+      const getActiveIndexMtimeMs = jest.fn().mockResolvedValue(sameMtimeMs);
+      const watcher = new ReindexTriggerWatcher(
+        triggerPath,
+        onTrigger,
+        60_000,
+        getActiveIndexMtimeMs,
+      );
+
+      await watcher.start();
+      await watcher.stop();
+
+      expect(onTrigger).not.toHaveBeenCalled();
+    });
+
+    it('after catch-up fire, a subsequent mtime bump still fires exactly once (idempotency)', async () => {
+      await fsp.writeFile(triggerPath, '');
+      const indexMtimeMs = Date.now() - 10_000;
+      const initialTriggerMtimeMs = indexMtimeMs + 5_000;
+      await setMtime(triggerPath, initialTriggerMtimeMs);
+
+      const onTrigger = jest.fn().mockResolvedValue(undefined);
+      const getActiveIndexMtimeMs = jest.fn().mockResolvedValue(indexMtimeMs);
+      const watcher = new ReindexTriggerWatcher(
+        triggerPath,
+        onTrigger,
+        60_000,
+        getActiveIndexMtimeMs,
+      );
+
+      await watcher.start();
+      // Allow the in-flight catch-up onTrigger to settle.
+      await new Promise((r) => setImmediate(r));
+      expect(onTrigger).toHaveBeenCalledTimes(1);
+
+      // A poll with NO mtime change must not double-fire.
+      await watcher.poll();
+      expect(onTrigger).toHaveBeenCalledTimes(1);
+
+      // A genuine post-catch-up bump (e.g. workflow ran again) must
+      // fire exactly once via the normal mtime-delta path.
+      const bumpedMtimeMs = initialTriggerMtimeMs + 5_000;
+      await setMtime(triggerPath, bumpedMtimeMs);
+      await watcher.poll();
+      await watcher.stop();
+
+      expect(onTrigger).toHaveBeenCalledTimes(2);
+    });
+
+    it('skips catch-up when no active index mtime can be resolved (lookup returns null)', async () => {
+      // No active model / no index built — defer to the normal poll
+      // loop so we don't fire on every server restart.
+      await fsp.writeFile(triggerPath, '');
+      await setMtime(triggerPath, Date.now() - 60_000);
+
+      const onTrigger = jest.fn().mockResolvedValue(undefined);
+      const getActiveIndexMtimeMs = jest.fn().mockResolvedValue(null);
+      const watcher = new ReindexTriggerWatcher(
+        triggerPath,
+        onTrigger,
+        60_000,
+        getActiveIndexMtimeMs,
+      );
+
+      await watcher.start();
+      await watcher.stop();
+
+      expect(getActiveIndexMtimeMs).toHaveBeenCalledTimes(1);
+      expect(onTrigger).not.toHaveBeenCalled();
+    });
+
+    it('skips catch-up when the trigger file is absent at startup', async () => {
+      // No trigger file → the workflow hasn't run yet. The existing
+      // `sawAbsent` path covers post-startup creation.
+      const onTrigger = jest.fn().mockResolvedValue(undefined);
+      const getActiveIndexMtimeMs = jest.fn().mockResolvedValue(Date.now());
+      const watcher = new ReindexTriggerWatcher(
+        triggerPath,
+        onTrigger,
+        60_000,
+        getActiveIndexMtimeMs,
+      );
+
+      await watcher.start();
+      await watcher.stop();
+
+      // The lookup is never called because the trigger stat fails fast
+      // with ENOENT.
+      expect(getActiveIndexMtimeMs).not.toHaveBeenCalled();
+      expect(onTrigger).not.toHaveBeenCalled();
+    });
+  });
+
   it('start() installs a timer that invokes poll() periodically', async () => {
     // Smoke test the real-timer path at a short interval — this is the
     // only test that exercises setInterval directly; the rest drive

--- a/src/triggerWatcher.ts
+++ b/src/triggerWatcher.ts
@@ -136,6 +136,9 @@ export class ReindexTriggerWatcher {
   private readonly triggerPath: string;
   private readonly onTrigger: () => Promise<void>;
   private readonly pollMs: number;
+  private readonly getActiveIndexMtimeMs:
+    | (() => Promise<number | null>)
+    | null;
 
   private timer: NodeJS.Timeout | null = null;
   private lastMtimeMs: number | null = null;
@@ -155,10 +158,12 @@ export class ReindexTriggerWatcher {
     triggerPath: string,
     onTrigger: () => Promise<void>,
     pollMs: number,
+    getActiveIndexMtimeMs?: () => Promise<number | null>,
   ) {
     this.triggerPath = triggerPath;
     this.onTrigger = onTrigger;
     this.pollMs = pollMs;
+    this.getActiveIndexMtimeMs = getActiveIndexMtimeMs ?? null;
   }
 
   /**
@@ -168,8 +173,16 @@ export class ReindexTriggerWatcher {
    * installed); callers that want the watcher off should avoid
    * constructing it at all, but this escape hatch matches the
    * `REINDEX_TRIGGER_POLL_MS=0` env contract.
+   *
+   * Issue #356 — when `getActiveIndexMtimeMs` is provided, `start()`
+   * does a one-shot comparison between the current trigger mtime and
+   * the active model's index mtime. If the trigger is newer (the same
+   * "refresh pending" condition `kb doctor` flags), one catch-up fire
+   * is scheduled before the poll loop installs its timer. Without
+   * this, a trigger touched while the server was offline would sit
+   * unindexed until something else bumps its mtime.
    */
-  start(): void {
+  async start(): Promise<void> {
     if (this.timer !== null || this.stopped) return;
     if (this.pollMs <= 0) {
       logger.info(
@@ -177,6 +190,9 @@ export class ReindexTriggerWatcher {
       );
       return;
     }
+    await this.catchUpAtStart();
+    // `stop()` may have arrived while we were resolving the index mtime.
+    if (this.stopped || this.timer !== null) return;
     logger.info(
       `ReindexTriggerWatcher started; poll=${this.pollMs}ms path=${this.triggerPath}`,
     );
@@ -189,6 +205,72 @@ export class ReindexTriggerWatcher {
     if (typeof this.timer.unref === 'function') {
       this.timer.unref();
     }
+  }
+
+  /**
+   * Issue #356 — one-shot catch-up. If the trigger file already exists
+   * and is newer than the active index, fire `onTrigger` once and seed
+   * `lastMtimeMs` to the current trigger mtime so the first poll tick
+   * does NOT re-fire (no double-fire) and a genuine subsequent bump
+   * still fires normally (idempotent).
+   *
+   * No-op when:
+   *  - No `getActiveIndexMtimeMs` callback was wired (legacy / tests).
+   *  - The trigger file doesn't exist yet (handled by `sawAbsent` —
+   *    a file that appears post-startup is its own signal).
+   *  - The active index mtime can't be resolved (no built index yet,
+   *    or the lookup throws). We defer to the existing baseline-seed
+   *    behaviour rather than firing on every startup when no index
+   *    exists.
+   *  - Trigger mtime ≤ index mtime (no refresh pending).
+   */
+  private async catchUpAtStart(): Promise<void> {
+    if (this.getActiveIndexMtimeMs === null) return;
+    let triggerMtimeMs: number;
+    try {
+      const st = await fsp.stat(this.triggerPath);
+      triggerMtimeMs = st.mtimeMs;
+    } catch (error) {
+      const code = (error as FsError | undefined)?.code;
+      if (code === 'ENOENT' || code === 'ENOTDIR') {
+        // No trigger file yet — defer to the normal poll loop, which
+        // already fires on the first successful stat post-absence.
+        this.sawAbsent = true;
+        return;
+      }
+      logger.warn(
+        `ReindexTriggerWatcher startup catch-up stat failed for ${this.triggerPath}: ${(error as Error).message}`,
+      );
+      return;
+    }
+
+    let indexMtimeMs: number | null;
+    try {
+      indexMtimeMs = await this.getActiveIndexMtimeMs();
+    } catch (error) {
+      logger.warn(
+        `ReindexTriggerWatcher startup catch-up index mtime lookup failed: ${(error as Error).message}`,
+      );
+      return;
+    }
+
+    if (indexMtimeMs === null || triggerMtimeMs <= indexMtimeMs) {
+      // No refresh pending — seed baseline so the first poll tick
+      // doesn't treat the existing trigger as a fresh signal.
+      this.lastMtimeMs = triggerMtimeMs;
+      return;
+    }
+
+    // Refresh pending: trigger touched after the active index was
+    // written. Fire ONCE before the poll loop starts, and seed
+    // `lastMtimeMs` to the current trigger mtime so the first poll
+    // tick sees no advance (idempotency) and any subsequent genuine
+    // bump still fires.
+    logger.info(
+      `Reindex trigger startup catch-up: trigger mtime ${new Date(triggerMtimeMs).toISOString()} > active index mtime ${new Date(indexMtimeMs).toISOString()}; scheduling updateIndex(*)`,
+    );
+    this.lastMtimeMs = triggerMtimeMs;
+    this.requestRun();
   }
 
   /**


### PR DESCRIPTION
## Summary
- `ReindexTriggerWatcher.start()` only fired on mtime changes observed AFTER the watcher started. If `.reindex-trigger` was already newer than the active FAISS index at startup, nothing ingested until something else bumped the trigger.
- On `start()`, compare the current trigger mtime against the active model's index mtime; if newer, schedule one catch-up `onTrigger` invocation before installing the poll timer.
- `KnowledgeBaseServer.startTriggerWatcher` wires in the lookup via `resolveActiveModel` + `resolveFaissIndexBinaryPath`; the watcher itself remains independent of FAISS internals.

Closes #356

## Repro scenario (from the issue)

> `ReindexTriggerWatcher.start()` only fires on mtime changes AFTER watcher start. If `.reindex-trigger` is already newer than the active FAISS index at startup (the same "refresh pending" condition `kb doctor` flags), nothing ingests until something else bumps the trigger.

## Implementation notes
- `lastMtimeMs` is seeded to the current trigger mtime after the catch-up fire, so the first poll tick does NOT double-fire and any subsequent genuine bump still fires exactly once (idempotency).
- A distinct log line — `Reindex trigger startup catch-up: ... > active index mtime ...; scheduling updateIndex(*)` — distinguishes catch-up fires from normal mtime-change fires.
- No-op when the trigger file is absent, the active index mtime can't be resolved (no built index yet), or trigger mtime ≤ index mtime.
- `start()` is now async so the catch-up comparison completes before the poll timer is installed (no race between catch-up and the first poll tick).

## Tests added (`src/triggerWatcher.test.ts`)
1. `fires the catch-up trigger once when trigger mtime > active index mtime`
2. `does NOT fire catch-up when trigger mtime is older than the active index`
3. `does NOT fire catch-up when trigger mtime equals the active index mtime`
4. `after catch-up fire, a subsequent mtime bump still fires exactly once (idempotency)`
5. `skips catch-up when no active index mtime can be resolved (lookup returns null)`
6. `skips catch-up when the trigger file is absent at startup`

## Test plan
- [x] `npm run build` (clean tsc)
- [x] `npm test -- src/triggerWatcher.test.ts` (17/17 pass, 6 new)
- [x] `npm test -- src/KnowledgeBaseServer.test.ts` (67/67 pass)
- [x] `npm test` (1345 passed, 4 skipped, 1 todo; 79 suites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)