### PR TITLE
feat(cli): save cited ask transcripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ kb search "INDEX_NOT_INITIALIZED" --mode=hybrid              # dense ⨁ BM25 fu
 kb search "src/cli-search.ts" --mode=auto    # opt-in heuristic: hybrid for code/path/error-shaped queries
 kb llm use-endpoint http://127.0.0.1:8080/v1/chat/completions --profile=local-research-agent
 kb ask "what changed in the daemonization notes?" --timing   # retrieval + local LLM answer with timings
+kb ask "what changed?" --kb=work --save-transcript --title="Ask - daemon changes" --yes
 kb remember --suggest --kb=work --title="Quarterly plan"
 printf '# Quarterly plan\n\n...' | kb remember --kb=work --title="Quarterly plan" --stdin --yes
 printf '\nFollow-up note.\n' | kb remember --kb=work --append=quarterly-plan.md --stdin --yes
@@ -90,11 +91,15 @@ The MCP server (`knowledge-base-mcp-server` bin) is unchanged and still works wi
 
 `kb ask` keeps retrieval deterministic and adds a local OpenAI-compatible chat step on top. It resolves the LLM endpoint from `--endpoint`, `KB_LLM_ENDPOINT`, `--llm-profile`, the active `kb llm` profile, then finally the local-research-agent default on `127.0.0.1:8080`.
 
+Add `--save-transcript --kb=<name> --yes` to persist the generated answer as a new markdown note in that KB. The saved record includes the question, answer, citations, source chunk ids, LLM endpoint/profile/model, retrieval model, and timing metadata when `--timing` is present. `--title=<title>` controls the note title and slug; existing transcript notes are never overwritten.
+
 ```bash
 # Reuse an already-running local-research-agent llama-server.
 kb llm use-endpoint http://127.0.0.1:8080/v1/chat/completions --profile=local-research-agent
 kb llm status
 kb ask "Which notes discuss reboot recovery?" --kb=operating-environment
+kb ask "Which notes discuss reboot recovery?" --kb=operating-environment \
+  --save-transcript --title="Reboot recovery answer" --yes
 
 # Optional managed service for machines that want kb to own the warm model.
 kb llm install --profile=qwen --runner=llama-server \
@@ -254,7 +259,7 @@ Use this path if you want to develop against the repo or pin an unreleased commi
     *   The server supports the `FAISS_INDEX_PATH` environment variable to specify the path to the FAISS index. If not set, it will default to `$HOME/knowledge_bases/.faiss`.
     *   **Single process per `FAISS_INDEX_PATH`.** Only one server process may write to a given `FAISS_INDEX_PATH` at a time. Running multiple processes (e.g. systemd `Restart=on-failure` racing the dying instance, pm2 with multiple replicas, Kubernetes pods sharing a PV, or a stray `kb search --refresh` overlapping the MCP server) against the same index directory can corrupt the FAISS store, hash sidecars, and pending-manifest. A process-level lockfile is the planned long-term fix — see [#44](https://github.com/jeanibarz/knowledge-base-mcp-server/issues/44) for tracking and [`docs/architecture/threat-model.md`](docs/architecture/threat-model.md) for the current concurrency posture.
     *   Logging can be routed to a file by setting `LOG_FILE=/path/to/logs/knowledge-base.log`. Log verbosity defaults to `info` and can be adjusted with `LOG_LEVEL=debug|info|warn|error`.
-    *   **Mutation audit log (opt-in).** Set `KB_MUTATION_AUDIT_LOG=/path/to/kb-mutations.jsonl` to capture an append-only JSONL ledger of KB content writes. Each line records `surface` (`cli.kb-remember` / `cli.kb-capture` / `mcp.add_document` / `mcp.delete_document`), `operation`, `kb`, `relative_path`, `timestamp`, `before_sha256`, `after_sha256`, `write_performed`, `refresh_requested`, `refresh_status`, and per-surface `decision_flags`. Note content is **not** stored; only hashes and metadata. The feature is best-effort — an audit write failure logs a `warn` to stderr but never aborts the primary mutation. KB names and paths are inherent to the records, so treat the audit log with the same sensitivity as the underlying KB directory.
+    *   **Mutation audit log (opt-in).** Set `KB_MUTATION_AUDIT_LOG=/path/to/kb-mutations.jsonl` to capture an append-only JSONL ledger of KB content writes. Each line records `surface` (`cli.kb-remember` / `cli.kb-capture` / `cli.kb-ask` / `mcp.add_document` / `mcp.delete_document`), `operation`, `kb`, `relative_path`, `timestamp`, `before_sha256`, `after_sha256`, `write_performed`, `refresh_requested`, `refresh_status`, and per-surface `decision_flags`. Note content is **not** stored; only hashes and metadata. The feature is best-effort — an audit write failure logs a `warn` to stderr but never aborts the primary mutation. KB names and paths are inherent to the records, so treat the audit log with the same sensitivity as the underlying KB directory.
     *   **Tailor tool descriptions per deployment.** The `retrieve_knowledge` and `list_knowledge_bases` descriptions the agent reads when picking tools can be overridden via `RETRIEVE_KNOWLEDGE_DESCRIPTION` and `LIST_KNOWLEDGE_BASES_DESCRIPTION`. Unset or empty falls back to the built-in defaults. Example:
         ```bash
         RETRIEVE_KNOWLEDGE_DESCRIPTION="Search engineering runbooks, RFCs, and postmortems."

