### PR TITLE
feat: implement RFC 019 reranker

### DIFF
--- a/docs/cli-json-contracts.md
+++ b/docs/cli-json-contracts.md
@@ -168,6 +168,9 @@ Optional stable fields:
   only when `KB_EDITOR_URI` is `vscode`, `cursor`, or `file` and the hit has
   enough source metadata. The default `KB_EDITOR_URI=none` omits local absolute
   paths.
+- `results[].rerank_score`: present for hits that were re-scored by the RFC 019
+  reranker. It is a cross-encoder relevance score, not a FAISS distance or RRF
+  score.
 - `auto_threshold`: present with `--threshold=auto`. Shape:
   `{"threshold": number, "knee_index": number|null, "kept": number}`.
 - `timing`: present with `--timing`; keys are elapsed millisecond counters and
@@ -237,14 +240,24 @@ Hybrid success envelope:
     "dense": { "fetched": 0, "model": "ollama__nomic-embed-text-latest" },
     "lexical": { "fetched": 0, "refreshed": 0, "failed": 0 }
   },
-  "rrf": { "c": 60, "fetch_k": 40 }
+  "rrf": { "c": 60, "fetch_k": 40 },
+  "rerank": {
+    "enabled": false,
+    "model": "Xenova/ms-marco-MiniLM-L-6-v2",
+    "candidates": 0,
+    "cache_hits": 0,
+    "degraded": false,
+    "degrade_reason": null
+  }
 }
 ```
 
 Stable hybrid fields are `mode`, `results`, `retrievers.dense.fetched`,
 `retrievers.dense.model`, `retrievers.lexical.fetched`,
 `retrievers.lexical.refreshed`, `retrievers.lexical.failed`, `rrf.c`, and
-`rrf.fetch_k`.
+`rrf.fetch_k`. `rerank.enabled`, `rerank.model`, `rerank.candidates`,
+`rerank.cache_hits`, `rerank.degraded`, and `rerank.degrade_reason` are stable
+when the `rerank` object is present.
 
 Stable error envelope for dense and hybrid JSON mode:
 
@@ -584,6 +597,14 @@ Report envelope:
     "healthy": true,
     "detail": "Ollama http://localhost:11434 is reachable..."
   },
+  "reranker": {
+    "enabled": false,
+    "model": "Xenova/ms-marco-MiniLM-L-6-v2",
+    "top_n": 40,
+    "status": "ok",
+    "cache_path": null,
+    "detail": "KB_RERANK is off"
+  },
   "llm_endpoint": {
     "status": "ok",
     "endpoint": "http://127.0.0.1:8080/v1/chat/completions",
@@ -626,6 +647,9 @@ Stable fields:
 - `stale_counts_by_kb`: object keyed by KB name with `modified_files` and
   `new_files`.
 - `backend`: `provider`, `healthy`, and `detail`.
+- `reranker`: RFC 019 reranker readiness. Stable fields are `enabled`,
+  `model`, `top_n`, `status`, `cache_path`, and `detail`; `cache_path` is
+  `null` when no local Transformers.js cache candidate is known.
 - `llm_endpoint`: local LLM readiness for `kb ask`. `status` is `ok` or
   `warn`; failed LLM readiness is a warning because search health can still be
   usable. `endpoint_source` is `env`, `profile`, `default`, or `unresolved`.

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -73,15 +73,15 @@ documented in RFC 017.
 
 ## Reranker
 
-RFC 019 defines the intended cross-encoder reranker surface. These flags are
-documented for rollout planning but are not active behavior until the reranker
-implementation lands.
+RFC 019 defines the optional cross-encoder reranker surface. The reranker runs
+after hybrid dense/BM25 fusion and before the relevance gate. It is fail-soft:
+provider load or scoring failures degrade to the fused order.
 
 | Feature | Env var or flag | Default | Surfaces | Status | Per-call override | Validation command |
 |---|---|---:|---|---|---|---|
-| Cross-encoder reranker | `KB_RERANK` | `off` | Planned CLI search and MCP retrieval | Planned in RFC 019 | planned `kb search --rerank`, `--no-rerank` | not available until implementation |
-| Reranker model | `KB_RERANK_MODEL` | `Xenova/ms-marco-MiniLM-L-6-v2` | Planned reranker provider | Planned in RFC 019 | none | not available until implementation |
-| Rerank candidate count | `KB_RERANK_TOP_N` | `40` | Planned reranker stage | Planned in RFC 019 | none | not available until implementation |
+| Cross-encoder reranker | `KB_RERANK` | `off` | CLI hybrid search, MCP hybrid retrieval, retrieval eval | Implemented, opt-in | `kb search --rerank`, `kb search --no-rerank`, MCP `rerank: "on"\|"off"` | `KB_RERANK=on kb search "query" --mode=hybrid --timing --format=json` |
+| Reranker model | `KB_RERANK_MODEL` | `Xenova/ms-marco-MiniLM-L-6-v2` | Local `@huggingface/transformers` provider | Implemented | none | `KB_RERANK=on kb doctor --format=json` |
+| Rerank candidate count | `KB_RERANK_TOP_N` | `40` | Reranker stage | Implemented | none | `KB_RERANK_TOP_N=20 KB_RERANK=on kb search "query" --mode=hybrid --timing` |
 
 ## Output, Diagnostics, and Logging
 

--- a/docs/requirements/INDEX.md
+++ b/docs/requirements/INDEX.md
@@ -1,6 +1,7 @@
 # Requirements
 
 - [Retrieval eval command](retrieval-eval.md)
+- [Reranker](reranker.md)
 
 ## Indexing
 
@@ -101,6 +102,21 @@
 **Dependencies:** NFR-INDEX-236
 
 ## Search
+
+### FR-SEARCH-374: Cross-Encoder Reranker
+**Status:** Implemented
+**Priority:** High
+
+**Requirement:** The system shall optionally rerank first-stage retrieval candidates with a local cross-encoder before result assembly and relevance gating.
+
+**Acceptance Criteria:**
+- [x] Given reranking is disabled, hybrid retrieval preserves fused ordering.
+- [x] Given reranking is enabled, the top candidate block is sorted by descending cross-encoder score and the unscored tail stays after it.
+- [x] Given JSON output, reranked results expose `rerank_score` alongside the original retrieval `score`.
+- [x] Given reranker failure, retrieval degrades to the fused baseline instead of failing.
+
+**Linked Tests:** TS-SEARCH-374
+**Dependencies:** RFC019
 
 ### FR-CLI-383: Machine-Readable Help Manifest
 **Status:** Implemented

--- a/docs/requirements/reranker.md
+++ b/docs/requirements/reranker.md
@@ -1,0 +1,20 @@
+# Reranker Requirements
+
+## Search
+
+### FR-SEARCH-374: Cross-Encoder Reranker
+**Status:** Implemented
+**Priority:** High
+
+**Requirement:** The system shall optionally rerank first-stage retrieval candidates with a local cross-encoder before result assembly and relevance gating.
+**Rationale:** Hybrid dense/BM25 fusion produces a rank-based score rather than a calibrated query-passage relevance score. A cross-encoder re-scores each query/candidate pair jointly and improves precision without replacing the existing retrievers.
+
+**Acceptance Criteria:**
+- [x] Given `KB_RERANK=off`, when hybrid retrieval runs, then result ordering and output remain the fused baseline.
+- [x] Given `KB_RERANK=on` or `kb search --rerank`, when hybrid retrieval produces candidates, then the system shall re-score the top `KB_RERANK_TOP_N` candidates, sort that block by descending reranker score, and leave unscored tail candidates after the reranked block.
+- [x] Given a reranked JSON search result, when the result is serialized, then the payload shall include `rerank_score` without replacing the original retrieval `score`.
+- [x] Given the reranker provider fails or returns an invalid score array, when retrieval runs, then the system shall degrade to the original fused order and shall not fail retrieval.
+- [x] Given repeated query/candidate pairs in a process, when reranking runs, then an in-memory score cache shall avoid duplicate provider calls.
+
+**Linked Tests:** TS-SEARCH-374
+**Dependencies:** RFC019, FR-SEARCH-206, FR-SEARCH-313, RFC018

--- a/docs/rfcs/019-cross-encoder-reranker.md
+++ b/docs/rfcs/019-cross-encoder-reranker.md
@@ -1,6 +1,6 @@
 # RFC 019 — Cross-Encoder Reranker
 
-**Status:** Draft (v1 — to be iterated via the `rfc-iterative-review` workflow before implementation)
+**Status:** Accepted; M0a/M0b complete; `KB_RERANK=off` remains the default
 **Depends on:** #206 (hybrid RRF), #313 (query-embedding cache pattern), RFC 009 (error taxonomy), RFC 010 (MCP surface)
 **Composes with:** RFC 017 (contextual retrieval — improves *what* is embedded), RFC 018 (relevance gating — decides *whether* to inject)
 **Tracks:** retrieval precision — first-stage fusion produces a rank ordering, not a calibrated relevance score
@@ -100,28 +100,29 @@ CLI: `kb search --rerank` / `--no-rerank` per-call override; `--timing` reports 
 
 ### 7. Observability
 
-- A `rerank.stage` canonical-log line: `query_sha`, `model`, `candidates_in`, `took_ms`, `cache_hits`.
-- `kb stats` reports rerank stage p50/p95 latency and cache hit rate.
-- `kb doctor` checks the reranker model is present in the cache when `KB_RERANK=on`.
-- `kb search --explain` shows fused rank vs. reranked rank side by side, so a reorder is auditable.
+- A `rerank.stage` canonical-log line: `query_sha256`, `model`, `candidates_in`, `took_ms`, `cache_hits`, and `degraded`.
+- `kb search --timing` reports rerank stage latency, candidates, and cache hits; `--format=json` adds the `rerank` status object and per-hit `rerank_score` when reranking ran.
+- MCP `retrieve_knowledge` hybrid output annotates the header when reranking ran.
+- `kb doctor` reports reranker config and whether the Transformers.js model appears to be cached when `KB_RERANK=on`.
+- Follow-up observability before default-on: `kb stats` p50/p95/cache-hit summaries and a `kb search --explain` rank-audit view that shows fused rank vs. reranked rank side by side.
 
 ## Failure modes
 
 | failure | detection | response |
 |---|---|---|
 | Reranker model not in cache, no network | provider load throws | `KB_RERANK=on` degrades to the fused order with a one-time `WARN`; `kb doctor` flags it. Retrieval never breaks. |
-| Reranker call exceeds a latency budget | per-call timer | abort, fall back to fused order for that query, log `rerank.degraded`. |
+| Reranker call is too slow for interactive use | `kb search --timing`, M0b report | keep `KB_RERANK=off` by default; add a timeout/abort guard before reconsidering default-on. |
 | ONNX runtime unavailable on the platform | provider init throws | degrade to fused order; `kb doctor` reports the platform gap. |
 | `topN` larger than the fused set | length check | re-score whatever exists; no error. |
 | Reranker returns a wrong-length score array | length mismatch | discard the rerank pass for that query, fall back to fused order, log. |
 
-The reranker is **always fail-soft**: any reranker failure degrades to today's fused ordering. It can never break retrieval and never empties a result set (that is RFC 018's concern, not this stage's).
+Provider load/scoring errors and malformed score arrays fail soft to today's fused ordering. M0a does not include a timeout/abort guard, so a hung provider call can still hang that query; this is one reason M0b kept reranking opt-in. The stage never empties a result set by itself (that is RFC 018's concern, not this stage's).
 
 ## Migration / rollout
 
-- **M0a — Reranker provider + stage** (one PR). `src/reranker.ts` (provider interface + the `transformers.js` ONNX implementation), `rerankFusedResults`, `KB_RERANK*` config, wire into the shared retrieval path behind the flag, `rerank_score` in JSON output, score cache, canonical log + `kb doctor` check. Default `off`. Unit tests with a stub reranker; an integration test with the real model on a small fixture.
-- **M0b — Eval** (one PR / operator run). The `retrieval-eval` harness already computes nDCG@10 / MRR@10 / recall@k — run it with `KB_RERANK` off vs. on over the existing fixtures and report the precision lift. This is the reranker's natural validation: unlike RFC 018's gate, the reranker is *not* recall-negative (it reorders, never drops), so the bar is simply "nDCG/MRR improve, latency acceptable."
-- **M0c — Default on** (separate PR, conditional on M0b). If M0b shows a clear nDCG/MRR lift at acceptable latency, flip the default to `on`.
+- **M0a — Reranker provider + stage** (one PR). `src/reranker.ts` (provider interface + the `transformers.js` ONNX implementation), `rerankFusedResults`, `KB_RERANK*` config, wire into the shared retrieval path behind the flag, `rerank_score` in JSON output, score cache, canonical log + `kb doctor` check. Default `off`. Unit tests with a stub reranker; an integration test with the real model on a small fixture. **Implemented for hybrid retrieval and eval.**
+- **M0b — Eval** (one PR / operator run). The `retrieval-eval` harness already computes nDCG@10 / MRR@10 / recall@k — run it with `KB_RERANK` off vs. on over the existing fixtures and report the precision lift. This is the reranker's natural validation: unlike RFC 018's gate, the reranker is *not* recall-negative (it reorders, never drops), so the bar is simply "nDCG/MRR improve, latency acceptable." **Completed 2026-05-19; see [`019-m0b-reranker-report.md`](019-m0b-reranker-report.md).**
+- **M0c — Default on** (separate PR, conditional on M0b). If M0b shows a clear nDCG/MRR lift at acceptable latency, flip the default to `on`. Otherwise keep `KB_RERANK=off`. **Decision: no-go for default-on on the 2026-05-19 operating-environment canary. The corrected cross-encoder path produced a small nDCG@10/MRR@10 lift, but cold CLI latency was too high for default-on. Keep opt-in.**
 
 **Composition note.** RFC 019 and RFC 018 are concurrent tracks. When both land, the order is fusion → rerank → gate; the gate's A1/A2 thresholds are re-tuned against the reranker's calibrated score (which is a far better floor signal than a raw distance). RFC 017 is independent of both.
 
@@ -134,4 +135,4 @@ The reranker is **always fail-soft**: any reranker failure degrades to today's f
 - **Interaction with RFC 018's `KB_GATE_JUDGE_INPUT` cap.** With the reranker on, the top-`k` handed to the gate is already precision-ordered — the gate's judge may need fewer candidates. A tuning question for when both land.
 - **Reranking the contextual-preface text vs. the original** (§4 picks the original) — worth an A/B in M0b if RFC 017 is also enabled.
 
-_This RFC is a v1 draft. It should pass through the `rfc-iterative-review` workflow (critic rounds + empirical probe) before implementation, the same as RFC 018._
+_This RFC has moved from draft to implementation. M0b did not justify a default-on flip; reranking remains available as an opt-in hybrid retrieval stage._

--- a/docs/rfcs/019-m0b-reranker-report.md
+++ b/docs/rfcs/019-m0b-reranker-report.md
@@ -1,0 +1,42 @@
+# RFC 019 M0b Reranker Report
+
+**Date:** 2026-05-19
+**Fixture:** [`docs/testing/fixtures/rfc-019-reranker-eval.yml`](../testing/fixtures/rfc-019-reranker-eval.yml)
+**Shelf:** `operating-environment`
+**Embedding model:** `ollama__nomic-embed-text-latest`
+**Reranker model:** `Xenova/ms-marco-MiniLM-L-6-v2`
+**Retrieval mode:** `hybrid`
+
+## Commands
+
+```bash
+KB_RERANK=off node build/cli.js eval docs/testing/fixtures/rfc-019-reranker-eval.yml --format=json > /tmp/rfc019-ranked-off.json
+KB_RERANK=on node build/cli.js eval docs/testing/fixtures/rfc-019-reranker-eval.yml --format=json > /tmp/rfc019-ranked-on.json
+KB_RERANK=on node build/cli.js search "where does the kookr task-spawning daemon store its registry state" \
+  --kb=operating-environment --mode=hybrid --format=json --timing --no-freshness \
+  > /tmp/rfc019-search-smoke.json
+```
+
+## Results
+
+| metric | `KB_RERANK=off` | `KB_RERANK=on` | delta |
+|---|---:|---:|---:|
+| passed cases | 8 | 8 | 0 |
+| failed cases | 0 | 0 | 0 |
+| nDCG@10 | 0.8772228201007499 | 0.8827007889556063 | 0.005477968854856408 |
+| MRR@10 | 0.8375 | 0.84375 | 0.006249999999999978 |
+| recall@k | 1 | 1 | 0 |
+| precision@k | 0.09999999999999999 | 0.09999999999999999 | 0 |
+| MAP@k | 0.8375 | 0.84375 | 0.006249999999999978 |
+| hit rate | 1 | 1 | 0 |
+
+Live search smoke with `KB_RERANK=on`:
+
+- Canonical `rerank.stage` emitted with `candidates_in=40`, `degraded=false`, `cache_hits=0`.
+- JSON output exposed `rerank.enabled=true`, `rerank.candidates=40`, and per-result `rerank_score`.
+- Smoke timing reported `fusion_ms=1`, `rerank_ms=3294`, and `total_ms=4285` for a cold CLI process.
+- Top result remained `~/knowledge_bases/operating-environment/kookr-task-spawning-daemon-oss-registry-state-paths.md`.
+
+## Decision
+
+M0b is a **no-go for default-on**. The corrected cross-encoder path produced a small precision lift on this canary (`nDCG@10 +0.00548`, `MRR@10 +0.00625`) without recall loss, but the cold CLI latency is too high to enable by default. Keep `KB_RERANK=off` by default and treat reranking as an opt-in hybrid retrieval feature until a broader or harder fixture demonstrates a larger precision improvement or the reranker is warmed/accelerated.

--- a/docs/testing/INDEX.md
+++ b/docs/testing/INDEX.md
@@ -65,6 +65,17 @@
 
 ## Search
 
+### TS-SEARCH-374: Cross-Encoder Reranker
+**Requirement:** FR-SEARCH-374
+
+**Test Cases:**
+- `resolveRerankerConfig` shall parse `KB_RERANK`, `KB_RERANK_MODEL`, and `KB_RERANK_TOP_N`, with per-call overrides taking precedence.
+- `rerankFusedResults` shall sort the configured top-N candidate block by descending reranker score and preserve the unscored tail after that block.
+- `rerankFusedResults` shall cache repeated query/candidate scores in memory.
+- `rerankFusedResults` shall degrade to the original fused order when the provider throws or returns a wrong-length score array.
+- `formatRetrievalAsJson` shall include `rerank_score` when a retrieval result carries a reranker score.
+- `kb eval` shall compare `KB_RERANK=off` and `KB_RERANK=on` ranked metrics before any default-on rollout.
+
 ### TS-CLI-383: Machine-Readable Help Manifest
 **Requirement:** FR-CLI-383
 

--- a/docs/testing/fixtures/README.md
+++ b/docs/testing/fixtures/README.md
@@ -13,9 +13,10 @@ KB named `dogfood`, then run:
 ```sh
 kb eval docs/testing/fixtures/dogfood-frozen-core.yml --mode=auto
 kb eval docs/testing/fixtures/dogfood-rotating-arena.yml --mode=auto
