### PR TITLE
feat: add kb logs canonical reader

### DIFF
--- a/docs/cli-json-contracts.md
+++ b/docs/cli-json-contracts.md
@@ -557,6 +557,71 @@ Source and test anchors: `src/cli-doctor.ts:66-99`,
 `src/cli-doctor.ts:114-130`, `src/cli-doctor.ts:149-237`,
 `src/cli-doctor.test.ts:39-180`.
 
+## `kb logs`
+
+Invocation:
+
+```bash
+kb logs recent --format=json [--limit=<n>] [--file=<path>]
+kb logs show --request-id=<id> --format=json [--file=<path>]
+kb logs show --query-sha=<hash> --format=json [--file=<path>]
+```
+
+Report envelope:
+
+```json
+{
+  "schema_version": "kb.logs.v1",
+  "action": "show",
+  "source": "/tmp/kb.log",
+  "filters": { "request_id": "req-1" },
+  "scanned_line_count": 10,
+  "canonical_event_count": 3,
+  "ignored_line_count": 6,
+  "malformed_canonical_line_count": 1,
+  "result_count": 1,
+  "events": [
+    {
+      "ts": "2026-05-18T20:00:00.000Z",
+      "request_id": "req-1",
+      "process": "cli",
+      "cmd": "kb search",
+      "query_sha256": "0123456789abcdef",
+      "took_ms": 42,
+      "timings": { "embed_ms": 10, "faiss_ms": 20, "format_ms": 3 },
+      "cache": "miss",
+      "result_count": 3,
+      "top_sources": ["docs/a.md"],
+      "error": { "code": "PROVIDER_TIMEOUT", "category": "provider" },
+      "recovery_hint": "Run `kb doctor`."
+    }
+  ]
+}
+```
+
+Stable fields:
+
+- `schema_version` is `kb.logs.v1`.
+- `action` is `recent` or `show`.
+- `source` is the resolved log file path. Resolution uses `--file`, then
+  `LOG_FILE`, then existing local default paths.
+- Counts report the scan outcome before filtering.
+- `events[]` contains summaries of `kb-canonical.v1` lines only. Text log
+  lines are ignored. Each event includes `timings`; optional fields are
+  present only when the canonical log line carried them.
+
+Stdout/stderr and exit codes:
+
+- JSON reports are stdout. No matches still exit `0` with `result_count: 0`.
+- If no log file is discoverable, JSON output uses an error envelope with
+  `schema_version: "kb.logs.v1"` and exits `2`.
+- Argument errors print `kb logs: ...` to stderr and exit `2`.
+- File read failures use a JSON error envelope and exit `1`.
+
+Source and test anchors: `src/cli-logs.ts:114-161`,
+`src/cli-logs.ts:222-259`, `src/cli-logs.ts:309-390`,
+`src/cli-logs.test.ts:68-174`.
+
 ## `kb eval`
 
 Invocation:

