### PR TITLE
feat(rfc-017): M0c — kb eval --compare-index measurement infra

### DIFF
--- a/src/FaissIndexManager.ts
+++ b/src/FaissIndexManager.ts
@@ -46,6 +46,7 @@ import {
 import { mapBounded, resolveFsConcurrency } from './bounded-concurrency.js';
 import {
   loadFaissStoreAtomic,
+  loadFaissStoreFromVersionDir,
   resolveActiveIndexFilePath as resolveActiveIndexFilePathFromLayout,
   saveFaissStoreAtomic,
 } from './faiss-store-layout.js';
@@ -998,6 +999,30 @@ export class FaissIndexManager {
    */
   async reloadPersistedIndex(): Promise<void> {
     this.faissIndex = await this.loadAtomic();
+  }
+
+  /**
+   * RFC 017 M0c — load a specific `index.vN/` directory directly,
+   * bypassing the `index` symlink. Used by `kb eval --compare-index`
+   * to evaluate the same fixture against two different versions of the
+   * persisted store (typically before/after a contextual-retrieval
+   * reindex). The caller passes a directory containing `faiss.index`
+   * and `docstore.json`; we replace `this.faissIndex` with an adapter
+   * around the loaded store.
+   *
+   * Read-only — this method does NOT acquire the per-model write lock.
+   * It is the caller's responsibility to ensure no concurrent writer is
+   * mutating the version dir during the load.
+   */
+  async loadFromVersionDir(versionDir: string): Promise<void> {
+    if (!this.embeddings) {
+      throw new Error('FaissIndexManager.loadFromVersionDir requires initialize() first');
+    }
+    const store = await loadFaissStoreFromVersionDir({
+      versionDir,
+      embeddings: this.embeddings,
+    });
+    this.faissIndex = FaissStoreAdapter.fromStore(store);
   }
 
   /**

--- a/src/cli-eval-compare.test.ts
+++ b/src/cli-eval-compare.test.ts
@@ -1,0 +1,270 @@
+// RFC 017 M0c — unit tests for `src/cli-eval-compare.ts`.
+//
+// The compare path requires two loaded FAISS indexes. Rather than
+// constructing real ones, we drive `runCompareEval` against a mock
+// manager whose `similaritySearch` returns scripted results — that
+// covers the diff/report logic without touching faiss-node.
+
+import { describe, expect, it } from '@jest/globals';
+import * as fsp from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+
+import {
+  formatCompareReportMarkdown,
+  resolveIndexVersionPath,
+  runCompareEval,
+  type CompareReport,
+} from './cli-eval-compare.js';
+import type { ScoredDocument } from './formatter.js';
+import type { RetrievalEvalFixture } from './retrieval-eval.js';
+import type { FaissIndexManager } from './FaissIndexManager.js';
+
+// Build a fake document that retrieval-eval's pipeline accepts.
+function doc(source: string, score: number): ScoredDocument {
+  return {
+    pageContent: `content of ${source}`,
+    metadata: {
+      source,
+      relativePath: source,
+      knowledgeBase: 'alpha',
+      extension: '.md',
+      chunkIndex: 0,
+      score,
+    },
+  } as unknown as ScoredDocument;
+}
+
+function fixture(): RetrievalEvalFixture {
+  return {
+    cases: [
+      { name: 'case A', query: 'query about deployments' } as RetrievalEvalFixture['cases'][0],
+    ],
+  } as RetrievalEvalFixture;
+}
+
+// Stage scripted results for each pass. The compare flow calls
+// `loadFromVersionDir(dir)` then runs queries; we use the dir path to
+// pick which result set to return on the next `similaritySearch` call.
+function fakeManager(scripted: Record<string, ScoredDocument[]>): FaissIndexManager {
+  let activeDir = '';
+  const handle = {
+    modelDir: '/fake/model',
+    async loadFromVersionDir(dir: string): Promise<void> {
+      activeDir = dir;
+    },
+    async similaritySearch(
+      _query: string,
+      _k: number,
+      _threshold: number,
+    ): Promise<ScoredDocument[]> {
+      const r = scripted[activeDir];
+      if (r === undefined) {
+        throw new Error(`fakeManager: no scripted results for ${activeDir}`);
+      }
+      return r;
+    },
+  };
+  return handle as unknown as FaissIndexManager;
+}
+
+// runCompareEval requires the version dirs to exist on disk. Stage a
+// pair of empty version dirs with the two required files inside.
+async function stageVersionDir(tmp: string, name: string): Promise<string> {
+  const dir = path.join(tmp, name);
+  await fsp.mkdir(dir, { recursive: true });
+  await fsp.writeFile(path.join(dir, 'faiss.index'), 'fake');
+  await fsp.writeFile(path.join(dir, 'docstore.json'), '{}');
+  return dir;
+}
+
+describe('resolveIndexVersionPath', () => {
+  it('expands a numeric version into <modelDir>/index.v<n>', () => {
+    expect(resolveIndexVersionPath('42', '/m')).toBe('/m/index.v42');
+    expect(resolveIndexVersionPath('0', '/m')).toBe('/m/index.v0');
+  });
+
+  it('passes absolute paths through unchanged', () => {
+    expect(resolveIndexVersionPath('/some/abs/path', '/m')).toBe('/some/abs/path');
+  });
+
+  it('resolves relative paths against the model dir', () => {
+    expect(resolveIndexVersionPath('index.v17', '/m')).toBe('/m/index.v17');
+    expect(resolveIndexVersionPath('subdir/index.v1', '/m')).toBe('/m/subdir/index.v1');
+  });
+});
+
+describe('runCompareEval', () => {
+  it('reports rank changes when sources reorder between versions', async () => {
+    const tmp = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-eval-compare-'));
+    try {
+      const beforeDir = await stageVersionDir(tmp, 'index.v1');
+      const afterDir = await stageVersionDir(tmp, 'index.v2');
+
+      // Before: notes/deploy.md is rank 1; notes/rollback.md is rank 2.
+      // After: rollback.md jumps to rank 1, deploy.md slips to rank 2.
+      const manager = fakeManager({
+        [beforeDir]: [doc('notes/deploy.md', 0.10), doc('notes/rollback.md', 0.20)],
+        [afterDir]: [doc('notes/rollback.md', 0.08), doc('notes/deploy.md', 0.12)],
+      });
+
+      const report = await runCompareEval({
+        manager,
+        fixture: fixture(),
+        before: beforeDir,
+        after: afterDir,
+        defaultK: 10,
+        defaultThreshold: 2,
+        defaultMode: 'dense',
+      });
+
+      expect(report.case_count).toBe(1);
+      const c = report.cases[0];
+      expect(c.before.top_sources).toEqual(['notes/deploy.md', 'notes/rollback.md']);
+      expect(c.after.top_sources).toEqual(['notes/rollback.md', 'notes/deploy.md']);
+      expect(c.changes.result_count_delta).toBe(0);
+      expect(c.changes.new_sources).toEqual([]);
+      expect(c.changes.dropped_sources).toEqual([]);
+      expect(c.changes.rank_changes).toHaveLength(2);
+      // rollback.md improved from rank 1 (index 1) to rank 0 (index 0) — rank_delta = +1
+      const rollbackChange = c.changes.rank_changes.find((rc) => rc.source === 'notes/rollback.md');
+      expect(rollbackChange?.rank_delta).toBe(1);
+      const deployChange = c.changes.rank_changes.find((rc) => rc.source === 'notes/deploy.md');
+      expect(deployChange?.rank_delta).toBe(-1);
+
+      expect(report.aggregate.cases_with_top1_change).toBe(1);
+    } finally {
+      await fsp.rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('reports new and dropped sources when top-K membership changes', async () => {
+    const tmp = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-eval-compare-'));
+    try {
+      const beforeDir = await stageVersionDir(tmp, 'index.v1');
+      const afterDir = await stageVersionDir(tmp, 'index.v2');
+
+      const manager = fakeManager({
+        [beforeDir]: [doc('a.md', 0.1), doc('b.md', 0.2), doc('c.md', 0.3)],
+        [afterDir]: [doc('a.md', 0.1), doc('d.md', 0.2), doc('e.md', 0.3)],
+      });
+
+      const report = await runCompareEval({
+        manager,
+        fixture: fixture(),
+        before: beforeDir,
+        after: afterDir,
+        defaultK: 10,
+        defaultThreshold: 2,
+        defaultMode: 'dense',
+      });
+
+      const c = report.cases[0];
+      expect(c.changes.new_sources.sort()).toEqual(['d.md', 'e.md']);
+      expect(c.changes.dropped_sources.sort()).toEqual(['b.md', 'c.md']);
+    } finally {
+      await fsp.rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('reports mean_score_delta when scores shift', async () => {
+    const tmp = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-eval-compare-'));
+    try {
+      const beforeDir = await stageVersionDir(tmp, 'index.v1');
+      const afterDir = await stageVersionDir(tmp, 'index.v2');
+
+      const manager = fakeManager({
+        [beforeDir]: [doc('a.md', 0.5), doc('b.md', 0.5)],
+        [afterDir]: [doc('a.md', 0.1), doc('b.md', 0.1)],
+      });
+
+      const report = await runCompareEval({
+        manager,
+        fixture: fixture(),
+        before: beforeDir,
+        after: afterDir,
+        defaultK: 10,
+        defaultThreshold: 2,
+        defaultMode: 'dense',
+      });
+
+      const c = report.cases[0];
+      expect(c.before.mean_score).toBeCloseTo(0.5, 4);
+      expect(c.after.mean_score).toBeCloseTo(0.1, 4);
+      // Lower score = closer match for dense retrieval (L2 distance), so a
+      // negative delta means the AFTER side is closer to the query than
+      // BEFORE — i.e. retrieval improved.
+      expect(c.changes.mean_score_delta).toBeCloseTo(-0.4, 4);
+    } finally {
+      await fsp.rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects a version dir that is missing faiss.index', async () => {
+    const tmp = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-eval-compare-'));
+    try {
+      const beforeDir = await stageVersionDir(tmp, 'index.v1');
+      const afterDir = path.join(tmp, 'index.v2');
+      await fsp.mkdir(afterDir, { recursive: true });
+      // Only write the docstore, omit faiss.index.
+      await fsp.writeFile(path.join(afterDir, 'docstore.json'), '{}');
+
+      const manager = fakeManager({});
+      await expect(
+        runCompareEval({
+          manager,
+          fixture: fixture(),
+          before: beforeDir,
+          after: afterDir,
+          defaultK: 10,
+          defaultThreshold: 2,
+          defaultMode: 'dense',
+        }),
+      ).rejects.toThrow(/missing faiss\.index/);
+    } finally {
+      await fsp.rm(tmp, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('formatCompareReportMarkdown', () => {
+  it('renders the aggregate table and per-case sections', () => {
+    const report: CompareReport = {
+      schema_version: 'kb-eval-compare.v1',
+      before_path: '/m/index.v1',
+      after_path: '/m/index.v2',
+      case_count: 1,
+      cases: [
+        {
+          name: 'case A',
+          query: 'q',
+          mode: 'dense',
+          before: { result_count: 2, top_sources: ['a', 'b'], top_scores: [0.1, 0.2], mean_score: 0.15 },
+          after:  { result_count: 2, top_sources: ['b', 'a'], top_scores: [0.1, 0.2], mean_score: 0.15 },
+          changes: {
+            result_count_delta: 0,
+            mean_score_delta: 0,
+            new_sources: [],
+            dropped_sources: [],
+            rank_changes: [
+              { source: 'a', before_rank: 0, after_rank: 1, rank_delta: -1 },
+              { source: 'b', before_rank: 1, after_rank: 0, rank_delta: 1 },
+            ],
+          },
+        },
+      ],
+      aggregate: {
+        mean_result_count_delta: 0,
+        mean_score_delta: 0,
+        new_sources_per_case: 0,
+        dropped_sources_per_case: 0,
+        cases_with_top1_change: 1,
+      },
+    };
+    const md = formatCompareReportMarkdown(report);
+    expect(md).toContain('# kb eval --compare-index');
+    expect(md).toContain('case A');
+    expect(md).toContain('Rank shifts');
+    expect(md).toContain('Cases with top-1 change');
+  });
+});

--- a/src/cli-eval-compare.ts
+++ b/src/cli-eval-compare.ts
@@ -1,0 +1,337 @@
+// RFC 017 M0c — `kb eval --compare-index --before=<v> --after=<v>`.
+//
+// Measurement infrastructure that M1 needs to make a real go/no-go
+// call on contextual retrieval. Runs the same fixture against two
+// historical index versions of the active model and emits a per-case
+// rank/score diff.
+//
+// The two indexes are loaded sequentially through the same
+// FaissIndexManager (via `loadFromVersionDir`) — there's no need to
+// hold both in memory at once, and the single-manager design reuses
+// every query-side concern (post-filters, query cache, mode dispatch)
+// from `manager.similaritySearch`.
+
+import * as path from 'path';
+import * as fsp from 'fs/promises';
+
+import { FaissIndexManager } from './FaissIndexManager.js';
+import {
+  retrieveForRetrievalEvalCase,
+  type RetrievalEvalFixture,
+} from './retrieval-eval.js';
+import type { ScoredDocument } from './formatter.js';
+import type { SearchMode } from './search-core.js';
+
+export interface CompareEvalOptions {
+  manager: FaissIndexManager;
+  fixture: RetrievalEvalFixture;
+  before: string;
+  after: string;
+  defaultK: number;
+  defaultThreshold: number;
+  defaultMode: SearchMode;
+}
+
+export interface CompareCaseResult {
+  name: string;
+  query: string;
+  kb?: string;
+  mode: SearchMode;
+  before: CompareSnapshot;
+  after: CompareSnapshot;
+  changes: CompareChanges;
+}
+
+export interface CompareSnapshot {
+  result_count: number;
+  top_sources: string[]; // up to 10
+  top_scores: number[];  // aligned with top_sources
+  mean_score: number | null;
+}
+
+export interface CompareChanges {
+  result_count_delta: number;
+  mean_score_delta: number | null;
+  // Sources that appeared in `after` but not `before` (within top-K).
+  new_sources: string[];
+  // Sources that vanished from top-K.
+  dropped_sources: string[];
+  // For sources present in both top-K snapshots: rank delta (positive = improved).
+  rank_changes: Array<{ source: string; before_rank: number; after_rank: number; rank_delta: number }>;
+}
+
+export interface CompareReport {
+  schema_version: 'kb-eval-compare.v1';
+  before_path: string;
+  after_path: string;
+  case_count: number;
+  cases: CompareCaseResult[];
+  aggregate: {
+    mean_result_count_delta: number;
+    mean_score_delta: number | null;
+    new_sources_per_case: number;
+    dropped_sources_per_case: number;
+    cases_with_top1_change: number;
+  };
+}
+
+/**
+ * Resolve `--before=<arg>` to an absolute path. If `arg` parses as a
+ * non-negative integer, it's expanded to `<modelDir>/index.v<arg>`.
+ * Otherwise treated as a path (relative paths are resolved against
+ * `<modelDir>`).
+ */
+export function resolveIndexVersionPath(arg: string, modelDir: string): string {
+  if (/^\d+$/.test(arg)) {
+    return path.join(modelDir, `index.v${arg}`);
+  }
+  if (path.isAbsolute(arg)) return arg;
+  return path.join(modelDir, arg);
+}
+
+export async function assertIndexVersionDir(versionPath: string): Promise<void> {
+  let stat: import('fs').Stats;
+  try {
+    stat = await fsp.stat(versionPath);
+  } catch (err) {
+    throw new Error(
+      `kb eval --compare-index: index version directory not found: ${versionPath} (${(err as Error).message})`,
+    );
+  }
+  if (!stat.isDirectory()) {
+    throw new Error(
+      `kb eval --compare-index: expected a directory at ${versionPath}, found a file`,
+    );
+  }
+  // FaissStore.load reads `${versionPath}/faiss.index` and
+  // `${versionPath}/docstore.json`; fail fast if either is missing so
+  // we don't surface a cryptic load error to the operator.
+  for (const name of ['faiss.index', 'docstore.json']) {
+    try {
+      await fsp.access(path.join(versionPath, name));
+    } catch {
+      throw new Error(
+        `kb eval --compare-index: ${versionPath} is not a complete FAISS version dir (missing ${name})`,
+      );
+    }
+  }
+}
+
+export async function runCompareEval(opts: CompareEvalOptions): Promise<CompareReport> {
+  await assertIndexVersionDir(opts.before);
+  await assertIndexVersionDir(opts.after);
+
+  // Pass 1 — load `before`, query every case, collect results.
+  await opts.manager.loadFromVersionDir(opts.before);
+  const beforeResults = await queryFixture(opts);
+
+  // Pass 2 — load `after`, query every case again.
+  await opts.manager.loadFromVersionDir(opts.after);
+  const afterResults = await queryFixture(opts);
+
+  const cases: CompareCaseResult[] = opts.fixture.cases.map((fixtureCase, i) => {
+    const before = toSnapshot(beforeResults[i]);
+    const after = toSnapshot(afterResults[i]);
+    return {
+      name: fixtureCase.name,
+      query: fixtureCase.query,
+      ...(fixtureCase.kb !== undefined ? { kb: fixtureCase.kb } : {}),
+      mode: fixtureCase.mode ?? opts.defaultMode,
+      before,
+      after,
+      changes: diffSnapshots(before, after),
+    };
+  });
+
+  return {
+    schema_version: 'kb-eval-compare.v1',
+    before_path: opts.before,
+    after_path: opts.after,
+    case_count: cases.length,
+    cases,
+    aggregate: aggregate(cases),
+  };
+}
+
+async function queryFixture(opts: CompareEvalOptions): Promise<ScoredDocument[][]> {
+  const out: ScoredDocument[][] = [];
+  for (const fixtureCase of opts.fixture.cases) {
+    const requestedMode = fixtureCase.mode ?? opts.defaultMode;
+    const search = await retrieveForRetrievalEvalCase(
+      fixtureCase,
+      {
+        manager: opts.manager,
+        defaultK: opts.defaultK,
+        defaultThreshold: opts.defaultThreshold,
+      },
+      requestedMode,
+    );
+    out.push(search.results);
+  }
+  return out;
+}
+
+function toSnapshot(results: ScoredDocument[]): CompareSnapshot {
+  const topK = Math.min(results.length, 10);
+  const sources = results.slice(0, topK).map((r) => sourceOf(r));
+  const scores = results.slice(0, topK).map((r) => scoreOf(r));
+  const meanScore = results.length === 0
+    ? null
+    : results.reduce((sum, r) => sum + scoreOf(r), 0) / results.length;
+  return {
+    result_count: results.length,
+    top_sources: sources,
+    top_scores: scores,
+    mean_score: meanScore,
+  };
+}
+
+function diffSnapshots(before: CompareSnapshot, after: CompareSnapshot): CompareChanges {
+  const beforeSources = new Set(before.top_sources);
+  const afterSources = new Set(after.top_sources);
+  const newSources = [...afterSources].filter((s) => !beforeSources.has(s));
+  const droppedSources = [...beforeSources].filter((s) => !afterSources.has(s));
+  const rankChanges: CompareChanges['rank_changes'] = [];
+  for (const source of beforeSources) {
+    if (!afterSources.has(source)) continue;
+    const beforeRank = before.top_sources.indexOf(source);
+    const afterRank = after.top_sources.indexOf(source);
+    if (beforeRank === afterRank) continue;
+    rankChanges.push({
+      source,
+      before_rank: beforeRank,
+      after_rank: afterRank,
+      rank_delta: beforeRank - afterRank, // positive = improved (smaller rank index)
+    });
+  }
+  rankChanges.sort((a, b) => Math.abs(b.rank_delta) - Math.abs(a.rank_delta));
+  return {
+    result_count_delta: after.result_count - before.result_count,
+    mean_score_delta:
+      before.mean_score !== null && after.mean_score !== null
+        ? after.mean_score - before.mean_score
+        : null,
+    new_sources: newSources,
+    dropped_sources: droppedSources,
+    rank_changes: rankChanges,
+  };
+}
+
+function aggregate(cases: CompareCaseResult[]): CompareReport['aggregate'] {
+  if (cases.length === 0) {
+    return {
+      mean_result_count_delta: 0,
+      mean_score_delta: null,
+      new_sources_per_case: 0,
+      dropped_sources_per_case: 0,
+      cases_with_top1_change: 0,
+    };
+  }
+  let totalResultDelta = 0;
+  let totalScoreDelta = 0;
+  let scoreDeltaCount = 0;
+  let totalNew = 0;
+  let totalDropped = 0;
+  let top1Changes = 0;
+  for (const c of cases) {
+    totalResultDelta += c.changes.result_count_delta;
+    if (c.changes.mean_score_delta !== null) {
+      totalScoreDelta += c.changes.mean_score_delta;
+      scoreDeltaCount += 1;
+    }
+    totalNew += c.changes.new_sources.length;
+    totalDropped += c.changes.dropped_sources.length;
+    if (
+      c.before.top_sources.length > 0 &&
+      c.after.top_sources.length > 0 &&
+      c.before.top_sources[0] !== c.after.top_sources[0]
+    ) {
+      top1Changes += 1;
+    }
+  }
+  return {
+    mean_result_count_delta: totalResultDelta / cases.length,
+    mean_score_delta: scoreDeltaCount > 0 ? totalScoreDelta / scoreDeltaCount : null,
+    new_sources_per_case: totalNew / cases.length,
+    dropped_sources_per_case: totalDropped / cases.length,
+    cases_with_top1_change: top1Changes,
+  };
+}
+
+function sourceOf(result: ScoredDocument): string {
+  const meta = result.metadata as Record<string, unknown> | undefined;
+  const rel = meta?.relativePath;
+  if (typeof rel === 'string' && rel.length > 0) return rel;
+  const src = meta?.source;
+  if (typeof src === 'string' && src.length > 0) return src;
+  return '<unknown>';
+}
+
+function scoreOf(result: ScoredDocument): number {
+  const meta = result.metadata as Record<string, unknown> | undefined;
+  const score = meta?.score;
+  if (typeof score === 'number' && Number.isFinite(score)) return score;
+  return 0;
+}
+
+export function formatCompareReportMarkdown(report: CompareReport): string {
+  const lines: string[] = [];
+  lines.push(`# kb eval --compare-index`);
+  lines.push('');
+  lines.push(`- **Before**: \`${report.before_path}\``);
+  lines.push(`- **After**:  \`${report.after_path}\``);
+  lines.push(`- **Cases**:  ${report.case_count}`);
+  lines.push('');
+  lines.push('## Aggregate');
+  lines.push('');
+  lines.push(`| metric | value |`);
+  lines.push(`| --- | ---: |`);
+  lines.push(`| Mean result-count delta | ${report.aggregate.mean_result_count_delta.toFixed(2)} |`);
+  lines.push(
+    `| Mean score delta | ${
+      report.aggregate.mean_score_delta === null ? 'n/a' : report.aggregate.mean_score_delta.toFixed(4)
+    } |`,
+  );
+  lines.push(`| New sources per case (avg) | ${report.aggregate.new_sources_per_case.toFixed(2)} |`);
+  lines.push(`| Dropped sources per case (avg) | ${report.aggregate.dropped_sources_per_case.toFixed(2)} |`);
+  lines.push(`| Cases with top-1 change | ${report.aggregate.cases_with_top1_change} / ${report.case_count} |`);
+  lines.push('');
+  lines.push('## Per case');
+  lines.push('');
+  for (const c of report.cases) {
+    lines.push(`### ${c.name}`);
+    lines.push(`- Query: \`${c.query}\`${c.kb !== undefined ? `  (kb=${c.kb})` : ''}`);
+    lines.push(`- Mode: ${c.mode}`);
+    const resultDeltaStr = c.changes.result_count_delta >= 0
+      ? `+${c.changes.result_count_delta}`
+      : String(c.changes.result_count_delta);
+    lines.push(`- Results: ${c.before.result_count} → ${c.after.result_count} (Δ ${resultDeltaStr})`);
+    lines.push(
+      `- Mean score: ${formatNum(c.before.mean_score)} → ${formatNum(c.after.mean_score)} (Δ ${formatNum(c.changes.mean_score_delta, true)})`,
+    );
+    if (c.changes.new_sources.length > 0) {
+      lines.push(`- **New top-K sources**: ${c.changes.new_sources.map((s) => `\`${s}\``).join(', ')}`);
+    }
+    if (c.changes.dropped_sources.length > 0) {
+      lines.push(`- **Dropped from top-K**: ${c.changes.dropped_sources.map((s) => `\`${s}\``).join(', ')}`);
+    }
+    if (c.changes.rank_changes.length > 0) {
+      lines.push(`- **Rank shifts** (top 3):`);
+      for (const rc of c.changes.rank_changes.slice(0, 3)) {
+        const arrow = rc.rank_delta > 0 ? '↑' : '↓';
+        lines.push(`  - ${arrow} \`${rc.source}\` rank ${rc.before_rank + 1} → ${rc.after_rank + 1}`);
+      }
+    }
+    lines.push('');
+  }
+  return lines.join('\n');
+}
+
+function formatNum(value: number | null, signed = false): string {
+  if (value === null) return 'n/a';
+  if (signed) {
+    const formatted = value.toFixed(4);
+    return value > 0 ? `+${formatted}` : formatted;
+  }
+  return value.toFixed(4);
+}

