### PR TITLE
feat(rfc-018): M0c - relevance gate observability (#371)

### DIFF
--- a/src/KnowledgeBaseServer.ts
+++ b/src/KnowledgeBaseServer.ts
@@ -615,6 +615,7 @@ export class KnowledgeBaseServer {
         candidates: similaritySearchResults,
         denseDistanceById,
         gateOverride,
+        process: 'mcp',
       });
       similaritySearchResults = gate.results;
       emitRelevanceGateDecision({
@@ -623,6 +624,8 @@ export class KnowledgeBaseServer {
         kbScope: knowledgeBaseName ?? null,
         searchMode,
         verdict: gate.verdict,
+        taskContext,
+        observability: gate.observability,
       });
       if (process.env.KB_LOG_VERBOSE === '1') {
         logger.debug(`[${Date.now()}] Similarity search completed`);
@@ -761,6 +764,7 @@ export class KnowledgeBaseServer {
         denseDistanceById: fusion.denseDistanceById,
         lexicalHitIds: fusion.lexicalHitIds,
         gateOverride,
+        process: 'mcp',
       });
       ranked = gate.results;
       emitRelevanceGateDecision({
@@ -769,6 +773,8 @@ export class KnowledgeBaseServer {
         kbScope: knowledgeBaseName ?? null,
         searchMode: 'hybrid',
         verdict: gate.verdict,
+        taskContext,
+        observability: gate.observability,
       });
 
       const formatStartedAt = Date.now();

--- a/src/canonical-log.ts
+++ b/src/canonical-log.ts
@@ -33,6 +33,8 @@ export interface CanonicalLogEvent {
   ts: string;
   request_id: string;
   process: CanonicalProcess;
+  event?: string;
+  level?: 'warn';
   tool?: string;
   cmd?: string;
   model_id?: string;
@@ -51,6 +53,8 @@ export interface CanonicalLogEvent {
   format_ms?: number;
   cache?: CanonicalCacheStatus;
   error?: CanonicalError;
+  recovery_hint?: string;
+  gate?: Record<string, unknown>;
 }
 
 export type CanonicalLogInput = Omit<
@@ -68,6 +72,8 @@ const CANONICAL_FIELD_ORDER: readonly (keyof CanonicalLogEvent)[] = [
   'ts',
   'request_id',
   'process',
+  'event',
+  'level',
   'tool',
   'cmd',
   'model_id',
@@ -86,6 +92,8 @@ const CANONICAL_FIELD_ORDER: readonly (keyof CanonicalLogEvent)[] = [
   'format_ms',
   'cache',
   'error',
+  'recovery_hint',
+  'gate',
 ];
 
 export function createCanonicalRequestId(): string {
@@ -110,6 +118,8 @@ export function normalizeCanonicalEvent(input: CanonicalLogInput): CanonicalLogE
   };
 
   assignIfDefined(event, 'tool', input.tool);
+  assignIfDefined(event, 'event', input.event);
+  assignIfDefined(event, 'level', input.level);
   assignIfDefined(event, 'cmd', input.cmd);
   assignIfDefined(event, 'model_id', input.model_id);
   assignIfDefined(event, 'kb_scope', input.kb_scope);
@@ -126,6 +136,8 @@ export function normalizeCanonicalEvent(input: CanonicalLogInput): CanonicalLogE
   assignIfDefined(event, 'format_ms', roundNonNegative(input.format_ms));
   assignIfDefined(event, 'cache', input.cache);
   assignIfDefined(event, 'error', input.error);
+  assignIfDefined(event, 'recovery_hint', input.recovery_hint);
+  assignIfDefined(event, 'gate', input.gate);
 
   return event;
 }

--- a/src/cli-eval.ts
+++ b/src/cli-eval.ts
@@ -463,6 +463,17 @@ export function toJsonReport(report: ReturnType<typeof summarizeRetrievalEval>):
       requested_mode: result.requestedMode,
       effective_mode: result.effectiveMode,
       ...(result.autoMode !== undefined ? { auto_mode: result.autoMode } : {}),
+      ...(result.expectedGateVerdict !== undefined ? {
+        expected_gate_verdict: {
+          state: result.expectedGateVerdict.state,
+          ...(result.expectedGateVerdict.provenance !== undefined
+            ? { provenance: result.expectedGateVerdict.provenance }
+            : {}),
+          ...(result.expectedGateVerdict.verification !== undefined
+            ? { verification: result.expectedGateVerdict.verification }
+            : {}),
+        },
+      } : {}),
       passed: result.passed,
       failures: result.failures,
       warnings: result.warnings,

--- a/src/cli-search.test.ts
+++ b/src/cli-search.test.ts
@@ -126,6 +126,14 @@ describe('parseSearchArgs --explain-empty (#328)', () => {
   });
 });
 
+describe('parseSearchArgs --explain (RFC 018 M0c)', () => {
+  it('accepts relevance-gate explanation output', () => {
+    expect(parseSearchArgs(['query', '--explain'])).toMatchObject({
+      explain: true,
+    });
+  });
+});
+
 describe('parseSearchArgs relevance gate (RFC 018)', () => {
   it('accepts gate overrides and task context inputs', () => {
     expect(parseSearchArgs([
@@ -265,6 +273,36 @@ describe('runSearch timing guard (#331)', () => {
 
     expect(out.code).toBe(0);
     expect(out.stdout).toContain('> _Relevance gate: injected; kept 1/1._');
+  });
+
+  it('renders the relevance gate dropped list when --explain is used', () => {
+    const out = formatDenseSearchMarkdownOutput({
+      results: [],
+      groupBySource: false,
+      staleness: null,
+      refreshed: false,
+      autoModeDecision: null,
+      autoThresholdDecision: null,
+      timing: null,
+      explain: true,
+      gateVerdict: {
+        schema_version: 'kb.relevance-gate.v1',
+        state: 'injected',
+        low_confidence: false,
+        input_count: 2,
+        output_count: 1,
+        dropped: [{
+          id: '/kb/a.md#1',
+          stage: 'A2-distribution-knee',
+          reason: 'after score-distribution knee',
+        }],
+        judge: { status: 'skipped', reason: 'task_context absent or too short' },
+        empty_verdict_enabled: false,
+      },
+    });
+
+    expect(out).toContain('> _Relevance gate dropped candidates:_');
+    expect(out).toContain('> - /kb/a.md#1 (A2-distribution-knee): after score-distribution knee');
   });
 });
 

--- a/src/cli-search.ts
+++ b/src/cli-search.ts
@@ -59,6 +59,7 @@ import {
 import {
   applyRelevanceGate,
   emitRelevanceGateDecision,
+  formatGateDroppedList,
   formatGateVerdictFooter,
   type RelevanceGateOverride,
 } from './relevance-gate.js';
@@ -145,6 +146,8 @@ Output:
                         filter candidate counts, per-filter drops, scope,
                         index freshness, and the nearest non-matching
                         candidates. Has no effect when results are non-empty.
+  --explain             Include relevance-gate dropped-candidate details in
+                        markdown output. JSON always includes gate_verdict.
 
 Indexing:
   --refresh             Re-scan KB files; acquires the per-model write lock.
@@ -186,6 +189,7 @@ interface SearchArgs {
   noCache: boolean;
   freshness: boolean;
   explainEmpty: boolean;
+  explain: boolean;
   neighborContext?: NeighborContextOptions;
   gateOverride?: RelevanceGateOverride;
   taskContext?: string;
@@ -371,6 +375,7 @@ export async function runSearch(
       candidates: results,
       denseDistanceById,
       gateOverride: parsed.gateOverride,
+      process: 'cli',
     });
     results = gate.results;
     gateVerdict = gate.verdict;
@@ -380,6 +385,7 @@ export async function runSearch(
       kbScope: parsed.kb ?? null,
       searchMode: effectiveMode,
       verdict: gateVerdict,
+      observability: gate.observability,
     });
   } catch (err) {
     return reportFailure(classifyKbSearchError(err), parsed.format);
@@ -442,6 +448,7 @@ export async function runSearch(
       timing,
       explainEmptyDiagnostics,
       gateVerdict,
+      explain: parsed.explain,
     }));
   }
 
@@ -524,6 +531,7 @@ export function parseSearchArgs(rest: string[]): SearchArgs {
     noCache: false,
     freshness: true,
     explainEmpty: false,
+    explain: false,
   };
   for (const raw of rest) {
     if (raw === '--refresh') { out.refresh = true; continue; }
@@ -535,6 +543,7 @@ export function parseSearchArgs(rest: string[]): SearchArgs {
     if (raw === '--no-gate') { out.gateOverride = 'off'; continue; }
     if (raw === '--no-freshness') { out.freshness = false; continue; }
     if (raw === '--explain-empty') { out.explainEmpty = true; continue; }
+    if (raw === '--explain') { out.explain = true; continue; }
     if (raw === '--interactive' || raw === '-i') { out.interactive = true; continue; }
     if (raw.startsWith('--context-before=')) {
       out.neighborContext = {
@@ -863,6 +872,7 @@ export interface DenseSearchMarkdownOutputInput {
   /** Issue #328 — opt-in deep diagnostics block, rendered only when results is empty. */
   explainEmptyDiagnostics?: ExplainEmptyDiagnostics | null;
   gateVerdict?: RelevanceGateVerdict;
+  explain?: boolean;
 }
 
 export function formatDenseSearchMarkdownOutput(input: DenseSearchMarkdownOutputInput): string {
@@ -902,6 +912,9 @@ export function formatDenseSearchMarkdownOutput(input: DenseSearchMarkdownOutput
   const gateVerdict = input.gateVerdict ?? defaultBypassedGateVerdict(input.results.length);
   if (gateVerdict.state !== 'bypassed') {
     output += `${formatGateVerdictFooter(gateVerdict)}\n`;
+  }
+  if (input.explain) {
+    output += `${formatGateDroppedList(gateVerdict)}\n`;
   }
   if (input.timing) {
     output += `${formatTimingFooter('Timing', input.timing)}\n`;
@@ -1267,6 +1280,7 @@ async function runHybridSearch(
       denseDistanceById: fusion.denseDistanceById,
       lexicalHitIds: fusion.lexicalHitIds,
       gateOverride: parsed.gateOverride,
+      process: 'cli',
     });
     ranked = gate.results;
     gateVerdict = gate.verdict;
@@ -1276,6 +1290,7 @@ async function runHybridSearch(
       kbScope: parsed.kb ?? null,
       searchMode: 'hybrid',
       verdict: gateVerdict,
+      observability: gate.observability,
     });
   } catch (err) {
     return reportFailure(classifyKbSearchError(err), parsed.format);
@@ -1321,6 +1336,9 @@ async function runHybridSearch(
     );
     if (gateVerdict.state !== 'bypassed') {
       process.stdout.write(`${formatGateVerdictFooter(gateVerdict)}\n`);
+    }
+    if (parsed.explain) {
+      process.stdout.write(`${formatGateDroppedList(gateVerdict)}\n`);
     }
     if (timing) {
       process.stdout.write(formatTimingFooter('Timing', timing));

--- a/src/cli-stats.test.ts
+++ b/src/cli-stats.test.ts
@@ -69,6 +69,23 @@ function payload(): KbStatsPayload {
       l1_size: 0,
       disk_size_bytes: 0,
     },
+    relevance_gate: {
+      gated_queries: 0,
+      verdict_injected: 0,
+      verdict_no_relevant_context: 0,
+      verdict_empty_index: 0,
+      low_confidence_rate: 0,
+      drop_rate_A1: 0,
+      drop_rate_A2: 0,
+      drop_rate_B: 0,
+      judge_degrade_rate: 0,
+      judge_window: {
+        size: 0,
+        degraded: 0,
+        rate: 0,
+        warn_threshold: 0.1,
+      },
+    },
   };
 }
 
@@ -150,6 +167,8 @@ describe('kb stats CLI', () => {
     expect(out).toContain('- Provider: ollama');
     expect(out).toContain('- Model: nomic-embed-text:latest');
     expect(out).toContain('- Index path: `/tmp/kb-index`');
+    expect(out).toContain('## Relevance Gate');
+    expect(out).toContain('- Gated queries: 0');
   });
 
   it('returns exit 2 for argv errors', async () => {

--- a/src/cli-stats.ts
+++ b/src/cli-stats.ts
@@ -20,6 +20,7 @@ Usage:
 
 Mirrors the MCP \`kb_stats\` payload for local shell use: per-KB file/chunk/byte
 counts, last-indexed time, embedding model, index path, and version context.
+Includes process-lifetime relevance-gate counters when the gate has run.
 Strictly read-only — does not refresh the index.
 
 Options:
@@ -154,6 +155,20 @@ export function formatStatsMarkdown(payload: KbStatsPayload): string {
     `- Server version: ${payload.server.version}`,
     `- Uptime: ${formatInteger(uptimeMs)} ms`,
     '',
+    '## Relevance Gate',
+    '',
+    `- Gated queries: ${formatInteger(payload.relevance_gate.gated_queries)}`,
+    `- Verdicts: injected=${formatInteger(payload.relevance_gate.verdict_injected)}, ` +
+      `no_relevant_context=${formatInteger(payload.relevance_gate.verdict_no_relevant_context)}, ` +
+      `empty_index=${formatInteger(payload.relevance_gate.verdict_empty_index)}`,
+    `- Low confidence rate: ${formatRate(payload.relevance_gate.low_confidence_rate)}`,
+    `- Drop rates: A1=${formatRate(payload.relevance_gate.drop_rate_A1)}, ` +
+      `A2=${formatRate(payload.relevance_gate.drop_rate_A2)}, B=${formatRate(payload.relevance_gate.drop_rate_B)}`,
+    `- Judge degrade rate: ${formatRate(payload.relevance_gate.judge_degrade_rate)} ` +
+      `(window ${formatInteger(payload.relevance_gate.judge_window.degraded)}/` +
+      `${formatInteger(payload.relevance_gate.judge_window.size)}, ` +
+      `warn>${formatRate(payload.relevance_gate.judge_window.warn_threshold)})`,
+    '',
   ].join('\n');
 }
 
@@ -163,6 +178,10 @@ function escapeTableCell(value: string): string {
 
 function formatInteger(value: number): string {
   return new Intl.NumberFormat('en-US', { maximumFractionDigits: 0 }).format(value);
+}
+
+function formatRate(value: number): string {
+  return `${(value * 100).toFixed(1)}%`;
 }
 
 function readPackageVersion(): string {

--- a/src/kb-stats.ts
+++ b/src/kb-stats.ts
@@ -34,6 +34,10 @@ import {
 } from './metrics.js';
 import { countIngestQuarantine } from './ingest-quarantine.js';
 import { queryEmbeddingCache, type QueryCacheStats } from './query-cache.js';
+import {
+  relevanceGateMetrics,
+  type RelevanceGateMetricsSnapshot,
+} from './relevance-gate-metrics.js';
 
 export interface KbStatsRow {
   file_count: number;
@@ -78,6 +82,7 @@ export interface KbStatsPayload {
    */
   provider_calls: Record<string, ProviderCallSnapshot>;
   query_cache: QueryCacheStats;
+  relevance_gate: RelevanceGateMetricsSnapshot;
 }
 
 export interface ComputeKbStatsOptions {
@@ -195,6 +200,7 @@ export async function computeKbStats(
     },
     provider_calls: metricsSource.snapshot(),
     query_cache: await queryEmbeddingCache.stats(),
+    relevance_gate: relevanceGateMetrics.snapshot(),
   };
 }
 

--- a/src/relevance-gate-metrics.ts
+++ b/src/relevance-gate-metrics.ts
@@ -1,0 +1,133 @@
+import { emitCanonicalLog, type CanonicalProcess } from './canonical-log.js';
+import type { RelevanceGateVerdict } from './relevance-gate-schema.js';
+
+export interface RelevanceGateMetricsSnapshot {
+  gated_queries: number;
+  verdict_injected: number;
+  verdict_no_relevant_context: number;
+  verdict_empty_index: number;
+  low_confidence_rate: number;
+  drop_rate_A1: number;
+  drop_rate_A2: number;
+  drop_rate_B: number;
+  judge_degrade_rate: number;
+  judge_window: {
+    size: number;
+    degraded: number;
+    rate: number;
+    warn_threshold: number;
+  };
+}
+
+const JUDGE_WINDOW_SIZE = 50;
+const JUDGE_WARN_THRESHOLD = 0.10;
+const JUDGE_WARN_MIN_SAMPLES = 5;
+
+export class RelevanceGateMetrics {
+  private gatedQueries = 0;
+  private verdictInjected = 0;
+  private verdictNoRelevantContext = 0;
+  private verdictEmptyIndex = 0;
+  private lowConfidence = 0;
+  private inputCandidates = 0;
+  private stageDrops = { A1: 0, A2: 0, B: 0 };
+  private judgeRuns = 0;
+  private judgeDegrades = 0;
+  private judgeWindow: boolean[] = [];
+  private lastWarnedWindow: string | null = null;
+
+  record(verdict: RelevanceGateVerdict, process: CanonicalProcess = 'cli'): void {
+    if (verdict.state === 'bypassed') return;
+
+    this.gatedQueries += 1;
+    this.inputCandidates += verdict.input_count;
+    if (verdict.low_confidence) this.lowConfidence += 1;
+    if (verdict.state === 'injected') this.verdictInjected += 1;
+    if (verdict.state === 'no-relevant-context') this.verdictNoRelevantContext += 1;
+    if (verdict.state === 'empty-index') this.verdictEmptyIndex += 1;
+
+    for (const drop of verdict.dropped) {
+      if (drop.stage.startsWith('A1-')) this.stageDrops.A1 += 1;
+      if (drop.stage.startsWith('A2-')) this.stageDrops.A2 += 1;
+      if (drop.stage.startsWith('B-')) this.stageDrops.B += 1;
+    }
+
+    if (verdict.judge.status === 'succeeded' || verdict.judge.status === 'failed') {
+      const degraded = verdict.judge.status === 'failed';
+      this.judgeRuns += 1;
+      if (degraded) this.judgeDegrades += 1;
+      this.judgeWindow.push(degraded);
+      if (this.judgeWindow.length > JUDGE_WINDOW_SIZE) this.judgeWindow.shift();
+      this.maybeEmitDegradeAlarm(process);
+    }
+  }
+
+  snapshot(): RelevanceGateMetricsSnapshot {
+    const windowDegraded = this.judgeWindow.filter(Boolean).length;
+    const windowRate = rate(windowDegraded, this.judgeWindow.length);
+    return {
+      gated_queries: this.gatedQueries,
+      verdict_injected: this.verdictInjected,
+      verdict_no_relevant_context: this.verdictNoRelevantContext,
+      verdict_empty_index: this.verdictEmptyIndex,
+      low_confidence_rate: rate(this.lowConfidence, this.gatedQueries),
+      drop_rate_A1: rate(this.stageDrops.A1, this.inputCandidates),
+      drop_rate_A2: rate(this.stageDrops.A2, this.inputCandidates),
+      drop_rate_B: rate(this.stageDrops.B, this.inputCandidates),
+      judge_degrade_rate: rate(this.judgeDegrades, this.judgeRuns),
+      judge_window: {
+        size: this.judgeWindow.length,
+        degraded: windowDegraded,
+        rate: windowRate,
+        warn_threshold: JUDGE_WARN_THRESHOLD,
+      },
+    };
+  }
+
+  reset(): void {
+    this.gatedQueries = 0;
+    this.verdictInjected = 0;
+    this.verdictNoRelevantContext = 0;
+    this.verdictEmptyIndex = 0;
+    this.lowConfidence = 0;
+    this.inputCandidates = 0;
+    this.stageDrops = { A1: 0, A2: 0, B: 0 };
+    this.judgeRuns = 0;
+    this.judgeDegrades = 0;
+    this.judgeWindow = [];
+    this.lastWarnedWindow = null;
+  }
+
+  private maybeEmitDegradeAlarm(process: CanonicalProcess): void {
+    if (this.judgeWindow.length < JUDGE_WARN_MIN_SAMPLES) return;
+    const degraded = this.judgeWindow.filter(Boolean).length;
+    const currentRate = rate(degraded, this.judgeWindow.length);
+    if (currentRate <= JUDGE_WARN_THRESHOLD) return;
+    const windowKey = this.judgeWindow.map((value) => value ? '1' : '0').join('');
+    if (this.lastWarnedWindow === windowKey) return;
+    this.lastWarnedWindow = windowKey;
+    emitCanonicalLog({
+      process,
+      event: 'relevance-gate.degrade-rate',
+      level: 'warn',
+      tool: process === 'mcp' ? 'relevance-gate.degrade-rate' : undefined,
+      cmd: process === 'cli' ? 'relevance-gate.degrade-rate' : undefined,
+      took_ms: 0,
+      recovery_hint:
+        'Check KB_GATE_LLM_ENDPOINT / KB_GATE_LLM_MODEL health; the relevance gate is degrading to the statistical path.',
+      gate: {
+        judge_window_size: this.judgeWindow.length,
+        judge_window_degraded: degraded,
+        judge_degrade_rate: currentRate,
+        warn_threshold: JUDGE_WARN_THRESHOLD,
+      },
+    });
+  }
+}
+
+function rate(numerator: number, denominator: number): number {
+  if (denominator <= 0) return 0;
+  return Math.round((numerator / denominator) * 10000) / 10000;
+}
+
+export const relevanceGateMetrics = new RelevanceGateMetrics();

--- a/src/relevance-gate.test.ts
+++ b/src/relevance-gate.test.ts
@@ -1,7 +1,9 @@
-import { describe, expect, it } from '@jest/globals';
-import { applyRelevanceGate } from './relevance-gate.js';
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { applyRelevanceGate, emitRelevanceGateDecision } from './relevance-gate.js';
 import type { RelevanceGateConfig } from './config/relevance-gate.js';
 import { chunkIdFromMetadata } from './rrf.js';
+import { RelevanceGateMetrics, relevanceGateMetrics } from './relevance-gate-metrics.js';
+import type { RelevanceGateVerdict } from './relevance-gate-schema.js';
 
 function config(overrides: Partial<RelevanceGateConfig> = {}): RelevanceGateConfig {
   return {
@@ -36,7 +38,25 @@ function fakeFetchJson(content: string): typeof fetch {
   }), { status: 200, headers: { 'Content-Type': 'application/json' } })) as unknown as typeof fetch;
 }
 
+function metricVerdict(overrides: Partial<RelevanceGateVerdict> = {}): RelevanceGateVerdict {
+  return {
+    schema_version: 'kb.relevance-gate.v1',
+    state: 'injected',
+    low_confidence: false,
+    input_count: 1,
+    output_count: 1,
+    dropped: [],
+    judge: { status: 'not-run' },
+    empty_verdict_enabled: false,
+    ...overrides,
+  };
+}
+
 describe('relevance gate', () => {
+  beforeEach(() => {
+    relevanceGateMetrics.reset();
+  });
+
   it('bypasses by default when the feature flag is off', async () => {
     const rows = [candidate('/kb/a.md', 0, 0.2, 'alpha')];
     const result = await applyRelevanceGate({
@@ -243,5 +263,168 @@ describe('relevance gate', () => {
 
     const cached = await applyRelevanceGate(input);
     expect(cached.results).toEqual(rows);
+  });
+
+  it('records exact A2 drop-rate counters for kb stats', async () => {
+    const rows = [
+      candidate('/kb/a.md', 0, 0.1, 'near'),
+      candidate('/kb/a.md', 1, 0.2, 'also near'),
+      candidate('/kb/a.md', 2, 1.4, 'far'),
+    ];
+
+    await applyRelevanceGate({
+      query: 'metrics drop',
+      candidates: rows,
+      config: config({ judgeEndpoint: undefined }),
+    });
+
+    expect(relevanceGateMetrics.snapshot()).toMatchObject({
+      gated_queries: 1,
+      verdict_injected: 1,
+      low_confidence_rate: 0,
+      drop_rate_A1: 0,
+      drop_rate_A2: 0.3333,
+      drop_rate_B: 0,
+    });
+  });
+
+  it('records exact A1 drop-rate counters for kb stats', async () => {
+    const rows = [
+      candidate('/kb/a.md', 0, 0.1, 'near'),
+      candidate('/kb/b.md', 0, 0.2, 'far by dense distance'),
+    ];
+
+    await applyRelevanceGate({
+      query: 'metrics a1 drop',
+      candidates: rows,
+      denseDistanceById: new Map([
+        [idOf(rows[0]), 0.1],
+        [idOf(rows[1]), 1.2],
+      ]),
+      config: config({ judgeEndpoint: undefined }),
+    });
+
+    expect(relevanceGateMetrics.snapshot()).toMatchObject({
+      gated_queries: 1,
+      verdict_injected: 1,
+      drop_rate_A1: 0.5,
+      drop_rate_A2: 0,
+      drop_rate_B: 0,
+    });
+  });
+
+  it('records exact Stage B drop-rate counters for kb stats', async () => {
+    const rows = [
+      candidate('/kb/a.md', 0, 0.1, 'deployment rollback checklist'),
+      candidate('/kb/b.md', 0, 0.1, 'obsolete deployment rollback notes'),
+    ];
+
+    await applyRelevanceGate({
+      query: 'metrics b drop',
+      taskContext: 'please answer a deployment rollback question with precise operational context',
+      candidates: rows,
+      config: config(),
+      fetchImpl: fakeFetchJson('{"overall":"relevant","verdicts":[{"id":"/kb/a.md#0","decision":"keep","reason":"rollback checklist"},{"id":"/kb/b.md#0","decision":"drop","reason":"obsolete deployment rollback"}]}'),
+    });
+
+    expect(relevanceGateMetrics.snapshot()).toMatchObject({
+      gated_queries: 1,
+      verdict_injected: 1,
+      drop_rate_A1: 0,
+      drop_rate_A2: 0,
+      drop_rate_B: 0.5,
+    });
+  });
+
+  it('records empty-index and no-relevant-context verdict counters for kb stats', async () => {
+    await applyRelevanceGate({
+      query: 'metrics empty index',
+      candidates: [],
+      config: config(),
+    });
+    await applyRelevanceGate({
+      query: 'metrics no relevant context',
+      taskContext: 'please answer a deployment rollback question with precise operational context',
+      candidates: [candidate('/kb/a.md', 0, 0.1, 'deployment rollback')],
+      config: config({ emptyVerdictEnabled: true }),
+      fetchImpl: fakeFetchJson('{"overall":"no-relevant-context","verdicts":[]}'),
+    });
+
+    expect(relevanceGateMetrics.snapshot()).toMatchObject({
+      gated_queries: 2,
+      verdict_empty_index: 1,
+      verdict_no_relevant_context: 1,
+    });
+  });
+
+  it('emits process-aware canonical alarms when judge degrade rate is high', () => {
+    const metrics = new RelevanceGateMetrics();
+    const stderr = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    try {
+      for (let i = 0; i < 5; i += 1) {
+        metrics.record(metricVerdict({
+          judge: { status: 'failed', reason: 'judge unavailable' },
+        }), 'mcp');
+      }
+
+      const event = JSON.parse(String(stderr.mock.calls.at(-1)?.[0]).trim());
+      expect(event).toMatchObject({
+        process: 'mcp',
+        event: 'relevance-gate.degrade-rate',
+        level: 'warn',
+        tool: 'relevance-gate.degrade-rate',
+        recovery_hint: expect.stringContaining('KB_GATE_LLM_ENDPOINT'),
+        gate: {
+          judge_window_size: 5,
+          judge_window_degraded: 5,
+          judge_degrade_rate: 1,
+          warn_threshold: 0.1,
+        },
+      });
+      expect(event.cmd).toBeUndefined();
+    } finally {
+      stderr.mockRestore();
+    }
+  });
+
+  it('emits reproduction fields in the canonical decision event', async () => {
+    const rows = [candidate('/kb/a.md', 0, 0.2, 'deployment rollback')];
+    const gate = await applyRelevanceGate({
+      query: 'canonical fields',
+      taskContext: 'please answer a deployment rollback question with precise operational context',
+      candidates: rows,
+      config: config(),
+      fetchImpl: fakeFetchJson('{"overall":"relevant","verdicts":[{"id":"/kb/a.md#0","decision":"keep","reason":"rollback"}]}'),
+    });
+    const stderr = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    try {
+      emitRelevanceGateDecision({
+        process: 'cli',
+        query: 'canonical fields',
+        taskContext: 'please answer a deployment rollback question with precise operational context',
+        searchMode: 'dense',
+        verdict: gate.verdict,
+        observability: gate.observability,
+      });
+      const line = String(stderr.mock.calls[0][0]).trim();
+      const event = JSON.parse(line);
+      expect(event.cmd).toBe('relevance-gate.decision');
+      expect(event.gate).toMatchObject({
+        query_sha: expect.any(String),
+        task_context_sha: expect.any(String),
+        judge_model: 'judge-model',
+        judge_prompt_hash: expect.any(String),
+        floor: 0.95,
+        degraded: false,
+      });
+      expect(event.gate.candidates[0]).toMatchObject({
+        id: '/kb/a.md#0',
+        content_sha: expect.any(String),
+        decision: 'kept',
+      });
+      expect(event.gate.shuffled_order).toEqual(['/kb/a.md#0']);
+    } finally {
+      stderr.mockRestore();
+    }
   });
 });

--- a/src/relevance-gate.ts
+++ b/src/relevance-gate.ts
@@ -14,6 +14,7 @@ import {
   RELEVANCE_GATE_SCHEMA_VERSION,
   type RelevanceGateVerdict,
 } from './relevance-gate-schema.js';
+import { relevanceGateMetrics } from './relevance-gate-metrics.js';
 
 export type RelevanceGateOverride = 'on' | 'off' | undefined;
 
@@ -30,19 +31,44 @@ export interface RelevanceGateInput<T extends RelevanceGateCandidate = Relevance
   gateOverride?: RelevanceGateOverride;
   config?: RelevanceGateConfig;
   fetchImpl?: typeof fetch;
+  process?: CanonicalProcess;
 }
 
 export interface RelevanceGateResult<T extends RelevanceGateCandidate = RelevanceGateCandidate> {
   results: T[];
   verdict: RelevanceGateVerdict;
+  observability: RelevanceGateObservability;
 }
 
 export interface RelevanceGateCanonicalInput {
   process: CanonicalProcess;
   query: string;
+  taskContext?: string;
   kbScope?: string | null;
   searchMode: CanonicalSearchMode;
   verdict: RelevanceGateVerdict;
+  observability?: RelevanceGateObservability;
+}
+
+export interface RelevanceGateObservability {
+  task_context_sha: string | null;
+  query_sha: string;
+  floor: number;
+  judge_model: string | null;
+  judge_prompt_hash: string | null;
+  shuffled_order: string[];
+  degraded: boolean;
+  degrade_reason: string | null;
+  judge_skipped: string | null;
+  candidates: RelevanceGateCandidateReproduction[];
+}
+
+export interface RelevanceGateCandidateReproduction {
+  id: string;
+  content_sha: string;
+  decision: 'kept' | 'dropped';
+  stage: string | null;
+  reason: string | null;
 }
 
 interface CandidateRow<T extends RelevanceGateCandidate> {
@@ -60,6 +86,7 @@ interface DropRecord {
 interface CachedGateDecision {
   verdict: RelevanceGateVerdict;
   resultIds: Set<string>;
+  observability: RelevanceGateObservability;
 }
 
 const verdictCache = new Map<string, CachedGateDecision>();
@@ -70,27 +97,48 @@ export async function applyRelevanceGate<T extends RelevanceGateCandidate>(
   const config = input.config ?? resolveRelevanceGateConfig();
   const enabled = input.gateOverride === 'on' || (config.enabled && input.gateOverride !== 'off');
   if (!enabled) {
+    const verdict = buildVerdict({
+      state: 'bypassed',
+      inputCount: input.candidates.length,
+      outputCount: input.candidates.length,
+      emptyVerdictEnabled: config.emptyVerdictEnabled,
+      judge: { status: 'not-run', reason: 'gate disabled' },
+    });
     return {
       results: input.candidates,
-      verdict: buildVerdict({
-        state: 'bypassed',
-        inputCount: input.candidates.length,
-        outputCount: input.candidates.length,
-        emptyVerdictEnabled: config.emptyVerdictEnabled,
-        judge: { status: 'not-run', reason: 'gate disabled' },
+      verdict,
+      observability: buildObservability({
+        query: input.query,
+        taskContext: input.taskContext,
+        config,
+        rows: rowsForObservability(input.candidates),
+        survivors: rowsForObservability(input.candidates),
+        dropped: [],
+        judge: verdict.judge,
       }),
     };
   }
 
   if (input.candidates.length === 0) {
+    const verdict = buildVerdict({
+      state: 'empty-index',
+      inputCount: 0,
+      outputCount: 0,
+      emptyVerdictEnabled: config.emptyVerdictEnabled,
+      judge: { status: 'not-run', reason: 'no candidates' },
+    });
+    relevanceGateMetrics.record(verdict, input.process);
     return {
       results: [],
-      verdict: buildVerdict({
-        state: 'empty-index',
-        inputCount: 0,
-        outputCount: 0,
-        emptyVerdictEnabled: config.emptyVerdictEnabled,
-        judge: { status: 'not-run', reason: 'no candidates' },
+      verdict,
+      observability: buildObservability({
+        query: input.query,
+        taskContext: input.taskContext,
+        config,
+        rows: [],
+        survivors: [],
+        dropped: [],
+        judge: verdict.judge,
       }),
     };
   }
@@ -98,9 +146,11 @@ export async function applyRelevanceGate<T extends RelevanceGateCandidate>(
   const cacheKey = buildCacheKey(input, config);
   const cached = verdictCache.get(cacheKey);
   if (cached !== undefined) {
+    relevanceGateMetrics.record(cached.verdict, input.process);
     return {
       results: replayVerdict(input.candidates, cached),
       verdict: cached.verdict,
+      observability: cached.observability,
     };
   }
 
@@ -115,6 +165,8 @@ export async function applyRelevanceGate<T extends RelevanceGateCandidate>(
   const lexicalHitIds = input.lexicalHitIds ?? new Set<string>();
   let survivors: CandidateRow<T>[];
   let judge: RelevanceGateVerdict['judge'];
+  let judgePromptHash: string | null = null;
+  let shuffledOrder: string[] = [];
   let lowConfidence = false;
   let state: RelevanceGateVerdict['state'] = 'injected';
 
@@ -139,6 +191,8 @@ export async function applyRelevanceGate<T extends RelevanceGateCandidate>(
     judge = judged.judge;
     state = judged.state;
     if (judged.lowConfidence) lowConfidence = true;
+    judgePromptHash = judged.judgePromptHash;
+    shuffledOrder = judged.shuffledOrder;
     if (judged.degraded) {
       survivors = applyA2(afterA1, dropped, input.denseDistanceById);
     }
@@ -162,11 +216,24 @@ export async function applyRelevanceGate<T extends RelevanceGateCandidate>(
     judge,
     emptyVerdictEnabled: config.emptyVerdictEnabled,
   });
+  const observability = buildObservability({
+    query: input.query,
+    taskContext: input.taskContext,
+    config,
+    rows,
+    survivors,
+    dropped,
+    judge,
+    judgePromptHash,
+    shuffledOrder,
+  });
+  relevanceGateMetrics.record(verdict, input.process);
   verdictCache.set(cacheKey, {
     verdict,
     resultIds: new Set(survivors.map((row) => row.id)),
+    observability,
   });
-  return { results, verdict };
+  return { results, verdict, observability };
 }
 
 export function emitRelevanceGateDecision(input: RelevanceGateCanonicalInput): void {
@@ -180,6 +247,26 @@ export function emitRelevanceGateDecision(input: RelevanceGateCanonicalInput): v
     search_mode: input.searchMode,
     result_count: input.verdict.output_count,
     took_ms: 0,
+    gate: {
+      state: input.verdict.state,
+      input_count: input.verdict.input_count,
+      output_count: input.verdict.output_count,
+      low_confidence: input.verdict.low_confidence,
+      task_context_sha: input.observability?.task_context_sha ?? hashNullable(input.taskContext),
+      query_sha: input.observability?.query_sha ?? shortHash(input.query),
+      candidates: input.observability?.candidates ?? [],
+      judge_model: input.observability?.judge_model ?? input.verdict.judge.model ?? null,
+      judge_prompt_hash: input.observability?.judge_prompt_hash ?? null,
+      floor: input.observability?.floor ?? null,
+      shuffled_order: input.observability?.shuffled_order ?? [],
+      degraded: input.observability?.degraded ?? (input.verdict.judge.status === 'failed'),
+      degrade_reason:
+        input.observability?.degrade_reason ??
+        (input.verdict.judge.status === 'failed' ? input.verdict.judge.reason ?? 'judge failed' : null),
+      judge_skipped:
+        input.observability?.judge_skipped ??
+        (input.verdict.judge.status === 'skipped' ? input.verdict.judge.reason ?? 'skipped' : null),
+    },
   });
 }
 
@@ -190,6 +277,18 @@ export function formatGateVerdictFooter(verdict: RelevanceGateVerdict): string {
   const low = verdict.low_confidence ? '; low confidence' : '';
   const judge = verdict.judge.status === 'failed' ? '; judge degraded' : '';
   return `> _Relevance gate: ${verdict.state}; kept ${verdict.output_count}/${verdict.input_count}${low}${judge}._`;
+}
+
+export function formatGateDroppedList(verdict: RelevanceGateVerdict): string {
+  const lines = ['> _Relevance gate dropped candidates:_'];
+  if (verdict.dropped.length === 0) {
+    lines.push('> - none');
+    return lines.join('\n');
+  }
+  for (const drop of verdict.dropped) {
+    lines.push(`> - ${drop.id} (${drop.stage}): ${drop.reason}`);
+  }
+  return lines.join('\n');
 }
 
 function applyA1<T extends RelevanceGateCandidate>(
@@ -273,6 +372,8 @@ async function applyStageB<T extends RelevanceGateCandidate>(input: {
   state: RelevanceGateVerdict['state'];
   lowConfidence: boolean;
   degraded: boolean;
+  judgePromptHash: string | null;
+  shuffledOrder: string[];
 }> {
   const judgedRows = input.rows.slice(0, input.config.judgeInputLimit);
   const overflowRows = input.rows.slice(input.config.judgeInputLimit);
@@ -301,6 +402,8 @@ async function applyStageB<T extends RelevanceGateCandidate>(input: {
       state: 'injected',
       lowConfidence: false,
       degraded: true,
+      judgePromptHash: null,
+      shuffledOrder: [],
     };
   }
 
@@ -311,6 +414,8 @@ async function applyStageB<T extends RelevanceGateCandidate>(input: {
       state: 'injected',
       lowConfidence: false,
       degraded: false,
+      judgePromptHash: result.promptHash,
+      shuffledOrder: result.shuffledIds,
     };
   }
 
@@ -330,6 +435,8 @@ async function applyStageB<T extends RelevanceGateCandidate>(input: {
         state: 'no-relevant-context',
         lowConfidence: false,
         degraded: false,
+        judgePromptHash: result.promptHash,
+        shuffledOrder: result.shuffledIds,
       };
     }
     const reason = input.config.emptyVerdictEnabled
@@ -341,6 +448,8 @@ async function applyStageB<T extends RelevanceGateCandidate>(input: {
       state: 'injected',
       lowConfidence: true,
       degraded: false,
+      judgePromptHash: result.promptHash,
+      shuffledOrder: result.shuffledIds,
     };
   }
 
@@ -362,6 +471,8 @@ async function applyStageB<T extends RelevanceGateCandidate>(input: {
     state: 'injected',
     lowConfidence: result.verdicts.some((verdict) => verdict.downgraded === true),
     degraded: false,
+    judgePromptHash: result.promptHash,
+    shuffledOrder: result.shuffledIds,
   };
 }
 
@@ -427,6 +538,68 @@ function buildCacheKey<T extends RelevanceGateCandidate>(
     hash.update(candidate.pageContent);
   }
   return hash.digest('hex');
+}
+
+function rowsForObservability<T extends RelevanceGateCandidate>(
+  candidates: T[],
+): CandidateRow<T>[] {
+  return candidates.map((candidate, originalIndex) => ({
+    id: chunkIdFromMetadata(candidate.metadata as Record<string, unknown>),
+    result: candidate,
+    originalIndex,
+  }));
+}
+
+function buildObservability<T extends RelevanceGateCandidate>(input: {
+  query: string;
+  taskContext?: string;
+  config: RelevanceGateConfig;
+  rows: CandidateRow<T>[];
+  survivors: CandidateRow<T>[];
+  dropped: DropRecord[];
+  judge: RelevanceGateVerdict['judge'];
+  judgePromptHash?: string | null;
+  shuffledOrder?: string[];
+}): RelevanceGateObservability {
+  const survivorIds = new Set(input.survivors.map((row) => row.id));
+  const firstDropById = new Map<string, DropRecord>();
+  for (const drop of input.dropped) {
+    if (!firstDropById.has(drop.id)) firstDropById.set(drop.id, drop);
+  }
+  return {
+    task_context_sha: hashNullable(input.taskContext),
+    query_sha: shortHash(input.query),
+    floor: input.config.scoreFloor,
+    judge_model: input.judge.model ?? input.config.judgeModel ?? null,
+    judge_prompt_hash: input.judgePromptHash ?? null,
+    shuffled_order: input.shuffledOrder ?? [],
+    degraded: input.judge.status === 'failed',
+    degrade_reason: input.judge.status === 'failed' ? input.judge.reason ?? 'judge failed' : null,
+    judge_skipped: input.judge.status === 'skipped' ? input.judge.reason ?? 'skipped' : null,
+    candidates: input.rows.map((row) => {
+      const drop = firstDropById.get(row.id);
+      const kept = survivorIds.has(row.id);
+      return {
+        id: row.id,
+        content_sha: shortHash(row.result.pageContent),
+        decision: kept ? 'kept' : 'dropped',
+        stage: kept ? null : drop?.stage ?? null,
+        reason: kept ? null : drop?.reason ?? null,
+      };
+    }),
+  };
+}
+
+function hashNullable(value: string | undefined): string | null {
+  if (value === undefined || value.trim() === '') return null;
+  return shortHash(value);
+}
+
+function shortHash(value: string): string {
+  return createHash('sha256')
+    .update(value.trim().replace(/\s+/g, ' '), 'utf-8')
+    .digest('hex')
+    .slice(0, 16);
 }
 
 function normalizeTaskContext(taskContext: string | undefined): string {

--- a/src/relevance-judge.ts
+++ b/src/relevance-judge.ts
@@ -38,6 +38,15 @@ export interface RelevanceJudgeResult {
   verdicts: RelevanceJudgeVerdict[];
   model: string | null;
   rawContent: string;
+  shuffledIds: string[];
+  promptHash: string;
+}
+
+interface ParsedJudgeResult {
+  overall: RelevanceJudgeOverall;
+  verdicts: RelevanceJudgeVerdict[];
+  model: string | null;
+  rawContent: string;
 }
 
 export class RelevanceJudgeError extends Error {
@@ -77,21 +86,26 @@ const STOP_WORDS = new Set([
 
 export async function judgeRelevance(options: RelevanceJudgeOptions): Promise<RelevanceJudgeResult> {
   const shuffled = deterministicShuffle(options.candidates, options.seed);
+  const messages = buildJudgeMessages(options.query, options.taskContext, shuffled);
   const response = await callChatCompletion({
     endpoint: options.endpoint,
     model: options.model,
     temperature: 0,
     timeoutMs: options.timeoutMs,
-    messages: buildJudgeMessages(options.query, options.taskContext, shuffled),
+    messages,
   }, options.fetchImpl ?? fetch);
 
-  return normalizeJudgeResponse(response, options.candidates);
+  return {
+    ...normalizeJudgeResponse(response, options.candidates),
+    shuffledIds: shuffled.map((candidate) => candidate.id),
+    promptHash: hashPrompt(messages),
+  };
 }
 
 export function normalizeJudgeResponse(
   response: Pick<ChatCompletionResult, 'content' | 'model'>,
   candidates: RelevanceJudgeCandidate[],
-): RelevanceJudgeResult {
+): ParsedJudgeResult {
   const parsed = parseJudgeJson(response.content);
   const overall = parseOverall(parsed.overall);
   const rawVerdicts = Array.isArray(parsed.verdicts) ? parsed.verdicts : [];
@@ -129,6 +143,13 @@ export function normalizeJudgeResponse(
     model: response.model,
     rawContent: response.content,
   };
+}
+
+function hashPrompt(messages: readonly LlmChatMessage[]): string {
+  return createHash('sha256')
+    .update(JSON.stringify(messages), 'utf-8')
+    .digest('hex')
+    .slice(0, 16);
 }
 
 function buildJudgeMessages(

--- a/src/retrieval-eval.test.ts
+++ b/src/retrieval-eval.test.ts
@@ -128,6 +128,34 @@ describe('normalizeRetrievalEvalFixture', () => {
     ]);
   });
 
+  it('normalizes optional expected_gate_verdict with judge-suggested unverified provenance', () => {
+    const fixture = normalizeRetrievalEvalFixture({
+      cases: [{
+        query: 'deployment notes',
+        expected_gate_verdict: {
+          state: 'no-relevant-context',
+          provenance: 'judge-suggested',
+          verification: 'unverified',
+        },
+      }],
+    });
+
+    expect(fixture.cases[0].expectedGateVerdict).toEqual({
+      state: 'no-relevant-context',
+      provenance: 'judge-suggested',
+      verification: 'unverified',
+    });
+  });
+
+  it('rejects invalid expected_gate_verdict states', () => {
+    expect(() => normalizeRetrievalEvalFixture({
+      cases: [{
+        query: 'deployment notes',
+        expected_gate_verdict: 'maybe',
+      }],
+    })).toThrow('expected_gate_verdict must be "bypassed", "empty-index", "injected", or "no-relevant-context"');
+  });
+
   it('preserves the normalized fixture shape when judgments are absent', () => {
     const fixture = normalizeRetrievalEvalFixture({
       cases: [{ query: 'deployment notes' }],
@@ -327,6 +355,54 @@ describe('evaluateRetrievalCase', () => {
       effectiveMode: 'hybrid',
       autoMode: { mode: 'hybrid', reason: 'constant or error-code token' },
     });
+  });
+
+  it('warns when an expected gate verdict cannot be checked', () => {
+    const result = evaluateRetrievalCase(
+      fixtureCase({
+        expectedGateVerdict: {
+          state: 'no-relevant-context',
+          provenance: 'judge-suggested',
+          verification: 'unverified',
+        },
+      }),
+      [],
+      FRESH,
+    );
+
+    expect(result.warnings).toEqual([
+      'expected gate verdict no-relevant-context was not checked; retrieval path did not report a gate verdict',
+      'expected gate verdict is judge-suggested and unverified',
+    ]);
+    expect(summarizeRetrievalEval([result]).expectedGateVerdictWarnings).toBe(1);
+  });
+
+  it('compares expected gate verdicts against reported retrieval results', () => {
+    const matching = evaluateRetrievalCase(
+      fixtureCase({ expectedGateVerdict: { state: 'injected' } }),
+      [],
+      FRESH,
+      false,
+      {
+        requestedMode: 'dense',
+        effectiveMode: 'dense',
+        gateVerdictState: 'injected',
+      },
+    );
+    const mismatched = evaluateRetrievalCase(
+      fixtureCase({ expectedGateVerdict: { state: 'no-relevant-context' } }),
+      [],
+      FRESH,
+      false,
+      {
+        requestedMode: 'dense',
+        effectiveMode: 'dense',
+        gateVerdictState: 'injected',
+      },
+    );
+
+    expect(matching.warnings).toEqual([]);
+    expect(mismatched.warnings).toContain('expected gate verdict no-relevant-context, got injected');
   });
 
   it('fails when a required source is missing', () => {
@@ -639,6 +715,11 @@ describe('summarizeRetrievalEval', () => {
     const result = evaluateRetrievalCase(
       fixtureCase({
         k: 2,
+        expectedGateVerdict: {
+          state: 'injected',
+          provenance: 'human-labeled',
+          verification: 'verified',
+        },
         relevanceJudgments: [{ source: 'runbooks/deploy.md', relevance: 1 }],
       }),
       [doc('runbooks/deploy.md'), doc('notes/other.md')],
@@ -653,10 +734,28 @@ describe('summarizeRetrievalEval', () => {
     expect(markdown).toContain('Diversity metrics: unique-source@k=2.000');
   });
 
+  it('prints expected gate verdict metadata and warning totals in markdown', () => {
+    const result = evaluateRetrievalCase(
+      fixtureCase({ expectedGateVerdict: { state: 'no-relevant-context' } }),
+      [],
+      FRESH,
+    );
+
+    const markdown = formatRetrievalEvalMarkdown(summarizeRetrievalEval([result]));
+
+    expect(markdown).toContain('expected gate: no-relevant-context');
+    expect(markdown).toContain('1 expected gate warning(s).');
+  });
+
   it('includes ranked and diversity metrics in JSON output when judgments are present', () => {
     const result = evaluateRetrievalCase(
       fixtureCase({
         k: 2,
+        expectedGateVerdict: {
+          state: 'injected',
+          provenance: 'human-labeled',
+          verification: 'verified',
+        },
         relevanceJudgments: [{ source: 'runbooks/deploy.md', relevance: 1 }],
       }),
       [doc('runbooks/deploy.md'), doc('notes/other.md')],
@@ -683,6 +782,11 @@ describe('summarizeRetrievalEval', () => {
         hit_rate: 1,
       },
       cases: [{
+        expected_gate_verdict: {
+          state: 'injected',
+          provenance: 'human-labeled',
+          verification: 'verified',
+        },
         ranked_metrics: {
           k: 2,
           judged_relevant_count: 1,

--- a/src/retrieval-eval.ts
+++ b/src/retrieval-eval.ts
@@ -98,9 +98,16 @@ export interface RetrievalEvalCase {
   requiredSources: string[];
   forbiddenSources: string[];
   expectedMetadata: ExpectedMetadataRule[];
+  expectedGateVerdict?: ExpectedGateVerdict;
   relevanceJudgments?: RelevanceJudgment[];
   maxDuplicateGroups?: number;
   stalePolicy: StalePolicy;
+}
+
+export interface ExpectedGateVerdict {
+  state: 'bypassed' | 'empty-index' | 'injected' | 'no-relevant-context';
+  provenance?: 'human-labeled' | 'judge-suggested';
+  verification?: 'verified' | 'unverified';
 }
 
 export interface RetrievalEvalCaseInput {
@@ -116,6 +123,11 @@ export interface RetrievalEvalCaseInput {
   relevant_sources?: Array<string | { source?: unknown; relevance?: unknown }>;
   judgments?: Record<string, unknown> | Array<string | { source?: unknown; relevance?: unknown }>;
   expected_metadata?: Record<string, unknown> | Array<Record<string, unknown>>;
+  expected_gate_verdict?: string | {
+    state?: unknown;
+    provenance?: unknown;
+    verification?: unknown;
+  };
   max_duplicate_groups?: number;
   stale_policy?: StalePolicy | { expect?: StalePolicy };
 }
@@ -134,6 +146,7 @@ export interface RetrievalEvalCaseResult {
   effectiveMode: EffectiveSearchMode;
   autoMode?: AutoSearchModeDecision;
   gate: boolean;
+  expectedGateVerdict?: ExpectedGateVerdict;
   passed: boolean;
   failures: string[];
   warnings: string[];
@@ -149,6 +162,7 @@ export interface RetrievalEvalReport {
   passed: number;
   failed: number;
   gateFailed: number;
+  expectedGateVerdictWarnings: number;
   diversityMetrics: RetrievalEvalAggregateDiversityMetrics;
   rankedMetrics?: RetrievalEvalAggregateRankedMetrics;
 }
@@ -164,6 +178,7 @@ export interface RetrievalEvalSearchResult {
   requestedMode: SearchMode;
   effectiveMode: EffectiveSearchMode;
   autoMode?: AutoSearchModeDecision;
+  gateVerdictState?: ExpectedGateVerdict['state'];
 }
 
 export interface RetrievalEvalScaffoldOptions {
@@ -331,6 +346,23 @@ export function evaluateRetrievalCase(
   }
 
   const gate = fixtureCase.gate ?? fixtureGate;
+  if (fixtureCase.expectedGateVerdict !== undefined) {
+    if (search?.gateVerdictState === undefined) {
+      warnings.push(
+        `expected gate verdict ${fixtureCase.expectedGateVerdict.state} was not checked; retrieval path did not report a gate verdict`,
+      );
+    } else if (search.gateVerdictState !== fixtureCase.expectedGateVerdict.state) {
+      warnings.push(
+        `expected gate verdict ${fixtureCase.expectedGateVerdict.state}, got ${search.gateVerdictState}`,
+      );
+    }
+    if (
+      fixtureCase.expectedGateVerdict.provenance === 'judge-suggested' &&
+      fixtureCase.expectedGateVerdict.verification === 'unverified'
+    ) {
+      warnings.push('expected gate verdict is judge-suggested and unverified');
+    }
+  }
   const rankedMetrics = computeRankedMetrics(fixtureCase, results);
   const diversityMetrics = computeDiversityMetrics(fixtureCase, results);
   return {
@@ -341,6 +373,9 @@ export function evaluateRetrievalCase(
     effectiveMode: search?.effectiveMode ?? 'dense',
     ...(search?.autoMode !== undefined ? { autoMode: search.autoMode } : {}),
     gate,
+    ...(fixtureCase.expectedGateVerdict !== undefined
+      ? { expectedGateVerdict: fixtureCase.expectedGateVerdict }
+      : {}),
     passed: failures.length === 0,
     failures,
     warnings,
@@ -361,6 +396,10 @@ export function summarizeRetrievalEval(results: RetrievalEvalCaseResult[]): Retr
     passed: results.length - failed,
     failed,
     gateFailed: results.filter((r) => r.gate && !r.passed).length,
+    expectedGateVerdictWarnings: results.filter((r) =>
+      r.expectedGateVerdict !== undefined &&
+      r.warnings.some((warning) => warning.startsWith('expected gate verdict')),
+    ).length,
     diversityMetrics,
     ...(rankedMetrics !== undefined ? { rankedMetrics } : {}),
   };
@@ -382,8 +421,11 @@ export function formatRetrievalEvalMarkdown(report: RetrievalEvalReport): string
       ? ''
       : `, ranked: ${formatRankedMetrics(result.rankedMetrics)}`;
     const diversity = `, diversity: ${formatDiversityMetrics(result.diversityMetrics)}`;
+    const expectedGate = result.expectedGateVerdict === undefined
+      ? ''
+      : `, expected gate: ${result.expectedGateVerdict.state}`;
     lines.push(
-      `- ${status} ${result.name} (${scope}, mode: ${mode}, ${result.resultCount} result(s), duplicate groups: ${result.duplicateGroups}${ranked}${diversity})`,
+      `- ${status} ${result.name} (${scope}, mode: ${mode}, ${result.resultCount} result(s), duplicate groups: ${result.duplicateGroups}${expectedGate}${ranked}${diversity})`,
     );
     for (const failure of result.failures) {
       lines.push(`  - ${failure}`);
@@ -394,7 +436,7 @@ export function formatRetrievalEvalMarkdown(report: RetrievalEvalReport): string
   }
   lines.push('');
   lines.push(
-    `Summary: ${report.passed}/${report.total} passed; ${report.failed} failed; ${report.gateFailed} gate failure(s).`,
+    `Summary: ${report.passed}/${report.total} passed; ${report.failed} failed; ${report.gateFailed} gate failure(s); ${report.expectedGateVerdictWarnings} expected gate warning(s).`,
   );
   if (report.rankedMetrics !== undefined) {
     lines.push(`Ranked metrics: ${formatAggregateRankedMetrics(report.rankedMetrics)}.`);
@@ -414,6 +456,7 @@ function normalizeCase(raw: unknown, caseNumber: number): RetrievalEvalCase {
   const gate = readOptionalBoolean(raw, 'gate');
   const maxDuplicateGroups = readOptionalNonNegativeInteger(raw, 'max_duplicate_groups');
   const relevanceJudgments = normalizeRelevanceJudgments(raw, caseNumber);
+  const expectedGateVerdict = normalizeExpectedGateVerdict(raw.expected_gate_verdict, caseNumber);
   return {
     name: readOptionalString(raw, 'name') ?? `case ${caseNumber}`,
     query,
@@ -425,10 +468,65 @@ function normalizeCase(raw: unknown, caseNumber: number): RetrievalEvalCase {
     requiredSources: readOptionalStringArray(raw, 'required_sources') ?? [],
     forbiddenSources: readOptionalStringArray(raw, 'forbidden_sources') ?? [],
     expectedMetadata: normalizeExpectedMetadata(raw.expected_metadata, caseNumber),
+    ...(expectedGateVerdict !== undefined ? { expectedGateVerdict } : {}),
     ...(relevanceJudgments.length > 0 ? { relevanceJudgments } : {}),
     ...(maxDuplicateGroups !== undefined ? { maxDuplicateGroups } : {}),
     stalePolicy: normalizeStalePolicy(raw.stale_policy, caseNumber),
   };
+}
+
+function normalizeExpectedGateVerdict(
+  raw: unknown,
+  caseNumber: number,
+): ExpectedGateVerdict | undefined {
+  if (raw === undefined) return undefined;
+  if (typeof raw === 'string') {
+    return { state: normalizeGateVerdictState(raw, `case ${caseNumber} expected_gate_verdict`) };
+  }
+  if (!isRecord(raw)) {
+    throw new Error(`case ${caseNumber} expected_gate_verdict must be a string or object`);
+  }
+  const state = normalizeGateVerdictState(raw.state, `case ${caseNumber} expected_gate_verdict.state`);
+  const provenance = normalizeGateVerdictProvenance(raw.provenance, caseNumber);
+  const verification = normalizeGateVerdictVerification(raw.verification, caseNumber);
+  return {
+    state,
+    ...(provenance !== undefined ? { provenance } : {}),
+    ...(verification !== undefined ? { verification } : {}),
+  };
+}
+
+function normalizeGateVerdictState(
+  raw: unknown,
+  context: string,
+): ExpectedGateVerdict['state'] {
+  if (
+    raw === 'bypassed' ||
+    raw === 'empty-index' ||
+    raw === 'injected' ||
+    raw === 'no-relevant-context'
+  ) {
+    return raw;
+  }
+  throw new Error(`${context} must be "bypassed", "empty-index", "injected", or "no-relevant-context"`);
+}
+
+function normalizeGateVerdictProvenance(
+  raw: unknown,
+  caseNumber: number,
+): ExpectedGateVerdict['provenance'] | undefined {
+  if (raw === undefined) return undefined;
+  if (raw === 'human-labeled' || raw === 'judge-suggested') return raw;
+  throw new Error(`case ${caseNumber} expected_gate_verdict.provenance must be "human-labeled" or "judge-suggested"`);
+}
+
+function normalizeGateVerdictVerification(
+  raw: unknown,
+  caseNumber: number,
+): ExpectedGateVerdict['verification'] | undefined {
+  if (raw === undefined) return undefined;
+  if (raw === 'verified' || raw === 'unverified') return raw;
+  throw new Error(`case ${caseNumber} expected_gate_verdict.verification must be "verified" or "unverified"`);
 }
 
 async function retrieveDense(


### PR DESCRIPTION
Closes #371

Stacked on #377 / `feat/rfc-018-m0a-gate-core`.

## Summary
- add process-lifetime relevance gate metrics and expose them through `kb_stats` / `kb stats`
- emit canonical relevance-gate decision records with reproduction hashes, candidate decisions, judge metadata, and process-aware degrade alarms
- add `kb search --explain` dropped-candidate output and expected gate verdict metadata in eval reports

## Verification
- `npm run build`
- `npm test -- --runTestsByPath src/relevance-gate.test.ts src/cli-search.test.ts src/cli-stats.test.ts src/retrieval-eval.test.ts`
- `npm test`

Generated with [Claude Code](https://claude.ai/code)