### PR TITLE
feat: make PDF ingest opt-in by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,14 +258,14 @@ Use this path if you want to develop against the repo or pin an unreleased commi
         RETRIEVE_KNOWLEDGE_DESCRIPTION="Search engineering runbooks, RFCs, and postmortems."
         LIST_KNOWLEDGE_BASES_DESCRIPTION="List available engineering knowledge bases."
         ```
-    *   **Ingest filter overrides (RFC 011 M1).** The server embeds only files whose extension is in `{.md, .markdown, .txt, .rst}` and excludes workflow sidecars (`_seen.jsonl`, `_index.jsonl`), log / staging subtrees (`logs/`, `tmp/`, `_tmp/`), and OS turds (`.DS_Store`, `Thumbs.db`, `desktop.ini`). To extend the allowlist or add more exclusions:
+    *   **Ingest filter overrides (RFC 011 M1).** The server embeds only files whose extension is in `{.md, .markdown, .txt, .rst, .html, .htm}` and excludes PDFs, workflow sidecars (`_seen.jsonl`, `_index.jsonl`), log / staging subtrees (`logs/`, `tmp/`, `_tmp/`), and OS turds (`.DS_Store`, `Thumbs.db`, `desktop.ini`). To extend the allowlist or add more exclusions:
         ```bash
         # Comma-separated extensions (case-insensitive; leading dot optional).
         INGEST_EXTRA_EXTENSIONS=".json,.yaml"
         # Comma-separated minimatch globs relative to the KB root.
         INGEST_EXCLUDE_PATHS="drafts/**,scratch.md"
         ```
-        Extensionless files (e.g. `README`, `LICENSE`, `Makefile`) are **not** embedded by the default allowlist; rename them with a `.md` or `.txt` suffix if you want them indexed. The base exclusions are authoritative: operators can add more but cannot remove the built-ins.
+        Extensionless files (e.g. `README`, `LICENSE`, `Makefile`) and PDFs are **not** embedded by the default allowlist; use `INGEST_EXTRA_EXTENSIONS=".pdf"` only when PDF extraction is intentional. The base exclusions are authoritative: operators can add more but cannot remove the built-ins.
     *   You can set these environment variables in your `.bashrc` or `.zshrc` file, or directly in the MCP settings.
 
 4.  **Build the server:**

--- a/docs/requirements/INDEX.md
+++ b/docs/requirements/INDEX.md
@@ -4,6 +4,22 @@
 
 ## Indexing
 
+### NFR-INDEX-358: Default Text-First Ingest Filter
+**Status:** Implemented
+**Priority:** High
+
+**Requirement:** The system shall exclude PDF files from the default ingest allowlist while preserving explicit operator opt-in for PDF extraction.
+**Rationale:** PDF extraction is heavyweight and many knowledge bases store markdown notes beside source PDFs; default refreshes should avoid duplicate, expensive PDF ingestion.
+
+**Acceptance Criteria:**
+- [x] Given markdown and PDF files in the same knowledge base, when default ingest filtering runs, then markdown files are accepted and PDF files are excluded.
+- [x] Given `INGEST_EXTRA_EXTENSIONS` includes `.pdf`, when ingest filtering runs, then PDF files are accepted unless an exclusion glob also matches them.
+- [x] Given `INGEST_EXCLUDE_PATHS` matches an opt-in PDF subtree, when ingest filtering runs, then matching PDF files remain excluded.
+- [x] Given an existing index was written when PDFs were ingestable, when refresh runs with the new default filter, then the system rebuilds from currently ingestable files and purges stale PDF sidecars.
+
+**Linked Tests:** TS-INDEX-358
+**Dependencies:** RFC011
+
 ### NFR-INDEX-236: Batched Changed-File Embeddings
 **Status:** Implemented
 **Priority:** High

--- a/docs/rfcs/011-arxiv-backend.md
+++ b/docs/rfcs/011-arxiv-backend.md
@@ -188,12 +188,12 @@ Dotfile-prefixed entries were already excluded by `src/utils.ts:28`, so `.index/
 **Rule B — extension allowlist.** After Rule A, a file is included only if its lowercased extension is in the ingest allowlist:
 
 ```
-.md, .markdown, .txt, .rst
+.md, .markdown, .txt, .rst, .html, .htm
 ```
 
 Explicitly excluded by omission: `.pdf`, `.jsonl`, `.json` (unless revisited — see below), `.log`, `.png`, `.jpg`, `.docx`, `.epub`. This is narrower than the RFC 010 §5.3.3 Resources mimetype map by design:
 
-- `.json` / `.yaml` / `.csv` / `.xml` / `.html` are **not** in the ingest allowlist. They *may* be in a KB (the Resources surface in RFC 010 M5 is happy to serve them), but their text content typically isn't prose — embedding a JSON array or a CSV row as a dense chunk is almost always the wrong retrieval unit. An operator who *does* want those embedded sets `INGEST_EXTRA_EXTENSIONS=".json,.yaml"` (§5.2.3).
+- `.json` / `.yaml` / `.csv` / `.xml` are **not** in the ingest allowlist. They *may* be in a KB (the Resources surface in RFC 010 M5 is happy to serve them), but their text content typically isn't prose — embedding a JSON array or a CSV row as a dense chunk is almost always the wrong retrieval unit. An operator who *does* want those embedded sets `INGEST_EXTRA_EXTENSIONS=".json,.yaml"` (§5.2.3).
 - `.pdf` is handled as a sibling-file surface (§5.3), not corpus.
 
 The allowlist is file-extension-based; the walker does not inspect file magic. This matches `FaissIndexManager.buildChunkDocuments`'s existing extension test at `src/FaissIndexManager.ts:224`.
@@ -209,15 +209,17 @@ Two env vars, read once at `FaissIndexManager` construction:
 
 Rule A's built-in list is authoritative — operators can *add* exclusions but not remove them. A KB that actually wants `_seen.jsonl` embedded is not a KB this server supports; that's a workflow design bug.
 
+PDFs are not in the default extension allowlist. The PDF loader remains available for explicit opt-in deployments via `INGEST_EXTRA_EXTENSIONS=".pdf"`, but arxiv-shaped KBs default to indexing markdown notes instead of sibling `pdfs/` payloads.
+
 #### 5.2.4 Implementation site
 