+KB_RERANK=off kb eval docs/testing/fixtures/rfc-019-reranker-eval.yml --format=json
+KB_RERANK=on kb eval docs/testing/fixtures/rfc-019-reranker-eval.yml --format=json
 ```
 
-Both packs are warning-only for now (`gate: false`). Promote a case to gated use
-only after it is stable across the supported provider matrix and its
-source-of-truth comment still matches the committed corpus.
-
+The listed packs are warning-only for now (`gate: false`). Promote a case to
+gated use only after it is stable across the supported provider matrix and its
+source-of-truth comment still matches the committed corpus or shelf note.

--- a/docs/testing/fixtures/rfc-019-reranker-eval.yml
+++ b/docs/testing/fixtures/rfc-019-reranker-eval.yml
@@ -1,0 +1,126 @@
+# RFC 019 M0b — reranker precision canary for the operating-environment shelf.
+#
+# Purpose. Compare `KB_RERANK=off` vs `KB_RERANK=on` under hybrid retrieval:
+#
+#   KB_RERANK=off kb eval docs/testing/fixtures/rfc-019-reranker-eval.yml --format=json
+#   KB_RERANK=on  kb eval docs/testing/fixtures/rfc-019-reranker-eval.yml --format=json
+#
+# This fixture starts from the RFC 017 recall canary queries but adds
+# `relevant_sources` so `kb eval` reports nDCG@10, MRR@10, recall@k, and
+# precision@k for the default-on decision.
+
+gate: false
+mode: hybrid
+
+cases:
+  # author: rfc-019-m0b
+  # source-of-truth: operating-environment/local-research-agent.md
+  # protects: reranker precision for local stack shutdown and GPU release advice
+  - name: rerank - local research agent stop procedure
+    query: how do I stop the local research agent and free GPU memory
+    kb: operating-environment
+    k: 10
+    required_sources:
+      - operating-environment/local-research-agent.md
+    relevant_sources:
+      - source: operating-environment/local-research-agent.md
+        relevance: 3
+    stale_policy: allow_stale
+
+  # author: rfc-019-m0b
+  # source-of-truth: operating-environment/local-research-agent.md
+  # protects: reranker precision for the one-command LRA stack control surface
+  - name: rerank - local research agent wrapper command
+    query: which command starts and stops llama-server ollama and n8n together
+    kb: operating-environment
+    k: 10
+    required_sources:
+      - operating-environment/local-research-agent.md
+    relevant_sources:
+      - source: operating-environment/local-research-agent.md
+        relevance: 3
+    stale_policy: allow_stale
+
+  # author: rfc-019-m0b
+  # source-of-truth: operating-environment/qwen36-hybrid-ssm-blocks-speculative-decoding.md
+  # protects: reranker precision for a hardware/model compatibility gotcha
+  - name: rerank - speculative decoding incompatibility
+    query: why can't I use speculative decoding with the relevance gate model
+    kb: operating-environment
+    k: 10
+    required_sources:
+      - operating-environment/qwen36-hybrid-ssm-blocks-speculative-decoding.md
+    relevant_sources:
+      - source: operating-environment/qwen36-hybrid-ssm-blocks-speculative-decoding.md
+        relevance: 3
+    stale_policy: allow_stale
+
+  # author: rfc-019-m0b
+  # source-of-truth: operating-environment/update-local-kb-cli-from-symlinked-checkout.md
+  # protects: reranker precision for operational CLI refresh procedure retrieval
+  - name: rerank - refresh local kb CLI
+    query: how do I refresh the kb command line tool to the newest build
+    kb: operating-environment
+    k: 10
+    required_sources:
+      - operating-environment/update-local-kb-cli-from-symlinked-checkout.md
+    relevant_sources:
+      - source: operating-environment/update-local-kb-cli-from-symlinked-checkout.md
+        relevance: 3
+    stale_policy: allow_stale
+
+  # author: rfc-019-m0b
+  # source-of-truth: operating-environment/local-research-agent.md
+  # protects: reranker precision for VRAM budget queries deep in the stack note
+  - name: rerank - local stack GPU memory
+    query: how much GPU memory does each model in the local stack consume
+    kb: operating-environment
+    k: 10
+    required_sources:
+      - operating-environment/local-research-agent.md
+    relevant_sources:
+      - source: operating-environment/local-research-agent.md
+        relevance: 3
+    stale_policy: allow_stale
+
+  # author: rfc-019-m0b
+  # source-of-truth: operating-environment/kookr-task-spawning-daemon-oss-registry-state-paths.md
+  # protects: reranker precision for exact operational state-path retrieval
+  - name: rerank - kookr daemon registry state
+    query: where does the kookr task-spawning daemon store its registry state
+    kb: operating-environment
+    k: 10
+    required_sources:
+      - operating-environment/kookr-task-spawning-daemon-oss-registry-state-paths.md
+    relevant_sources:
+      - source: operating-environment/kookr-task-spawning-daemon-oss-registry-state-paths.md
+        relevance: 3
+    stale_policy: allow_stale
+
+  # author: rfc-019-m0b
+  # source-of-truth: operating-environment/bandwidth-surgery.md
+  # protects: reranker precision for GPU co-tenancy experiment context
+  - name: rerank - GPU coexistence experiment
+    query: what experiment has to share the GPU with the always-on research stack
+    kb: operating-environment
+    k: 10
+    required_sources:
+      - operating-environment/bandwidth-surgery.md
+    relevant_sources:
+      - source: operating-environment/bandwidth-surgery.md
+        relevance: 3
+    stale_policy: allow_stale
+
+  # author: rfc-019-m0b
+  # source-of-truth: operating-environment/local-research-agent.md
+  # protects: reranker precision for cron schedule and quiet-window retrieval
+  - name: rerank - arxiv ingestion schedule
+    query: when does the daily arxiv ingestion run and which hours should I avoid heavy GPU work
+    kb: operating-environment
+    k: 10
+    required_sources:
+      - operating-environment/local-research-agent.md
+    relevant_sources:
+      - source: operating-environment/local-research-agent.md
+        relevance: 3
+    stale_policy: allow_stale

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Unlicense",
       "dependencies": {
         "@huggingface/inference": "^4.13.15",
+        "@huggingface/transformers": "^3.8.1",
         "@langchain/community": "^0.3.59",
         "@langchain/core": "^0.3.62",
         "@langchain/ollama": "^0.2.3",
@@ -705,6 +706,16 @@
       "integrity": "sha512-PSBhJ2/SmeRPRHuBv7i/fHWIdSC3JTyq56qb+Rq0wjOagi0/fdV5/B/3Md5zFZus/W6OkSPMaxMKKMNMrSmubg==",
       "license": "MIT"
     },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.7",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
@@ -1216,6 +1227,19 @@
       "integrity": "sha512-nfV9luJbvwGQ/5oKXkKhCV9h4X7mwh1YaGG3ORd6UMLDSwr1OFSSatcBX0O9OtBtmNK19aGSjbLFqqgcIR6+IA==",
       "license": "MIT"
     },
+    "node_modules/@huggingface/transformers": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@huggingface/transformers/-/transformers-3.8.1.tgz",
+      "integrity": "sha512-tsTk4zVjImqdqjS8/AOZg2yNLd1z9S5v+7oUPpXaasDRwEDhB+xnglK1k5cad26lL5/ZIaeREgWWy0bs9y9pPA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@huggingface/jinja": "^0.5.3",
+        "onnxruntime-node": "1.21.0",
+        "onnxruntime-web": "1.22.0-dev.20250409-89f8206ba4",
+        "sharp": "^0.34.1"
+      }
+    },
     "node_modules/@ibm-cloud/watsonx-ai": {
       "version": "1.7.11",
       "resolved": "https://registry.npmjs.org/@ibm-cloud/watsonx-ai/-/watsonx-ai-1.7.11.tgz",
@@ -1246,6 +1270,483 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "license": "MIT"
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -3579,6 +4080,13 @@
         "node": ">=18"
       }
     },
+    "node_modules/boolean": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
+      "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT"
+    },
     "node_modules/brace-expansion": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
@@ -4229,6 +4737,40 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -4257,9 +4799,9 @@
       }
     },
     "node_modules/detect-libc": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
-      "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -4274,6 +4816,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/detect-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
+      "license": "MIT"
     },
     "node_modules/devlop": {
       "version": "1.1.0",
@@ -4520,6 +5068,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.27.7",
@@ -4945,6 +5499,12 @@
         "flat": "cli.js"
       }
     },
+    "node_modules/flatbuffers": {
+      "version": "25.9.23",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.9.23.tgz",
+      "integrity": "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/follow-redirects": {
       "version": "1.16.0",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
@@ -5246,6 +5806,39 @@
         "node": "*"
       }
     },
+    "node_modules/global-agent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
+      "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "es6-error": "^4.1.1",
+        "matcher": "^3.0.0",
+        "roarr": "^2.15.3",
+        "semver": "^7.3.2",
+        "serialize-error": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=10.0"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -5287,6 +5880,12 @@
         "graphql": "14 - 16"
       }
     },
+    "node_modules/guid-typescript": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/guid-typescript/-/guid-typescript-1.0.9.tgz",
+      "integrity": "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==",
+      "license": "ISC"
+    },
     "node_modules/handlebars": {
       "version": "4.7.8",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
@@ -5318,6 +5917,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/has-symbols": {
@@ -7156,6 +7767,12 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "license": "MIT"
     },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "license": "ISC"
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -7537,6 +8154,30 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "tmpl": "1.0.5"
+      }
+    },
+    "node_modules/matcher": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
+      "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/matcher/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/math-expression-evaluator": {
@@ -8142,6 +8783,27 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/mkdirp-classic": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
@@ -8403,6 +9065,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/ollama": {
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/ollama/-/ollama-0.5.16.tgz",
@@ -8448,6 +9119,49 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/onnxruntime-common": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.21.0.tgz",
+      "integrity": "sha512-Q632iLLrtCAVOTO65dh2+mNbQir/QNTVBG3h/QdZBpns7mZ0RYbLRBgGABPbpU9351AgYy7SJf1WaeVwMrBFPQ==",
+      "license": "MIT"
+    },
+    "node_modules/onnxruntime-node": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-node/-/onnxruntime-node-1.21.0.tgz",
+      "integrity": "sha512-NeaCX6WW2L8cRCSqy3bInlo5ojjQqu2fD3D+9W5qb5irwxhEyWKXeH2vZ8W9r6VxaMPUan+4/7NDwZMtouZxEw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "os": [
+        "win32",
+        "darwin",
+        "linux"
+      ],
+      "dependencies": {
+        "global-agent": "^3.0.0",
+        "onnxruntime-common": "1.21.0",
+        "tar": "^7.0.1"
+      }
+    },
+    "node_modules/onnxruntime-web": {
+      "version": "1.22.0-dev.20250409-89f8206ba4",
+      "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.22.0-dev.20250409-89f8206ba4.tgz",
+      "integrity": "sha512-0uS76OPgH0hWCPrFKlL8kYVV7ckM7t/36HfbgoFw6Nd0CZVVbQC4PkrR8mBX8LtNUFZO25IQBqV2Hx2ho3FlbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "flatbuffers": "^25.1.24",
+        "guid-typescript": "^1.0.9",
+        "long": "^5.2.3",
+        "onnxruntime-common": "1.22.0-dev.20250409-89f8206ba4",
+        "platform": "^1.3.6",
+        "protobufjs": "^7.2.4"
+      }
+    },
+    "node_modules/onnxruntime-web/node_modules/onnxruntime-common": {
+      "version": "1.22.0-dev.20250409-89f8206ba4",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.22.0-dev.20250409-89f8206ba4.tgz",
+      "integrity": "sha512-vDJMkfCfb0b1A836rgHj+ORuZf4B4+cc2bASQtpeoJLueuFc5DuYwjIZUBrSvx/fO5IrLjLz+oTrB3pcGlhovQ==",
+      "license": "MIT"
     },
     "node_modules/openai": {
       "version": "4.83.0",
@@ -8809,6 +9523,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/platform": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
+      "license": "MIT"
     },
     "node_modules/playwright": {
       "version": "1.59.1",
@@ -9260,6 +9980,29 @@
         "axios": "*"
       }
     },
+    "node_modules/roarr": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
+      "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "detect-node": "^2.0.4",
+        "globalthis": "^1.0.1",
+        "json-stringify-safe": "^5.0.1",
+        "semver-compare": "^1.0.0",
+        "sprintf-js": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/roarr/node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/router": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
@@ -9315,9 +10058,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -9325,6 +10068,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
+      "license": "MIT"
     },
     "node_modules/send": {
       "version": "1.2.0",
@@ -9369,6 +10118,33 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/serialize-error": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+      "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/serialize-error/node_modules/type-fest": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/serve-static": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
@@ -9389,6 +10165,50 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -9740,6 +10560,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/tar": {
+      "version": "7.5.15",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.15.tgz",
+      "integrity": "sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tar-fs": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
@@ -9765,6 +10601,24 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/tar/node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tar/node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/test-exclude": {
@@ -9957,19 +10811,6 @@
         }
       }
     },
-    "node_modules/ts-jest/node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/ts-jest/node_modules/type-fest": {
       "version": "4.41.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
@@ -10030,7 +10871,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
+      "devOptional": true,
       "license": "0BSD"
     },
     "node_modules/tsx": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "license": "Unlicense",
   "dependencies": {
     "@huggingface/inference": "^4.13.15",
+    "@huggingface/transformers": "^3.8.1",
     "@langchain/community": "^0.3.59",
     "@langchain/core": "^0.3.62",
     "@langchain/ollama": "^0.2.3",

--- a/src/KnowledgeBaseServer.test.ts
+++ b/src/KnowledgeBaseServer.test.ts
@@ -81,6 +81,8 @@ describe('KnowledgeBaseServer handlers', () => {
     HUGGINGFACE_API_KEY: process.env.HUGGINGFACE_API_KEY,
     LOG_FILE: process.env.LOG_FILE,
     KB_LOG_FORMAT: process.env.KB_LOG_FORMAT,
+    KB_RERANK: process.env.KB_RERANK,
+    KB_RERANK_TOP_N: process.env.KB_RERANK_TOP_N,
     RETRIEVE_KNOWLEDGE_DESCRIPTION: process.env.RETRIEVE_KNOWLEDGE_DESCRIPTION,
     LIST_KNOWLEDGE_BASES_DESCRIPTION: process.env.LIST_KNOWLEDGE_BASES_DESCRIPTION,
   };
@@ -1159,6 +1161,41 @@ describe('KnowledgeBaseServer handlers', () => {
       input_count: 2,
       output_count: 2,
     });
+  });
+
+  it('handleRetrieveKnowledge reranks hybrid results before returning markdown', async () => {
+    const tempDir = await setRetrieveEnv();
+    await fsp.mkdir(path.join(tempDir, 'alpha'), { recursive: true });
+    await fsp.writeFile(path.join(tempDir, 'alpha', 'winner.md'), 'Lexical winner content');
+    process.env.KB_RERANK = 'on';
+    process.env.KB_RERANK_TOP_N = '2';
+    updateIndexMock.mockResolvedValue(undefined);
+    similaritySearchMock.mockResolvedValue([
+      { pageContent: 'Dense loser content', metadata: { source: '/kb/dense-loser.md', chunkIndex: 0 }, score: 0.2 },
+    ]);
+
+    const server = await freshServer();
+    const { setRerankerFactoryForTests } = await import('./reranker.js');
+    const restoreFactory = setRerankerFactoryForTests(async () => ({
+      id: 'stub-reranker',
+      rerank: async (_query: string, candidates: string[]) =>
+        candidates.map((candidate) => (candidate.includes('Lexical winner') ? 10 : 0)),
+    }));
+    try {
+      const result = await server['handleRetrieveKnowledge']({
+        query: 'winner',
+        knowledge_base_name: 'alpha',
+        search_mode: 'hybrid',
+      });
+
+      expect(result.isError).toBeUndefined();
+      const text = result.content[0].text;
+      expect(text).toContain('rerank stub-reranker');
+      expect(text.indexOf('Lexical winner content')).toBeGreaterThanOrEqual(0);
+      expect(text.indexOf('Lexical winner content')).toBeLessThan(text.indexOf('Dense loser content'));
+    } finally {
+      restoreFactory();
+    }
   });
 
   it('handleRetrieveKnowledge emits one canonical event with redacted query and result fields (#216)', async () => {

--- a/src/KnowledgeBaseServer.ts
+++ b/src/KnowledgeBaseServer.ts
@@ -99,6 +99,11 @@ import {
 } from './relevance-gate.js';
 import type { RelevanceGateVerdict } from './relevance-gate-schema.js';
 import { chunkIdFromMetadata } from './rrf.js';
+import {
+  applyRerankerIfEnabled,
+  resolveRerankerConfig,
+  type RerankOverride,
+} from './reranker.js';
 
 const SERVER_NAME = 'knowledge-base-server';
 const SERVER_VERSION = '0.1.0';
@@ -234,6 +239,7 @@ export class KnowledgeBaseServer {
         search_mode: z.enum(['dense', 'hybrid']).optional().describe('Retrieval mode. "dense" (default) uses FAISS only. "hybrid" fuses FAISS top-N with per-KB BM25 top-N via Reciprocal Rank Fusion. See #206.'),
         task_context: z.string().optional().describe('Optional task context used by the relevance gate judge. Truncated to 2000 characters.'),
         gate: z.enum(['on', 'off']).optional().describe('Per-call relevance gate override. Omit to use KB_RELEVANCE_GATE.'),
+        rerank: z.enum(['on', 'off']).optional().describe('Per-call RFC 019 reranker override for hybrid retrieval. Omit to use KB_RERANK.'),
       },
       async (args) => this.handleRetrieveKnowledge(args)
     );
@@ -510,6 +516,7 @@ export class KnowledgeBaseServer {
     search_mode?: 'dense' | 'hybrid';
     task_context?: string;
     gate?: 'on' | 'off';
+    rerank?: 'on' | 'off';
   }): Promise<CallToolResult> {
     const canonical: Partial<CanonicalLogInput> = {};
     const query: string = args.query;
@@ -522,6 +529,7 @@ export class KnowledgeBaseServer {
     const searchMode: 'dense' | 'hybrid' = args.search_mode ?? 'dense';
     const taskContext = args.task_context;
     const gateOverride: RelevanceGateOverride = args.gate;
+    const rerankOverride: RerankOverride = args.rerank;
     const neighborContext = resolveNeighborContextOptions(args);
 
     return this.withCanonicalTool({
@@ -555,6 +563,7 @@ export class KnowledgeBaseServer {
           canonical,
           taskContext,
           gateOverride,
+          rerankOverride,
         });
       }
 
@@ -702,8 +711,9 @@ export class KnowledgeBaseServer {
     canonical?: Partial<CanonicalLogInput>;
     taskContext?: string;
     gateOverride?: RelevanceGateOverride;
+    rerankOverride?: RerankOverride;
   }): Promise<CallToolResult> {
-    const { query, knowledgeBaseName, modelNameOverride, filters, canonical, taskContext, gateOverride } = input;
+    const { query, knowledgeBaseName, modelNameOverride, filters, canonical, taskContext, gateOverride, rerankOverride } = input;
     const HYBRID_TOP_K = 10;
     const fetchK = hybridFetchK(HYBRID_TOP_K);
 
@@ -751,12 +761,23 @@ export class KnowledgeBaseServer {
         canonical.faiss_ms = denseTiming.faiss_search_ms ?? denseTiming.query_search_ms;
       }
 
+      const rerankConfig = resolveRerankerConfig(process.env, rerankOverride);
       const fusion = fuseHybridResultsWithDiagnostics({
         denseResults,
         lexicalResults,
-        k: HYBRID_TOP_K,
+        k: rerankConfig.enabled ? Math.max(HYBRID_TOP_K, rerankConfig.topN) : HYBRID_TOP_K,
       });
       let ranked = fusion.results;
+      const rerankResult = await applyRerankerIfEnabled({
+        query,
+        results: ranked,
+        k: HYBRID_TOP_K,
+        override: rerankOverride,
+        process: 'mcp',
+        searchMode: 'hybrid',
+        kbScope: knowledgeBaseName ?? null,
+      });
+      ranked = rerankResult.results;
       const gate = await applyRelevanceGate({
         query,
         taskContext,
@@ -788,7 +809,10 @@ export class KnowledgeBaseServer {
         canonical.top_sources = topSourcesForCanonicalLog(ranked);
         canonical.format_ms = Date.now() - formatStartedAt;
       }
-      const header = `> _Mode: hybrid (RRF c=${HYBRID_RRF_C}); dense fetched ${denseResults.length}, lexical fetched ${lexicalResults.length} (#206 stage 2)._`;
+      const rerankHeader = rerankResult.candidatesIn > 0
+        ? `; rerank ${rerankResult.model}${rerankResult.degraded ? ' degraded' : ''}`
+        : '';
+      const header = `> _Mode: hybrid (RRF c=${HYBRID_RRF_C}); dense fetched ${denseResults.length}, lexical fetched ${lexicalResults.length}${rerankHeader} (#206 stage 2)._`;
       responseText = modelNameOverride !== undefined
         ? `> _Model: ${activeModelId}_\n${header}\n\n${responseText}`
         : `${header}\n\n${responseText}`;

--- a/src/canonical-log.ts
+++ b/src/canonical-log.ts
@@ -54,6 +54,7 @@ export interface CanonicalLogEvent {
   cache?: CanonicalCacheStatus;
   error?: CanonicalError;
   recovery_hint?: string;
+  rerank?: Record<string, unknown>;
   gate?: Record<string, unknown>;
 }
 
@@ -93,6 +94,7 @@ const CANONICAL_FIELD_ORDER: readonly (keyof CanonicalLogEvent)[] = [
   'cache',
   'error',
   'recovery_hint',
+  'rerank',
   'gate',
 ];
 
@@ -137,6 +139,7 @@ export function normalizeCanonicalEvent(input: CanonicalLogInput): CanonicalLogE
   assignIfDefined(event, 'cache', input.cache);
   assignIfDefined(event, 'error', input.error);
   assignIfDefined(event, 'recovery_hint', input.recovery_hint);
+  assignIfDefined(event, 'rerank', input.rerank);
   assignIfDefined(event, 'gate', input.gate);
 
   return event;

--- a/src/cli-doctor.test.ts
+++ b/src/cli-doctor.test.ts
@@ -20,10 +20,17 @@ const originalEnv = {
   KB_LLM_ENDPOINT: process.env.KB_LLM_ENDPOINT,
   KB_LLM_CONFIG_DIR: process.env.KB_LLM_CONFIG_DIR,
   KB_LLM_STATE_DIR: process.env.KB_LLM_STATE_DIR,
+  KB_RERANK: process.env.KB_RERANK,
+  KB_RERANK_MODEL: process.env.KB_RERANK_MODEL,
+  KB_RERANK_TOP_N: process.env.KB_RERANK_TOP_N,
+  HF_HOME: process.env.HF_HOME,
+  TRANSFORMERS_CACHE: process.env.TRANSFORMERS_CACHE,
+  HOME: process.env.HOME,
 };
 
 const MODEL_ID = 'huggingface__BAAI-bge-small-en-v1.5';
 const MODEL_NAME = 'BAAI/bge-small-en-v1.5';
+const RERANK_MODEL = 'Xenova/ms-marco-MiniLM-L-6-v2';
 
 afterEach(() => {
   for (const [key, value] of Object.entries(originalEnv)) {
@@ -52,6 +59,15 @@ async function seedVersionedIndex(modelDir: string): Promise<string> {
   await fsp.writeFile(path.join(versionDir, 'faiss.index'), 'fake-index');
   await fsp.symlink('index.v1', path.join(modelDir, 'index'), 'dir');
   return versionDir;
+}
+
+async function seedDoctorBase(tempDir: string): Promise<{ rootDir: string; faissDir: string }> {
+  const rootDir = path.join(tempDir, 'kbs');
+  const faissDir = path.join(tempDir, '.faiss');
+  await fsp.mkdir(rootDir, { recursive: true });
+  const modelDir = await seedRegisteredModel(faissDir);
+  await seedVersionedIndex(modelDir);
+  return { rootDir, faissDir };
 }
 
 function persistedSuccessSummary() {
@@ -1156,6 +1172,181 @@ describe('kb doctor', () => {
         const md = formatDoctorMarkdown(report);
         expect(md).toContain('model=ollama__nomic calls=10 errors=8');
         expect(md).toMatch(/p50=\d+(\.\d+)?ms p95=\d+(\.\d+)?ms p99=\d+(\.\d+)?ms tokens=n\/a, WARN/);
+      } finally {
+        await fsp.rm(tempDir, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe('reranker health', () => {
+    it('reports the reranker as OK when disabled', async () => {
+      const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-doctor-rerank-off-'));
+      try {
+        const { rootDir, faissDir } = await seedDoctorBase(tempDir);
+        const { buildDoctorReport, formatDoctorMarkdown } = await freshDoctor({
+          KNOWLEDGE_BASES_ROOT_DIR: rootDir,
+          FAISS_INDEX_PATH: faissDir,
+          EMBEDDING_PROVIDER: 'huggingface',
+          HUGGINGFACE_MODEL_NAME: MODEL_NAME,
+          HUGGINGFACE_API_KEY: 'test-key',
+          KB_RERANK: 'off',
+          HF_HOME: path.join(tempDir, 'hf'),
+        });
+
+        const report = await buildDoctorReport({
+          backendHealthCheck: async () => ({ healthy: true, detail: 'backend ok' }),
+          packageRoot: tempDir,
+          invokedPath: null,
+          packageVersion: '9.9.9',
+          llmEndpointProbe: healthyLlmProbe,
+        });
+
+        expect(report.reranker).toEqual({
+          enabled: false,
+          model: RERANK_MODEL,
+          top_n: 40,
+          status: 'ok',
+          cache_path: null,
+          detail: 'KB_RERANK is off',
+        });
+        expect(report.checks).toContainEqual({
+          name: 'reranker',
+          status: 'ok',
+          detail: 'KB_RERANK is off',
+        });
+        const markdown = formatDoctorMarkdown(report);
+        expect(markdown).toContain('Reranker:');
+        expect(markdown).toContain('enabled: no');
+      } finally {
+        await fsp.rm(tempDir, { recursive: true, force: true });
+      }
+    });
+
+    it('reports invalid reranker configuration as an error', async () => {
+      const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-doctor-rerank-invalid-'));
+      try {
+        const { rootDir, faissDir } = await seedDoctorBase(tempDir);
+        const { buildDoctorReport, formatDoctorMarkdown } = await freshDoctor({
+          KNOWLEDGE_BASES_ROOT_DIR: rootDir,
+          FAISS_INDEX_PATH: faissDir,
+          EMBEDDING_PROVIDER: 'huggingface',
+          HUGGINGFACE_MODEL_NAME: MODEL_NAME,
+          HUGGINGFACE_API_KEY: 'test-key',
+          KB_RERANK: 'on',
+          KB_RERANK_TOP_N: '0',
+          HF_HOME: path.join(tempDir, 'hf'),
+        });
+
+        const report = await buildDoctorReport({
+          backendHealthCheck: async () => ({ healthy: true, detail: 'backend ok' }),
+          packageRoot: tempDir,
+          invokedPath: null,
+          packageVersion: '9.9.9',
+          llmEndpointProbe: healthyLlmProbe,
+        });
+
+        expect(report.status).toBe('error');
+        expect(report.reranker).toMatchObject({
+          enabled: false,
+          model: '<invalid>',
+          top_n: 0,
+          status: 'error',
+          cache_path: null,
+        });
+        expect(report.reranker.detail).toContain('KB_RERANK_TOP_N');
+        const check = report.checks.find((c) => c.name === 'reranker');
+        expect(check?.status).toBe('error');
+        expect(check?.detail).toContain('KB_RERANK_TOP_N');
+        const markdown = formatDoctorMarkdown(report);
+        expect(markdown).toContain('status: error');
+        expect(markdown).toContain('model: <invalid>');
+      } finally {
+        await fsp.rm(tempDir, { recursive: true, force: true });
+      }
+    });
+
+    it('warns when enabled and the reranker model cache is missing', async () => {
+      const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-doctor-rerank-cache-missing-'));
+      try {
+        const { rootDir, faissDir } = await seedDoctorBase(tempDir);
+        const hfHome = path.join(tempDir, 'hf');
+        const { buildDoctorReport, formatDoctorMarkdown } = await freshDoctor({
+          KNOWLEDGE_BASES_ROOT_DIR: rootDir,
+          FAISS_INDEX_PATH: faissDir,
+          EMBEDDING_PROVIDER: 'huggingface',
+          HUGGINGFACE_MODEL_NAME: MODEL_NAME,
+          HUGGINGFACE_API_KEY: 'test-key',
+          KB_RERANK: 'on',
+          HF_HOME: hfHome,
+        });
+
+        const report = await buildDoctorReport({
+          backendHealthCheck: async () => ({ healthy: true, detail: 'backend ok' }),
+          packageRoot: tempDir,
+          invokedPath: null,
+          packageVersion: '9.9.9',
+          llmEndpointProbe: healthyLlmProbe,
+        });
+
+        expect(report.status).toBe('warn');
+        expect(report.reranker).toMatchObject({
+          enabled: true,
+          model: RERANK_MODEL,
+          top_n: 40,
+          status: 'warn',
+          cache_path: null,
+        });
+        expect(report.reranker.detail).toContain('cache not found');
+        const check = report.checks.find((c) => c.name === 'reranker');
+        expect(check?.status).toBe('warn');
+        const markdown = formatDoctorMarkdown(report);
+        expect(markdown).toContain('enabled: yes');
+        expect(markdown).toContain('cache_path: <not found>');
+      } finally {
+        await fsp.rm(tempDir, { recursive: true, force: true });
+      }
+    });
+
+    it('reports OK when enabled and the reranker model cache is present', async () => {
+      const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-doctor-rerank-cache-present-'));
+      try {
+        const { rootDir, faissDir } = await seedDoctorBase(tempDir);
+        const hfHome = path.join(tempDir, 'hf');
+        const modelCachePath = path.join(hfHome, 'hub', 'models--Xenova--ms-marco-MiniLM-L-6-v2');
+        await fsp.mkdir(modelCachePath, { recursive: true });
+        const { buildDoctorReport, formatDoctorMarkdown } = await freshDoctor({
+          KNOWLEDGE_BASES_ROOT_DIR: rootDir,
+          FAISS_INDEX_PATH: faissDir,
+          EMBEDDING_PROVIDER: 'huggingface',
+          HUGGINGFACE_MODEL_NAME: MODEL_NAME,
+          HUGGINGFACE_API_KEY: 'test-key',
+          KB_RERANK: 'on',
+          HF_HOME: hfHome,
+        });
+
+        const report = await buildDoctorReport({
+          backendHealthCheck: async () => ({ healthy: true, detail: 'backend ok' }),
+          packageRoot: tempDir,
+          invokedPath: null,
+          packageVersion: '9.9.9',
+          llmEndpointProbe: healthyLlmProbe,
+        });
+
+        expect(report.reranker).toEqual({
+          enabled: true,
+          model: RERANK_MODEL,
+          top_n: 40,
+          status: 'ok',
+          cache_path: modelCachePath,
+          detail: 'reranker model cache found',
+        });
+        expect(report.checks).toContainEqual({
+          name: 'reranker',
+          status: 'ok',
+          detail: 'reranker model cache found',
+        });
+        const markdown = formatDoctorMarkdown(report);
+        expect(markdown).toContain(`cache_path: ${modelCachePath}`);
       } finally {
         await fsp.rm(tempDir, { recursive: true, force: true });
       }

--- a/src/cli-doctor.ts
+++ b/src/cli-doctor.ts
@@ -63,6 +63,7 @@ import {
   resolveProfile,
   type LlmProfile,
 } from './llm-profiles.js';
+import { resolveRerankerConfig } from './config/reranker.js';
 
 /**
  * Issue #210 — error-rate threshold above which the doctor surfaces a
@@ -211,6 +212,14 @@ export interface DoctorReport {
     chat_ok: boolean;
     detail: string;
     next_action: string | null;
+  };
+  reranker: {
+    enabled: boolean;
+    model: string;
+    top_n: number;
+    status: HealthStatus;
+    cache_path: string | null;
+    detail: string;
   };
   cli: {
     version: string;
@@ -482,6 +491,13 @@ export async function buildDoctorReport(
     detail: llmEndpoint.detail,
   });
 
+  const reranker = await readRerankerHealth();
+  checks.push({
+    name: 'reranker',
+    status: reranker.status,
+    detail: reranker.detail,
+  });
+
   const metricsSource = options.providerCallMetrics ?? providerCallMetrics;
   const providerCalls = metricsSource.snapshot();
   // Issue #210 — only emit the row when at least one call has been
@@ -554,6 +570,7 @@ export async function buildDoctorReport(
     incomplete_models: incompleteModels,
     backend,
     llm_endpoint: llmEndpoint,
+    reranker,
     cli,
     git,
     last_index_update: lastIndexUpdate,
@@ -908,6 +925,65 @@ async function countFiles(dir: string): Promise<number> {
   return count;
 }
 
+async function readRerankerHealth(): Promise<DoctorReport['reranker']> {
+  let config;
+  try {
+    config = resolveRerankerConfig();
+  } catch (err) {
+    return {
+      enabled: false,
+      model: '<invalid>',
+      top_n: 0,
+      status: 'error',
+      cache_path: null,
+      detail: (err as Error).message,
+    };
+  }
+
+  if (!config.enabled) {
+    return {
+      enabled: false,
+      model: config.model,
+      top_n: config.topN,
+      status: 'ok',
+      cache_path: null,
+      detail: 'KB_RERANK is off',
+    };
+  }
+
+  const cachePath = await findHuggingFaceModelCachePath(config.model);
+  return {
+    enabled: true,
+    model: config.model,
+    top_n: config.topN,
+    status: cachePath === null ? 'warn' : 'ok',
+    cache_path: cachePath,
+    detail: cachePath === null
+      ? 'reranker model cache not found; first enabled call may download the model or degrade offline'
+      : 'reranker model cache found',
+  };
+}
+
+async function findHuggingFaceModelCachePath(model: string): Promise<string | null> {
+  const hfHome = process.env.HF_HOME || process.env.TRANSFORMERS_CACHE ||
+    (process.env.HOME ? path.join(process.env.HOME, '.cache', 'huggingface') : null);
+  if (hfHome === null) return null;
+  const modelDirName = `models--${model.replace(/\//g, '--')}`;
+  const candidates = [
+    path.join(hfHome, 'hub', modelDirName),
+    path.join(hfHome, modelDirName),
+  ];
+  for (const candidate of candidates) {
+    try {
+      const stat = await fsp.stat(candidate);
+      if (stat.isDirectory()) return candidate;
+    } catch {
+      // best-effort cache probe
+    }
+  }
+  return null;
+}
+
 async function readBackendHealth(
   provider: string | null,
   modelName: string | null,
@@ -1258,6 +1334,13 @@ export function formatDoctorMarkdown(report: DoctorReport): string {
   if (report.llm_endpoint.next_action !== null) {
     lines.push(`  next_action: ${report.llm_endpoint.next_action}`);
   }
+  lines.push('Reranker:');
+  lines.push(`  enabled: ${report.reranker.enabled ? 'yes' : 'no'}`);
+  lines.push(`  model: ${report.reranker.model}`);
+  lines.push(`  top_n: ${report.reranker.top_n}`);
+  lines.push(`  status: ${report.reranker.status}`);
+  lines.push(`  cache_path: ${report.reranker.cache_path ?? '<not found>'}`);
+  lines.push(`  detail: ${report.reranker.detail}`);
   lines.push(`kb version: ${report.cli.version}`);
   if (report.cli.symlinked_checkout_path !== null) {
     lines.push(`Linked checkout: ${report.cli.symlinked_checkout_path}`);

--- a/src/cli-search.test.ts
+++ b/src/cli-search.test.ts
@@ -15,6 +15,7 @@ import { compactTimingPayload, type TimingPayload } from './timing-core.js';
 import type { ScoredDocument } from './formatter.js';
 import type { FaissIndexManager, SimilaritySearchTiming } from './FaissIndexManager.js';
 import type { ExplainEmptyDiagnostics, Staleness } from './search-core.js';
+import { setRerankerFactoryForTests } from './reranker.js';
 
 const MTIME = '2026-05-03T15:33:56.964Z';
 
@@ -155,6 +156,17 @@ describe('parseSearchArgs relevance gate (RFC 018)', () => {
   });
 });
 
+describe('parseSearchArgs reranker (RFC 019)', () => {
+  it('accepts per-call reranker overrides', () => {
+    expect(parseSearchArgs(['query', '--rerank'])).toMatchObject({
+      rerankOverride: 'on',
+    });
+    expect(parseSearchArgs(['query', '--no-rerank'])).toMatchObject({
+      rerankOverride: 'off',
+    });
+  });
+});
+
 describe('runSearch timing guard (#331)', () => {
   function makeDeps(): {
     deps: RunSearchDeps;
@@ -256,6 +268,150 @@ describe('runSearch timing guard (#331)', () => {
       input_count: 1,
       output_count: 1,
       judge: { status: 'skipped' },
+    });
+  });
+
+  it('ignores invalid reranker-only topN config when dense mode cannot rerank', async () => {
+    const { deps } = makeDeps();
+    const previousRerank = process.env.KB_RERANK;
+    const previousTopN = process.env.KB_RERANK_TOP_N;
+    process.env.KB_RERANK = 'on';
+    process.env.KB_RERANK_TOP_N = 'nope';
+
+    try {
+      const out = await captureSearchOutput(['query', '--mode=dense', '--no-freshness'], deps);
+
+      expect(out.code).toBe(0);
+      expect(out.stderr).toContain('rerank is currently hybrid-only; ignored under --mode=dense');
+    } finally {
+      if (previousRerank === undefined) delete process.env.KB_RERANK;
+      else process.env.KB_RERANK = previousRerank;
+      if (previousTopN === undefined) delete process.env.KB_RERANK_TOP_N;
+      else process.env.KB_RERANK_TOP_N = previousTopN;
+    }
+  });
+
+  it('reranks the hybrid runtime path before emitting JSON results', async () => {
+    const manager = {
+      modelDir: '/tmp/kb-test-model',
+      initialize: jest.fn(async () => {}),
+      updateIndex: jest.fn(async () => {}),
+      similaritySearch: jest.fn(async (...args: unknown[]) => {
+        const timing = args[5] as SimilaritySearchTiming | undefined;
+        if (timing) timing.faiss_search_ms = (timing.faiss_search_ms ?? 0) + 1;
+        return [
+          {
+            pageContent: 'dense loser',
+            metadata: { source: '/kb/dense-loser.md', chunkIndex: 0 },
+            score: 0.1,
+          },
+          {
+            pageContent: 'dense middle',
+            metadata: { source: '/kb/dense-middle.md', chunkIndex: 0 },
+            score: 0.2,
+          },
+        ];
+      }),
+    } as unknown as FaissIndexManager & { similaritySearch: jest.Mock };
+    const deps: RunSearchDeps = {
+      bootstrapLayout: jest.fn(async () => {}),
+      resolveActiveModel: jest.fn(async () => 'ollama__nomic-embed-text-latest'),
+      loadManagerForModel: jest.fn(async () => manager),
+      loadWithJsonRetry: jest.fn(async () => {}),
+      listLexicalKbs: jest.fn(async () => [{ kbName: 'alpha', kbPath: '/kb/alpha' }]),
+      runLexicalLeg: jest.fn(async () => ({
+        refreshed: 0,
+        failed: 0,
+        hits: [
+          {
+            pageContent: 'lexical winner',
+            metadata: { source: '/kb/lexical-winner.md', chunkIndex: 0 },
+            score: 10,
+          },
+        ],
+      })),
+    };
+    const restoreFactory = setRerankerFactoryForTests(async () => ({
+      id: 'stub-reranker',
+      rerank: async (_query, candidates) =>
+        candidates.map((candidate) => (candidate.includes('winner') ? 10 : 0)),
+    }));
+    const previousRerank = process.env.KB_RERANK;
+    const previousTopN = process.env.KB_RERANK_TOP_N;
+    process.env.KB_RERANK = 'on';
+    process.env.KB_RERANK_TOP_N = '3';
+
+    try {
+      const out = await captureSearchOutput(
+        ['query', '--mode=hybrid', '--k=2', '--format=json', '--timing', '--no-freshness'],
+        deps,
+      );
+
+      expect(out.code).toBe(0);
+      expect(out.stderr).toContain('"cmd":"rerank.stage"');
+      expect(manager.similaritySearch).toHaveBeenCalledWith(
+        'query',
+        8,
+        Number.POSITIVE_INFINITY,
+        undefined,
+        undefined,
+        expect.any(Object),
+        { noCache: false },
+      );
+      expect(deps.runLexicalLeg).toHaveBeenCalledWith(expect.objectContaining({
+        query: 'query',
+        fetchK: 8,
+      }));
+      const payload = JSON.parse(out.stdout);
+      expect(payload).toMatchObject({
+        mode: 'hybrid',
+        rerank: {
+          enabled: true,
+          model: 'stub-reranker',
+          candidates: 3,
+          cache_hits: 0,
+          degraded: false,
+        },
+      });
+      expect(payload.results[0]).toMatchObject({
+        content: 'lexical winner',
+        rerank_score: 10,
+      });
+      expect(payload.timing).toMatchObject({
+        rerank_candidates: 3,
+      });
+    } finally {
+      restoreFactory();
+      if (previousRerank === undefined) delete process.env.KB_RERANK;
+      else process.env.KB_RERANK = previousRerank;
+      if (previousTopN === undefined) delete process.env.KB_RERANK_TOP_N;
+      else process.env.KB_RERANK_TOP_N = previousTopN;
+    }
+  });
+
+  it('includes rerank_score in JSON result output when present', () => {
+    const payload = buildDenseSearchJsonPayload({
+      results: [{
+        pageContent: 'deployment rollback',
+        metadata: { source: '/kb/deploy.md', chunkIndex: 0 },
+        score: 0.02,
+        rerankScore: 0.93,
+      } as ScoredDocument,
+      ],
+      requestedMode: 'hybrid',
+      effectiveMode: 'hybrid',
+      autoModeDecision: null,
+      groupBySource: false,
+      refreshed: false,
+      scopedKb: undefined,
+      staleness: null,
+      autoThresholdDecision: null,
+      timing: null,
+    });
+
+    expect((payload.results as Array<Record<string, unknown>>)[0]).toMatchObject({
+      score: 0.02,
+      rerank_score: 0.93,
     });
   });
 

--- a/src/cli-search.ts
+++ b/src/cli-search.ts
@@ -68,6 +68,12 @@ import {
   type RelevanceGateVerdict,
 } from './relevance-gate-schema.js';
 import {
+  applyRerankerIfEnabled,
+  parseRerankFlag,
+  resolveRerankerConfig,
+  type RerankOverride,
+} from './reranker.js';
+import {
   inspectTaskContext,
   resolveTaskContextArgvMax,
   resolveTaskContextPolicyMode,
@@ -135,6 +141,9 @@ Result tuning:
   --gate                Run the relevance gate for this call even when
                         KB_RELEVANCE_GATE is off.
   --no-gate             Bypass the relevance gate for this call.
+  --rerank              Run the RFC 019 cross-encoder reranker for this call
+                        (currently applies to hybrid retrieval).
+  --no-rerank           Bypass the reranker for this call.
   --task-context=<str>  Task context used by the relevance judge. Prefer
                         --task-context-file for long or prompt-like text:
                         argv is exposed in 'ps', shell history, and hooks.
@@ -204,6 +213,7 @@ interface SearchArgs {
   explain: boolean;
   neighborContext?: NeighborContextOptions;
   gateOverride?: RelevanceGateOverride;
+  rerankOverride?: RerankOverride;
   taskContext?: string;
   taskContextFile?: string;
 }
@@ -213,6 +223,8 @@ export interface RunSearchDeps {
   resolveActiveModel: typeof resolveActiveModel;
   loadManagerForModel: typeof loadManagerForModel;
   loadWithJsonRetry: typeof loadWithJsonRetry;
+  listLexicalKbs?: typeof listLexicalKbs;
+  runLexicalLeg?: typeof runLexicalLeg;
 }
 
 const DEFAULT_RUN_SEARCH_DEPS: RunSearchDeps = {
@@ -220,6 +232,8 @@ const DEFAULT_RUN_SEARCH_DEPS: RunSearchDeps = {
   resolveActiveModel,
   loadManagerForModel,
   loadWithJsonRetry,
+  listLexicalKbs,
+  runLexicalLeg,
 };
 
 export async function runSearch(
@@ -309,11 +323,13 @@ export async function runSearch(
   }
 
   if (effectiveMode === 'lexical') {
+    warnIfRerankIgnored(parsed, effectiveMode);
     return runLexicalSearch(effectiveParsed, timing, totalStartedAt, autoModeDecision);
   }
   if (effectiveMode === 'hybrid') {
-    return runHybridSearch(effectiveParsed, timing, totalStartedAt, autoModeDecision);
+    return runHybridSearch(effectiveParsed, timing, totalStartedAt, autoModeDecision, deps);
   }
+  warnIfRerankIgnored(parsed, effectiveMode);
 
   try {
     const startedAt = nowMs();
@@ -576,6 +592,8 @@ export function parseSearchArgs(rest: string[]): SearchArgs {
     if (raw === '--no-cache') { out.noCache = true; continue; }
     if (raw === '--gate') { out.gateOverride = 'on'; continue; }
     if (raw === '--no-gate') { out.gateOverride = 'off'; continue; }
+    if (raw === '--rerank') { out.rerankOverride = 'on'; continue; }
+    if (raw === '--no-rerank') { out.rerankOverride = 'off'; continue; }
     if (raw === '--no-freshness') { out.freshness = false; continue; }
     if (raw === '--explain-empty') { out.explainEmpty = true; continue; }
     if (raw === '--explain') { out.explain = true; continue; }
@@ -632,6 +650,27 @@ export function parseSearchArgs(rest: string[]): SearchArgs {
     throw new Error(`unexpected argument: ${raw}`);
   }
   return out;
+}
+
+function warnIfRerankIgnored(parsed: SearchArgs, effectiveMode: EffectiveSearchMode): void {
+  let enabled: boolean;
+  if (parsed.rerankOverride === 'on') {
+    enabled = true;
+  } else if (parsed.rerankOverride === 'off') {
+    enabled = false;
+  } else {
+    try {
+      enabled = parseRerankFlag(process.env.KB_RERANK);
+    } catch (err) {
+      process.stderr.write(
+        `kb search: invalid KB_RERANK ignored under --mode=${effectiveMode}: ${(err as Error).message}\n`,
+      );
+      return;
+    }
+  }
+  if (enabled && effectiveMode !== 'hybrid') {
+    process.stderr.write(`kb search: rerank is currently hybrid-only; ignored under --mode=${effectiveMode}\n`);
+  }
 }
 
 function parseNeighborContextCount(raw: string, prefix: string): number {
@@ -1188,6 +1227,7 @@ async function runHybridSearch(
   timing: TimingPayload | null = null,
   totalStartedAt: number = nowMs(),
   autoModeDecision: AutoSearchModeDecision | null = null,
+  deps: RunSearchDeps = DEFAULT_RUN_SEARCH_DEPS,
 ): Promise<number> {
   if (parsed.thresholdAuto || parsed.threshold !== undefined) {
     process.stderr.write('kb search: --threshold/--threshold=auto are dense-only; ignored under --mode=hybrid\n');
@@ -1205,10 +1245,10 @@ async function runHybridSearch(
   let activeModelId: string | null = null;
   try {
     let startedAt = nowMs();
-    await FaissIndexManager.bootstrapLayout();
+    await deps.bootstrapLayout();
     if (timing) timing.bootstrap_ms = elapsedMs(startedAt);
     startedAt = nowMs();
-    activeModelId = await resolveActiveModel({ explicitOverride: parsed.model });
+    activeModelId = await deps.resolveActiveModel({ explicitOverride: parsed.model });
     if (timing) timing.model_resolution_ms = elapsedMs(startedAt);
   } catch (err) {
     return reportFailure(classifyKbSearchError(err), parsed.format);
@@ -1216,7 +1256,7 @@ async function runHybridSearch(
   let manager: FaissIndexManager;
   try {
     const startedAt = nowMs();
-    manager = await loadManagerForModel(activeModelId);
+    manager = await deps.loadManagerForModel(activeModelId);
     if (timing) timing.manager_load_ms = elapsedMs(startedAt);
   } catch (err) {
     return reportFailure(classifyKbSearchError(err), parsed.format);
@@ -1232,7 +1272,7 @@ async function runHybridSearch(
         });
       });
     } else {
-      await loadWithJsonRetry(manager);
+      await deps.loadWithJsonRetry(manager);
     }
     if (timing) timing.index_load_ms = elapsedMs(startedAt);
   } catch (err) {
@@ -1266,7 +1306,7 @@ async function runHybridSearch(
   let lexicalKbs: Array<{ kbName: string; kbPath: string }>;
   try {
     const startedAt = nowMs();
-    lexicalKbs = await listLexicalKbs(parsed.kb);
+    lexicalKbs = await (deps.listLexicalKbs ?? listLexicalKbs)(parsed.kb);
     if (timing) timing.lexical_kb_list_ms = elapsedMs(startedAt);
   } catch (err) {
     process.stderr.write(`kb search (hybrid): could not list KBs: ${(err as Error).message}\n`);
@@ -1274,7 +1314,7 @@ async function runHybridSearch(
   }
 
   const lexicalStartedAt = nowMs();
-  const lexicalPromise = runLexicalLeg({
+  const lexicalPromise = (deps.runLexicalLeg ?? runLexicalLeg)({
     kbs: lexicalKbs,
     query,
     fetchK,
@@ -1295,14 +1335,32 @@ async function runHybridSearch(
 
   // -- fuse ----------------------------------------------------------------
   const fusionStartedAt = nowMs();
+  const rerankConfig = resolveRerankerConfig(process.env, parsed.rerankOverride);
+  const fusionK = rerankConfig.enabled ? Math.max(parsed.k, rerankConfig.topN) : parsed.k;
   const fusion = fuseHybridResultsWithDiagnostics({
     denseResults,
     lexicalResults,
-    k: parsed.k,
+    k: fusionK,
   });
   let ranked = fusion.results;
+  if (timing) timing.fusion_ms = elapsedMs(fusionStartedAt);
+  const rerankResult = await applyRerankerIfEnabled({
+    query,
+    results: ranked,
+    k: parsed.k,
+    override: parsed.rerankOverride,
+    process: 'cli',
+    searchMode: 'hybrid',
+    kbScope: parsed.kb ?? null,
+  });
+  ranked = rerankResult.results;
   if (timing) {
-    timing.fusion_ms = elapsedMs(fusionStartedAt);
+    if (rerankResult.candidatesIn > 0) {
+      timing.rerank_ms = rerankResult.tookMs;
+      timing.rerank_cache_hits = rerankResult.cacheHits;
+      timing.rerank_candidates = rerankResult.candidatesIn;
+      if (rerankResult.degraded) timing.rerank_degraded = true;
+    }
     timing.total_ms = elapsedMs(totalStartedAt);
   }
 
@@ -1347,6 +1405,14 @@ async function runHybridSearch(
         lexical: { fetched: lexicalResults.length, refreshed: lexicalResultsRow.refreshed, failed: lexicalResultsRow.failed },
       },
       rrf: { c: HYBRID_RRF_C, fetch_k: fetchK },
+      rerank: {
+        enabled: rerankResult.candidatesIn > 0,
+        model: rerankResult.model,
+        candidates: rerankResult.candidatesIn,
+        cache_hits: rerankResult.cacheHits,
+        degraded: rerankResult.degraded,
+        degrade_reason: rerankResult.degradeReason,
+      },
       gate_verdict: gateVerdict,
       ...(timing ? { timing: compactTimingPayload(timing) } : {}),
     };
@@ -1359,7 +1425,7 @@ async function runHybridSearch(
       process.stdout.write(formatAutoModeHeader(autoModeDecision));
       process.stdout.write('\n\n');
     }
-    process.stdout.write(`> _Mode: hybrid (RRF c=${HYBRID_RRF_C}). Stage 2 — dense ⨁ lexical; see #206._\n\n`);
+    process.stdout.write(`> _Mode: hybrid (RRF c=${HYBRID_RRF_C}). Stage 2 - dense + lexical; see #206._\n\n`);
     if (ranked.length === 0) {
       process.stdout.write(`_No matches._\n\n`);
     } else {
@@ -1369,6 +1435,12 @@ async function runHybridSearch(
     process.stdout.write(
       `> _Hybrid status: dense fetched ${denseResults.length}, lexical fetched ${lexicalResults.length} (refreshed ${lexicalResultsRow.refreshed}, ${lexicalResultsRow.failed} failed); fused via RRF (c=${HYBRID_RRF_C}, fetch_k=${fetchK})._\n`,
     );
+    if (rerankResult.candidatesIn > 0) {
+      const degraded = rerankResult.degraded ? '; degraded to fused order' : '';
+      process.stdout.write(
+        `> _Rerank: ${rerankResult.model}; rescored ${rerankResult.candidatesIn} candidate(s), cache hits ${rerankResult.cacheHits}${degraded}._\n`,
+      );
+    }
     if (gateVerdict.state !== 'bypassed') {
       process.stdout.write(`${formatGateVerdictFooter(gateVerdict)}\n`);
     }

--- a/src/config/reranker.test.ts
+++ b/src/config/reranker.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from '@jest/globals';
+
+import {
+  DEFAULT_RERANK_MODEL,
+  DEFAULT_RERANK_TOP_N,
+  parseRerankFlag,
+  parseRerankTopN,
+  resolveRerankerConfig,
+} from './reranker.js';
+
+describe('reranker config (RFC 019)', () => {
+  it('defaults the reranker off with the fast local model and topN=40', () => {
+    expect(resolveRerankerConfig({})).toEqual({
+      enabled: false,
+      model: DEFAULT_RERANK_MODEL,
+      topN: DEFAULT_RERANK_TOP_N,
+    });
+  });
+
+  it('parses KB_RERANK as an on/off feature flag', () => {
+    expect(parseRerankFlag(undefined)).toBe(false);
+    expect(parseRerankFlag('')).toBe(false);
+    expect(parseRerankFlag('off')).toBe(false);
+    expect(parseRerankFlag('false')).toBe(false);
+    expect(parseRerankFlag('0')).toBe(false);
+    expect(parseRerankFlag('on')).toBe(true);
+    expect(parseRerankFlag('true')).toBe(true);
+    expect(parseRerankFlag('1')).toBe(true);
+    expect(() => parseRerankFlag('maybe')).toThrow(/KB_RERANK/);
+  });
+
+  it('parses KB_RERANK_TOP_N as a positive bounded integer', () => {
+    expect(parseRerankTopN(undefined)).toBe(DEFAULT_RERANK_TOP_N);
+    expect(parseRerankTopN('')).toBe(DEFAULT_RERANK_TOP_N);
+    expect(parseRerankTopN('7')).toBe(7);
+    expect(() => parseRerankTopN('7.9')).toThrow(/KB_RERANK_TOP_N/);
+    expect(() => parseRerankTopN('0')).toThrow(/KB_RERANK_TOP_N/);
+    expect(() => parseRerankTopN('1001')).toThrow(/KB_RERANK_TOP_N/);
+  });
+
+  it('lets per-call overrides win over the environment flag', () => {
+    expect(resolveRerankerConfig({ KB_RERANK: 'off' }, 'on').enabled).toBe(true);
+    expect(resolveRerankerConfig({ KB_RERANK: 'on' }, 'off').enabled).toBe(false);
+    expect(resolveRerankerConfig({ KB_RERANK: 'on', KB_RERANK_MODEL: 'custom/model', KB_RERANK_TOP_N: '12' })).toEqual({
+      enabled: true,
+      model: 'custom/model',
+      topN: 12,
+    });
+  });
+
+  it('does not validate reranker-only topN config when reranking is disabled', () => {
+    expect(resolveRerankerConfig({ KB_RERANK: 'off', KB_RERANK_TOP_N: 'nope' })).toEqual({
+      enabled: false,
+      model: DEFAULT_RERANK_MODEL,
+      topN: DEFAULT_RERANK_TOP_N,
+    });
+    expect(resolveRerankerConfig({ KB_RERANK: 'on', KB_RERANK_TOP_N: 'nope' }, 'off')).toEqual({
+      enabled: false,
+      model: DEFAULT_RERANK_MODEL,
+      topN: DEFAULT_RERANK_TOP_N,
+    });
+    expect(() => resolveRerankerConfig({ KB_RERANK: 'on', KB_RERANK_TOP_N: 'nope' })).toThrow(/KB_RERANK_TOP_N/);
+  });
+});

--- a/src/config/reranker.ts
+++ b/src/config/reranker.ts
@@ -1,0 +1,53 @@
+export const DEFAULT_RERANK_MODEL = 'Xenova/ms-marco-MiniLM-L-6-v2';
+export const DEFAULT_RERANK_TOP_N = 40;
+export const MAX_RERANK_TOP_N = 1000;
+
+export type RerankOverride = 'on' | 'off' | undefined;
+
+export interface RerankerConfig {
+  enabled: boolean;
+  model: string;
+  topN: number;
+}
+
+export interface RerankerEnv {
+  [key: string]: string | undefined;
+  KB_RERANK?: string;
+  KB_RERANK_MODEL?: string;
+  KB_RERANK_TOP_N?: string;
+}
+
+export function parseRerankFlag(raw: string | undefined): boolean {
+  if (raw === undefined || raw.trim() === '') return false;
+  const value = raw.trim().toLowerCase();
+  if (value === 'on' || value === 'true' || value === '1') return true;
+  if (value === 'off' || value === 'false' || value === '0') return false;
+  throw new Error(`invalid KB_RERANK=${JSON.stringify(raw)} (expected on/off, true/false, or 1/0)`);
+}
+
+export function parseRerankTopN(raw: string | undefined): number {
+  if (raw === undefined || raw.trim() === '') return DEFAULT_RERANK_TOP_N;
+  const trimmed = raw.trim();
+  if (!/^\d+$/.test(trimmed)) {
+    throw new Error(`invalid KB_RERANK_TOP_N=${JSON.stringify(raw)} (expected integer 1-${MAX_RERANK_TOP_N})`);
+  }
+  const value = Number(trimmed);
+  if (!Number.isInteger(value) || value < 1 || value > MAX_RERANK_TOP_N) {
+    throw new Error(`invalid KB_RERANK_TOP_N=${JSON.stringify(raw)} (expected integer 1-${MAX_RERANK_TOP_N})`);
+  }
+  return value;
+}
+
+export function resolveRerankerConfig(
+  env: RerankerEnv = process.env,
+  override?: RerankOverride,
+): RerankerConfig {
+  const enabled = override === 'on'
+    ? true
+    : override === 'off'
+      ? false
+      : parseRerankFlag(env.KB_RERANK);
+  const model = env.KB_RERANK_MODEL?.trim() || DEFAULT_RERANK_MODEL;
+  const topN = enabled ? parseRerankTopN(env.KB_RERANK_TOP_N) : DEFAULT_RERANK_TOP_N;
+  return { enabled, model, topN };
+}

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -20,6 +20,7 @@ import { getInjectionSignals, type InjectionSignal } from './kb-shield.js';
  */
 export interface ScoredDocument extends Document {
   score?: number;
+  rerankScore?: number;
   matchType?: 'semantic';
   semanticMatch?: true;
   contextChunks?: ContextDocument[];
@@ -35,6 +36,7 @@ export interface ContextDocument extends Document {
 
 export interface RetrievalJsonResult {
   score: number | null;
+  rerank_score?: number;
   content: string;
   metadata: Record<string, unknown>;
   chunk_id?: string;
@@ -216,6 +218,7 @@ export function formatRetrievalAsJson(
     const signals = getShieldSignals(doc.pageContent, metadata, guardOptions);
     return {
       score: doc.score ?? null,
+      ...(doc.rerankScore !== undefined ? { rerank_score: doc.rerankScore } : {}),
       content: guarded.content,
       metadata: guarded.metadata,
       ...(citation ? { chunk_id: citation.chunk_id } : {}),

--- a/src/reranker.test.ts
+++ b/src/reranker.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it, jest } from '@jest/globals';
+
+import {
+  InMemoryRerankScoreCache,
+  rerankFusedResults,
+  scoresFromSequenceClassifierOutput,
+  type Reranker,
+  type RerankableDocument,
+} from './reranker.js';
+
+function doc(source: string, score: number, body = source): RerankableDocument {
+  return {
+    pageContent: body,
+    metadata: { source, chunkIndex: 0 },
+    score,
+  };
+}
+
+function stubReranker(scores: number[]): Reranker {
+  return {
+    id: 'stub-reranker',
+    rerank: jest.fn(async () => scores),
+  };
+}
+
+describe('rerankFusedResults (RFC 019)', () => {
+  it('reranks the topN block by descending cross-encoder score and returns top k', async () => {
+    const reranker = stubReranker([0.10, 0.95, 0.40]);
+    const fused = [doc('a.md', 0.030), doc('b.md', 0.025), doc('c.md', 0.020)];
+
+    const out = await rerankFusedResults({
+      query: 'how do rollbacks work',
+      fused,
+      k: 2,
+      topN: 3,
+      reranker,
+    });
+
+    expect(out.degraded).toBe(false);
+    expect(out.results.map((r) => r.metadata.source)).toEqual(['b.md', 'c.md']);
+    expect(out.results.map((r) => r.rerankScore)).toEqual([0.95, 0.40]);
+    expect(out.results[0].score).toBe(0.025);
+  });
+
+  it('keeps unscored tail candidates after the reranked block in original fused order', async () => {
+    const reranker = stubReranker([0.20, 0.90]);
+    const fused = [
+      doc('a.md', 0.040),
+      doc('b.md', 0.030),
+      doc('c.md', 0.020),
+      doc('d.md', 0.010),
+    ];
+
+    const out = await rerankFusedResults({
+      query: 'query',
+      fused,
+      k: 4,
+      topN: 2,
+      reranker,
+    });
+
+    expect(out.results.map((r) => r.metadata.source)).toEqual(['b.md', 'a.md', 'c.md', 'd.md']);
+    expect(out.results.map((r) => r.rerankScore ?? null)).toEqual([0.90, 0.20, null, null]);
+  });
+
+  it('uses an in-memory cache keyed by normalized query, model id, and candidate content', async () => {
+    const reranker = stubReranker([0.75, 0.25]);
+    const cache = new InMemoryRerankScoreCache({ maxEntries: 10 });
+    const fused = [doc('a.md', 0.020, 'same body'), doc('b.md', 0.010, 'other body')];
+
+    await rerankFusedResults({ query: '  Query   Text ', fused, k: 2, topN: 2, reranker, cache });
+    const second = await rerankFusedResults({ query: 'query text', fused, k: 2, topN: 2, reranker, cache });
+
+    expect(reranker.rerank).toHaveBeenCalledTimes(1);
+    expect(second.cacheHits).toBe(2);
+    expect(second.results.map((r) => r.rerankScore)).toEqual([0.75, 0.25]);
+  });
+
+  it('degrades to the original fused order when the provider fails', async () => {
+    const reranker: Reranker = {
+      id: 'throwing',
+      rerank: jest.fn(async () => {
+        throw new Error('model unavailable');
+      }),
+    };
+    const fused = [doc('a.md', 0.030), doc('b.md', 0.020)];
+
+    const out = await rerankFusedResults({ query: 'q', fused, k: 2, topN: 2, reranker });
+
+    expect(out.degraded).toBe(true);
+    expect(out.degradeReason).toContain('model unavailable');
+    expect(out.results).toEqual(fused);
+  });
+
+  it('degrades to the original fused order when the provider returns the wrong number of scores', async () => {
+    const reranker = stubReranker([0.1]);
+    const fused = [doc('a.md', 0.030), doc('b.md', 0.020)];
+
+    const out = await rerankFusedResults({ query: 'q', fused, k: 2, topN: 2, reranker });
+
+    expect(out.degraded).toBe(true);
+    expect(out.degradeReason).toMatch(/expected 2 scores, got 1/);
+    expect(out.results).toEqual(fused);
+  });
+});
+
+describe('scoresFromSequenceClassifierOutput', () => {
+  it('uses raw logits for one-label MS MARCO cross-encoder models', () => {
+    expect(scoresFromSequenceClassifierOutput({
+      logits: { dims: [3, 1], data: [8.1, -2.4, 0.5] },
+    })).toEqual([8.1, -2.4, 0.5]);
+  });
+
+  it('uses the positive-label softmax probability for two-label classifiers', () => {
+    const scores = scoresFromSequenceClassifierOutput(
+      { logits: { dims: [2, 2], data: [1, 3, 4, 1] } },
+      { label2id: { negative: 0, positive: 1 } },
+    );
+
+    expect(scores[0]).toBeCloseTo(0.8808, 4);
+    expect(scores[1]).toBeCloseTo(0.0474, 4);
+  });
+});

--- a/src/reranker.ts
+++ b/src/reranker.ts
@@ -1,0 +1,425 @@
+import { createHash } from 'crypto';
+import type { Document } from '@langchain/core/documents';
+import { emitCanonicalLog, type CanonicalProcess, type CanonicalSearchMode } from './canonical-log.js';
+import {
+  DEFAULT_RERANK_MODEL,
+  DEFAULT_RERANK_TOP_N,
+  parseRerankFlag,
+  parseRerankTopN,
+  resolveRerankerConfig,
+  type RerankOverride,
+  type RerankerConfig,
+} from './config/reranker.js';
+import { logger } from './logger.js';
+
+export {
+  DEFAULT_RERANK_MODEL,
+  DEFAULT_RERANK_TOP_N,
+  parseRerankFlag,
+  parseRerankTopN,
+  resolveRerankerConfig,
+  type RerankOverride,
+  type RerankerConfig,
+};
+
+export interface Reranker {
+  id: string;
+  rerank(query: string, candidates: string[]): Promise<number[]>;
+}
+
+export interface RerankableDocument extends Document {
+  score?: number;
+  rerankScore?: number;
+}
+
+export interface RerankScoreCache {
+  get(modelId: string, query: string, candidateText: string): number | null;
+  set(modelId: string, query: string, candidateText: string, score: number): void;
+}
+
+export interface RerankFusedResultsInput<T extends RerankableDocument> {
+  query: string;
+  fused: readonly T[];
+  k: number;
+  topN: number;
+  reranker: Reranker;
+  cache?: RerankScoreCache;
+}
+
+export interface RerankFusedResultsOutput<T extends RerankableDocument> {
+  results: T[];
+  degraded: boolean;
+  degradeReason: string | null;
+  model: string;
+  candidatesIn: number;
+  cacheHits: number;
+  tookMs: number;
+}
+
+export interface ApplyRerankerInput<T extends RerankableDocument> {
+  query: string;
+  results: readonly T[];
+  k: number;
+  override?: RerankOverride;
+  process?: CanonicalProcess;
+  searchMode?: CanonicalSearchMode;
+  kbScope?: string | null;
+}
+
+export class InMemoryRerankScoreCache implements RerankScoreCache {
+  private readonly values = new Map<string, number>();
+
+  constructor(private readonly options: { maxEntries: number } = { maxEntries: 512 }) {}
+
+  get(modelId: string, query: string, candidateText: string): number | null {
+    const key = rerankCacheKey(modelId, query, candidateText);
+    const value = this.values.get(key);
+    if (value === undefined) return null;
+    this.values.delete(key);
+    this.values.set(key, value);
+    return value;
+  }
+
+  set(modelId: string, query: string, candidateText: string, score: number): void {
+    if (this.options.maxEntries <= 0) return;
+    const key = rerankCacheKey(modelId, query, candidateText);
+    if (this.values.has(key)) this.values.delete(key);
+    this.values.set(key, score);
+    while (this.values.size > this.options.maxEntries) {
+      const oldest = this.values.keys().next().value as string | undefined;
+      if (oldest === undefined) break;
+      this.values.delete(oldest);
+    }
+  }
+}
+
+export const globalRerankScoreCache = new InMemoryRerankScoreCache();
+
+const providerCache = new Map<string, Promise<Reranker>>();
+const warnedDegradeReasons = new Set<string>();
+
+type RerankerFactory = (config: RerankerConfig) => Promise<Reranker>;
+
+let rerankerFactory: RerankerFactory = async (config) => TransformersJsReranker.create(config.model);
+
+export function setRerankerFactoryForTests(factory: RerankerFactory | null): () => void {
+  const previous = rerankerFactory;
+  rerankerFactory = factory ?? (async (config) => TransformersJsReranker.create(config.model));
+  providerCache.clear();
+  return () => {
+    rerankerFactory = previous;
+    providerCache.clear();
+  };
+}
+
+export async function getDefaultReranker(config: RerankerConfig): Promise<Reranker> {
+  let promise = providerCache.get(config.model);
+  if (promise === undefined) {
+    promise = rerankerFactory(config);
+    providerCache.set(config.model, promise);
+    promise.catch(() => {
+      if (providerCache.get(config.model) === promise) providerCache.delete(config.model);
+    });
+  }
+  return promise;
+}
+
+export async function applyRerankerIfEnabled<T extends RerankableDocument>(
+  input: ApplyRerankerInput<T>,
+): Promise<RerankFusedResultsOutput<T>> {
+  const config = resolveRerankerConfig(process.env, input.override);
+  if (!config.enabled) {
+    return {
+      results: input.results.slice(0, input.k),
+      degraded: false,
+      degradeReason: null,
+      model: config.model,
+      candidatesIn: 0,
+      cacheHits: 0,
+      tookMs: 0,
+    };
+  }
+
+  const startedAt = Date.now();
+  let out: RerankFusedResultsOutput<T>;
+  try {
+    const reranker = await getDefaultReranker(config);
+    out = await rerankFusedResults({
+      query: input.query,
+      fused: input.results,
+      k: input.k,
+      topN: config.topN,
+      reranker,
+      cache: globalRerankScoreCache,
+    });
+  } catch (err) {
+    out = {
+      results: input.results.slice(0, input.k),
+      degraded: true,
+      degradeReason: (err as Error).message,
+      model: config.model,
+      candidatesIn: Math.min(config.topN, input.results.length),
+      cacheHits: 0,
+      tookMs: Date.now() - startedAt,
+    };
+  }
+
+  if (out.degraded && out.degradeReason !== null) warnOnce(out.degradeReason, out.model);
+  if (input.process !== undefined) {
+    emitRerankStageLog({
+      process: input.process,
+      query: input.query,
+      kbScope: input.kbScope ?? null,
+      searchMode: input.searchMode ?? 'hybrid',
+      output: out,
+    });
+  }
+  return out;
+}
+
+export async function rerankFusedResults<T extends RerankableDocument>(
+  input: RerankFusedResultsInput<T>,
+): Promise<RerankFusedResultsOutput<T>> {
+  const startedAt = Date.now();
+  if (!Number.isInteger(input.k) || input.k < 1) {
+    throw new Error(`rerankFusedResults: invalid k=${input.k}; expected a positive integer`);
+  }
+  if (!Number.isInteger(input.topN) || input.topN < 1) {
+    throw new Error(`rerankFusedResults: invalid topN=${input.topN}; expected a positive integer`);
+  }
+
+  const rerankCount = Math.min(input.topN, input.fused.length);
+  const block = input.fused.slice(0, rerankCount);
+  const tail = input.fused.slice(rerankCount);
+  const scores = new Array<number>(block.length);
+  const misses: Array<{ index: number; text: string }> = [];
+  let cacheHits = 0;
+
+  block.forEach((candidate, index) => {
+    const text = candidate.pageContent;
+    const cached = input.cache?.get(input.reranker.id, input.query, text) ?? null;
+    if (cached === null) {
+      misses.push({ index, text });
+    } else {
+      scores[index] = cached;
+      cacheHits += 1;
+    }
+  });
+
+  try {
+    if (misses.length > 0) {
+      const freshScores = await input.reranker.rerank(input.query, misses.map((m) => m.text));
+      if (freshScores.length !== misses.length) {
+        throw new Error(`reranker returned wrong-length score array: expected ${misses.length} scores, got ${freshScores.length}`);
+      }
+      freshScores.forEach((score, idx) => {
+        if (!Number.isFinite(score)) {
+          throw new Error(`reranker returned non-finite score at index ${idx}`);
+        }
+        const miss = misses[idx];
+        scores[miss.index] = score;
+        input.cache?.set(input.reranker.id, input.query, miss.text, score);
+      });
+    }
+  } catch (err) {
+    return {
+      results: input.fused.slice(0, input.k) as T[],
+      degraded: true,
+      degradeReason: (err as Error).message,
+      model: input.reranker.id,
+      candidatesIn: rerankCount,
+      cacheHits,
+      tookMs: Date.now() - startedAt,
+    };
+  }
+
+  const reranked = block
+    .map((candidate, index) => ({
+      candidate: { ...candidate, rerankScore: scores[index] } as T,
+      originalIndex: index,
+    }))
+    .sort((a, b) => {
+      const byScore = (b.candidate.rerankScore as number) - (a.candidate.rerankScore as number);
+      return byScore !== 0 ? byScore : a.originalIndex - b.originalIndex;
+    })
+    .map((entry) => entry.candidate);
+
+  return {
+    results: [...reranked, ...tail].slice(0, input.k) as T[],
+    degraded: false,
+    degradeReason: null,
+    model: input.reranker.id,
+    candidatesIn: rerankCount,
+    cacheHits,
+    tookMs: Date.now() - startedAt,
+  };
+}
+
+export function emitRerankStageLog<T extends RerankableDocument>(input: {
+  process: CanonicalProcess;
+  query: string;
+  kbScope: string | null;
+  searchMode: CanonicalSearchMode;
+  output: RerankFusedResultsOutput<T>;
+}): void {
+  emitCanonicalLog({
+    process: input.process,
+    tool: input.process === 'mcp' ? 'rerank.stage' : undefined,
+    cmd: input.process === 'cli' ? 'rerank.stage' : undefined,
+    query: input.query,
+    kb_scope: input.kbScope,
+    search_mode: input.searchMode,
+    result_count: input.output.results.length,
+    took_ms: input.output.tookMs,
+    rerank: {
+      model: input.output.model,
+      candidates_in: input.output.candidatesIn,
+      cache_hits: input.output.cacheHits,
+      degraded: input.output.degraded,
+      degrade_reason: input.output.degradeReason,
+    },
+  });
+}
+
+function warnOnce(reason: string, model: string): void {
+  const key = `${model}:${reason}`;
+  if (warnedDegradeReasons.has(key)) return;
+  warnedDegradeReasons.add(key);
+  logger.warn(`reranker ${model} degraded to fused order: ${reason}`);
+}
+
+function normalizeQuery(query: string): string {
+  return query.trim().replace(/\s+/g, ' ').toLowerCase();
+}
+
+function rerankCacheKey(modelId: string, query: string, candidateText: string): string {
+  return createHash('sha256')
+    .update(modelId)
+    .update('\0')
+    .update(normalizeQuery(query))
+    .update('\0')
+    .update(createHash('sha256').update(candidateText, 'utf-8').digest('hex'))
+    .digest('hex');
+}
+
+interface TransformersModule {
+  AutoTokenizer: {
+    from_pretrained(model: string): Promise<Tokenizer>;
+  };
+  AutoModelForSequenceClassification: {
+    from_pretrained(model: string, options?: Record<string, unknown>): Promise<SequenceClassificationModel>;
+  };
+}
+
+type Tokenizer = (
+  text: string[],
+  options: {
+    text_pair: string[];
+    padding: boolean;
+    truncation: boolean;
+  },
+) => unknown;
+
+type SequenceClassificationModel = ((inputs: unknown) => Promise<SequenceClassifierOutput>) & {
+  config?: SequenceClassifierConfig;
+};
+
+interface SequenceClassifierOutput {
+  logits?: {
+    data?: ArrayLike<number>;
+    dims?: number[];
+  };
+}
+
+interface SequenceClassifierConfig {
+  id2label?: Record<string, string>;
+  label2id?: Record<string, number>;
+}
+
+class TransformersJsReranker implements Reranker {
+  private constructor(
+    readonly id: string,
+    private readonly tokenizer: Tokenizer,
+    private readonly model: SequenceClassificationModel,
+  ) {}
+
+  static async create(model: string): Promise<TransformersJsReranker> {
+    const mod = await import('@huggingface/transformers') as unknown as TransformersModule;
+    const [tokenizer, classifier] = await Promise.all([
+      mod.AutoTokenizer.from_pretrained(model),
+      mod.AutoModelForSequenceClassification.from_pretrained(model, { quantized: true }),
+    ]);
+    return new TransformersJsReranker(model, tokenizer, classifier);
+  }
+
+  async rerank(query: string, candidates: string[]): Promise<number[]> {
+    if (candidates.length === 0) return [];
+    const inputs = this.tokenizer(
+      candidates.map(() => query),
+      {
+        text_pair: candidates,
+        padding: true,
+        truncation: true,
+      },
+    );
+    const output = await this.model(inputs);
+    return scoresFromSequenceClassifierOutput(output, this.model.config);
+  }
+}
+
+export function scoresFromSequenceClassifierOutput(
+  output: SequenceClassifierOutput,
+  config: SequenceClassifierConfig = {},
+): number[] {
+  const logits = output.logits;
+  const data = logits?.data;
+  const dims = logits?.dims;
+  if (data === undefined || dims === undefined || dims.length < 2) {
+    throw new Error('reranker returned unparseable logits');
+  }
+
+  const batchSize = dims[0];
+  const labelCount = dims[dims.length - 1];
+  if (!Number.isInteger(batchSize) || batchSize < 1 || !Number.isInteger(labelCount) || labelCount < 1) {
+    throw new Error(`reranker returned invalid logits shape: ${JSON.stringify(dims)}`);
+  }
+  if (data.length !== batchSize * labelCount) {
+    throw new Error(`reranker returned logits shape ${JSON.stringify(dims)} but data length ${data.length}`);
+  }
+
+  const scores: number[] = [];
+  const positiveLabelIndex = labelCount === 1 ? 0 : findPositiveLabelIndex(config, labelCount);
+  for (let batchIndex = 0; batchIndex < batchSize; batchIndex += 1) {
+    const row = Array.from(
+      { length: labelCount },
+      (_, labelIndex) => Number(data[batchIndex * labelCount + labelIndex]),
+    );
+    if (!row.every(Number.isFinite)) {
+      throw new Error(`reranker returned non-finite logits at batch index ${batchIndex}`);
+    }
+    scores.push(labelCount === 1 ? row[0] : softmax(row)[positiveLabelIndex]);
+  }
+  return scores;
+}
+
+function findPositiveLabelIndex(config: SequenceClassifierConfig, labelCount: number): number {
+  for (const [label, index] of Object.entries(config.label2id ?? {})) {
+    if (index >= 0 && index < labelCount && isPositiveLabel(label)) return index;
+  }
+  for (const [rawIndex, label] of Object.entries(config.id2label ?? {})) {
+    const index = Number(rawIndex);
+    if (Number.isInteger(index) && index >= 0 && index < labelCount && isPositiveLabel(label)) return index;
+  }
+  return labelCount === 2 ? 1 : labelCount - 1;
+}
+
+function isPositiveLabel(label: string): boolean {
+  return /^(positive|relevant|entailment|true|yes|label_1|1)$/i.test(label.trim());
+}
+
+function softmax(values: number[]): number[] {
+  const maxValue = Math.max(...values);
+  const exps = values.map((value) => Math.exp(value - maxValue));
+  const sum = exps.reduce((acc, value) => acc + value, 0);
+  return exps.map((value) => value / sum);
+}

--- a/src/retrieval-eval.test.ts
+++ b/src/retrieval-eval.test.ts
@@ -10,11 +10,13 @@ import {
   evaluateRetrievalCase,
   formatRetrievalEvalMarkdown,
   normalizeRetrievalEvalFixture,
+  retrieveForRetrievalEvalCase,
   retrievalEvalExitCode,
   resolveRetrievalEvalMode,
   summarizeRetrievalEval,
   type RetrievalEvalCase,
 } from './retrieval-eval.js';
+import { setRerankerFactoryForTests } from './reranker.js';
 
 const FRESH: Staleness = { indexMtime: '2026-05-09T08:00:00.000Z', modifiedFiles: 0, newFiles: 0 };
 const STALE: Staleness = { indexMtime: '2026-05-09T08:00:00.000Z', modifiedFiles: 1, newFiles: 0 };
@@ -308,6 +310,54 @@ describe('resolveRetrievalEvalMode', () => {
       effectiveMode: 'hybrid',
       autoMode: { mode: 'hybrid', reason: 'constant or error-code token' },
     });
+  });
+});
+
+describe('retrieveForRetrievalEvalCase', () => {
+  it('reranks the hybrid runtime path before returning eval results', async () => {
+    const previousRerank = process.env.KB_RERANK;
+    const previousTopN = process.env.KB_RERANK_TOP_N;
+    process.env.KB_RERANK = 'on';
+    process.env.KB_RERANK_TOP_N = '2';
+    const restoreFactory = setRerankerFactoryForTests(async () => ({
+      id: 'stub-reranker',
+      rerank: async (_query, candidates) =>
+        candidates.map((candidate) => (candidate.includes('winner') ? 5 : 0)),
+    }));
+
+    try {
+      const result = await retrieveForRetrievalEvalCase(
+        fixtureCase({ k: 1, query: 'deployment winner' }),
+        {
+          defaultK: 10,
+          defaultThreshold: 2,
+          manager: {
+            similaritySearch: async () => [
+              {
+                pageContent: 'content from /kb/dense-loser.md',
+                metadata: { source: '/kb/dense-loser.md', relativePath: '/kb/dense-loser.md' },
+                score: 0.1,
+              },
+            ],
+          },
+          retrieveLexical: async () => [
+            doc('/kb/lexical-winner.md', 10),
+          ],
+        },
+        'hybrid',
+      );
+
+      expect(result.effectiveMode).toBe('hybrid');
+      expect(result.results).toHaveLength(1);
+      expect(result.results[0].metadata.source).toBe('/kb/lexical-winner.md');
+      expect(result.results[0].rerankScore).toBe(5);
+    } finally {
+      restoreFactory();
+      if (previousRerank === undefined) delete process.env.KB_RERANK;
+      else process.env.KB_RERANK = previousRerank;
+      if (previousTopN === undefined) delete process.env.KB_RERANK_TOP_N;
+      else process.env.KB_RERANK_TOP_N = previousTopN;
+    }
   });
 });
 

--- a/src/retrieval-eval.ts
+++ b/src/retrieval-eval.ts
@@ -14,6 +14,7 @@ import {
   hybridFetchK,
   listLexicalKbs,
 } from './hybrid-retrieval.js';
+import { applyRerankerIfEnabled, resolveRerankerConfig } from './reranker.js';
 
 export type StalePolicy = 'allow_stale' | 'fresh' | 'stale';
 
@@ -171,6 +172,7 @@ export interface RetrievalEvalSearchContext {
   manager: Pick<FaissIndexManager, 'similaritySearch'>;
   defaultK: number;
   defaultThreshold: number;
+  retrieveLexical?: (query: string, k: number, scopedKb?: string) => Promise<ScoredDocument[]>;
 }
 
 export interface RetrievalEvalSearchResult {
@@ -272,7 +274,7 @@ export async function retrieveForRetrievalEvalCase(
   if (mode.effectiveMode === 'dense') {
     results = await retrieveDense(fixtureCase, context);
   } else if (mode.effectiveMode === 'lexical') {
-    results = await retrieveLexical(
+    results = await (context.retrieveLexical ?? retrieveLexical)(
       fixtureCase.query,
       fixtureCase.k ?? context.defaultK,
       fixtureCase.kb,
@@ -573,6 +575,7 @@ async function retrieveHybrid(
 ): Promise<ScoredDocument[]> {
   const k = fixtureCase.k ?? context.defaultK;
   const fetchK = hybridFetchK(k);
+  const retrieveLexicalFn = context.retrieveLexical ?? retrieveLexical;
   const [denseResults, lexicalResults] = await Promise.all([
     context.manager.similaritySearch(
       fixtureCase.query,
@@ -580,13 +583,21 @@ async function retrieveHybrid(
       Number.POSITIVE_INFINITY,
       fixtureCase.kb,
     ),
-    retrieveLexical(fixtureCase.query, fetchK, fixtureCase.kb),
+    retrieveLexicalFn(fixtureCase.query, fetchK, fixtureCase.kb),
   ]);
-  return fuseHybridResults({
+  const rerankConfig = resolveRerankerConfig();
+  const fused = fuseHybridResults({
     denseResults,
     lexicalResults,
-    k,
+    k: rerankConfig.enabled ? Math.max(k, rerankConfig.topN) : k,
   });
+  const reranked = await applyRerankerIfEnabled({
+    query: fixtureCase.query,
+    results: fused,
+    k,
+    searchMode: 'hybrid',
+  });
+  return reranked.results;
 }
 
 function toScoredDocument(result: LexicalSearchResult): ScoredDocument {


### PR DESCRIPTION
## Summary

- Implements RFC 019 as an opt-in hybrid reranker: `KB_RERANK`, per-call CLI/MCP overrides, Transformers.js cross-encoder provider, score cache, canonical `rerank.stage`, and JSON/markdown/timing surfaces.
- Wires reranking before the RFC 018 relevance gate across `kb search --mode=hybrid`, MCP `retrieve_knowledge`, and `kb eval`.
- Adds `kb doctor` reranker readiness, JSON contract/docs/requirements updates, and an M0b eval report.

## M0b Result

The corrected cross-encoder path improved the operating-environment canary slightly but not enough to justify default-on:

- nDCG@10: `0.8772228201007499` -> `0.8827007889556063` (`+0.005477968854856408`)
- MRR@10: `0.8375` -> `0.84375` (`+0.00625`)
- MAP@k: `0.8375` -> `0.84375` (`+0.00625`)
- Live smoke top result was correct, but cold CLI rerank latency was ~3.3s, so `KB_RERANK` remains default-off.

## Verification

- `npm run build`
- `npx jest src/reranker.test.ts src/config/reranker.test.ts src/cli-search.test.ts src/KnowledgeBaseServer.test.ts src/retrieval-eval.test.ts src/cli-doctor.test.ts --runInBand` — 6 suites, 196 tests
- `npm test` — 101 suites, 1783 passing, 4 skipped, 1 todo
- `npx jest src/retrieval-eval.test.ts src/retrieval-eval-dogfood.test.ts --runInBand` — 2 suites, 41 tests after final fixture-doc amendment
- Live eval off/on for `docs/testing/fixtures/rfc-019-reranker-eval.yml`
- Live smoke: `KB_RERANK=on node build/cli.js search ... --mode=hybrid --format=json --timing --no-freshness`
- `git diff --check`
- Added-line portability scan
- Pre-PR specialist reviews: correctness, tests, conventions, dead code all pass

Closes #374.
Closes #375.
