### PR TITLE
feat: add doctor LLM endpoint readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,14 +427,14 @@ For a command-oriented runbook covering empty results, stale-index footers, link
 
 ### KB availability smoke check
 
-When `kb search` (or the MCP `retrieve_knowledge` tool) is not returning results, run the read-only `kb doctor` command first — it is the canonical availability check and aggregates the four things that can break a search:
+When `kb search` (or the MCP `retrieve_knowledge` tool) is not returning results, run the read-only `kb doctor` command first — it is the canonical availability check for retrieval and also reports local LLM readiness for `kb ask`:
 
 ```bash
 kb doctor                # human-readable report
 kb doctor --format=json  # machine-readable for agent shells
 ```
 
-The report covers active-model resolution, FAISS index version + mtime, the latest in-process index-update summary, per-KB stale counts, embedding-backend reachability (Ollama / HuggingFace / OpenAI), CLI version, and local git state. The command exits non-zero when any required check fails (active model unresolved, index missing, backend unreachable), so it is safe to use as a precondition gate from scripts.
+The report covers active-model resolution, FAISS index version + mtime, the latest in-process index-update summary, per-KB stale counts, embedding-backend reachability (Ollama / HuggingFace / OpenAI), local LLM endpoint readiness, CLI version, and local git state. The command exits non-zero when any required retrieval check fails (active model unresolved, index missing, backend unreachable); LLM endpoint failures are WARN rows because search can remain healthy while `kb ask` is not ready.
 
 ### Distinguishing search failure modes
 

--- a/docs/cli-json-contracts.md
+++ b/docs/cli-json-contracts.md
@@ -508,6 +508,20 @@ Report envelope:
     "healthy": true,
     "detail": "Ollama http://localhost:11434 is reachable..."
   },