--- a/src/cli-logs.test.ts
+++ b/src/cli-logs.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+  parseCanonicalLogLines,
+  parseLogsArgs,
+  runLogs,
+  type RunLogsDeps,
+} from './cli-logs.js';
+
+function canonical(overrides: Record<string, unknown>): string {
+  return JSON.stringify({
+    schema_version: 'kb-canonical.v1',
+    ts: '2026-05-18T20:00:00.000Z',
+    request_id: 'req-1',
+    process: 'cli',
+    cmd: 'kb search',
+    took_ms: 42,
+    ...overrides,
+  });
+}
+
+function depsFor(files: Record<string, string>, env: NodeJS.ProcessEnv = {}): {
+  deps: RunLogsDeps;
+  stdout: string[];
+  stderr: string[];
+} {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const deps: RunLogsDeps = {
+    readFile: (filePath) => {
+      const text = files[filePath];
+      if (text === undefined) throw new Error(`ENOENT: ${filePath}`);
+      return text;
+    },
+    exists: (filePath) => files[filePath] !== undefined,
+    env,
+    cwd: () => '/repo',
+    homedir: () => '/home/alice',
+    stdout: (text) => stdout.push(text),
+    stderr: (text) => stderr.push(text),
+  };
+  return { deps, stdout, stderr };
+}
+
+describe('parseLogsArgs', () => {
+  it('parses recent and show commands', () => {
+    expect(parseLogsArgs(['recent', '--limit=5', '--file=./kb.log', '--format=json'])).toEqual({
+      action: 'recent',
+      format: 'json',
+      file: './kb.log',
+      limit: 5,
+    });
+    expect(parseLogsArgs(['show', '--request-id=req-1'])).toEqual({
+      action: 'show',
+      format: 'md',
+      limit: 20,
+      requestId: 'req-1',
+    });
+    expect(parseLogsArgs(['show', '--query-sha=abc123'])).toMatchObject({
+      action: 'show',
+      querySha: 'abc123',
+    });
+  });
+
+  it('rejects ambiguous filters and invalid limits', () => {
+    expect(() => parseLogsArgs(['show'])).toThrow(/requires exactly one/);
+    expect(() => parseLogsArgs(['show', '--request-id=a', '--query-sha=b'])).toThrow(/exactly one/);
+    expect(() => parseLogsArgs(['recent', '--request-id=a'])).toThrow(/recent does not accept/);
+    expect(() => parseLogsArgs(['recent', '--limit=0'])).toThrow(/between 1 and 500/);
+  });
+});
+
+describe('parseCanonicalLogLines', () => {
+  it('keeps canonical JSON lines and tolerates mixed text logs', () => {
+    const parsed = parseCanonicalLogLines([
+      '2026-05-18T20:00:00Z [INFO] text log',
+      canonical({ request_id: 'req-1' }),
+      '{"schema_version":"kb-canonical.v1",',
+      canonical({ request_id: 'req-2', query_sha256: 'abc123' }),
+      '',
+    ].join('\n'));
+
+    expect(parsed.scannedLineCount).toBe(4);
+    expect(parsed.ignoredLineCount).toBe(1);
+    expect(parsed.malformedCanonicalLineCount).toBe(1);
+    expect(parsed.events.map((event) => event.request_id)).toEqual(['req-1', 'req-2']);
+  });
+});
+
+describe('runLogs', () => {
+  it('prints recent canonical events as stable JSON from LOG_FILE', async () => {
+    const { deps, stdout, stderr } = depsFor({
+      '/repo/kb.log': [
+        canonical({ request_id: 'req-1', query_sha256: 'old' }),
+        canonical({ request_id: 'req-2', query_sha256: 'new', result_count: 3 }),
+      ].join('\n'),
+    }, { LOG_FILE: './kb.log' });
+
+    const code = await runLogs(['recent', '--limit=1', '--format=json'], deps);
+
+    expect(code).toBe(0);
+    expect(stderr).toEqual([]);
+    const payload = JSON.parse(stdout.join('')) as {
+      schema_version: string;
+      source: string;
+      result_count: number;
+      events: Array<{ request_id: string; query_sha256: string; result_count?: number }>;
+    };
+    expect(payload.schema_version).toBe('kb.logs.v1');
+    expect(payload.source).toBe('/repo/kb.log');
+    expect(payload.result_count).toBe(1);
+    expect(payload.events).toEqual([
+      expect.objectContaining({ request_id: 'req-2', query_sha256: 'new', result_count: 3 }),
+    ]);
+  });
+
+  it('shows request details with timings, sources, gate, rerank, and recovery hints in markdown', async () => {
+    const { deps, stdout } = depsFor({
+      '/tmp/canonical.log': [
+        canonical({
+          request_id: 'req-match',
+          query_sha256: 'abc123',
+          took_ms: 125,
+          embed_ms: 20,
+          faiss_ms: 40,
+          format_ms: 5,
+          top_sources: ['docs/a.md', 'docs/b.md'],
+          gate: { verdict: 'injected', kept: 2 },
+          rerank_ms: 11,
+          error: { code: 'PROVIDER_TIMEOUT', category: 'provider' },
+          recovery_hint: 'Run `kb doctor`.',
+        }),
+        canonical({ request_id: 'req-other' }),
+      ].join('\n'),
+    });
+
+    const code = await runLogs(['show', '--request-id=req-match', '--file=/tmp/canonical.log'], deps);
+
+    expect(code).toBe(0);
+    const md = stdout.join('');
+    expect(md).toContain('# KB Logs');
+    expect(md).toContain('`req-match`');
+    expect(md).not.toContain('req-other');
+    expect(md).toContain('took=125ms, embed=20ms, faiss=40ms, format=5ms');
+    expect(md).toContain('`docs/a.md`, `docs/b.md`');
+    expect(md).toContain('Gate: `{"verdict":"injected","kept":2}`');
+    expect(md).toContain('Rerank: `{"rerank_ms":11}`');
+    expect(md).toContain('Recovery hint: Run `kb doctor`.');
+  });
+
+  it('does not crash markdown output when optional canonical fields are malformed', async () => {
+    const { deps, stdout, stderr } = depsFor({
+      '/tmp/malformed.log': JSON.stringify({
+        schema_version: 'kb-canonical.v1',
+        ts: '2026-05-18T20:00:00.000Z',
+        request_id: 'req-bad-fields',
+        process: 'cli',
+        cmd: 'kb search',
+        took_ms: 8,
+        top_sources: 'not-array',
+        result_count: 'not-number',
+      }),
+    });
+
+    const code = await runLogs(['recent', '--file=/tmp/malformed.log'], deps);
+
+    expect(code).toBe(0);
+    expect(stderr).toEqual([]);
+    const md = stdout.join('');
+    expect(md).toContain('`req-bad-fields`');
+    expect(md).not.toContain('Top sources:');
+    expect(md).not.toContain('not-array');
+  });
+
+  it('uses an existing default path when LOG_FILE is not set', async () => {
+    const defaultPath = '/home/alice/.local/state/knowledge-base-mcp-server/kb.log';
+    const { deps, stdout } = depsFor({
+      [defaultPath]: canonical({ request_id: 'req-default' }),
+    });
+
+    const code = await runLogs(['recent', '--format=json'], deps);
+
+    expect(code).toBe(0);
+    expect(JSON.parse(stdout.join('')).source).toBe(defaultPath);
+  });
+
+  it('returns a machine-readable error when no log file is discoverable for JSON output', async () => {
+    const { deps, stdout, stderr } = depsFor({});
+
+    const code = await runLogs(['recent', '--format=json'], deps);
+
+    expect(code).toBe(2);
+    expect(stderr).toEqual([]);
+    expect(JSON.parse(stdout.join(''))).toEqual({
+      schema_version: 'kb.logs.v1',
+      error: {
+        code: 'LOG_FILE_NOT_FOUND',
+        message: 'no log file found; pass --file=<path> or set LOG_FILE',
+      },
+    });
+  });
+});

