### PR TITLE
feat(serve): add kb serve status and daemon-fallback diagnostics (#410)

### DIFF
--- a/docs/troubleshooting-local-kb.md
+++ b/docs/troubleshooting-local-kb.md
@@ -22,6 +22,7 @@ kb doctor --format=json
 | `PROVIDER_UNAVAILABLE`, `PROVIDER_TIMEOUT`, or backend check is unhealthy | Ollama is down, remote provider is unreachable, or API credentials are missing/invalid | `kb doctor` | Start the backend, fix API keys/env, then retry the search. |
 | `REFRESH_LOCK_BUSY` | Another refresh or model add is already writing the same model index | `kb doctor` | Wait for the writer to finish; retry read-only search without `--refresh` if stale results are acceptable. |
 | `kb` command uses the wrong code after `git pull` | Global bin points at an old npm install or a different `npm link` checkout | `which -a kb` | Inspect the symlinked checkout, rebuild it with `npm run build`, or reinstall the published package. |
+| `kb search --daemon` feels no faster than a plain search | No `kb serve` daemon is running, so each call silently falls back to direct execution | `kb serve status` | Start a daemon with `kb serve`; the fallback notice on stderr names the URL that was tried. |
 
 ## Empty Result Flow
 
@@ -169,6 +170,33 @@ kb search "known phrase" --k=5
 
 If read-only results are acceptable, keep working from the existing index and retry `--refresh` later. If the writer appears stuck, identify the shell, MCP client, or service that started a refresh before removing any lock file manually.
 
+## Warm Daemon (`kb serve`)
+
+`kb serve` starts a localhost-only HTTP daemon that keeps the index warm so
+repeated `kb search --daemon` calls skip cold-start cost. The daemon is
+read-only (search/list/stats), binds loopback only, and exits after its idle
+timeout. `kb serve` itself adds no start/stop supervision — run it under your
+own shell, `tmux`, or a user service.
+
+Use `kb serve status` to inspect lifecycle without starting anything:
+
+```bash
+kb serve status          # human-readable: URL, PID, uptime, idle timeout, commands
+kb serve status --json   # { "reachable": true|false, "url": ..., "daemon": {...} }
+```
+
+Exit codes make it scriptable: `0` a daemon answered, `3` nothing is listening
+at the configured URL, `2` a bad argument or `KB_DAEMON_URL` value.
+
+`kb search --daemon` never fails just because the daemon is down — it prints a
+one-line notice to stderr (`kb search: daemon unavailable at <url>; ran search
+directly ...`) and runs the search in-process. If you expected the warm path,
+that notice and `kb serve status` together tell you whether to start a daemon.
+
+`KB_DAEMON_URL` (default `http://127.0.0.1:17799`) selects the daemon that
+both `kb serve status` and `kb search --daemon` talk to. A `/health` probe
+counts as activity, so polling `kb serve status` also defers the idle timeout.
+
 ## Command Choice
 
 | Need | Command |
@@ -178,6 +206,8 @@ If read-only results are acceptable, keep working from the existing index and re
 | Confirm KB names | `kb list` |
 | Confirm file/chunk counts and index metadata | `kb stats` or `kb stats --kb=<name>` |
 | Search without changing index state | `kb search "query"` |
+| Check whether a warm `kb serve` daemon is running | `kb serve status` |
+| Warm repeated searches through the daemon | `kb serve` then `kb search "query" --daemon` |
 | Refresh a specific KB and then search | `kb search "query" --kb=<name> --refresh` |
 | Refresh all KBs and then search | `kb search "query" --refresh` |
 | Debug code/path/error-code queries | `kb search "query" --mode=hybrid` or `--mode=auto` |

--- a/src/cli-serve.test.ts
+++ b/src/cli-serve.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from '@jest/globals';
+import { afterEach, describe, expect, it } from '@jest/globals';
 import * as http from 'node:http';
-import { parseServeArgs, startDaemonServer } from './cli-serve.js';
+import { parseServeArgs, runServeStatus, startDaemonServer } from './cli-serve.js';
 import type { DaemonRunResult } from './daemon-client.js';
 
 interface RawResponse {
@@ -61,7 +61,16 @@ describe('kb serve daemon', () => {
     try {
       const health = await request(daemon.url, { path: '/health' });
       expect(health.statusCode).toBe(200);
-      expect(JSON.parse(health.body)).toEqual({ status: 'ok' });
+      const healthBody = JSON.parse(health.body);
+      expect(healthBody).toMatchObject({
+        status: 'ok',
+        pid: process.pid,
+        url: daemon.url.href,
+        idle_timeout_ms: 0,
+        commands: ['search', 'list', 'stats'],
+      });
+      expect(typeof healthBody.uptime_ms).toBe('number');
+      expect(healthBody.uptime_ms).toBeGreaterThanOrEqual(0);
 
       const run = await request(daemon.url, {
         method: 'POST',
@@ -93,5 +102,82 @@ describe('kb serve daemon', () => {
 
   it('keeps serve binding loopback-only', () => {
     expect(() => parseServeArgs(['--host=0.0.0.0'])).toThrow(/non-loopback/);
+  });
+});
+
+describe('kb serve status', () => {
+  const originalDaemonUrl = process.env.KB_DAEMON_URL;
+
+  afterEach(() => {
+    if (originalDaemonUrl === undefined) delete process.env.KB_DAEMON_URL;
+    else process.env.KB_DAEMON_URL = originalDaemonUrl;
+  });
+
+  async function captureStatus(args: string[]): Promise<{ code: number; stdout: string }> {
+    const chunks: string[] = [];
+    const originalWrite = process.stdout.write;
+    process.stdout.write = ((chunk: unknown, ...rest: unknown[]) => {
+      chunks.push(String(chunk));
+      const callback = rest.find((arg): arg is (err?: Error) => void => typeof arg === 'function');
+      if (callback) callback();
+      return true;
+    }) as typeof process.stdout.write;
+    try {
+      const code = await runServeStatus(args);
+      return { code, stdout: chunks.join('') };
+    } finally {
+      process.stdout.write = originalWrite;
+    }
+  }
+
+  it('reports a reachable daemon with its lifecycle details', async () => {
+    const daemon = await startDaemonServer({ port: 0, idleTimeoutMs: 0 });
+    process.env.KB_DAEMON_URL = daemon.url.href;
+    try {
+      const result = await captureStatus([]);
+      expect(result.code).toBe(0);
+      expect(result.stdout).toContain('daemon running');
+      expect(result.stdout).toContain(`pid:          ${process.pid}`);
+      expect(result.stdout).toContain('commands:     search, list, stats');
+    } finally {
+      await daemon.stop();
+    }
+  });
+
+  it('emits a machine-readable envelope with --json', async () => {
+    const daemon = await startDaemonServer({ port: 0, idleTimeoutMs: 0 });
+    process.env.KB_DAEMON_URL = daemon.url.href;
+    try {
+      const result = await captureStatus(['--json']);
+      expect(result.code).toBe(0);
+      const payload = JSON.parse(result.stdout);
+      expect(payload).toMatchObject({
+        reachable: true,
+        url: daemon.url.href,
+        daemon: { status: 'ok', commands: ['search', 'list', 'stats'] },
+      });
+    } finally {
+      await daemon.stop();
+    }
+  });
+
+  it('exits 3 and reports when no daemon is reachable', async () => {
+    const daemon = await startDaemonServer({ port: 0, idleTimeoutMs: 0 });
+    const url = daemon.url.href;
+    await daemon.stop();
+    process.env.KB_DAEMON_URL = url;
+
+    const result = await captureStatus([]);
+    expect(result.code).toBe(3);
+    expect(result.stdout).toContain(`no daemon reachable at ${url}`);
+
+    const jsonResult = await captureStatus(['--json']);
+    expect(jsonResult.code).toBe(3);
+    expect(JSON.parse(jsonResult.stdout)).toEqual({ reachable: false, url });
+  });
+
+  it('rejects unknown arguments with exit code 2', async () => {
+    const result = await captureStatus(['--bogus']);
+    expect(result.code).toBe(2);
   });
 });

--- a/src/cli-serve.ts
+++ b/src/cli-serve.ts
@@ -3,23 +3,50 @@ import type { AddressInfo } from 'node:net';
 import { runList } from './cli-list.js';
 import { runSearch } from './cli-search.js';
 import { runStats } from './cli-stats.js';
-import type { DaemonCommand, DaemonRunResult } from './daemon-client.js';
+import {
+  daemonUrlFromEnv,
+  tryFetchDaemonHealth,
+  type DaemonCommand,
+  type DaemonHealth,
+  type DaemonRunResult,
+} from './daemon-client.js';
 
 export const SERVE_HELP = `kb serve — resident local daemon for warm CLI reads
 
 Usage:
   kb serve [--host=127.0.0.1] [--port=17799] [--idle-timeout-ms=300000]
+  kb serve status [--json]
 
 Starts a localhost-only JSON HTTP daemon used by \`kb search --daemon\`.
 The daemon accepts read-only search/list/stats requests and exits after the
 idle timeout.
 
+\`kb serve status\` reports whether a daemon is reachable at the configured
+URL along with its PID, idle timeout, supported commands, and uptime. It
+never starts or stops a daemon. When \`kb search --daemon\` cannot reach a
+daemon it prints a one-line notice to stderr and runs the search directly.
+
 Options:
   --host=<host>             Loopback host to bind (default: 127.0.0.1).
   --port=<port>             TCP port to bind (default: 17799; 0 for tests).
   --idle-timeout-ms=<ms>    Stop after this much idle time (default: 300000).
+  --json                    \`kb serve status\`: emit the daemon health JSON.
   --help, -h                Show this help.
+
+Environment:
+  KB_DAEMON_URL             Daemon URL queried by \`kb serve status\` and
+                            \`kb search --daemon\` (default
+                            http://127.0.0.1:17799).
+
+Exit codes:
+  0   daemon started, or \`kb serve status\` found a reachable daemon
+  1   runtime error
+  2   invalid arguments or environment
+  3   \`kb serve status\`: no daemon reachable at the configured URL
 `;
+
+/** Read-only commands the daemon accepts, advertised by \`GET /health\`. */
+const DAEMON_COMMANDS: readonly DaemonCommand[] = ['search', 'list', 'stats'];
 
 interface ServeArgs {
   host: string;
@@ -51,6 +78,10 @@ const DEFAULT_SERVE_ARGS: ServeArgs = {
 };
 
 export async function runServe(rest: string[]): Promise<number> {
+  if (rest[0] === 'status') {
+    return runServeStatus(rest.slice(1));
+  }
+
   let parsed: ServeArgs;
   try {
     parsed = parseServeArgs(rest);
@@ -79,6 +110,84 @@ export async function runServe(rest: string[]): Promise<number> {
   return 0;
 }
 
+/**
+ * `kb serve status` — a read-only lifecycle probe for the resident daemon.
+ *
+ * Queries `GET /health` at the configured `KB_DAEMON_URL` and reports
+ * reachability without ever starting or stopping a daemon. Exit codes: 0
+ * reachable, 2 bad argument/environment, 3 no daemon listening, 1 a daemon
+ * answered with an unusable payload.
+ */
+export async function runServeStatus(args: string[]): Promise<number> {
+  let json = false;
+  for (const raw of args) {
+    if (raw === '--json') {
+      json = true;
+      continue;
+    }
+    process.stderr.write(`kb serve status: unexpected argument: ${raw}\n`);
+    return 2;
+  }
+
+  let url: URL;
+  try {
+    url = daemonUrlFromEnv();
+  } catch (err) {
+    process.stderr.write(`kb serve status: ${(err as Error).message}\n`);
+    return 2;
+  }
+
+  let health: DaemonHealth | null;
+  try {
+    health = await tryFetchDaemonHealth();
+  } catch (err) {
+    // A daemon answered but its /health payload was unusable.
+    process.stderr.write(`kb serve status: ${(err as Error).message}\n`);
+    return 1;
+  }
+
+  if (health === null) {
+    if (json) {
+      process.stdout.write(`${JSON.stringify({ reachable: false, url: url.href })}\n`);
+    } else {
+      process.stdout.write(`kb serve: no daemon reachable at ${url.href}\n`);
+      process.stdout.write('  start one with: kb serve\n');
+    }
+    return 3;
+  }
+
+  if (json) {
+    process.stdout.write(`${JSON.stringify({ reachable: true, url: url.href, daemon: health })}\n`);
+  } else {
+    process.stdout.write(formatServeStatus(health, url));
+  }
+  return 0;
+}
+
+function formatServeStatus(health: DaemonHealth, queriedUrl: URL): string {
+  const lines = [`kb serve: daemon running at ${health.url ?? queriedUrl.href}`];
+  if (health.pid !== undefined) lines.push(`  pid:          ${health.pid}`);
+  if (health.uptime_ms !== undefined) {
+    lines.push(`  uptime:       ${formatDuration(health.uptime_ms)}`);
+  }
+  if (health.idle_timeout_ms !== undefined) {
+    lines.push(
+      `  idle timeout: ${health.idle_timeout_ms === 0 ? 'disabled' : formatDuration(health.idle_timeout_ms)}`,
+    );
+  }
+  if (health.commands !== undefined) {
+    lines.push(`  commands:     ${health.commands.join(', ')}`);
+  }
+  return `${lines.join('\n')}\n`;
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  const seconds = Math.round(ms / 1000);
+  if (seconds < 120) return `${seconds}s`;
+  return `${Math.round(seconds / 60)}m`;
+}
+
 export async function startDaemonServer(
   options: StartDaemonServerOptions = {},
 ): Promise<ResidentDaemon> {
@@ -91,15 +200,26 @@ export async function startDaemonServer(
   const handlers = options.handlers ?? defaultHandlers();
   let idleTimer: NodeJS.Timeout | undefined;
   let queue: Promise<void> = Promise.resolve();
+  const startedAt = Date.now();
+  let boundUrl = '';
 
   let resolveClosed!: () => void;
   const closed = new Promise<void>((resolve) => {
     resolveClosed = resolve;
   });
 
+  const buildHealth = (): DaemonHealth => ({
+    status: 'ok',
+    pid: process.pid,
+    url: boundUrl,
+    idle_timeout_ms: parsed.idleTimeoutMs,
+    commands: [...DAEMON_COMMANDS],
+    uptime_ms: Date.now() - startedAt,
+  });
+
   const server = http.createServer((req, res) => {
     resetIdleTimer();
-    void handleRequest(req, res, handlers, (job) => {
+    void handleRequest(req, res, handlers, buildHealth, (job) => {
       queue = queue.then(job, job);
       return queue;
     });
@@ -127,9 +247,11 @@ export async function startDaemonServer(
   resetIdleTimer();
   const address = server.address() as AddressInfo;
   const hostForUrl = parsed.host.includes(':') ? `[${parsed.host}]` : parsed.host;
+  const url = new URL(`http://${hostForUrl}:${address.port}`);
+  boundUrl = url.href;
   return {
     server,
-    url: new URL(`http://${hostForUrl}:${address.port}`),
+    url,
     stop: () => new Promise<void>((resolve, reject) => {
       if (!server.listening) {
         resolve();
@@ -194,10 +316,11 @@ async function handleRequest(
   req: http.IncomingMessage,
   res: http.ServerResponse,
   handlers: DaemonCommandHandlers,
+  buildHealth: () => DaemonHealth,
   enqueue: (job: () => Promise<void>) => Promise<void>,
 ): Promise<void> {
   if (req.method === 'GET' && req.url === '/health') {
-    writeJson(res, 200, { status: 'ok' });
+    writeJson(res, 200, buildHealth());
     return;
   }
   if (req.method !== 'POST' || req.url !== '/v1/run') {

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -602,6 +602,18 @@ describe('kb CLI — argv parsing and dispatch', () => {
     expect(r.stderr).not.toContain('unknown flag');
   });
 
+  it('search --daemon prints a stderr fallback notice when the daemon is unreachable', () => {
+    const r = runCli(['search', 'q', '--daemon'], { KB_DAEMON_URL: 'http://127.0.0.1:17798' });
+    expect(r.stderr).toContain('daemon unavailable at http://127.0.0.1:17798/');
+    expect(r.stderr).toMatch(/fell back after \d+ms/);
+  });
+
+  it('serve status exits 3 with a notice when no daemon is reachable', () => {
+    const r = runCli(['serve', 'status'], { KB_DAEMON_URL: 'http://127.0.0.1:17798' });
+    expect(r.code).toBe(3);
+    expect(r.stdout).toContain('no daemon reachable at http://127.0.0.1:17798/');
+  });
+
   it('search with --threshold=auto is accepted by the parser', () => {
     // Parser must accept the literal "auto"; the call still fails downstream
     // (no model registered in this test env) but never with an "invalid

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -31,7 +31,7 @@ import { STALE_CHECK_HELP, runStaleCheck } from './cli-stale-check.js';
 import { STATS_HELP, runStats } from './cli-stats.js';
 import { SUPERSEDED_HELP, runSuperseded } from './cli-superseded.js';
 import { WHERE_HELP, runWhere } from './cli-where.js';
-import { tryRunDaemonCommand } from './daemon-client.js';
+import { daemonUrlFromEnv, tryRunDaemonCommand } from './daemon-client.js';
 import { emitCanonicalLog } from './canonical-log.js';
 
 // ----- Subcommand registry --------------------------------------------------
@@ -516,13 +516,29 @@ async function runSearchMaybeViaDaemon(rest: string[]): Promise<number> {
     return runSearch(directRest);
   }
 
+  const startedAt = Date.now();
   const daemonResult = await tryRunDaemonCommand('search', directRest);
   if (daemonResult === null) {
+    // The daemon was unreachable: tell the operator the search still ran,
+    // just directly, and how long the daemon probe cost before falling back.
+    process.stderr.write(
+      `kb search: daemon unavailable${daemonUrlSuffix()}; ran search directly `
+      + `(fell back after ${Date.now() - startedAt}ms)\n`,
+    );
     return runSearch(directRest);
   }
   if (daemonResult.stdout !== '') process.stdout.write(daemonResult.stdout);
   if (daemonResult.stderr !== '') process.stderr.write(daemonResult.stderr);
   return daemonResult.exitCode;
+}
+
+/** ` at <url>` for the fallback notice, or '' when the daemon URL is unset. */
+function daemonUrlSuffix(): string {
+  try {
+    return ` at ${daemonUrlFromEnv().href}`;
+  } catch {
+    return '';
+  }
 }
 
 // ----- version --------------------------------------------------------------

--- a/src/daemon-client.test.ts
+++ b/src/daemon-client.test.ts
@@ -4,7 +4,9 @@ import type { AddressInfo } from 'node:net';
 import {
   DaemonProtocolError,
   daemonUrlFromEnv,
+  fetchDaemonHealth,
   runDaemonCommand,
+  tryFetchDaemonHealth,
   tryRunDaemonCommand,
 } from './daemon-client.js';
 
@@ -65,6 +67,59 @@ describe('daemon client', () => {
       res.end(JSON.stringify({ stdout: 'missing exitCode', stderr: '' }));
     }, async (url) => {
       await expect(runDaemonCommand('search', ['q'], { env: { KB_DAEMON_URL: url.href } }))
+        .rejects.toBeInstanceOf(DaemonProtocolError);
+    });
+  });
+
+  it('reads the daemon lifecycle snapshot from GET /health', async () => {
+    await withServer((req, res) => {
+      expect(req.method).toBe('GET');
+      expect(req.url).toBe('/health');
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({
+        status: 'ok',
+        pid: 4242,
+        url: 'http://127.0.0.1:17799/',
+        idle_timeout_ms: 300_000,
+        commands: ['search', 'list', 'stats'],
+        uptime_ms: 1234,
+      }));
+    }, async (url) => {
+      await expect(fetchDaemonHealth({ env: { KB_DAEMON_URL: url.href } })).resolves.toEqual({
+        status: 'ok',
+        pid: 4242,
+        url: 'http://127.0.0.1:17799/',
+        idle_timeout_ms: 300_000,
+        commands: ['search', 'list', 'stats'],
+        uptime_ms: 1234,
+      });
+    });
+  });
+
+  it('tolerates an older daemon that only answers { status }', async () => {
+    await withServer((_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ status: 'ok' }));
+    }, async (url) => {
+      await expect(fetchDaemonHealth({ env: { KB_DAEMON_URL: url.href } }))
+        .resolves.toEqual({ status: 'ok' });
+    });
+  });
+
+  it('returns null from tryFetchDaemonHealth when no daemon is listening', async () => {
+    const result = await tryFetchDaemonHealth({
+      env: { KB_DAEMON_URL: 'http://127.0.0.1:17798' },
+      timeoutMs: 50,
+    });
+    expect(result).toBeNull();
+  });
+
+  it('treats a malformed /health payload as a protocol error', async () => {
+    await withServer((_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ commands: ['search'] }));
+    }, async (url) => {
+      await expect(fetchDaemonHealth({ env: { KB_DAEMON_URL: url.href } }))
         .rejects.toBeInstanceOf(DaemonProtocolError);
     });
   });

--- a/src/daemon-client.ts
+++ b/src/daemon-client.ts
@@ -6,6 +6,21 @@ export interface DaemonRunResult {
 
 export type DaemonCommand = 'search' | 'list' | 'stats';
 
+/**
+ * Lifecycle snapshot returned by the daemon's `GET /health` endpoint and
+ * surfaced verbatim by `kb serve status --json`. Every field beyond `status`
+ * is optional so a newer client stays compatible with an older daemon that
+ * only answers `{ status: 'ok' }`.
+ */
+export interface DaemonHealth {
+  status: string;
+  pid?: number;
+  url?: string;
+  idle_timeout_ms?: number;
+  commands?: string[];
+  uptime_ms?: number;
+}
+
 export interface DaemonClientOptions {
   env?: NodeJS.ProcessEnv;
   fetchImpl?: typeof fetch;
@@ -78,22 +93,73 @@ export async function runDaemonCommand(
     const payload = await response.json();
     return parseDaemonRunResult(payload);
   } catch (err) {
-    if (err instanceof DaemonProtocolError) throw err;
-    const code = (err as NodeJS.ErrnoException | undefined)?.code;
-    if (
-      code === 'ECONNREFUSED' ||
-      code === 'ECONNRESET' ||
-      code === 'ENOTFOUND' ||
-      code === 'EHOSTUNREACH' ||
-      (err as Error | undefined)?.name === 'AbortError' ||
-      (err as Error | undefined)?.name === 'TypeError'
-    ) {
-      throw new DaemonUnavailableError(`kb daemon is not reachable at ${endpoint.href}`, { cause: err });
-    }
-    throw err;
+    rethrowDaemonFetchError(err, endpoint.href);
   } finally {
     clearTimeout(timeout);
   }
+}
+
+/**
+ * Query the daemon's `GET /health` endpoint without running a command.
+ *
+ * Throws {@link DaemonUnavailableError} when nothing is listening and
+ * {@link DaemonProtocolError} when a daemon answers with an unusable payload.
+ */
+export async function fetchDaemonHealth(
+  options: DaemonClientOptions = {},
+): Promise<DaemonHealth> {
+  const endpoint = new URL('/health', daemonUrlFromEnv(options.env));
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), options.timeoutMs ?? 1500);
+  try {
+    const response = await fetchImpl(endpoint, { method: 'GET', signal: controller.signal });
+    if (!response.ok) {
+      const text = await response.text().catch(() => '');
+      throw new DaemonProtocolError(`daemon returned HTTP ${response.status}${text ? `: ${text}` : ''}`);
+    }
+    return parseDaemonHealth(await response.json());
+  } catch (err) {
+    rethrowDaemonFetchError(err, endpoint.href);
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+/**
+ * Like {@link fetchDaemonHealth} but resolves to `null` when no daemon is
+ * reachable, so callers can render a "not running" status without a try/catch.
+ */
+export async function tryFetchDaemonHealth(
+  options: DaemonClientOptions = {},
+): Promise<DaemonHealth | null> {
+  try {
+    return await fetchDaemonHealth(options);
+  } catch (err) {
+    if (err instanceof DaemonUnavailableError) return null;
+    throw err;
+  }
+}
+
+/**
+ * Re-throw a `fetch` failure as a {@link DaemonUnavailableError} when it looks
+ * like nothing is listening; pass {@link DaemonProtocolError} and anything
+ * unexpected through unchanged.
+ */
+function rethrowDaemonFetchError(err: unknown, endpointHref: string): never {
+  if (err instanceof DaemonProtocolError) throw err;
+  const code = (err as NodeJS.ErrnoException | undefined)?.code;
+  if (
+    code === 'ECONNREFUSED' ||
+    code === 'ECONNRESET' ||
+    code === 'ENOTFOUND' ||
+    code === 'EHOSTUNREACH' ||
+    (err as Error | undefined)?.name === 'AbortError' ||
+    (err as Error | undefined)?.name === 'TypeError'
+  ) {
+    throw new DaemonUnavailableError(`kb daemon is not reachable at ${endpointHref}`, { cause: err });
+  }
+  throw err;
 }
 
 function parseDaemonRunResult(payload: unknown): DaemonRunResult {
@@ -113,4 +179,23 @@ function parseDaemonRunResult(payload: unknown): DaemonRunResult {
     stdout: obj.stdout,
     stderr: obj.stderr,
   };
+}
+
+function parseDaemonHealth(payload: unknown): DaemonHealth {
+  if (typeof payload !== 'object' || payload === null) {
+    throw new DaemonProtocolError('daemon /health returned a non-object payload');
+  }
+  const obj = payload as Record<string, unknown>;
+  if (typeof obj.status !== 'string') {
+    throw new DaemonProtocolError('daemon /health response missing status string');
+  }
+  const health: DaemonHealth = { status: obj.status };
+  if (typeof obj.pid === 'number') health.pid = obj.pid;
+  if (typeof obj.url === 'string') health.url = obj.url;
+  if (typeof obj.idle_timeout_ms === 'number') health.idle_timeout_ms = obj.idle_timeout_ms;
+  if (Array.isArray(obj.commands) && obj.commands.every((item) => typeof item === 'string')) {
+    health.commands = obj.commands as string[];
+  }
+  if (typeof obj.uptime_ms === 'number') health.uptime_ms = obj.uptime_ms;
+  return health;
 }


### PR DESCRIPTION
## Summary

Closes #410.

`kb serve` could keep repeated `kb search --daemon` reads warm, but gave operators no way to ask whether a daemon was running, which URL it used, or whether a daemon-backed search quietly fell back to direct execution. This adds a read-only ops surface for the resident daemon — without adding any start/stop supervision.

## Changes

- **Richer `GET /health`** — the daemon now answers with a lifecycle snapshot (`status`, `pid`, bound `url`, `idle_timeout_ms`, supported `commands`, `uptime_ms`) instead of bare `{ status: 'ok' }`.
- **New `kb serve status [--json]`** — probes the configured daemon read-only and reports reachability plus its PID, uptime, idle timeout, and commands. Exit codes: `0` a daemon answered, `3` nothing listening at the configured URL, `2` bad argument / `KB_DAEMON_URL`. `--json` emits `{ reachable, url, daemon }`. It never starts or stops a daemon.
- **`daemon-client.ts`** gains `fetchDaemonHealth` / `tryFetchDaemonHealth` and a `DaemonHealth` type. The `fetch`-error → `DaemonUnavailableError` mapping that `runDaemonCommand` already used is extracted into a shared `rethrowDaemonFetchError` helper so both code paths classify unreachable daemons identically. `parseDaemonHealth` only requires `status`, so a newer client stays compatible with an older `{ status: 'ok' }` daemon.
- **`kb search --daemon` fallback is no longer silent** — when the daemon is unreachable it prints a one-line stderr notice naming the URL tried and how long the probe cost before falling back, then runs the search directly as before. stdout/JSON output is unchanged.
- **Docs** — `SERVE_HELP` documents the `status` subcommand, `--json`, environment, and exit codes; `docs/troubleshooting-local-kb.md` gains a "Warm Daemon (`kb serve`)" section plus symptom-table and command-table rows.

The change is additive: `/v1/run` dispatch, the read-only refresh rejection, and loopback-only binding are untouched, and no JSON contract or default changes for existing commands.

## Verification

- `npm run build` — clean.
- `npx jest --runInBand` — **91 suites / 1576 passed / 0 failures** (4 skipped, 1 todo), including **10 new tests**: 4 in `daemon-client.test.ts` (health snapshot parse, older-daemon tolerance, unreachable → `null`, malformed `/health` → `DaemonProtocolError`), 4 in `cli-serve.test.ts` (`kb serve status` reachable / `--json` envelope / exit 3 when down / exit 2 on bad arg) plus the enriched `/health` assertion, and 2 in `cli.test.ts` (search fallback stderr notice, `kb serve status` exit 3 end-to-end).
- `npm run docs:check-anchors` — no new stale anchors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)