### PR TITLE
docs(reindex): clarify kb reindex --kb is a guard hint, not a scoped rebuild (#406)

### DIFF
--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -50,6 +50,13 @@ is off.
 | Preface token budget | `KB_CONTEXTUAL_MAX_TOKENS` | `150` | Contextual ingest LLM call | Implemented | none | `KB_CONTEXTUAL_RETRIEVAL=on KB_CONTEXTUAL_MAX_TOKENS=120 KB_LLM_ENDPOINT=http://127.0.0.1:8080/v1/chat/completions kb reindex --with-context` |
 | Preface LLM endpoint | `KB_LLM_ENDPOINT` | unset for contextual ingest | Contextual ingest | Implemented | none | `KB_CONTEXTUAL_RETRIEVAL=on KB_LLM_ENDPOINT=http://127.0.0.1:8080/v1/chat/completions kb reindex --with-context` |
 
+`kb reindex --with-context` accepts `--kb=<name>`, but it is a guard and
+estimator hint, not a scoped rebuild: the rebuild always covers the whole
+single-index-per-model FAISS index. `--kb` only narrows the runtime estimate
+and the LRA cron-window guard, and validates that the named KBs exist. A
+partial rebuild is impossible without orphaning the other shelves' vectors;
+see RFC 017 §5.
+
 Hard-coded contextual-ingest constants are intentionally not env flags:
 48,000 character document truncation, 30 second LLM timeout, 2 retries, 5
 consecutive timeouts before circuit breaking, and the reindex guard window

--- a/docs/rfcs/017-contextual-retrieval.md
+++ b/docs/rfcs/017-contextual-retrieval.md
@@ -213,12 +213,22 @@ Hard-coded parameters:
 ```
 kb reindex --with-context [--kb=<name>…] [--force]
 
-  --kb=<name>     Reindex only this KB. Repeat the flag to reindex several.
+  --kb=<name>     Guard/estimator hint only — NOT a scoped rebuild (see
+                  the implementation note below). Repeat to pass several.
                   Default: every shelf.
   --force         Skip the LRA-cron-window guard AND the self-runtime-budget guard.
 ```
 
 (`--dry-run` and `kb reindex` without `--with-context` deferred to follow-up PRs.)
+
+> **Implementation note (M0b).** `--kb` does **not** scope the rebuild.
+> The M0b runner delegates to `FaissIndexManager.updateIndex(undefined,
+> { force: true })`, which always rebuilds the whole single-index-per-model
+> FAISS index (step 6 — a per-KB rebuild would orphan the other shelves'
+> vectors). `--kb` only narrows the chunk-count estimate (step 1) and the
+> cron-window guard arithmetic, and validates that the named KBs exist
+> (unknown name → exit 2). A genuinely scoped rebuild is deferred to a
+> follow-up.
 
 Behavior:
 

--- a/src/cli-reindex.test.ts
+++ b/src/cli-reindex.test.ts
@@ -1,0 +1,28 @@
+// Issue #406 — `kb reindex --kb` is a guard/estimator hint, not a scoped
+// rebuild. The M0b runner delegates to `updateIndex(undefined, { force:
+// true })`, which always rebuilds the whole single-index-per-model FAISS
+// index. These tests pin the help text so it cannot drift back to the
+// earlier wording that implied `--kb` limits which vectors are rebuilt.
+
+import { describe, expect, it } from '@jest/globals';
+import { REINDEX_HELP } from './cli-reindex.js';
+
+describe('REINDEX_HELP — --kb scope accuracy (issue #406)', () => {
+  it('does not claim --kb limits or scopes the rebuild', () => {
+    // The pre-#406 wording was "Limit reindex to this KB" / "Reindex
+    // only this KB" — both overstate what --kb does.
+    expect(REINDEX_HELP).not.toMatch(/Limit reindex to this KB/i);
+    expect(REINDEX_HELP).not.toMatch(/Reindex only this KB/i);
+  });
+
+  it('describes --kb as a guard/estimator hint, not a scoped rebuild', () => {
+    expect(REINDEX_HELP).toMatch(/--kb/);
+    expect(REINDEX_HELP).toMatch(/guard\/estimator hint/i);
+    expect(REINDEX_HELP).toMatch(/NOT a scoped\s+rebuild/i);
+  });
+
+  it('states the rebuild is always global regardless of --kb', () => {
+    expect(REINDEX_HELP).toMatch(/always\s+global/i);
+    expect(REINDEX_HELP).toMatch(/entire FAISS index/i);
+  });
+});

--- a/src/cli-reindex.ts
+++ b/src/cli-reindex.ts
@@ -17,11 +17,12 @@ Usage:
   kb reindex --with-context [--kb=<name>...] [--force]
 
 The \`--with-context\` flag is REQUIRED in this milestone (M0b). It
-triggers a full rebuild of every in-scope KB through the contextual-
-retrieval ingest path: per-chunk LLM-generated prefaces are prepended
-for embedding while the docstore content stays byte-identical. The
-\`KB_CONTEXTUAL_RETRIEVAL=on\` environment variable must also be set;
-the CLI emits a warning otherwise.
+triggers a full rebuild of the ENTIRE FAISS index — every KB, every
+chunk — through the contextual-retrieval ingest path: per-chunk
+LLM-generated prefaces are prepended for embedding while the docstore
+content stays byte-identical. The \`KB_CONTEXTUAL_RETRIEVAL=on\`
+environment variable must also be set; the CLI emits a warning
+otherwise.
 
 Behavior:
   - Refuses to start inside the LRA cron window (06:00-10:30 UTC) or
@@ -35,13 +36,23 @@ Behavior:
     \`FaissIndexManager.updateIndex(undefined, { force: true })\` —
     same machinery the existing \`kb search --refresh\` path uses, so
     sidecar invalidation, error handling, and atomic FAISS swaps come
-    for free.
+    for free. The \`undefined\` scope argument is deliberate: the
+    rebuild is ALWAYS global and \`--kb\` never narrows it (see below).
 
 Options:
   --with-context        Required in M0b. Required for the CLI to do
                         anything; without it, exit code 2.
-  --kb=<name>           Limit reindex to this KB. Repeat the flag for
-                        multiple KBs. Default: every registered KB.
+  --kb=<name>           Guard/estimator hint only — NOT a scoped
+                        rebuild. The FAISS index is single-index-per-
+                        model with every KB co-located, so a partial
+                        rebuild would orphan the other shelves'
+                        vectors; the rebuild is therefore always
+                        global regardless of this flag. --kb only
+                        narrows the chunk-count estimate and the
+                        cron-window guard arithmetic, and is validated
+                        against registered KBs (unknown name -> exit
+                        2). Repeat for multiple KBs. Default: every
+                        registered KB.
   --force               Bypass the LRA cron window guard AND the
                         self-runtime-budget guard. Required to start
                         a reindex inside 06:00-10:30 UTC or when the

--- a/src/reindex-runner.ts
+++ b/src/reindex-runner.ts
@@ -58,7 +58,14 @@ export const REINDEX_RUN_FILENAME = '.reindex.run.json';
 export const REINDEX_RUN_SCHEMA_VERSION = 'reindex-run.v1';
 
 export interface ReindexOptions {
-  /** Scope to these KB names. Empty array means "every registered KB". */
+  /**
+   * KB names used for the chunk-count estimate and the cron-window guard
+   * arithmetic — NOT a scoped rebuild. `updateIndex` is always invoked
+   * with an `undefined` (whole-corpus) scope; see `runManagerUpdateIndex`.
+   * A partial rebuild would orphan the other shelves' vectors in the
+   * single-index-per-model FAISS layout. Empty array means "every
+   * registered KB".
+   */
   knowledgeBases: readonly string[];
   /**
    * Skip the LRA-cron guard AND the self-runtime-budget guard. Operators


### PR DESCRIPTION
## Summary

Implements **issue #406** — a docs/help-text correction for the RFC 017 contextual reindex path.

`kb reindex --with-context --kb=<name>` currently reads as if it limits *which vectors are rebuilt*. It does not. The M0b runner delegates the rebuild to:

```ts
FaissIndexManager.updateIndex(undefined, { force: true })
```

— an **unconditional global rebuild**. The FAISS index is single-index-per-model with every KB co-located and filtered by `metadata.knowledgeBase`, so a *partial* rebuild would orphan the other shelves' vectors (RFC 017 §5 step 6, the v3→v4 author correction). `--kb` only:

- narrows the chunk-count **estimate** (step 1),
- narrows the LRA **cron-window guard** arithmetic, and
- **validates** that the named KBs exist (unknown name → exit 2).

So `--kb` is a guard/estimator hint, not a scope. The prior wording could lead operators to underestimate runtime and blast radius. This PR fixes the overstated text — no behavior change.

## What this changes

| File | Change |
| --- | --- |
| `src/cli-reindex.ts` | `REINDEX_HELP`: `--kb` is now described as a guard/estimator hint; the `--with-context` intro and the `updateIndex` behavior bullet state the rebuild is always global. |
| `src/reindex-runner.ts` | `ReindexOptions.knowledgeBases` jsdoc no longer calls itself a "scope" — it documents the estimate/guard role and the `undefined` whole-corpus `updateIndex` call. |
| `docs/rfcs/017-contextual-retrieval.md` | §5: replaces `--kb=<name>  Reindex only this KB` with `Guard/estimator hint only` plus an **Implementation note (M0b)** explaining why a scoped rebuild is infeasible today. |
| `docs/feature-flags.md` | Adds a note under *Contextual Retrieval at Ingest* clarifying `--kb` is not a scoped rebuild. |
| `src/cli-reindex.test.ts` *(new)* | Pins the corrected help wording so it cannot regress to "Limit reindex to this KB" / "Reindex only this KB". |

**README is intentionally unchanged** — it carries no `kb reindex` documentation, so there is nothing there to correct (the issue listed README as a candidate file, but a grep confirms it never mentions `reindex` / `with-context`).

## Verification

- `npm run build` — clean.
- `npx jest --runInBand src/cli-reindex.test.ts src/reindex-runner.test.ts src/cli.test.ts` — **3 suites, 142 tests, 0 failures** (includes the new suite).
- `npm run docs:check-anchors` — no new stale anchors introduced (59 pre-existing stale anchors across other docs are unrelated; no anchor targets `017-contextual-retrieval.md` or `feature-flags.md` by line).
- Smoke test: `node build/cli.js reindex --help` renders the corrected `--kb` text and exits 0.

Closes #406.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