--- a/docs/architecture/threat-model.md
+++ b/docs/architecture/threat-model.md
@@ -102,7 +102,7 @@ Setting `LOG_FILE` (`src/logger.ts:18-49`) mirrors stderr to disk. The server wr
 
 ## 7. Mutation audit log (`KB_MUTATION_AUDIT_LOG`)
 
-Setting `KB_MUTATION_AUDIT_LOG` (`src/audit-log.ts`) opts into an append-only JSONL ledger of content mutations performed by `kb remember`, `kb capture`, MCP `add_document`, and MCP `delete_document`. Each record carries `surface`, `operation`, `kb`, `relative_path`, before/after `sha256` hashes, `write_performed`, refresh status, and `decision_flags`. Note bodies are **not** written; the hashes are the only content-derived field. KB names and relative paths reveal the same surface area as the underlying KB directory listing, so secure the ledger with the same permissions you grant `$KNOWLEDGE_BASES_ROOT_DIR`. Audit writes are best-effort: a failed append degrades to a `warn` line on stderr and never blocks the primary mutation.
+Setting `KB_MUTATION_AUDIT_LOG` (`src/audit-log.ts`) opts into an append-only JSONL ledger of content mutations performed by `kb remember`, `kb capture`, `kb ask --save-transcript`, MCP `add_document`, and MCP `delete_document`. Each record carries `surface`, `operation`, `kb`, `relative_path`, before/after `sha256` hashes, `write_performed`, refresh status, and `decision_flags`. Note bodies are **not** written; the hashes are the only content-derived field. KB names and relative paths reveal the same surface area as the underlying KB directory listing, so secure the ledger with the same permissions you grant `$KNOWLEDGE_BASES_ROOT_DIR`. Audit writes are best-effort: a failed append degrades to a `warn` line on stderr and never blocks the primary mutation.
 
 ## 8. Remote MCP transport (`MCP_TRANSPORT=sse` / `=http`)
 

--- a/docs/requirements/INDEX.md
+++ b/docs/requirements/INDEX.md
@@ -102,6 +102,22 @@
 
 ## Search
 
+### FR-ASK-382: Cited Ask Transcript Records
+**Status:** Implemented
+**Priority:** Medium
+
+**Requirement:** The system shall let `kb ask` persist a cited answer transcript as a new knowledge-base note only when the caller explicitly requests transcript saving and confirms the write.
+**Rationale:** Generated answers are useful durable knowledge only when the saved record includes the original question, answer, citations, source chunk identifiers, LLM provenance, retrieval metadata, and write-path safeguards.
+
+**Acceptance Criteria:**
+- [x] Given `kb ask --save-transcript --kb=<name> --yes`, when retrieval and LLM answering succeed, then the system writes a new markdown note in the target knowledge base containing the question, answer, citations, source chunk ids, LLM endpoint/profile/model, retrieval model, and timing metadata when available.
+- [x] Given `--save-transcript` without `--yes`, when argument validation runs, then the system refuses to write and exits with an input error.
+- [x] Given `--save-transcript` without `--kb=<name>`, when argument validation runs, then the system refuses the call because no transcript target is defined.
+- [x] Given a transcript title whose slug already exists, when the write path runs, then the system refuses to overwrite the existing note.
+
+**Linked Tests:** TS-ASK-382
+**Dependencies:** FR-STATS-230
+
 ### FR-SUPERSEDED-232: Superseded Memory Review
 **Status:** Implemented
 **Priority:** High

--- a/docs/testing/INDEX.md
+++ b/docs/testing/INDEX.md
@@ -65,6 +65,15 @@
 
 ## Search
 
+### TS-ASK-382: Cited Ask Transcript Records
+**Requirement:** FR-ASK-382
+
+**Test Cases:**
+- `parseAskArgs` shall parse `--save-transcript`, `--title=<title>`, and `--yes`.
+- `parseAskArgs` shall reject transcript saves without `--yes` or without a target `--kb=<name>`.
+- `buildAskTranscriptMarkdown` shall include the question, answer, citation paths, source chunk ids, LLM provenance, retrieval metadata, and timing metadata when present.
+- `createAskTranscriptNote` shall create a new slugged markdown note and shall refuse to overwrite an existing transcript note.
+
 ### TS-SUPERSEDED-232: Superseded Memory Review
 **Requirement:** FR-SUPERSEDED-232
 

--- a/src/audit-log.ts
+++ b/src/audit-log.ts
@@ -15,6 +15,7 @@ import { logger } from './logger.js';
 export type MutationSurface =
   | 'cli.kb-remember'
   | 'cli.kb-capture'
+  | 'cli.kb-ask'
   | 'mcp.add_document'
   | 'mcp.delete_document';
 
@@ -23,6 +24,7 @@ export type MutationOperation =
   | 'append'
   | 'append-section'
   | 'capture'
+  | 'ask-transcript'
   | 'add'
   | 'delete';
 

