### PR TITLE
feat: add batch JSONL search mode

### DIFF
--- a/docs/cli-json-contracts.md
+++ b/docs/cli-json-contracts.md
@@ -259,6 +259,62 @@ Stable hybrid fields are `mode`, `results`, `retrievers.dense.fetched`,
 `rerank.cache_hits`, `rerank.degraded`, and `rerank.degrade_reason` are stable
 when the `rerank` object is present.
 
+Batch JSONL envelope:
+
+```json
+{
+  "schema_version": "kb.search.batch-jsonl.v1",
+  "line": 1,
+  "ok": true,
+  "exit_code": 0,
+  "query": "deploy",
+  "kb": "work",
+  "requested_mode": "auto",
+  "result": {
+    "results": []
+  }
+}
+```
+
+`kb search --batch-jsonl` reads newline-delimited JSON objects from stdin and
+prints one compact JSON envelope per nonblank input row. Each row must include
+`query`. Supported row overrides are the snake_case or camelCase equivalents of
+the single-query flags: `kb`, `model`, `k`, `threshold`, `mode`, `no_cache`,
+`noCache`, `gate`, `no_gate`, `noGate`, `rerank`, `no_rerank`, `noRerank`,
+`task_context`, `taskContext`, `task_context_file`, `taskContextFile`,
+`group_by_source`, `groupBySource`, `timing`, `freshness`, `no_freshness`,
+`noFreshness`, `explain_empty`, `explainEmpty`, `explain`, `context_before`,
+`contextBefore`, `context_after`, `contextAfter`, `context_window`, and
+`contextWindow`.
+
+Stable batch fields:
+
+- `schema_version`: currently `kb.search.batch-jsonl.v1`.
+- `line`: 1-based JSONL input line number.
+- `ok`: `true` when that row's search exited `0`.
+- `exit_code`: row-level search or parse/build exit code.
+- `query`: input query string when available, otherwise `null` for row-shape
+  failures.
+- `kb`, `model`, and `requested_mode`: present when supplied on the row.
+- `result`: parsed JSON stdout from the row's delegated `kb search
+  --format=json` run when that stdout is valid JSON.
+- `stdout`: raw row stdout when the delegated row output was not valid JSON.
+- `stderr`: row stderr when nonempty.
+- `error.message`: present for row parse/build errors before a row search runs.
+
+Batch stdout/stderr and exit codes:
+
+- Batch stdout is valid JSONL, not one JSON array. Each line is an independent
+  envelope.
+- Process exit code is the maximum row exit code.
+- Parser/runtime diagnostics that happen before row execution are represented
+  as row envelopes. Logger output and canonical CLI logs remain stderr.
+- `--batch-jsonl` rejects top-level `--refresh`, row `refresh`, `--stdin`,
+  and interactive output. Run single-query `kb search --refresh` before
+  batching when the dense index needs updating.
+- Row `mode=lexical`, `mode=hybrid`, and `mode=auto` retain the existing
+  single-query search behavior for auxiliary lexical indexes.
+
 Stable error envelope for dense and hybrid JSON mode:
 
 ```json

