### PR TITLE
feat: add doctor endpoint preflight

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,9 +459,12 @@ When `kb search` (or the MCP `retrieve_knowledge` tool) is not returning results
 ```bash
 kb doctor                # human-readable report
 kb doctor --format=json  # machine-readable for agent shells
+kb doctor --endpoints    # focused bind/connect endpoint preflight
 ```
 
 The report covers active-model resolution, FAISS index version + mtime, the latest in-process index-update summary, per-KB stale counts, embedding-backend reachability (Ollama / HuggingFace / OpenAI), local LLM endpoint readiness, CLI version, and local git state. The command exits non-zero when any required retrieval check fails (active model unresolved, index missing, backend unreachable); LLM endpoint failures are WARN rows because search can remain healthy while `kb ask` is not ready.
+
+Use `kb doctor --endpoints` when you only need configured local endpoint readiness before starting or wiring clients. It checks MCP bind address/port availability, configured `KB_DAEMON_URL` health, configured Ollama embedding reachability, and configured `KB_LLM_ENDPOINT` or active LLM profile readiness without loading the full index health report.
 
 ### Distinguishing search failure modes
 

--- a/docs/cli-json-contracts.md
+++ b/docs/cli-json-contracts.md
@@ -568,6 +568,7 @@ Invocation:
 
 ```bash
 kb doctor --format=json
+kb doctor --endpoints --format=json
 ```
 
 Report envelope:
@@ -680,10 +681,37 @@ Stdout/stderr and exit codes:
   the report with `status: "error"`.
 - Argument errors print `kb doctor: ...` to stderr and exit `2`.
 
-Source and test anchors: `src/cli-doctor.ts:84-107`,
-`src/cli-doctor.ts:201-214`, `src/cli-doctor.ts:476-483`,
-`src/cli-doctor.ts:926-1045`, `src/cli-doctor.ts:1243-1260`,
-`src/cli-doctor.test.ts:336-602`.
+`kb doctor --endpoints --format=json` emits the focused endpoint-readiness
+schema instead of the full report:
+
+```json
+{
+  "schema_version": "kb.doctor.endpoints.v1",
+  "status": "ok",
+  "endpoints": [
+    {
+      "name": "mcp_bind",
+      "kind": "bind",
+      "status": "ok",
+      "configured": true,
+      "target": "127.0.0.1:8765",
+      "source": "env",
+      "detail": "bind target is available"
+    }
+  ]
+}
+```
+
+Endpoint rows use `status: "ok" | "warn" | "error" | "skipped"`. The current
+row names are `mcp_bind`, `kb_daemon`, `embedding_ollama`, and
+`llm_endpoint`. Skipped rows mean the relevant endpoint is not configured in
+the current process environment/profile state. The command exits `1` only when
+the focused endpoint report has overall `status: "error"`.
+
+Source and test anchors: `src/cli-doctor.ts:92-146`,
+`src/cli-doctor.ts:347-418`, `src/cli-doctor.ts:421-743`,
+`src/cli-doctor.ts:1365-1452`, `src/cli-doctor.test.ts:923-1120`,
+`src/cli-json-contracts.test.ts:215-237`.
 
 ## `kb logs`
 

--- a/docs/troubleshooting-local-kb.md
+++ b/docs/troubleshooting-local-kb.md
@@ -11,9 +11,12 @@ Start with the read-only health check:
 ```bash
 kb doctor
 kb doctor --format=json
+kb doctor --endpoints
 ```
 
 `kb doctor` reports active-model resolution, index path and version, stale file counts, embedding backend health, local LLM endpoint readiness for `kb ask`, CLI package and symlink state, git drift for linked checkouts, and the latest index-update summary. Use it before deleting index files, changing client configuration, or debugging local LLM answers.
+
+Use `kb doctor --endpoints` for the narrower port/URL preflight: MCP bind target availability, configured `KB_DAEMON_URL`, configured Ollama embedding endpoint, and configured `KB_LLM_ENDPOINT` or active LLM profile.
 
 ## Quick Symptom Table
 

--- a/src/cli-doctor.test.ts
+++ b/src/cli-doctor.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, jest } from '@jest/globals';
 import * as fsp from 'fs/promises';
+import * as net from 'net';
 import * as os from 'os';
 import * as path from 'path';
 