--- a/src/cli-ask.test.ts
+++ b/src/cli-ask.test.ts
@@ -1,5 +1,14 @@
-import { describe, expect, it } from '@jest/globals';
-import { parseAskArgs } from './cli-ask.js';
+import { describe, expect, it, jest } from '@jest/globals';
+import * as fsp from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  buildAskTranscriptMarkdown,
+  createAskTranscriptNote,
+  parseAskArgs,
+  runAsk,
+  type RunAskDeps,
+} from './cli-ask.js';
 
 describe('parseAskArgs', () => {
   it('parses retrieval and LLM options', () => {
@@ -13,6 +22,9 @@ describe('parseAskArgs', () => {
       '--refresh',
       '--format=json',
       '--timing',
+      '--save-transcript',
+      '--title=Incident answer',
+      '--yes',
     ])).toEqual({
       question: 'what changed?',
       kb: 'ops',
@@ -24,6 +36,9 @@ describe('parseAskArgs', () => {
       stdin: false,
       format: 'json',
       timing: true,
+      saveTranscript: true,
+      title: 'Incident answer',
+      yes: true,
     });
   });
 
@@ -32,5 +47,159 @@ describe('parseAskArgs', () => {
     expect(() => parseAskArgs(['q', '--format=yaml'])).toThrow(/invalid --format/);
     expect(() => parseAskArgs(['q', '--bad'])).toThrow(/unknown flag/);
     expect(() => parseAskArgs(['q', 'extra'])).toThrow(/unexpected argument/);
+  });
+
+  it('requires explicit confirmation and a target KB before saving transcripts', () => {
+    expect(() => parseAskArgs(['q', '--save-transcript', '--kb=ops'])).toThrow(/requires --yes/);
+    expect(() => parseAskArgs(['q', '--save-transcript', '--yes'])).toThrow(/requires --kb/);
+    expect(() => parseAskArgs(['q', '--title=Incident answer'])).toThrow(/requires --save-transcript/);
+  });
+});
+
+describe('ask transcript records', () => {
+  it('renders question, answer, citations, chunk ids, and model provenance', () => {
+    const markdown = buildAskTranscriptMarkdown({
+      title: 'Incident answer',
+      createdAt: '2026-05-18T00:00:00.000Z',
+      question: 'What changed?',
+      answer: 'The deployment switched models.',
+      citations: [
+        {
+          knowledge_base: 'ops',
+          path: 'deploys.md',
+          score: 0.1234,
+          chunk_id: 'ops/deploys.md#L10-L18',
+        },
+      ],
+      llm: {
+        endpoint: 'http://127.0.0.1:8080/v1/chat/completions',
+        profile: 'local',
+        mode: 'external',
+        source: 'profile',
+        model: 'qwen3',
+      },
+      retrieval: {
+        embedding_model: 'ollama__nomic-embed-text-latest',
+        k: 4,
+        refreshed: false,
+        knowledge_base: 'ops',
+      },
+      timing: { retrieval_ms: 12, llm_total_ms: 34, total_ms: 56 },
+    });
+
+    expect(markdown).toContain('type: kb_ask_transcript');
+    expect(markdown).toContain('# Incident answer');
+    expect(markdown).toContain('## Question\n\nWhat changed?');
+    expect(markdown).toContain('## Answer\n\nThe deployment switched models.');
+    expect(markdown).toContain('`ops:deploys.md`');
+    expect(markdown).toContain('chunks `ops/deploys.md#L10-L18`');
+    expect(markdown).toContain('retrieval model: `ollama__nomic-embed-text-latest`');
+    expect(markdown).toContain('LLM profile: `local`');
+  });
+
+  it('creates a new transcript note and refuses duplicate titles', async () => {
+    const root = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-ask-transcript-'));
+    try {
+      await fsp.mkdir(path.join(root, 'ops'), { recursive: true });
+      const relativePath = await createAskTranscriptNote(root, 'ops', 'Incident answer', '# Body\n');
+
+      expect(relativePath).toBe('incident-answer.md');
+      await expect(createAskTranscriptNote(root, 'ops', 'Incident answer', '# Body\n'))
+        .rejects.toThrow(/refusing to overwrite existing transcript/);
+    } finally {
+      await fsp.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('writes a transcript through the runAsk CLI path', async () => {
+    const root = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-ask-run-'));
+    const previousEndpoint = process.env.KB_LLM_ENDPOINT;
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const stdoutSpy = jest.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+      stdout.push(String(chunk));
+      return true;
+    });
+    const stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation((chunk) => {
+      stderr.push(String(chunk));
+      return true;
+    });
+
+    try {
+      process.env.KB_LLM_ENDPOINT = 'http://127.0.0.1:8080/v1/chat/completions';
+      await fsp.mkdir(path.join(root, 'ops'), { recursive: true });
+      const manager = {
+        modelDir: path.join(root, '.faiss', 'models', 'ollama__nomic'),
+        initialize: jest.fn(async () => {}),
+        updateIndex: jest.fn(async () => {}),
+        similaritySearch: jest.fn(async () => [
+          {
+            pageContent: 'The deployment switched embedding models.',
+            metadata: {
+              knowledgeBase: 'ops',
+              relativePath: 'deploys.md',
+              loc: { lines: { from: 10, to: 18 } },
+            },
+            score: 0.1234,
+          },
+        ]),
+      };
+      const deps: RunAskDeps = {
+        bootstrapLayout: jest.fn(async () => {}),
+        resolveActiveModel: jest.fn(async () => 'ollama__nomic-embed-text-latest'),
+        loadManagerForModel: jest.fn(async () => manager as never),
+        loadWithJsonRetry: jest.fn(async () => {}),
+        withWriteLock: jest.fn(async <T>(_resource: string, action: () => Promise<T>) => action()) as RunAskDeps['withWriteLock'],
+        callChatCompletion: jest.fn(async () => ({
+          content: 'The deployment switched embedding models.',
+          model: 'qwen3',
+          raw: {},
+        })),
+        createTranscriptNote: createAskTranscriptNote,
+        knowledgeBasesRootDir: root,
+      };
+
+      const code = await runAsk([
+        'What changed?',
+        '--kb=ops',
+        '--format=json',
+        '--save-transcript',
+        '--title=Incident answer',
+        '--yes',
+      ], deps);
+
+      expect(code).toBe(0);
+      expect(stderr.join('')).toBe('');
+      const payload = JSON.parse(stdout.join('')) as {
+        answer: string;
+        transcript?: { knowledge_base: string; path: string; title: string };
+      };
+      expect(payload.answer).toBe('The deployment switched embedding models.');
+      expect(payload.transcript).toEqual({
+        saved: true,
+        knowledge_base: 'ops',
+        path: 'incident-answer.md',
+        title: 'Incident answer',
+      });
+      const transcript = await fsp.readFile(path.join(root, 'ops', 'incident-answer.md'), 'utf-8');
+      expect(transcript).toContain('## Question\n\nWhat changed?');
+      expect(transcript).toContain('## Answer\n\nThe deployment switched embedding models.');
+      expect(transcript).toContain('chunks `ops/deploys.md#L10-L18`');
+      expect(deps.callChatCompletion).toHaveBeenCalledTimes(1);
+      expect(manager.similaritySearch).toHaveBeenCalledWith(
+        'What changed?',
+        8,
+        undefined,
+        'ops',
+        undefined,
+        undefined,
+      );
+    } finally {
+      stdoutSpy.mockRestore();
+      stderrSpy.mockRestore();
+      if (previousEndpoint === undefined) delete process.env.KB_LLM_ENDPOINT;
+      else process.env.KB_LLM_ENDPOINT = previousEndpoint;
+      await fsp.rm(root, { recursive: true, force: true });
+    }
   });
 });

--- a/src/cli-ask.ts
+++ b/src/cli-ask.ts
@@ -1,5 +1,14 @@
+import * as crypto from 'crypto';
+import * as fsp from 'fs/promises';
+import * as path from 'path';
 import { FaissIndexManager, type SimilaritySearchTiming } from './FaissIndexManager.js';
 import { resolveActiveModel } from './active-model.js';
+import {
+  auditEnabled,
+  recordMutation,
+  sha256OfFileOrNull,
+  type RefreshStatus,
+} from './audit-log.js';
 import {
   classifyKbSearchError,
   exitCodeForFailure,
@@ -23,6 +32,10 @@ import {
   writeLease,
   type LlmProfile,
 } from './llm-profiles.js';
+import type { ChatCompletionOptions, ChatCompletionResult } from './llm-client.js';
+import { KNOWLEDGE_BASES_ROOT_DIR } from './config/paths.js';
+import { resolveKbPath, resolveKnowledgeBaseDir } from './kb-fs.js';
+import { slugifyTitle } from './slug.js';
 import { withWriteLock } from './write-lock.js';
 
 export const ASK_HELP = `kb ask — answer a question from retrieved KB context using a local LLM
@@ -46,6 +59,10 @@ Options:
   --format=md|json      Output format (default: md).
   --timing              Include elapsed milliseconds for retrieval and LLM stages.
   --stdin               Read question from stdin.
+  --save-transcript     Save the question, answer, citations, and provenance
+                        as a new markdown note. Requires --kb and --yes.
+  --title=<title>       Transcript note title (default: derived from question).
+  --yes                 Confirm transcript write when --save-transcript is set.
   --help, -h            Show this help.
 `;
 
@@ -60,6 +77,9 @@ interface AskArgs {
   stdin: boolean;
   format: 'md' | 'json';
   timing: boolean;
+  saveTranscript: boolean;
+  title?: string;
+  yes: boolean;
 }
 
 interface LlmTarget {
@@ -67,7 +87,70 @@ interface LlmTarget {
   source: 'flag' | 'env' | 'profile' | 'default';
 }
 
-export async function runAsk(rest: string[]): Promise<number> {
+interface AskCitation {
+  knowledge_base: string | null;
+  path: string;
+  score: number | null;
+  chunk_id?: string;
+  chunk_ids?: string[];
+}
+
+interface AskLlmPayload {
+  endpoint: string;
+  profile: string;
+  mode: string;
+  source: LlmTarget['source'];
+  model: string | null;
+}
+
+interface AskRetrievalPayload {
+  embedding_model: string;
+  k: number;
+  refreshed: boolean;
+  knowledge_base: string | null;
+}
+
+interface AskTranscriptRecord {
+  title: string;
+  createdAt: string;
+  question: string;
+  answer: string;
+  citations: AskCitation[];
+  llm: AskLlmPayload;
+  retrieval: AskRetrievalPayload;
+  timing?: Record<string, unknown>;
+}
+
+interface SavedTranscriptInfo {
+  saved: true;
+  knowledge_base: string;
+  path: string;
+  title: string;
+}
+
+export interface RunAskDeps {
+  bootstrapLayout: typeof FaissIndexManager.bootstrapLayout;
+  resolveActiveModel: typeof resolveActiveModel;
+  loadManagerForModel: typeof loadManagerForModel;
+  loadWithJsonRetry: typeof loadWithJsonRetry;
+  withWriteLock: typeof withWriteLock;
+  callChatCompletion: (options: ChatCompletionOptions) => Promise<ChatCompletionResult>;
+  createTranscriptNote: typeof createAskTranscriptNote;
+  knowledgeBasesRootDir: string;
+}
+
+const defaultRunAskDeps: RunAskDeps = {
+  bootstrapLayout: FaissIndexManager.bootstrapLayout.bind(FaissIndexManager),
+  resolveActiveModel,
+  loadManagerForModel,
+  loadWithJsonRetry,
+  withWriteLock,
+  callChatCompletion,
+  createTranscriptNote: createAskTranscriptNote,
+  knowledgeBasesRootDir: KNOWLEDGE_BASES_ROOT_DIR,
+};
+
+export async function runAsk(rest: string[], deps: RunAskDeps = defaultRunAskDeps): Promise<number> {
   const totalStartedAt = nowMs();
   let args: AskArgs;
   try {
@@ -89,22 +172,22 @@ export async function runAsk(rest: string[]): Promise<number> {
   const timing: TimingPayload | null = args.timing ? {} : null;
   try {
     let startedAt = nowMs();
-    await FaissIndexManager.bootstrapLayout();
+    await deps.bootstrapLayout();
     if (timing) timing.bootstrap_ms = elapsedMs(startedAt);
     startedAt = nowMs();
-    activeModelId = await resolveActiveModel({ explicitOverride: args.model });
+    activeModelId = await deps.resolveActiveModel({ explicitOverride: args.model });
     if (timing) timing.model_resolution_ms = elapsedMs(startedAt);
     startedAt = nowMs();
-    const manager = await loadManagerForModel(activeModelId);
+    const manager = await deps.loadManagerForModel(activeModelId);
     if (timing) timing.manager_load_ms = elapsedMs(startedAt);
     startedAt = nowMs();
     if (args.refresh) {
-      await withWriteLock(manager.modelDir, async () => {
+      await deps.withWriteLock(manager.modelDir, async () => {
         await manager.initialize();
         await manager.updateIndex(args.kb);
       });
     } else {
-      await loadWithJsonRetry(manager);
+      await deps.loadWithJsonRetry(manager);
     }
     if (timing) timing.index_load_ms = elapsedMs(startedAt);
     const denseTiming: SimilaritySearchTiming = {};
@@ -150,7 +233,7 @@ export async function runAsk(rest: string[]): Promise<number> {
   let llmModel: string | null = null;
   try {
     const startedAt = nowMs();
-    const response = await callChatCompletion({
+    const response = await deps.callChatCompletion({
       endpoint: target.profile.endpoint,
       messages: buildAskMessages(args.question, retrieval),
       temperature: 0.2,
@@ -165,26 +248,98 @@ export async function runAsk(rest: string[]): Promise<number> {
     return reportAskError(args.format, `kb ask: ${(err as Error).message}`, 1);
   }
 
-  const citations = buildCitations(retrieval);
   if (timing) timing.total_ms = elapsedMs(totalStartedAt);
+  const citations = buildCitations(retrieval);
+  const compactTiming = timing ? compactTimingPayload(timing) : undefined;
+  const llmPayload: AskLlmPayload = {
+    endpoint: target.profile.endpoint,
+    profile: target.profile.name,
+    mode: target.profile.mode,
+    source: target.source,
+    model: llmModel,
+  };
+  const retrievalPayload: AskRetrievalPayload = {
+    embedding_model: activeModelId,
+    k: args.k,
+    refreshed: args.refresh,
+    knowledge_base: args.kb ?? null,
+  };
+  let savedTranscript: SavedTranscriptInfo | null = null;
+  if (args.saveTranscript) {
+    const title = args.title ?? defaultAskTranscriptTitle(args.question);
+    const content = buildAskTranscriptMarkdown({
+      title,
+      createdAt: new Date().toISOString(),
+      question: args.question,
+      answer,
+      citations,
+      llm: llmPayload,
+      retrieval: retrievalPayload,
+      ...(compactTiming ? { timing: compactTiming } : {}),
+    });
+    const auditing = auditEnabled();
+    let relativePath = '';
+    let writePerformed = false;
+    let writeError: Error | undefined;
+    try {
+      relativePath = await deps.createTranscriptNote(
+        deps.knowledgeBasesRootDir,
+        args.kb!,
+        title,
+        content,
+      );
+      writePerformed = true;
+    } catch (err) {
+      writeError = err as Error;
+    }
+    const refreshStatus: RefreshStatus = null;
+    if (auditing) {
+      const afterDocPath = writePerformed
+        ? await safeResolveKbPath(deps.knowledgeBasesRootDir, args.kb!, relativePath)
+        : null;
+      const afterHash = afterDocPath !== null
+        ? await sha256OfFileOrNull(afterDocPath)
+        : null;
+      await recordMutation({
+        surface: 'cli.kb-ask',
+        operation: 'ask-transcript',
+        kb: args.kb!,
+        relative_path: writePerformed ? relativePath : null,
+        before_sha256: null,
+        after_sha256: afterHash,
+        write_performed: writePerformed,
+        refresh_requested: false,
+        refresh_status: refreshStatus,
+        decision_flags: {
+          citation_count: citations.length,
+          llm_profile: target.profile.name,
+          llm_mode: target.profile.mode,
+          llm_source: target.source,
+          retrieval_model: activeModelId,
+          k: args.k,
+        },
+        error: writeError?.message,
+      });
+    }
+    if (writeError !== undefined) {
+      return reportAskError(args.format, `kb ask: ${writeError.message}`, 1);
+    }
+    savedTranscript = {
+      saved: true,
+      knowledge_base: args.kb!,
+      path: relativePath,
+      title,
+    };
+  }
+
   if (args.format === 'json') {
     process.stdout.write(`${JSON.stringify({
       answer,
       citations,
-      llm: {
-        endpoint: target.profile.endpoint,
-        profile: target.profile.name,
-        mode: target.profile.mode,
-        source: target.source,
-        model: llmModel,
-      },
-      retrieval: {
-        embedding_model: activeModelId,
-        k: args.k,
-        refreshed: args.refresh,
-        knowledge_base: args.kb ?? null,
-      },
-      ...(timing ? { timing: compactTimingPayload(timing) } : {}),
+      llm: llmPayload,
+      retrieval: retrievalPayload,
+      ...(compactTiming ? { timing: compactTiming } : {}),
+      ...(savedTranscript ? { transcript: savedTranscript } : {}),
     }, null, 2)}\n`);
   } else {
     process.stdout.write(`${answer}\n\n`);
@@ -193,10 +348,14 @@ export async function runAsk(rest: string[]): Promise<number> {
       for (const c of citations) {
         const kb = c.knowledge_base ? `${c.knowledge_base}:` : '';
         const score = typeof c.score === 'number' ? ` (score ${c.score.toFixed(2)})` : '';
-        process.stdout.write(`- ${kb}${c.path}${score}\n`);
+        const chunk = c.chunk_id ? ` - chunk ${c.chunk_id}` : '';
+        process.stdout.write(`- ${kb}${c.path}${score}${chunk}\n`);
       }
     }
     process.stdout.write(`\n> _LLM: ${target.profile.name} (${target.profile.mode}) at ${target.profile.endpoint}; retrieval model: ${activeModelId}._\n`);
+    if (savedTranscript) {
+      process.stdout.write(`> _Transcript saved: ${savedTranscript.knowledge_base}:${savedTranscript.path}._\n`);
+    }
     if (timing) {
       process.stdout.write(formatTimingFooter('Timing', timing));
       process.stdout.write('\n');
@@ -213,15 +372,28 @@ export function parseAskArgs(rest: string[]): AskArgs {
     stdin: false,
     format: 'md',
     timing: false,
+    saveTranscript: false,
+    yes: false,
   };
-  for (const raw of rest) {
+  for (let i = 0; i < rest.length; i++) {
+    const raw = rest[i];
     if (raw === '--refresh') { out.refresh = true; continue; }
     if (raw === '--stdin') { out.stdin = true; continue; }
     if (raw === '--timing') { out.timing = true; continue; }
+    if (raw === '--save-transcript') { out.saveTranscript = true; continue; }
+    if (raw === '--yes') { out.yes = true; continue; }
     if (raw.startsWith('--kb=')) { out.kb = raw.slice('--kb='.length); continue; }
     if (raw.startsWith('--model=')) { out.model = raw.slice('--model='.length); continue; }
     if (raw.startsWith('--llm-profile=')) { out.llmProfile = raw.slice('--llm-profile='.length); continue; }
     if (raw.startsWith('--endpoint=')) { out.endpoint = raw.slice('--endpoint='.length); continue; }
+    if (raw.startsWith('--title=')) { out.title = raw.slice('--title='.length); continue; }
+    if (raw === '--title') {
+      const next = rest[i + 1];
+      if (next === undefined) throw new Error('--title requires a value');
+      out.title = next;
+      i++;
+      continue;
+    }
     if (raw.startsWith('--k=')) {
       const n = Number(raw.slice('--k='.length));
       if (!Number.isInteger(n) || n <= 0) throw new Error(`invalid --k: ${raw}`);
@@ -235,6 +407,17 @@ export function parseAskArgs(rest: string[]): AskArgs {
     if (raw.startsWith('--')) throw new Error(`unknown flag: ${raw}`);
     if (out.question === null) { out.question = raw; continue; }
     throw new Error(`unexpected argument: ${raw}`);
+  }
+  if (out.saveTranscript) {
+    if (!out.yes) throw new Error('--save-transcript requires --yes');
+    if (out.kb === undefined || out.kb.trim() === '') {
+      throw new Error('--save-transcript requires --kb=<name>');
+    }
+    if (out.title !== undefined && out.title.trim() === '') {
+      throw new Error('--title must not be empty');
+    }
+  } else if (out.title !== undefined) {
+    throw new Error('--title requires --save-transcript');
   }
   return out;
 }
@@ -274,24 +457,164 @@ function buildAskMessages(question: string, retrieval: RetrievalJsonResult[]) {
   ];
 }
 
-function buildCitations(retrieval: RetrievalJsonResult[]): Array<{
-  knowledge_base: string | null;
-  path: string;
-  score: number | null;
-}> {
-  const seen = new Set<string>();
-  const out: Array<{ knowledge_base: string | null; path: string; score: number | null }> = [];
+function buildCitations(retrieval: RetrievalJsonResult[]): AskCitation[] {
+  const seen = new Map<string, AskCitation>();
+  const out: AskCitation[] = [];
   for (const r of retrieval) {
     const pathValue = stringMetadata(r.metadata, 'relativePath')
       ?? stringMetadata(r.metadata, 'source')
       ?? '(unknown source)';
     const kb = stringMetadata(r.metadata, 'knowledgeBase');
     const key = `${kb ?? ''}:${pathValue}`;
-    if (seen.has(key)) continue;
-    seen.add(key);
-    out.push({ knowledge_base: kb, path: pathValue, score: r.score });
+    const existing = seen.get(key);
+    if (existing !== undefined) {
+      if (r.chunk_id !== undefined) {
+        const chunkIds = existing.chunk_ids ?? (existing.chunk_id ? [existing.chunk_id] : []);
+        if (!chunkIds.includes(r.chunk_id)) {
+          chunkIds.push(r.chunk_id);
+          existing.chunk_ids = chunkIds;
+        }
+      }
+      continue;
+    }
+    const citation: AskCitation = {
+      knowledge_base: kb,
+      path: pathValue,
+      score: r.score,
+      ...(r.chunk_id ? { chunk_id: r.chunk_id } : {}),
+      ...(r.chunk_id ? { chunk_ids: [r.chunk_id] } : {}),
+    };
+    seen.set(key, citation);
+    out.push(citation);
   }
   return out;
+}
+
+export function buildAskTranscriptMarkdown(record: AskTranscriptRecord): string {
+  const lines: string[] = [];
+  lines.push('---');
+  lines.push('type: kb_ask_transcript');
+  lines.push(`created_at: ${yamlString(record.createdAt)}`);
+  lines.push(`question_sha256: ${yamlString(sha256(record.question))}`);
+  if (record.retrieval.knowledge_base !== null) {
+    lines.push(`knowledge_base: ${yamlString(record.retrieval.knowledge_base)}`);
+  }
+  lines.push(`retrieval_model: ${yamlString(record.retrieval.embedding_model)}`);
+  lines.push(`llm_profile: ${yamlString(record.llm.profile)}`);
+  lines.push(`llm_mode: ${yamlString(record.llm.mode)}`);
+  if (record.llm.model !== null) {
+    lines.push(`llm_model: ${yamlString(record.llm.model)}`);
+  }
+  lines.push('---');
+  lines.push('');
+  lines.push(`# ${record.title}`);
+  lines.push('');
+  lines.push('## Question');
+  lines.push('');
+  lines.push(record.question.trim());
+  lines.push('');
+  lines.push('## Answer');
+  lines.push('');
+  lines.push(record.answer.trim());
+  lines.push('');
+  lines.push('## Citations');
+  lines.push('');
+  if (record.citations.length === 0) {
+    lines.push('_No citations returned._');
+  } else {
+    record.citations.forEach((citation, index) => {
+      const kbPrefix = citation.knowledge_base ? `${citation.knowledge_base}:` : '';
+      const score = typeof citation.score === 'number' ? `, score ${citation.score.toFixed(4)}` : '';
+      const chunkIds = citation.chunk_ids ?? (citation.chunk_id ? [citation.chunk_id] : []);
+      const chunks = chunkIds.length > 0 ? `, chunks ${chunkIds.map((id) => `\`${id}\``).join(', ')}` : '';
+      lines.push(`${index + 1}. \`${kbPrefix}${citation.path}\`${score}${chunks}`);
+    });
+  }
+  lines.push('');
+  lines.push('## Provenance');
+  lines.push('');
+  lines.push(`- asked at: \`${record.createdAt}\``);
+  lines.push(`- LLM profile: \`${record.llm.profile}\``);
+  lines.push(`- LLM mode: \`${record.llm.mode}\``);
+  lines.push(`- LLM source: \`${record.llm.source}\``);
+  lines.push(`- LLM endpoint: \`${record.llm.endpoint}\``);
+  lines.push(`- LLM model: \`${record.llm.model ?? 'unknown'}\``);
+  lines.push(`- retrieval model: \`${record.retrieval.embedding_model}\``);
+  lines.push(`- retrieval knowledge base: \`${record.retrieval.knowledge_base ?? 'all'}\``);
+  lines.push(`- retrieval k: \`${record.retrieval.k}\``);
+  lines.push(`- refreshed before retrieval: \`${record.retrieval.refreshed}\``);
+  if (record.timing !== undefined) {
+    lines.push('');
+    lines.push('## Timing');
+    lines.push('');
+    lines.push('```json');
+    lines.push(JSON.stringify(record.timing, null, 2));
+    lines.push('```');
+  }
+  lines.push('');
+  return `${lines.join('\n')}`;
+}
+
+export async function createAskTranscriptNote(
+  rootDir: string,
+  kbName: string,
+  title: string,
+  content: string,
+): Promise<string> {
+  const relativePath = `${slugifyTitle(title, { fallback: 'ask-transcript' })}.md`;
+  const documentPath = await resolveKbPath(rootDir, kbName, relativePath, { mustExist: false });
+  await fsp.mkdir(path.dirname(documentPath), { recursive: true });
+  const tmpPath = `${documentPath}.kb-tmp.${process.pid}.${Date.now()}.${Math.random().toString(16).slice(2)}`;
+  try {
+    const handle = await fsp.open(tmpPath, 'wx');
+    try {
+      await handle.writeFile(content, 'utf-8');
+      await handle.sync();
+    } finally {
+      await handle.close();
+    }
+    await fsp.link(tmpPath, documentPath);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'EEXIST') {
+      throw new Error(`refusing to overwrite existing transcript: ${relativePath}`);
+    }
+    throw err;
+  } finally {
+    await fsp.unlink(tmpPath).catch(() => {});
+  }
+  const kbDir = await resolveKnowledgeBaseDir(rootDir, kbName);
+  return path.relative(kbDir, documentPath).split(path.sep).join('/');
+}
+
+async function safeResolveKbPath(
+  rootDir: string,
+  kbName: string,
+  relativePath: string,
+): Promise<string | null> {
+  try {
+    return await resolveKbPath(
+      rootDir,
+      kbName,
+      relativePath,
+      { mustExist: false },
+    );
+  } catch {
+    return null;
+  }
+}
+
+function defaultAskTranscriptTitle(question: string): string {
+  const compact = question.replace(/\s+/g, ' ').trim();
+  const suffix = compact.length > 80 ? `${compact.slice(0, 77)}...` : compact;
+  return `Ask transcript - ${suffix}`;
+}
+
+function yamlString(value: string): string {
+  return JSON.stringify(value);
+}
+
+function sha256(value: string): string {
+  return crypto.createHash('sha256').update(value).digest('hex');
 }
 
 function stringMetadata(metadata: Record<string, unknown>, key: string): string | null {

--- a/src/cli-remember.ts
+++ b/src/cli-remember.ts
@@ -19,6 +19,7 @@ import {
   formatBlockedMarkdown,
   type SimilarCandidate,
 } from './cli-remember-similarity.js';
+import { slugifyTitle } from './slug.js';
 import {
   auditEnabled,
   recordMutation,
@@ -1001,17 +1002,6 @@ async function appendSectionInExistingNote(
   return path.relative(await resolveKnowledgeBaseDir(KNOWLEDGE_BASES_ROOT_DIR, kbName), documentPath)
     .split(path.sep)
     .join('/');
-}
-
-function slugifyTitle(title: string): string {
-  const slug = title
-    .normalize('NFKD')
-    .replace(/[\u0300-\u036f]/g, '')
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')
-    .replace(/-{2,}/g, '-');
-  return slug.length > 0 ? slug.slice(0, 80).replace(/-+$/g, '') : 'note';
 }
 
 async function refreshKnowledgeBase(kbName: string): Promise<void> {

--- a/src/slug.ts
+++ b/src/slug.ts
@@ -1,0 +1,17 @@
+export interface SlugifyTitleOptions {
+  fallback?: string;
+  maxLength?: number;
+}
+
+export function slugifyTitle(title: string, options: SlugifyTitleOptions = {}): string {
+  const maxLength = options.maxLength ?? 80;
+  const fallback = options.fallback ?? 'note';
+  const slug = title
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .replace(/-{2,}/g, '-');
+  return slug.length > 0 ? slug.slice(0, maxLength).replace(/-+$/g, '') : fallback;
+}


### PR DESCRIPTION
## Summary
- add `kb ask --save-transcript` with `--title` and `--yes` validation to persist cited answer records as markdown notes
- include question/answer, citations with chunk ids, LLM provenance, retrieval metadata, optional timing, and mutation audit log coverage
- share slug generation between `kb remember` and transcript writes, and document the new CLI behavior and requirements/tests

Closes #382

## Verification
- `npm test -- --runTestsByPath src/cli-ask.test.ts`
- `npm run build`
- `npm test -- --runInBand`
- `git diff --check`
- manual portability scan for added absolute user paths

## Pre-PR Review
- test specialist: added integrated `runAsk` save-transcript path coverage
- conventions specialist: extracted shared slug helper and documented audit surface
- correctness specialist: changed transcript writes to temp-file + fsync + exclusive hardlink to avoid partial direct writes
- dead-code specialist: no dead code findings