--- a/src/cli-logs.ts
+++ b/src/cli-logs.ts
@@ -1,0 +1,496 @@
+import { existsSync, readFileSync } from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { CANONICAL_SCHEMA_VERSION, type CanonicalLogEvent } from './canonical-log.js';
+
+export const LOGS_HELP = `kb logs — inspect historical canonical request logs
+
+Usage:
+  kb logs recent [--limit=<n>] [--file=<path>] [--format=md|json]
+  kb logs show --request-id=<id> [--file=<path>] [--format=md|json]
+  kb logs show --query-sha=<hash> [--file=<path>] [--format=md|json]
+
+Reads mixed text/canonical log files, keeps only \`kb-canonical.v1\` JSON lines,
+and summarizes request ids, query hashes, timings, errors, cache state, gate
+fields, rerank fields, top sources, and recovery hints.
+
+Options:
+  --file=<path>         Log file to read. Defaults to LOG_FILE, then known
+                        local log paths if they exist.
+  --format=md|json      Output format (default: md).
+  --limit=<n>           Number of recent canonical events to show (default: 20).
+  --request-id=<id>     Show canonical events for one request id.
+  --query-sha=<hash>    Show canonical events for one query_sha256 value.
+  --help, -h            Show this help.
+
+Examples:
+  kb logs recent
+  kb logs recent --limit=5 --format=json
+  kb logs show --request-id=maw6d3qfabcd1234
+  kb logs show --query-sha=0123456789abcdef
+`;
+
+const LOGS_SCHEMA_VERSION = 'kb.logs.v1';
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 500;
+
+type LogsAction = 'recent' | 'show';
+type LogsFormat = 'md' | 'json';
+
+export interface LogsArgs {
+  action: LogsAction;
+  format: LogsFormat;
+  file?: string;
+  limit: number;
+  requestId?: string;
+  querySha?: string;
+}
+
+export interface ParsedCanonicalLogs {
+  events: CanonicalLogRecord[];
+  scannedLineCount: number;
+  ignoredLineCount: number;
+  malformedCanonicalLineCount: number;
+}
+
+export type CanonicalLogRecord = CanonicalLogEvent & Record<string, unknown>;
+
+interface LogsPayload {
+  schema_version: typeof LOGS_SCHEMA_VERSION;
+  action: LogsAction;
+  source: string;
+  filters: {
+    request_id?: string;
+    query_sha256?: string;
+  };
+  scanned_line_count: number;
+  canonical_event_count: number;
+  ignored_line_count: number;
+  malformed_canonical_line_count: number;
+  result_count: number;
+  events: CanonicalLogSummary[];
+}
+
+interface CanonicalLogSummary {
+  ts?: string;
+  request_id?: string;
+  process?: string;
+  event?: string;
+  cmd?: string;
+  tool?: string;
+  model_id?: string;
+  kb_scope?: string | null;
+  query_sha256?: string;
+  took_ms?: number;
+  timings: {
+    embed_ms?: number;
+    faiss_ms?: number;
+    format_ms?: number;
+  };
+  cache?: string;
+  result_count?: number;
+  top_score?: number;
+  top_sources?: string[];
+  error?: unknown;
+  recovery_hint?: string;
+  gate?: unknown;
+  rerank?: Record<string, unknown>;
+}
+
+export interface RunLogsDeps {
+  readFile: (filePath: string) => string;
+  exists: (filePath: string) => boolean;
+  env: NodeJS.ProcessEnv;
+  cwd: () => string;
+  homedir: () => string;
+  stdout: (text: string) => void;
+  stderr: (text: string) => void;
+}
+
+const DEFAULT_DEPS: RunLogsDeps = {
+  readFile: (filePath) => readFileSync(filePath, 'utf-8'),
+  exists: (filePath) => existsSync(filePath),
+  env: process.env,
+  cwd: () => process.cwd(),
+  homedir: () => os.homedir(),
+  stdout: (text) => process.stdout.write(text),
+  stderr: (text) => process.stderr.write(text),
+};
+
+export async function runLogs(rest: string[], deps: RunLogsDeps = DEFAULT_DEPS): Promise<number> {
+  let args: LogsArgs;
+  try {
+    args = parseLogsArgs(rest);
+  } catch (err) {
+    deps.stderr(`kb logs: ${(err as Error).message}\n`);
+    return 2;
+  }
+
+  const source = resolveLogFile(args, deps);
+  if (source === null) {
+    const message = 'no log file found; pass --file=<path> or set LOG_FILE';
+    if (args.format === 'json') {
+      deps.stdout(`${JSON.stringify({
+        schema_version: LOGS_SCHEMA_VERSION,
+        error: { code: 'LOG_FILE_NOT_FOUND', message },
+      }, null, 2)}\n`);
+    } else {
+      deps.stderr(`kb logs: ${message}\n`);
+    }
+    return 2;
+  }
+
+  let parsed: ParsedCanonicalLogs;
+  try {
+    parsed = parseCanonicalLogLines(deps.readFile(source));
+  } catch (err) {
+    const message = (err as Error).message;
+    if (args.format === 'json') {
+      deps.stdout(`${JSON.stringify({
+        schema_version: LOGS_SCHEMA_VERSION,
+        source,
+        error: { code: 'LOG_READ_FAILED', message },
+      }, null, 2)}\n`);
+    } else {
+      deps.stderr(`kb logs: failed to read ${source}: ${message}\n`);
+    }
+    return 1;
+  }
+
+  const events = selectEvents(parsed.events, args);
+  const payload = buildLogsPayload(args, source, parsed, events);
+  if (args.format === 'json') {
+    deps.stdout(`${JSON.stringify(payload, null, 2)}\n`);
+  } else {
+    deps.stdout(formatLogsMarkdown(payload));
+  }
+  return 0;
+}
+
+export function parseLogsArgs(rest: string[]): LogsArgs {
+  if (rest.length === 0) {
+    throw new Error('missing action: expected recent or show');
+  }
+  const action = rest[0];
+  if (action !== 'recent' && action !== 'show') {
+    throw new Error(`unknown action: ${JSON.stringify(action)}`);
+  }
+
+  const out: LogsArgs = { action, format: 'md', limit: DEFAULT_LIMIT };
+  for (const raw of rest.slice(1)) {
+    if (raw.startsWith('--file=')) {
+      const value = raw.slice('--file='.length);
+      if (value === '') throw new Error('empty --file value');
+      out.file = value;
+      continue;
+    }
+    if (raw.startsWith('--format=')) {
+      const value = raw.slice('--format='.length);
+      if (value !== 'md' && value !== 'json') {
+        throw new Error(`invalid --format: ${raw}`);
+      }
+      out.format = value;
+      continue;
+    }
+    if (raw.startsWith('--limit=')) {
+      out.limit = parseLimit(raw.slice('--limit='.length));
+      continue;
+    }
+    if (raw.startsWith('--request-id=')) {
+      const value = raw.slice('--request-id='.length);
+      if (value === '') throw new Error('empty --request-id value');
+      out.requestId = value;
+      continue;
+    }
+    if (raw.startsWith('--query-sha=')) {
+      const value = raw.slice('--query-sha='.length);
+      if (value === '') throw new Error('empty --query-sha value');
+      out.querySha = value;
+      continue;
+    }
+    if (raw.startsWith('--query-sha256=')) {
+      const value = raw.slice('--query-sha256='.length);
+      if (value === '') throw new Error('empty --query-sha256 value');
+      out.querySha = value;
+      continue;
+    }
+    if (raw.startsWith('--')) throw new Error(`unknown flag: ${raw}`);
+    throw new Error(`unexpected argument: ${JSON.stringify(raw)}`);
+  }
+
+  if (out.action === 'recent') {
+    if (out.requestId !== undefined || out.querySha !== undefined) {
+      throw new Error('recent does not accept --request-id or --query-sha; use `kb logs show`');
+    }
+  } else if ((out.requestId === undefined) === (out.querySha === undefined)) {
+    throw new Error('show requires exactly one of --request-id or --query-sha');
+  }
+  return out;
+}
+
+export function parseCanonicalLogLines(text: string): ParsedCanonicalLogs {
+  const events: CanonicalLogRecord[] = [];
+  let ignoredLineCount = 0;
+  let malformedCanonicalLineCount = 0;
+  const lines = text.split(/\r?\n/);
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed === '') continue;
+    if (!trimmed.includes(`"schema_version":"${CANONICAL_SCHEMA_VERSION}"`) &&
+        !trimmed.includes(`"schema_version": "${CANONICAL_SCHEMA_VERSION}"`)) {
+      ignoredLineCount++;
+      continue;
+    }
+    try {
+      const parsed = JSON.parse(trimmed) as unknown;
+      if (isCanonicalLogRecord(parsed)) {
+        events.push(parsed);
+      } else {
+        ignoredLineCount++;
+      }
+    } catch {
+      malformedCanonicalLineCount++;
+    }
+  }
+
+  return {
+    events,
+    scannedLineCount: lines.filter((line) => line.trim() !== '').length,
+    ignoredLineCount,
+    malformedCanonicalLineCount,
+  };
+}
+
+function parseLimit(raw: string): number {
+  if (!/^\d+$/.test(raw)) {
+    throw new Error(`invalid --limit: --limit=${raw}`);
+  }
+  const value = Number(raw);
+  if (value < 1 || value > MAX_LIMIT) {
+    throw new Error(`--limit must be between 1 and ${MAX_LIMIT}`);
+  }
+  return value;
+}
+
+function resolveLogFile(args: LogsArgs, deps: RunLogsDeps): string | null {
+  if (args.file !== undefined) {
+    return expandPath(args.file, deps);
+  }
+  if (deps.env.LOG_FILE !== undefined && deps.env.LOG_FILE !== '') {
+    return expandPath(deps.env.LOG_FILE, deps);
+  }
+  for (const candidate of defaultLogPaths(deps)) {
+    if (deps.exists(candidate)) return candidate;
+  }
+  return null;
+}
+
+function defaultLogPaths(deps: RunLogsDeps): string[] {
+  const stateHome = deps.env.XDG_STATE_HOME && deps.env.XDG_STATE_HOME !== ''
+    ? deps.env.XDG_STATE_HOME
+    : path.join(deps.homedir(), '.local', 'state');
+  return [
+    path.join(stateHome, 'knowledge-base-mcp-server', 'knowledge-base.log'),
+    path.join(stateHome, 'knowledge-base-mcp-server', 'kb.log'),
+    path.join(deps.cwd(), 'logs', 'knowledge-base.log'),
+    path.join(deps.cwd(), 'knowledge-base.log'),
+  ];
+}
+
+function expandPath(filePath: string, deps: RunLogsDeps): string {
+  if (filePath === '~') return deps.homedir();
+  if (filePath.startsWith('~/')) return path.join(deps.homedir(), filePath.slice(2));
+  return path.resolve(deps.cwd(), filePath);
+}
+
+function selectEvents(events: CanonicalLogRecord[], args: LogsArgs): CanonicalLogRecord[] {
+  if (args.action === 'recent') {
+    return events.slice(-args.limit);
+  }
+  if (args.requestId !== undefined) {
+    return events.filter((event) => event.request_id === args.requestId);
+  }
+  return events.filter((event) => event.query_sha256 === args.querySha);
+}
+
+function buildLogsPayload(
+  args: LogsArgs,
+  source: string,
+  parsed: ParsedCanonicalLogs,
+  events: CanonicalLogRecord[],
+): LogsPayload {
+  return {
+    schema_version: LOGS_SCHEMA_VERSION,
+    action: args.action,
+    source,
+    filters: {
+      ...(args.requestId !== undefined ? { request_id: args.requestId } : {}),
+      ...(args.querySha !== undefined ? { query_sha256: args.querySha } : {}),
+    },
+    scanned_line_count: parsed.scannedLineCount,
+    canonical_event_count: parsed.events.length,
+    ignored_line_count: parsed.ignoredLineCount,
+    malformed_canonical_line_count: parsed.malformedCanonicalLineCount,
+    result_count: events.length,
+    events: events.map(summarizeEvent),
+  };
+}
+
+function summarizeEvent(event: CanonicalLogRecord): CanonicalLogSummary {
+  return {
+    ts: stringField(event.ts),
+    request_id: stringField(event.request_id),
+    process: stringField(event.process),
+    event: stringField(event.event),
+    cmd: stringField(event.cmd),
+    tool: stringField(event.tool),
+    model_id: stringField(event.model_id),
+    kb_scope: kbScopeField(event.kb_scope),
+    query_sha256: stringField(event.query_sha256),
+    took_ms: numberField(event.took_ms),
+    timings: {
+      embed_ms: numberField(event.embed_ms),
+      faiss_ms: numberField(event.faiss_ms),
+      format_ms: numberField(event.format_ms),
+    },
+    cache: stringField(event.cache),
+    result_count: numberField(event.result_count),
+    top_score: numberField(event.top_score),
+    top_sources: stringArrayField(event.top_sources),
+    error: event.error,
+    recovery_hint: stringField(event.recovery_hint),
+    gate: event.gate,
+    rerank: extractRerankFields(event),
+  };
+}
+
+function extractRerankFields(event: CanonicalLogRecord): Record<string, unknown> | undefined {
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(event)) {
+    if (key.toLowerCase().includes('rerank')) {
+      out[key] = value;
+    }
+  }
+  return Object.keys(out).length === 0 ? undefined : out;
+}
+
+function formatLogsMarkdown(payload: LogsPayload): string {
+  const filterText = payload.filters.request_id !== undefined
+    ? `request_id=${payload.filters.request_id}`
+    : payload.filters.query_sha256 !== undefined
+      ? `query_sha256=${payload.filters.query_sha256}`
+      : 'none';
+  const lines = [
+    '# KB Logs',
+    '',
+    `- Source: \`${payload.source}\``,
+    `- Filter: ${filterText}`,
+    `- Scanned lines: ${payload.scanned_line_count}`,
+    `- Canonical events: ${payload.canonical_event_count}`,
+    `- Ignored lines: ${payload.ignored_line_count}`,
+    `- Malformed canonical lines: ${payload.malformed_canonical_line_count}`,
+    '',
+  ];
+
+  if (payload.events.length === 0) {
+    lines.push('No matching canonical log events.', '');
+    return lines.join('\n');
+  }
+
+  lines.push(
+    '| Time | Request | Command/tool | Query SHA | Took | Results | Error | Cache |',
+    '| --- | --- | --- | --- | ---: | ---: | --- | --- |',
+  );
+  for (const event of payload.events) {
+    lines.push([
+      event.ts ?? '',
+      code(event.request_id),
+      code(event.cmd ?? event.tool ?? event.event ?? event.process ?? ''),
+      code(event.query_sha256 ?? ''),
+      event.took_ms === undefined ? '' : `${event.took_ms} ms`,
+      event.result_count === undefined ? '' : String(event.result_count),
+      code(formatError(event.error)),
+      event.cache ?? '',
+    ].map(escapeTableCell).join(' | ').replace(/^/, '| ').replace(/$/, ' |'));
+  }
+
+  lines.push('');
+  for (const event of payload.events) {
+    lines.push(...formatEventDetails(event));
+  }
+  return lines.join('\n');
+}
+
+function formatEventDetails(event: CanonicalLogSummary): string[] {
+  const title = event.request_id ?? event.ts ?? 'event';
+  const lines = [`## ${title}`, ''];
+  lines.push(`- Timings: ${formatTimings(event)}`);
+  if (event.model_id !== undefined) lines.push(`- Model: \`${event.model_id}\``);
+  if (event.kb_scope !== undefined) lines.push(`- KB scope: \`${event.kb_scope ?? 'all'}\``);
+  if (event.top_sources !== undefined && event.top_sources.length > 0) {
+    lines.push(`- Top sources: ${event.top_sources.map(code).join(', ')}`);
+  }
+  if (event.gate !== undefined) lines.push(`- Gate: \`${compactJson(event.gate)}\``);
+  if (event.rerank !== undefined) lines.push(`- Rerank: \`${compactJson(event.rerank)}\``);
+  if (event.recovery_hint !== undefined) lines.push(`- Recovery hint: ${event.recovery_hint}`);
+  lines.push('');
+  return lines;
+}
+
+function formatTimings(event: CanonicalLogSummary): string {
+  const parts = [
+    event.took_ms === undefined ? undefined : `took=${event.took_ms}ms`,
+    event.timings.embed_ms === undefined ? undefined : `embed=${event.timings.embed_ms}ms`,
+    event.timings.faiss_ms === undefined ? undefined : `faiss=${event.timings.faiss_ms}ms`,
+    event.timings.format_ms === undefined ? undefined : `format=${event.timings.format_ms}ms`,
+  ].filter((part): part is string => part !== undefined);
+  return parts.length === 0 ? 'unknown' : parts.join(', ');
+}
+
+function formatError(error: unknown): string {
+  if (error === undefined) return '';
+  if (typeof error === 'object' && error !== null) {
+    const record = error as { code?: unknown; category?: unknown };
+    const codeText = typeof record.code === 'string' ? record.code : 'ERROR';
+    const categoryText = typeof record.category === 'string' ? `/${record.category}` : '';
+    return `${codeText}${categoryText}`;
+  }
+  return String(error);
+}
+
+function isCanonicalLogRecord(value: unknown): value is CanonicalLogRecord {
+  if (typeof value !== 'object' || value === null) return false;
+  const record = value as Record<string, unknown>;
+  return record.schema_version === CANONICAL_SCHEMA_VERSION;
+}
+
+function stringField(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+function numberField(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function kbScopeField(value: unknown): string | null | undefined {
+  return value === null || typeof value === 'string' ? value : undefined;
+}
+
+function stringArrayField(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  return value.filter((item): item is string => typeof item === 'string');
+}
+
+function compactJson(value: unknown): string {
+  return JSON.stringify(value);
+}
+
+function code(value: string | undefined): string {
+  if (value === undefined || value === '') return '';
+  return `\`${value.replace(/`/g, '\\`')}\``;
+}
+
+function escapeTableCell(value: string | number): string {
+  return String(value).replace(/\\/g, '\\\\').replace(/\|/g, '\\|').replace(/\n/g, ' ');
+}

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -54,6 +54,7 @@ describe('kb CLI — argv parsing and dispatch', () => {
       'capture',
       'compare',
       'doctor',
+      'logs',
       'stats',
       'eval',
       'eval-gate',
@@ -85,6 +86,7 @@ describe('kb CLI — argv parsing and dispatch', () => {
     ['capture', 'kb capture'],
     ['compare', 'kb compare'],
     ['doctor', 'kb doctor'],
+    ['logs', 'kb logs'],
     ['stats', 'kb stats'],
     ['eval', 'kb eval'],
     ['eval-gate', 'kb eval-gate'],
@@ -144,6 +146,8 @@ describe('kb CLI — argv parsing and dispatch', () => {
     expect(manifest.environment).toEqual(expect.arrayContaining([
       expect.objectContaining({ name: 'KNOWLEDGE_BASES_ROOT_DIR' }),
       expect.objectContaining({ name: 'KB_LLM_ENDPOINT' }),
+      expect.objectContaining({ name: 'LOG_FILE' }),
+      expect.objectContaining({ name: 'KB_LOG_FORMAT' }),
       expect.objectContaining({
         name: 'OLLAMA_*',
         description: expect.stringContaining('Provider-specific config'),
@@ -173,6 +177,7 @@ describe('kb CLI — argv parsing and dispatch', () => {
       'capture',
       'compare',
       'doctor',
+      'logs',
       'stats',
       'eval',
       'eval-gate',
@@ -398,6 +403,63 @@ describe('kb CLI — argv parsing and dispatch', () => {
       });
       expect(typeof event.request_id).toBe('string');
       expect(typeof event.took_ms).toBe('number');
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('dispatches kb logs through the built CLI with default deps (#387)', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-cli-logs-'));
+    const logFile = path.join(tempDir, 'canonical.log');
+
+    try {
+      await fsp.writeFile(logFile, [
+        JSON.stringify({
+          schema_version: 'kb-canonical.v1',
+          ts: '2026-05-18T20:00:00.000Z',
+          request_id: 'req-cli-1',
+          process: 'cli',
+          cmd: 'kb search',
+          query_sha256: 'old',
+          took_ms: 10,
+        }),
+        JSON.stringify({
+          schema_version: 'kb-canonical.v1',
+          ts: '2026-05-18T20:01:00.000Z',
+          request_id: 'req-cli-2',
+          process: 'cli',
+          cmd: 'kb search',
+          query_sha256: 'new',
+          result_count: 2,
+          took_ms: 20,
+        }),
+      ].join('\n'));
+
+      const recent = runCli(['logs', 'recent', '--limit=1', '--format=json', `--file=${logFile}`]);
+      expect(recent.code).toBe(0);
+      expect(recent.stderr).toBe('');
+      const payload = JSON.parse(recent.stdout) as {
+        schema_version: string;
+        result_count: number;
+        events: Array<{ request_id: string; query_sha256: string }>;
+      };
+      expect(payload.schema_version).toBe('kb.logs.v1');
+      expect(payload.result_count).toBe(1);
+      expect(payload.events).toEqual([
+        expect.objectContaining({ request_id: 'req-cli-2', query_sha256: 'new' }),
+      ]);
+
+      const shown = runCli([
+        'logs',
+        'show',
+        '--query-sha=old',
+        '--format=json',
+        `--file=${logFile}`,
+      ]);
+      expect(shown.code).toBe(0);
+      expect(JSON.parse(shown.stdout).events).toEqual([
+        expect.objectContaining({ request_id: 'req-cli-1', query_sha256: 'old' }),
+      ]);
     } finally {
       await fsp.rm(tempDir, { recursive: true, force: true });
     }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,6 +18,7 @@ import { EVAL_GATE_HELP, runEvalGate } from './cli-eval-gate.js';
 import { EXPLAIN_HELP, runExplain } from './cli-explain.js';
 import { LIST_HELP, runList } from './cli-list.js';
 import { LLM_HELP, runLlm } from './cli-llm.js';
+import { LOGS_HELP, runLogs } from './cli-logs.js';
 import { MODELS_HELP, runModels } from './cli-models.js';
 import { PROMOTE_HELP, runPromote } from './cli-promote.js';
 import { QUARANTINE_HELP, runQuarantine } from './cli-quarantine.js';
@@ -92,6 +93,7 @@ const SUBCOMMANDS: readonly Subcommand[] = [
   { name: 'capture',      summary: 'Run a command and append its stdout to a KB note as a fenced block.',    help: CAPTURE_HELP,      handler: runCapture },
   { name: 'compare',      summary: 'Side-by-side rank/score table for two embedding models.',                help: COMPARE_HELP,      handler: runCompare },
   { name: 'doctor',       summary: 'Aggregate model / index / backend health report.',                       help: DOCTOR_HELP,       handler: runDoctor },
+  { name: 'logs',         summary: 'Inspect historical canonical request logs.',                             help: LOGS_HELP,         handler: runLogs },
   { name: 'stats',        summary: 'Read-only index/corpus stats (mirrors the MCP kb_stats payload).',       help: STATS_HELP,        handler: runStats },
   { name: 'eval',         summary: 'Run fixture-driven retrieval checks.',                                   help: EVAL_HELP,         handler: runEval },
   { name: 'eval-gate',    summary: 'RFC 018 M0 relevance-gate validation harness (downstream answer quality).', help: EVAL_GATE_HELP,  handler: runEvalGate },
@@ -133,6 +135,8 @@ Environment:
   KB_ACTIVE_MODEL           Override the active model for this process (RFC 013 §4.7).
   KB_DAEMON_URL             URL for \`kb search --daemon\` (default http://127.0.0.1:17799).
   KB_LLM_ENDPOINT           OpenAI-compatible endpoint used by \`kb ask\`.
+  LOG_FILE                  Optional file used by \`kb logs\` and by runtime logging.
+  KB_LOG_FORMAT             text | canonical | both (default both).
   OLLAMA_*, OPENAI_*, HUGGINGFACE_*
                             Provider-specific config; see the provider's docs.
 


### PR DESCRIPTION
## Summary

- Add `kb logs recent` and `kb logs show` for reading historical `kb-canonical.v1` log lines from `--file`, `LOG_FILE`, or known local defaults.
- Support request-id and query-hash filtering with markdown and JSON output.
- Document the `kb.logs.v1` JSON contract and wire the command into top-level CLI help.

Closes #387.

## Verification

- `npm run build`
- `npm test -- --runTestsByPath src/cli-logs.test.ts src/cli.test.ts`
- `npm test`
- `git diff --check`
- Pre-PR reviewer specialists: conventions, correctness, dead-code, test. Blocking correctness/test findings were fixed and re-reviewed clean.