--- a/src/cli-eval.ts
+++ b/src/cli-eval.ts
@@ -5,6 +5,11 @@ import {
   ActiveModelResolutionError,
   resolveActiveModel,
 } from './active-model.js';
+import {
+  formatCompareReportMarkdown,
+  resolveIndexVersionPath,
+  runCompareEval,
+} from './cli-eval-compare.js';
 import { computeStaleness, type SearchMode } from './search-core.js';
 import { loadManagerForModel, loadWithJsonRetry } from './cli-shared.js';
 import {
@@ -36,6 +41,8 @@ interface EvalRunArgs extends EvalBaseArgs {
   action: 'run';
   fixturePath: string | null;
   format: 'md' | 'json';
+  /** RFC 017 M0c — `--compare-index` activates the two-index comparison flow. */
+  compareIndex?: { before: string; after: string };
 }
 
 interface EvalScaffoldArgs extends EvalBaseArgs {
@@ -89,6 +96,15 @@ Options:
   --required-sources=<int>
                         Max unique result sources to seed in scaffold YAML
                         (default: ${DEFAULT_SCAFFOLD_REQUIRED_SOURCES}).
+  --compare-index       RFC 017 M0c — run the fixture against two FAISS
+                        index versions and emit a per-case rank/score diff
+                        report. Requires --before and --after.
+  --before=<v>          Index version to evaluate as the BEFORE side. May be
+                        a numeric version (e.g. \`42\` → \`<modelDir>/index.v42\`)
+                        or an absolute path to a directory containing
+                        \`faiss.index\` + \`docstore.json\`.
+  --after=<v>           Index version to evaluate as the AFTER side. Same
+                        format as --before.
   --help, -h            Show this help.
 
 Fixture example (YAML):
@@ -164,6 +180,34 @@ export async function runEval(rest: string[]): Promise<number> {
     return 1;
   }
 
+  // RFC 017 M0c — when `--compare-index` is set, fork off the compare
+  // path. Returns its own exit code; standard fixture-eval result
+  // formatting is bypassed.
+  if (parsed.compareIndex) {
+    try {
+      const beforePath = resolveIndexVersionPath(parsed.compareIndex.before, manager.modelDir);
+      const afterPath = resolveIndexVersionPath(parsed.compareIndex.after, manager.modelDir);
+      const report = await runCompareEval({
+        manager,
+        fixture,
+        before: beforePath,
+        after: afterPath,
+        defaultK: parsed.k,
+        defaultThreshold: parsed.threshold,
+        defaultMode: parsed.mode ?? fixture.mode ?? 'dense',
+      });
+      if (parsed.format === 'json') {
+        process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+      } else {
+        process.stdout.write(formatCompareReportMarkdown(report));
+      }
+      return 0;
+    } catch (err) {
+      process.stderr.write(`kb eval: ${(err as Error).message}\n`);
+      return 1;
+    }
+  }
+
   const results = [];
   for (const fixtureCase of fixture.cases) {
     try {
@@ -208,6 +252,13 @@ export function parseEvalArgs(rest: string[]): EvalArgs {
     threshold: DEFAULT_THRESHOLD,
     thresholdExplicit: false,
   };
+  // RFC 017 M0c — staging for --compare-index. `--compare-index` is a
+  // pure flag (no value); the two sides come from `--before=<v>` and
+  // `--after=<v>`. We collect them and assemble the final tuple after
+  // the loop so the order of flags doesn't matter.
+  let compareEnabled = false;
+  let compareBefore: string | null = null;
+  let compareAfter: string | null = null;
 
   for (const raw of args) {
     if (raw.startsWith('--fixture=')) {
@@ -263,6 +314,31 @@ export function parseEvalArgs(rest: string[]): EvalArgs {
       out.requiredSources = value;
       continue;
     }
+    if (raw === '--compare-index') {
+      if (out.action === 'scaffold') {
+        throw new Error('--compare-index is not supported for scaffold');
+      }
+      compareEnabled = true;
+      continue;
+    }
+    if (raw.startsWith('--before=')) {
+      if (out.action === 'scaffold') {
+        throw new Error('--before=<v> is not supported for scaffold');
+      }
+      const value = raw.slice('--before='.length);
+      if (value.length === 0) throw new Error('--before=<v> requires a non-empty value');
+      compareBefore = value;
+      continue;
+    }
+    if (raw.startsWith('--after=')) {
+      if (out.action === 'scaffold') {
+        throw new Error('--after=<v> is not supported for scaffold');
+      }
+      const value = raw.slice('--after='.length);
+      if (value.length === 0) throw new Error('--after=<v> requires a non-empty value');
+      compareAfter = value;
+      continue;
+    }
     if (raw.startsWith('--')) throw new Error(`unknown flag: ${raw}`);
     if (out.action === 'scaffold') {
       if (out.query !== null) throw new Error(`unexpected argument: ${JSON.stringify(raw)}`);
@@ -271,6 +347,19 @@ export function parseEvalArgs(rest: string[]): EvalArgs {
       if (out.fixturePath !== null) throw new Error(`unexpected argument: ${JSON.stringify(raw)}`);
       out.fixturePath = raw;
     }
+  }
+
+  if (compareEnabled || compareBefore !== null || compareAfter !== null) {
+    if (out.action !== 'run') {
+      throw new Error('--compare-index is only supported for the run action');
+    }
+    if (!compareEnabled) {
+      throw new Error('--before / --after require --compare-index');
+    }
+    if (compareBefore === null || compareAfter === null) {
+      throw new Error('--compare-index requires both --before=<v> and --after=<v>');
+    }
+    out.compareIndex = { before: compareBefore, after: compareAfter };
   }
 
   return out;

--- a/src/faiss-store-layout.ts
+++ b/src/faiss-store-layout.ts
@@ -144,6 +144,25 @@ export async function pruneInactiveIndexVersions(
 
 type FsOperationErrorHandler = (action: string, targetPath: string, error: unknown) => never;
 
+/**
+ * RFC 017 M0c — load a specific `index.vN/` directory directly,
+ * bypassing the `index` symlink. Used by `kb eval --compare-index` to
+ * load two different historical versions of the same model's index for
+ * a side-by-side recall comparison. Read-only (no symlink mutation, no
+ * corruption-repair side effects). Throws if the directory or its
+ * `faiss.index`/`docstore.json` contents are missing or corrupt.
+ */
+export async function loadFaissStoreFromVersionDir(options: {
+  versionDir: string;
+  embeddings: EmbeddingsInterface;
+}): Promise<FaissStore> {
+  const { versionDir, embeddings } = options;
+  if (!(await pathExists(versionDir))) {
+    throw new Error(`loadFromVersionDir: directory not found: ${versionDir}`);
+  }
+  return FaissStore.load(versionDir, embeddings);
+}
+
 export async function loadFaissStoreAtomic(options: {
   modelDir: string;
   modelId: string;


### PR DESCRIPTION
## Summary

Third implementation milestone of [RFC 017](https://github.com/jeanibarz/knowledge-base-mcp-server/blob/main/docs/rfcs/017-contextual-retrieval.md). Ships the measurement infrastructure M1's go/no-go decision depends on: a side-by-side rank/score diff between two index versions of the same model.

The single-manager design avoids holding two FAISS stores in memory at once — the orchestrator calls `manager.loadFromVersionDir(...)` for the BEFORE pass, captures results, reloads for the AFTER pass, then diffs.

## Operator workflow

```bash
# 1. Capture the BEFORE version number (whatever's currently active).
$ ls $FAISS_INDEX_PATH/models/<id>/
index -> index.v42  index.v42/  index.v41/  ...

# 2. Run the contextual reindex from M0b.
$ KB_CONTEXTUAL_RETRIEVAL=on kb reindex --with-context --kb=operating-environment

# 3. Compare against the prior version.
$ kb eval --compare-index --before=42 --after=43 fixtures/recall-canary.yml
```

## What lands

| File | Change |
| --- | --- |
| `src/faiss-store-layout.ts` | New `loadFaissStoreFromVersionDir(dir, embeddings)` — loads a specific index.vN directly, bypassing the `index` symlink. |
| `src/FaissIndexManager.ts` | New public `loadFromVersionDir(versionDir)` method; swaps the manager's in-memory store. Read-only — does not acquire the per-model write lock. |
| `src/cli-eval-compare.ts` (new) | Orchestration: `resolveIndexVersionPath` (numeric \"42\" → \`<modelDir>/index.v42\`; absolute path passthrough; relative path resolves against model dir), `assertIndexVersionDir` (fail-fast pre-flight), `runCompareEval` (two passes + diff), `formatCompareReportMarkdown` (human-readable report with aggregate table). |
| `src/cli-eval.ts` | New flags `--compare-index --before=<v> --after=<v>` parsed and dispatched. Help text updated. Output honours `--format=md|json`. |
| `src/cli-eval-compare.test.ts` (new) | 8 tests: numeric/absolute/relative path resolution; rank-reorder diff; new/dropped source detection; mean-score delta; missing faiss.index rejection; markdown formatter coverage. |

## Test plan

- [x] Type-check clean
- [x] Build clean
- [x] Full unit suite: 84/84 suites, 1408 passing, 0 failures
- [x] CLI smoke: `kb eval --help` shows new flags
- [ ] `workflow-validation` CI green
- [ ] After merge: M1 canary on `operating-environment` shelf — run a contextual reindex, then `kb eval --compare-index --before=<v_pre> --after=<v_post> fixtures/recall-canary.yml`

## Diff report fields

Per case:
- `before` / `after` snapshots — result_count, top_sources, top_scores, mean_score
- `changes` — result_count_delta, mean_score_delta, new_sources, dropped_sources, rank_changes (sorted by absolute rank shift)

Aggregate:
- mean_result_count_delta, mean_score_delta, new_sources_per_case (avg), dropped_sources_per_case (avg), cases_with_top1_change

## Deferred to follow-up PRs

- M1 — operator-driven canary on `operating-environment` shelf, with recall delta measured against this very tool
- M2 — full reindex across every shelf during the 11:00-23:00 UTC quiet window

🤖 Generated with [Claude Code](https://claude.com/claude-code)