### PR TITLE
fix(reindex-runner): construct FaissIndexManager lazily — unbreaks CI

### DIFF
--- a/src/reindex-runner.ts
+++ b/src/reindex-runner.ts
@@ -359,10 +359,18 @@ export async function runReindex(options: ReindexOptions): Promise<ReindexResult
   //    per-model write lock is acquired internally by updateIndex.
   let summary: IndexUpdateSummary;
   try {
-    const manager = options.manager ?? (await createManagerForReindex());
-    summary = options.runUpdateIndex
-      ? await options.runUpdateIndex()
-      : await runManagerUpdateIndex(manager);
+    if (options.runUpdateIndex) {
+      // Test seam (or an injecting caller): bypass manager construction
+      // entirely. `createManagerForReindex()` calls `initialize()`, which
+      // resolves the embedding provider and throws when no provider key
+      // is configured (e.g. in CI) — even though the real `updateIndex`
+      // is being mocked here. The manager is only consumed by the
+      // non-seam path below, so construct it lazily there.
+      summary = await options.runUpdateIndex();
+    } else {
+      const manager = options.manager ?? (await createManagerForReindex());
+      summary = await runManagerUpdateIndex(manager);
+    }
   } catch (err) {
     await deleteRunState();
     emitCanonicalLog({


### PR DESCRIPTION
## Summary

`main`'s `test` workflow has been **red since #364 (RFC 017 M0b, 2026-05-14)** — 7 tests in `src/reindex-runner.test.ts` fail in CI.

**Root cause:** `runReindex` constructed a `FaissIndexManager` *unconditionally* (`options.manager ?? await createManagerForReindex()`), even when the `runUpdateIndex` test seam was supplied. `createManagerForReindex()` → `initialize()` → embedding-provider resolution, which throws `HUGGINGFACE_API_KEY environment variable is required ...` when no provider key is set. CI has no key, so every result-path test failed there. Dev machines with a key set never saw it — which is why RFC 017's checkpoint reported "1408 passing" locally while CI was red.

**Fix:** the manager is only consumed on the non-seam path — construct it lazily inside the `else` branch. An injected `runUpdateIndex` now never triggers provider resolution. Production behaviour is unchanged (production callers omit `runUpdateIndex`).

## Verification

`npm run build && npm test` under a CI-like env (no `HUGGINGFACE_API_KEY` / `OPENAI_API_KEY` / `OLLAMA_HOST` / `EMBEDDING_PROVIDER`):

```
Test Suites: 86 passed, 86 total
Tests:       4 skipped, 1 todo, 1445 passed, 1450 total
```

`reindex-runner.test.ts`: 14/14 pass. No production behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)