--- a/src/cli-json-contracts.test.ts
+++ b/src/cli-json-contracts.test.ts
@@ -154,7 +154,7 @@ const docAssertions: Record<DocumentedCommand, (examples: unknown[]) => void> = 
     expect(record(commandSpecific.command)).toMatchObject({ name: 'search', stability: 'stable' });
   },
   'kb search': (examples) => {
-    expect(examples).toHaveLength(4);
+    expect(examples).toHaveLength(5);
     expect(record(examples[0])).toMatchObject({
       results: expect.any(Array),
       stale: expect.any(Boolean),
@@ -162,7 +162,14 @@ const docAssertions: Record<DocumentedCommand, (examples: unknown[]) => void> = 
     });
     expect(record(examples[1])).toMatchObject({ mode: 'lexical', results: expect.any(Array) });
     expect(record(examples[2])).toMatchObject({ mode: 'hybrid', retrievers: expect.any(Object) });
-    expect(record(record(examples[3]).error)).toMatchObject({
+    expect(record(examples[3])).toMatchObject({
+      schema_version: 'kb.search.batch-jsonl.v1',
+      line: expect.any(Number),
+      ok: expect.any(Boolean),
+      exit_code: expect.any(Number),
+      result: expect.any(Object),
+    });
+    expect(record(record(examples[4]).error)).toMatchObject({
       code: expect.any(String),
       category: expect.any(String),
       message: expect.any(String),

--- a/src/cli-search-batch-jsonl.test.ts
+++ b/src/cli-search-batch-jsonl.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+  parseSearchArgs,
+  runSearchBatchJsonlForText,
+  type RunSearchDeps,
+} from './cli-search.js';
+
+function parseJsonl(stdout: string): Array<Record<string, unknown>> {
+  return stdout.trim().split('\n').filter(Boolean).map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
+describe('kb search --batch-jsonl', () => {
+  it('runs one JSON search per row while caching shared model/index setup', async () => {
+    const calls = {
+      bootstrap: 0,
+      resolve: 0,
+      loadManager: 0,
+      loadIndex: 0,
+    };
+    const manager = { id: 'manager-1' };
+    const deps: RunSearchDeps = {
+      bootstrapLayout: async () => { calls.bootstrap += 1; },
+      resolveActiveModel: async (opts = {}) => {
+        calls.resolve += 1;
+        return opts.explicitOverride ?? 'ollama__default';
+      },
+      loadManagerForModel: async () => {
+        calls.loadManager += 1;
+        return manager as never;
+      },
+      loadWithJsonRetry: async () => { calls.loadIndex += 1; },
+    };
+    const runOne = async (args: string[], cachedDeps: RunSearchDeps): Promise<number> => {
+      await cachedDeps.bootstrapLayout();
+      const modelArg = args.find((arg) => arg.startsWith('--model='));
+      const activeModel = await cachedDeps.resolveActiveModel({
+        explicitOverride: modelArg?.slice('--model='.length),
+      });
+      const loadedManager = await cachedDeps.loadManagerForModel(activeModel);
+      await cachedDeps.loadWithJsonRetry(loadedManager);
+      process.stdout.write(JSON.stringify({ args, activeModel }));
+      return 0;
+    };
+
+    const base = parseSearchArgs([
+      '--batch-jsonl',
+      '--model=ollama__demo',
+      '--k=5',
+      '--no-freshness',
+    ]);
+    const result = await runSearchBatchJsonlForText(
+      '{"query":"deploy"}\n{"query":"rollback","k":2,"mode":"auto","no_cache":true}\n',
+      base,
+      deps,
+      runOne,
+    );
+
+    expect(result.code).toBe(0);
+    const rows = parseJsonl(result.stdout);
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toMatchObject({
+      schema_version: 'kb.search.batch-jsonl.v1',
+      line: 1,
+      ok: true,
+      exit_code: 0,
+      query: 'deploy',
+    });
+    expect(rows[1]).toMatchObject({ line: 2, ok: true, query: 'rollback', requested_mode: 'auto' });
+    expect((rows[0].result as { args: string[] }).args).toEqual([
+      'deploy',
+      '--model=ollama__demo',
+      '--k=5',
+      '--no-freshness',
+      '--format=json',
+    ]);
+    expect((rows[1].result as { args: string[] }).args).toEqual([
+      'rollback',
+      '--model=ollama__demo',
+      '--k=2',
+      '--mode=auto',
+      '--no-cache',
+      '--no-freshness',
+      '--format=json',
+    ]);
+    expect(calls).toEqual({
+      bootstrap: 1,
+      resolve: 1,
+      loadManager: 1,
+      loadIndex: 1,
+    });
+  });
+
+  it('emits per-row error envelopes for invalid JSON and invalid row options', async () => {
+    const base = parseSearchArgs(['--batch-jsonl']);
+    const result = await runSearchBatchJsonlForText(
+      '{"query":1}\nnot json\n',
+      base,
+      {
+        bootstrapLayout: async () => undefined,
+        resolveActiveModel: async () => 'ollama__default',
+        loadManagerForModel: async () => ({}) as never,
+        loadWithJsonRetry: async () => undefined,
+      },
+      async () => 0,
+    );
+
+    expect(result.code).toBe(2);
+    expect(parseJsonl(result.stdout)).toEqual([
+      {
+        schema_version: 'kb.search.batch-jsonl.v1',
+        line: 1,
+        ok: false,
+        exit_code: 2,
+        error: { message: 'row query must be a string' },
+      },
+      expect.objectContaining({
+        schema_version: 'kb.search.batch-jsonl.v1',
+        line: 2,
+        ok: false,
+        exit_code: 2,
+      }),
+    ]);
+  });
+
+  it('wraps valid row search failures with stderr in the row envelope', async () => {
+    const base = parseSearchArgs(['--batch-jsonl']);
+    const result = await runSearchBatchJsonlForText(
+      '{"query":"deploy"}\n',
+      base,
+      {
+        bootstrapLayout: async () => undefined,
+        resolveActiveModel: async () => 'ollama__default',
+        loadManagerForModel: async () => ({}) as never,
+        loadWithJsonRetry: async () => undefined,
+      },
+      async () => {
+        process.stdout.write(JSON.stringify({ error: { code: 'BOOM' } }));
+        process.stderr.write('search failed\n');
+        return 1;
+      },
+    );
+
+    expect(result.code).toBe(1);
+    expect(parseJsonl(result.stdout)).toEqual([
+      {
+        schema_version: 'kb.search.batch-jsonl.v1',
+        line: 1,
+        ok: false,
+        exit_code: 1,
+        query: 'deploy',
+        result: { error: { code: 'BOOM' } },
+        stderr: 'search failed\n',
+      },
+    ]);
+  });
+
+  it('rejects single-query and mutating base arguments in batch mode', async () => {
+    const withQuery = await runSearchBatchJsonlForText(
+      '{"query":"deploy"}\n',
+      parseSearchArgs(['--batch-jsonl', 'deploy']),
+    );
+    expect(withQuery).toMatchObject({
+      code: 2,
+      stdout: '',
+      stderr: 'kb search: --batch-jsonl reads queries from JSONL stdin; omit <query>\n',
+    });
+
+    const withRefresh = await runSearchBatchJsonlForText(
+      '{"query":"deploy"}\n',
+      parseSearchArgs(['--batch-jsonl', '--refresh']),
+    );
+    expect(withRefresh).toMatchObject({
+      code: 2,
+      stdout: '',
+      stderr: 'kb search: --batch-jsonl does not run --refresh; run single-query --refresh before batching\n',
+    });
+  });
+});

--- a/src/cli-search.ts
+++ b/src/cli-search.ts
@@ -111,6 +111,7 @@ export const SEARCH_HELP = `kb search — semantic search across knowledge bases
 Usage:
   kb search <query> [options]
   kb search --stdin [options]
+  kb search --batch-jsonl [options] < queries.jsonl
   kb search <query> --refresh [options]
 
 Default is dense (FAISS) similarity search, read-only. \`--refresh\` re-scans
@@ -179,6 +180,14 @@ Indexing:
 
 Input:
   --stdin               Read query from stdin (multi-line safe).
+  --batch-jsonl         Read newline-delimited JSON rows from stdin and emit
+                        one JSON result envelope per row. Each row requires
+                        "query"; common per-row overrides include kb, model,
+                        k, threshold, mode, no_cache, gate, rerank,
+                        task_context, group_by_source, timing, no_freshness,
+                        explain_empty, and explain. Batch mode rejects
+                        --refresh; run single-query --refresh before batching
+                        when the dense index needs updating.
   -i, --interactive     Open an interactive results picker (TTY only; ignored
                         when --format=json or --format=vimgrep is set).
   --help, -h            Show this help.
@@ -190,11 +199,12 @@ Examples:
   kb search "INDEX_NOT_INITIALIZED" --mode=hybrid
   kb search "src/cli.ts" --mode=auto --timing
   kb search --stdin --format=json < query.txt
+  printf '{"query":"deploy","kb":"work"}\n{"query":"rollback","k":3}\n' | kb search --batch-jsonl
 `;
 
 type SearchFormat = 'md' | 'json' | 'vimgrep';
 
-interface SearchArgs {
+export interface SearchArgs {
   query: string | null;
   kb?: string;
   model?: string;
@@ -208,6 +218,7 @@ interface SearchArgs {
   mode: SearchMode;
   timing: boolean;
   interactive: boolean;
+  batchJsonl: boolean;
   noCache: boolean;
   freshness: boolean;
   explainEmpty: boolean;
@@ -248,6 +259,10 @@ export async function runSearch(
   } catch (err) {
     process.stderr.write(`kb search: ${(err as Error).message}\n`);
     return 2;
+  }
+
+  if (parsed.batchJsonl) {
+    return runSearchBatchJsonl(parsed, deps);
   }
 
   if (parsed.stdin && parsed.query === null) {
@@ -580,6 +595,7 @@ export function parseSearchArgs(rest: string[]): SearchArgs {
     mode: 'dense',
     timing: false,
     interactive: false,
+    batchJsonl: false,
     noCache: false,
     freshness: true,
     explainEmpty: false,
@@ -590,6 +606,7 @@ export function parseSearchArgs(rest: string[]): SearchArgs {
     if (raw === '--stdin')   { out.stdin = true; continue; }
     if (raw === '--group-by-source') { out.groupBySource = true; continue; }
     if (raw === '--timing') { out.timing = true; continue; }
+    if (raw === '--batch-jsonl') { out.batchJsonl = true; continue; }
     if (raw === '--no-cache') { out.noCache = true; continue; }
     if (raw === '--gate') { out.gateOverride = 'on'; continue; }
     if (raw === '--no-gate') { out.gateOverride = 'off'; continue; }
@@ -1053,6 +1070,399 @@ async function readAllStdin(): Promise<string> {
     process.stdin.on('end', () => resolve(Buffer.concat(chunks).toString('utf-8')));
     process.stdin.on('error', reject);
   });
+}
+
+type RunSearchLike = (rest: string[], deps: RunSearchDeps) => Promise<number>;
+
+interface BatchJsonlRunResult {
+  code: number;
+  stdout: string;
+  stderr: string;
+}
+
+interface CapturedOutput {
+  code: number;
+  stdout: string;
+  stderr: string;
+}
+
+async function runSearchBatchJsonl(
+  base: SearchArgs,
+  deps: RunSearchDeps,
+): Promise<number> {
+  const input = await readAllStdin();
+  const result = await runSearchBatchJsonlForText(input, base, deps);
+  if (result.stdout !== '') process.stdout.write(result.stdout);
+  if (result.stderr !== '') process.stderr.write(result.stderr);
+  return result.code;
+}
+
+export async function runSearchBatchJsonlForText(
+  input: string,
+  base: SearchArgs,
+  deps: RunSearchDeps = DEFAULT_RUN_SEARCH_DEPS,
+  runOne: RunSearchLike = runSearch,
+): Promise<BatchJsonlRunResult> {
+  const baseError = validateBatchBaseArgs(base);
+  if (baseError !== null) {
+    return { code: 2, stdout: '', stderr: `kb search: ${baseError}\n` };
+  }
+
+  const cachedDeps = createBatchCachedSearchDeps(deps);
+  const envelopes: string[] = [];
+  let exitCode = 0;
+  for (const row of parseBatchJsonlRows(input)) {
+    if (row.kind === 'blank') continue;
+    if (row.kind === 'error') {
+      exitCode = Math.max(exitCode, 2);
+      envelopes.push(JSON.stringify(buildBatchErrorEnvelope(row.line, 2, row.message)));
+      continue;
+    }
+
+    let rowArgs: string[];
+    try {
+      rowArgs = buildBatchRowSearchArgs(base, row.value);
+    } catch (err) {
+      exitCode = Math.max(exitCode, 2);
+      envelopes.push(JSON.stringify(buildBatchErrorEnvelope(row.line, 2, (err as Error).message)));
+      continue;
+    }
+
+    const captured = await captureProcessOutput(() => runOne(rowArgs, cachedDeps));
+    exitCode = Math.max(exitCode, captured.code);
+    envelopes.push(JSON.stringify(buildBatchRunEnvelope(row.line, row.value, captured)));
+  }
+
+  return {
+    code: exitCode,
+    stdout: envelopes.length === 0 ? '' : `${envelopes.join('\n')}\n`,
+    stderr: '',
+  };
+}
+
+function validateBatchBaseArgs(base: SearchArgs): string | null {
+  if (base.query !== null) return '--batch-jsonl reads queries from JSONL stdin; omit <query>';
+  if (base.stdin) return '--batch-jsonl cannot be combined with --stdin';
+  if (base.refresh) return '--batch-jsonl does not run --refresh; run single-query --refresh before batching';
+  if (base.interactive) return '--batch-jsonl cannot be combined with --interactive';
+  if (base.format === 'vimgrep') return '--batch-jsonl emits JSONL envelopes; --format=vimgrep is not supported';
+  return null;
+}
+
+type ParsedBatchRow =
+  | { kind: 'blank'; line: number }
+  | { kind: 'error'; line: number; message: string }
+  | { kind: 'row'; line: number; value: Record<string, unknown> };
+
+function parseBatchJsonlRows(input: string): ParsedBatchRow[] {
+  const lines = input.split(/\r?\n/);
+  if (lines.length > 0 && lines[lines.length - 1] === '') lines.pop();
+  return lines.map((line, index) => {
+    const lineNumber = index + 1;
+    if (line.trim() === '') return { kind: 'blank', line: lineNumber };
+    try {
+      const parsed = JSON.parse(line) as unknown;
+      if (!isPlainObject(parsed)) {
+        return { kind: 'error', line: lineNumber, message: 'row must be a JSON object' };
+      }
+      return { kind: 'row', line: lineNumber, value: parsed };
+    } catch (err) {
+      return { kind: 'error', line: lineNumber, message: `invalid JSON: ${(err as Error).message}` };
+    }
+  });
+}
+
+function buildBatchRowSearchArgs(base: SearchArgs, row: Record<string, unknown>): string[] {
+  const args: string[] = [];
+  const query = requireStringField(row, 'query');
+  if (query.trim() === '') throw new Error('row query must be non-empty');
+  if (readOptionalString(row, 'format') !== undefined) {
+    throw new Error('row format is not supported; batch rows always run with --format=json');
+  }
+  if (readOptionalBoolean(row, 'refresh') === true) {
+    throw new Error('row refresh is not supported in --batch-jsonl');
+  }
+  if (readOptionalBoolean(row, 'stdin') === true) {
+    throw new Error('row stdin is not supported in --batch-jsonl');
+  }
+  if (readOptionalBoolean(row, 'interactive') === true) {
+    throw new Error('row interactive is not supported in --batch-jsonl');
+  }
+
+  args.push(query);
+  appendOptionalStringArg(args, '--kb=', row, 'kb', base.kb);
+  appendOptionalStringArg(args, '--model=', row, 'model', base.model);
+  appendOptionalIntegerArg(args, '--k=', row, 'k', base.k);
+  appendThresholdArg(args, row, base);
+  appendModeArg(args, row, base.mode);
+  appendOptionalAliasedStringArg(args, '--task-context=', row, 'task_context', 'taskContext', base.taskContext);
+  appendOptionalAliasedStringArg(args, '--task-context-file=', row, 'task_context_file', 'taskContextFile', base.taskContextFile);
+  if (readBatchBoolean(row, 'group_by_source', 'groupBySource', base.groupBySource)) args.push('--group-by-source');
+  if (readBatchBoolean(row, 'timing', 'timing', base.timing)) args.push('--timing');
+  if (readBatchBoolean(row, 'no_cache', 'noCache', base.noCache)) args.push('--no-cache');
+  if (!readBatchBoolean(row, 'freshness', 'freshness', base.freshness)) args.push('--no-freshness');
+  if (readBatchBoolean(row, 'no_freshness', 'noFreshness', false)) {
+    if (!args.includes('--no-freshness')) args.push('--no-freshness');
+  }
+  if (readBatchBoolean(row, 'explain_empty', 'explainEmpty', base.explainEmpty)) args.push('--explain-empty');
+  if (readBatchBoolean(row, 'explain', 'explain', base.explain)) args.push('--explain');
+  appendGateArgs(args, row, base);
+  appendRerankArgs(args, row, base);
+  appendNeighborContextArgs(args, row, base);
+  args.push('--format=json');
+  return args;
+}
+
+function appendThresholdArg(args: string[], row: Record<string, unknown>, base: SearchArgs): void {
+  if (Object.prototype.hasOwnProperty.call(row, 'threshold')) {
+    const value = row.threshold;
+    if (value === 'auto') {
+      args.push('--threshold=auto');
+      return;
+    }
+    if (typeof value !== 'number' || !Number.isFinite(value)) {
+      throw new Error('row threshold must be a finite number or "auto"');
+    }
+    args.push(`--threshold=${value}`);
+    return;
+  }
+  if (base.thresholdAuto) args.push('--threshold=auto');
+  else if (base.threshold !== undefined) args.push(`--threshold=${base.threshold}`);
+}
+
+function appendModeArg(args: string[], row: Record<string, unknown>, fallback: SearchMode): void {
+  const mode = readOptionalString(row, 'mode') ?? fallback;
+  if (mode !== 'dense' && mode !== 'lexical' && mode !== 'hybrid' && mode !== 'auto') {
+    throw new Error('row mode must be "dense", "lexical", "hybrid", or "auto"');
+  }
+  if (mode !== 'dense') args.push(`--mode=${mode}`);
+}
+
+function appendGateArgs(args: string[], row: Record<string, unknown>, base: SearchArgs): void {
+  const noGate = readBatchBoolean(row, 'no_gate', 'noGate', base.gateOverride === 'off');
+  const gate = readBatchBoolean(row, 'gate', 'gate', base.gateOverride === 'on');
+  if (noGate) args.push('--no-gate');
+  else if (gate) args.push('--gate');
+}
+
+function appendRerankArgs(args: string[], row: Record<string, unknown>, base: SearchArgs): void {
+  const noRerank = readBatchBoolean(row, 'no_rerank', 'noRerank', base.rerankOverride === 'off');
+  const rerank = readBatchBoolean(row, 'rerank', 'rerank', base.rerankOverride === 'on');
+  if (noRerank) args.push('--no-rerank');
+  else if (rerank) args.push('--rerank');
+}
+
+function appendNeighborContextArgs(args: string[], row: Record<string, unknown>, base: SearchArgs): void {
+  const before = readOptionalInteger(row, 'context_before') ?? readOptionalInteger(row, 'contextBefore') ?? base.neighborContext?.before;
+  const after = readOptionalInteger(row, 'context_after') ?? readOptionalInteger(row, 'contextAfter') ?? base.neighborContext?.after;
+  const window = readOptionalInteger(row, 'context_window') ?? readOptionalInteger(row, 'contextWindow');
+  if (window !== undefined) {
+    args.push(`--context-window=${window}`);
+    return;
+  }
+  if (before !== undefined) args.push(`--context-before=${before}`);
+  if (after !== undefined) args.push(`--context-after=${after}`);
+}
+
+function appendOptionalStringArg(
+  args: string[],
+  flag: string,
+  row: Record<string, unknown>,
+  field: string,
+  fallback: string | undefined,
+): void {
+  const value = readOptionalString(row, field) ?? fallback;
+  if (value !== undefined) args.push(`${flag}${value}`);
+}
+
+function appendOptionalAliasedStringArg(
+  args: string[],
+  flag: string,
+  row: Record<string, unknown>,
+  snakeField: string,
+  camelField: string,
+  fallback: string | undefined,
+): void {
+  const value = readOptionalString(row, snakeField)
+    ?? readOptionalString(row, camelField)
+    ?? fallback;
+  if (value !== undefined) args.push(`${flag}${value}`);
+}
+
+function appendOptionalIntegerArg(
+  args: string[],
+  flag: string,
+  row: Record<string, unknown>,
+  field: string,
+  fallback: number,
+): void {
+  const value = readOptionalInteger(row, field) ?? fallback;
+  args.push(`${flag}${value}`);
+}
+
+function requireStringField(row: Record<string, unknown>, field: string): string {
+  const value = row[field];
+  if (typeof value !== 'string') throw new Error(`row ${field} must be a string`);
+  return value;
+}
+
+function readOptionalString(row: Record<string, unknown>, field: string): string | undefined {
+  const value = row[field];
+  if (value === undefined) return undefined;
+  if (typeof value !== 'string') throw new Error(`row ${field} must be a string`);
+  return value;
+}
+
+function readOptionalInteger(row: Record<string, unknown>, field: string): number | undefined {
+  const value = row[field];
+  if (value === undefined) return undefined;
+  if (!Number.isInteger(value)) throw new Error(`row ${field} must be an integer`);
+  return value as number;
+}
+
+function readOptionalBoolean(row: Record<string, unknown>, field: string): boolean | undefined {
+  const value = row[field];
+  if (value === undefined) return undefined;
+  if (typeof value !== 'boolean') throw new Error(`row ${field} must be a boolean`);
+  return value;
+}
+
+function readBatchBoolean(
+  row: Record<string, unknown>,
+  snakeField: string,
+  camelField: string,
+  fallback: boolean,
+): boolean {
+  return readOptionalBoolean(row, snakeField)
+    ?? readOptionalBoolean(row, camelField)
+    ?? fallback;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object'
+    && value !== null
+    && !Array.isArray(value);
+}
+
+function createBatchCachedSearchDeps(deps: RunSearchDeps): RunSearchDeps {
+  let bootstrapPromise: Promise<void> | null = null;
+  const modelPromises = new Map<string, Promise<string>>();
+  const managerPromises = new Map<string, Promise<FaissIndexManager>>();
+  const loadPromises = new WeakMap<FaissIndexManager, Promise<void>>();
+
+  return {
+    ...deps,
+    bootstrapLayout: () => {
+      bootstrapPromise ??= deps.bootstrapLayout();
+      return bootstrapPromise;
+    },
+    resolveActiveModel: (input = {}) => {
+      const key = input.explicitOverride ?? '';
+      let promise = modelPromises.get(key);
+      if (promise === undefined) {
+        promise = deps.resolveActiveModel(input);
+        modelPromises.set(key, promise);
+      }
+      return promise;
+    },
+    loadManagerForModel: (activeModelId) => {
+      let promise = managerPromises.get(activeModelId);
+      if (promise === undefined) {
+        promise = deps.loadManagerForModel(activeModelId);
+        managerPromises.set(activeModelId, promise);
+      }
+      return promise;
+    },
+    loadWithJsonRetry: (manager) => {
+      let promise = loadPromises.get(manager);
+      if (promise === undefined) {
+        promise = deps.loadWithJsonRetry(manager);
+        loadPromises.set(manager, promise);
+      }
+      return promise;
+    },
+  };
+}
+
+async function captureProcessOutput(operation: () => Promise<number>): Promise<CapturedOutput> {
+  const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+  const originalStderrWrite = process.stderr.write.bind(process.stderr);
+  let stdout = '';
+  let stderr = '';
+  process.stdout.write = ((chunk: unknown, encodingOrCallback?: unknown, callback?: unknown) => {
+    stdout += bufferChunkToString(chunk);
+    invokeWriteCallback(encodingOrCallback, callback);
+    return true;
+  }) as typeof process.stdout.write;
+  process.stderr.write = ((chunk: unknown, encodingOrCallback?: unknown, callback?: unknown) => {
+    stderr += bufferChunkToString(chunk);
+    invokeWriteCallback(encodingOrCallback, callback);
+    return true;
+  }) as typeof process.stderr.write;
+  try {
+    const code = await operation();
+    return { code, stdout, stderr };
+  } finally {
+    process.stdout.write = originalStdoutWrite as typeof process.stdout.write;
+    process.stderr.write = originalStderrWrite as typeof process.stderr.write;
+  }
+}
+
+function bufferChunkToString(chunk: unknown): string {
+  if (Buffer.isBuffer(chunk)) return chunk.toString('utf-8');
+  return String(chunk);
+}
+
+function invokeWriteCallback(encodingOrCallback: unknown, callback: unknown): void {
+  if (typeof encodingOrCallback === 'function') {
+    encodingOrCallback();
+  } else if (typeof callback === 'function') {
+    callback();
+  }
+}
+
+function buildBatchRunEnvelope(
+  line: number,
+  row: Record<string, unknown>,
+  captured: CapturedOutput,
+): Record<string, unknown> {
+  const parsedStdout = parseCapturedJson(captured.stdout);
+  return {
+    schema_version: 'kb.search.batch-jsonl.v1',
+    line,
+    ok: captured.code === 0,
+    exit_code: captured.code,
+    query: typeof row.query === 'string' ? row.query : null,
+    ...(typeof row.kb === 'string' ? { kb: row.kb } : {}),
+    ...(typeof row.model === 'string' ? { model: row.model } : {}),
+    ...(typeof row.mode === 'string' ? { requested_mode: row.mode } : {}),
+    ...(parsedStdout.ok ? { result: parsedStdout.value } : { stdout: captured.stdout }),
+    ...(captured.stderr !== '' ? { stderr: captured.stderr } : {}),
+  };
+}
+
+function buildBatchErrorEnvelope(
+  line: number,
+  exitCode: number,
+  message: string,
+): Record<string, unknown> {
+  return {
+    schema_version: 'kb.search.batch-jsonl.v1',
+    line,
+    ok: false,
+    exit_code: exitCode,
+    error: {
+      message,
+    },
+  };
+}
+
+function parseCapturedJson(stdout: string): { ok: true; value: unknown } | { ok: false } {
+  try {
+    return { ok: true, value: JSON.parse(stdout) };
+  } catch {
+    return { ok: false };
+  }
 }
 
 // -- #206 stage 1 — lexical search dispatch ----------------------------------

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -672,6 +672,33 @@ describe('kb CLI — argv parsing and dispatch', () => {
     expect(r.stderr).toMatch(/fell back after \d+ms/);
   });
 
+  it('search --batch-jsonl reads stdin through the real CLI dispatch', () => {
+    const r = runCli(['search', '--batch-jsonl'], {}, '{"query":1}\n');
+    expect(r.code).toBe(2);
+    expect(JSON.parse(r.stdout)).toMatchObject({
+      schema_version: 'kb.search.batch-jsonl.v1',
+      line: 1,
+      ok: false,
+      exit_code: 2,
+      error: { message: 'row query must be a string' },
+    });
+  });
+
+  it('search --batch-jsonl bypasses daemon routing even when --daemon is present', () => {
+    const r = runCli(
+      ['search', '--batch-jsonl', '--daemon'],
+      { KB_DAEMON_URL: 'http://127.0.0.1:17798' },
+      '{"query":1}\n',
+    );
+    expect(r.code).toBe(2);
+    expect(r.stderr).not.toContain('daemon unavailable');
+    expect(JSON.parse(r.stdout)).toMatchObject({
+      schema_version: 'kb.search.batch-jsonl.v1',
+      line: 1,
+      ok: false,
+    });
+  });
+
   it('serve status exits 3 with a notice when no daemon is reachable', () => {
     const r = runCli(['serve', 'status'], { KB_DAEMON_URL: 'http://127.0.0.1:17798' });
     expect(r.code).toBe(3);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -518,7 +518,7 @@ async function runSearchMaybeViaDaemon(rest: string[]): Promise<number> {
   if (daemonIndex === -1) return runSearch(rest);
 
   const directRest = rest.filter((arg) => arg !== '--daemon');
-  if (directRest.includes('--refresh')) {
+  if (directRest.includes('--refresh') || directRest.includes('--batch-jsonl')) {
     return runSearch(directRest);
   }
 


### PR DESCRIPTION
Closes #429

## Summary
- add `kb search --batch-jsonl` to read JSONL query rows from stdin and emit one JSON envelope per row
- cache shared search setup during a batch so repeated dense rows reuse bootstrap/model/manager/index loading
- document `kb.search.batch-jsonl.v1` and add CLI/runtime/error-path coverage

## Verification
- `npm run build`
- `git diff --check origin/main..HEAD`
- `npx jest --runInBand src/cli-search-batch-jsonl.test.ts src/cli-json-contracts.test.ts src/cli.test.ts`
- `npm test` (105 suites passed; 1808 passed, 4 skipped, 1 todo)

## Pre-PR Review
- detected project type: npm
- type/build checks: passed (`npm run build`)
- tests: passed (`npm test`)
- bug reproduction: skipped (feature PR)
- diff review: done
- portability check: clean by manual added-line scan (repo helper absent)
- reviewer specialists: run; blocking correctness finding fixed; docs/test suggestions addressed; dead-code review clean
- OSS base-branch policy: skipped (same-repo PR)
