### PR TITLE
feat: add relevance feedback ledger

### DIFF
--- a/src/cli-feedback.test.ts
+++ b/src/cli-feedback.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from '@jest/globals';
+import { parseFeedbackArgs } from './cli-feedback.js';
+
+describe('parseFeedbackArgs', () => {
+  it('parses add, list, and promote modes', () => {
+    expect(parseFeedbackArgs([
+      'add',
+      '--kb=ops',
+      '--query=rollback',
+      '--source=runbooks/deploy.md',
+      '--verdict=relevant',
+      '--relevance=2',
+      '--group=procedure',
+      '--format=json',
+    ])).toMatchObject({
+      action: 'add',
+      kb: 'ops',
+      query: 'rollback',
+      source: 'runbooks/deploy.md',
+      verdict: 'relevant',
+      relevance: 2,
+      groups: ['procedure'],
+      format: 'json',
+    });
+
+    expect(parseFeedbackArgs(['list', '--kb=ops', '--limit=10'])).toMatchObject({
+      action: 'list',
+      limit: 10,
+    });
+
+    expect(parseFeedbackArgs([
+      'promote',
+      '--kb=ops',
+      '--query=rollback',
+      '--fixture=eval.yml',
+      '--yes',
+      '--gate',
+    ])).toMatchObject({
+      action: 'promote',
+      fixture: 'eval.yml',
+      yes: true,
+      gate: true,
+    });
+  });
+
+  it('requires explicit confirmation before promote writes a fixture', () => {
+    expect(() => parseFeedbackArgs([
+      'promote',
+      '--kb=ops',
+      '--query=rollback',
+      '--fixture=eval.yml',
+    ])).toThrow('--fixture=<path> requires --yes');
+  });
+});

