### PR TITLE
feat(cli): expose JSON help manifest

### DIFF
--- a/docs/cli-json-contracts.md
+++ b/docs/cli-json-contracts.md
@@ -14,6 +14,89 @@ Contract policy:
   command section says otherwise. Human diagnostics, warnings, logger output,
   and argv/runtime errors generally go to stderr.
 
+## `kb help`
+
+Invocation:
+
+```bash
+kb help --format=json
+kb help <command> --format=json
+```
+
+Top-level success envelope:
+
+```json
+{
+  "schema_version": "kb.help.v1",
+  "command": "kb",
+  "usage": ["kb <command> [options]"],
+  "commands": [
+    {
+      "name": "search",
+      "summary": "Semantic search across one or all knowledge bases.",
+      "usage": ["kb search <query> [options]"],
+      "options": [
+        {
+          "flags": ["--format"],
+          "value": "md|json|vimgrep",
+          "description": "Output format."
+        }
+      ],
+      "stability": "stable"
+    }
+  ],
+  "environment": [
+    {
+      "name": "KNOWLEDGE_BASES_ROOT_DIR",
+      "description": "Root directory containing one folder per KB."
+    }
+  ],
+  "exit_codes": [
+    { "code": 0, "description": "success (results found or empty)" }
+  ],
+  "stability": "stable"
+}
+```
+
+Command-specific success envelope:
+
+```json
+{
+  "schema_version": "kb.help.v1",
+  "command": {
+    "name": "search",
+    "summary": "Semantic search across one or all knowledge bases.",
+    "usage": ["kb search <query> [options]"],
+    "options": [],
+    "stability": "stable"
+  }
+}
+```
+
+Stable fields:
+
+- `schema_version`: currently `kb.help.v1`.
+- Top-level `command`: literal `kb`.
+- Top-level `usage`: array of usage lines from the top-level help block.
+- Top-level `commands`: one object per registered command, in CLI help order.
+- Command `name`, `summary`, `usage`, `options`, and `stability`.
+- Option `flags`: array of flag names without value placeholders, such as
+  `--format` and `-h`.
+- Option `value`: string value placeholder when the help text declares one,
+  otherwise `null`.
+- Option `description`: prose description from the command help.
+- Top-level `environment` and `exit_codes`: metadata from the top-level help
+  block.
+- `stability`: currently `stable`; consumers should feature-detect fields and
+  check `schema_version` before assuming compatibility.
+
+Stdout/stderr and exit codes:
+
+- Success JSON is stdout with exit `0`.
+- Unknown command handling matches prose help: stderr diagnostic, empty stdout,
+  exit `2`.
+- `kb help` without `--format=json` keeps the existing human-readable output.
+
 ## `kb search`
 
 Invocation:

--- a/docs/requirements/INDEX.md
+++ b/docs/requirements/INDEX.md
@@ -102,6 +102,22 @@
 
 ## Search
 
+### FR-CLI-383: Machine-Readable Help Manifest
+**Status:** Implemented
+**Priority:** Medium
+
+**Requirement:** The system shall expose command and option metadata through `kb help --format=json` without requiring callers to parse prose help output.
+**Rationale:** Contributor tooling, completions, and agent workflows need a stable command manifest that stays aligned with the CLI registry and per-command help text.
+
+**Acceptance Criteria:**
+- [x] Given `kb help --format=json`, when the command runs, then stdout is valid JSON with a stable schema version, top-level usage, environment variables, exit codes, and every registered command.
+- [x] Given `kb help <command> --format=json`, when the command exists, then stdout is valid JSON for that command with its name, summary, usage lines, option metadata, and stability tag.
+- [x] Given `kb help <command> --format=json`, when the command does not exist, then the CLI preserves the existing unknown-command stderr error and exit code.
+- [x] Given `kb help` without `--format=json`, when the command runs, then existing markdown/plain help output remains unchanged.
+
+**Linked Tests:** TS-CLI-383
+**Dependencies:** RFC012
+
 ### FR-ASK-382: Cited Ask Transcript Records
 **Status:** Implemented
 **Priority:** Medium

--- a/docs/testing/INDEX.md
+++ b/docs/testing/INDEX.md
@@ -65,6 +65,17 @@
 
 ## Search
 
