### PR TITLE
fix: classify hybrid reranker config errors

### DIFF
--- a/src/KnowledgeBaseServer.test.ts
+++ b/src/KnowledgeBaseServer.test.ts
@@ -1198,6 +1198,32 @@ describe('KnowledgeBaseServer handlers', () => {
     }
   });
 
+  it('handleRetrieveKnowledge reports malformed hybrid reranker config with a stable code', async () => {
+    const tempDir = await setRetrieveEnv();
+    await fsp.mkdir(path.join(tempDir, 'alpha'), { recursive: true });
+    await fsp.writeFile(path.join(tempDir, 'alpha', 'doc.md'), 'Alpha content');
+    process.env.KB_RERANK = 'on';
+    process.env.KB_RERANK_TOP_N = 'nope';
+    updateIndexMock.mockResolvedValue(undefined);
+    similaritySearchMock.mockResolvedValue([
+      { pageContent: 'Alpha content', metadata: { source: '/kb/a.md', chunkIndex: 0 }, score: 0.2 },
+    ]);
+
+    const server = await freshServer();
+    const result = await server['handleRetrieveKnowledge']({
+      query: 'what is alpha',
+      knowledge_base_name: 'alpha',
+      search_mode: 'hybrid',
+    });
+
+    expect(result.isError).toBe(true);
+    const payload = JSON.parse(result.content[0].text);
+    expect(payload.error).toMatchObject({
+      code: 'RERANK_CONFIG_INVALID',
+      message: 'invalid KB_RERANK_TOP_N="nope" (expected integer 1-1000)',
+    });
+  });
+
   it('handleRetrieveKnowledge emits one canonical event with redacted query and result fields (#216)', async () => {
     const tempDir = await setRetrieveEnv();
     const logFile = path.join(tempDir, 'canonical.log');

--- a/src/KnowledgeBaseServer.ts
+++ b/src/KnowledgeBaseServer.ts
@@ -101,6 +101,7 @@ import type { RelevanceGateVerdict } from './relevance-gate-schema.js';
 import { chunkIdFromMetadata } from './rrf.js';
 import {
   applyRerankerIfEnabled,
+  RerankerConfigError,
   resolveRerankerConfig,
   type RerankOverride,
 } from './reranker.js';
@@ -109,7 +110,11 @@ const SERVER_NAME = 'knowledge-base-server';
 const SERVER_VERSION = '0.1.0';
 
 function mcpErrorContent(error: Error): TextContent {
-  const code: KBErrorCode = error instanceof KBError ? error.code : 'INTERNAL';
+  const code = error instanceof KBError
+    ? error.code
+    : error instanceof RerankerConfigError
+      ? error.code
+      : 'INTERNAL';
   return {
     type: 'text',
     text: JSON.stringify({
@@ -773,6 +778,7 @@ export class KnowledgeBaseServer {
         results: ranked,
         k: HYBRID_TOP_K,
         override: rerankOverride,
+        config: rerankConfig,
         process: 'mcp',
         searchMode: 'hybrid',
         kbScope: knowledgeBaseName ?? null,

--- a/src/cli-search.test.ts
+++ b/src/cli-search.test.ts
@@ -291,6 +291,47 @@ describe('runSearch timing guard (#331)', () => {
     }
   });
 
+  it('reports malformed hybrid reranker config as a structured search failure', async () => {
+    const manager = {
+      modelDir: '/tmp/kb-test-model',
+      initialize: jest.fn(async () => {}),
+      updateIndex: jest.fn(async () => {}),
+      similaritySearch: jest.fn(async () => []),
+    } as unknown as FaissIndexManager & { similaritySearch: jest.Mock };
+    const deps: RunSearchDeps = {
+      bootstrapLayout: jest.fn(async () => {}),
+      resolveActiveModel: jest.fn(async () => 'ollama__nomic-embed-text-latest'),
+      loadManagerForModel: jest.fn(async () => manager),
+      loadWithJsonRetry: jest.fn(async () => {}),
+      listLexicalKbs: jest.fn(async () => [{ kbName: 'alpha', kbPath: '/kb/alpha' }]),
+      runLexicalLeg: jest.fn(async () => ({
+        refreshed: 0,
+        failed: 0,
+        hits: [],
+      })),
+    };
+    const previousRerank = process.env.KB_RERANK;
+    const previousTopN = process.env.KB_RERANK_TOP_N;
+    process.env.KB_RERANK = 'on';
+    process.env.KB_RERANK_TOP_N = 'nope';
+
+    try {
+      const out = await captureSearchOutput(['query', '--mode=hybrid', '--no-freshness'], deps);
+
+      expect(out.code).toBe(2);
+      expect(out.stdout).toBe('');
+      expect(out.stderr).toContain('kb search: invalid KB_RERANK_TOP_N="nope"');
+      expect(out.stderr).toContain('category: configuration (code: RERANK_CONFIG_INVALID)');
+      expect(out.stderr).toContain('kb doctor');
+      expect(deps.runLexicalLeg).toHaveBeenCalledTimes(1);
+    } finally {
+      if (previousRerank === undefined) delete process.env.KB_RERANK;
+      else process.env.KB_RERANK = previousRerank;
+      if (previousTopN === undefined) delete process.env.KB_RERANK_TOP_N;
+      else process.env.KB_RERANK_TOP_N = previousTopN;
+    }
+  });
+
   it('reranks the hybrid runtime path before emitting JSON results', async () => {
     const manager = {
       modelDir: '/tmp/kb-test-model',

--- a/src/cli-search.ts
+++ b/src/cli-search.ts
@@ -72,6 +72,7 @@ import {
   parseRerankFlag,
   resolveRerankerConfig,
   type RerankOverride,
+  type RerankerConfig,
 } from './reranker.js';
 import {
   inspectTaskContext,
@@ -1335,7 +1336,12 @@ async function runHybridSearch(
 
   // -- fuse ----------------------------------------------------------------
   const fusionStartedAt = nowMs();
-  const rerankConfig = resolveRerankerConfig(process.env, parsed.rerankOverride);
+  let rerankConfig: RerankerConfig;
+  try {
+    rerankConfig = resolveRerankerConfig(process.env, parsed.rerankOverride);
+  } catch (err) {
+    return reportFailure(classifyKbSearchError(err), parsed.format);
+  }
   const fusionK = rerankConfig.enabled ? Math.max(parsed.k, rerankConfig.topN) : parsed.k;
   const fusion = fuseHybridResultsWithDiagnostics({
     denseResults,
@@ -1349,6 +1355,7 @@ async function runHybridSearch(
     results: ranked,
     k: parsed.k,
     override: parsed.rerankOverride,
+    config: rerankConfig,
     process: 'cli',
     searchMode: 'hybrid',
     kbScope: parsed.kb ?? null,

--- a/src/config/reranker.ts
+++ b/src/config/reranker.ts
@@ -17,23 +17,32 @@ export interface RerankerEnv {
   KB_RERANK_TOP_N?: string;
 }
 
+export class RerankerConfigError extends Error {
+  readonly code = 'RERANK_CONFIG_INVALID';
+
+  constructor(message: string) {
+    super(message);
+    this.name = 'RerankerConfigError';
+  }
+}
+
 export function parseRerankFlag(raw: string | undefined): boolean {
   if (raw === undefined || raw.trim() === '') return false;
   const value = raw.trim().toLowerCase();
   if (value === 'on' || value === 'true' || value === '1') return true;
   if (value === 'off' || value === 'false' || value === '0') return false;
-  throw new Error(`invalid KB_RERANK=${JSON.stringify(raw)} (expected on/off, true/false, or 1/0)`);
+  throw new RerankerConfigError(`invalid KB_RERANK=${JSON.stringify(raw)} (expected on/off, true/false, or 1/0)`);
 }
 
 export function parseRerankTopN(raw: string | undefined): number {
   if (raw === undefined || raw.trim() === '') return DEFAULT_RERANK_TOP_N;
   const trimmed = raw.trim();
   if (!/^\d+$/.test(trimmed)) {
-    throw new Error(`invalid KB_RERANK_TOP_N=${JSON.stringify(raw)} (expected integer 1-${MAX_RERANK_TOP_N})`);
+    throw new RerankerConfigError(`invalid KB_RERANK_TOP_N=${JSON.stringify(raw)} (expected integer 1-${MAX_RERANK_TOP_N})`);
   }
   const value = Number(trimmed);
   if (!Number.isInteger(value) || value < 1 || value > MAX_RERANK_TOP_N) {
-    throw new Error(`invalid KB_RERANK_TOP_N=${JSON.stringify(raw)} (expected integer 1-${MAX_RERANK_TOP_N})`);
+    throw new RerankerConfigError(`invalid KB_RERANK_TOP_N=${JSON.stringify(raw)} (expected integer 1-${MAX_RERANK_TOP_N})`);
   }
   return value;
 }

--- a/src/reranker.ts
+++ b/src/reranker.ts
@@ -7,6 +7,7 @@ import {
   parseRerankFlag,
   parseRerankTopN,
   resolveRerankerConfig,
+  RerankerConfigError,
   type RerankOverride,
   type RerankerConfig,
 } from './config/reranker.js';
@@ -18,6 +19,7 @@ export {
   parseRerankFlag,
   parseRerankTopN,
   resolveRerankerConfig,
+  RerankerConfigError,
   type RerankOverride,
   type RerankerConfig,
 };
@@ -61,6 +63,7 @@ export interface ApplyRerankerInput<T extends RerankableDocument> {
   results: readonly T[];
   k: number;
   override?: RerankOverride;
+  config?: RerankerConfig;
   process?: CanonicalProcess;
   searchMode?: CanonicalSearchMode;
   kbScope?: string | null;
@@ -127,7 +130,7 @@ export async function getDefaultReranker(config: RerankerConfig): Promise<Rerank
 export async function applyRerankerIfEnabled<T extends RerankableDocument>(
   input: ApplyRerankerInput<T>,
 ): Promise<RerankFusedResultsOutput<T>> {
-  const config = resolveRerankerConfig(process.env, input.override);
+  const config = input.config ?? resolveRerankerConfig(process.env, input.override);
   if (!config.enabled) {
     return {
       results: input.results.slice(0, input.k),

--- a/src/search-errors-core.ts
+++ b/src/search-errors-core.ts
@@ -15,6 +15,7 @@
 
 import { ActiveModelResolutionError } from './active-model.js';
 import { KBError, type KBErrorCode } from './errors.js';
+import { RerankerConfigError } from './config/reranker.js';
 import { WriteLockContentionError } from './write-lock.js';
 
 export type SearchFailureCategory =
@@ -64,6 +65,16 @@ export function classifyKbSearchError(err: unknown): SearchFailure {
       next_action:
         'Run `kb models list` to see registered models, then `kb models add <provider> <model>` or ' +
         '`kb models set-active <id>` to make one active. `kb doctor` shows the current resolution state.',
+    };
+  }
+
+  if (err instanceof RerankerConfigError) {
+    return {
+      code: err.code,
+      category: 'configuration',
+      message: err.message,
+      next_action:
+        'Fix KB_RERANK and KB_RERANK_TOP_N, or pass `--no-rerank` for this search. `kb doctor` reports reranker configuration.',
     };
   }
 


### PR DESCRIPTION
## Summary
- classify malformed reranker env config with a stable `RERANK_CONFIG_INVALID` code
- route hybrid CLI config parse failures through the structured `kb search` failure path
- preserve the parsed reranker config when applying CLI/MCP reranking so the env is not parsed twice
- preserve the same stable code in the MCP error envelope

## Review
- Pre-PR specialist review run: conventions no findings, dead-code no findings
- Correctness/test findings identified missing MCP invalid-config coverage; addressed before PR creation

## Verification
- `npm test -- --runTestsByPath src/KnowledgeBaseServer.test.ts --testNamePattern "malformed hybrid reranker config"`
- `npm test -- --runTestsByPath src/cli-search.test.ts src/config/reranker.test.ts src/search-errors-core.test.ts`
- `npm run build`

## Notes
- Full `npm test` was attempted before the MCP follow-up and hit unrelated existing 5s timeouts in `src/cli.test.ts`, `src/KnowledgeBaseServer.test.ts`, and `src/triggerWatcher.test.ts`; focused regression coverage and build passed.