-`src/FaissIndexManager.ts:289` (`const filePaths = await getFilesRecursively(knowledgeBasePath);`) and `src/FaissIndexManager.ts:361` (the rebuild-path equivalent) both consume the walker output. A shared helper `filterIngestablePaths(paths, kbPath)` at `src/utils.ts` (next to `getFilesRecursively`) runs Rule A then Rule B, returns the filtered list. Both call sites wrap the walker:
+`src/FaissIndexManager.ts` consumes `enumerateIngestableKbFiles(...)`, the shared per-KB walk plus ingest-filter helper from `src/kb-fs.ts`. The helper applies `filterIngestablePaths(paths, kbPath)` from `src/ingest-filter.ts`, which runs Rule A then Rule B and returns the filtered list:
 
 ```ts
-const filePaths = filterIngestablePaths(
-  await getFilesRecursively(knowledgeBasePath),
-  knowledgeBasePath
-);
+const entries = await enumerateIngestableKbFiles(rootDir, kbNames, {
+  extraExtensions: INGEST_EXTRA_EXTENSIONS,
+  excludePaths: INGEST_EXCLUDE_PATHS,
+});
 ```
 
 Behaviour on an all-markdown KB (the three pre-existing KBs) is identical to today — every `.md` is in the allowlist, no path matches Rule A.

--- a/docs/testing/INDEX.md
+++ b/docs/testing/INDEX.md
@@ -4,6 +4,17 @@
 
 ## Indexing
 
+### TS-INDEX-358: Default Text-First Ingest Filter
+**Requirement:** NFR-INDEX-358
+
+**Test Cases:**
+- `filterIngestablePaths` shall exclude `.pdf` files by default while accepting markdown notes.
+- `filterIngestablePaths` shall accept `.pdf` files when `.pdf` is supplied through `extraExtensions`.
+- `filterIngestablePaths` shall let `excludePaths` suppress PDF files even after PDF extension opt-in.
+- `FaissIndexManager.updateIndex` shall let `INGEST_EXCLUDE_PATHS` suppress PDFs after `.pdf` extension opt-in.
+- `FaissIndexManager.updateIndex` shall rebuild from current ingestable files when the freshness manifest records an older base allowlist that admitted PDFs.
+- `RecursiveFsWatcher` shall honor ingest exclusion globs for otherwise ingestable markdown paths.
+
 ### TS-INDEX-236: Batched Changed-File Embeddings
 **Requirement:** NFR-INDEX-236
 