+  "llm_endpoint": {
+    "status": "ok",
+    "endpoint": "http://127.0.0.1:8080/v1/chat/completions",
+    "health_url": "http://127.0.0.1:8080/health",
+    "endpoint_source": "profile",
+    "profile_name": "local-research-agent",
+    "profile_mode": "external",
+    "managed_by": "local-research-agent",
+    "unit_name": null,
+    "health_ok": true,
+    "chat_ok": true,
+    "detail": "ready; profile=local-research-agent; source=profile; ...",
+    "next_action": null
+  },
   "cli": {
     "version": "0.2.2",
     "package_root": "/path/to/package",
@@ -536,6 +550,13 @@ Stable fields:
 - `stale_counts_by_kb`: object keyed by KB name with `modified_files` and
   `new_files`.
 - `backend`: `provider`, `healthy`, and `detail`.
+- `llm_endpoint`: local LLM readiness for `kb ask`. `status` is `ok` or
+  `warn`; failed LLM readiness is a warning because search health can still be
+  usable. `endpoint_source` is `env`, `profile`, `default`, or `unresolved`.
+  `profile_name`, `profile_mode`, `managed_by`, and `unit_name` describe the
+  resolved profile/ownership when known. `health_ok` checks the derived
+  `/health` URL and `chat_ok` checks an OpenAI-compatible chat completion.
+  `next_action` is `null` when ready, otherwise a human-readable repair hint.
 - `cli`: `version`, `package_root`, `invoked_path`, and
   `symlinked_checkout_path`.
 - `git`: either `null` or an object with `branch`, `head`, `origin_main`, and
@@ -553,9 +574,10 @@ Stdout/stderr and exit codes:
   the report with `status: "error"`.
 - Argument errors print `kb doctor: ...` to stderr and exit `2`.
 
-Source and test anchors: `src/cli-doctor.ts:66-99`,
-`src/cli-doctor.ts:114-130`, `src/cli-doctor.ts:149-237`,
-`src/cli-doctor.test.ts:39-180`.
+Source and test anchors: `src/cli-doctor.ts:84-107`,
+`src/cli-doctor.ts:201-214`, `src/cli-doctor.ts:476-483`,
+`src/cli-doctor.ts:926-1045`, `src/cli-doctor.ts:1243-1260`,
+`src/cli-doctor.test.ts:336-602`.
 
 ## `kb logs`
 

--- a/docs/troubleshooting-local-kb.md
+++ b/docs/troubleshooting-local-kb.md
@@ -9,7 +9,7 @@ kb doctor
 kb doctor --format=json
 ```
 
-`kb doctor` reports active-model resolution, index path and version, stale file counts, embedding backend health, CLI package and symlink state, git drift for linked checkouts, and the latest index-update summary. Use it before deleting index files or changing client configuration.
+`kb doctor` reports active-model resolution, index path and version, stale file counts, embedding backend health, local LLM endpoint readiness for `kb ask`, CLI package and symlink state, git drift for linked checkouts, and the latest index-update summary. Use it before deleting index files, changing client configuration, or debugging local LLM answers.
 
 ## Quick Symptom Table
 

--- a/src/cli-doctor.test.ts
+++ b/src/cli-doctor.test.ts
@@ -17,6 +17,9 @@ const originalEnv = {
   REINDEX_TRIGGER_PATH: process.env.REINDEX_TRIGGER_PATH,
   REINDEX_TRIGGER_POLL_MS: process.env.REINDEX_TRIGGER_POLL_MS,
   KB_FS_WATCH: process.env.KB_FS_WATCH,
+  KB_LLM_ENDPOINT: process.env.KB_LLM_ENDPOINT,
+  KB_LLM_CONFIG_DIR: process.env.KB_LLM_CONFIG_DIR,
+  KB_LLM_STATE_DIR: process.env.KB_LLM_STATE_DIR,
 };
 
 const MODEL_ID = 'huggingface__BAAI-bge-small-en-v1.5';
@@ -73,6 +76,16 @@ function persistedSuccessSummary() {
   };
 }
 
+async function healthyLlmProbe(endpoint: string) {
+  return {
+    endpoint,
+    health_url: endpoint.replace(/\/v1\/chat\/completions$/, '/health'),
+    health_ok: true,
+    chat_ok: true,
+    detail: 'health and chat completion succeeded',
+  };
+}
+
 describe('kb doctor', () => {
   const itOnPosix = process.platform === 'win32' ? it.skip : it;
 
@@ -102,6 +115,7 @@ describe('kb doctor', () => {
         packageRoot: tempDir,
         invokedPath: null,
         packageVersion: '9.9.9',
+        llmEndpointProbe: healthyLlmProbe,
       });
 
       expect(report.index_security.ownership_check).toBe('checked');
@@ -150,6 +164,7 @@ describe('kb doctor', () => {
         packageRoot: tempDir,
         invokedPath: null,
         packageVersion: '9.9.9',
+        llmEndpointProbe: healthyLlmProbe,
       });
 
       expect(report.status).toBe('warn');
@@ -248,6 +263,7 @@ describe('kb doctor', () => {
         packageRoot: tempDir,
         invokedPath: linkedBin,
         packageVersion: '9.9.9',
+        llmEndpointProbe: healthyLlmProbe,
         lastIndexUpdateSummary: {
           status: 'success',
           scope: 'global',
@@ -317,6 +333,274 @@ describe('kb doctor', () => {
     }
   });
 
+  it('reports active external LLM profile readiness in JSON and markdown', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-doctor-llm-external-'));
+    try {
+      const rootDir = path.join(tempDir, 'kbs');
+      const faissDir = path.join(tempDir, '.faiss');
+      const llmConfigDir = path.join(tempDir, 'llm-config');
+      const llmStateDir = path.join(tempDir, 'llm-state');
+      await fsp.mkdir(rootDir, { recursive: true });
+      const modelDir = await seedRegisteredModel(faissDir);
+      await seedVersionedIndex(modelDir);
+
+      const { buildDoctorReport, formatDoctorMarkdown } = await freshDoctor({
+        KNOWLEDGE_BASES_ROOT_DIR: rootDir,
+        FAISS_INDEX_PATH: faissDir,
+        EMBEDDING_PROVIDER: 'huggingface',
+        HUGGINGFACE_MODEL_NAME: MODEL_NAME,
+        HUGGINGFACE_API_KEY: 'test-key',
+        KB_LLM_CONFIG_DIR: llmConfigDir,
+        KB_LLM_STATE_DIR: llmStateDir,
+      });
+      const { createExternalProfile, writeActiveProfile, writeProfile } = await import('./llm-profiles.js');
+      const profile = await createExternalProfile(
+        'local-research-agent',
+        'http://127.0.0.1:8080',
+        'local-research-agent',
+      );
+      await writeProfile(profile);
+      await writeActiveProfile(profile.name);
+
+      const report = await buildDoctorReport({
+        backendHealthCheck: async () => ({ healthy: true, detail: 'backend ok' }),
+        packageRoot: tempDir,
+        invokedPath: null,
+        packageVersion: '9.9.9',
+        llmEndpointProbe: async (endpoint) => ({
+          endpoint,
+          health_url: 'http://127.0.0.1:8080/health',
+          health_ok: true,
+          chat_ok: true,
+          detail: 'health and chat completion succeeded',
+        }),
+      });
+
+      expect(report.llm_endpoint).toMatchObject({
+        status: 'ok',
+        endpoint: 'http://127.0.0.1:8080/v1/chat/completions',
+        health_url: 'http://127.0.0.1:8080/health',
+        endpoint_source: 'profile',
+        profile_name: 'local-research-agent',
+        profile_mode: 'external',
+        managed_by: 'local-research-agent',
+        unit_name: null,
+        health_ok: true,
+        chat_ok: true,
+        next_action: null,
+      });
+      expect(report.checks).toContainEqual({
+        name: 'llm_endpoint',
+        status: 'ok',
+        detail: expect.stringContaining('ready; profile=local-research-agent'),
+      });
+      const markdown = formatDoctorMarkdown(report);
+      expect(markdown).toContain('LLM endpoint:');
+      expect(markdown).toContain('source: profile');
+      expect(markdown).toContain('managed_by: local-research-agent');
+      expect(markdown).toContain('chat_ok: yes');
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('warns on an unhealthy managed LLM endpoint without starting the service', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-doctor-llm-managed-'));
+    try {
+      const rootDir = path.join(tempDir, 'kbs');
+      const faissDir = path.join(tempDir, '.faiss');
+      const llmConfigDir = path.join(tempDir, 'llm-config');
+      const llmStateDir = path.join(tempDir, 'llm-state');
+      await fsp.mkdir(rootDir, { recursive: true });
+      const modelDir = await seedRegisteredModel(faissDir);
+      await seedVersionedIndex(modelDir);
+
+      const { buildDoctorReport, formatDoctorMarkdown } = await freshDoctor({
+        KNOWLEDGE_BASES_ROOT_DIR: rootDir,
+        FAISS_INDEX_PATH: faissDir,
+        EMBEDDING_PROVIDER: 'huggingface',
+        HUGGINGFACE_MODEL_NAME: MODEL_NAME,
+        HUGGINGFACE_API_KEY: 'test-key',
+        KB_LLM_CONFIG_DIR: llmConfigDir,
+        KB_LLM_STATE_DIR: llmStateDir,
+      });
+      const { createManagedProfile, writeActiveProfile, writeProfile } = await import('./llm-profiles.js');
+      const modelPath = path.join(tempDir, 'model.gguf');
+      await fsp.writeFile(modelPath, 'model-bytes', 'utf-8');
+      const profile = await createManagedProfile({
+        name: 'qwen',
+        runnerBin: '/bin/llama-server',
+        modelPath,
+        port: 8091,
+      });
+      await writeProfile(profile);
+      await writeActiveProfile(profile.name);
+
+      const report = await buildDoctorReport({
+        backendHealthCheck: async () => ({ healthy: true, detail: 'backend ok' }),
+        packageRoot: tempDir,
+        invokedPath: null,
+        packageVersion: '9.9.9',
+        llmEndpointProbe: async (endpoint) => ({
+          endpoint,
+          health_url: 'http://127.0.0.1:8091/health',
+          health_ok: false,
+          chat_ok: false,
+          detail: 'health failed: connect ECONNREFUSED; chat failed: local LLM request failed: connect ECONNREFUSED',
+        }),
+      });
+
+      expect(report.llm_endpoint).toMatchObject({
+        status: 'warn',
+        endpoint: 'http://127.0.0.1:8091/v1/chat/completions',
+        endpoint_source: 'profile',
+        profile_name: 'qwen',
+        profile_mode: 'managed',
+        unit_name: 'kb-llm@qwen.service',
+        managed_by: null,
+        health_ok: false,
+        chat_ok: false,
+      });
+      expect(report.llm_endpoint.next_action).toContain('kb llm start --profile=qwen');
+      expect(report.checks).toContainEqual({
+        name: 'llm_endpoint',
+        status: 'warn',
+        detail: expect.stringContaining('not ready; profile=qwen'),
+      });
+      const markdown = formatDoctorMarkdown(report);
+      expect(markdown).toContain('unit: kb-llm@qwen.service');
+      expect(markdown).toContain('chat_ok: no');
+      expect(markdown).toContain('next_action: Run kb llm start --profile=qwen');
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('uses KB_LLM_ENDPOINT before the active LLM profile', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-doctor-llm-env-'));
+    try {
+      const rootDir = path.join(tempDir, 'kbs');
+      const faissDir = path.join(tempDir, '.faiss');
+      const llmConfigDir = path.join(tempDir, 'llm-config');
+      const llmStateDir = path.join(tempDir, 'llm-state');
+      await fsp.mkdir(rootDir, { recursive: true });
+      const modelDir = await seedRegisteredModel(faissDir);
+      await seedVersionedIndex(modelDir);
+
+      const { buildDoctorReport } = await freshDoctor({
+        KNOWLEDGE_BASES_ROOT_DIR: rootDir,
+        FAISS_INDEX_PATH: faissDir,
+        EMBEDDING_PROVIDER: 'huggingface',
+        HUGGINGFACE_MODEL_NAME: MODEL_NAME,
+        HUGGINGFACE_API_KEY: 'test-key',
+        KB_LLM_CONFIG_DIR: llmConfigDir,
+        KB_LLM_STATE_DIR: llmStateDir,
+        KB_LLM_ENDPOINT: 'http://127.0.0.1:9999',
+      });
+      const { createExternalProfile, writeActiveProfile, writeProfile } = await import('./llm-profiles.js');
+      const profile = await createExternalProfile('active-profile', 'http://127.0.0.1:8080');
+      await writeProfile(profile);
+      await writeActiveProfile(profile.name);
+
+      const probed: string[] = [];
+      const report = await buildDoctorReport({
+        backendHealthCheck: async () => ({ healthy: true, detail: 'backend ok' }),
+        packageRoot: tempDir,
+        invokedPath: null,
+        packageVersion: '9.9.9',
+        llmEndpointProbe: async (endpoint) => {
+          probed.push(endpoint);
+          return {
+            endpoint,
+            health_url: 'http://127.0.0.1:9999/health',
+            health_ok: true,
+            chat_ok: false,
+            detail: 'health HTTP 200; chat failed: local LLM returned non-JSON response: Unexpected token',
+          };
+        },
+      });
+
+      expect(probed).toEqual(['http://127.0.0.1:9999/v1/chat/completions']);
+      expect(report.llm_endpoint).toMatchObject({
+        status: 'warn',
+        endpoint_source: 'env',
+        profile_name: 'env',
+        profile_mode: 'external',
+        health_ok: true,
+        chat_ok: false,
+      });
+      expect(report.llm_endpoint.detail).toContain('chat failed');
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('uses the production LLM endpoint probe when no test probe is injected', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-doctor-llm-default-probe-'));
+    const oldFetch = global.fetch;
+    try {
+      const rootDir = path.join(tempDir, 'kbs');
+      const faissDir = path.join(tempDir, '.faiss');
+      const llmConfigDir = path.join(tempDir, 'llm-config');
+      const llmStateDir = path.join(tempDir, 'llm-state');
+      await fsp.mkdir(rootDir, { recursive: true });
+      const modelDir = await seedRegisteredModel(faissDir);
+      await seedVersionedIndex(modelDir);
+
+      const fetchMock = jest.fn(async (input: string | URL | Request) => {
+        const url = String(input);
+        if (url.endsWith('/health')) {
+          return new Response('{"status":"ok"}', { status: 200 });
+        }
+        return new Response(JSON.stringify({
+          choices: [{ message: { content: 'ok' } }],
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      });
+      global.fetch = fetchMock as unknown as typeof fetch;
+
+      const { buildDoctorReport } = await freshDoctor({
+        KNOWLEDGE_BASES_ROOT_DIR: rootDir,
+        FAISS_INDEX_PATH: faissDir,
+        EMBEDDING_PROVIDER: 'huggingface',
+        HUGGINGFACE_MODEL_NAME: MODEL_NAME,
+        HUGGINGFACE_API_KEY: 'test-key',
+        KB_LLM_CONFIG_DIR: llmConfigDir,
+        KB_LLM_STATE_DIR: llmStateDir,
+        KB_LLM_ENDPOINT: '',
+      });
+
+      const report = await buildDoctorReport({
+        backendHealthCheck: async () => ({ healthy: true, detail: 'backend ok' }),
+        packageRoot: tempDir,
+        invokedPath: null,
+        packageVersion: '9.9.9',
+      });
+
+      expect(report.llm_endpoint).toMatchObject({
+        status: 'ok',
+        endpoint_source: 'default',
+        profile_name: 'local-research-agent',
+        profile_mode: 'external',
+        managed_by: 'local-research-agent',
+        endpoint: 'http://127.0.0.1:8080/v1/chat/completions',
+        health_url: 'http://127.0.0.1:8080/health',
+        health_ok: true,
+        chat_ok: true,
+      });
+      expect(fetchMock).toHaveBeenCalledWith(
+        'http://127.0.0.1:8080/health',
+        expect.objectContaining({ method: 'GET' }),
+      );
+      expect(fetchMock).toHaveBeenCalledWith(
+        'http://127.0.0.1:8080/v1/chat/completions',
+        expect.objectContaining({ method: 'POST' }),
+      );
+    } finally {
+      global.fetch = oldFetch;
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it('reports reindex-trigger configuration, filesystem state, and freshness in markdown and JSON', async () => {
     const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-doctor-trigger-'));
     try {
@@ -350,6 +634,7 @@ describe('kb doctor', () => {
         packageRoot: tempDir,
         invokedPath: null,
         packageVersion: '9.9.9',
+        llmEndpointProbe: healthyLlmProbe,
       });
 
       expect(report.reindex_trigger).toMatchObject({
@@ -430,6 +715,7 @@ describe('kb doctor', () => {
         packageRoot: tempDir,
         invokedPath: null,
         packageVersion: '9.9.9',
+        llmEndpointProbe: healthyLlmProbe,
       });
 
       expect(report.quarantine_counts_by_kb).toEqual({ alpha: 1 });
@@ -473,6 +759,7 @@ describe('kb doctor', () => {
         packageRoot: tempDir,
         invokedPath: null,
         packageVersion: '9.9.9',
+        llmEndpointProbe: healthyLlmProbe,
       });
 
       expect(report.last_index_update).toMatchObject({
@@ -522,6 +809,7 @@ describe('kb doctor', () => {
         packageRoot: tempDir,
         invokedPath: null,
         packageVersion: '9.9.9',
+        llmEndpointProbe: healthyLlmProbe,
       });
 
       expect(report.checks).toContainEqual({
@@ -563,6 +851,7 @@ describe('kb doctor', () => {
         packageRoot: tempDir,
         invokedPath: null,
         packageVersion: '9.9.9',
+        llmEndpointProbe: healthyLlmProbe,
       });
 
       expect(report.status).toBe('error');
@@ -620,6 +909,7 @@ describe('kb doctor', () => {
           packageRoot: tempDir,
           invokedPath: null,
           packageVersion: '9.9.9',
+          llmEndpointProbe: healthyLlmProbe,
         });
         expect(report.age_budgets).toEqual({});
         expect(report.age_budget_config_errors).toEqual([]);
@@ -655,6 +945,7 @@ describe('kb doctor', () => {
           packageRoot: tempDir,
           invokedPath: null,
           packageVersion: '9.9.9',
+          llmEndpointProbe: healthyLlmProbe,
         });
         expect(report.age_budgets.alpha).toMatchObject({
           configured_hours: 24,
@@ -699,6 +990,7 @@ describe('kb doctor', () => {
           packageRoot: tempDir,
           invokedPath: null,
           packageVersion: '9.9.9',
+          llmEndpointProbe: healthyLlmProbe,
         });
         expect(report.age_budgets.alpha).toMatchObject({
           configured_hours: 24,
@@ -729,6 +1021,7 @@ describe('kb doctor', () => {
           packageRoot: tempDir,
           invokedPath: null,
           packageVersion: '9.9.9',
+          llmEndpointProbe: healthyLlmProbe,
         });
         expect(report.age_budget_config_errors).toEqual([
           expect.objectContaining({
@@ -771,6 +1064,7 @@ describe('kb doctor', () => {
           packageRoot: tempDir,
           invokedPath: null,
           packageVersion: '9.9.9',
+          llmEndpointProbe: healthyLlmProbe,
           providerCallMetrics: new ProviderCallMetrics({ now: () => 0 }),
         });
         expect(report.provider_calls).toEqual({});
@@ -810,6 +1104,7 @@ describe('kb doctor', () => {
           packageRoot: tempDir,
           invokedPath: null,
           packageVersion: '9.9.9',
+          llmEndpointProbe: healthyLlmProbe,
           providerCallMetrics: metrics,
         });
         const check = report.checks.find((c) => c.name === 'provider_calls');
@@ -851,6 +1146,7 @@ describe('kb doctor', () => {
           packageRoot: tempDir,
           invokedPath: null,
           packageVersion: '9.9.9',
+          llmEndpointProbe: healthyLlmProbe,
           providerCallMetrics: metrics,
         });
         const check = report.checks.find((c) => c.name === 'provider_calls');
@@ -896,6 +1192,7 @@ describe('kb doctor', () => {
           packageRoot: tempDir,
           invokedPath: null,
           packageVersion: '9.9.9',
+          llmEndpointProbe: healthyLlmProbe,
         });
 
         expect(report.active_model.provider).toBe('fake');

--- a/src/cli-doctor.ts
+++ b/src/cli-doctor.ts
@@ -57,6 +57,12 @@ import {
 } from './metrics.js';
 import { countIngestQuarantine } from './ingest-quarantine.js';
 import { inspectReindexTriggerFilesystem } from './triggerWatcher.js';
+import { deriveHealthUrl, probeLlmEndpoint, type LlmProbeResult } from './llm-client.js';
+import {
+  createExternalProfile,
+  resolveProfile,
+  type LlmProfile,
+} from './llm-profiles.js';
 
 /**
  * Issue #210 — error-rate threshold above which the doctor surfaces a
@@ -65,6 +71,9 @@ import { inspectReindexTriggerFilesystem } from './triggerWatcher.js';
  * trip an operator's alarm.
  */
 export const PROVIDER_CALL_ERROR_RATE_WARN_THRESHOLD = 0.05;
+const DEFAULT_LLM_ENDPOINT = 'http://127.0.0.1:8080/v1/chat/completions';
+const DOCTOR_LLM_HEALTH_TIMEOUT_MS = 1_000;
+const DOCTOR_LLM_CHAT_TIMEOUT_MS = 3_000;
 
 const execFileAsync = promisify(execFile);
 
@@ -75,8 +84,9 @@ Usage:
 
 Composes existing read-only checks (env vars, registered models, active
 model, FAISS index presence + mtime, knowledge-base count, embedding
-backend reachability) into a single status report. Does NOT load the
-FAISS store or embed documents.
+backend reachability, and local LLM endpoint readiness for kb ask) into
+a single status report. Does NOT load the FAISS store, embed documents,
+or start managed LLM services.
 
 Report status is one of \`ok\`, \`warn\`, or \`error\`. The exit code is non-zero
 when any required check fails, so \`kb doctor && kb search ...\` is a safe
@@ -188,6 +198,20 @@ export interface DoctorReport {
     healthy: boolean;
     detail: string;
   };
+  llm_endpoint: {
+    status: HealthStatus;
+    endpoint: string | null;
+    health_url: string | null;
+    endpoint_source: 'env' | 'profile' | 'default' | 'unresolved';
+    profile_name: string | null;
+    profile_mode: 'managed' | 'external' | null;
+    managed_by: string | null;
+    unit_name: string | null;
+    health_ok: boolean;
+    chat_ok: boolean;
+    detail: string;
+    next_action: string | null;
+  };
   cli: {
     version: string;
     package_root: string;
@@ -260,12 +284,19 @@ export interface BuildDoctorReportOptions {
    * singleton is read.
    */
   providerCallMetrics?: ProviderCallMetrics;
+  /**
+   * Issue #388 — test seam for the local LLM endpoint readiness check.
+   * Production callers leave this undefined so the doctor performs a
+   * short, read-only probe without starting any services.
+   */
+  llmEndpointProbe?: LlmEndpointProbe;
 }
 
 export type BackendHealthCheck = (
   provider: string,
   modelName: string,
 ) => Promise<{ healthy: boolean; detail: string }>;
+export type LlmEndpointProbe = (endpoint: string) => Promise<LlmProbeResult>;
 
 export async function runDoctor(rest: string[]): Promise<number> {
   let parsed: DoctorArgs;
@@ -442,6 +473,15 @@ export async function buildDoctorReport(
     detail: backend.detail,
   });
 
+  const llmEndpoint = await readLlmEndpointHealth(
+    options.llmEndpointProbe ?? defaultLlmEndpointProbe,
+  );
+  checks.push({
+    name: 'llm_endpoint',
+    status: llmEndpoint.status,
+    detail: llmEndpoint.detail,
+  });
+
   const metricsSource = options.providerCallMetrics ?? providerCallMetrics;
   const providerCalls = metricsSource.snapshot();
   // Issue #210 — only emit the row when at least one call has been
@@ -513,6 +553,7 @@ export async function buildDoctorReport(
     age_budget_config_errors: ageBudgetResult.configErrors,
     incomplete_models: incompleteModels,
     backend,
+    llm_endpoint: llmEndpoint,
     cli,
     git,
     last_index_update: lastIndexUpdate,
@@ -882,6 +923,127 @@ async function readBackendHealth(
   return { provider, ...result };
 }
 
+async function readLlmEndpointHealth(
+  check: LlmEndpointProbe,
+): Promise<DoctorReport['llm_endpoint']> {
+  let target: { profile: LlmProfile; source: DoctorReport['llm_endpoint']['endpoint_source'] };
+  try {
+    target = await resolveDoctorLlmTarget();
+  } catch (err) {
+    return {
+      status: 'warn',
+      endpoint: null,
+      health_url: null,
+      endpoint_source: 'unresolved',
+      profile_name: null,
+      profile_mode: null,
+      managed_by: null,
+      unit_name: null,
+      health_ok: false,
+      chat_ok: false,
+      detail: `LLM profile resolution failed: ${(err as Error).message}`,
+      next_action: 'Run kb llm status --format=json, then fix or remove the active LLM profile.',
+    };
+  }
+
+  const { profile, source } = target;
+  try {
+    const probe = await check(profile.endpoint);
+    const status: HealthStatus = probe.health_ok && probe.chat_ok ? 'ok' : 'warn';
+    return {
+      status,
+      endpoint: probe.endpoint,
+      health_url: probe.health_url,
+      endpoint_source: source,
+      profile_name: profile.name,
+      profile_mode: profile.mode,
+      managed_by: profile.mode === 'external' ? profile.managed_by ?? null : null,
+      unit_name: profile.mode === 'managed' ? profile.unit_name : null,
+      health_ok: probe.health_ok,
+      chat_ok: probe.chat_ok,
+      detail: formatLlmEndpointDetail(profile, source, probe),
+      next_action: status === 'ok' ? null : llmEndpointNextAction(profile, probe),
+    };
+  } catch (err) {
+    const endpoint = profile.endpoint;
+    return {
+      status: 'warn',
+      endpoint,
+      health_url: safeDeriveHealthUrl(endpoint),
+      endpoint_source: source,
+      profile_name: profile.name,
+      profile_mode: profile.mode,
+      managed_by: profile.mode === 'external' ? profile.managed_by ?? null : null,
+      unit_name: profile.mode === 'managed' ? profile.unit_name : null,
+      health_ok: false,
+      chat_ok: false,
+      detail: `LLM endpoint probe failed: ${(err as Error).message}`,
+      next_action: `Run kb llm probe --endpoint=${endpoint} after starting or fixing the local LLM service.`,
+    };
+  }
+}
+
+async function resolveDoctorLlmTarget(): Promise<{
+  profile: LlmProfile;
+  source: DoctorReport['llm_endpoint']['endpoint_source'];
+}> {
+  if (process.env.KB_LLM_ENDPOINT?.trim()) {
+    return {
+      profile: await createExternalProfile('env', process.env.KB_LLM_ENDPOINT),
+      source: 'env',
+    };
+  }
+  const configured = await resolveProfile();
+  if (configured) return { profile: configured, source: 'profile' };
+  return {
+    profile: await createExternalProfile(
+      'local-research-agent',
+      DEFAULT_LLM_ENDPOINT,
+      'local-research-agent',
+    ),
+    source: 'default',
+  };
+}
+
+async function defaultLlmEndpointProbe(endpoint: string): Promise<LlmProbeResult> {
+  return probeLlmEndpoint(endpoint, fetch, {
+    healthTimeoutMs: DOCTOR_LLM_HEALTH_TIMEOUT_MS,
+    chatTimeoutMs: DOCTOR_LLM_CHAT_TIMEOUT_MS,
+  });
+}
+
+function formatLlmEndpointDetail(
+  profile: LlmProfile,
+  source: DoctorReport['llm_endpoint']['endpoint_source'],
+  probe: LlmProbeResult,
+): string {
+  const owner = profile.mode === 'managed'
+    ? `managed ${profile.unit_name}`
+    : `external${profile.managed_by ? ` (${profile.managed_by})` : ''}`;
+  const readiness = probe.chat_ok
+    ? (probe.health_ok ? 'ready' : 'chat ready, health endpoint unhealthy')
+    : 'not ready';
+  return `${readiness}; profile=${profile.name}; source=${source}; owner=${owner}; ${probe.detail}`;
+}
+
+function llmEndpointNextAction(profile: LlmProfile, probe: LlmProbeResult): string {
+  if (profile.mode === 'managed') {
+    return `Run kb llm start --profile=${profile.name}, then kb llm probe --endpoint=${probe.endpoint}.`;
+  }
+  if (profile.mode === 'external' && profile.managed_by) {
+    return `Start or fix ${profile.managed_by}, then run kb llm probe --endpoint=${probe.endpoint}.`;
+  }
+  return `Start or fix the external LLM service, then run kb llm probe --endpoint=${probe.endpoint}.`;
+}
+
+function safeDeriveHealthUrl(endpoint: string): string | null {
+  try {
+    return deriveHealthUrl(endpoint);
+  } catch {
+    return null;
+  }
+}
+
 async function defaultBackendHealthCheck(
   provider: string,
   modelName: string,
@@ -1078,6 +1240,24 @@ export function formatDoctorMarkdown(report: DoctorReport): string {
   }
   lines.push(`  note: ${report.reindex_trigger.limitation}`);
   lines.push(`Backend: ${report.backend.healthy ? 'ok' : 'error'} — ${report.backend.detail}`);
+  lines.push('LLM endpoint:');
+  lines.push(`  status: ${report.llm_endpoint.status}`);
+  lines.push(`  source: ${report.llm_endpoint.endpoint_source}`);
+  lines.push(`  profile: ${report.llm_endpoint.profile_name ?? '<unresolved>'} (${report.llm_endpoint.profile_mode ?? 'n/a'})`);
+  if (report.llm_endpoint.unit_name !== null) {
+    lines.push(`  unit: ${report.llm_endpoint.unit_name}`);
+  }
+  if (report.llm_endpoint.managed_by !== null) {
+    lines.push(`  managed_by: ${report.llm_endpoint.managed_by}`);
+  }
+  lines.push(`  endpoint: ${report.llm_endpoint.endpoint ?? '<unresolved>'}`);
+  lines.push(`  health_url: ${report.llm_endpoint.health_url ?? '<unresolved>'}`);
+  lines.push(`  health_ok: ${report.llm_endpoint.health_ok ? 'yes' : 'no'}`);
+  lines.push(`  chat_ok: ${report.llm_endpoint.chat_ok ? 'yes' : 'no'}`);
+  lines.push(`  detail: ${report.llm_endpoint.detail}`);
+  if (report.llm_endpoint.next_action !== null) {
+    lines.push(`  next_action: ${report.llm_endpoint.next_action}`);
+  }
   lines.push(`kb version: ${report.cli.version}`);
   if (report.cli.symlinked_checkout_path !== null) {
     lines.push(`Linked checkout: ${report.cli.symlinked_checkout_path}`);

--- a/src/llm-client.ts
+++ b/src/llm-client.ts
@@ -25,6 +25,11 @@ export interface LlmProbeResult {
   detail: string;
 }
 
+export interface LlmProbeOptions {
+  healthTimeoutMs?: number;
+  chatTimeoutMs?: number;
+}
+
 export class LlmClientError extends Error {
   constructor(message: string) {
     super(message);
@@ -100,13 +105,17 @@ export async function callChatCompletion(
 export async function probeLlmEndpoint(
   endpoint: string,
   fetchImpl: FetchLike = fetch,
+  options: LlmProbeOptions = {},
 ): Promise<LlmProbeResult> {
   const chatEndpoint = normalizeChatEndpoint(endpoint);
   const healthUrl = deriveHealthUrl(chatEndpoint);
   let healthOk = false;
   let healthDetail = '';
   try {
-    const health = await fetchImpl(healthUrl, { method: 'GET', signal: AbortSignal.timeout(3_000) });
+    const health = await fetchImpl(healthUrl, {
+      method: 'GET',
+      signal: AbortSignal.timeout(options.healthTimeoutMs ?? 3_000),
+    });
     healthOk = health.ok;
     healthDetail = `health HTTP ${health.status}`;
   } catch (err) {
@@ -122,7 +131,7 @@ export async function probeLlmEndpoint(
         { role: 'user', content: 'health check' },
       ],
       temperature: 0,
-      timeoutMs: 15_000,
+      timeoutMs: options.chatTimeoutMs ?? 15_000,
     }, fetchImpl);
     return {
       endpoint: chatEndpoint,


### PR DESCRIPTION
## Summary
- add a `llm_endpoint` section to `kb doctor` JSON and markdown output
- resolve LLM readiness using the same env/profile/default precedence as `kb ask`
- probe health/chat readiness without starting managed services and report ask-only failures as WARN
- document the new JSON contract and troubleshooting behavior

Closes #388

## Verification
- `git diff --check`
- `npm run build`
- `npm test -- --runTestsByPath src/cli-doctor.test.ts src/llm-client.test.ts`
- `npm test`

## Pre-PR Review
- detected project type: npm
- type/build checks: passed (`npm run build`)
- tests: passed (`npm test`)
- bug reproduction: skipped (feature PR)
- diff review: done
- portability check: clean (manual added-line scan; no helper in repo)
- reviewer specialists: run (conventions/test findings fixed; correctness/deadcode clean)
- OSS base-branch policy: skipped (same-repo PR)
- gate file: created
