### PR TITLE
feat: add refresh quiescence guard

### DIFF
--- a/docs/cli-json-contracts.md
+++ b/docs/cli-json-contracts.md
@@ -665,6 +665,12 @@ Stable fields:
   compact persisted summary for the active model when no update has run in the
   current process. The object shape is shared with stats/manager observability;
   agents should branch first on `last_index_update.status`.
+  When `KB_REFRESH_QUIESCE_MS` is non-zero, recently modified files or files
+  that change during the refresh scan are deferred and reported additively via
+  `warning_count` and `warnings[]`. Warning entries contain `relative_path`,
+  stable `code`, `message`, and may include numeric `mtime_age_ms` and
+  `quiesce_ms`. Stable codes are `KB_REFRESH_NOT_QUIESCENT` and
+  `KB_REFRESH_FILE_CHANGED_DURING_SCAN`.
 
 Stdout/stderr and exit codes:
 

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -113,6 +113,7 @@ provider load or scoring failures degrade to the fused order.
 | HuggingFace API key | `HUGGINGFACE_API_KEY` | required for HuggingFace | HuggingFace embedding provider | Implemented | none | `EMBEDDING_PROVIDER=huggingface kb doctor` |
 | Extra ingest extensions | `INGEST_EXTRA_EXTENSIONS` | empty | Ingest and refresh | Implemented | none | `INGEST_EXTRA_EXTENSIONS=.pdf kb search "known phrase" --refresh` |
 | Extra ingest exclusions | `INGEST_EXCLUDE_PATHS` | empty | Ingest and refresh | Implemented | none | `INGEST_EXCLUDE_PATHS="drafts/**" kb search "known phrase" --refresh` |
+| Refresh quiescence guard | `KB_REFRESH_QUIESCE_MS` | `0` | Ingest and refresh | Implemented, opt-in | none | `KB_REFRESH_QUIESCE_MS=1000 kb search "query" --refresh` |
 | Maximum raw file size | `KB_MAX_FILE_BYTES` | `104857600` | Ingest and refresh | Implemented | none | `KB_MAX_FILE_BYTES=1048576 kb search "query" --refresh` |
 | Maximum extracted text size | `KB_MAX_EXTRACTED_TEXT_BYTES` | `16777216` | Ingest and refresh | Implemented | none | `KB_MAX_EXTRACTED_TEXT_BYTES=1048576 kb search "query" --refresh` |
 | Large-file policy | `KB_LARGE_FILE_POLICY` | `skip` | Ingest and refresh | Implemented | none | `KB_LARGE_FILE_POLICY=error kb search "query" --refresh` |