+### TS-CLI-383: Machine-Readable Help Manifest
+**Requirement:** FR-CLI-383
+
+**Test Cases:**
+- `kb help --format=json` shall emit parseable JSON with schema version `kb.help.v1`, top-level usage, environment variables, exit codes, and every registered command.
+- `kb help <command> --format=json` shall emit parseable JSON for the selected command with name, summary, usage, options, and stability metadata.
+- `kb help <command> --format=json` shall preserve wrapped usage blocks without parsing example continuations as option definitions.
+- `kb help --format=<unsupported>` and unknown `kb help` flags shall exit 2 with stderr diagnostics and empty stdout.
+- `kb help <command> --format=json` shall preserve the existing unknown-command stderr error and exit code when the command is not registered.
+- `kb help` without `--format=json` shall preserve the existing human-readable help output.
+
 ### TS-ASK-382: Cited Ask Transcript Records
 **Requirement:** FR-ASK-382
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -117,6 +117,111 @@ describe('kb CLI — argv parsing and dispatch', () => {
     expect(r.stdout).toContain('Available commands:');
   });
 
+  it('kb help --format=json emits a stable command manifest (#383)', () => {
+    const r = runCli(['help', '--format=json']);
+    expect(r.code).toBe(0);
+    expect(r.stderr).toBe('');
+    const manifest = JSON.parse(r.stdout) as {
+      schema_version: string;
+      command: string;
+      usage: string[];
+      commands: Array<{
+        name: string;
+        summary: string;
+        usage: string[];
+        options: Array<{ flags: string[]; value: string | null; description: string }>;
+        stability: string;
+      }>;
+      environment: Array<{ name: string; description: string }>;
+      exit_codes: Array<{ code: number; description: string }>;
+      stability: string;
+    };
+
+    expect(manifest.schema_version).toBe('kb.help.v1');
+    expect(manifest.command).toBe('kb');
+    expect(manifest.usage).toContain('kb <command> [options]');
+    expect(manifest.stability).toBe('stable');
+    expect(manifest.environment).toEqual(expect.arrayContaining([
+      expect.objectContaining({ name: 'KNOWLEDGE_BASES_ROOT_DIR' }),
+      expect.objectContaining({ name: 'KB_LLM_ENDPOINT' }),
+      expect.objectContaining({
+        name: 'OLLAMA_*',
+        description: expect.stringContaining('Provider-specific config'),
+      }),
+      expect.objectContaining({
+        name: 'OPENAI_*',
+        description: expect.stringContaining('Provider-specific config'),
+      }),
+      expect.objectContaining({
+        name: 'HUGGINGFACE_*',
+        description: expect.stringContaining('Provider-specific config'),
+      }),
+    ]));
+    expect(manifest.environment.find((entry) => entry.name === 'KB_LLM_ENDPOINT')?.description)
+      .toBe('OpenAI-compatible endpoint used by `kb ask`.');
+    expect(manifest.exit_codes).toEqual(expect.arrayContaining([
+      { code: 0, description: 'success (results found or empty)' },
+      { code: 2, description: 'argv / env / model-resolution error' },
+    ]));
+    const names = manifest.commands.map((command) => command.name);
+    expect(names).toEqual([
+      'list',
+      'search',
+      'serve',
+      'ask',
+      'remember',
+      'capture',
+      'compare',
+      'doctor',
+      'stats',
+      'eval',
+      'eval-gate',
+      'explain',
+      'stale-check',
+      'superseded',
+      'promote',
+      'quarantine',
+      'where',
+      'models',
+      'llm',
+      'reindex',
+    ]);
+    for (const command of manifest.commands) {
+      for (const option of command.options) {
+        for (const flag of option.flags) {
+          expect(`${command.name}:${flag}`).toMatch(/^[a-z0-9-]+:--?$|^[a-z0-9-]+:--?[A-Za-z0-9][A-Za-z0-9-]*$/);
+        }
+      }
+    }
+    const search = manifest.commands.find((command) => command.name === 'search');
+    expect(search).toMatchObject({
+      summary: 'Semantic search across one or all knowledge bases.',
+      stability: 'stable',
+    });
+    expect(search?.usage).toContain('kb search <query> [options]');
+    expect(search?.options).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        flags: ['--format'],
+        value: 'md|json|vimgrep',
+      }),
+      expect.objectContaining({
+        flags: ['--help', '-h'],
+        value: null,
+      }),
+    ]));
+    const llm = manifest.commands.find((command) => command.name === 'llm');
+    expect(llm?.options).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        flags: ['--profile'],
+        value: '<name>',
+      }),
+      expect.objectContaining({
+        flags: ['--all'],
+        value: null,
+      }),
+    ]));
+  });
+
   it('kb help <command> mirrors `kb <command> --help`', () => {
     const a = runCli(['help', 'search']);
     const b = runCli(['search', '--help']);
@@ -125,11 +230,93 @@ describe('kb CLI — argv parsing and dispatch', () => {
     expect(a.stdout).toBe(b.stdout);
   });
 
+  it('kb help <command> --format=json emits only the selected command manifest (#383)', () => {
+    const r = runCli(['help', 'search', '--format=json']);
+    expect(r.code).toBe(0);
+    expect(r.stderr).toBe('');
+    const payload = JSON.parse(r.stdout) as {
+      schema_version: string;
+      command: {
+        name: string;
+        summary: string;
+        usage: string[];
+        options: Array<{ flags: string[]; value: string | null; description: string }>;
+        stability: string;
+      };
+    };
+
+    expect(payload.schema_version).toBe('kb.help.v1');
+    expect(payload.command.name).toBe('search');
+    expect(payload.command.usage).toContain('kb search <query> [options]');
+    expect(payload.command.options).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        flags: ['--kb'],
+        value: '<name>',
+      }),
+      expect.objectContaining({
+        flags: ['--format'],
+        value: 'md|json|vimgrep',
+      }),
+    ]));
+    expect(payload.command.stability).toBe('stable');
+  });
+
+  it('kb help <command> --format=json handles wrapped usage and examples safely (#383)', () => {
+    const r = runCli(['help', 'promote', '--format=json']);
+    expect(r.code).toBe(0);
+    expect(r.stderr).toBe('');
+    const payload = JSON.parse(r.stdout) as {
+      command: {
+        usage: string[];
+        options: Array<{ flags: string[]; value: string | null; description: string }>;
+      };
+    };
+
+    expect(payload.command.usage).toEqual(expect.arrayContaining([
+      'kb promote --kb=<name> --query=<topic> [--k=<int>] [--format=md|json]',
+      'kb promote --kb=<name> --path=<rel.md>',
+      '[--review-status=approved|needs-review]',
+      '[--format=md|json] [--yes]',
+    ]));
+    const reviewStatusOptions = payload.command.options.filter((option) => (
+      option.flags.includes('--review-status')
+    ));
+    expect(reviewStatusOptions).toHaveLength(1);
+    expect(reviewStatusOptions[0]).toMatchObject({
+      value: '<value>',
+      description: expect.stringContaining('New review status'),
+    });
+    expect(payload.command.options).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        value: 'approved --last-verified-at=now --yes',
+      }),
+    ]));
+  });
+
   it('kb help unknown-cmd exits 2 with a stderr error', () => {
     const r = runCli(['help', 'not-a-real-command']);
     expect(r.code).toBe(2);
     expect(r.stderr).toContain("unknown command 'not-a-real-command'");
     expect(r.stdout).toBe('');
+  });
+
+  it('kb help unknown-cmd --format=json keeps the existing error contract (#383)', () => {
+    const r = runCli(['help', 'not-a-real-command', '--format=json']);
+    expect(r.code).toBe(2);
+    expect(r.stderr).toContain("unknown command 'not-a-real-command'");
+    expect(r.stdout).toBe('');
+  });
+
+  it('kb help --format rejects unsupported formats and unknown flags (#383)', () => {
+    const invalidFormat = runCli(['help', '--format=yaml']);
+    expect(invalidFormat.code).toBe(2);
+    expect(invalidFormat.stderr).toContain('invalid --format: --format=yaml');
+    expect(invalidFormat.stdout).toBe('');
+
+    const unknownFlag = runCli(['help', 'search', '--bogus']);
+    expect(unknownFlag.code).toBe(2);
+    expect(unknownFlag.stderr).toContain('unknown flag: --bogus');
+    expect(unknownFlag.stdout).toBe('');
   });
 
   it('--help anywhere in argv intercepts before the subcommand runs', () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -45,6 +45,44 @@ interface Subcommand {
   handler: (rest: string[]) => Promise<number>;
 }
 
+interface HelpManifestOption {
+  flags: string[];
+  value: string | null;
+  description: string;
+}
+
+interface HelpManifestCommand {
+  name: string;
+  summary: string;
+  usage: string[];
+  options: HelpManifestOption[];
+  stability: 'stable';
+}
+
+interface HelpManifestDefinition {
+  name: string;
+  description: string;
+}
+
+interface HelpManifestExitCode {
+  code: number;
+  description: string;
+}
+
+interface HelpArgs {
+  command?: string;
+  format: 'md' | 'json';
+}
+
+const HELP_SCHEMA_VERSION = 'kb.help.v1';
+const NON_OPTION_HELP_SECTIONS = new Set([
+  'Usage:',
+  'Examples:',
+  'Notes:',
+  'Environment:',
+  'Exit codes:',
+]);
+
 const SUBCOMMANDS: readonly Subcommand[] = [
   { name: 'list',         summary: 'List available knowledge bases.',                                         help: LIST_HELP,         handler: runList },
   { name: 'search',       summary: 'Semantic search across one or all knowledge bases.',                     help: SEARCH_HELP,       handler: runSearch },
@@ -132,16 +170,35 @@ export async function main(argv: string[]): Promise<number> {
 
   // `kb help` and `kb help <command>` mirror `kb --help` and `kb <command> --help`.
   if (sub === 'help') {
-    if (rest.length === 0 || wantsHelp(rest)) {
+    if (wantsHelp(rest)) {
       process.stdout.write(HELP);
       return 0;
     }
-    const target = SUBCOMMANDS.find((s) => s.name === rest[0]);
-    if (!target) {
-      process.stderr.write(`kb help: unknown command '${rest[0]}'\n`);
+    let helpArgs: HelpArgs;
+    try {
+      helpArgs = parseHelpArgs(rest);
+    } catch (err) {
+      process.stderr.write(`kb help: ${(err as Error).message}\n`);
       return 2;
     }
-    process.stdout.write(target.help);
+    if (helpArgs.command === undefined) {
+      if (helpArgs.format === 'json') writeJson(buildTopLevelHelpManifest());
+      else process.stdout.write(HELP);
+      return 0;
+    }
+    const target = SUBCOMMANDS.find((s) => s.name === helpArgs.command);
+    if (!target) {
+      process.stderr.write(`kb help: unknown command '${helpArgs.command}'\n`);
+      return 2;
+    }
+    if (helpArgs.format === 'json') {
+      writeJson({
+        schema_version: HELP_SCHEMA_VERSION,
+        command: buildCommandHelpManifest(target),
+      });
+    } else {
+      process.stdout.write(target.help);
+    }
     return 0;
   }
 
@@ -162,6 +219,246 @@ export async function main(argv: string[]): Promise<number> {
       ? () => runSearchMaybeViaDaemon(rest)
       : () => target.handler(rest),
   );
+}
+
+function parseHelpArgs(rest: readonly string[]): HelpArgs {
+  const out: HelpArgs = { format: 'md' };
+  for (const raw of rest) {
+    if (raw === '--format=json') {
+      out.format = 'json';
+      continue;
+    }
+    if (raw === '--format=md') {
+      out.format = 'md';
+      continue;
+    }
+    if (raw.startsWith('--format=')) {
+      throw new Error(`invalid --format: ${raw}`);
+    }
+    if (raw.startsWith('--')) {
+      throw new Error(`unknown flag: ${raw}`);
+    }
+    if (out.command === undefined) {
+      out.command = raw;
+    }
+  }
+  return out;
+}
+
+function writeJson(payload: unknown): void {
+  process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+}
+
+function buildTopLevelHelpManifest() {
+  return {
+    schema_version: HELP_SCHEMA_VERSION,
+    command: 'kb',
+    usage: extractUsageLines(HELP),
+    commands: SUBCOMMANDS.map(buildCommandHelpManifest),
+    environment: extractDefinitionList(HELP, 'Environment:'),
+    exit_codes: extractExitCodes(HELP),
+    stability: 'stable' as const,
+  };
+}
+
+function buildCommandHelpManifest(command: Subcommand): HelpManifestCommand {
+  return {
+    name: command.name,
+    summary: command.summary,
+    usage: extractUsageLines(command.help),
+    options: extractOptions(command.help),
+    stability: 'stable',
+  };
+}
+
+function extractUsageLines(help: string): string[] {
+  const lines = help.split('\n');
+  const usageIndex = lines.findIndex((line) => line.trim() === 'Usage:');
+  if (usageIndex === -1) return [];
+  const usage: string[] = [];
+  for (let i = usageIndex + 1; i < lines.length; i++) {
+    const line = lines[i];
+    if (line.trim() === '') {
+      if (usage.length === 0) continue;
+      const nextContent = lines.slice(i + 1).find((nextLine) => nextLine.trim() !== '');
+      if (nextContent !== undefined && nextContent.startsWith('  ')) continue;
+      break;
+    }
+    if (!line.startsWith('  ')) break;
+    const trimmed = line.trim();
+    if (trimmed.startsWith('#')) {
+      continue;
+    }
+    usage.push(trimmed);
+  }
+  return usage;
+}
+
+function extractOptions(help: string): HelpManifestOption[] {
+  const options: HelpManifestOption[] = [];
+  let current: HelpManifestOption | null = null;
+  let inOptionSection = false;
+  for (const line of help.split('\n')) {
+    if (!line.startsWith(' ') && line.trim().endsWith(':')) {
+      inOptionSection = isOptionMetadataSection(line.trim());
+      current = null;
+      continue;
+    }
+    if (!inOptionSection) {
+      continue;
+    }
+    const optionLine = parseOptionLine(line);
+    if (optionLine !== null) {
+      current = optionLine;
+      options.push(optionLine);
+      continue;
+    }
+    if (current !== null && isContinuationLine(line)) {
+      current.description = appendDescription(current.description, line.trim());
+    } else if (line.trim() === '') {
+      current = null;
+    }
+  }
+  addUsageOptions(options, extractUsageLines(help));
+  return options;
+}
+
+function isOptionMetadataSection(heading: string): boolean {
+  return !NON_OPTION_HELP_SECTIONS.has(heading);
+}
+
+function parseOptionLine(line: string): HelpManifestOption | null {
+  if (!line.startsWith('  ')) return null;
+  const trimmed = line.trimStart();
+  if (!trimmed.startsWith('-')) return null;
+  const match = /^(\S+(?:,\s+\S+)*)\s{2,}(.*)$/.exec(trimmed);
+  const flagSpec = match?.[1] ?? trimmed;
+  const parsedFlags = parseFlagSpec(flagSpec);
+  if (parsedFlags.flags.length === 0) return null;
+  return {
+    flags: parsedFlags.flags,
+    value: parsedFlags.value,
+    description: match?.[2]?.trim() ?? '',
+  };
+}
+
+function parseFlagSpec(flagSpec: string): { flags: string[]; value: string | null } {
+  const flags: string[] = [];
+  let value: string | null = null;
+  for (const rawPart of flagSpec.split(',')) {
+    const part = rawPart.trim();
+    if (part === '') continue;
+    const eqIndex = part.indexOf('=');
+    const flag = eqIndex === -1 ? part : part.slice(0, eqIndex);
+    if (!isHelpFlagToken(flag)) continue;
+    flags.push(flag);
+    if (eqIndex !== -1 && value === null) value = part.slice(eqIndex + 1);
+  }
+  return { flags, value };
+}
+
+function addUsageOptions(options: HelpManifestOption[], usageLines: string[]): void {
+  const seen = new Set(options.flatMap((option) => option.flags));
+  for (const usageLine of usageLines) {
+    for (const flagSpec of usageFlagSpecs(usageLine)) {
+      const parsed = parseFlagSpec(flagSpec);
+      const newFlags = parsed.flags.filter((flag) => !seen.has(flag));
+      if (newFlags.length === 0) continue;
+      for (const flag of newFlags) seen.add(flag);
+      options.push({
+        flags: newFlags,
+        value: parsed.value,
+        description: '',
+      });
+    }
+  }
+}
+
+function usageFlagSpecs(usageLine: string): string[] {
+  const specs: string[] = [];
+  const matches = usageLine.match(/--[A-Za-z0-9][A-Za-z0-9-]*(?:=[^\s\]]+)?/g) ?? [];
+  for (const match of matches) {
+    if (match.includes('|--')) {
+      specs.push(...match.split('|').filter((part) => part.startsWith('--')));
+    } else {
+      specs.push(match);
+    }
+  }
+  return specs;
+}
+
+function isHelpFlagToken(value: string): boolean {
+  return value === '--' || /^--?[A-Za-z0-9][A-Za-z0-9-]*$/.test(value);
+}
+
+function extractDefinitionList(help: string, heading: string): HelpManifestDefinition[] {
+  const lines = help.split('\n');
+  const headingIndex = lines.findIndex((line) => line.trim() === heading);
+  if (headingIndex === -1) return [];
+  const definitions: HelpManifestDefinition[] = [];
+  let current: HelpManifestDefinition[] = [];
+  for (const line of lines.slice(headingIndex + 1)) {
+    if (line.trim() === '') {
+      if (definitions.length > 0) break;
+      continue;
+    }
+    if (!line.startsWith('  ')) break;
+    if (isDefinitionContinuationLine(line) && current.length > 0) {
+      for (const definition of current) {
+        definition.description = appendDescription(definition.description, line.trim());
+      }
+      continue;
+    }
+    const match = /^ {2}(.+?)\s{2,}(.*)$/.exec(line);
+    if (match) {
+      current = pushDefinitions(definitions, match[1], match[2].trim());
+      continue;
+    }
+    current = pushDefinitions(definitions, line.trim(), '');
+  }
+  return definitions;
+}
+
+function pushDefinitions(
+  definitions: HelpManifestDefinition[],
+  namesText: string,
+  description: string,
+): HelpManifestDefinition[] {
+  const current = namesText.split(',').map((name) => ({
+    name: name.trim(),
+    description,
+  })).filter((definition) => definition.name !== '');
+  definitions.push(...current);
+  return current;
+}
+
+function extractExitCodes(help: string): HelpManifestExitCode[] {
+  const lines = help.split('\n');
+  const headingIndex = lines.findIndex((line) => line.trim() === 'Exit codes:');
+  if (headingIndex === -1) return [];
+  const exitCodes: HelpManifestExitCode[] = [];
+  for (const line of lines.slice(headingIndex + 1)) {
+    if (line.trim() === '') {
+      if (exitCodes.length > 0) break;
+      continue;
+    }
+    const match = /^ {2}(\d+)\s{2,}(.*)$/.exec(line);
+    if (!match) break;
+    exitCodes.push({ code: Number(match[1]), description: match[2].trim() });
+  }
+  return exitCodes;
+}
+
+function isContinuationLine(line: string): boolean {
+  return line.startsWith('                        ') && line.trim() !== '';
+}
+
+function isDefinitionContinuationLine(line: string): boolean {
+  return /^ {4,}\S/.test(line);
+}
+
+function appendDescription(description: string, continuation: string): string {
+  return description === '' ? continuation : `${description} ${continuation}`;
 }
 
 async function runSubcommandWithCanonicalLog(


### PR DESCRIPTION
## Summary
- add `kb help --format=json` and `kb help <command> --format=json` with schema `kb.help.v1`
- derive command usage, options, environment variables, exit codes, and stability metadata from the existing CLI registry/help text
- document the JSON contract and add requirements/testing traceability for FR-CLI-383

Closes #383

## Verification
- `npm run build`
- `npm test -- --runTestsByPath src/cli.test.ts`
- `npm test -- --runInBand`
- `git diff --check`
- portability scan of added diff lines for user-specific absolute paths

## Pre-PR Review
- correctness specialist: fixed wrapped `promote` usage omission and prevented example continuation lines from becoming options
- test specialist: added invalid `--format` and unknown help flag coverage; runtime path is tested through `node build/cli.js`
- conventions specialist: centralized `HELP_SCHEMA_VERSION`
- dead-code specialist: no dead code introduced

## Pre-PR Checklist
- detected project type: npm
- type/build checks: passed
- tests: passed
- bug reproduction: skipped; feature PR, not a bug-fix PR
- diff review: done
- portability check: clean
- reviewer specialists: run, findings addressed
- OSS base-branch policy: skipped; same-repo PR