--- a/src/cli-feedback.ts
+++ b/src/cli-feedback.ts
@@ -1,0 +1,355 @@
+import * as path from 'path';
+import {
+  appendFeedbackEntry,
+  appendPromotedCaseToFixtureFile,
+  buildPromotedEvalFixture,
+  dumpPromotedEvalFixture,
+  feedbackLedgerPath,
+  readFeedbackLedger,
+  type FeedbackLedgerEntry,
+  type FeedbackVerdict,
+  type PromotedFixture,
+} from './feedback-ledger.js';
+import { KNOWLEDGE_BASES_ROOT_DIR } from './config/paths.js';
+import { resolveKnowledgeBaseDir } from './kb-fs.js';
+import type { SearchMode } from './search-core.js';
+
+type FeedbackArgs = FeedbackAddArgs | FeedbackListArgs | FeedbackPromoteArgs;
+
+interface FeedbackBaseArgs {
+  action: 'add' | 'list' | 'promote';
+  kb: string;
+  format: 'md' | 'json';
+}
+
+interface FeedbackAddArgs extends FeedbackBaseArgs {
+  action: 'add';
+  query: string;
+  source: string;
+  verdict?: FeedbackVerdict;
+  relevance?: number;
+  chunkId?: string;
+  taskContext?: string;
+  note?: string;
+  groups: string[];
+}
+
+interface FeedbackListArgs extends FeedbackBaseArgs {
+  action: 'list';
+  query?: string;
+  limit: number;
+}
+
+interface FeedbackPromoteArgs extends FeedbackBaseArgs {
+  action: 'promote';
+  query: string;
+  name?: string;
+  k?: number;
+  mode?: SearchMode;
+  gate?: boolean;
+  fixture?: string;
+  yes: boolean;
+}
+
+const DEFAULT_LIST_LIMIT = 50;
+
+export const FEEDBACK_HELP = `kb feedback — record relevance judgments and promote them to eval fixtures
+
+Usage:
+  kb feedback add --kb=<name> --query=<query> --source=<rel-path>
+                  [--chunk-id=<id>] [--verdict=relevant|irrelevant|stale|misleading]
+                  [--relevance=<0..3>] [--task-context=<text>] [--note=<text>]
+                  [--group=<label>]... [--format=md|json]
+  kb feedback list --kb=<name> [--query=<query>] [--limit=<int>] [--format=md|json]
+  kb feedback promote --kb=<name> --query=<query> [--name=<case-name>]
+                      [--k=<int>] [--mode=dense|lexical|hybrid|auto] [--gate]
+                      [--fixture=<path> --yes] [--format=md|json]
+
+Records human or agent judgments in <kb>/.index/relevance-feedback.jsonl.
+\`promote\` converts all rows for one query into a \`kb eval\` fixture case.
+Without \`--fixture --yes\`, promote is read-only and prints YAML to stdout.
+
+Options:
+  --kb=<name>            Knowledge base under KNOWLEDGE_BASES_ROOT_DIR.
+  --query=<query>        Search query the judgment applies to.
+  --source=<rel-path>    KB-relative source/result path to judge.
+  --chunk-id=<id>        Optional result chunk id from kb search JSON/Markdown.
+  --verdict=<value>      relevant, irrelevant, stale, or misleading
+                         (default: relevant unless --relevance=0).
+  --relevance=<0..3>     Graded relevance for eval metrics. Non-relevant
+                         verdicts default to 0; relevant defaults to 3.
+  --task-context=<text>  Hashed with SHA-256 before storage.
+  --note=<text>          Short reviewer note stored in the ledger.
+  --group=<label>        Intent/group label for diversity metrics. Repeatable.
+  --limit=<int>          Max rows for list output (default ${DEFAULT_LIST_LIMIT}).
+  --name=<case-name>     Eval case name for promote.
+  --k=<int>              Optional eval case K.
+  --mode=<mode>          Optional eval retrieval mode.
+  --gate                 Mark the promoted case as gated.
+  --fixture=<path>       YAML fixture file to append to. Requires --yes.
+  --yes                  Required before promote writes --fixture.
+  --format=md|json       Output format (default md).
+  --help, -h             Show this help.
+`;
+
+export async function runFeedback(rest: string[]): Promise<number> {
+  let parsed: FeedbackArgs;
+  try {
+    parsed = parseFeedbackArgs(rest);
+  } catch (err) {
+    process.stderr.write(`kb feedback: ${(err as Error).message}\n`);
+    return 2;
+  }
+
+  let kbDir: string;
+  try {
+    kbDir = await resolveKnowledgeBaseDir(KNOWLEDGE_BASES_ROOT_DIR, parsed.kb);
+  } catch (err) {
+    process.stderr.write(`kb feedback: ${(err as Error).message}\n`);
+    return 2;
+  }
+
+  try {
+    if (parsed.action === 'add') {
+      const entry = await appendFeedbackEntry(kbDir, parsed);
+      writeFeedbackAddResult(entry, feedbackLedgerPath(kbDir), parsed.format);
+      return 0;
+    }
+    if (parsed.action === 'list') {
+      const entries = (await readFeedbackLedger(kbDir))
+        .filter((entry) => parsed.query === undefined || entry.query === parsed.query)
+        .sort((a, b) => b.created_at.localeCompare(a.created_at))
+        .slice(0, parsed.limit);
+      writeFeedbackListResult(entries, feedbackLedgerPath(kbDir), parsed.format);
+      return 0;
+    }
+
+    const entries = await readFeedbackLedger(kbDir);
+    const fixture = buildPromotedEvalFixture(entries, parsed);
+    if (parsed.fixture !== undefined && parsed.yes) {
+      const result = await appendPromotedCaseToFixtureFile(parsed.fixture, fixture);
+      writeFeedbackPromoteWriteResult(parsed, result, parsed.format);
+    } else {
+      writeFeedbackPromotePreview(parsed, fixture, parsed.format);
+    }
+    return 0;
+  } catch (err) {
+    process.stderr.write(`kb feedback: ${(err as Error).message}\n`);
+    return 1;
+  }
+}
+
+export function parseFeedbackArgs(rest: string[]): FeedbackArgs {
+  const action = rest[0];
+  if (action !== 'add' && action !== 'list' && action !== 'promote') {
+    throw new Error('missing action: add, list, or promote');
+  }
+
+  const base = parseCommonArgs(action, rest.slice(1));
+  if (base.kb.length === 0) throw new Error('missing --kb=<name>');
+
+  if (action === 'add') {
+    const out = base as FeedbackAddArgs;
+    if (out.query === undefined) throw new Error('add requires --query=<query>');
+    if (out.source === undefined) throw new Error('add requires --source=<rel-path>');
+    return out;
+  }
+  if (action === 'list') {
+    return base as FeedbackListArgs;
+  }
+
+  const out = base as FeedbackPromoteArgs;
+  if (out.query === undefined) throw new Error('promote requires --query=<query>');
+  if (out.fixture !== undefined && !out.yes) throw new Error('--fixture=<path> requires --yes to write');
+  if (out.fixture === undefined && out.yes) throw new Error('--yes requires --fixture=<path>');
+  return out;
+}
+
+function parseCommonArgs(action: FeedbackArgs['action'], args: readonly string[]): FeedbackArgs {
+  const base: FeedbackBaseArgs = { action, kb: '', format: 'md' };
+  const out: Record<string, unknown> = {
+    ...base,
+    ...(action === 'add' ? { groups: [] } : {}),
+    ...(action === 'list' ? { limit: DEFAULT_LIST_LIMIT } : {}),
+    ...(action === 'promote' ? { yes: false } : {}),
+  };
+
+  for (const raw of args) {
+    if (raw.startsWith('--kb=')) { out.kb = nonEmptyValue(raw, '--kb='); continue; }
+    if (raw.startsWith('--query=')) { out.query = nonEmptyValue(raw, '--query='); continue; }
+    if (raw.startsWith('--format=')) {
+      const value = nonEmptyValue(raw, '--format=');
+      if (value !== 'md' && value !== 'json') throw new Error(`invalid --format: ${raw}`);
+      out.format = value;
+      continue;
+    }
+    if (action === 'add' && raw.startsWith('--source=')) {
+      out.source = nonEmptyValue(raw, '--source=');
+      continue;
+    }
+    if (action === 'add' && raw.startsWith('--chunk-id=')) {
+      out.chunkId = nonEmptyValue(raw, '--chunk-id=');
+      continue;
+    }
+    if (action === 'add' && raw.startsWith('--verdict=')) {
+      out.verdict = parseVerdict(nonEmptyValue(raw, '--verdict='));
+      continue;
+    }
+    if (action === 'add' && raw.startsWith('--relevance=')) {
+      out.relevance = parseBoundedNumber(raw, '--relevance=', 0, 3);
+      continue;
+    }
+    if (action === 'add' && raw.startsWith('--task-context=')) {
+      out.taskContext = nonEmptyValue(raw, '--task-context=');
+      continue;
+    }
+    if (action === 'add' && raw.startsWith('--note=')) {
+      out.note = nonEmptyValue(raw, '--note=');
+      continue;
+    }
+    if (action === 'add' && raw.startsWith('--group=')) {
+      (out.groups as string[]).push(nonEmptyValue(raw, '--group='));
+      continue;
+    }
+    if (action === 'list' && raw.startsWith('--limit=')) {
+      const value = Number(nonEmptyValue(raw, '--limit='));
+      if (!Number.isInteger(value) || value <= 0) throw new Error(`invalid --limit: ${raw}`);
+      out.limit = value;
+      continue;
+    }
+    if (action === 'promote' && raw.startsWith('--name=')) {
+      out.name = nonEmptyValue(raw, '--name=');
+      continue;
+    }
+    if (action === 'promote' && raw.startsWith('--k=')) {
+      const value = Number(nonEmptyValue(raw, '--k='));
+      if (!Number.isInteger(value) || value <= 0) throw new Error(`invalid --k: ${raw}`);
+      out.k = value;
+      continue;
+    }
+    if (action === 'promote' && raw.startsWith('--mode=')) {
+      out.mode = parseSearchMode(raw);
+      continue;
+    }
+    if (action === 'promote' && raw === '--gate') {
+      out.gate = true;
+      continue;
+    }
+    if (action === 'promote' && raw.startsWith('--fixture=')) {
+      out.fixture = nonEmptyValue(raw, '--fixture=');
+      continue;
+    }
+    if (action === 'promote' && raw === '--yes') {
+      out.yes = true;
+      continue;
+    }
+    if (raw.startsWith('--')) throw new Error(`unknown flag: ${raw}`);
+    throw new Error(`unexpected argument: ${JSON.stringify(raw)}`);
+  }
+
+  return out as unknown as FeedbackArgs;
+}
+
+function writeFeedbackAddResult(
+  entry: FeedbackLedgerEntry,
+  ledgerPath: string,
+  format: 'md' | 'json',
+): void {
+  if (format === 'json') {
+    process.stdout.write(`${JSON.stringify({ ledger_path: ledgerPath, entry }, null, 2)}\n`);
+    return;
+  }
+  process.stdout.write(
+    `Recorded feedback ${entry.id}\n\n` +
+    `- KB: ${entry.kb}\n` +
+    `- Query: ${entry.query}\n` +
+    `- Source: ${entry.source}\n` +
+    `- Verdict: ${entry.verdict} (${entry.relevance})\n` +
+    `- Ledger: ${ledgerPath}\n`,
+  );
+}
+
+function writeFeedbackListResult(
+  entries: readonly FeedbackLedgerEntry[],
+  ledgerPath: string,
+  format: 'md' | 'json',
+): void {
+  if (format === 'json') {
+    process.stdout.write(`${JSON.stringify({ ledger_path: ledgerPath, entries }, null, 2)}\n`);
+    return;
+  }
+  const lines = [`# kb feedback`, '', `Ledger: ${ledgerPath}`, '', `Entries: ${entries.length}`, ''];
+  for (const entry of entries) {
+    lines.push(`- ${entry.created_at} ${entry.verdict}(${entry.relevance}) ${entry.source}`);
+    lines.push(`  query: ${entry.query}`);
+  }
+  process.stdout.write(`${lines.join('\n')}\n`);
+}
+
+function writeFeedbackPromotePreview(
+  parsed: FeedbackPromoteArgs,
+  fixture: PromotedFixture,
+  format: 'md' | 'json',
+): void {
+  const yamlText = dumpPromotedEvalFixture(fixture);
+  if (format === 'json') {
+    process.stdout.write(`${JSON.stringify({
+      query: parsed.query,
+      fixture_path: parsed.fixture ?? null,
+      wrote: false,
+      fixture_yaml: yamlText,
+    }, null, 2)}\n`);
+    return;
+  }
+  process.stdout.write(yamlText);
+}
+
+function writeFeedbackPromoteWriteResult(
+  parsed: FeedbackPromoteArgs,
+  result: { caseCount: number; created: boolean },
+  format: 'md' | 'json',
+): void {
+  if (format === 'json') {
+    process.stdout.write(`${JSON.stringify({
+      fixture_path: parsed.fixture,
+      wrote: true,
+      created: result.created,
+      case_count: result.caseCount,
+    }, null, 2)}\n`);
+    return;
+  }
+  process.stdout.write(
+    `Updated ${path.resolve(parsed.fixture!)}\n\n` +
+    `- Created: ${result.created ? 'yes' : 'no'}\n` +
+    `- Cases: ${result.caseCount}\n`,
+  );
+}
+
+function parseVerdict(value: string): FeedbackVerdict {
+  if (value === 'relevant' || value === 'irrelevant' || value === 'stale' || value === 'misleading') {
+    return value;
+  }
+  throw new Error(`invalid --verdict: ${JSON.stringify(value)}`);
+}
+
+function parseSearchMode(raw: string): SearchMode {
+  const value = nonEmptyValue(raw, '--mode=');
+  if (value !== 'dense' && value !== 'lexical' && value !== 'hybrid' && value !== 'auto') {
+    throw new Error(`invalid --mode: ${raw}`);
+  }
+  return value;
+}
+
+function parseBoundedNumber(raw: string, prefix: string, min: number, max: number): number {
+  const value = Number(nonEmptyValue(raw, prefix));
+  if (!Number.isFinite(value) || value < min || value > max) {
+    throw new Error(`invalid ${prefix.slice(0, -1)}: ${raw}`);
+  }
+  return value;
+}
+
+function nonEmptyValue(raw: string, prefix: string): string {
+  const value = raw.slice(prefix.length);
+  if (value.length === 0) throw new Error(`${prefix}<value> requires a non-empty value`);
+  return value;
+}

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -68,6 +68,7 @@ describe('kb CLI — argv parsing and dispatch', () => {
       'stats',
       'eval',
       'eval-gate',
+      'feedback',
       'explain',
       'stale-check',
       'superseded',
@@ -104,6 +105,7 @@ describe('kb CLI — argv parsing and dispatch', () => {
     ['stats', 'kb stats'],
     ['eval', 'kb eval'],
     ['eval-gate', 'kb eval-gate'],
+    ['feedback', 'kb feedback'],
     ['explain', 'kb explain'],
     ['stale-check', 'kb stale-check'],
     ['superseded', 'kb superseded'],
@@ -199,6 +201,7 @@ describe('kb CLI — argv parsing and dispatch', () => {
       'stats',
       'eval',
       'eval-gate',
+      'feedback',
       'explain',
       'stale-check',
       'superseded',
@@ -360,6 +363,60 @@ describe('kb CLI — argv parsing and dispatch', () => {
     expect(a.code).toBe(0);
     expect(b.code).toBe(0);
     expect(a.stdout).toBe(b.stdout);
+  });
+
+  it('feedback add/list/promote records ledger rows and writes eval fixtures', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-feedback-cli-'));
+    const kbRoot = path.join(tempDir, 'kbs');
+    const fixturePath = path.join(tempDir, 'fixtures', 'feedback.yml');
+    await fsp.mkdir(path.join(kbRoot, 'ops'), { recursive: true });
+    const env = { KNOWLEDGE_BASES_ROOT_DIR: kbRoot };
+
+    const add = runCli([
+      'feedback',
+      'add',
+      '--kb=ops',
+      '--query=rollback',
+      '--source=runbooks/deploy.md',
+      '--relevance=2',
+      '--group=procedure',
+      '--format=json',
+    ], env);
+
+    expect(add.code).toBe(0);
+    const ledger = await fsp.readFile(
+      path.join(kbRoot, 'ops', '.index', 'relevance-feedback.jsonl'),
+      'utf-8',
+    );
+    expect(JSON.parse(ledger.trim())).toMatchObject({
+      kb: 'ops',
+      query: 'rollback',
+      source: 'runbooks/deploy.md',
+      relevance: 2,
+      groups: ['procedure'],
+    });
+
+    const list = runCli(['feedback', 'list', '--kb=ops', '--query=rollback', '--format=json'], env);
+    expect(list.code).toBe(0);
+    const listPayload = JSON.parse(list.stdout) as { entries: Array<{ source: string }> };
+    expect(listPayload.entries).toEqual([
+      expect.objectContaining({ source: 'runbooks/deploy.md' }),
+    ]);
+
+    const promote = runCli([
+      'feedback',
+      'promote',
+      '--kb=ops',
+      '--query=rollback',
+      `--fixture=${fixturePath}`,
+      '--yes',
+      '--format=json',
+    ], env);
+    expect(promote.code).toBe(0);
+    const fixtureText = await fsp.readFile(fixturePath, 'utf-8');
+    expect(fixtureText).toContain('query: rollback');
+    expect(fixtureText).toContain('source: runbooks/deploy.md');
+    expect(fixtureText).toContain('groups:');
   });
 
   it('kb help <command> --format=json emits only the selected command manifest (#383)', () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,6 +17,7 @@ import { DOCTOR_HELP, runDoctor } from './cli-doctor.js';
 import { EVAL_HELP, runEval } from './cli-eval.js';
 import { EVAL_GATE_HELP, runEvalGate } from './cli-eval-gate.js';
 import { EXPLAIN_HELP, runExplain } from './cli-explain.js';
+import { FEEDBACK_HELP, runFeedback } from './cli-feedback.js';
 import { IMPORT_URL_HELP, runImportUrl } from './cli-import-url.js';
 import { LIST_HELP, runList } from './cli-list.js';
 import { LLM_HELP, runLlm } from './cli-llm.js';
@@ -102,6 +103,7 @@ const SUBCOMMANDS: readonly Subcommand[] = [
   { name: 'stats',        summary: 'Read-only index/corpus stats (mirrors the MCP kb_stats payload).',       help: STATS_HELP,        handler: runStats },
   { name: 'eval',         summary: 'Run fixture-driven retrieval checks.',                                   help: EVAL_HELP,         handler: runEval },
   { name: 'eval-gate',    summary: 'RFC 018 M0 relevance-gate validation harness (downstream answer quality).', help: EVAL_GATE_HELP,  handler: runEvalGate },
+  { name: 'feedback',     summary: 'Record relevance judgments and promote them into eval fixtures.',         help: FEEDBACK_HELP,     handler: runFeedback },
   { name: 'explain',      summary: 'Verbose single-query retrieval trace for debugging and bug reports.',   help: EXPLAIN_HELP,      handler: runExplain },
   { name: 'stale-check',  summary: 'Scan markdown notes for path / URL references that no longer resolve.',  help: STALE_CHECK_HELP,  handler: runStaleCheck },
   { name: 'superseded',   summary: 'Scan a KB for obsolete / contradicted / deprecated / stale notes.',      help: SUPERSEDED_HELP,   handler: runSuperseded },

--- a/src/feedback-ledger.test.ts
+++ b/src/feedback-ledger.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from '@jest/globals';
+import * as fsp from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import yaml from 'js-yaml';
+import {
+  appendFeedbackEntry,
+  appendPromotedCaseToFixtureFile,
+  buildFeedbackEntry,
+  buildPromotedEvalFixture,
+  feedbackLedgerPath,
+  parseFeedbackJsonl,
+  readFeedbackLedger,
+} from './feedback-ledger.js';
+import { normalizeRetrievalEvalFixture } from './retrieval-eval.js';
+
+describe('feedback ledger entries', () => {
+  it('builds stable JSONL records with hashed task context and default relevant verdict', () => {
+    const entry = buildFeedbackEntry({
+      id: 'entry-1',
+      now: new Date('2026-05-19T10:00:00.000Z'),
+      kb: 'ops',
+      query: 'rollback procedure',
+      source: 'runbooks/deploy.md',
+      taskContext: 'incident-123',
+      groups: ['procedure', 'procedure'],
+    });
+
+    expect(entry).toMatchObject({
+      schema_version: 'kb-feedback.v1',
+      id: 'entry-1',
+      created_at: '2026-05-19T10:00:00.000Z',
+      kb: 'ops',
+      query: 'rollback procedure',
+      source: 'runbooks/deploy.md',
+      verdict: 'relevant',
+      relevance: 3,
+      groups: ['procedure'],
+    });
+    expect(entry.task_context_hash).toHaveLength(64);
+    expect(entry.task_context_hash).not.toBe('incident-123');
+  });
+
+  it('round-trips appended entries from a per-KB .index ledger', async () => {
+    const dir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-feedback-'));
+    const kbDir = path.join(dir, 'ops');
+    await fsp.mkdir(kbDir, { recursive: true });
+
+    await appendFeedbackEntry(kbDir, {
+      id: 'entry-1',
+      now: new Date('2026-05-19T10:00:00.000Z'),
+      kb: 'ops',
+      query: 'rollback procedure',
+      source: 'runbooks/deploy.md',
+    });
+
+    expect(feedbackLedgerPath(kbDir)).toBe(path.join(kbDir, '.index', 'relevance-feedback.jsonl'));
+    await expect(readFeedbackLedger(kbDir)).resolves.toMatchObject([
+      { id: 'entry-1', query: 'rollback procedure', source: 'runbooks/deploy.md' },
+    ]);
+  });
+
+  it('rejects invalid JSONL rows with line numbers', () => {
+    expect(() => parseFeedbackJsonl('{"schema_version":"wrong"}\n'))
+      .toThrow('feedback ledger line 1');
+  });
+});
+
+describe('feedback promotion', () => {
+  it('promotes positive and negative judgments into a valid retrieval-eval fixture', () => {
+    const fixture = buildPromotedEvalFixture([
+      buildFeedbackEntry({
+        id: 'relevant-1',
+        now: new Date('2026-05-19T10:00:00.000Z'),
+        kb: 'ops',
+        query: 'rollback procedure',
+        source: 'runbooks/deploy.md',
+        relevance: 2,
+        groups: ['procedure'],
+      }),
+      buildFeedbackEntry({
+        id: 'stale-1',
+        now: new Date('2026-05-19T10:01:00.000Z'),
+        kb: 'ops',
+        query: 'rollback procedure',
+        source: 'archive/old-deploy.md',
+        verdict: 'stale',
+      }),
+    ], {
+      kb: 'ops',
+      query: 'rollback procedure',
+      name: 'rollback feedback',
+      k: 5,
+      mode: 'hybrid',
+      gate: true,
+    });
+
+    const normalized = normalizeRetrievalEvalFixture(fixture);
+    expect(normalized.cases[0]).toMatchObject({
+      name: 'rollback feedback',
+      query: 'rollback procedure',
+      kb: 'ops',
+      k: 5,
+      mode: 'hybrid',
+      gate: true,
+      requiredSources: ['runbooks/deploy.md'],
+      forbiddenSources: ['archive/old-deploy.md'],
+      relevanceJudgments: [
+        { source: 'runbooks/deploy.md', relevance: 2, groups: ['procedure'] },
+      ],
+      stalePolicy: 'allow_stale',
+    });
+  });
+
+  it('appends promoted cases to an existing fixture file', async () => {
+    const dir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-feedback-fixture-'));
+    const fixturePath = path.join(dir, 'fixture.yml');
+    await fsp.writeFile(fixturePath, 'gate: false\nmode: hybrid\ncases:\n  - query: existing\n', 'utf-8');
+    const promoted = buildPromotedEvalFixture([
+      buildFeedbackEntry({
+        id: 'entry-1',
+        kb: 'ops',
+        query: 'rollback procedure',
+        source: 'runbooks/deploy.md',
+      }),
+    ], { kb: 'ops', query: 'rollback procedure' });
+
+    const result = await appendPromotedCaseToFixtureFile(fixturePath, promoted);
+    const parsed = normalizeRetrievalEvalFixture(yaml.load(await fsp.readFile(fixturePath, 'utf-8')));
+
+    expect(result).toEqual({ caseCount: 2, created: false });
+    expect(parsed.mode).toBe('hybrid');
+    expect(parsed.cases.map((c) => c.query)).toEqual(['existing', 'rollback procedure']);
+  });
+});

--- a/src/feedback-ledger.ts
+++ b/src/feedback-ledger.ts
@@ -1,0 +1,323 @@
+import * as crypto from 'crypto';
+import * as fsp from 'fs/promises';
+import * as path from 'path';
+import yaml from 'js-yaml';
+import { atomicWriteFile } from './file-mutation.js';
+import { normalizeRetrievalEvalFixture } from './retrieval-eval.js';
+
+export const FEEDBACK_LEDGER_SCHEMA_VERSION = 'kb-feedback.v1';
+export const FEEDBACK_LEDGER_FILENAME = 'relevance-feedback.jsonl';
+
+export type FeedbackVerdict = 'relevant' | 'irrelevant' | 'stale' | 'misleading';
+
+export interface FeedbackLedgerEntry {
+  schema_version: typeof FEEDBACK_LEDGER_SCHEMA_VERSION;
+  id: string;
+  created_at: string;
+  kb: string;
+  query: string;
+  source: string;
+  verdict: FeedbackVerdict;
+  relevance: number;
+  chunk_id?: string;
+  task_context_hash?: string;
+  note?: string;
+  groups?: string[];
+}
+
+export interface FeedbackAddInput {
+  kb: string;
+  query: string;
+  source: string;
+  verdict?: FeedbackVerdict;
+  relevance?: number;
+  chunkId?: string;
+  taskContext?: string;
+  note?: string;
+  groups?: string[];
+  now?: Date;
+  id?: string;
+}
+
+export interface FeedbackPromoteOptions {
+  kb: string;
+  query: string;
+  name?: string;
+  k?: number;
+  mode?: 'dense' | 'lexical' | 'hybrid' | 'auto';
+  gate?: boolean;
+}
+
+export interface PromotedFixture {
+  gate: boolean;
+  mode?: 'dense' | 'lexical' | 'hybrid' | 'auto';
+  cases: Array<Record<string, unknown>>;
+}
+
+export function feedbackLedgerPath(kbDir: string): string {
+  return path.join(kbDir, '.index', FEEDBACK_LEDGER_FILENAME);
+}
+
+export async function appendFeedbackEntry(kbDir: string, input: FeedbackAddInput): Promise<FeedbackLedgerEntry> {
+  const entry = buildFeedbackEntry(input);
+  const ledgerPath = feedbackLedgerPath(kbDir);
+  await fsp.mkdir(path.dirname(ledgerPath), { recursive: true });
+  await fsp.appendFile(ledgerPath, `${JSON.stringify(entry)}\n`, 'utf-8');
+  return entry;
+}
+
+export async function readFeedbackLedger(kbDir: string): Promise<FeedbackLedgerEntry[]> {
+  const ledgerPath = feedbackLedgerPath(kbDir);
+  let raw: string;
+  try {
+    raw = await fsp.readFile(ledgerPath, 'utf-8');
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return [];
+    throw err;
+  }
+  return parseFeedbackJsonl(raw);
+}
+
+export function parseFeedbackJsonl(raw: string): FeedbackLedgerEntry[] {
+  const entries: FeedbackLedgerEntry[] = [];
+  const lines = raw.split(/\r?\n/);
+  lines.forEach((line, idx) => {
+    if (line.trim().length === 0) return;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch (err) {
+      throw new Error(`feedback ledger line ${idx + 1} is not valid JSON: ${(err as Error).message}`);
+    }
+    entries.push(normalizeFeedbackEntry(parsed, idx + 1));
+  });
+  return entries;
+}
+
+export function buildFeedbackEntry(input: FeedbackAddInput): FeedbackLedgerEntry {
+  const verdict = input.verdict ?? defaultVerdict(input.relevance);
+  const relevance = input.relevance ?? defaultRelevance(verdict);
+  const groups = uniqueNonEmpty(input.groups ?? []);
+  const entry: FeedbackLedgerEntry = {
+    schema_version: FEEDBACK_LEDGER_SCHEMA_VERSION,
+    id: input.id ?? crypto.randomUUID(),
+    created_at: (input.now ?? new Date()).toISOString(),
+    kb: nonEmpty(input.kb, 'kb'),
+    query: nonEmpty(input.query, 'query'),
+    source: nonEmpty(input.source, 'source'),
+    verdict,
+    relevance: validateRelevance(relevance),
+    ...(input.chunkId !== undefined ? { chunk_id: nonEmpty(input.chunkId, 'chunk_id') } : {}),
+    ...(input.taskContext !== undefined
+      ? { task_context_hash: hashTaskContext(nonEmpty(input.taskContext, 'task_context')) }
+      : {}),
+    ...(input.note !== undefined ? { note: nonEmpty(input.note, 'note') } : {}),
+    ...(groups.length > 0 ? { groups } : {}),
+  };
+  return normalizeFeedbackEntry(entry, 0);
+}
+
+export function buildPromotedEvalFixture(
+  entries: readonly FeedbackLedgerEntry[],
+  options: FeedbackPromoteOptions,
+): PromotedFixture {
+  const matching = entries.filter((entry) => entry.kb === options.kb && entry.query === options.query);
+  if (matching.length === 0) {
+    throw new Error(`no feedback entries found for query ${JSON.stringify(options.query)} in KB ${JSON.stringify(options.kb)}`);
+  }
+
+  const positive = new Map<string, FeedbackLedgerEntry>();
+  const negative = new Map<string, FeedbackLedgerEntry>();
+  for (const entry of matching) {
+    const existingPositive = positive.get(entry.source);
+    if (entry.relevance > 0 && entry.verdict === 'relevant') {
+      positive.set(entry.source, chooseStrongerJudgment(existingPositive, entry));
+      negative.delete(entry.source);
+      continue;
+    }
+    if (!positive.has(entry.source)) {
+      negative.set(entry.source, chooseLatestJudgment(negative.get(entry.source), entry));
+    }
+  }
+
+  const relevantSources = Array.from(positive.values())
+    .sort((a, b) => b.relevance - a.relevance || a.source.localeCompare(b.source))
+    .map((entry) => ({
+      source: entry.source,
+      relevance: entry.relevance,
+      ...(entry.groups !== undefined ? { groups: entry.groups } : {}),
+    }));
+  const forbiddenSources = Array.from(negative.values())
+    .sort((a, b) => a.source.localeCompare(b.source))
+    .map((entry) => entry.source);
+
+  const fixture: PromotedFixture = {
+    gate: false,
+    cases: [{
+      name: options.name ?? fixtureCaseName(options.query),
+      query: options.query,
+      kb: options.kb,
+      ...(options.k !== undefined ? { k: options.k } : {}),
+      ...(options.mode !== undefined ? { mode: options.mode } : {}),
+      ...(options.gate !== undefined ? { gate: options.gate } : {}),
+      required_sources: relevantSources.map((entry) => entry.source),
+      ...(forbiddenSources.length > 0 ? { forbidden_sources: forbiddenSources } : {}),
+      ...(relevantSources.length > 0 ? { relevant_sources: relevantSources } : {}),
+      stale_policy: 'allow_stale',
+    }],
+  };
+  normalizeRetrievalEvalFixture(fixture);
+  return fixture;
+}
+
+export function dumpPromotedEvalFixture(fixture: PromotedFixture): string {
+  return yaml.dump(fixture, { lineWidth: -1, noRefs: true, sortKeys: false });
+}
+
+export async function appendPromotedCaseToFixtureFile(
+  fixturePath: string,
+  promoted: PromotedFixture,
+): Promise<{ caseCount: number; created: boolean }> {
+  let created = false;
+  let mode: number | undefined;
+  let fixture: PromotedFixture;
+  try {
+    mode = (await fsp.stat(fixturePath)).mode;
+    const raw = await fsp.readFile(fixturePath, 'utf-8');
+    const parsed = yaml.load(raw);
+    fixture = normalizePromotableFixture(parsed);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+    created = true;
+    fixture = { gate: false, cases: [] };
+  }
+
+  fixture.cases.push(...promoted.cases);
+  normalizeRetrievalEvalFixture(fixture);
+  await fsp.mkdir(path.dirname(path.resolve(fixturePath)), { recursive: true });
+  await atomicWriteFile(fixturePath, dumpPromotedEvalFixture(fixture), mode);
+  return { caseCount: fixture.cases.length, created };
+}
+
+function normalizePromotableFixture(raw: unknown): PromotedFixture {
+  if (!isRecord(raw)) throw new Error('fixture must be an object');
+  const normalized = normalizeRetrievalEvalFixture(raw);
+  const gate = typeof raw.gate === 'boolean' ? raw.gate : false;
+  if (!Array.isArray(raw.cases)) throw new Error('fixture cases must be an array');
+  const fixture: PromotedFixture = {
+    gate,
+    ...(normalized.mode !== undefined ? { mode: normalized.mode } : {}),
+    cases: raw.cases.map((entry) => {
+      if (!isRecord(entry)) throw new Error('fixture cases must contain objects');
+      return { ...entry };
+    }),
+  };
+  normalizeRetrievalEvalFixture(fixture);
+  return fixture;
+}
+
+function normalizeFeedbackEntry(raw: unknown, lineNumber: number): FeedbackLedgerEntry {
+  if (!isRecord(raw)) throw new Error(feedbackLinePrefix(lineNumber, 'entry must be an object'));
+  if (raw.schema_version !== FEEDBACK_LEDGER_SCHEMA_VERSION) {
+    throw new Error(feedbackLinePrefix(lineNumber, `unsupported schema_version: ${JSON.stringify(raw.schema_version)}`));
+  }
+  const groups = raw.groups === undefined ? undefined : normalizeGroups(raw.groups, lineNumber);
+  return {
+    schema_version: FEEDBACK_LEDGER_SCHEMA_VERSION,
+    id: nonEmpty(raw.id, feedbackLinePrefix(lineNumber, 'id')),
+    created_at: nonEmpty(raw.created_at, feedbackLinePrefix(lineNumber, 'created_at')),
+    kb: nonEmpty(raw.kb, feedbackLinePrefix(lineNumber, 'kb')),
+    query: nonEmpty(raw.query, feedbackLinePrefix(lineNumber, 'query')),
+    source: nonEmpty(raw.source, feedbackLinePrefix(lineNumber, 'source')),
+    verdict: normalizeVerdict(raw.verdict, lineNumber),
+    relevance: validateRelevance(raw.relevance),
+    ...(raw.chunk_id !== undefined ? { chunk_id: nonEmpty(raw.chunk_id, feedbackLinePrefix(lineNumber, 'chunk_id')) } : {}),
+    ...(raw.task_context_hash !== undefined
+      ? { task_context_hash: nonEmpty(raw.task_context_hash, feedbackLinePrefix(lineNumber, 'task_context_hash')) }
+      : {}),
+    ...(raw.note !== undefined ? { note: nonEmpty(raw.note, feedbackLinePrefix(lineNumber, 'note')) } : {}),
+    ...(groups !== undefined && groups.length > 0 ? { groups } : {}),
+  };
+}
+
+function defaultVerdict(relevance: number | undefined): FeedbackVerdict {
+  return relevance === 0 ? 'irrelevant' : 'relevant';
+}
+
+function defaultRelevance(verdict: FeedbackVerdict): number {
+  return verdict === 'relevant' ? 3 : 0;
+}
+
+function validateRelevance(raw: unknown): number {
+  if (typeof raw !== 'number' || !Number.isFinite(raw) || raw < 0 || raw > 3) {
+    throw new Error('relevance must be a finite number in [0, 3]');
+  }
+  return raw;
+}
+
+function normalizeVerdict(raw: unknown, lineNumber: number): FeedbackVerdict {
+  if (raw === 'relevant' || raw === 'irrelevant' || raw === 'stale' || raw === 'misleading') {
+    return raw;
+  }
+  throw new Error(feedbackLinePrefix(lineNumber, `invalid verdict: ${JSON.stringify(raw)}`));
+}
+
+function normalizeGroups(raw: unknown, lineNumber: number): string[] {
+  if (!Array.isArray(raw)) throw new Error(feedbackLinePrefix(lineNumber, 'groups must be an array'));
+  return uniqueNonEmpty(raw.map((entry) => nonEmpty(entry, feedbackLinePrefix(lineNumber, 'group'))));
+}
+
+function uniqueNonEmpty(values: readonly string[]): string[] {
+  return Array.from(new Set(values.map((value) => nonEmpty(value, 'group'))));
+}
+
+function hashTaskContext(value: string): string {
+  return crypto.createHash('sha256').update(value).digest('hex');
+}
+
+function fixtureCaseName(query: string): string {
+  return query.trim().toLowerCase().replace(/[^a-z0-9]+/g, ' ').trim().slice(0, 80) || 'feedback case';
+}
+
+function chooseStrongerJudgment(
+  existing: FeedbackLedgerEntry | undefined,
+  incoming: FeedbackLedgerEntry,
+): FeedbackLedgerEntry {
+  if (existing === undefined) return incoming;
+  if (incoming.relevance > existing.relevance) return mergeGroups(incoming, existing);
+  if (incoming.relevance < existing.relevance) return mergeGroups(existing, incoming);
+  return chooseLatestJudgment(existing, incoming);
+}
+
+function chooseLatestJudgment(
+  existing: FeedbackLedgerEntry | undefined,
+  incoming: FeedbackLedgerEntry,
+): FeedbackLedgerEntry {
+  if (existing === undefined) return incoming;
+  return Date.parse(incoming.created_at) >= Date.parse(existing.created_at)
+    ? mergeGroups(incoming, existing)
+    : mergeGroups(existing, incoming);
+}
+
+function mergeGroups(primary: FeedbackLedgerEntry, secondary: FeedbackLedgerEntry): FeedbackLedgerEntry {
+  const groups = uniqueNonEmpty([...(primary.groups ?? []), ...(secondary.groups ?? [])]);
+  return {
+    ...primary,
+    ...(groups.length > 0 ? { groups } : {}),
+  };
+}
+
+function feedbackLinePrefix(lineNumber: number, message: string): string {
+  return lineNumber > 0 ? `feedback ledger line ${lineNumber}: ${message}` : message;
+}
+
+function nonEmpty(raw: unknown, name: string): string {
+  if (typeof raw !== 'string' || raw.trim() === '') {
+    throw new Error(`${name} must be a non-empty string`);
+  }
+  return raw;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}


### PR DESCRIPTION
## Summary
- add `kb feedback add/list/promote` for durable per-KB relevance judgments
- store feedback as `.index/relevance-feedback.jsonl` with task-context hashing and graded relevance
- promote query feedback into `kb eval` YAML cases without dropping existing fixture-level mode

Closes #425

## Pre-PR Review
- detected project type: npm
- type/build checks: passed (`npm run build`)
- tests: passed (`npm test -- --runTestsByPath src/cli-feedback.test.ts src/feedback-ledger.test.ts`; `npm test -- --runTestsByPath src/cli.test.ts`; focused `KnowledgeBaseServer` timeout rerun passed). Full `npm test` was run before reviewer fixes: 1790 passed, with one expected CLI manifest failure since fixed and one load-sensitive existing timeout that passed by name.
- bug reproduction: skipped (feature PR)
- diff review: done
- portability check: manual clean; repo helper `scripts/check-portability.sh` is not present
- reviewer specialists: run; correctness blocking finding fixed, test/conventions suggestions addressed, dead-code clean
- OSS base-branch policy: skipped (same repo PR)

## Verification
- `npm run build`
- `npm test -- --runTestsByPath src/cli-feedback.test.ts src/feedback-ledger.test.ts`
- `npm test -- --runTestsByPath src/cli.test.ts`
- `npm test -- --runTestsByPath src/KnowledgeBaseServer.test.ts --testNamePattern "handleListKnowledgeBases returns filtered"`
- `git diff --check`
