### PR TITLE
fix(index): recover pending sidecar commits

### DIFF
--- a/docs/architecture/data-model.md
+++ b/docs/architecture/data-model.md
@@ -56,6 +56,19 @@ Written after a successful FAISS save by `writeSidecarHashes` (`src/file-ingest.
 
 The path structure mirrors the source tree under `<kb>/`: a file at `<kb>/a/b/c.md` gets a sidecar at `<kb>/.index/a/b/c.md`. ADR [`0002-per-file-hash-sidecars.md`](./adr/0002-per-file-hash-sidecars.md) covers why this layout was chosen over a single `hashes.json` manifest.
 
+### Pending sidecar commit manifest
+
+`pending-manifest.json` lives in `models/<model_id>/` while an index-mutating `updateIndex` is between FAISS persistence and sidecar persistence. It records the hash sidecars and chunk manifests that must be written for the saved vectors to be considered committed.
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `schema_version` | `kb.pending-sidecar-commit.v1` | Parser guard. |
+| `phase` | `save-started` or `save-complete` | Whether the FAISS save has been confirmed. |
+| `pending_hash_writes` | array of `{path, hash}` | Absolute hash sidecar paths plus source sha256. |
+| `pending_chunk_manifest_writes` | array of `{path, manifest}` | Absolute chunk-manifest sidecar paths plus manifest JSON. |
+
+Normal completion removes the manifest after all sidecars are durable. On startup, `save-complete` rolls forward by writing the sidecars and removing the manifest. `save-started` is intentionally conservative: recovery purges the persisted store and stale sidecars so the next update rebuilds instead of risking duplicate vectors or hashes for missing vectors.
+
 ### Model registry
 
 `$FAISS_INDEX_PATH/active.txt` records the active `model_id`; callers can override it with `KB_ACTIVE_MODEL` (`src/active-model.ts:5`, `:26`). Each registered model lives at `$FAISS_INDEX_PATH/models/<model_id>/`, where `<model_id>` is derived from provider and model name (`README.md:102`, `src/active-model.ts:37-43`).

--- a/docs/architecture/sequence-retrieve.md
+++ b/docs/architecture/sequence-retrieve.md
@@ -91,7 +91,7 @@ sequenceDiagram
 
 ### Ordering invariant
 
-One `save()` per `updateIndex` call; hash sidecars are written **after** `save()` completes and use tmp+rename so each is atomic. If the process dies between `save()` and finishing sidecar writes, the un-sidecar'd files are re-embedded on the next call and their vectors are duplicated. RFC 007 §6.2.1 tracks the pending-manifest protocol that will close this gap; the current state is documented at `src/FaissIndexManager.ts:356-377` and in [`state-index.md`](./state-index.md) under **Recovering**.
+One `save()` per index-mutating `updateIndex` call; hash and chunk sidecars are written **after** `save()` completes and use tmp+rename so each sidecar is atomic. Before the save, `updateIndex` writes `$FAISS_INDEX_PATH/models/<model_id>/pending-manifest.json` with the pending sidecar set and phase `save-started`; after the FAISS save succeeds it advances the phase to `save-complete`; after every sidecar is durable it removes the manifest. On the next normal `initialize()`, `save-complete` manifests are rolled forward by finishing the sidecar writes. Ambiguous `save-started` manifests cause the persisted store and stale sidecars to be purged so the next scan rebuilds instead of duplicating vectors.
 
 ### Fallback rebuild edge case
 

--- a/docs/architecture/state-index.md
+++ b/docs/architecture/state-index.md
@@ -1,8 +1,6 @@
 # State — FAISS index lifecycle
 
-Lifecycle of the in-memory `this.faissIndex: FaissStore | null` field (`src/FaissIndexManager.ts:81`) and its on-disk counterpart at `$FAISS_INDEX_PATH/faiss.index`. The diagram describes observable states from the caller's perspective — the field is either `null` or a `FaissStore`; the lifecycle enriches that single bit with the *reason* for its current value.
-
-`Recovering` is planned-but-not-yet-implemented state gated on RFC 007 §6.2.1 (pending-manifest protocol). It is drawn so this doc tracks the direction of travel; see the footnote below.
+Lifecycle of the in-memory `this.faissIndex: FaissStore | null` field and its on-disk counterpart under `$FAISS_INDEX_PATH/models/<model_id>/`. The diagram describes observable states from the caller's perspective: the field is either `null` or a loaded FAISS store; the lifecycle enriches that single bit with the reason for its current value.
 
 ## Diagram
 
@@ -13,57 +11,56 @@ stateDiagram-v2
   state "None" as None
   note left of None
     faissIndex = null
-    $FAISS_INDEX_PATH may or may not exist
-    src/FaissIndexManager.ts:81
+    model directory may or may not exist
+    FaissIndexManager.initialize()
   end note
 
-  None --> Loading: initialize() sees faiss.index on disk<br/>:166
+  None --> Loading: initialize() sees a versioned<br/>or legacy FAISS store on disk
 
   state "Loading" as Loading
   note right of Loading
     FaissStore.load(path, embeddings)
-    src/FaissIndexManager.ts:169
+    loadFaissStoreAtomic()
     (may throw → handleFsOperationError)
   end note
 
-  Loading --> Loaded: load() resolves<br/>:173
+  Loading --> Loaded: load() resolves
   Loading --> None: load() fails → re-thrown; next init retries
 
-  None --> Rebuilding: initialize() sees model_name.txt mismatch<br/>:153-164
-  Loaded --> Rebuilding: (not today — index is kept; rebuild happens only via initialize())
+  None --> Rebuilding: force reindex or freshness manifest mismatch
+  Loaded --> Rebuilding: force reindex or freshness manifest mismatch
 
   state "Rebuilding" as Rebuilding
   note right of Rebuilding
-    unlink(faiss.index)
     faissIndex = null
-    model_name.txt rewritten on exit of initialize()
-    src/FaissIndexManager.ts:154-164, :181
+    persisted index store removed
+    updateIndex() embeds from current files
   end note
 
-  Rebuilding --> None: initialize() returns<br/>(next updateIndex hits fallback :302-346)
+  Rebuilding --> None: persisted store purged
 
-  None --> Loaded: updateIndex fallback rebuild<br/>:302-346 → FaissStore.fromTexts
-  None --> Loaded: first updateIndex call with changed files<br/>:278-284
+  None --> Loaded: updateIndex fallback rebuild
+  None --> Loaded: first updateIndex call with changed files
 
   state "Loaded" as Loaded
   note left of Loaded
-    faissIndex is a FaissStore
-    $FAISS_INDEX_PATH/faiss.index persisted
-    ready to answer similaritySearch :394-408
+    faissIndex wraps a FaissStore
+    models/<model_id>/index -> index.vN
+    ready to answer similaritySearch
   end note
 
-  Loaded --> Loaded: updateIndex with new / changed files<br/>addDocuments + save :285-287, :348-355
-  Loaded --> Loaded: updateIndex with all-matching hashes<br/>(no-op save path :348)
+  Loaded --> Loaded: updateIndex with new / changed files<br/>add documents + atomicSave()
+  Loaded --> Loaded: updateIndex with all-matching hashes<br/>(no-op save path)
 
-  Loaded --> Recovering: [RFC 007 §6.2.1 — not yet]<br/>initialize() sees pending-manifest.json
-  Recovering --> Loaded: finish pending hash-sidecar writes
+  Loaded --> Recovering: initialize() sees pending-manifest.json<br/>phase=save-complete
+  Recovering --> Loaded: finish pending sidecar writes
+  Recovering --> None: phase=save-started<br/>purge persisted store + sidecars
 
   state "Recovering" as Recovering
   note right of Recovering
-    PLANNED, not implemented
-    save() persisted vectors but
-    sidecar writes did not complete →
-    pending-manifest.json is the flag
+    pending-manifest.json records
+    hash + chunk sidecars that
+    must match the saved vectors
   end note
 
   Loaded --> [*]: SIGINT → McpServer.close()<br/>src/KnowledgeBaseServer.ts:27-30
@@ -73,24 +70,23 @@ stateDiagram-v2
 
 | From → To                     | Trigger                                                                                   | Anchor                                             |
 | ----------------------------- | ----------------------------------------------------------------------------------------- | -------------------------------------------------- |
-| `[*]` → `None`                | Process start; constructor runs but does not touch disk.                                  | `src/FaissIndexManager.ts:81, :86-131`             |
-| `None` → `Loading`            | `initialize()` finds `faiss.index` and no model-name mismatch.                            | `src/FaissIndexManager.ts:166`                     |
-| `Loading` → `Loaded`          | `FaissStore.load` resolves.                                                               | `src/FaissIndexManager.ts:169-173`                 |
-| `Loading` → `None`            | `FaissStore.load` rejects (permission / corrupt / incompatible). Error propagated; caller retries. | `src/FaissIndexManager.ts:170-172`                 |
-| `None` → `Rebuilding`         | `initialize()` sees `model_name.txt` ≠ `this.modelName`.                                  | `src/FaissIndexManager.ts:153-154`                 |
-| `Rebuilding` → `None`         | `unlink` completes, `faissIndex = null`, `initialize()` returns; next `updateIndex` will rebuild. | `src/FaissIndexManager.ts:157-163, :181`           |
-| `None` → `Loaded` (build)     | Changed-file branch creates the store with `FaissStore.fromTexts`.                        | `src/FaissIndexManager.ts:278-284`                 |
-| `None` → `Loaded` (fallback)  | All hashes match but `faissIndex` was null → full rebuild from every file.                | `src/FaissIndexManager.ts:302-346`                 |
-| `Loaded` → `Loaded` (delta)   | Subsequent `updateIndex` with new/changed files; `addDocuments` + one `save()`.           | `src/FaissIndexManager.ts:285-287, :348-355`       |
-| `Loaded` → `Recovering`       | **Planned.** `initialize()` detects `pending-manifest.json` on disk.                     | RFC 007 §6.2.1 (not yet implemented).              |
+| `[*]` → `None`                | Process start; constructor runs but does not load a FAISS store.                          | `FaissIndexManager.constructor`                    |
+| `None` → `Loading`            | `initialize()` asks the atomic loader for the active versioned or legacy FAISS store.     | `FaissIndexManager.initialize`, `loadFaissStoreAtomic` |
+| `Loading` → `Loaded`          | `FaissStore.load` resolves.                                                               | `loadFaissStoreAtomic`                             |
+| `Loading` → `None`            | `FaissStore.load` rejects (permission / corrupt / incompatible). Error propagated or repaired to null depending on read-only mode. | `loadFaissStoreAtomic` |
+| `None` → `Rebuilding`         | Forced reindex, freshness-manifest mismatch, or ambiguous pending sidecar commit requires a full rebuild. | `FaissIndexManager.updateIndex`, `recoverPendingSidecarCommit` |
+| `Rebuilding` → `None`         | Persisted store and stale sidecars are purged; next `updateIndex` embeds from source files. | `purgePersistedIndexStore`, `purgeStaleSidecars` |
+| `None` → `Loaded` (build)     | Changed-file branch creates the in-memory store from pending documents.                  | `addDocumentsToIndex`                              |
+| `None` → `Loaded` (fallback)  | All hashes match but `faissIndex` was null → full rebuild from every file.                | `FaissIndexManager.updateIndex`                    |
+| `Loaded` → `Loaded` (delta)   | Subsequent `updateIndex` with new/changed files; add documents and one atomic save.       | `addDocumentsToIndex`, `atomicSave`                |
+| `Loaded` → `Recovering`       | `initialize()` detects a `save-complete` `pending-manifest.json` on disk.                | `src/FaissIndexManager.ts`, `src/pending-sidecar-commit.ts` |
+| `Recovering` → `None`         | `initialize()` detects an ambiguous `save-started` manifest and purges persisted store + sidecars for a rebuild. | `src/FaissIndexManager.ts`, `src/pending-sidecar-commit.ts` |
 | `Loaded` → `[*]`              | SIGINT handler closes the MCP server.                                                     | `src/KnowledgeBaseServer.ts:27-30`                 |
 
 ## Invariants
 
-- **`model_name.txt` is written only in `initialize()`** (`src/FaissIndexManager.ts:181`). Consequence: between a successful rebuild and the subsequent save in `updateIndex`, a crash leaves a `model_name.txt` matching the *new* model but no `faiss.index` — which is the exact scenario the `None → Loaded (fallback)` transition is built to handle.
-- **`faissIndex === null` and `$FAISS_INDEX_PATH/faiss.index` exists** is only possible between `initialize()`'s `unlink` call (`:157`) and the eventual `save()` in the next `updateIndex`.
-- **`Loaded → Loaded` with all hashes matching does NOT write** (`indexMutated` stays `false`, so the block at `src/FaissIndexManager.ts:348-378` is skipped).
-
-## Footnote — Recovering is drawn but not live
-
-The `Recovering` state is on the diagram so that future readers of this page see that the crash-safety story is *incomplete today*. The current code atomically renames each sidecar but has no manifest that survives a crash between `save()` and the last rename — a crash there causes the un-renamed files to be re-embedded on next startup, duplicating their vectors in the FAISS store (FAISS does not dedup by source). Details in RFC 007 §6.2.1.
+- **`model_name.txt` is written only in `initialize()`**. Consequence: between a successful rebuild and the subsequent save in `updateIndex`, a crash can leave a model metadata file without an active `index` symlink, which is the scenario the `None → Loaded (fallback)` transition handles.
+- **`faissIndex === null` and a persisted store exists** is possible after an interrupted or failed rebuild until recovery purges the store or a later `updateIndex` rebuilds from source files.
+- **`Loaded → Loaded` with all hashes matching does NOT write** (`indexMutated` stays `false`, so the save/sidecar block is skipped).
+- **A `save-complete` pending manifest is a roll-forward record.** The saved FAISS store is assumed durable enough to claim the sidecars, so recovery finishes hash and chunk manifest writes before loading the store.
+- **A `save-started` pending manifest is ambiguous.** The process may have crashed before or after the symlink swap. Recovery chooses a rebuild by deleting the persisted store and stale sidecars instead of writing sidecars for vectors that may not be present.

--- a/src/FaissIndexManager.test.ts
+++ b/src/FaissIndexManager.test.ts
@@ -1,4 +1,5 @@
 import * as fsp from 'fs/promises';
+import * as crypto from 'crypto';
 import * as os from 'os';
 import * as path from 'path';
 
@@ -21,6 +22,20 @@ function modelNameFileIn(faissPath: string): string {
 }
 function lastIndexUpdatePathIn(faissPath: string): string {
   return path.join(modelDirIn(faissPath), 'last-index-update.json');
+}
+function pendingManifestPathIn(faissPath: string): string {
+  return path.join(modelDirIn(faissPath), 'pending-manifest.json');
+}
+async function seedVersionedIndex(faissPath: string): Promise<void> {
+  const modelDirPath = modelDirIn(faissPath);
+  const versionDir = versionedIndexPathIn(faissPath);
+  await fsp.mkdir(versionDir, { recursive: true });
+  await fsp.writeFile(path.join(versionDir, 'faiss.index'), 'mock-index');
+  await fsp.writeFile(path.join(versionDir, 'docstore.json'), '{}');
+  await fsp.symlink('index.v0', path.join(modelDirPath, 'index'));
+}
+function sha256Hex(value: string): string {
+  return crypto.createHash('sha256').update(value).digest('hex');
 }
 
 const saveMock = jest.fn();
@@ -618,6 +633,180 @@ describe('FaissIndexManager permission handling', () => {
       expect(sidecarContent).toMatch(/^[0-9a-f]{64}$/);
       await expect(fsp.stat(`${sidecarPath}.tmp`)).rejects.toMatchObject({ code: 'ENOENT' });
     }
+    await expect(fsp.stat(pendingManifestPathIn(process.env.FAISS_INDEX_PATH!)))
+      .rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('recovers a save-complete pending manifest by finishing hash and chunk sidecars', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-faiss-pending-complete-'));
+    const kbDir = path.join(tempDir, 'kb');
+    const defaultKb = path.join(kbDir, 'default');
+    await fsp.mkdir(defaultKb, { recursive: true });
+    const docPath = path.join(defaultKb, 'doc.md');
+    const sourceHash = sha256Hex('# Title\n\nRecovered content.');
+    await fsp.writeFile(docPath, '# Title\n\nRecovered content.');
+
+    const faissDir = path.join(tempDir, '.faiss');
+    process.env.KNOWLEDGE_BASES_ROOT_DIR = kbDir;
+    process.env.FAISS_INDEX_PATH = faissDir;
+    process.env.EMBEDDING_PROVIDER = 'huggingface';
+    process.env.HUGGINGFACE_API_KEY = 'test-key';
+
+    const sidecarPath = path.join(defaultKb, '.index', 'doc.md');
+    const chunkManifestPath = `${sidecarPath}.chunks.json`;
+    const chunkManifest = {
+      schema_version: 'kb.chunk-manifest.v1',
+      source_sha256: sourceHash,
+      chunks: [{
+        chunkIndex: 0,
+        textHash: sha256Hex('Recovered content.'),
+        metadataHash: sha256Hex('metadata'),
+        vectorDocstoreId: sha256Hex('docstore-id'),
+      }],
+    };
+    await seedVersionedIndex(faissDir);
+    await fsp.writeFile(
+      pendingManifestPathIn(faissDir),
+      JSON.stringify({
+        schema_version: 'kb.pending-sidecar-commit.v1',
+        phase: 'save-complete',
+        pending_hash_writes: [{ path: sidecarPath, hash: sourceHash }],
+        pending_chunk_manifest_writes: [{
+          path: chunkManifestPath,
+          manifest: chunkManifest,
+        }],
+      }),
+      'utf-8',
+    );
+
+    jest.resetModules();
+    const { FaissIndexManager } = await import('./FaissIndexManager.js');
+    const manager = new FaissIndexManager();
+    await manager.initialize();
+
+    await expect(fsp.readFile(sidecarPath, 'utf-8')).resolves.toBe(sourceHash);
+    await expect(fsp.readFile(chunkManifestPath, 'utf-8'))
+      .resolves.toBe(JSON.stringify(chunkManifest));
+    await expect(fsp.stat(pendingManifestPathIn(faissDir)))
+      .rejects.toMatchObject({ code: 'ENOENT' });
+    expect(loadMock).toHaveBeenCalledWith(versionedIndexPathIn(faissDir), expect.anything());
+  });
+
+  it('refuses a save-complete pending manifest when the active FAISS index is missing', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-faiss-pending-missing-index-'));
+    const kbDir = path.join(tempDir, 'kb');
+    const defaultKb = path.join(kbDir, 'default');
+    await fsp.mkdir(defaultKb, { recursive: true });
+    const faissDir = path.join(tempDir, '.faiss');
+    await fsp.mkdir(modelDirIn(faissDir), { recursive: true });
+
+    process.env.KNOWLEDGE_BASES_ROOT_DIR = kbDir;
+    process.env.FAISS_INDEX_PATH = faissDir;
+    process.env.EMBEDDING_PROVIDER = 'huggingface';
+    process.env.HUGGINGFACE_API_KEY = 'test-key';
+
+    const sidecarPath = path.join(defaultKb, '.index', 'doc.md');
+    await fsp.writeFile(
+      pendingManifestPathIn(faissDir),
+      JSON.stringify({
+        schema_version: 'kb.pending-sidecar-commit.v1',
+        phase: 'save-complete',
+        pending_hash_writes: [{ path: sidecarPath, hash: 'a'.repeat(64) }],
+        pending_chunk_manifest_writes: [],
+      }),
+      'utf-8',
+    );
+
+    jest.resetModules();
+    const { FaissIndexManager } = await import('./FaissIndexManager.js');
+    const manager = new FaissIndexManager();
+    await expect(manager.initialize()).rejects.toThrow(/marked save-complete/);
+    await expect(fsp.stat(sidecarPath)).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('leaves a save-complete pending manifest when sidecar writes fail after FAISS save', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-faiss-pending-sidecar-fail-'));
+    const kbDir = path.join(tempDir, 'kb');
+    const defaultKb = path.join(kbDir, 'default');
+    await fsp.mkdir(defaultKb, { recursive: true });
+    const docPath = path.join(defaultKb, 'doc.md');
+    const docContent = '# Title\n\nSidecar failure content.';
+    const sourceHash = sha256Hex(docContent);
+    await fsp.writeFile(docPath, docContent);
+
+    process.env.KNOWLEDGE_BASES_ROOT_DIR = kbDir;
+    process.env.FAISS_INDEX_PATH = path.join(tempDir, '.faiss');
+    process.env.EMBEDDING_PROVIDER = 'huggingface';
+    process.env.HUGGINGFACE_API_KEY = 'test-key';
+
+    jest.resetModules();
+    const { FaissIndexManager } = await import('./FaissIndexManager.js');
+    const manager = new FaissIndexManager();
+    await manager.initialize();
+
+    const sidecarPath = path.join(defaultKb, '.index', 'doc.md');
+    await fsp.mkdir(path.dirname(sidecarPath), { recursive: true });
+    await fsp.chmod(path.dirname(sidecarPath), 0o500);
+
+    await expect(manager.updateIndex()).rejects.toThrow(/write file hash metadata/);
+    expect(saveMock).toHaveBeenCalledTimes(1);
+
+    const manifest = JSON.parse(
+      await fsp.readFile(pendingManifestPathIn(process.env.FAISS_INDEX_PATH!), 'utf-8'),
+    ) as {
+      phase: string;
+      pending_hash_writes: Array<{ path: string; hash: string }>;
+      pending_chunk_manifest_writes: Array<{ path: string; manifest: { source_sha256: string } }>;
+    };
+    expect(manifest.phase).toBe('save-complete');
+    expect(manifest.pending_hash_writes).toEqual([{ path: sidecarPath, hash: sourceHash }]);
+    expect(manifest.pending_chunk_manifest_writes).toEqual([
+      expect.objectContaining({
+        path: `${sidecarPath}.chunks.json`,
+        manifest: expect.objectContaining({ source_sha256: sourceHash }),
+      }),
+    ]);
+  });
+
+  it('purges the persisted store and sidecars for an ambiguous save-started pending manifest', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-faiss-pending-started-'));
+    const kbDir = path.join(tempDir, 'kb');
+    const defaultKb = path.join(kbDir, 'default');
+    await fsp.mkdir(path.join(defaultKb, '.index'), { recursive: true });
+    const sidecarPath = path.join(defaultKb, '.index', 'doc.md');
+    await fsp.writeFile(sidecarPath, 'b'.repeat(64));
+
+    const faissDir = path.join(tempDir, '.faiss');
+    process.env.KNOWLEDGE_BASES_ROOT_DIR = kbDir;
+    process.env.FAISS_INDEX_PATH = faissDir;
+    process.env.EMBEDDING_PROVIDER = 'huggingface';
+    process.env.HUGGINGFACE_API_KEY = 'test-key';
+
+    await seedVersionedIndex(faissDir);
+    await fsp.writeFile(
+      pendingManifestPathIn(faissDir),
+      JSON.stringify({
+        schema_version: 'kb.pending-sidecar-commit.v1',
+        phase: 'save-started',
+        pending_hash_writes: [{ path: sidecarPath, hash: 'c'.repeat(64) }],
+        pending_chunk_manifest_writes: [],
+      }),
+      'utf-8',
+    );
+
+    jest.resetModules();
+    const { FaissIndexManager } = await import('./FaissIndexManager.js');
+    const manager = new FaissIndexManager();
+    await manager.initialize();
+
+    await expect(fsp.stat(path.join(modelDirIn(faissDir), 'index')))
+      .rejects.toMatchObject({ code: 'ENOENT' });
+    await expect(fsp.stat(versionedIndexPathIn(faissDir)))
+      .rejects.toMatchObject({ code: 'ENOENT' });
+    await expect(fsp.stat(path.join(defaultKb, '.index')))
+      .rejects.toMatchObject({ code: 'ENOENT' });
+    await expect(fsp.stat(pendingManifestPathIn(faissDir)))
+      .rejects.toMatchObject({ code: 'ENOENT' });
   });
 
   it('batches changed-file embeddings according to INDEXING_BATCH_SIZE', async () => {

--- a/src/FaissIndexManager.ts
+++ b/src/FaissIndexManager.ts
@@ -56,6 +56,11 @@ import {
   writeFreshnessManifest,
 } from './freshness-manifest.js';
 import {
+  clearPendingSidecarCommitManifest,
+  readPendingSidecarCommitManifest,
+  writePendingSidecarCommitManifest,
+} from './pending-sidecar-commit.js';
+import {
   createSimilaritySearchPostFilter,
   type ScoredDocument,
   type SimilaritySearchFilters,
@@ -643,6 +648,9 @@ export class FaissIndexManager {
           handleFsOperationError('create FAISS model directory', this.modelDir, error);
         }
       }
+      if (!readOnly) {
+        await this.recoverPendingSidecarCommit();
+      }
       // RFC 013: no model-switch wipe at initialize time. Each model has its
       // own dir; a different provider+model goes to a different `models/<id>/`.
       // RFC 014: load via the new versioned layout if present, fall back to
@@ -737,13 +745,13 @@ export class FaissIndexManager {
    * by default.
    */
   private async purgeStaleSidecars(
-    reason: 'store_missing' | 'ingest_filter_changed',
+    reason: 'store_missing' | 'ingest_filter_changed' | 'pending_sidecar_commit',
   ): Promise<void> {
     await withSidecarLock(() => this.purgeStaleSidecarsLocked(reason));
   }
 
   private async purgeStaleSidecarsLocked(
-    reason: 'store_missing' | 'ingest_filter_changed',
+    reason: 'store_missing' | 'ingest_filter_changed' | 'pending_sidecar_commit',
   ): Promise<void> {
     let kbs: string[];
     try {
@@ -801,6 +809,12 @@ export class FaissIndexManager {
           `Common causes: manual removal of $FAISS_INDEX_PATH, partial backup restore, ` +
           `crash mid-rebuild, or model switch with the prior model's store moved aside.`,
       );