--- a/src/FaissIndexManager.test.ts
+++ b/src/FaissIndexManager.test.ts
@@ -382,6 +382,7 @@ describe('FaissIndexManager permission handling', () => {
     KB_LARGE_FILE_POLICY: process.env.KB_LARGE_FILE_POLICY,
     KB_CHUNK_SIZE: process.env.KB_CHUNK_SIZE,
     KB_CHUNK_OVERLAP: process.env.KB_CHUNK_OVERLAP,
+    KB_REFRESH_QUIESCE_MS: process.env.KB_REFRESH_QUIESCE_MS,
   };
 
 
@@ -1275,6 +1276,150 @@ describe('FaissIndexManager permission handling', () => {
       files_unchanged: 1,
       saved: false,
     });
+  });
+
+  it('defers files inside the refresh quiescence window and indexes them on a later pass', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-faiss-quiesce-'));
+    const kbDir = path.join(tempDir, 'kb');
+    const defaultKb = path.join(kbDir, 'default');
+    await fsp.mkdir(defaultKb, { recursive: true });
+    const docPath = path.join(defaultKb, 'draft.md');
+    await fsp.writeFile(docPath, '# Draft\n\nProducer is still settling.');
+
+    process.env.KNOWLEDGE_BASES_ROOT_DIR = kbDir;
+    process.env.FAISS_INDEX_PATH = path.join(tempDir, '.faiss');
+    process.env.EMBEDDING_PROVIDER = 'huggingface';
+    process.env.HUGGINGFACE_API_KEY = 'test-key';
+    process.env.KB_REFRESH_QUIESCE_MS = '60000';
+
+    jest.resetModules();
+    const { FaissIndexManager } = await import('./FaissIndexManager.js');
+    const manager = new FaissIndexManager();
+    await manager.initialize();
+
+    await manager.updateIndex('default');
+    expect(fromTextsMock).not.toHaveBeenCalled();
+    expect(manager.getLastIndexUpdateSummary()).toMatchObject({
+      status: 'success',
+      scope: 'default',
+      files_scanned: 1,
+      files_changed: 0,
+      files_skipped: 1,
+      warning_count: 1,
+      warnings: [
+        expect.objectContaining({
+          relative_path: 'draft.md',
+          code: 'KB_REFRESH_NOT_QUIESCENT',
+          quiesce_ms: 60000,
+        }),
+      ],
+      failure_count: 0,
+    });
+    const persistedDeferredSummary = JSON.parse(
+      await fsp.readFile(lastIndexUpdatePathIn(process.env.FAISS_INDEX_PATH!), 'utf-8'),
+    );
+    expect(persistedDeferredSummary.summary).toMatchObject({
+      files_skipped: 1,
+      warning_count: 1,
+      warnings: [
+        expect.objectContaining({
+          relative_path: 'draft.md',
+          code: 'KB_REFRESH_NOT_QUIESCENT',
+        }),
+      ],
+    });
+
+    fromTextsMock.mockClear();
+    const oldTimestamp = new Date(Date.now() - 120_000);
+    await fsp.utimes(docPath, oldTimestamp, oldTimestamp);
+
+    await manager.updateIndex('default');
+    expect(fromTextsMock).toHaveBeenCalledTimes(1);
+    expect(manager.getLastIndexUpdateSummary()).toMatchObject({
+      status: 'success',
+      files_scanned: 1,
+      files_changed: 1,
+      files_skipped: 0,
+      warning_count: 0,
+      warnings: [],
+      failure_count: 0,
+    });
+  });
+
+  it('defers files that change during the refresh scan and indexes them on a later pass', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-faiss-quiesce-race-'));
+    const kbDir = path.join(tempDir, 'kb');
+    const defaultKb = path.join(kbDir, 'default');
+    await fsp.mkdir(defaultKb, { recursive: true });
+    const docPath = path.join(defaultKb, 'draft.md');
+    await fsp.writeFile(docPath, '# Draft\n\nInitial content.');
+    const oldTimestamp = new Date(Date.now() - 120_000);
+    await fsp.utimes(docPath, oldTimestamp, oldTimestamp);
+
+    process.env.KNOWLEDGE_BASES_ROOT_DIR = kbDir;
+    process.env.FAISS_INDEX_PATH = path.join(tempDir, '.faiss');
+    process.env.EMBEDDING_PROVIDER = 'huggingface';
+    process.env.HUGGINGFACE_API_KEY = 'test-key';
+    process.env.KB_REFRESH_QUIESCE_MS = '60000';
+
+    jest.resetModules();
+    const actualFileUtils = jest.requireActual<typeof import('./file-utils.js')>('./file-utils.js');
+    let mutatedDuringHash = false;
+    jest.doMock('./file-utils.js', () => ({
+      ...actualFileUtils,
+      calculateSHA256: jest.fn(async (filePath: string) => {
+        const hash = await actualFileUtils.calculateSHA256(filePath);
+        if (filePath === docPath && !mutatedDuringHash) {
+          mutatedDuringHash = true;
+          await fsp.writeFile(docPath, '# Draft\n\nChanged while refresh was scanning.');
+        }
+        return hash;
+      }),
+    }));
+
+    try {
+      const { FaissIndexManager } = await import('./FaissIndexManager.js');
+      const manager = new FaissIndexManager();
+      await manager.initialize();
+
+      await manager.updateIndex('default');
+      expect(fromTextsMock).not.toHaveBeenCalled();
+      expect(manager.getLastIndexUpdateSummary()).toMatchObject({
+        status: 'success',
+        scope: 'default',
+        files_scanned: 1,
+        files_changed: 0,
+        files_skipped: 1,
+        warning_count: 1,
+        warnings: [
+          expect.objectContaining({
+            relative_path: 'draft.md',
+            code: 'KB_REFRESH_FILE_CHANGED_DURING_SCAN',
+            quiesce_ms: 60000,
+          }),
+        ],
+        failure_count: 0,
+      });
+
+      fromTextsMock.mockClear();
+      mutatedDuringHash = true;
+      await fsp.utimes(docPath, oldTimestamp, oldTimestamp);
+
+      await manager.updateIndex('default');
+      expect(fromTextsMock).toHaveBeenCalledTimes(1);
+      expect(manager.getLastIndexUpdateSummary()).toMatchObject({
+        status: 'success',
+        files_scanned: 1,
+        files_changed: 1,
+        files_skipped: 0,
+        warning_count: 0,
+        warnings: [],
+        failure_count: 0,
+      });
+    } finally {
+      jest.dontMock('./file-utils.js');
+      jest.resetModules();
+    }
   });
 
   it('quarantines load failures, skips them during backoff, and clears the entry after content changes and indexes', async () => {

--- a/src/FaissIndexManager.ts
+++ b/src/FaissIndexManager.ts
@@ -24,6 +24,7 @@ import {
 import {
   INGEST_EXCLUDE_PATHS,
   INGEST_EXTRA_EXTENSIONS,
+  resolveRefreshQuiesceMs,
 } from './config/ingest.js';
 import {
   resolveIndexingBatchSize,
@@ -261,6 +262,18 @@ export interface IndexUpdateFailureSummary {
   message: string;
 }
 
+export type IndexUpdateWarningCode =
+  | 'KB_REFRESH_NOT_QUIESCENT'
+  | 'KB_REFRESH_FILE_CHANGED_DURING_SCAN';
+
+export interface IndexUpdateWarningSummary {
+  relative_path: string | null;
+  code: IndexUpdateWarningCode;
+  message: string;
+  mtime_age_ms?: number;
+  quiesce_ms?: number;
+}
+
 export interface IndexUpdateSummary {
   status: IndexUpdateSummaryStatus;
   scope: 'global' | string | null;
@@ -277,6 +290,8 @@ export interface IndexUpdateSummary {
   index_mutated: boolean;
   saved: boolean;
   sidecars_written: boolean;
+  warning_count: number;
+  warnings: IndexUpdateWarningSummary[];
   failure_count: number;
   failures: IndexUpdateFailureSummary[];
 }
@@ -347,6 +362,8 @@ export function createNeverRunIndexUpdateSummary(modelId: string | null = null):
     index_mutated: false,
     saved: false,
     sidecars_written: false,
+    warning_count: 0,
+    warnings: [],
     failure_count: 0,
     failures: [],
   };
@@ -355,6 +372,8 @@ export function createNeverRunIndexUpdateSummary(modelId: string | null = null):
 function cloneIndexUpdateSummary(summary: IndexUpdateSummary): IndexUpdateSummary {
   return {
     ...summary,
+    warning_count: summary.warning_count ?? 0,
+    warnings: (summary.warnings ?? []).map((warning) => ({ ...warning })),
     failures: summary.failures.map((failure) => ({ ...failure })),
   };
 }
@@ -454,6 +473,30 @@ function parsePersistedIndexUpdateSummary(value: unknown): IndexUpdateSummary | 
           message: typeof failure.message === 'string' ? failure.message : '',
         }))
     : [];
+  const warnings = Array.isArray(candidate.warnings)
+    ? candidate.warnings
+        .filter(isRecord)
+        .map((warning): IndexUpdateWarningSummary | null => {
+          const code = warning.code;
+          if (
+            code !== 'KB_REFRESH_NOT_QUIESCENT' &&
+            code !== 'KB_REFRESH_FILE_CHANGED_DURING_SCAN'
+          ) {
+            return null;
+          }
+          const parsed: IndexUpdateWarningSummary = {
+            relative_path: stringOrNull(warning.relative_path),
+            code,
+            message: typeof warning.message === 'string' ? warning.message : '',
+          };
+          const mtimeAgeMs = numberOrNull(warning.mtime_age_ms);
+          const quiesceMs = numberOrNull(warning.quiesce_ms);
+          if (mtimeAgeMs !== null) parsed.mtime_age_ms = mtimeAgeMs;
+          if (quiesceMs !== null) parsed.quiesce_ms = quiesceMs;
+          return parsed;
+        })
+        .filter((warning): warning is IndexUpdateWarningSummary => warning !== null)
+    : [];
 
   return {
     ...base,
@@ -471,6 +514,8 @@ function parsePersistedIndexUpdateSummary(value: unknown): IndexUpdateSummary | 
     index_mutated: booleanOrDefault(candidate.index_mutated, base.index_mutated),
     saved: booleanOrDefault(candidate.saved, base.saved),
     sidecars_written: booleanOrDefault(candidate.sidecars_written, base.sidecars_written),
+    warning_count: numberOrDefault(candidate.warning_count, warnings.length),
+    warnings,
     failure_count: numberOrDefault(candidate.failure_count, failures.length),
     failures,
   };
@@ -1210,6 +1255,12 @@ export class FaissIndexManager {
         runSummary.failures.push(failureSummary(relativePath, phase, error));
       }
     };
