### PR TITLE
feat: expose remote transport counters in stats

### DIFF
--- a/src/KnowledgeBaseServer.test.ts
+++ b/src/KnowledgeBaseServer.test.ts
@@ -1,6 +1,9 @@
 import * as fsp from 'fs/promises';
 import * as os from 'os';
 import * as path from 'path';
+import { AddressInfo } from 'node:net';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 
 const initializeMock = jest.fn();
 const updateIndexMock = jest.fn();
@@ -424,6 +427,96 @@ describe('KnowledgeBaseServer handlers', () => {
     expect(payload.server.version.length).toBeGreaterThan(0);
     expect(typeof payload.server.uptime_ms).toBe('number');
     expect(payload.server.uptime_ms).toBeGreaterThanOrEqual(0);
+  });
+
+  it('handleKbStats includes live remote transport counters when running over HTTP (#430)', async () => {
+    const tempDir = await setRetrieveEnv();
+    await fsp.mkdir(path.join(tempDir, 'alpha'));
+    await fsp.writeFile(path.join(tempDir, 'alpha', 'a.md'), 'aaa');
+
+    const server = await freshServer();
+    server['transportMode'] = 'http';
+    server['httpHost'] = {
+      getRuntimeStats: () => ({
+        transport: 'http',
+        current_sessions: 2,
+        sessions_opened: 5,
+        sessions_closed: 3,
+        in_flight_requests: 1,
+        response_status_buckets: { '2xx': 10, '4xx': 2 },
+        auth_failures: 1,
+        origin_denials: 1,
+        last_transport_error: null,
+      }),
+    } as any;
+
+    const result = await server['handleKbStats']({});
+
+    expect(result.isError).toBeUndefined();
+    const payload = JSON.parse(result.content[0].text);
+    expect(payload.transport).toEqual({
+      transport: 'http',
+      current_sessions: 2,
+      sessions_opened: 5,
+      sessions_closed: 3,
+      in_flight_requests: 1,
+      response_status_buckets: { '2xx': 10, '4xx': 2 },
+      auth_failures: 1,
+      origin_denials: 1,
+      last_transport_error: null,
+    });
+  });
+
+  it('HTTP MCP kb_stats returns the live transport snapshot from the active host (#430)', async () => {
+    const tempDir = await setRetrieveEnv();
+    await fsp.mkdir(path.join(tempDir, 'alpha'));
+    await fsp.writeFile(path.join(tempDir, 'alpha', 'a.md'), 'aaa');
+    getStatsMock.mockReturnValue({
+      totalChunks: 1,
+      chunkCountsByKb: { alpha: 1 },
+      dim: 384,
+    });
+
+    const server = await freshServer();
+    await server['runHttp']({
+      transport: 'http',
+      port: 0,
+      bindAddr: '127.0.0.1',
+      authToken: 'remote-stats-token',
+      allowedOrigins: [],
+    });
+    const httpServer = server['httpHost']['server'];
+    const addr = httpServer.address() as AddressInfo;
+    const client = new Client({ name: 'kb-http-stats-test', version: '0.0.0-test' });
+    const transport = new StreamableHTTPClientTransport(
+      new URL(`http://127.0.0.1:${addr.port}/mcp`),
+      { requestInit: { headers: { Authorization: 'Bearer remote-stats-token' } } },
+    );
+
+    try {
+      await client.connect(transport);
+      const result = await client.callTool({ name: 'kb_stats', arguments: {} });
+
+      expect(result.isError).toBeFalsy();
+      const content = result.content as Array<{ type: string; text?: string }>;
+      const text = content[0].type === 'text' ? content[0].text ?? '' : '';
+      const payload = JSON.parse(text);
+      expect(payload.knowledge_bases.alpha.chunk_count).toBe(1);
+      expect(payload.transport).toMatchObject({
+        transport: 'http',
+        current_sessions: 1,
+        sessions_opened: 1,
+        sessions_closed: 0,
+        auth_failures: 0,
+        origin_denials: 0,
+        last_transport_error: null,
+      });
+      expect(payload.transport.in_flight_requests).toBeGreaterThanOrEqual(0);
+      expect(payload.transport.response_status_buckets['2xx']).toBeGreaterThanOrEqual(1);
+    } finally {
+      await client.close();
+      await server.shutdown();
+    }
   });
 
   it('handleKbStats with knowledge_base_name returns only that KB and asserts chunk_count', async () => {

--- a/src/KnowledgeBaseServer.ts
+++ b/src/KnowledgeBaseServer.ts
@@ -105,6 +105,7 @@ import {
   resolveRerankerConfig,
   type RerankOverride,
 } from './reranker.js';
+import type { TransportRuntimeStats } from './transport-runtime-stats.js';
 
 const SERVER_NAME = 'knowledge-base-server';
 const SERVER_VERSION = '0.1.0';
@@ -429,6 +430,7 @@ export class KnowledgeBaseServer {
         knowledgeBaseName: args.knowledge_base_name,
         serverVersion: SERVER_VERSION,
         startedAt: this.startedAt,
+        transportStats: this.currentTransportStats(),
       });
       return {
         content: [{ type: 'text', text: JSON.stringify(payload, null, 2) }],
@@ -442,6 +444,16 @@ export class KnowledgeBaseServer {
       return { content: [mcpErrorContent(err)], isError: true };
       }
     });