--- a/src/FaissIndexManager.test.ts
+++ b/src/FaissIndexManager.test.ts
@@ -2393,12 +2393,7 @@ describe('FaissIndexManager ingest filter (RFC 011 M1)', () => {
     process.env.EMBEDDING_PROVIDER = 'huggingface';
     process.env.HUGGINGFACE_API_KEY = 'test-key';
     delete process.env.INGEST_EXTRA_EXTENSIONS;
-    // Issue #46 — `.pdf` is now in the base allowlist, so the arxiv
-    // workflow (which already pairs each notes/*.md with a sibling
-    // pdfs/*.pdf) must opt PDFs out via INGEST_EXCLUDE_PATHS to keep its
-    // pre-#46 behavior of "embed the markdown sibling only, not the
-    // binary PDF".
-    process.env.INGEST_EXCLUDE_PATHS = 'pdfs/**';
+    delete process.env.INGEST_EXCLUDE_PATHS;
 
     jest.resetModules();
     const { FaissIndexManager } = await import('./FaissIndexManager.js');
@@ -2476,10 +2471,10 @@ describe('FaissIndexManager ingest filter (RFC 011 M1)', () => {
     // The steady-state per-KB update loop and the store-loss recovery
     // path (#90, sidecars purged at initialize → all files re-embedded
     // through the per-file path on the next updateIndex) are conceptually
-    // independent — but both go through the same `filterIngestablePaths`
-    // call site (line 967 in updateIndex). This test guards against a
-    // future refactor that adds a second `getFilesRecursively` site
-    // without wrapping it in the filter.
+    // independent — but both go through the same `enumerateIngestableKbFiles`
+    // path in updateIndex. This test guards against a future refactor that
+    // adds a second `getFilesRecursively` site without wrapping it in the
+    // filter.
     //
     // Pre-#90 this test drove the (now-effectively-dead) fallback rebuild
     // branch by seeding sidecars then deleting the FAISS store. Post-#90
@@ -2496,8 +2491,7 @@ describe('FaissIndexManager ingest filter (RFC 011 M1)', () => {
     process.env.EMBEDDING_PROVIDER = 'huggingface';
     process.env.HUGGINGFACE_API_KEY = 'test-key';
     delete process.env.INGEST_EXTRA_EXTENSIONS;
-    // Issue #46 — same pdfs/** opt-out as the steady-state arxiv test.
-    process.env.INGEST_EXCLUDE_PATHS = 'pdfs/**';
+    delete process.env.INGEST_EXCLUDE_PATHS;
 
     // First pass: seed sidecars via the per-KB update loop.
     jest.resetModules();
@@ -2668,7 +2662,7 @@ describe('FaissIndexManager ingest — PDF + HTML loaders (issue #46)', () => {
     process.env.FAISS_INDEX_PATH = path.join(tempDir, '.faiss');
     process.env.EMBEDDING_PROVIDER = 'huggingface';
     process.env.HUGGINGFACE_API_KEY = 'test-key';
-    delete process.env.INGEST_EXTRA_EXTENSIONS;
+    process.env.INGEST_EXTRA_EXTENSIONS = '.pdf';
     delete process.env.INGEST_EXCLUDE_PATHS;
 
     jest.resetModules();
@@ -2689,6 +2683,122 @@ describe('FaissIndexManager ingest — PDF + HTML loaders (issue #46)', () => {
       extension: '.pdf',
       knowledgeBase: 'docs',
     });
+  });
+
+  it('lets INGEST_EXCLUDE_PATHS suppress PDFs even when .pdf is explicitly opted in', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-ingest-pdf-excluded-'));
+    const kbRoot = path.join(tempDir, 'kb');
+    const docsKb = path.join(kbRoot, 'docs');
+    const notesDir = path.join(docsKb, 'notes');
+    const pdfsDir = path.join(docsKb, 'pdfs');
+    await fsp.mkdir(notesDir, { recursive: true });
+    await fsp.mkdir(pdfsDir, { recursive: true });
+    await fsp.writeFile(path.join(notesDir, 'summary.md'), '# Summary\n\nUse the note.\n');
+    await fsp.writeFile(
+      path.join(pdfsDir, 'paper.pdf'),
+      Buffer.from('%PDF-1.4\n%mocked content does not need to be valid here'),
+    );
+
+    process.env.KNOWLEDGE_BASES_ROOT_DIR = kbRoot;
+    process.env.FAISS_INDEX_PATH = path.join(tempDir, '.faiss');
+    process.env.EMBEDDING_PROVIDER = 'huggingface';
+    process.env.HUGGINGFACE_API_KEY = 'test-key';
+    process.env.INGEST_EXTRA_EXTENSIONS = '.pdf';
+    process.env.INGEST_EXCLUDE_PATHS = 'pdfs/**';
+
+    jest.resetModules();
+    const { FaissIndexManager } = await import('./FaissIndexManager.js');
+    const manager = new FaissIndexManager();
+    await manager.initialize();
+    await manager.updateIndex();
+
+    const { texts, metadatas } = collectIngestedDocs();
+    const sources = new Set(metadatas.map((m) => String(m.source)));
+    expect(sources.has(path.join(docsKb, 'notes', 'summary.md'))).toBe(true);
+    expect(sources.has(path.join(docsKb, 'pdfs', 'paper.pdf'))).toBe(false);
+    expect(texts.some((t) => t.includes('Mock PDF body'))).toBe(false);
+    await expect(
+      fsp.stat(path.join(docsKb, '.index', 'pdfs', 'paper.pdf')),
+    ).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('rebuilds once when an existing index has a freshness manifest from the old PDF-default filter', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-ingest-pdf-migration-'));
+    const kbRoot = path.join(tempDir, 'kb');
+    const docsKb = path.join(kbRoot, 'docs');
+    await fsp.mkdir(docsKb, { recursive: true });
+    await fsp.writeFile(path.join(docsKb, 'summary.md'), '# Summary\n\nUse the note.\n');
+    await fsp.writeFile(
+      path.join(docsKb, 'paper.pdf'),
+      Buffer.from('%PDF-1.4\n%mocked content does not need to be valid here'),
+    );
+
+    process.env.KNOWLEDGE_BASES_ROOT_DIR = kbRoot;
+    process.env.FAISS_INDEX_PATH = path.join(tempDir, '.faiss');
+    process.env.EMBEDDING_PROVIDER = 'huggingface';
+    process.env.HUGGINGFACE_API_KEY = 'test-key';
+    process.env.INGEST_EXTRA_EXTENSIONS = '.pdf';
+    delete process.env.INGEST_EXCLUDE_PATHS;
+
+    jest.resetModules();
+    {
+      const { FaissIndexManager } = await import('./FaissIndexManager.js');
+      const first = new FaissIndexManager();
+      await first.initialize();
+      await first.updateIndex();
+    }
+    expect(collectIngestedDocs().metadatas.some((m) => String(m.source).endsWith('.pdf'))).toBe(
+      true,
+    );
+    await expect(
+      fsp.stat(path.join(docsKb, '.index', 'paper.pdf')),
+    ).resolves.toMatchObject({ isFile: expect.any(Function) });
+
+    // The mocked FaissStore.save creates the versioned directory + symlink
+    // but not a concrete faiss.index file. Seed one so the freshness
+    // migration path sees the same on-disk signal as a real index.
+    const activeIndexPath = path.join(
+      versionedIndexPathIn(process.env.FAISS_INDEX_PATH!),
+      'faiss.index',
+    );
+    await fsp.mkdir(path.dirname(activeIndexPath), { recursive: true });
+    await fsp.writeFile(activeIndexPath, 'mock faiss bytes', 'utf-8');
+    const activeIndexStat = await fsp.stat(activeIndexPath);
+    const { writeFreshnessManifest } = await import('./freshness-manifest.js');
+    await writeFreshnessManifest({
+      modelId: DEFAULT_MODEL_ID,
+      modelDir: modelDirIn(process.env.FAISS_INDEX_PATH!),
+      kbRootDir: kbRoot,
+      indexMtimeMs: activeIndexStat.mtimeMs,
+      filterConfig: {
+        baseExtensions: ['.md', '.markdown', '.txt', '.rst', '.html', '.htm', '.pdf'],
+        extraExtensions: [],
+        excludePaths: [],
+      },
+    });
+
+    saveMock.mockReset();
+    addDocumentsMock.mockReset();
+    fromTextsMock.mockReset();
+    loadMock.mockReset();
+    delete process.env.INGEST_EXTRA_EXTENSIONS;
+
+    jest.resetModules();
+    const { FaissIndexManager } = await import('./FaissIndexManager.js');
+    const second = new FaissIndexManager();
+    await second.initialize();
+    await second.updateIndex();
+
+    expect(loadMock).toHaveBeenCalledTimes(1);
+    expect(fromTextsMock).toHaveBeenCalledTimes(1);
+    const { texts, metadatas } = collectIngestedDocs();
+    const sources = new Set(metadatas.map((m) => String(m.source)));
+    expect(sources.has(path.join(docsKb, 'summary.md'))).toBe(true);
+    expect(sources.has(path.join(docsKb, 'paper.pdf'))).toBe(false);
+    expect(texts.some((t) => t.includes('Mock PDF body'))).toBe(false);
+    await expect(
+      fsp.stat(path.join(docsKb, '.index', 'paper.pdf')),
+    ).rejects.toMatchObject({ code: 'ENOENT' });
   });
 
   it('ingests a `.html` file via the HTML loader (tags stripped before embedding)', async () => {
@@ -2760,7 +2870,7 @@ describe('FaissIndexManager ingest — PDF + HTML loaders (issue #46)', () => {
     expect(sources.has(path.join(docsKb, 'tool.exe'))).toBe(false);
   });
 
-  it('mixed-extension KB: .md + .pdf + .html all ingest, dispatched by extension', async () => {
+  it('mixed-extension KB: .md + opt-in .pdf + .html all ingest, dispatched by extension', async () => {
     const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-ingest-mixed-'));
     const kbRoot = path.join(tempDir, 'kb');
     const docsKb = path.join(kbRoot, 'docs');
@@ -2779,7 +2889,7 @@ describe('FaissIndexManager ingest — PDF + HTML loaders (issue #46)', () => {
     process.env.FAISS_INDEX_PATH = path.join(tempDir, '.faiss');
     process.env.EMBEDDING_PROVIDER = 'huggingface';
     process.env.HUGGINGFACE_API_KEY = 'test-key';
-    delete process.env.INGEST_EXTRA_EXTENSIONS;
+    process.env.INGEST_EXTRA_EXTENSIONS = '.pdf';
     delete process.env.INGEST_EXCLUDE_PATHS;
 
     jest.resetModules();
@@ -3169,10 +3279,7 @@ describe('FaissIndexManager integration — frontmatter + pdf_path (RFC 011 M2)'
     process.env.EMBEDDING_PROVIDER = 'huggingface';
     process.env.HUGGINGFACE_API_KEY = 'test-key';
     delete process.env.INGEST_EXTRA_EXTENSIONS;
-    // Issue #46 — `.pdf` is in the base allowlist; the arxiv layout pairs
-    // the .md note with the actual PDF, so keep the PDF out of embeddings
-    // to mirror the workflow's intent (notes are the source of truth).
-    process.env.INGEST_EXCLUDE_PATHS = 'pdfs/**';
+    delete process.env.INGEST_EXCLUDE_PATHS;
 
     jest.resetModules();
     const { FaissIndexManager } = await import('./FaissIndexManager.js');

--- a/src/FaissIndexManager.test.ts
+++ b/src/FaissIndexManager.test.ts
@@ -2801,6 +2801,83 @@ describe('FaissIndexManager ingest — PDF + HTML loaders (issue #46)', () => {
     ).rejects.toMatchObject({ code: 'ENOENT' });
   });
 
+  it('removes a stale PDF-only persisted index when the new default filter has no ingestable files', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-ingest-pdf-only-migration-'));
+    const kbRoot = path.join(tempDir, 'kb');
+    const docsKb = path.join(kbRoot, 'docs');
+    await fsp.mkdir(docsKb, { recursive: true });
+    await fsp.writeFile(
+      path.join(docsKb, 'paper.pdf'),
+      Buffer.from('%PDF-1.4\n%mocked content does not need to be valid here'),
+    );
+
+    process.env.KNOWLEDGE_BASES_ROOT_DIR = kbRoot;
+    process.env.FAISS_INDEX_PATH = path.join(tempDir, '.faiss');
+    process.env.EMBEDDING_PROVIDER = 'huggingface';
+    process.env.HUGGINGFACE_API_KEY = 'test-key';
+    process.env.INGEST_EXTRA_EXTENSIONS = '.pdf';
+    delete process.env.INGEST_EXCLUDE_PATHS;
+
+    jest.resetModules();
+    {
+      const { FaissIndexManager } = await import('./FaissIndexManager.js');
+      const first = new FaissIndexManager();
+      await first.initialize();
+      await first.updateIndex();
+    }
+    expect(collectIngestedDocs().metadatas.some((m) => String(m.source).endsWith('.pdf'))).toBe(
+      true,
+    );
+
+    const modelDir = modelDirIn(process.env.FAISS_INDEX_PATH!);
+    const activeIndexPath = path.join(
+      versionedIndexPathIn(process.env.FAISS_INDEX_PATH!),
+      'faiss.index',
+    );
+    await fsp.mkdir(path.dirname(activeIndexPath), { recursive: true });
+    await fsp.writeFile(activeIndexPath, 'mock faiss bytes', 'utf-8');
+    const activeIndexStat = await fsp.stat(activeIndexPath);
+    const { freshnessManifestPath, writeFreshnessManifest } = await import(
+      './freshness-manifest.js'
+    );
+    await writeFreshnessManifest({
+      modelId: DEFAULT_MODEL_ID,
+      modelDir,
+      kbRootDir: kbRoot,
+      indexMtimeMs: activeIndexStat.mtimeMs,
+      filterConfig: {
+        baseExtensions: ['.md', '.markdown', '.txt', '.rst', '.html', '.htm', '.pdf'],
+        extraExtensions: [],
+        excludePaths: [],
+      },
+    });
+
+    saveMock.mockReset();
+    addDocumentsMock.mockReset();
+    fromTextsMock.mockReset();
+    loadMock.mockReset();
+    delete process.env.INGEST_EXTRA_EXTENSIONS;
+
+    jest.resetModules();
+    const { FaissIndexManager } = await import('./FaissIndexManager.js');
+    const second = new FaissIndexManager();
+    await second.initialize();
+    await second.updateIndex();
+
+    expect(loadMock).toHaveBeenCalledTimes(1);
+    expect(fromTextsMock).not.toHaveBeenCalled();
+    expect(addDocumentsMock).not.toHaveBeenCalled();
+    await expect(fsp.stat(path.join(modelDir, 'index'))).rejects.toMatchObject({
+      code: 'ENOENT',
+    });
+    await expect(
+      fsp.stat(versionedIndexPathIn(process.env.FAISS_INDEX_PATH!)),
+    ).rejects.toMatchObject({ code: 'ENOENT' });
+    await expect(fsp.stat(freshnessManifestPath(modelDir))).rejects.toMatchObject({
+      code: 'ENOENT',
+    });
+  });
+
   it('ingests a `.html` file via the HTML loader (tags stripped before embedding)', async () => {
     const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-ingest-html-'));
     const kbRoot = path.join(tempDir, 'kb');

--- a/src/FaissIndexManager.ts
+++ b/src/FaissIndexManager.ts
@@ -46,6 +46,7 @@ import {
   saveFaissStoreAtomic,
 } from './faiss-store-layout.js';
 import {
+  freshnessManifestPath,
   readFreshnessManifest,
   writeFreshnessManifest,
 } from './freshness-manifest.js';
@@ -818,6 +819,58 @@ export class FaissIndexManager {
     }
   }
 
+  private async purgePersistedIndexStore(
+    reason: 'force_reindex' | 'ingest_filter_changed',
+  ): Promise<void> {
+    const removed: string[] = [];
+    let entries: Array<{ name: string }>;
+    try {
+      entries = await fsp.readdir(this.modelDir, { withFileTypes: true });
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === 'ENOENT' || code === 'ENOTDIR') return;
+      logger.warn(
+        `Could not list persisted index store for ${this.modelId} at ${this.modelDir}: ` +
+          `${(err as Error).message}`,
+      );
+      return;
+    }
+
+    for (const entry of entries) {
+      if (
+        entry.name !== 'index' &&
+        entry.name !== 'faiss.index' &&
+        !/^index\.v\d+$/.test(entry.name)
+      ) {
+        continue;
+      }
+      const target = path.join(this.modelDir, entry.name);
+      try {
+        await fsp.rm(target, { recursive: true, force: true });
+        removed.push(entry.name);
+      } catch (err) {
+        logger.warn(
+          `Could not remove stale persisted index entry ${target}: ${(err as Error).message}`,
+        );
+      }
+    }
+
+    try {
+      await fsp.rm(freshnessManifestPath(this.modelDir), { force: true });
+    } catch (err) {
+      logger.warn(
+        `Could not remove stale freshness manifest for ${this.modelId}: ${(err as Error).message}`,
+      );
+    }
+
+    if (removed.length > 0) {
+      logger.warn(
+        `Removed stale persisted FAISS index for model ${this.modelId} ` +
+          `(${reason}; entries=${removed.join(', ')}).`,
+      );
+    }
+  }
+
   /**
    * Issue #283 — absolute path of this model's predicate-pushdown sidecar.
    * Lives next to `last-index-update.json` and `model_name.txt` under the
@@ -1125,8 +1178,10 @@ export class FaissIndexManager {
       // Both are wrong. Treat scope as advisory under force: log the
       // upgrade and rebuild globally.
       let scopedKnowledgeBase = specificKnowledgeBase;
+      let shouldPurgePersistedIndexIfEmpty = false;
       if (forceReindex) {
         this.faissIndex = null;
+        shouldPurgePersistedIndexIfEmpty = true;
         if (scopedKnowledgeBase !== undefined) {
           logger.info(
             `Forced reindex of "${scopedKnowledgeBase}" upgraded to a global rebuild ` +
@@ -1148,6 +1203,7 @@ export class FaissIndexManager {
           });
           if (freshnessManifest === null) {
             this.faissIndex = null;
+            shouldPurgePersistedIndexIfEmpty = true;
             if (scopedKnowledgeBase !== undefined) {
               logger.info(
                 `Ingest filter changed for "${scopedKnowledgeBase}"; upgrading scoped ` +
@@ -1893,7 +1949,11 @@ export class FaissIndexManager {
       try {
         const manifestStartedAtMs = Date.now();
         const activeIndexFilePath = await this.resolveActiveIndexFilePath();
-        if (activeIndexFilePath !== null) {
+        if (this.faissIndex === null && shouldPurgePersistedIndexIfEmpty) {
+          await this.purgePersistedIndexStore(
+            forceReindex ? 'force_reindex' : 'ingest_filter_changed',
+          );
+        } else if (activeIndexFilePath !== null) {
           const indexStat = await fsp.stat(activeIndexFilePath);
           await writeFreshnessManifest({
             modelId: this.modelId,

--- a/src/FaissIndexManager.ts
+++ b/src/FaissIndexManager.ts
@@ -45,7 +45,10 @@ import {
   resolveActiveIndexFilePath as resolveActiveIndexFilePathFromLayout,
   saveFaissStoreAtomic,
 } from './faiss-store-layout.js';
-import { writeFreshnessManifest } from './freshness-manifest.js';
+import {
+  readFreshnessManifest,
+  writeFreshnessManifest,
+} from './freshness-manifest.js';
 import {
   createSimilaritySearchPostFilter,
   type ScoredDocument,
@@ -677,7 +680,7 @@ export class FaissIndexManager {
       //
       // Skipped under readOnly:true (no mutation allowed in that mode).
       if (this.faissIndex === null && !readOnly) {
-        await this.purgeStaleSidecars();
+        await this.purgeStaleSidecars('store_missing');
       }
 
       // Save the current model name for this model's dir. Skipped under
@@ -727,11 +730,15 @@ export class FaissIndexManager {
    * still works for those KBs since `find` does not follow symlinks
    * by default.
    */
-  private async purgeStaleSidecars(): Promise<void> {
-    await withSidecarLock(() => this.purgeStaleSidecarsLocked());
+  private async purgeStaleSidecars(
+    reason: 'store_missing' | 'ingest_filter_changed',
+  ): Promise<void> {
+    await withSidecarLock(() => this.purgeStaleSidecarsLocked(reason));
   }
 
-  private async purgeStaleSidecarsLocked(): Promise<void> {
+  private async purgeStaleSidecarsLocked(
+    reason: 'store_missing' | 'ingest_filter_changed',
+  ): Promise<void> {
     let kbs: string[];
     try {
       kbs = await listKnowledgeBases(KNOWLEDGE_BASES_ROOT_DIR);
@@ -780,13 +787,20 @@ export class FaissIndexManager {
       }
     }
 
-    if (purged.length > 0) {
+    if (purged.length > 0 && reason === 'store_missing') {
       logger.warn(
         `Issue #90: FAISS store for model ${this.modelId} not found on disk but ` +
           `per-KB hash sidecars existed. Purged stale sidecars for ${purged.length} ` +
           `knowledge base(s) [${purged.join(', ')}] so the next updateIndex re-embeds. ` +
           `Common causes: manual removal of $FAISS_INDEX_PATH, partial backup restore, ` +
           `crash mid-rebuild, or model switch with the prior model's store moved aside.`,
+      );
+    } else if (purged.length > 0) {
+      logger.warn(
+        `Ingest filter for model ${this.modelId} changed since the last successful index ` +
+          `save. Purged stale sidecars for ${purged.length} knowledge base(s) ` +
+          `[${purged.join(', ')}] so the next updateIndex rebuilds only currently ` +
+          `ingestable files.`,
       );
     }
     // Issue #283 — drop the metadata sidecar too; it indexes the same
@@ -1120,6 +1134,34 @@ export class FaissIndexManager {
               `vectors or drop other KBs).`,
           );
           scopedKnowledgeBase = undefined;
+        }
+      }
+
+      if (!forceReindex && this.faissIndex !== null) {
+        const activeIndexFilePath = await this.resolveActiveIndexFilePath();
+        if (activeIndexFilePath !== null) {
+          const indexStat = await fsp.stat(activeIndexFilePath);
+          const freshnessManifest = await readFreshnessManifest({
+            modelId: this.modelId,
+            modelDir: this.modelDir,
+            indexMtimeMs: indexStat.mtimeMs,
+          });
+          if (freshnessManifest === null) {
+            this.faissIndex = null;
+            if (scopedKnowledgeBase !== undefined) {
+              logger.info(
+                `Ingest filter changed for "${scopedKnowledgeBase}"; upgrading scoped ` +
+                  `refresh to a global rebuild because FAISS vector deletion is unsupported.`,
+              );
+              scopedKnowledgeBase = undefined;
+            }
+            logger.info(
+              `Freshness manifest for model ${this.modelId} is missing or stale; ` +
+                `rebuilding the full FAISS index to avoid stale vectors from files that ` +
+                `are no longer ingestable.`,
+            );
+            await this.purgeStaleSidecars('ingest_filter_changed');
+          }
         }
       }
       runSummary.scope = scopedKnowledgeBase ?? 'global';

--- a/src/cli-search-staleness.test.ts
+++ b/src/cli-search-staleness.test.ts
@@ -214,10 +214,10 @@ describe('refresh preflight estimate (issue #318)', () => {
       await fsp.mkdir(beta, { recursive: true });
 
       const alphaModified = path.join(alpha, 'modified.md');
-      const alphaPdf = path.join(alpha, 'new.pdf');
+      const alphaLarge = path.join(alpha, 'new.md');
       const betaNew = path.join(beta, 'new.md');
       await fsp.writeFile(alphaModified, 'x'.repeat(64), 'utf-8');
-      await fsp.writeFile(alphaPdf, 'p'.repeat(REFRESH_PREFLIGHT_BYTE_THRESHOLD + 1), 'utf-8');
+      await fsp.writeFile(alphaLarge, 'p'.repeat(REFRESH_PREFLIGHT_BYTE_THRESHOLD + 1), 'utf-8');
       await fsp.writeFile(betaNew, 'b'.repeat(32), 'utf-8');
       await fsp.writeFile(path.join(alpha, '.index', 'modified.md'), 'old-hash', 'utf-8');
       const indexMtimeMs = Date.parse('2026-05-12T10:00:00.000Z');
@@ -244,7 +244,6 @@ describe('refresh preflight estimate (issue #318)', () => {
       expect(text).toContain('- beta: 0 modified, 1 new');
       expect(text).toContain('Top stale KBs:');
       expect(text).toContain('kb search "<query>" --refresh --kb=alpha');
-      expect(text).toContain('INGEST_EXCLUDE_PATHS=pdfs/**');
     } finally {
       await fsp.rm(tempDir, { recursive: true, force: true });
     }

--- a/src/cli-search-staleness.ts
+++ b/src/cli-search-staleness.ts
@@ -231,7 +231,7 @@ export function formatRefreshPreflightEstimate(
     lines.push(`- Start with \`kb search "<query>" --refresh --kb=${estimate.topKbs[0].kb}\` to refresh the largest stale KB first.`);
   }
   if (estimate.stalePdfFiles > 0) {
-    lines.push('- Exclude bulky PDFs with `INGEST_EXCLUDE_PATHS=pdfs/**` when they are not needed for this run.');
+    lines.push('- PDFs are excluded by default; if you opted them in, use `INGEST_EXCLUDE_PATHS=pdfs/**` to skip bulky PDF subtrees for this run.');
   }
   lines.push('- This preflight is informational: TTY and non-TTY runs continue without prompting.');
   return `${lines.join('\n')}\n`;

--- a/src/freshness-manifest.test.ts
+++ b/src/freshness-manifest.test.ts
@@ -59,6 +59,10 @@ describe('freshness manifest', () => {
       modified_files: 0,
       new_files: 1,
     });
+    expect(manifest.filter.base_extensions).toEqual(
+      expect.arrayContaining(['.md', '.html', '.htm']),
+    );
+    expect(manifest.filter.base_extensions).not.toContain('.pdf');
     await expect(fsp.stat(freshnessManifestPath(modelDir))).resolves.toMatchObject({
       isFile: expect.any(Function),
     });
@@ -86,6 +90,30 @@ describe('freshness manifest', () => {
       kbRootDir: kbRoot,
       indexMtimeMs: 1000,
       filterConfig: { extraExtensions: ['.adoc'], excludePaths: [] },
+    })).resolves.toBeNull();
+
+    await writeFreshnessManifest({
+      modelId: 'huggingface__test',
+      modelDir,
+      kbRootDir: kbRoot,
+      indexMtimeMs: 1000,
+      filterConfig: {
+        baseExtensions: ['.md', '.markdown', '.txt', '.rst', '.html', '.htm', '.pdf'],
+        extraExtensions: [],
+        excludePaths: [],
+      },
+    });
+
+    await expect(readFreshnessManifest({
+      modelId: 'huggingface__test',
+      modelDir,
+      kbRootDir: kbRoot,
+      indexMtimeMs: 1000,
+      filterConfig: {
+        baseExtensions: ['.md', '.markdown', '.txt', '.rst', '.html', '.htm'],
+        extraExtensions: [],
+        excludePaths: [],
+      },
     })).resolves.toBeNull();
   });
 
@@ -125,6 +153,15 @@ describe('freshness manifest', () => {
     })).toBe(computeFreshnessManifestFilterHash({
       extraExtensions: ['.adoc'],
       excludePaths: ['drafts/**'],
+    }));
+    expect(computeFreshnessManifestFilterHash({
+      baseExtensions: ['.md', '.pdf'],
+      extraExtensions: [],
+      excludePaths: [],
+    })).not.toBe(computeFreshnessManifestFilterHash({
+      baseExtensions: ['.md'],
+      extraExtensions: [],
+      excludePaths: [],
     }));
     expect(computeFreshnessManifestFilterHash({
       extraExtensions: ['.mdx'],

--- a/src/freshness-manifest.ts
+++ b/src/freshness-manifest.ts
@@ -6,12 +6,14 @@ import {
   INGEST_EXTRA_EXTENSIONS,
   KNOWLEDGE_BASES_ROOT_DIR,
 } from './config.js';
+import { INGEST_BASE_EXTENSIONS } from './ingest-filter.js';
 import { enumerateIngestableKbFiles, listKnowledgeBases } from './kb-fs.js';
 
 export const FRESHNESS_MANIFEST_SCHEMA_VERSION = 'kb.freshness-manifest.v1';
 export const FRESHNESS_MANIFEST_FILE = 'freshness.json';
 
 export interface FreshnessManifestFilterConfig {
+  baseExtensions?: readonly string[];
   extraExtensions: readonly string[];
   excludePaths: readonly string[];
 }
@@ -32,6 +34,7 @@ export interface FreshnessManifest {
   index_mtime_ms: number;
   filter_hash: string;
   filter: {
+    base_extensions: string[];
     extra_extensions: string[];
     exclude_paths: string[];
   };
@@ -113,6 +116,7 @@ export async function writeFreshnessManifest(
     index_mtime_ms: input.indexMtimeMs,
     filter_hash: filterHash,
     filter: {
+      base_extensions: [...normalizedFilter.baseExtensions],
       extra_extensions: [...normalizedFilter.extraExtensions],
       exclude_paths: [...normalizedFilter.excludePaths],
     },
@@ -176,6 +180,7 @@ export async function countSidecarFiles(dir: string): Promise<number> {
 
 function defaultFilterConfig(): FreshnessManifestFilterConfig {
   return {
+    baseExtensions: INGEST_BASE_EXTENSIONS,
     extraExtensions: INGEST_EXTRA_EXTENSIONS,
     excludePaths: INGEST_EXCLUDE_PATHS,
   };
@@ -183,8 +188,9 @@ function defaultFilterConfig(): FreshnessManifestFilterConfig {
 
 function normalizeFilterConfig(
   config: FreshnessManifestFilterConfig,
-): { extraExtensions: string[]; excludePaths: string[] } {
+): { baseExtensions: string[]; extraExtensions: string[]; excludePaths: string[] } {
   return {
+    baseExtensions: [...(config.baseExtensions ?? INGEST_BASE_EXTENSIONS)],
     extraExtensions: [...config.extraExtensions],
     excludePaths: [...config.excludePaths],
   };
@@ -199,6 +205,7 @@ function isFreshnessManifest(value: unknown): value is FreshnessManifest {
   if (typeof value.index_mtime_ms !== 'number') return false;
   if (typeof value.filter_hash !== 'string') return false;
   if (!isRecord(value.filter)) return false;
+  if (!isStringArray(value.filter.base_extensions)) return false;
   if (!isStringArray(value.filter.extra_extensions)) return false;
   if (!isStringArray(value.filter.exclude_paths)) return false;
   if (value.complete !== true) return false;

--- a/src/ingest-filter.ts
+++ b/src/ingest-filter.ts
@@ -8,13 +8,12 @@ import { logger } from './logger.js';
 // getFilesRecursively already skips dotfiles (`.index/`, `.reindex-trigger`,
 // `.DS_Store`-when-dot-prefixed). The ingest filter runs on top of that walker
 // output to refuse content that is not retrieval-worthy: workflow sidecars
-// (`_seen.jsonl`), log directories (`logs/`, `tmp/`), and image / archive
-// extensions (`.jsonl`, `.log`, images). Issue #46 added `.pdf`, `.html`, and
-// `.htm` to the allowlist with dedicated loaders in `src/loaders.ts`. The
+// (`_seen.jsonl`), log directories (`logs/`, `tmp/`), and bulky / non-text
+// extensions (`.pdf`, `.jsonl`, `.log`, images). Issue #46 added dedicated
+// loaders for `.pdf`, `.html`, and `.htm`; only HTML is base-allowed. The
 // arxiv ingestion workflow's ledger must still NOT reach the splitter - the
 // walker today would chunk `_seen.jsonl` as JSON lines (RFC 011 §2.2). KBs
-// that pair markdown notes with sibling PDFs (e.g. arxiv `notes/` + `pdfs/`)
-// can suppress the PDFs with `INGEST_EXCLUDE_PATHS=pdfs/**`.
+// that explicitly want PDF extraction can opt in with `INGEST_EXTRA_EXTENSIONS=.pdf`.
 // -----------------------------------------------------------------------------
 
 /**
@@ -22,18 +21,17 @@ import { logger } from './logger.js';
  * lowercased and include the leading dot. `INGEST_EXTRA_EXTENSIONS` merges
  * into this set; operators cannot remove base entries.
  *
- * Issue #46 - `.pdf`, `.html`, `.htm` ride the extension-routed loader layer
- * in `src/loaders.ts`. Adding here without a loader would re-introduce the
- * UTF-8-decoded-binary-noise bug; `loaders.ts` is the single source of truth
- * for what a loader exists for, this list is the source of truth for what
- * the ingest filter admits.
+ * Issue #46 - `.html` and `.htm` ride the extension-routed loader layer in
+ * `src/loaders.ts`. `.pdf` also has a loader, but is deliberately excluded
+ * from the base allowlist because PDF extraction is heavyweight and most
+ * arxiv-shaped KBs already store markdown notes next to sibling PDFs. Operators
+ * can opt PDFs back in with `INGEST_EXTRA_EXTENSIONS=.pdf`.
  */
 export const INGEST_BASE_EXTENSIONS: readonly string[] = [
   '.md',
   '.markdown',
   '.txt',
   '.rst',
-  '.pdf',
   '.html',
   '.htm',
 ] as const;

--- a/src/loaders.test.ts
+++ b/src/loaders.test.ts
@@ -48,8 +48,8 @@ const SAMPLE_PDF_FIXTURE = path.join(
 
 // Mock pdf-parse so the suite never actually drives pdfjs-dist. Real PDF
 // round-trip is exercised by `scripts/generate-pdf-fixture.cjs` and by the
-// runtime path that ingests `.pdf` files at `npm start`. The mock here
-// verifies that the PDF loader (a) reads the file from disk into a buffer,
+// runtime path when `.pdf` is enabled with INGEST_EXTRA_EXTENSIONS. The mock
+// here verifies that the PDF loader (a) reads the file from disk into a buffer,
 // (b) hands it to pdf-parse, and (c) returns the extracted text — which is
 // the only logic in `loadPdf` worth unit-testing in isolation.
 const pdfParseFnMock = jest.fn();

--- a/src/recursive-fs-watch.test.ts
+++ b/src/recursive-fs-watch.test.ts
@@ -102,11 +102,11 @@ describe('RecursiveKbWatcher (RFC 007 §6.6 / issue #212)', () => {
     const watcher = makeWatcher({
       onChange,
       debounceMs: 25,
-      excludePaths: ['pdfs/**'],
+      excludePaths: ['drafts/**'],
     });
     await watcher.start();
 
-    watcher.handleFsEvent(KB, 'pdfs/paper.pdf');
+    watcher.handleFsEvent(KB, 'drafts/paper.md');
     await drain(80);
     expect(onChange).not.toHaveBeenCalled();
 

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -235,7 +235,7 @@ describe('filterIngestablePaths (RFC 011 §5.2)', () => {
   const kbRoot = '/kbs/arxiv';
   const abs = (rel: string): string => `${kbRoot}/${rel}`;
 
-  it('(a) arxiv KB: notes/*.md and PDFs pass (issue #46); _seen.jsonl and logs/** excluded', () => {
+  it('(a) arxiv KB: notes/*.md pass while PDFs, _seen.jsonl, and logs/** are excluded', () => {
     const input = [
       abs('notes/2604.21215.md'),
       abs('notes/2604.21221.md'),
@@ -245,27 +245,32 @@ describe('filterIngestablePaths (RFC 011 §5.2)', () => {
       abs('logs/2026-04-24.log'),
     ];
     const output = filterIngestablePaths(input, kbRoot);
-    // Issue #46 — `.pdf` is now part of the base allowlist; arxiv-shaped KBs
-    // that want to keep their `pdfs/` directory out of the embedding (because
-    // a markdown sibling already covers it) opt in via
-    // `INGEST_EXCLUDE_PATHS=pdfs/**` (see test (a.1) below).
     expect(output).toEqual([
       abs('notes/2604.21215.md'),
       abs('notes/2604.21221.md'),
-      abs('pdfs/2604.21215.pdf'),
-      abs('pdfs/2604.21221.pdf'),
     ]);
   });
 
-  it('(a.1) arxiv KB with INGEST_EXCLUDE_PATHS="pdfs/**" suppresses the PDF subtree', () => {
-    // The natural arxiv migration after issue #46: notes/ stay embedded,
-    // pdfs/ stays out so the same paper isn't double-indexed.
+  it('(a.1) PDFs are opt-in through INGEST_EXTRA_EXTENSIONS=".pdf"', () => {
     const input = [
       abs('notes/2604.21215.md'),
       abs('pdfs/2604.21215.pdf'),
       abs('_seen.jsonl'),
     ];
     const output = filterIngestablePaths(input, kbRoot, {
+      extraExtensions: ['.pdf'],
+    });
+    expect(output).toEqual([abs('notes/2604.21215.md'), abs('pdfs/2604.21215.pdf')]);
+  });
+
+  it('(a.2) INGEST_EXCLUDE_PATHS can still suppress opt-in PDF subtrees', () => {
+    const input = [
+      abs('notes/2604.21215.md'),
+      abs('pdfs/2604.21215.pdf'),
+      abs('_seen.jsonl'),
+    ];
+    const output = filterIngestablePaths(input, kbRoot, {
+      extraExtensions: ['.pdf'],
       excludePaths: ['pdfs/**'],
     });
     expect(output).toEqual([abs('notes/2604.21215.md')]);
@@ -316,11 +321,10 @@ describe('filterIngestablePaths (RFC 011 §5.2)', () => {
     expect(output).toEqual([abs('notes/paper.md')]);
   });
 
-  it('(e) case sensitivity: .MD and .PDF normalize to lowercase and pass; .EXE stays excluded', () => {
+  it('(e) case sensitivity: .MD normalizes to lowercase; .PDF and .EXE stay excluded by default', () => {
     const input = [abs('pdfs/Paper.PDF'), abs('NOTES/PAPER.MD'), abs('bin/tool.EXE')];
     const output = filterIngestablePaths(input, kbRoot);
-    // Issue #46 — `.pdf` is base-allowed; .EXE is not.
-    expect(output).toEqual([abs('pdfs/Paper.PDF'), abs('NOTES/PAPER.MD')]);
+    expect(output).toEqual([abs('NOTES/PAPER.MD')]);
   });
 
   it('(f) basename _seen.jsonl is excluded even if placed under notes/', () => {


### PR DESCRIPTION
## Summary
- Remove `.pdf` from the default ingest allowlist while preserving explicit opt-in via `INGEST_EXTRA_EXTENSIONS=.pdf`.
- Keep `INGEST_EXCLUDE_PATHS` effective for opted-in PDF subtrees and update operator docs/preflight guidance.
- Include the base ingest allowlist in the freshness manifest so older PDF-ingesting indexes rebuild once and purge stale PDF sidecars.

## Verification
- `npm run build`
- `npm test -- --runTestsByPath src/FaissIndexManager.test.ts src/freshness-manifest.test.ts src/utils.test.ts src/recursive-fs-watch.test.ts src/cli-search-staleness.test.ts`
- `npm test`
- `git diff --check`
- Changed-line portability/secret scan: clean

## Review Notes
- Addressed reviewer findings for stale RFC allowlist docs, missing runtime coverage for `.pdf` opt-in plus `INGEST_EXCLUDE_PATHS`, and the existing-index migration case where old PDF vectors/sidecars could otherwise survive.
