### PR TITLE
feat: expose remote transport counters in stats

### DIFF
--- a/src/KnowledgeBaseServer.test.ts
+++ b/src/KnowledgeBaseServer.test.ts
@@ -472,6 +472,46 @@ describe('KnowledgeBaseServer handlers', () => {
     expect(payload.embedding.dim).toBeNull();
   });
 
+  it('handleKbStats includes remote transport counters when HTTP mode is active (#430)', async () => {
+    const tempDir = await setRetrieveEnv();
+    await fsp.mkdir(path.join(tempDir, 'alpha'));
+    await fsp.writeFile(path.join(tempDir, 'alpha', 'a.md'), 'aaa');
+
+    const remoteTransportStats = {
+      transport: 'http' as const,
+      sessions_opened: 2,
+      sessions_closed: 1,
+      current_sessions: 1,
+      in_flight_requests: 3,
+      requests_total: 8,
+      response_status_buckets: {
+        '1xx': 0,
+        '2xx': 5,
+        '3xx': 0,
+        '4xx': 2,
+        '5xx': 1,
+      },
+      auth_failures: 1,
+      origin_denials: 1,
+      last_error: {
+        at: '2026-05-20T07:00:00.000Z',
+        message: 'socket parse error',
+      },
+    };
+
+    const server = await freshServer();
+    server['transportMode'] = 'http';
+    server['httpHost'] = {
+      getRuntimeStats: () => remoteTransportStats,
+    } as any;
+
+    const result = await server['handleKbStats']({});
+
+    expect(result.isError).toBeUndefined();
+    const payload = JSON.parse(result.content[0].text);
+    expect(payload.remote_transport).toEqual(remoteTransportStats);
+  });
+
   it('handleKbStats with unknown knowledge_base_name returns KB_NOT_FOUND error', async () => {
     const tempDir = await setRetrieveEnv();
     await fsp.mkdir(path.join(tempDir, 'alpha'));

--- a/src/KnowledgeBaseServer.ts
+++ b/src/KnowledgeBaseServer.ts
@@ -105,6 +105,7 @@ import {
   resolveRerankerConfig,
   type RerankOverride,
 } from './reranker.js';
+import type { TransportRuntimeStatsSnapshot } from './transport-runtime-stats.js';
 
 const SERVER_NAME = 'knowledge-base-server';
 const SERVER_VERSION = '0.1.0';
@@ -429,6 +430,7 @@ export class KnowledgeBaseServer {
         knowledgeBaseName: args.knowledge_base_name,
         serverVersion: SERVER_VERSION,
         startedAt: this.startedAt,
+        remoteTransportStats: this.getRemoteTransportStats(),
       });
       return {
         content: [{ type: 'text', text: JSON.stringify(payload, null, 2) }],
@@ -920,6 +922,12 @@ export class KnowledgeBaseServer {
     this.startActiveManagerWarmup();
     this.startTriggerWatcher();
     await this.startFsWatcher();
+  }
+
+  private getRemoteTransportStats(): TransportRuntimeStatsSnapshot | undefined {
+    if (this.transportMode === 'sse') return this.sseHost?.getRuntimeStats();
+    if (this.transportMode === 'http') return this.httpHost?.getRuntimeStats();
+    return undefined;
   }
 
   /**

--- a/src/cli-stats.test.ts
+++ b/src/cli-stats.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it, jest } from '@jest/globals';
-import { formatContextualSection, runStats, type RunStatsDeps } from './cli-stats.js';
+import {
+  formatContextualSection,
+  formatRemoteTransportSection,
+  runStats,
+  type RunStatsDeps,
+} from './cli-stats.js';
 import type { FaissIndexManager } from './FaissIndexManager.js';
 import type { KbStatsContextualPrefaceBlock, KbStatsPayload } from './kb-stats.js';
 import { KBError } from './errors.js';
@@ -189,6 +194,48 @@ describe('kb stats CLI', () => {
     expect(out).toContain('- Index path: `/tmp/kb-index`');
     expect(out).toContain('## Relevance Gate');
     expect(out).toContain('- Gated queries: 0');
+  });
+
+  it('renders a Remote Transport section when HTTP/SSE counters are present (#430)', async () => {
+    const withTransport = payload();
+    withTransport.remote_transport = {
+      transport: 'http',
+      sessions_opened: 3,
+      sessions_closed: 1,
+      current_sessions: 2,
+      in_flight_requests: 4,
+      requests_total: 12,
+      response_status_buckets: {
+        '1xx': 0,
+        '2xx': 8,
+        '3xx': 0,
+        '4xx': 3,
+        '5xx': 1,
+      },
+      auth_failures: 2,
+      origin_denials: 1,
+      last_error: {
+        at: '2026-05-20T07:00:00.000Z',
+        message: 'client socket error',
+      },
+    };
+    const { deps, stdout } = makeDeps({ payload: withTransport });
+
+    const code = await runStats([], deps);
+
+    expect(code).toBe(0);
+    const out = stdout.join('');
+    expect(out).toContain('## Remote Transport');
+    expect(out).toContain('- Mode: http');
+    expect(out).toContain('- Sessions: current=2, opened=3, closed=1');
+    expect(out).toContain('- Requests: total=12, in_flight=4, 1xx=0, 2xx=8, 3xx=0, 4xx=3, 5xx=1');
+    expect(out).toContain('- Auth failures: 2');
+    expect(out).toContain('- Origin denials: 1');
+    expect(out).toContain('- Last error: 2026-05-20T07:00:00.000Z client socket error');
+  });
+
+  it('omits the Remote Transport section for stdio/local stats payloads (#430)', () => {
+    expect(formatRemoteTransportSection(payload())).toEqual([]);
   });
 
   it('renders a Contextual Retrieval section in markdown when sidecars exist (#409)', async () => {

--- a/src/cli-stats.ts
+++ b/src/cli-stats.ts
@@ -176,8 +176,40 @@ export function formatStatsMarkdown(payload: KbStatsPayload): string {
       `${formatInteger(payload.relevance_gate.judge_window.size)}, ` +
       `warn>${formatRate(payload.relevance_gate.judge_window.warn_threshold)})`,
     '',
+    ...formatRemoteTransportSection(payload),
     ...formatContextualSection(payload),
   ].join('\n');
+}
+
+export function formatRemoteTransportSection(payload: KbStatsPayload): string[] {
+  const stats = payload.remote_transport;
+  if (stats === undefined) return [];
+
+  const buckets = stats.response_status_buckets;
+  const bucketSummary = [
+    `1xx=${formatInteger(buckets['1xx'])}`,
+    `2xx=${formatInteger(buckets['2xx'])}`,
+    `3xx=${formatInteger(buckets['3xx'])}`,
+    `4xx=${formatInteger(buckets['4xx'])}`,
+    `5xx=${formatInteger(buckets['5xx'])}`,
+  ].join(', ');
+  const lastError = stats.last_error === null
+    ? 'none'
+    : `${stats.last_error.at} ${stats.last_error.message}`;
+
+  return [
+    '## Remote Transport',
+    '',
+    `- Mode: ${stats.transport}`,
+    `- Sessions: current=${formatInteger(stats.current_sessions)}, ` +
+      `opened=${formatInteger(stats.sessions_opened)}, closed=${formatInteger(stats.sessions_closed)}`,
+    `- Requests: total=${formatInteger(stats.requests_total)}, ` +
+      `in_flight=${formatInteger(stats.in_flight_requests)}, ${bucketSummary}`,
+    `- Auth failures: ${formatInteger(stats.auth_failures)}`,
+    `- Origin denials: ${formatInteger(stats.origin_denials)}`,
+    `- Last error: ${lastError}`,
+    '',
+  ];
 }
 
 /**

--- a/src/config/mcp-descriptions.ts
+++ b/src/config/mcp-descriptions.ts
@@ -30,7 +30,7 @@ export const LIST_MODELS_DESCRIPTION =
 
 // Issue #54 - kb_stats tool description.
 export const DEFAULT_KB_STATS_DESCRIPTION =
-  'Reports observability stats for the knowledge base index: per-KB file_count, chunk_count, total_bytes_indexed and last_updated_at; the active embedding provider/model/dim; the on-disk index_path; and server version/uptime. Pass `knowledge_base_name` to scope to a single KB; omit it to get an entry per registered KB.';
+  'Reports observability stats for the knowledge base index: per-KB file_count, chunk_count, total_bytes_indexed and last_updated_at; the active embedding provider/model/dim; the on-disk index_path; server version/uptime; and HTTP/SSE transport counters when a remote transport is active. Pass `knowledge_base_name` to scope to a single KB; omit it to get an entry per registered KB.';
 export const KB_STATS_DESCRIPTION =
   process.env.KB_STATS_DESCRIPTION && process.env.KB_STATS_DESCRIPTION.length > 0
     ? process.env.KB_STATS_DESCRIPTION

--- a/src/kb-stats.test.ts
+++ b/src/kb-stats.test.ts
@@ -422,6 +422,52 @@ describe('computeKbStats', () => {
     }
   });
 
+  it('includes remote transport counters only when supplied by the server (issue #430)', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-stats-transport-'));
+    try {
+      await fsp.mkdir(path.join(tempDir, 'alpha'));
+      await fsp.writeFile(path.join(tempDir, 'alpha', 'a.md'), 'a');
+
+      const { computeKbStats } = await freshKbStats({
+        KNOWLEDGE_BASES_ROOT_DIR: tempDir,
+        FAISS_INDEX_PATH: path.join(tempDir, '.faiss'),
+      });
+
+      const withoutTransport = await computeKbStats(makeManager({}) as any, {
+        serverVersion: '0.0.0',
+        startedAt: Date.now(),
+      });
+      expect(withoutTransport.remote_transport).toBeUndefined();
+
+      const remoteTransportStats = {
+        transport: 'sse' as const,
+        sessions_opened: 2,
+        sessions_closed: 1,
+        current_sessions: 1,
+        in_flight_requests: 0,
+        requests_total: 5,
+        response_status_buckets: {
+          '1xx': 0,
+          '2xx': 3,
+          '3xx': 0,
+          '4xx': 2,
+          '5xx': 0,
+        },
+        auth_failures: 1,
+        origin_denials: 1,
+        last_error: null,
+      };
+      const withTransport = await computeKbStats(makeManager({}) as any, {
+        serverVersion: '0.0.0',
+        startedAt: Date.now(),
+        remoteTransportStats,
+      });
+      expect(withTransport.remote_transport).toEqual(remoteTransportStats);
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it('respects INGEST_EXCLUDE_PATHS so excluded files do not contribute to file_count or bytes', async () => {
     const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-stats-exclude-'));
     await fsp.mkdir(path.join(tempDir, 'alpha'));

--- a/src/kb-stats.ts
+++ b/src/kb-stats.ts
@@ -41,6 +41,7 @@ import {
   relevanceGateMetrics,
   type RelevanceGateMetricsSnapshot,
 } from './relevance-gate-metrics.js';
+import type { TransportRuntimeStatsSnapshot } from './transport-runtime-stats.js';
 
 export interface KbStatsRow {
   file_count: number;
@@ -100,6 +101,12 @@ export interface KbStatsPayload {
   provider_calls: Record<string, ProviderCallSnapshot>;
   query_cache: QueryCacheStats;
   relevance_gate: RelevanceGateMetricsSnapshot;
+  /**
+   * Issue #430 — live counters for the optional HTTP/SSE MCP transport.
+   * Omitted for stdio-only processes and for local `kb stats` invocations
+   * that are not serving a remote transport.
+   */
+  remote_transport?: TransportRuntimeStatsSnapshot;
 }
 
 export interface ComputeKbStatsOptions {
@@ -115,6 +122,8 @@ export interface ComputeKbStatsOptions {
    * singleton is read.
    */
   metrics?: ProviderCallMetrics;
+  /** Process-local HTTP/SSE counters, supplied by KnowledgeBaseServer when active. */
+  remoteTransportStats?: TransportRuntimeStatsSnapshot;
 }
 
 /**
@@ -218,6 +227,9 @@ export async function computeKbStats(
     provider_calls: metricsSource.snapshot(),
     query_cache: await queryEmbeddingCache.stats(),
     relevance_gate: relevanceGateMetrics.snapshot(),
+    ...(options.remoteTransportStats !== undefined
+      ? { remote_transport: options.remoteTransportStats }
+      : {}),
   };
 }
 

--- a/src/transport-runtime-stats.ts
+++ b/src/transport-runtime-stats.ts
@@ -1,0 +1,39 @@
+export type RemoteTransportKind = 'http' | 'sse';
+
+export type ResponseStatusBucket = '1xx' | '2xx' | '3xx' | '4xx' | '5xx';
+
+export interface TransportRuntimeErrorSnapshot {
+  at: string;
+  message: string;
+}
+
+export interface TransportRuntimeStatsSnapshot {
+  transport: RemoteTransportKind;
+  sessions_opened: number;
+  sessions_closed: number;
+  current_sessions: number;
+  in_flight_requests: number;
+  requests_total: number;
+  response_status_buckets: Record<ResponseStatusBucket, number>;
+  auth_failures: number;
+  origin_denials: number;
+  last_error: TransportRuntimeErrorSnapshot | null;
+}
+
+export function emptyResponseStatusBuckets(): Record<ResponseStatusBucket, number> {
+  return {
+    '1xx': 0,
+    '2xx': 0,
+    '3xx': 0,
+    '4xx': 0,
+    '5xx': 0,
+  };
+}
+
+export function responseStatusBucket(status: number): ResponseStatusBucket {
+  if (status >= 100 && status < 200) return '1xx';
+  if (status >= 200 && status < 300) return '2xx';
+  if (status >= 300 && status < 400) return '3xx';
+  if (status >= 400 && status < 500) return '4xx';
+  return '5xx';
+}

--- a/src/transport/base-http-host.ts
+++ b/src/transport/base-http-host.ts
@@ -24,6 +24,14 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 import { normalizeOrigin, type TransportConfig } from '../transport-config.js';
 import { logger } from '../logger.js';
+import {
+  emptyResponseStatusBuckets,
+  responseStatusBucket,
+  type RemoteTransportKind,
+  type ResponseStatusBucket,
+  type TransportRuntimeErrorSnapshot,
+  type TransportRuntimeStatsSnapshot,
+} from '../transport-runtime-stats.js';
 
 const HEALTH_ENDPOINT = '/health';
 const SHUTDOWN_DRAIN_DEADLINE_MS = 10_000;
@@ -54,6 +62,14 @@ export abstract class BaseHttpHost<TTransport extends { close(): Promise<void> }
   protected readonly sessions = new Map<string, BaseSessionEntry<TTransport>>();
   protected readonly originAllowList: ReadonlySet<string>;
   private readonly authTokenBuf: Buffer;
+  private sessionsOpened = 0;
+  private sessionsClosed = 0;
+  private requestsTotal = 0;
+  private readonly responseStatusBuckets: Record<ResponseStatusBucket, number> =
+    emptyResponseStatusBuckets();
+  private authFailures = 0;
+  private originDenials = 0;
+  private lastError: TransportRuntimeErrorSnapshot | null = null;
   protected server?: http.Server;
   protected inFlight = 0;
   protected shuttingDown = false;
@@ -77,6 +93,9 @@ export abstract class BaseHttpHost<TTransport extends { close(): Promise<void> }
 
   /** Short tag used in log lines (`sse`, `http`). */
   protected abstract get logPrefix(): string;
+
+  /** Stable transport label used in stats payloads. */
+  protected abstract get transportKind(): RemoteTransportKind;
 
   /** Human-readable transport label used in the start banner. */
   protected abstract get bannerLabel(): string;
@@ -126,6 +145,21 @@ export abstract class BaseHttpHost<TTransport extends { close(): Promise<void> }
     return this.sessions.size;
   }
 
+  getRuntimeStats(): TransportRuntimeStatsSnapshot {
+    return {
+      transport: this.transportKind,
+      sessions_opened: this.sessionsOpened,
+      sessions_closed: this.sessionsClosed,
+      current_sessions: this.sessions.size,
+      in_flight_requests: this.inFlight,
+      requests_total: this.requestsTotal,
+      response_status_buckets: { ...this.responseStatusBuckets },
+      auth_failures: this.authFailures,
+      origin_denials: this.originDenials,
+      last_error: this.lastError === null ? null : { ...this.lastError },
+    };
+  }
+
   /**
    * Issue #157 step 4 — fan a logging notification out across every live
    * session. The host owns the iteration so callers never see the session
@@ -165,6 +199,7 @@ export abstract class BaseHttpHost<TTransport extends { close(): Promise<void> }
       } catch {
         // best-effort
       }
+      this.recordTransportError(err);
       logger.warn(`[${this.logPrefix}] clientError: ${err.message}`);
     });
 
@@ -254,6 +289,8 @@ export abstract class BaseHttpHost<TTransport extends { close(): Promise<void> }
     const authPresent = Boolean(req.headers.authorization);
 
     const finalize = (status: number) => {
+      this.requestsTotal += 1;
+      this.responseStatusBuckets[responseStatusBucket(status)] += 1;
       this.writeAccessLog({
         ts: new Date(startedAt).toISOString(),
         method,
@@ -267,7 +304,9 @@ export abstract class BaseHttpHost<TTransport extends { close(): Promise<void> }
 
     // 1. CORS preflight short-circuits before auth.
     if (method === 'OPTIONS') {
-      finalize(this.handlePreflight(res, originHeader, normalizedOrigin));
+      const status = this.handlePreflight(res, originHeader, normalizedOrigin);
+      if (status === 403) this.originDenials += 1;
+      finalize(status);
       return;
     }
 
@@ -281,6 +320,7 @@ export abstract class BaseHttpHost<TTransport extends { close(): Promise<void> }
     //    caller and accepted; if Origin is present it must be in the
     //    allow-list (after normalization).
     if (normalizedOrigin !== null && !this.originAllowList.has(normalizedOrigin)) {
+      this.originDenials += 1;
       respond(res, 403, 'Origin not allowed');
       finalize(403);
       return;
@@ -288,6 +328,7 @@ export abstract class BaseHttpHost<TTransport extends { close(): Promise<void> }
 
     // 4. Bearer-token auth.
     if (!this.verifyBearer(req.headers.authorization)) {
+      this.authFailures += 1;
       res.setHeader('WWW-Authenticate', 'Bearer realm="knowledge-base-mcp"');
       respond(res, 401, 'Unauthorized');
       finalize(401);
@@ -404,7 +445,7 @@ export abstract class BaseHttpHost<TTransport extends { close(): Promise<void> }
   // ---------------------------------------------------------------------------
 
   protected async closeEntry(sessionId: string, entry: BaseSessionEntry<TTransport>): Promise<void> {
-    this.sessions.delete(sessionId);
+    this.unregisterSession(sessionId);
     try {
       await entry.transport.close();
     } catch (err) {
@@ -415,6 +456,29 @@ export abstract class BaseHttpHost<TTransport extends { close(): Promise<void> }
     } catch (err) {
       logger.warn(`[${this.logPrefix}] error closing mcp: ${(err as Error).message}`);
     }
+  }
+
+  protected registerSession(sessionId: string, entry: BaseSessionEntry<TTransport>): void {
+    if (!this.sessions.has(sessionId)) {
+      this.sessionsOpened += 1;
+    }
+    this.sessions.set(sessionId, entry);
+  }
+
+  protected unregisterSession(sessionId: string): BaseSessionEntry<TTransport> | undefined {
+    const entry = this.sessions.get(sessionId);
+    if (entry !== undefined) {
+      this.sessions.delete(sessionId);
+      this.sessionsClosed += 1;
+    }
+    return entry;
+  }
+
+  protected recordTransportError(error: Error): void {
+    this.lastError = {
+      at: new Date().toISOString(),
+      message: error.message,
+    };
   }
 }
 

--- a/src/transport/http.test.ts
+++ b/src/transport/http.test.ts
@@ -3,6 +3,7 @@
 // Stage 2 of RFC 008 / issue #48: streamable HTTP in stateful mode.
 
 import * as http from 'node:http';
+import * as net from 'node:net';
 import { AddressInfo } from 'node:net';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
@@ -124,6 +125,19 @@ async function waitFor(
   throw new Error('condition was not met before timeout');
 }
 
+function sendMalformedHttpRequest(port: number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const socket = net.createConnection({ host: '127.0.0.1', port }, () => {
+      socket.write('not an HTTP request\r\n\r\n');
+    });
+    socket.on('data', () => {
+      socket.destroy();
+    });
+    socket.on('close', () => resolve());
+    socket.on('error', reject);
+  });
+}
+
 describe('StreamableHttpHost — endpoints', () => {
   let stop: (() => Promise<void>) | undefined;
 
@@ -149,6 +163,58 @@ describe('StreamableHttpHost — endpoints', () => {
     const res = await request(started.port, { method: 'POST', path: '/mcp' });
     expect(res.statusCode).toBe(401);
     expect(res.headers['www-authenticate']).toMatch(/^Bearer /);
+  });
+
+  it('exposes process-lifetime HTTP transport counters', async () => {
+    const started = await startHost({
+      allowedOrigins: ['https://app.example'],
+    });
+    stop = started.stop;
+
+    const initial = started.host.getRuntimeStats();
+    expect(initial).toMatchObject({
+      transport: 'http',
+      sessions_opened: 0,
+      sessions_closed: 0,
+      current_sessions: 0,
+      in_flight_requests: 0,
+      requests_total: 0,
+      auth_failures: 0,
+      origin_denials: 0,
+      last_error: null,
+    });
+
+    await request(started.port, { path: '/health' });
+    await request(started.port, { method: 'POST', path: '/mcp' });
+    await request(started.port, {
+      method: 'POST',
+      path: '/mcp',
+      headers: {
+        Authorization: `Bearer ${VALID_TOKEN}`,
+        Origin: 'https://evil.example',
+      },
+    });
+
+    const { client } = await connectClient(started.port);
+    await waitFor(() => started.host.sessionCount === 1);
+    await client.close();
+    await waitFor(() => started.host.sessionCount === 0);
+
+    await sendMalformedHttpRequest(started.port);
+    await waitFor(() => started.host.getRuntimeStats().last_error !== null);
+
+    const stats = started.host.getRuntimeStats();
+    expect(stats.transport).toBe('http');
+    expect(stats.sessions_opened).toBe(1);
+    expect(stats.sessions_closed).toBe(1);
+    expect(stats.current_sessions).toBe(0);
+    expect(stats.in_flight_requests).toBe(0);
+    expect(stats.requests_total).toBeGreaterThanOrEqual(4);
+    expect(stats.response_status_buckets['2xx']).toBeGreaterThanOrEqual(2);
+    expect(stats.response_status_buckets['4xx']).toBeGreaterThanOrEqual(2);
+    expect(stats.auth_failures).toBe(1);
+    expect(stats.origin_denials).toBe(1);
+    expect(stats.last_error?.message).toEqual(expect.any(String));
   });
 
   it('preflight OPTIONS from listed origin gets streamable HTTP CORS headers', async () => {

--- a/src/transport/http.ts
+++ b/src/transport/http.ts
@@ -41,6 +41,10 @@ export class StreamableHttpHost extends BaseHttpHost<StreamableHTTPServerTranspo
     return 'http';
   }
 
+  protected get transportKind(): 'http' {
+    return 'http';
+  }
+
   protected get bannerLabel(): string {
     return 'streamable HTTP';
   }
@@ -180,15 +184,16 @@ export class StreamableHttpHost extends BaseHttpHost<StreamableHTTPServerTranspo
     transport = new StreamableHTTPServerTransport({
       sessionIdGenerator: () => randomUUID(),
       onsessioninitialized: (sessionId) => {
-        this.sessions.set(sessionId, { transport, mcp });
+        this.registerSession(sessionId, { transport, mcp });
       },
     });
     transport.onclose = () => {
       if (transport.sessionId) {
-        this.sessions.delete(transport.sessionId);
+        this.unregisterSession(transport.sessionId);
       }
     };
     transport.onerror = (error) => {
+      this.recordTransportError(error);
       logger.warn(`[http] transport error: ${error.message}`);
     };
     try {
@@ -196,7 +201,7 @@ export class StreamableHttpHost extends BaseHttpHost<StreamableHTTPServerTranspo
       await transport.handleRequest(req, res, parsedBody);
     } catch (err) {
       if (transport.sessionId) {
-        this.sessions.delete(transport.sessionId);
+        this.unregisterSession(transport.sessionId);
       }
       try {
         await transport.close();

--- a/src/transport/sse.test.ts
+++ b/src/transport/sse.test.ts
@@ -156,6 +156,18 @@ function openSseStream(
   });
 }
 
+async function waitFor(
+  predicate: () => boolean,
+  timeoutMs = 1000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error('condition was not met before timeout');
+}
+
 describe('loadTransportConfig validation', () => {
   const originalEnv = { ...process.env };
   afterEach(() => {
@@ -230,6 +242,45 @@ describe('SseHost — endpoints', () => {
       await stop();
       stop = undefined;
     }
+  });
+
+  it('exposes process-lifetime SSE transport counters', async () => {
+    const started = await startHost({
+      allowedOrigins: ['https://app.example'],
+    });
+    stop = started.stop;
+
+    await request(started.port, { path: '/health' });
+    await request(started.port, { method: 'GET', path: '/sse' });
+    await request(started.port, {
+      method: 'GET',
+      path: '/sse',
+      headers: {
+        Authorization: `Bearer ${VALID_TOKEN}`,
+        Origin: 'https://evil.example',
+      },
+    });
+
+    const stream = await openSseStream(started.port, {
+      Authorization: `Bearer ${VALID_TOKEN}`,
+    });
+    expect(stream.statusCode).toBe(200);
+    expect(stream.sessionId).toBeTruthy();
+    await waitFor(() => started.host.sessionCount === 1);
+    stream.close();
+    await waitFor(() => started.host.sessionCount === 0);
+
+    const stats = started.host.getRuntimeStats();
+    expect(stats.transport).toBe('sse');
+    expect(stats.sessions_opened).toBe(1);
+    expect(stats.sessions_closed).toBe(1);
+    expect(stats.current_sessions).toBe(0);
+    expect(stats.in_flight_requests).toBe(0);
+    expect(stats.requests_total).toBe(4);
+    expect(stats.response_status_buckets['2xx']).toBe(2);
+    expect(stats.response_status_buckets['4xx']).toBe(2);
+    expect(stats.auth_failures).toBe(1);
+    expect(stats.origin_denials).toBe(1);
   });
 
   it('(e) GET /health returns 200 JSON {"status":"ok"} without auth (RFC 008 §6.8: no fingerprinting)', async () => {

--- a/src/transport/sse.ts
+++ b/src/transport/sse.ts
@@ -38,6 +38,10 @@ export class SseHost extends BaseHttpHost<SSEServerTransport> {
     return 'sse';
   }
 
+  protected get transportKind(): 'sse' {
+    return 'sse';
+  }
+
   protected get bannerLabel(): string {
     return 'SSE';
   }
@@ -107,13 +111,13 @@ export class SseHost extends BaseHttpHost<SSEServerTransport> {
     // recursion. Map delete is idempotent, so multiple onclose firings are
     // harmless.
     transport.onclose = () => {
-      this.sessions.delete(sessionId);
+      this.unregisterSession(sessionId);
     };
-    this.sessions.set(sessionId, { transport, mcp });
+    this.registerSession(sessionId, { transport, mcp });
     try {
       await mcp.connect(transport);
     } catch (err) {
-      this.sessions.delete(sessionId);
+      this.unregisterSession(sessionId);
       throw err;
     }
   }


### PR DESCRIPTION
Closes #430

## Summary
- add process-lifetime HTTP/SSE transport counters for sessions, requests, status buckets, auth failures, origin denials, in-flight requests, and last transport error
- include the counters in the `kb_stats` payload when the server is running a remote transport
- render a Remote Transport section when a stats payload contains those counters

## Verification
- `npm run build`
- `git diff --check`
- `npx jest --runInBand src/KnowledgeBaseServer.test.ts src/transport/http.test.ts src/transport/sse.test.ts src/kb-stats.test.ts src/cli-stats.test.ts`
- `npm test` (104 suites passed; 1812 passed, 4 skipped, 1 todo)

## Pre-PR Review
- detected project type: npm
- type/build checks: passed (`npm run build`)
- tests: passed (`npm test`)
- bug reproduction: skipped (feature PR)
- diff review: done
- portability check: clean by manual added-line scan (repo helper absent)
- reviewer specialists: run; docs/test suggestions addressed before PR creation
- OSS base-branch policy: skipped (same-repo PR)