+    } else if (purged.length > 0 && reason === 'pending_sidecar_commit') {
+      logger.warn(
+        `Pending sidecar commit recovery for model ${this.modelId} purged stale ` +
+          `sidecars for ${purged.length} knowledge base(s) [${purged.join(', ')}] ` +
+          `because the previous process crashed before the FAISS save outcome was confirmed.`,
+      );
     } else if (purged.length > 0) {
       logger.warn(
         `Ingest filter for model ${this.modelId} changed since the last successful index ` +
@@ -825,7 +839,7 @@ export class FaissIndexManager {
   }
 
   private async purgePersistedIndexStore(
-    reason: 'force_reindex' | 'ingest_filter_changed',
+    reason: 'force_reindex' | 'ingest_filter_changed' | 'pending_sidecar_commit',
   ): Promise<void> {
     const removed: string[] = [];
     let entries: Array<{ name: string }>;
@@ -874,6 +888,41 @@ export class FaissIndexManager {
           `(${reason}; entries=${removed.join(', ')}).`,
       );
     }
+  }
+
+  private async recoverPendingSidecarCommit(): Promise<void> {
+    const pending = await readPendingSidecarCommitManifest(this.modelDir);
+    if (pending === null) return;
+
+    if (pending.phase === 'save-started') {
+      logger.warn(
+        `Pending sidecar commit for model ${this.modelId} was interrupted before ` +
+          `the FAISS save was confirmed. Removing the persisted store and stale ` +
+          `sidecars so the next updateIndex rebuilds instead of risking duplicate vectors.`,
+      );
+      await this.purgePersistedIndexStore('pending_sidecar_commit');
+      await this.purgeStaleSidecars('pending_sidecar_commit');
+      await clearPendingSidecarCommitManifest(this.modelDir);
+      return;
+    }
+
+    const activeIndexFilePath = await this.resolveActiveIndexFilePath();
+    if (activeIndexFilePath === null) {
+      throw new Error(
+        `Pending sidecar commit for model ${this.modelId} is marked save-complete, ` +
+          `but no active FAISS index file exists under ${this.modelDir}. Refusing ` +
+          `to write hash sidecars for vectors that cannot be verified on disk.`,
+      );
+    }
+
+    logger.warn(
+      `Recovering pending sidecar commit for model ${this.modelId}: ` +
+        `${pending.pending_hash_writes.length} hash sidecar(s), ` +
+        `${pending.pending_chunk_manifest_writes.length} chunk manifest(s).`,
+    );
+    await writeSidecarHashes(pending.pending_hash_writes);
+    await writeChunkManifests(pending.pending_chunk_manifest_writes);
+    await clearPendingSidecarCommitManifest(this.modelDir);
   }
 
   /**
@@ -1033,7 +1082,7 @@ export class FaissIndexManager {
    * future caller that bypasses updateIndex must wrap in withWriteLock.
    * In NODE_ENV=test we assert the lock is held via proper-lockfile.check().
    */
-  private async atomicSave(): Promise<void> {
+  private async atomicSave(opts: { onCommitted?: () => Promise<void> } = {}): Promise<void> {
     if (!this.faissIndex) throw new Error('atomicSave called with null faissIndex');
 
     // PRECONDITION: caller MUST hold withWriteLock(this.modelDir). The four
@@ -1052,6 +1101,7 @@ export class FaissIndexManager {
       modelId: this.modelId,
       swapCounter: this.swapCounter,
       casRoot: casRootForIndexPath(FAISS_INDEX_PATH),
+      onCommitted: opts.onCommitted,
     });
   }
 
@@ -1889,7 +1939,11 @@ export class FaissIndexManager {
         // (if present from a pre-RFC-014 install) is intentionally NOT
         // updated; first save under v014 effectively migrates the model to
         // versioned layout.
+        const shouldPersistPendingSidecarCommit =
+          indexMutated &&
+          (pendingHashWrites.length > 0 || pendingChunkManifestWrites.length > 0);
         if (indexMutated) {
+          let faissStoreCommitted = false;
           try {
             const saveStartedAtMs = Date.now();
             await emitProgress({
@@ -1899,7 +1953,27 @@ export class FaissIndexManager {
               phase: 'save',
               phaseStatus: 'started',
             });
-            await this.atomicSave();
+            if (shouldPersistPendingSidecarCommit) {
+              await writePendingSidecarCommitManifest({
+                modelDir: this.modelDir,
+                phase: 'save-started',
+                pendingHashWrites,
+                pendingChunkManifestWrites,
+              });
+            }
+            await this.atomicSave({
+              onCommitted: shouldPersistPendingSidecarCommit
+                ? async () => {
+                    faissStoreCommitted = true;
+                    await writePendingSidecarCommitManifest({
+                      modelDir: this.modelDir,
+                      phase: 'save-complete',
+                      pendingHashWrites,
+                      pendingChunkManifestWrites,
+                    });
+                  }
+                : undefined,
+            });
             runSummary.saved = true;
             await emitProgress({
               processedFiles,
@@ -1917,6 +1991,10 @@ export class FaissIndexManager {
               this.modelId,
               saveError,
             );
+          } finally {
+            if (!faissStoreCommitted && shouldPersistPendingSidecarCommit) {
+              await clearPendingSidecarCommitManifest(this.modelDir).catch(() => undefined);
+            }
           }
         }
         // Sidecars are written only after any needed index save has
@@ -1925,10 +2003,9 @@ export class FaissIndexManager {
         // `writeSidecarHashes` runs the batch under `withSidecarLock` so a
         // concurrent model's `purgeStaleSidecars` cannot rmrf
         // `<kb>/.index/` between our pre-loop `mkdir` and `rename` (issue
-        // #90 follow-up). A crash between save() and every rename
-        // completing will re-embed the unhashed files on next start,
-        // duplicating their vectors until RFC 007 PR 2.1 lands the
-        // pending-manifest protocol.
+        // #90 follow-up). For index-mutating updates, pending-manifest.json
+        // remains on disk until every sidecar write completes so initialize()
+        // can finish the sidecar commit after a process crash.
         try {
           const sidecarStartedAtMs = Date.now();
           await emitProgress({
@@ -1969,6 +2046,9 @@ export class FaissIndexManager {
           });
           for (const entry of successfulIndexedFiles) {
             await recordQuarantineSuccess(entry.knowledgeBasePath, entry.relativePath);
+          }
+          if (shouldPersistPendingSidecarCommit) {
+            await clearPendingSidecarCommitManifest(this.modelDir);
           }
         } catch (sidecarError: unknown) {
           recordFailure(null, 'sidecar', sidecarError);

--- a/src/faiss-store-layout.ts
+++ b/src/faiss-store-layout.ts
@@ -287,8 +287,21 @@ export async function saveFaissStoreAtomic(options: {
    * that does not have a stable shared root to use).
    */
   casRoot?: string | null;
+  /**
+   * Called immediately after the active `index` symlink has been swapped to
+   * the new version, before best-effort pruning/GC. Callers use this as the
+   * durable commit point for sidecar recovery records.
+   */
+  onCommitted?: () => Promise<void>;
 }): Promise<void> {
-  const { store, modelDir, modelId, swapCounter, casRoot = null } = options;
+  const {
+    store,
+    modelDir,
+    modelId,
+    swapCounter,
+    casRoot = null,
+    onCommitted,
+  } = options;
   const symlinkPath = path.join(modelDir, SYMLINK_NAME);
   const currentTarget = await readSymlinkOrNull(symlinkPath);
   const nextVersion = nextVersionAfter(currentTarget);
@@ -315,6 +328,7 @@ export async function saveFaissStoreAtomic(options: {
   );
   await fsp.symlink(nextVersion, tmpLink);
   await fsp.rename(tmpLink, symlinkPath);
+  await onCommitted?.();
   logger.info(
     `atomicSave: ${modelId} ${currentTarget ?? '(none)'} -> ${nextVersion}` +
       (dedup

--- a/src/file-ingest.ts
+++ b/src/file-ingest.ts
@@ -139,7 +139,7 @@ function isChunkManifestEntry(value: unknown): value is ChunkManifestEntry {
   );
 }
 
-function isChunkManifest(value: unknown): value is ChunkManifest {
+export function isChunkManifest(value: unknown): value is ChunkManifest {
   if (!isJsonObject(value)) return false;
   return (
     value.schema_version === CHUNK_MANIFEST_SCHEMA_VERSION &&

--- a/src/pending-sidecar-commit.ts
+++ b/src/pending-sidecar-commit.ts
@@ -1,0 +1,147 @@
+import * as fsp from 'fs/promises';
+import * as path from 'path';
+import {
+  isChunkManifest,
+  type ChunkManifest,
+  type PendingChunkManifestWrite,
+  type PendingSidecarWrite,
+} from './file-ingest.js';
+
+export const PENDING_SIDECAR_COMMIT_FILENAME = 'pending-manifest.json';
+export const PENDING_SIDECAR_COMMIT_SCHEMA_VERSION = 'kb.pending-sidecar-commit.v1';
+
+export type PendingSidecarCommitPhase = 'save-started' | 'save-complete';
+
+export interface PendingSidecarCommitManifest {
+  schema_version: typeof PENDING_SIDECAR_COMMIT_SCHEMA_VERSION;
+  phase: PendingSidecarCommitPhase;
+  pending_hash_writes: PendingSidecarWrite[];
+  pending_chunk_manifest_writes: PendingChunkManifestWrite[];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isSha256(value: unknown): value is string {
+  return typeof value === 'string' && /^[0-9a-f]{64}$/.test(value);
+}
+
+function isAbsolutePath(value: unknown): value is string {
+  return typeof value === 'string' && path.isAbsolute(value);
+}
+
+function parsePendingHashWrite(value: unknown): PendingSidecarWrite | null {
+  if (!isRecord(value)) return null;
+  if (!isAbsolutePath(value.path) || !isSha256(value.hash)) return null;
+  return { path: value.path, hash: value.hash };
+}
+
+function parseChunkManifest(value: unknown): ChunkManifest | null {
+  return isChunkManifest(value) ? value : null;
+}
+
+function parsePendingChunkManifestWrite(value: unknown): PendingChunkManifestWrite | null {
+  if (!isRecord(value)) return null;
+  if (!isAbsolutePath(value.path)) return null;
+  const manifest = parseChunkManifest(value.manifest);
+  if (manifest === null) return null;
+  return { path: value.path, manifest };
+}
+
+function parsePhase(value: unknown): PendingSidecarCommitPhase | null {
+  if (value === 'save-started' || value === 'save-complete') return value;
+  return null;
+}
+
+export function pendingSidecarCommitManifestPath(modelDir: string): string {
+  return path.join(modelDir, PENDING_SIDECAR_COMMIT_FILENAME);
+}
+
+export async function readPendingSidecarCommitManifest(
+  modelDir: string,
+): Promise<PendingSidecarCommitManifest | null> {
+  const manifestPath = pendingSidecarCommitManifestPath(modelDir);
+  let raw: string;
+  try {
+    raw = await fsp.readFile(manifestPath, 'utf-8');
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT' || code === 'ENOTDIR') return null;
+    throw error;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!isRecord(parsed)) return null;
+  if (parsed.schema_version !== PENDING_SIDECAR_COMMIT_SCHEMA_VERSION) return null;
+  const phase = parsePhase(parsed.phase);
+  if (phase === null) return null;
+  if (!Array.isArray(parsed.pending_hash_writes)) return null;
+  if (!Array.isArray(parsed.pending_chunk_manifest_writes)) return null;
+
+  const pendingHashWrites = parsed.pending_hash_writes.map(parsePendingHashWrite);
+  const pendingChunkManifestWrites =
+    parsed.pending_chunk_manifest_writes.map(parsePendingChunkManifestWrite);
+  if (
+    pendingHashWrites.some((entry) => entry === null) ||
+    pendingChunkManifestWrites.some((entry) => entry === null)
+  ) {
+    return null;
+  }
+
+  return {
+    schema_version: PENDING_SIDECAR_COMMIT_SCHEMA_VERSION,
+    phase,
+    pending_hash_writes: pendingHashWrites as PendingSidecarWrite[],
+    pending_chunk_manifest_writes: pendingChunkManifestWrites as PendingChunkManifestWrite[],
+  };
+}
+
+export async function writePendingSidecarCommitManifest(options: {
+  modelDir: string;
+  phase: PendingSidecarCommitPhase;
+  pendingHashWrites: ReadonlyArray<PendingSidecarWrite>;
+  pendingChunkManifestWrites: ReadonlyArray<PendingChunkManifestWrite>;
+}): Promise<void> {
+  const {
+    modelDir,
+    phase,
+    pendingHashWrites,
+    pendingChunkManifestWrites,
+  } = options;
+  await fsp.mkdir(modelDir, { recursive: true });
+  const manifestPath = pendingSidecarCommitManifestPath(modelDir);
+  const tmpPath = path.join(
+    modelDir,
+    `.${PENDING_SIDECAR_COMMIT_FILENAME}.${process.pid}.${process.hrtime.bigint()}.tmp`,
+  );
+  const payload: PendingSidecarCommitManifest = {
+    schema_version: PENDING_SIDECAR_COMMIT_SCHEMA_VERSION,
+    phase,
+    pending_hash_writes: pendingHashWrites.map((entry) => ({ ...entry })),
+    pending_chunk_manifest_writes: pendingChunkManifestWrites.map((entry) => ({
+      path: entry.path,
+      manifest: entry.manifest,
+    })),
+  };
+
+  try {
+    await fsp.writeFile(tmpPath, JSON.stringify(payload), {
+      encoding: 'utf-8',
+      mode: 0o600,
+    });
+    await fsp.rename(tmpPath, manifestPath);
+  } catch (error) {
+    await fsp.rm(tmpPath, { force: true }).catch(() => undefined);
+    throw error;
+  }
+}
+
+export async function clearPendingSidecarCommitManifest(modelDir: string): Promise<void> {
+  await fsp.rm(pendingSidecarCommitManifestPath(modelDir), { force: true });
+}


### PR DESCRIPTION
## Summary
- add pending-manifest recovery around FAISS save and hash/chunk sidecar commits
- advance the manifest at the versioned index symlink commit point so post-save cleanup failures remain recoverable
- document the new Loaded/Recovering state transitions and cover crash/failure recovery paths

Closes #385

## Verification
- npm run build
- npx jest src/FaissIndexManager.test.ts --runInBand
- npm test
- git diff --check
- npm run docs:check-anchors (exits 0 in warning mode; reports 59 pre-existing stale anchors outside this patch)

## Pre-PR review
- Ran the local pre-PR review workflow. Addressed specialist feedback for stale state-index docs, duplicated chunk-manifest validation, missing sidecar-failure coverage, and the post-symlink-swap failure window.