+  }
+
+  private currentTransportStats(): TransportRuntimeStats | undefined {
+    if (this.transportMode === 'sse') {
+      return this.sseHost?.getRuntimeStats();
+    }
+    if (this.transportMode === 'http') {
+      return this.httpHost?.getRuntimeStats();
+    }
+    return undefined;
   }
 
   private async getActiveManagerForMutation(): Promise<FaissIndexManager> {

--- a/src/cli-stats.test.ts
+++ b/src/cli-stats.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it, jest } from '@jest/globals';
-import { formatContextualSection, runStats, type RunStatsDeps } from './cli-stats.js';
+import {
+  formatContextualSection,
+  formatTransportSection,
+  runStats,
+  type RunStatsDeps,
+} from './cli-stats.js';
 import type { FaissIndexManager } from './FaissIndexManager.js';
 import type { KbStatsContextualPrefaceBlock, KbStatsPayload } from './kb-stats.js';
 import { KBError } from './errors.js';
@@ -189,6 +194,42 @@ describe('kb stats CLI', () => {
     expect(out).toContain('- Index path: `/tmp/kb-index`');
     expect(out).toContain('## Relevance Gate');
     expect(out).toContain('- Gated queries: 0');
+  });
+
+  it('renders remote transport counters in markdown when present (#430)', async () => {
+    const withTransport = payload();
+    withTransport.transport = {
+      transport: 'http',
+      current_sessions: 1,
+      sessions_opened: 3,
+      sessions_closed: 2,
+      in_flight_requests: 4,
+      response_status_buckets: { '2xx': 7, '4xx': 2 },
+      auth_failures: 1,
+      origin_denials: 1,
+      last_transport_error: {
+        at: '2026-05-20T08:00:00.000Z',
+        message: 'socket hang up',
+      },
+    };
+    const { deps, stdout } = makeDeps({ payload: withTransport });
+
+    const code = await runStats([], deps);
+
+    expect(code).toBe(0);
+    const out = stdout.join('');
+    expect(out).toContain('## Remote Transport');
+    expect(out).toContain('- Mode: http');
+    expect(out).toContain('- Sessions: current=1, opened=3, closed=2');
+    expect(out).toContain('- In-flight requests: 4');
+    expect(out).toContain('- Response status buckets: 2xx=7, 4xx=2');
+    expect(out).toContain('- Auth failures: 1');
+    expect(out).toContain('- Origin denials: 1');
+    expect(out).toContain('- Last transport error: 2026-05-20T08:00:00.000Z socket hang up');
+  });
+
+  it('omits the remote transport markdown section when no host snapshot exists', () => {
+    expect(formatTransportSection(payload())).toEqual([]);
   });
 
   it('renders a Contextual Retrieval section in markdown when sidecars exist (#409)', async () => {

--- a/src/cli-stats.ts
+++ b/src/cli-stats.ts
@@ -27,7 +27,8 @@ Mirrors the MCP \`kb_stats\` payload for local shell use: per-KB file/chunk/byte
 counts, last-indexed time, embedding model, index path, and version context.
 Includes process-lifetime relevance-gate counters when the gate has run, and a
 Contextual Retrieval section with per-KB preface coverage and failure counts
-(by error code) when contextual-preface sidecars exist.
+(by error code) when contextual-preface sidecars exist. Remote MCP stats calls
+also include live HTTP/SSE transport counters.
 Strictly read-only — does not refresh the index.
 
 Options:
@@ -176,8 +177,40 @@ export function formatStatsMarkdown(payload: KbStatsPayload): string {
       `${formatInteger(payload.relevance_gate.judge_window.size)}, ` +
       `warn>${formatRate(payload.relevance_gate.judge_window.warn_threshold)})`,
     '',
+    ...formatTransportSection(payload),
     ...formatContextualSection(payload),
   ].join('\n');
+}
+
+export function formatTransportSection(payload: KbStatsPayload): string[] {
+  const stats = payload.transport;
+  if (stats === undefined) return [];
+
+  const statusBuckets = Object.entries(stats.response_status_buckets)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([bucket, count]) => `${bucket}=${formatInteger(count)}`)
+    .join(', ');
+
+  const lines = [
+    '## Remote Transport',
+    '',
+    `- Mode: ${stats.transport}`,
+    `- Sessions: current=${formatInteger(stats.current_sessions)}, ` +
+      `opened=${formatInteger(stats.sessions_opened)}, closed=${formatInteger(stats.sessions_closed)}`,
+    `- In-flight requests: ${formatInteger(stats.in_flight_requests)}`,
+    `- Response status buckets: ${statusBuckets.length > 0 ? statusBuckets : 'none'}`,
+    `- Auth failures: ${formatInteger(stats.auth_failures)}`,
+    `- Origin denials: ${formatInteger(stats.origin_denials)}`,
+  ];
+  if (stats.last_transport_error !== null) {
+    lines.push(
+      `- Last transport error: ${stats.last_transport_error.at} ${stats.last_transport_error.message}`,
+    );
+  } else {
+    lines.push('- Last transport error: none');
+  }
+  lines.push('');
+  return lines;
 }
 
 /**

--- a/src/config/mcp-descriptions.ts
+++ b/src/config/mcp-descriptions.ts
@@ -30,7 +30,7 @@ export const LIST_MODELS_DESCRIPTION =
 
 // Issue #54 - kb_stats tool description.
 export const DEFAULT_KB_STATS_DESCRIPTION =
-  'Reports observability stats for the knowledge base index: per-KB file_count, chunk_count, total_bytes_indexed and last_updated_at; the active embedding provider/model/dim; the on-disk index_path; and server version/uptime. Pass `knowledge_base_name` to scope to a single KB; omit it to get an entry per registered KB.';
+  'Reports observability stats for the knowledge base index: per-KB file_count, chunk_count, total_bytes_indexed and last_updated_at; the active embedding provider/model/dim; the on-disk index_path; server version/uptime; and, when served over HTTP/SSE, live remote transport counters. Pass `knowledge_base_name` to scope to a single KB; omit it to get an entry per registered KB.';
 export const KB_STATS_DESCRIPTION =
   process.env.KB_STATS_DESCRIPTION && process.env.KB_STATS_DESCRIPTION.length > 0
     ? process.env.KB_STATS_DESCRIPTION

--- a/src/kb-stats.test.ts
+++ b/src/kb-stats.test.ts
@@ -422,6 +422,40 @@ describe('computeKbStats', () => {
     }
   });
 
+  it('includes active remote transport counters when supplied by the MCP host (#430)', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-stats-transport-'));
+    try {
+      await fsp.mkdir(path.join(tempDir, 'alpha'));
+      await fsp.writeFile(path.join(tempDir, 'alpha', 'a.md'), 'a');
+
+      const { computeKbStats } = await freshKbStats({
+        KNOWLEDGE_BASES_ROOT_DIR: tempDir,
+        FAISS_INDEX_PATH: path.join(tempDir, '.faiss'),
+      });
+
+      const transportStats = {
+        transport: 'sse' as const,
+        current_sessions: 2,
+        sessions_opened: 5,
+        sessions_closed: 3,
+        in_flight_requests: 1,
+        response_status_buckets: { '2xx': 8, '4xx': 2 },
+        auth_failures: 1,
+        origin_denials: 1,
+        last_transport_error: null,
+      };
+      const payload = await computeKbStats(makeManager({}) as any, {
+        serverVersion: '0.0.0',
+        startedAt: Date.now(),
+        transportStats,
+      });
+
+      expect(payload.transport).toEqual(transportStats);
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it('respects INGEST_EXCLUDE_PATHS so excluded files do not contribute to file_count or bytes', async () => {
     const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-stats-exclude-'));
     await fsp.mkdir(path.join(tempDir, 'alpha'));

--- a/src/kb-stats.ts
+++ b/src/kb-stats.ts
@@ -41,6 +41,7 @@ import {
   relevanceGateMetrics,
   type RelevanceGateMetricsSnapshot,
 } from './relevance-gate-metrics.js';
+import type { TransportRuntimeStats } from './transport-runtime-stats.js';
 
 export interface KbStatsRow {
   file_count: number;
@@ -100,6 +101,12 @@ export interface KbStatsPayload {
   provider_calls: Record<string, ProviderCallSnapshot>;
   query_cache: QueryCacheStats;
   relevance_gate: RelevanceGateMetricsSnapshot;
+  /**
+   * Issue #430 — live HTTP/SSE transport counters. Present only when the
+   * stats call is served by an active remote transport host; omitted for
+   * stdio and local `kb stats` CLI calls.
+   */
+  transport?: TransportRuntimeStats;
 }
 
 export interface ComputeKbStatsOptions {
@@ -115,6 +122,8 @@ export interface ComputeKbStatsOptions {
    * singleton is read.
    */
   metrics?: ProviderCallMetrics;
+  /** Active HTTP/SSE transport counters for remote MCP stats calls. */
+  transportStats?: TransportRuntimeStats;
 }
 
 /**
@@ -218,6 +227,7 @@ export async function computeKbStats(
     provider_calls: metricsSource.snapshot(),
     query_cache: await queryEmbeddingCache.stats(),
     relevance_gate: relevanceGateMetrics.snapshot(),
+    ...(options.transportStats !== undefined ? { transport: options.transportStats } : {}),
   };
 }
 

--- a/src/transport-runtime-stats.ts
+++ b/src/transport-runtime-stats.ts
@@ -1,0 +1,14 @@
+export interface TransportRuntimeStats {
+  transport: 'http' | 'sse';
+  current_sessions: number;
+  sessions_opened: number;
+  sessions_closed: number;
+  in_flight_requests: number;
+  response_status_buckets: Record<string, number>;
+  auth_failures: number;
+  origin_denials: number;
+  last_transport_error: {
+    at: string;
+    message: string;
+  } | null;
+}

--- a/src/transport/base-http-host.ts
+++ b/src/transport/base-http-host.ts
@@ -24,6 +24,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 import { normalizeOrigin, type TransportConfig } from '../transport-config.js';
 import { logger } from '../logger.js';
+import type { TransportRuntimeStats } from '../transport-runtime-stats.js';
 
 const HEALTH_ENDPOINT = '/health';
 const SHUTDOWN_DRAIN_DEADLINE_MS = 10_000;
@@ -54,6 +55,12 @@ export abstract class BaseHttpHost<TTransport extends { close(): Promise<void> }
   protected readonly sessions = new Map<string, BaseSessionEntry<TTransport>>();
   protected readonly originAllowList: ReadonlySet<string>;
   private readonly authTokenBuf: Buffer;
+  private readonly responseStatusBuckets: Record<string, number> = {};
+  private sessionsOpened = 0;
+  private sessionsClosed = 0;
+  private authFailures = 0;
+  private originDenials = 0;
+  private lastTransportError: TransportRuntimeStats['last_transport_error'] = null;
   protected server?: http.Server;
   protected inFlight = 0;
   protected shuttingDown = false;
@@ -76,7 +83,7 @@ export abstract class BaseHttpHost<TTransport extends { close(): Promise<void> }
   // ---------------------------------------------------------------------------
 
   /** Short tag used in log lines (`sse`, `http`). */
-  protected abstract get logPrefix(): string;
+  protected abstract get logPrefix(): 'http' | 'sse';
 
   /** Human-readable transport label used in the start banner. */
   protected abstract get bannerLabel(): string;
@@ -126,6 +133,22 @@ export abstract class BaseHttpHost<TTransport extends { close(): Promise<void> }
     return this.sessions.size;
   }
 
+  getRuntimeStats(): TransportRuntimeStats {
+    return {
+      transport: this.logPrefix,
+      current_sessions: this.sessions.size,
+      sessions_opened: this.sessionsOpened,
+      sessions_closed: this.sessionsClosed,
+      in_flight_requests: this.inFlight,
+      response_status_buckets: { ...this.responseStatusBuckets },
+      auth_failures: this.authFailures,
+      origin_denials: this.originDenials,
+      last_transport_error: this.lastTransportError === null
+        ? null
+        : { ...this.lastTransportError },
+    };
+  }
+
   /**
    * Issue #157 step 4 — fan a logging notification out across every live
    * session. The host owns the iteration so callers never see the session
@@ -165,6 +188,7 @@ export abstract class BaseHttpHost<TTransport extends { close(): Promise<void> }
       } catch {
         // best-effort
       }
+      this.recordTransportError(err);
       logger.warn(`[${this.logPrefix}] clientError: ${err.message}`);
     });
 
@@ -254,6 +278,7 @@ export abstract class BaseHttpHost<TTransport extends { close(): Promise<void> }
     const authPresent = Boolean(req.headers.authorization);
 
     const finalize = (status: number) => {
+      this.recordResponseStatus(status);
       this.writeAccessLog({
         ts: new Date(startedAt).toISOString(),
         method,
@@ -281,6 +306,7 @@ export abstract class BaseHttpHost<TTransport extends { close(): Promise<void> }
     //    caller and accepted; if Origin is present it must be in the
     //    allow-list (after normalization).
     if (normalizedOrigin !== null && !this.originAllowList.has(normalizedOrigin)) {
+      this.originDenials += 1;
       respond(res, 403, 'Origin not allowed');
       finalize(403);
       return;
@@ -288,6 +314,7 @@ export abstract class BaseHttpHost<TTransport extends { close(): Promise<void> }
 
     // 4. Bearer-token auth.
     if (!this.verifyBearer(req.headers.authorization)) {
+      this.authFailures += 1;
       res.setHeader('WWW-Authenticate', 'Bearer realm="knowledge-base-mcp"');
       respond(res, 401, 'Unauthorized');
       finalize(401);
@@ -326,6 +353,7 @@ export abstract class BaseHttpHost<TTransport extends { close(): Promise<void> }
     // Origin header, which gets a 403.
     if (originHeader === null || normalizedOrigin === null ||
         !this.originAllowList.has(normalizedOrigin)) {
+      this.originDenials += 1;
       respond(res, 403, 'Origin not allowed');
       return 403;
     }
@@ -399,12 +427,39 @@ export abstract class BaseHttpHost<TTransport extends { close(): Promise<void> }
     logger.info(payload);
   }
 
+  protected recordTransportError(error: Error): void {
+    this.lastTransportError = {
+      at: new Date().toISOString(),
+      message: error.message,
+    };
+  }
+
+  protected registerSession(sessionId: string, entry: BaseSessionEntry<TTransport>): void {
+    if (!this.sessions.has(sessionId)) {
+      this.sessionsOpened += 1;
+    }
+    this.sessions.set(sessionId, entry);
+  }
+
+  protected unregisterSession(sessionId: string): boolean {
+    const deleted = this.sessions.delete(sessionId);
+    if (deleted) {
+      this.sessionsClosed += 1;
+    }
+    return deleted;
+  }
+
+  private recordResponseStatus(status: number): void {
+    const bucket = `${Math.floor(status / 100)}xx`;
+    this.responseStatusBuckets[bucket] = (this.responseStatusBuckets[bucket] ?? 0) + 1;
+  }
+
   // ---------------------------------------------------------------------------
   // Session cleanup — shared shape, used by stop() and subclass code paths.
   // ---------------------------------------------------------------------------
 
   protected async closeEntry(sessionId: string, entry: BaseSessionEntry<TTransport>): Promise<void> {
-    this.sessions.delete(sessionId);
+    this.unregisterSession(sessionId);
     try {
       await entry.transport.close();
     } catch (err) {

--- a/src/transport/http.test.ts
+++ b/src/transport/http.test.ts
@@ -151,6 +151,37 @@ describe('StreamableHttpHost — endpoints', () => {
     expect(res.headers['www-authenticate']).toMatch(/^Bearer /);
   });
 
+  it('records auth, origin, and status-bucket counters in the runtime snapshot (#430)', async () => {
+    const started = await startHost({
+      allowedOrigins: ['http://localhost:5173'],
+    });
+    stop = started.stop;
+
+    await request(started.port, { method: 'POST', path: '/mcp' });
+    await request(started.port, {
+      method: 'POST',
+      path: '/mcp',
+      headers: {
+        Origin: 'http://evil.example.com',
+        Authorization: `Bearer ${VALID_TOKEN}`,
+      },
+    });
+    await request(started.port, { path: '/health' });
+
+    expect(started.host.getRuntimeStats()).toMatchObject({
+      transport: 'http',
+      current_sessions: 0,
+      in_flight_requests: 0,
+      auth_failures: 1,
+      origin_denials: 1,
+      response_status_buckets: {
+        '2xx': 1,
+        '4xx': 2,
+      },
+      last_transport_error: null,
+    });
+  });
+
   it('preflight OPTIONS from listed origin gets streamable HTTP CORS headers', async () => {
     const started = await startHost({
       allowedOrigins: ['http://localhost:5173'],
@@ -251,8 +282,18 @@ describe('StreamableHttpHost — endpoints', () => {
     stop = started.stop;
     const { client } = await connectClient(started.port);
     await waitFor(() => started.host.sessionCount === 1);
+    expect(started.host.getRuntimeStats()).toMatchObject({
+      current_sessions: 1,
+      sessions_opened: 1,
+      sessions_closed: 0,
+    });
     await client.close();
     await waitFor(() => started.host.sessionCount === 0);
+    expect(started.host.getRuntimeStats()).toMatchObject({
+      current_sessions: 0,
+      sessions_opened: 1,
+      sessions_closed: 1,
+    });
   });
 
   // ---------------------------------------------------------------------

--- a/src/transport/http.ts
+++ b/src/transport/http.ts
@@ -37,7 +37,7 @@ const UUID_SHAPE =
 export type StreamableHttpHostOptions = BaseHttpHostOptions;
 
 export class StreamableHttpHost extends BaseHttpHost<StreamableHTTPServerTransport> {
-  protected get logPrefix(): string {
+  protected get logPrefix(): 'http' {
     return 'http';
   }
 
@@ -76,6 +76,7 @@ export class StreamableHttpHost extends BaseHttpHost<StreamableHTTPServerTranspo
     try {
       return await this.handleMcpRequest(req, res, method);
     } catch (err) {
+      this.recordTransportError(err as Error);
       logger.error(`[http] error handling ${method} /mcp: ${(err as Error).message}`);
       if (!res.headersSent) {
         respondJsonRpcError(res, 500, -32603, 'Internal Server Error');
@@ -180,15 +181,16 @@ export class StreamableHttpHost extends BaseHttpHost<StreamableHTTPServerTranspo
     transport = new StreamableHTTPServerTransport({
       sessionIdGenerator: () => randomUUID(),
       onsessioninitialized: (sessionId) => {
-        this.sessions.set(sessionId, { transport, mcp });
+        this.registerSession(sessionId, { transport, mcp });
       },
     });
     transport.onclose = () => {
       if (transport.sessionId) {
-        this.sessions.delete(transport.sessionId);
+        this.unregisterSession(transport.sessionId);
       }
     };
     transport.onerror = (error) => {
+      this.recordTransportError(error);
       logger.warn(`[http] transport error: ${error.message}`);
     };
     try {
@@ -196,7 +198,7 @@ export class StreamableHttpHost extends BaseHttpHost<StreamableHTTPServerTranspo
       await transport.handleRequest(req, res, parsedBody);
     } catch (err) {
       if (transport.sessionId) {
-        this.sessions.delete(transport.sessionId);
+        this.unregisterSession(transport.sessionId);
       }
       try {
         await transport.close();

--- a/src/transport/sse.test.ts
+++ b/src/transport/sse.test.ts
@@ -156,6 +156,18 @@ function openSseStream(
   });
 }
 
+async function waitFor(
+  predicate: () => boolean,
+  timeoutMs = 1000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error('condition was not met before timeout');
+}
+
 describe('loadTransportConfig validation', () => {
   const originalEnv = { ...process.env };
   afterEach(() => {
@@ -321,6 +333,45 @@ describe('SseHost — endpoints', () => {
       },
     });
     expect(res.statusCode).toBe(403);
+  });
+
+  it('records SSE session and gate counters in the runtime snapshot (#430)', async () => {
+    const started = await startHost({
+      allowedOrigins: ['http://localhost:5173'],
+    });
+    stop = started.stop;
+
+    await request(started.port, { path: '/sse' });
+    await request(started.port, {
+      path: '/sse',
+      headers: {
+        Origin: 'http://evil.example.com',
+        Authorization: `Bearer ${VALID_TOKEN}`,
+      },
+    });
+    const stream = await openSseStream(started.port, {
+      Authorization: `Bearer ${VALID_TOKEN}`,
+    });
+    expect(started.host.getRuntimeStats()).toMatchObject({
+      transport: 'sse',
+      current_sessions: 1,
+      sessions_opened: 1,
+      sessions_closed: 0,
+      auth_failures: 1,
+      origin_denials: 1,
+      response_status_buckets: {
+        '2xx': 1,
+        '4xx': 2,
+      },
+    });
+
+    stream.close();
+    await waitFor(() => started.host.getRuntimeStats().current_sessions === 0);
+    expect(started.host.getRuntimeStats()).toMatchObject({
+      sessions_opened: 1,
+      sessions_closed: 1,
+      in_flight_requests: 0,
+    });
   });
 
   it('OPTIONS preflight from listed origin gets 204 with CORS headers', async () => {

--- a/src/transport/sse.ts
+++ b/src/transport/sse.ts
@@ -34,7 +34,7 @@ const MESSAGES_ENDPOINT = '/messages';
 export type SseHostOptions = BaseHttpHostOptions;
 
 export class SseHost extends BaseHttpHost<SSEServerTransport> {
-  protected get logPrefix(): string {
+  protected get logPrefix(): 'sse' {
     return 'sse';
   }
 
@@ -66,6 +66,7 @@ export class SseHost extends BaseHttpHost<SSEServerTransport> {
         await this.handleSseOpen(req, res);
         return 200;
       } catch (err) {
+        this.recordTransportError(err as Error);
         logger.error(`[sse] error opening stream: ${(err as Error).message}`);
         if (!res.headersSent) {
           respond(res, 500, 'Error establishing SSE stream');
@@ -79,6 +80,7 @@ export class SseHost extends BaseHttpHost<SSEServerTransport> {
       try {
         return await this.handleMessagePost(req, res, url);
       } catch (err) {
+        this.recordTransportError(err as Error);
         logger.error(`[sse] error handling POST /messages: ${(err as Error).message}`);
         if (!res.headersSent) {
           respond(res, 500, 'Internal Server Error');
@@ -107,13 +109,13 @@ export class SseHost extends BaseHttpHost<SSEServerTransport> {
     // recursion. Map delete is idempotent, so multiple onclose firings are
     // harmless.
     transport.onclose = () => {
-      this.sessions.delete(sessionId);
+      this.unregisterSession(sessionId);
     };
-    this.sessions.set(sessionId, { transport, mcp });
+    this.registerSession(sessionId, { transport, mcp });
     try {
       await mcp.connect(transport);
     } catch (err) {
-      this.sessions.delete(sessionId);
+      this.unregisterSession(sessionId);
       throw err;
     }
   }


### PR DESCRIPTION
Closes #430

## Summary
- track live HTTP/SSE runtime counters on the shared remote host
- include the active host snapshot in MCP kb_stats and kb stats formatting when present
- cover HTTP/SSE counters plus a real HTTP MCP kb_stats call path

## Verification
- npm run build
- npm test
- git diff --check
- pre-pr review gate with reviewer specialists