+    const recordWarning = (warning: IndexUpdateWarningSummary): void => {
+      runSummary.warning_count += 1;
+      if (runSummary.warnings.length < MAX_INDEX_UPDATE_FAILURES) {
+        runSummary.warnings.push(warning);
+      }
+    };
     const recordQuarantineFailure = async (
       kbPath: string,
       relativePath: string,
@@ -1245,6 +1296,7 @@ export class FaissIndexManager {
     };
     try {
       const forceReindex = opts.force === true;
+      let hadActiveIndexBeforeForce = false;
       // FAISS has no per-vector delete API and we keep one global store
       // across all KBs. So a forced rebuild MUST null the in-memory index
       // AND walk every KB. A scoped force ("rebuild just KB alpha") would
@@ -1259,6 +1311,7 @@ export class FaissIndexManager {
       let scopedKnowledgeBase = specificKnowledgeBase;
       let shouldPurgePersistedIndexIfEmpty = false;
       if (forceReindex) {
+        hadActiveIndexBeforeForce = (await this.resolveActiveIndexFilePath()) !== null;
         this.faissIndex = null;
         shouldPurgePersistedIndexIfEmpty = true;
         if (scopedKnowledgeBase !== undefined) {
@@ -1320,6 +1373,53 @@ export class FaissIndexManager {
       const pendingHashWrites: { path: string; hash: string }[] = [];
       const pendingChunkManifestWrites: { path: string; manifest: ChunkManifest }[] = [];
       const loaderFailurePaths = new Set<string>();
+      const deferredNonQuiescentPaths = new Set<string>();
+      const refreshQuiesceMs = resolveRefreshQuiesceMs();
+      let skipFallbackBuild = false;
+      const changedDuringScanWarning = (relativePath: string): IndexUpdateWarningSummary => ({
+        relative_path: relativePath,
+        code: 'KB_REFRESH_FILE_CHANGED_DURING_SCAN',
+        message:
+          `Skipping ${relativePath} because its size, mtime, or hash changed ` +
+          `while refresh was scanning it; a later refresh will retry it.`,
+        quiesce_ms: refreshQuiesceMs,
+      });
+      const recordDeferredNonQuiescentPath = (
+        filePath: string,
+        warning: IndexUpdateWarningSummary,
+      ): void => {
+        if (deferredNonQuiescentPaths.has(filePath)) {
+          return;
+        }
+        deferredNonQuiescentPaths.add(filePath);
+        runSummary.files_skipped += 1;
+        recordWarning(warning);
+        logger.warn(warning.message);
+      };
+      const stillMatchesScan = async (scan: {
+        filePath: string;
+        relativePath: string;
+        fileHash: string;
+        fileSize: number;
+        mtimeMs: number;
+      }): Promise<IndexUpdateWarningSummary | null> => {
+        if (refreshQuiesceMs <= 0) {
+          return null;
+        }
+        try {
+          const afterLoadStat = await fsp.stat(scan.filePath);
+          if (afterLoadStat.size !== scan.fileSize || afterLoadStat.mtimeMs !== scan.mtimeMs) {
+            return changedDuringScanWarning(scan.relativePath);
+          }
+          const afterLoadHash = await calculateSHA256(scan.filePath);
+          if (afterLoadHash !== scan.fileHash) {
+            return changedDuringScanWarning(scan.relativePath);
+          }
+          return null;
+        } catch {
+          return changedDuringScanWarning(scan.relativePath);
+        }
+      };
 
       // First enumerate every candidate path so progress notifications can
       // report a stable denominator before embedding begins. `knowledgeBases`
@@ -1455,6 +1555,8 @@ export class FaissIndexManager {
         indexFilePath: string;
         chunkManifestPath: string;
         fileHash: string;
+        fileSize: number;
+        mtimeMs: number;
       }> = [];
       let requiresFullRebuild = false;
       const successfulIndexedFiles: Array<{ knowledgeBasePath: string; relativePath: string }> = [];
@@ -1483,7 +1585,53 @@ export class FaissIndexManager {
         fsConcurrency,
         async (job) => {
           try {
+            const beforeStat = await fsp.stat(job.filePath);
+            let stableStat = beforeStat;
+            if (refreshQuiesceMs > 0) {
+              const mtimeAgeMs = Math.max(0, Date.now() - beforeStat.mtimeMs);
+              if (mtimeAgeMs < refreshQuiesceMs) {
+                return {
+                  ...job,
+                  success: false as const,
+                  deferred: true as const,
+                  error: new Error('refresh file is not quiescent'),
+                  warning: {
+                    relative_path: job.relativePath,
+                    code: 'KB_REFRESH_NOT_QUIESCENT' as const,
+                    message:
+                      `Skipping ${job.relativePath} because its mtime age ` +
+                      `${Math.floor(mtimeAgeMs)}ms is below KB_REFRESH_QUIESCE_MS=${refreshQuiesceMs}; ` +
+                      `a later refresh will retry it.`,
+                    mtime_age_ms: Math.floor(mtimeAgeMs),
+                    quiesce_ms: refreshQuiesceMs,
+                  },
+                };
+              }
+            }
             const fileHash = await calculateSHA256(job.filePath);
+            if (refreshQuiesceMs > 0) {
+              const afterStat = await fsp.stat(job.filePath);
+              if (
+                beforeStat.size !== afterStat.size ||
+                beforeStat.mtimeMs !== afterStat.mtimeMs
+              ) {
+                return {
+                  ...job,
+                  success: false as const,
+                  deferred: true as const,
+                  error: new Error('refresh file changed during scan'),
+                  warning: {
+                    relative_path: job.relativePath,
+                    code: 'KB_REFRESH_FILE_CHANGED_DURING_SCAN' as const,
+                    message:
+                      `Skipping ${job.relativePath} because its size or mtime changed ` +
+                      `while refresh was scanning it; a later refresh will retry it.`,
+                    quiesce_ms: refreshQuiesceMs,
+                  },
+                };
+              }
+              stableStat = afterStat;
+            }
             let storedHash: string | null = null;
             try {
               const buffer = await fsp.readFile(job.indexFilePath);
@@ -1491,7 +1639,14 @@ export class FaissIndexManager {
             } catch {
               // The hash file may not exist yet; that's fine.
             }
-            return { ...job, success: true as const, fileHash, storedHash };
+            return {
+              ...job,
+              success: true as const,
+              fileHash,
+              storedHash,
+              fileSize: stableStat.size,
+              mtimeMs: stableStat.mtimeMs,
+            };
           } catch (error: unknown) {
             return { ...job, success: false as const, error };
           } finally {
@@ -1505,6 +1660,11 @@ export class FaissIndexManager {
         runSummary.files_scanned += 1;
 
         if (!scan.success) {
+          if ('deferred' in scan && scan.deferred) {
+            recordDeferredNonQuiescentPath(scan.filePath, scan.warning);
+            await reportLoadProgress(scan.filePath);
+            continue;
+          }
           logger.warn(`Quarantining unreadable file ${scan.filePath}:`, toError(scan.error));
           runSummary.files_skipped += 1;
           loaderFailurePaths.add(scan.filePath);
@@ -1541,6 +1701,8 @@ export class FaissIndexManager {
           indexFilePath: scan.indexFilePath,
           chunkManifestPath: scan.chunkManifestPath,
           fileHash: scan.fileHash,
+          fileSize: scan.fileSize,
+          mtimeMs: scan.mtimeMs,
         });
 
         // If the file is new/changed, or the index itself is absent,
@@ -1574,6 +1736,12 @@ export class FaissIndexManager {
               scan.fileHash,
               error,
             );
+            await reportLoadProgress(scan.filePath);
+            continue;
+          }
+          const loadWarning = await stillMatchesScan(scan);
+          if (loadWarning !== null) {
+            recordDeferredNonQuiescentPath(scan.filePath, loadWarning);
             await reportLoadProgress(scan.filePath);
             continue;
           }
@@ -1673,7 +1841,39 @@ export class FaissIndexManager {
         }
         await reportLoadProgress(scan.filePath);
       }
+      if (
+        forceReindex &&
+        hadActiveIndexBeforeForce &&
+        deferredNonQuiescentPaths.size > 0
+      ) {
+        await this.reloadPersistedIndex();
+        shouldPurgePersistedIndexIfEmpty = false;
+        skipFallbackBuild = true;
+        requiresFullRebuild = false;
+        changedFileDocuments.length = 0;
+        metadataOnlyFileUpdates.length = 0;
+        runSummary.chunks_attempted = 0;
+        logger.warn(
+          'Skipping forced FAISS rebuild because at least one file is not quiescent; ' +
+            'the existing persisted index remains active and a later refresh will retry.',
+        );
+      } else if (
+        requiresFullRebuild &&
+        this.faissIndex !== null &&
+        deferredNonQuiescentPaths.size > 0
+      ) {
+        requiresFullRebuild = false;
+        changedFileDocuments.length = 0;
+        metadataOnlyFileUpdates.length = 0;
+        runSummary.chunks_attempted = 0;
+        logger.warn(
+          'Deferring full FAISS rebuild because at least one file is not quiescent; ' +
+            'the existing index remains active and a later refresh will retry.',
+        );
+      }
       if (requiresFullRebuild) {
+        const hadIndexBeforeFullRebuild = this.faissIndex !== null;
+        const deferredCountBeforeFullRebuild = deferredNonQuiescentPaths.size;
         this.faissIndex = null;
         changedFileDocuments.length = 0;
         metadataOnlyFileUpdates.length = 0;
@@ -1697,6 +1897,11 @@ export class FaissIndexManager {
               scan.fileHash,
               error,
             );
+            continue;
+          }
+          const loadWarning = await stillMatchesScan(scan);
+          if (loadWarning !== null) {
+            recordDeferredNonQuiescentPath(scan.filePath, loadWarning);
             continue;
           }
 
@@ -1737,6 +1942,19 @@ export class FaissIndexManager {
             documents,
             manifest: buildChunkManifest(documents, scan.fileHash),
           });
+        }
+        if (
+          hadIndexBeforeFullRebuild &&
+          deferredNonQuiescentPaths.size > deferredCountBeforeFullRebuild
+        ) {
+          await this.reloadPersistedIndex();
+          changedFileDocuments.length = 0;
+          metadataOnlyFileUpdates.length = 0;
+          runSummary.chunks_attempted = 0;
+          logger.warn(
+            'Discarding in-progress full FAISS rebuild because a file changed during scan; ' +
+              'the existing persisted index remains active and a later refresh will retry.',
+          );
         }
       }
       const documentsToAdd = changedFileDocuments.flatMap((entry) => entry.documents);
@@ -1793,7 +2011,7 @@ export class FaissIndexManager {
 
       // If at least one file was processed but no changes triggered index creation,
       // then attempt to build the FAISS index from all available documents.
-      if (this.faissIndex === null && anyFileProcessed) {
+      if (this.faissIndex === null && anyFileProcessed && !skipFallbackBuild) {
         logger.info('No updates detected but FAISS index is not initialized. Building index from all available documents...');
         const fallbackDocuments: Array<{
           knowledgeBasePath: string;
@@ -1807,6 +2025,9 @@ export class FaissIndexManager {
         }> = [];
         for (const { knowledgeBaseName, knowledgeBasePath, filePaths } of knowledgeBaseFiles) {
           for (const filePath of filePaths) {
+            if (deferredNonQuiescentPaths.has(filePath)) {
+              continue;
+            }
             const relativePath = path.relative(knowledgeBasePath, filePath);
             let fileHash: string | null = null;
             try {
@@ -1839,6 +2060,18 @@ export class FaissIndexManager {
                 );
               }
               continue;
+            }
+            if (refreshQuiesceMs > 0 && fileHash !== null) {
+              try {
+                const afterLoadHash = await calculateSHA256(filePath);
+                if (afterLoadHash !== fileHash) {
+                  recordDeferredNonQuiescentPath(filePath, changedDuringScanWarning(relativePath));
+                  continue;
+                }
+              } catch {
+                recordDeferredNonQuiescentPath(filePath, changedDuringScanWarning(relativePath));
+                continue;
+              }
             }
             let documents: Document[];
             try {

--- a/src/cli-doctor.test.ts
+++ b/src/cli-doctor.test.ts
@@ -296,6 +296,8 @@ describe('kb doctor', () => {
           index_mutated: true,
           saved: true,
           sidecars_written: true,
+          warning_count: 0,
+          warnings: [],
           failure_count: 0,
           failures: [],
         },

--- a/src/cli-reindex.ts
+++ b/src/cli-reindex.ts
@@ -213,6 +213,7 @@ function formatHumanResult(result: ReindexResult): string {
       `  summary: files_scanned=${result.summary.files_scanned ?? 0} ` +
         `files_changed=${result.summary.files_changed ?? 0} ` +
         `files_unchanged=${result.summary.files_unchanged ?? 0} ` +
+        `warnings=${result.summary.warning_count ?? 0} ` +
         `failures=${result.summary.failure_count ?? 0}`,
     );
   }

--- a/src/cli-stats.test.ts
+++ b/src/cli-stats.test.ts
@@ -46,6 +46,8 @@ function payload(): KbStatsPayload {
       index_mutated: false,
       saved: false,
       sidecars_written: false,
+      warning_count: 0,
+      warnings: [],
       failure_count: 0,
       failures: [],
     },

--- a/src/config/ingest.ts
+++ b/src/config/ingest.ts
@@ -64,3 +64,18 @@ export function resolveLargeFileLimits(): {
     policy: parseKbLargeFilePolicy(process.env.KB_LARGE_FILE_POLICY),
   };
 }
+
+// ---------------------------------------------------------------------------
+// Refresh quiescence guard (#428).
+// ---------------------------------------------------------------------------
+
+export function parseRefreshQuiesceMs(raw: string | undefined): number {
+  if (raw === undefined || raw.trim() === '') return 0;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) return 0;
+  return Math.floor(parsed);
+}
+
+export function resolveRefreshQuiesceMs(): number {
+  return parseRefreshQuiesceMs(process.env.KB_REFRESH_QUIESCE_MS);
+}


### PR DESCRIPTION
## Summary

- Add opt-in `KB_REFRESH_QUIESCE_MS` handling for refresh indexing.
- Defer files that are too recently modified or that change during scan/load, returning structured refresh warnings instead of indexing unstable content.
- Document the additive refresh warning JSON contract and feature flag.

Closes #428

## Verification

- `git diff --check`
- `npm run build`
- `npm test -- --runTestsByPath src/FaissIndexManager.test.ts --runInBand`
- `npm test -- --runTestsByPath src/cli-reindex.test.ts src/kb-stats.test.ts src/cli-doctor.test.ts --runInBand`
- `npm test -- --runTestsByPath src/cli-stats.test.ts --runInBand`
- `npm test -- --runTestsByPath src/cli-json-contracts.test.ts --runInBand --testTimeout=30000`
- `npm test -- --runInBand --testTimeout=30000` (failed only in `src/cli-json-contracts.test.ts` due `spawnSync node ETIMEDOUT` under the long serial run; the suite passed in isolation immediately afterward)

## Pre-PR Review

- detected project type: npm
- type/build checks: passed
- tests: passed for focused changed paths; full suite had isolated timeout noise as noted above
- bug reproduction: skipped, feature PR
- diff review: done
- portability check: clean
- reviewer specialists: run; blocking findings fixed
- OSS base-branch policy: skipped, internal repo PR