@@ -26,6 +27,11 @@ const originalEnv = {
   HF_HOME: process.env.HF_HOME,
   TRANSFORMERS_CACHE: process.env.TRANSFORMERS_CACHE,
   HOME: process.env.HOME,
+  MCP_TRANSPORT: process.env.MCP_TRANSPORT,
+  MCP_PORT: process.env.MCP_PORT,
+  MCP_BIND_ADDR: process.env.MCP_BIND_ADDR,
+  KB_DAEMON_URL: process.env.KB_DAEMON_URL,
+  OLLAMA_BASE_URL: process.env.OLLAMA_BASE_URL,
 };
 
 const MODEL_ID = 'huggingface__BAAI-bge-small-en-v1.5';
@@ -100,6 +106,38 @@ async function healthyLlmProbe(endpoint: string) {
     chat_ok: true,
     detail: 'health and chat completion succeeded',
   };
+}
+
+function listen(server: net.Server, port = 0, host = '127.0.0.1'): Promise<number> {
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen({ port, host }, () => {
+      const address = server.address();
+      if (typeof address === 'object' && address !== null) resolve(address.port);
+      else reject(new Error('server did not report a TCP port'));
+    });
+  });
+}
+
+function closeServer(server: net.Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((err) => err ? reject(err) : resolve());
+  });
+}
+
+async function captureStdout(run: () => Promise<number>): Promise<{ code: number; stdout: string }> {
+  let stdout = '';
+  const spy = jest.spyOn(process.stdout, 'write')
+    .mockImplementation((chunk: string | Uint8Array) => {
+      stdout += String(chunk);
+      return true;
+    });
+  try {
+    const code = await run();
+    return { code, stdout };
+  } finally {
+    spy.mockRestore();
+  }
 }
 
 describe('kb doctor', () => {
@@ -882,15 +920,232 @@ describe('kb doctor', () => {
     }
   });
 
-  it('parses --format=json and rejects unsupported formats', async () => {
+  it('reports endpoint readiness for available bind and reachable configured HTTP targets', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-doctor-endpoints-ok-'));
+    const reserved = net.createServer();
+    try {
+      const port = await listen(reserved);
+      await closeServer(reserved);
+      const { buildEndpointReadinessReport, formatEndpointReadinessMarkdown } = await freshDoctor({
+        MCP_TRANSPORT: 'http',
+        MCP_BIND_ADDR: '127.0.0.1',
+        MCP_PORT: String(port),
+        KB_DAEMON_URL: 'http://127.0.0.1:17799',
+        EMBEDDING_PROVIDER: 'ollama',
+        OLLAMA_BASE_URL: 'http://127.0.0.1:11434',
+        KB_LLM_ENDPOINT: 'http://127.0.0.1:8080',
+        KB_LLM_CONFIG_DIR: path.join(tempDir, 'llm-config'),
+        KB_LLM_STATE_DIR: path.join(tempDir, 'llm-state'),
+      });
+      const fetchMock = jest.fn(async (input: string | URL | Request) => {
+        const url = String(input);
+        if (url === 'http://127.0.0.1:17799/health') {
+          return new Response('{"status":"ok"}', {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+        if (url === 'http://127.0.0.1:11434/api/tags') {
+          return new Response('{"models":[]}', { status: 200 });
+        }
+        throw new Error(`unexpected fetch ${url}`);
+      });
+
+      const report = await buildEndpointReadinessReport({
+        fetchImpl: fetchMock as unknown as typeof fetch,
+        llmEndpointProbe: healthyLlmProbe,
+      });
+
+      expect(report.status).toBe('ok');
+      expect(report.endpoints).toEqual([
+        expect.objectContaining({
+          name: 'mcp_bind',
+          status: 'ok',
+          configured: true,
+          target: `127.0.0.1:${port}`,
+        }),
+        expect.objectContaining({
+          name: 'kb_daemon',
+          status: 'ok',
+          target: 'http://127.0.0.1:17799/health',
+        }),
+        expect.objectContaining({
+          name: 'embedding_ollama',
+          status: 'ok',
+          target: 'http://127.0.0.1:11434/api/tags',
+        }),
+        expect.objectContaining({
+          name: 'llm_endpoint',
+          status: 'ok',
+          target: 'http://127.0.0.1:8080/v1/chat/completions',
+        }),
+      ]);
+      const markdown = formatEndpointReadinessMarkdown(report);
+      expect(markdown).toContain('Endpoint readiness:');
+      expect(markdown).toContain('OK      mcp_bind');
+      expect(JSON.parse(JSON.stringify(report)).schema_version).toBe('kb.doctor.endpoints.v1');
+    } finally {
+      await closeServer(reserved).catch(() => undefined);
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('reports endpoint errors for occupied bind targets and malformed endpoint config', async () => {
+    const occupied = net.createServer();
+    try {
+      const port = await listen(occupied);
+      const { buildEndpointReadinessReport } = await freshDoctor({
+        MCP_TRANSPORT: 'sse',
+        MCP_BIND_ADDR: '127.0.0.1',
+        MCP_PORT: String(port),
+        KB_DAEMON_URL: 'not a url',
+        EMBEDDING_PROVIDER: 'huggingface',
+        OLLAMA_BASE_URL: '',
+        KB_LLM_ENDPOINT: '',
+        KB_LLM_CONFIG_DIR: path.join(os.tmpdir(), 'kb-doctor-endpoints-empty-config'),
+        KB_LLM_STATE_DIR: path.join(os.tmpdir(), 'kb-doctor-endpoints-empty-state'),
+      });
+
+      const report = await buildEndpointReadinessReport({
+        llmEndpointProbe: healthyLlmProbe,
+      });
+
+      expect(report.status).toBe('error');
+      expect(report.endpoints).toEqual([
+        expect.objectContaining({
+          name: 'mcp_bind',
+          status: 'error',
+          detail: expect.stringContaining('EADDRINUSE'),
+        }),
+        expect.objectContaining({
+          name: 'kb_daemon',
+          status: 'error',
+          source: 'invalid',
+          detail: expect.stringContaining('invalid KB_DAEMON_URL'),
+        }),
+        expect.objectContaining({
+          name: 'embedding_ollama',
+          status: 'skipped',
+          configured: false,
+        }),
+        expect.objectContaining({
+          name: 'llm_endpoint',
+          status: 'skipped',
+          configured: false,
+        }),
+      ]);
+    } finally {
+      await closeServer(occupied);
+    }
+  });
+
+  it('reports malformed transport and dangling active LLM profile as endpoint errors', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-doctor-endpoints-config-errors-'));
+    try {
+      const llmConfigDir = path.join(tempDir, 'llm-config');
+      await fsp.mkdir(llmConfigDir, { recursive: true });
+      await fsp.writeFile(path.join(llmConfigDir, 'active.txt'), 'missing-profile\n');
+
+      const { buildEndpointReadinessReport } = await freshDoctor({
+        MCP_TRANSPORT: 'htp',
+        KB_LLM_CONFIG_DIR: llmConfigDir,
+        KB_LLM_STATE_DIR: path.join(tempDir, 'llm-state'),
+        EMBEDDING_PROVIDER: 'huggingface',
+        OLLAMA_BASE_URL: '',
+        KB_LLM_ENDPOINT: '',
+      });
+
+      const report = await buildEndpointReadinessReport({
+        llmEndpointProbe: healthyLlmProbe,
+      });
+
+      expect(report.status).toBe('error');
+      expect(report.endpoints).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          name: 'mcp_bind',
+          status: 'error',
+          source: 'invalid',
+          detail: 'invalid MCP_TRANSPORT="htp"; expected one of stdio|sse|http',
+        }),
+        expect.objectContaining({
+          name: 'llm_endpoint',
+          status: 'error',
+          source: 'invalid',
+          detail: 'active LLM profile "missing-profile" is configured but profile file is missing',
+        }),
+      ]));
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('routes --endpoints through runDoctor with JSON output and exit codes', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-doctor-run-endpoints-'));
+    try {
+      const { runDoctor } = await freshDoctor({
+        MCP_TRANSPORT: '',
+        MCP_PORT: '',
+        MCP_BIND_ADDR: '',
+        KB_DAEMON_URL: '',
+        EMBEDDING_PROVIDER: 'huggingface',
+        OLLAMA_BASE_URL: '',
+        KB_LLM_ENDPOINT: '',
+        KB_LLM_CONFIG_DIR: path.join(tempDir, 'llm-config'),
+        KB_LLM_STATE_DIR: path.join(tempDir, 'llm-state'),
+      });
+
+      const ok = await captureStdout(() => runDoctor(['--endpoints', '--format=json']));
+      expect(ok.code).toBe(0);
+      expect(JSON.parse(ok.stdout)).toMatchObject({
+        schema_version: 'kb.doctor.endpoints.v1',
+        status: 'ok',
+        endpoints: expect.arrayContaining([
+          expect.objectContaining({ name: 'mcp_bind', status: 'skipped' }),
+        ]),
+      });
+
+      process.env.MCP_PORT = '0';
+      const error = await captureStdout(() => runDoctor(['--endpoints', '--format=json']));
+      expect(error.code).toBe(1);
+      expect(JSON.parse(error.stdout)).toMatchObject({
+        schema_version: 'kb.doctor.endpoints.v1',
+        status: 'error',
+        endpoints: expect.arrayContaining([
+          expect.objectContaining({
+            name: 'mcp_bind',
+            status: 'error',
+            detail: 'invalid MCP_PORT="0"; expected integer in [1, 65535]',
+          }),
+        ]),
+      });
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('parses --format=json, --endpoints, and rejects unsupported formats', async () => {
     const { parseDoctorArgs } = await freshDoctor({});
-    expect(parseDoctorArgs(['--format=json'])).toEqual({ format: 'json', reindexTrigger: false });
-    expect(parseDoctorArgs(['--reindex-trigger'])).toEqual({ format: 'md', reindexTrigger: true });
+    expect(parseDoctorArgs(['--format=json'])).toEqual({
+      format: 'json',
+      reindexTrigger: false,
+      endpoints: false,
+    });
+    expect(parseDoctorArgs(['--reindex-trigger'])).toEqual({
+      format: 'md',
+      reindexTrigger: true,
+      endpoints: false,
+    });
+    expect(parseDoctorArgs(['--endpoints', '--format=json'])).toEqual({
+      format: 'json',
+      reindexTrigger: false,
+      endpoints: true,
+    });
     expect(parseDoctorArgs(['--reindex-trigger', '--format=json'])).toEqual({
       format: 'json',
       reindexTrigger: true,
+      endpoints: false,
     });
-    expect(parseDoctorArgs([])).toEqual({ format: 'md', reindexTrigger: false });
+    expect(parseDoctorArgs([])).toEqual({ format: 'md', reindexTrigger: false, endpoints: false });
     expect(() => parseDoctorArgs(['--format=yaml'])).toThrow(/invalid --format/);
   });
 

--- a/src/cli-doctor.ts
+++ b/src/cli-doctor.ts
@@ -5,6 +5,7 @@
 
 import * as fsp from 'fs/promises';
 import { realpathSync } from 'fs';
+import * as net from 'net';
 import * as path from 'path';
 import { execFile } from 'child_process';
 import { promisify } from 'util';
@@ -60,10 +61,20 @@ import { inspectReindexTriggerFilesystem } from './triggerWatcher.js';
 import { deriveHealthUrl, probeLlmEndpoint, type LlmProbeResult } from './llm-client.js';
 import {
   createExternalProfile,
+  readActiveProfileName,
+  readProfile,
   resolveProfile,
   type LlmProfile,
 } from './llm-profiles.js';
 import { resolveRerankerConfig } from './config/reranker.js';
+import {
+  daemonUrlFromEnv,
+  fetchDaemonHealth,
+} from './daemon-client.js';
+import {
+  DEFAULT_MCP_BIND_ADDR,
+  DEFAULT_MCP_PORT,
+} from './transport-config.js';
 
 /**
  * Issue #210 — error-rate threshold above which the doctor surfaces a
@@ -81,7 +92,7 @@ const execFileAsync = promisify(execFile);
 export const DOCTOR_HELP = `kb doctor — aggregate model / index / backend health report
 
 Usage:
-  kb doctor [--format=md|json] [--reindex-trigger]
+  kb doctor [--format=md|json] [--reindex-trigger] [--endpoints]
 
 Composes existing read-only checks (env vars, registered models, active
 model, FAISS index presence + mtime, knowledge-base count, embedding
@@ -98,6 +109,9 @@ Options:
                         underlying report shape for agent shells.
   --reindex-trigger     Include focused reindex-trigger diagnostics
                         (also included in the aggregate report).
+  --endpoints           Check only configured local bind/connect endpoint
+                        readiness (MCP bind target, KB_DAEMON_URL,
+                        Ollama embedding endpoint, and KB_LLM_ENDPOINT/profile).
   --help, -h            Show this help.
 
 Examples:
@@ -109,9 +123,27 @@ Examples:
 export interface DoctorArgs {
   format: 'md' | 'json';
   reindexTrigger: boolean;
+  endpoints: boolean;
 }
 
 export type HealthStatus = 'ok' | 'warn' | 'error';
+export type EndpointHealthStatus = HealthStatus | 'skipped';
+
+export interface EndpointReadinessEntry {
+  name: 'mcp_bind' | 'kb_daemon' | 'embedding_ollama' | 'llm_endpoint';
+  kind: 'bind' | 'http';
+  status: EndpointHealthStatus;
+  configured: boolean;
+  target: string | null;
+  source: 'env' | 'profile' | 'default' | 'not_configured' | 'invalid';
+  detail: string;
+}
+
+export interface EndpointReadinessReport {
+  schema_version: 'kb.doctor.endpoints.v1';
+  status: HealthStatus;
+  endpoints: EndpointReadinessEntry[];
+}
 
 export interface DoctorIndexSecurityEntry {
   name: 'faiss_root' | 'active_file' | 'active_model_dir' | 'active_index_version_dir';
@@ -301,6 +333,11 @@ export interface BuildDoctorReportOptions {
   llmEndpointProbe?: LlmEndpointProbe;
 }
 
+export interface BuildEndpointReadinessReportOptions {
+  fetchImpl?: typeof fetch;
+  llmEndpointProbe?: LlmEndpointProbe;
+}
+
 export type BackendHealthCheck = (
   provider: string,
   modelName: string,
@@ -316,6 +353,16 @@ export async function runDoctor(rest: string[]): Promise<number> {
     return 2;
   }
 
+  if (parsed.endpoints) {
+    const report = await buildEndpointReadinessReport();
+    if (parsed.format === 'json') {
+      process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    } else {
+      process.stdout.write(formatEndpointReadinessMarkdown(report));
+    }
+    return report.status === 'error' ? 1 : 0;
+  }
+
   const report = await buildDoctorReport();
   if (parsed.format === 'json') {
     process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
@@ -326,7 +373,7 @@ export async function runDoctor(rest: string[]): Promise<number> {
 }
 
 export function parseDoctorArgs(rest: string[]): DoctorArgs {
-  const out: DoctorArgs = { format: 'md', reindexTrigger: false };
+  const out: DoctorArgs = { format: 'md', reindexTrigger: false, endpoints: false };
   for (const raw of rest) {
     if (raw.startsWith('--format=')) {
       const value = raw.slice('--format='.length);
@@ -340,10 +387,360 @@ export function parseDoctorArgs(rest: string[]): DoctorArgs {
       out.reindexTrigger = true;
       continue;
     }
+    if (raw === '--endpoints') {
+      out.endpoints = true;
+      continue;
+    }
     if (raw.startsWith('--')) throw new Error(`unknown flag: ${raw}`);
     throw new Error(`unexpected argument: ${JSON.stringify(raw)}`);
   }
   return out;
+}
+
+export async function buildEndpointReadinessReport(
+  options: BuildEndpointReadinessReportOptions = {},
+): Promise<EndpointReadinessReport> {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const entries: EndpointReadinessEntry[] = [];
+  entries.push(await readMcpBindEndpointHealth());
+  entries.push(await readKbDaemonEndpointHealth(fetchImpl));
+  entries.push(await readOllamaEndpointHealth(fetchImpl));
+  entries.push(await readConfiguredLlmEndpointHealth(
+    options.llmEndpointProbe ?? ((endpoint) => probeLlmEndpoint(endpoint, fetchImpl, {
+      healthTimeoutMs: DOCTOR_LLM_HEALTH_TIMEOUT_MS,
+      chatTimeoutMs: DOCTOR_LLM_CHAT_TIMEOUT_MS,
+    })),
+  ));
+  return {
+    schema_version: 'kb.doctor.endpoints.v1',
+    status: summarizeEndpointStatus(entries),
+    endpoints: entries,
+  };
+}
+
+async function readMcpBindEndpointHealth(): Promise<EndpointReadinessEntry> {
+  const transport = process.env.MCP_TRANSPORT?.trim() ?? '';
+  if (
+    transport.length > 0 &&
+    transport !== 'stdio' &&
+    transport !== 'http' &&
+    transport !== 'sse'
+  ) {
+    const bindAddr = process.env.MCP_BIND_ADDR?.trim() || DEFAULT_MCP_BIND_ADDR;
+    const port = process.env.MCP_PORT?.trim() || String(DEFAULT_MCP_PORT);
+    return {
+      name: 'mcp_bind',
+      kind: 'bind',
+      status: 'error',
+      configured: true,
+      target: `${bindAddr}:${port}`,
+      source: 'invalid',
+      detail: `invalid MCP_TRANSPORT=${JSON.stringify(transport)}; expected one of stdio|sse|http`,
+    };
+  }
+  const explicitlyConfigured = Boolean(
+    transport === 'http' ||
+    transport === 'sse' ||
+    process.env.MCP_PORT?.trim() ||
+    process.env.MCP_BIND_ADDR?.trim(),
+  );
+  const bindAddr = process.env.MCP_BIND_ADDR?.trim() || DEFAULT_MCP_BIND_ADDR;
+  let port: number;
+  try {
+    port = parseEndpointPort(process.env.MCP_PORT, 'MCP_PORT', DEFAULT_MCP_PORT);
+  } catch (err) {
+    return {
+      name: 'mcp_bind',
+      kind: 'bind',
+      status: 'error',
+      configured: true,
+      target: `${bindAddr}:${process.env.MCP_PORT ?? ''}`,
+      source: 'invalid',
+      detail: (err as Error).message,
+    };
+  }
+  const target = `${bindAddr}:${port}`;
+  if (!explicitlyConfigured) {
+    return {
+      name: 'mcp_bind',
+      kind: 'bind',
+      status: 'skipped',
+      configured: false,
+      target,
+      source: 'not_configured',
+      detail: 'MCP_TRANSPORT is stdio and no MCP_PORT/MCP_BIND_ADDR override is configured',
+    };
+  }
+
+  try {
+    await probeTcpBind(bindAddr, port);
+    return {
+      name: 'mcp_bind',
+      kind: 'bind',
+      status: 'ok',
+      configured: true,
+      target,
+      source: process.env.MCP_PORT?.trim() || process.env.MCP_BIND_ADDR?.trim() ? 'env' : 'default',
+      detail: 'bind target is available',
+    };
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    const suffix = code ? `${code}: ${(err as Error).message}` : (err as Error).message;
+    return {
+      name: 'mcp_bind',
+      kind: 'bind',
+      status: 'error',
+      configured: true,
+      target,
+      source: process.env.MCP_PORT?.trim() || process.env.MCP_BIND_ADDR?.trim() ? 'env' : 'default',
+      detail: `bind target is not available: ${suffix}`,
+    };
+  }
+}
+
+async function readKbDaemonEndpointHealth(fetchImpl: typeof fetch): Promise<EndpointReadinessEntry> {
+  if (process.env.KB_DAEMON_URL === undefined || process.env.KB_DAEMON_URL.trim() === '') {
+    return {
+      name: 'kb_daemon',
+      kind: 'http',
+      status: 'skipped',
+      configured: false,
+      target: null,
+      source: 'not_configured',
+      detail: 'KB_DAEMON_URL is not configured',
+    };
+  }
+  let target: string;
+  try {
+    target = new URL('/health', daemonUrlFromEnv(process.env)).href;
+  } catch (err) {
+    return {
+      name: 'kb_daemon',
+      kind: 'http',
+      status: 'error',
+      configured: true,
+      target: process.env.KB_DAEMON_URL,
+      source: 'invalid',
+      detail: `invalid KB_DAEMON_URL: ${(err as Error).message}`,
+    };
+  }
+  try {
+    const health = await fetchDaemonHealth({ env: process.env, fetchImpl, timeoutMs: 1500 });
+    return {
+      name: 'kb_daemon',
+      kind: 'http',
+      status: 'ok',
+      configured: true,
+      target,
+      source: 'env',
+      detail: `daemon health responded with status=${JSON.stringify(health.status)}`,
+    };
+  } catch (err) {
+    return {
+      name: 'kb_daemon',
+      kind: 'http',
+      status: 'error',
+      configured: true,
+      target,
+      source: 'env',
+      detail: `daemon health is not reachable: ${(err as Error).message}`,
+    };
+  }
+}
+
+async function readOllamaEndpointHealth(fetchImpl: typeof fetch): Promise<EndpointReadinessEntry> {
+  const provider = process.env.EMBEDDING_PROVIDER?.trim() || 'huggingface';
+  const configured = provider === 'ollama' || Boolean(process.env.OLLAMA_BASE_URL?.trim());
+  if (!configured) {
+    return {
+      name: 'embedding_ollama',
+      kind: 'http',
+      status: 'skipped',
+      configured: false,
+      target: null,
+      source: 'not_configured',
+      detail: 'EMBEDDING_PROVIDER is not ollama and OLLAMA_BASE_URL is not configured',
+    };
+  }
+  let target: string;
+  try {
+    target = new URL('/api/tags', OLLAMA_BASE_URL).href;
+  } catch (err) {
+    return {
+      name: 'embedding_ollama',
+      kind: 'http',
+      status: 'error',
+      configured: true,
+      target: OLLAMA_BASE_URL,
+      source: 'invalid',
+      detail: `invalid OLLAMA_BASE_URL: ${(err as Error).message}`,
+    };
+  }
+  return probeHttpGet('embedding_ollama', target, 'env', fetchImpl, 'Ollama tags endpoint');
+}
+
+async function readConfiguredLlmEndpointHealth(
+  check: LlmEndpointProbe,
+): Promise<EndpointReadinessEntry> {
+  let target: { profile: LlmProfile; source: EndpointReadinessEntry['source'] } | null = null;
+  try {
+    if (process.env.KB_LLM_ENDPOINT?.trim()) {
+      target = {
+        profile: await createExternalProfile('env', process.env.KB_LLM_ENDPOINT),
+        source: 'env',
+      };
+    } else {
+      const activeProfileName = await readActiveProfileName();
+      if (activeProfileName !== null) {
+        const profile = await readProfile(activeProfileName);
+        if (profile === null) {
+          return {
+            name: 'llm_endpoint',
+            kind: 'http',
+            status: 'error',
+            configured: true,
+            target: null,
+            source: 'invalid',
+            detail: `active LLM profile ${JSON.stringify(activeProfileName)} is configured but profile file is missing`,
+          };
+        }
+        target = { profile, source: 'profile' };
+      }
+    }
+  } catch (err) {
+    return {
+      name: 'llm_endpoint',
+      kind: 'http',
+      status: 'error',
+      configured: true,
+      target: process.env.KB_LLM_ENDPOINT ?? null,
+      source: 'invalid',
+      detail: `LLM endpoint configuration is invalid: ${(err as Error).message}`,
+    };
+  }
+
+  if (target === null) {
+    return {
+      name: 'llm_endpoint',
+      kind: 'http',
+      status: 'skipped',
+      configured: false,
+      target: null,
+      source: 'not_configured',
+      detail: 'KB_LLM_ENDPOINT is not configured and no active LLM profile is set',
+    };
+  }
+
+  try {
+    const probe = await check(target.profile.endpoint);
+    const status: HealthStatus = probe.health_ok && probe.chat_ok ? 'ok' : 'error';
+    return {
+      name: 'llm_endpoint',
+      kind: 'http',
+      status,
+      configured: true,
+      target: probe.endpoint,
+      source: target.source,
+      detail: formatLlmEndpointDetail(target.profile, target.source === 'profile' ? 'profile' : 'env', probe),
+    };
+  } catch (err) {
+    return {
+      name: 'llm_endpoint',
+      kind: 'http',
+      status: 'error',
+      configured: true,
+      target: target.profile.endpoint,
+      source: target.source,
+      detail: `LLM endpoint probe failed: ${(err as Error).message}`,
+    };
+  }
+}
+
+function parseEndpointPort(raw: string | undefined, envVar: string, fallback: number): number {
+  if (raw === undefined || raw.trim() === '') return fallback;
+  const port = Number(raw);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new Error(`invalid ${envVar}=${JSON.stringify(raw)}; expected integer in [1, 65535]`);
+  }
+  return port;
+}
+
+function probeTcpBind(host: string, port: number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    let settled = false;
+    const finish = (err?: Error) => {
+      if (settled) return;
+      settled = true;
+      server.removeAllListeners();
+      if (err) reject(err);
+      else resolve();
+    };
+    server.once('error', finish);
+    server.listen({ host, port }, () => {
+      server.close((err) => finish(err ?? undefined));
+    });
+  });
+}
+
+async function probeHttpGet(
+  name: EndpointReadinessEntry['name'],
+  target: string,
+  source: EndpointReadinessEntry['source'],
+  fetchImpl: typeof fetch,
+  label: string,
+): Promise<EndpointReadinessEntry> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 1500);
+  try {
+    const response = await fetchImpl(target, { method: 'GET', signal: controller.signal });
+    return {
+      name,
+      kind: 'http',
+      status: response.ok ? 'ok' : 'error',
+      configured: true,
+      target,
+      source,
+      detail: response.ok
+        ? `${label} responded with HTTP ${response.status}`
+        : `${label} returned HTTP ${response.status}`,
+    };
+  } catch (err) {
+    const message = (err as Error).name === 'AbortError' ? 'timed out' : (err as Error).message;
+    return {
+      name,
+      kind: 'http',
+      status: 'error',
+      configured: true,
+      target,
+      source,
+      detail: `${label} is not reachable: ${message}`,
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function summarizeEndpointStatus(entries: EndpointReadinessEntry[]): HealthStatus {
+  if (entries.some((entry) => entry.status === 'error')) return 'error';
+  if (entries.some((entry) => entry.status === 'warn')) return 'warn';
+  return 'ok';
+}
+
+export function formatEndpointReadinessMarkdown(report: EndpointReadinessReport): string {
+  const lines: string[] = [];
+  lines.push(`Status: ${report.status.toUpperCase()}`);
+  lines.push('');
+  lines.push('Endpoint readiness:');
+  for (const entry of report.endpoints) {
+    const target = entry.target ?? '<not configured>';
+    const configured = entry.configured ? 'configured' : 'not configured';
+    lines.push(
+      `  ${entry.status.toUpperCase().padEnd(7)} ${entry.name}: ${target} ` +
+      `(${entry.kind}, ${entry.source}, ${configured}) - ${entry.detail}`,
+    );
+  }
+  return lines.join('\n') + '\n';
 }
 
 export async function buildDoctorReport(

--- a/src/cli-json-contracts.test.ts
+++ b/src/cli-json-contracts.test.ts
@@ -213,7 +213,7 @@ const docAssertions: Record<DocumentedCommand, (examples: unknown[]) => void> = 
     expect(record(examples[1])).toEqual({ recommended_kb: null, results: [] });
   },
   'kb doctor': (examples) => {
-    expect(examples).toHaveLength(1);
+    expect(examples).toHaveLength(2);
     expect(record(examples[0])).toMatchObject({
       status: expect.any(String),
       checks: expect.any(Array),
@@ -222,6 +222,19 @@ const docAssertions: Record<DocumentedCommand, (examples: unknown[]) => void> = 
       backend: expect.any(Object),
       cli: expect.any(Object),
       last_index_update: expect.any(Object),
+    });
+    expect(record(examples[1])).toMatchObject({
+      schema_version: 'kb.doctor.endpoints.v1',
+      status: expect.any(String),
+      endpoints: expect.arrayContaining([
+        expect.objectContaining({
+          name: expect.any(String),
+          kind: expect.any(String),
+          status: expect.any(String),
+          configured: expect.any(Boolean),
+          detail: expect.any(String),
+        }),
+      ]),
     });
   },
   'kb logs': (examples) => {


### PR DESCRIPTION
Closes #431

## Summary
- add `kb doctor --endpoints` with a focused `kb.doctor.endpoints.v1` JSON report
- preflight MCP bind availability, configured `KB_DAEMON_URL`, configured Ollama endpoint, and configured `KB_LLM_ENDPOINT`/active profile readiness
- document the new focused report and keep JSON contract examples covered

## Verification
- `git diff --check`
- `npm run build`
- `npm test -- --runTestsByPath src/cli-doctor.test.ts`
- `npm test -- --runTestsByPath src/cli-doctor.test.ts src/cli-json-contracts.test.ts`
- `npm test`
- `npm run docs:check-anchors` (warning mode exited 0; stale anchors reported only in older architecture/RFC docs)
- `env -i PATH="$PATH" HOME="$HOME" node build/cli.js doctor --endpoints --format=json`

## Pre-PR review
- conventions, correctness, dead-code, and test specialists ran
- fixed reviewer findings for stale contract anchors, direct `runDoctor --endpoints` coverage, invalid `MCP_TRANSPORT`, and dangling active LLM profile handling
