### PR TITLE
feat: add kb research evidence collection

### DIFF
--- a/docs/cli-json-contracts.md
+++ b/docs/cli-json-contracts.md
@@ -199,6 +199,107 @@ Source and test anchors: `src/cli-search.ts:262-320`,
 `src/formatter.ts:136-213`, `src/cli-search-errors.ts:181-215`,
 `src/formatter.test.ts:133-185`, `src/cli-search-errors.test.ts:121-159`.
 
+## `kb research`
+
+Invocation:
+
+```bash
+kb research plan "<question>" --format=json
+kb research collect "<question>" --run-dir <path> --format=json
+```
+
+`kb research` is read-only. `plan` reads KB descriptions and stats, then
+deterministically selects shelves and queries. `collect` writes a local run
+directory and retrieves evidence using existing hybrid search.
+
+Plan success envelope:
+
+```json
+{
+  "schema_version": "kb-research-plan.v1",
+  "question": "research question",
+  "selected_shelves": [
+    {
+      "name": "llm-agents",
+      "description": "Autonomous LLM agents",
+      "file_count": 4,
+      "chunk_count": 12,
+      "score": 6,
+      "reasons": ["1 shelf-name token match", "shelf has indexed-source files"],
+      "risks": []
+    }
+  ],
+  "queries": [
+    {
+      "id": "q1",
+      "text": "research question",
+      "purpose": "original research question",
+      "shelves": ["llm-agents"]
+    }
+  ],
+  "retrieval": { "mode": "hybrid", "k": 5 },
+  "risks": []
+}
+```
+
+Stable plan fields are `schema_version`, `question`, `selected_shelves`,
+`queries`, `retrieval`, and `risks`. `retrieval.mode` is currently `hybrid`.
+`selected_shelves[].risks` and top-level `risks` include
+`dense_index_empty_coverage` when a selected shelf has files but zero dense
+chunks; collection still uses hybrid search in that case.
+
+Collect summary success envelope:
+
+```json
+{
+  "schema_version": "kb-research-collect-summary.v1",
+  "question": "research question",
+  "run_dir": "/abs/path/to/run",
+  "status": "complete",
+  "artifact_paths": {
+    "run": "/abs/path/to/run/run.json",
+    "plan": "/abs/path/to/run/plan.json",
+    "ledger": "/abs/path/to/run/ledger.json",
+    "evidence_packet": "/abs/path/to/run/evidence_packet.md",
+    "events": "/abs/path/to/run/events.jsonl"
+  },
+  "evidence_count": 3,
+  "risk_count": 0,
+  "search_failure_count": 0
+}
+```
+
+Stable collect summary fields are `schema_version`, `question`, `run_dir`,
+`status`, `artifact_paths`, `evidence_count`, `risk_count`, and
+`search_failure_count`. `status` is `complete` when all hybrid searches
+complete without delegated search failures, and `failed` when at least one
+search failed.
+
+Collect artifacts:
+
+- `run.json`: run metadata with `schema_version`, `question`, `command`,
+  `run_dir`, `started_at`, `finished_at`, `status`, and `artifact_paths`.
+- `plan.json`: the same `kb-research-plan.v1` shape emitted by `plan`.
+- `ledger.json`: `kb-research-ledger.v1` with `question`, `retrieval_mode`,
+  `entries`, `risks`, and `search_failures`.
+- `evidence_packet.md`: markdown packet with Question, Selected Shelves,
+  Queries, Evidence Found, Evidence Gaps, and Sources sections.
+- `events.jsonl`: structured event stream for collection progress.
+
+Ledger entries have stable `source_id`, `shelf`, `relative_path`,
+`line_range`, `query`, `retrieval_mode`, `score`, `excerpt`, `source_kind`,
+`source_generation`, and `risk_flags` fields. `line_range`,
+`relative_path`, `source_kind`, and `source_generation` can be `null` when the
+underlying search metadata does not provide enough information.
+
+Stdout/stderr and exit codes:
+
+- `plan --format=json` writes the plan JSON to stdout and exits `0`.
+- `collect --format=json` writes the summary JSON to stdout after artifacts are
+  written. It exits `0` for `status=complete` and `1` for `status=failed`.
+- Parser errors are stderr and exit `2`.
+- Runtime errors before artifact completion are stderr and exit `1`.
+
 ## `kb remember`
 
 Invocation:

--- a/src/cli-research.test.ts
+++ b/src/cli-research.test.ts
@@ -1,0 +1,384 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import * as fsp from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  buildResearchPlan,
+  parseResearchArgs,
+  runResearch,
+  type ResearchDeps,
+  type ShelfDescription,
+} from './cli-research.js';
+import type { KbStatsPayload } from './kb-stats.js';
+
+function statsPayload(overrides: Partial<KbStatsPayload> = {}): KbStatsPayload {
+  return {
+    knowledge_bases: {
+      'llm-agents': {
+        file_count: 4,
+        chunk_count: 12,
+        total_bytes_indexed: 1000,
+        last_updated_at: '2026-05-21T08:00:00.000Z',
+      },
+      'llm-as-judge': {
+        file_count: 2,
+        chunk_count: 0,
+        total_bytes_indexed: 500,
+        last_updated_at: null,
+      },
+      recipes: {
+        file_count: 3,
+        chunk_count: 9,
+        total_bytes_indexed: 300,
+        last_updated_at: null,
+      },
+    },
+    quarantined: {},
+    embedding: {
+      provider: 'ollama',
+      model: 'nomic-embed-text:latest',
+      dim: 768,
+    },
+    index_path: '/tmp/kb-index',
+    last_index_update: {
+      status: 'never_run',
+      scope: null,
+      model_id: 'ollama__nomic-embed-text-latest',
+      started_at: null,
+      finished_at: null,
+      duration_ms: null,
+      files_scanned: 0,
+      files_changed: 0,
+      files_unchanged: 0,
+      files_skipped: 0,
+      chunks_attempted: 0,
+      chunks_added: 0,
+      index_mutated: false,
+      saved: false,
+      sidecars_written: false,
+      failure_count: 0,
+      failures: [],
+    },
+    server: {
+      version: 'test',
+      uptime_ms: 1,
+    },
+    provider_calls: {},
+    query_cache: {
+      hits: 0,
+      misses: 0,
+      hit_ratio: 0,
+      l1_hits: 0,
+      disk_hits: 0,
+      bypasses: 0,
+      writes: 0,
+      corruptions: 0,
+      l1_size: 0,
+      disk_size_bytes: 0,
+    },
+    ...overrides,
+  };
+}
+
+function shelfDescriptions(): ShelfDescription[] {
+  return [
+    { name: 'llm-agents', description: 'Autonomous LLM agents, planning, tool use, and evaluation' },
+    { name: 'llm-as-judge', description: 'LLM judge evals, rubric design, and critic reliability' },
+    { name: 'recipes', description: 'Cooking notes and kitchen experiments' },
+  ];
+}
+
+function makeDeps(opts: {
+  stats?: KbStatsPayload;
+  searchExitCode?: number;
+  searchPayload?: Record<string, unknown>;
+} = {}): { deps: ResearchDeps; stdout: string[]; stderr: string[] } {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const deps: ResearchDeps = {
+    loadShelfDescriptions: jest.fn(async () => shelfDescriptions()),
+    loadStats: jest.fn(async () => opts.stats ?? statsPayload()),
+    searchHybrid: jest.fn(async (input: { query: string; shelf: string; k: number }) => {
+      const { shelf } = input;
+      if (opts.searchExitCode !== undefined && opts.searchExitCode !== 0) {
+        return {
+          exitCode: opts.searchExitCode,
+          stdout: JSON.stringify({ error: { code: 'INDEX_ERROR', message: 'fixture search failed' } }),
+          stderr: 'fixture search failed',
+          payload: { error: { code: 'INDEX_ERROR', message: 'fixture search failed' } },
+        };
+      }
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify(opts.searchPayload ?? fixtureSearchPayload(shelf)),
+        stderr: '',
+        payload: opts.searchPayload ?? fixtureSearchPayload(shelf),
+      };
+    }),
+    now: jest.fn(() => new Date('2026-05-21T09:30:00.000Z')),
+    stdout: (text) => { stdout.push(text); },
+    stderr: (text) => { stderr.push(text); },
+  };
+  return { deps, stdout, stderr };
+}
+
+function fixtureSearchPayload(shelf: string): Record<string, unknown> {
+  return {
+    mode: 'hybrid',
+    results: [{
+      score: 0.42,
+      content: 'Agent evaluation evidence with rubric stability and tool-use traces.',
+      chunk_id: `${shelf}/papers/agent-evals.md#L10-L14`,
+      metadata: {
+        knowledgeBase: shelf,
+        relativePath: `${shelf}/papers/agent-evals.md`,
+        loc: { lines: { from: 10, to: 14 } },
+        frontmatter: {
+          source_kind: 'paper-note',
+          source_generation: 'lra',
+        },
+      },
+    }],
+    retrievers: {
+      dense: { fetched: 1, model: 'ollama__nomic-embed-text-latest' },
+      lexical: { fetched: 1, refreshed: 0, failed: 0 },
+    },
+  };
+}
+
+describe('kb research CLI', () => {
+  it('parses plan and collect arguments', () => {
+    expect(parseResearchArgs(['plan', 'agent evals', '--format=json'])).toMatchObject({
+      action: 'plan',
+      question: 'agent evals',
+      format: 'json',
+    });
+    expect(parseResearchArgs(['collect', 'agent evals', '--run-dir', 'runs/a', '--k=3'])).toMatchObject({
+      action: 'collect',
+      runDir: 'runs/a',
+      k: 3,
+    });
+    expect(() => parseResearchArgs(['collect', 'agent evals'])).toThrow('collect requires --run-dir');
+    expect(() => parseResearchArgs(['collect', 'agent evals', '--run-dir', '--format=json'])).toThrow(
+      'missing value for --run-dir',
+    );
+  });
+
+  it('builds deterministic plan JSON from shelf descriptions and stats', async () => {
+    const { deps } = makeDeps();
+
+    const first = await buildResearchPlan('autonomous agents as judges and evals', 5, deps);
+    const second = await buildResearchPlan('autonomous agents as judges and evals', 5, deps);
+
+    expect(first).toEqual(second);
+    expect(first).toMatchObject({
+      schema_version: 'kb-research-plan.v1',
+      question: 'autonomous agents as judges and evals',
+      retrieval: { mode: 'hybrid', k: 5 },
+    });
+    expect(first.selected_shelves.map((shelf) => shelf.name)).toEqual([
+      'llm-agents',
+      'llm-as-judge',
+    ]);
+    expect(first.queries[0]).toMatchObject({
+      id: 'q1',
+      text: 'autonomous agents as judges and evals',
+      shelves: ['llm-agents', 'llm-as-judge'],
+    });
+    expect(first.risks).toContainEqual(expect.objectContaining({
+      code: 'dense_index_empty_coverage',
+      shelf: 'llm-as-judge',
+    }));
+    expect(deps.searchHybrid).not.toHaveBeenCalled();
+  });
+
+  it('prints plan JSON shape without running search', async () => {
+    const { deps, stdout, stderr } = makeDeps();
+
+    const code = await runResearch(['plan', 'autonomous agents as judges', '--format=json'], deps);
+
+    expect(code).toBe(0);
+    expect(stderr.join('')).toBe('');
+    const parsed = JSON.parse(stdout.join(''));
+    expect(parsed.schema_version).toBe('kb-research-plan.v1');
+    expect(parsed.selected_shelves[0].name).toBe('llm-agents');
+    expect(deps.searchHybrid).not.toHaveBeenCalled();
+  });
+
+  it('collect creates run artifacts and ledger entries from fixture hybrid search results', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-research-test-'));
+    const runDir = path.join(tempDir, 'run');
+    const { deps, stdout, stderr } = makeDeps();
+
+    try {
+      const code = await runResearch([
+        'collect',
+        'autonomous agents as judges',
+        '--run-dir',
+        runDir,
+        '--format=json',
+      ], deps);
+
+      expect(code).toBe(0);
+      expect(stderr.join('')).toBe('');
+      const summary = JSON.parse(stdout.join(''));
+      expect(summary.status).toBe('complete');
+      for (const filename of ['run.json', 'plan.json', 'ledger.json', 'evidence_packet.md', 'events.jsonl']) {
+        await expect(fsp.stat(path.join(runDir, filename))).resolves.toBeTruthy();
+      }
+
+      const ledger = JSON.parse(await fsp.readFile(path.join(runDir, 'ledger.json'), 'utf-8'));
+      expect(ledger.schema_version).toBe('kb-research-ledger.v1');
+      expect(ledger.entries).toHaveLength(6);
+      expect(ledger.entries[0]).toMatchObject({
+        source_id: 'llm-agents/papers/agent-evals.md#L10-L14',
+        shelf: 'llm-agents',
+        relative_path: 'papers/agent-evals.md',
+        line_range: { from: 10, to: 14 },
+        query: 'autonomous agents as judges',
+        retrieval_mode: 'hybrid',
+        score: 0.42,
+        source_kind: 'paper-note',
+        source_generation: 'lra',
+      });
+      const denseRiskEntry = ledger.entries.find((entry: { shelf: string }) => entry.shelf === 'llm-as-judge');
+      expect(denseRiskEntry?.risk_flags).toContain('dense_index_empty_coverage');
+
+      const packet = await fsp.readFile(path.join(runDir, 'evidence_packet.md'), 'utf-8');
+      expect(packet).toContain('## Question');
+      expect(packet).toContain('## Selected Shelves');
+      expect(packet).toContain('## Queries');
+      expect(packet).toContain('## Evidence Found');
+      expect(packet).toContain('## Evidence Gaps');
+      expect(packet).toContain('## Sources');
+
+      const events = parseJsonl(await fsp.readFile(path.join(runDir, 'events.jsonl'), 'utf-8'));
+      expect(events.filter((event) => event.type === 'search_completed')).toHaveLength(6);
+      expect(deps.searchHybrid).toHaveBeenCalledTimes(6);
+      expect(deps.searchHybrid).toHaveBeenNthCalledWith(1, {
+        query: 'autonomous agents as judges',
+        shelf: 'llm-agents',
+        k: 5,
+      });
+      expect(deps.searchHybrid).toHaveBeenNthCalledWith(2, {
+        query: 'autonomous agents as judges',
+        shelf: 'llm-as-judge',
+        k: 5,
+      });
+      expect(deps.searchHybrid).toHaveBeenNthCalledWith(3, {
+        query: 'autonomous agent judge',
+        shelf: 'llm-agents',
+        k: 5,
+      });
+      expect(deps.searchHybrid).toHaveBeenNthCalledWith(4, {
+        query: 'autonomous agent judge',
+        shelf: 'llm-as-judge',
+        k: 5,
+      });
+      expect(deps.searchHybrid).toHaveBeenNthCalledWith(5, {
+        query: 'autonomous agents as judges llm agents llm as judge',
+        shelf: 'llm-agents',
+        k: 5,
+      });
+      expect(deps.searchHybrid).toHaveBeenNthCalledWith(6, {
+        query: 'autonomous agents as judges llm agents llm as judge',
+        shelf: 'llm-as-judge',
+        k: 5,
+      });
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('records kb search failures as events and exits non-zero after writing partial artifacts', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-research-fail-'));
+    const runDir = path.join(tempDir, 'run');
+    const { deps, stdout } = makeDeps({ searchExitCode: 1 });
+
+    try {
+      const code = await runResearch([
+        'collect',
+        'autonomous agents as judges',
+        '--run-dir',
+        runDir,
+        '--format=json',
+      ], deps);
+
+      expect(code).toBe(1);
+      const summary = JSON.parse(stdout.join(''));
+      expect(summary.status).toBe('failed');
+      expect(summary.search_failure_count).toBeGreaterThan(0);
+
+      const ledger = JSON.parse(await fsp.readFile(path.join(runDir, 'ledger.json'), 'utf-8'));
+      expect(ledger.search_failures[0]).toMatchObject({
+        shelf: 'llm-agents',
+        exit_code: 1,
+        message: 'fixture search failed',
+      });
+      const events = parseJsonl(await fsp.readFile(path.join(runDir, 'events.jsonl'), 'utf-8'));
+      expect(events.map((event) => event.type)).toContain('search_failure');
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('treats hybrid lexical leg failures as search failures even when search exits 0', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-research-hybrid-fail-'));
+    const runDir = path.join(tempDir, 'run');
+    const { deps, stdout } = makeDeps({
+      searchPayload: {
+        mode: 'hybrid',
+        results: [],
+        retrievers: {
+          dense: { fetched: 0, model: 'ollama__nomic-embed-text-latest' },
+          lexical: { fetched: 0, refreshed: 0, failed: 1 },
+        },
+      },
+    });
+    deps.searchHybrid = jest.fn(async () => ({
+      exitCode: 0,
+      stdout: JSON.stringify({
+        mode: 'hybrid',
+        results: [],
+        retrievers: {
+          dense: { fetched: 0, model: 'ollama__nomic-embed-text-latest' },
+          lexical: { fetched: 0, refreshed: 0, failed: 1 },
+        },
+      }),
+      stderr: 'kb search (hybrid lexical leg): llm-as-judge - broken lexical index',
+      payload: {
+        mode: 'hybrid',
+        results: [],
+        retrievers: {
+          dense: { fetched: 0, model: 'ollama__nomic-embed-text-latest' },
+          lexical: { fetched: 0, refreshed: 0, failed: 1 },
+        },
+      },
+    }));
+
+    try {
+      const code = await runResearch([
+        'collect',
+        'autonomous agents as judges',
+        '--run-dir',
+        runDir,
+        '--format=json',
+      ], deps);
+
+      expect(code).toBe(1);
+      const summary = JSON.parse(stdout.join(''));
+      expect(summary.status).toBe('failed');
+      const ledger = JSON.parse(await fsp.readFile(path.join(runDir, 'ledger.json'), 'utf-8'));
+      expect(ledger.search_failures[0]).toMatchObject({
+        exit_code: 0,
+        message: 'kb search (hybrid lexical leg): llm-as-judge - broken lexical index',
+      });
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+});
+
+function parseJsonl(content: string): Array<Record<string, unknown>> {
+  return content.trim().split('\n').map((line) => JSON.parse(line) as Record<string, unknown>);
+}

--- a/src/cli-research.ts
+++ b/src/cli-research.ts
@@ -1,0 +1,906 @@
+import * as fsp from 'fs/promises';
+import * as path from 'path';
+import { readFileSync, realpathSync } from 'fs';
+import { resolveActiveModel } from './active-model.js';
+import { captureProcessOutput, loadManagerForModel, loadWithJsonRetry } from './cli-shared.js';
+import { runSearch } from './cli-search.js';
+import { KNOWLEDGE_BASES_ROOT_DIR } from './config.js';
+import { FaissIndexManager } from './FaissIndexManager.js';
+import { describeKnowledgeBase, listKnowledgeBases } from './kb-fs.js';
+import { computeKbStats, type KbStatsPayload, type KbStatsRow } from './kb-stats.js';
+
+export const RESEARCH_HELP = `kb research — read-only KB evidence planning and collection
+
+Usage:
+  kb research plan "<question>" [--format=md|json]
+  kb research collect "<question>" --run-dir <path> [--format=md|json]
+
+The workflow is deterministic: it reads KB descriptions and stats, selects
+likely shelves and queries, then collect uses existing hybrid search. It does
+not call an LLM, trigger local-research-agent, or write KB notes.
+
+Commands:
+  plan                  Print a deterministic retrieval plan.
+  collect               Create run artifacts: run.json, plan.json, ledger.json,
+                        evidence_packet.md, and events.jsonl.
+
+Options:
+  --run-dir <path>      Directory for collect artifacts.
+  --run-dir=<path>      Same as above.
+  --format=md|json      Output format (default: md).
+  --k=<int>             Results per query/shelf search during collect (default: 5).
+  --help, -h            Show this help.
+
+Examples:
+  kb research plan "autonomous research agents and evals" --format=json
+  kb research collect "autonomous research agents and evals" --run-dir runs/agents --format=json
+`;
+
+type OutputFormat = 'md' | 'json';
+type ResearchAction = 'plan' | 'collect';
+type RetrievalMode = 'hybrid';
+
+interface ResearchArgs {
+  action: ResearchAction;
+  question: string;
+  format: OutputFormat;
+  runDir?: string;
+  k: number;
+}
+
+export interface ShelfDescription {
+  name: string;
+  description: string;
+}
+
+export interface SelectedShelf {
+  name: string;
+  description: string;
+  file_count: number;
+  chunk_count: number;
+  score: number;
+  reasons: string[];
+  risks: ResearchRisk[];
+}
+
+export interface ResearchRisk {
+  code: string;
+  severity: 'info' | 'warning' | 'error';
+  message: string;
+  shelf?: string;
+}
+
+export interface ResearchQuery {
+  id: string;
+  text: string;
+  purpose: string;
+  shelves: string[];
+}
+
+export interface ResearchPlan {
+  schema_version: 'kb-research-plan.v1';
+  question: string;
+  selected_shelves: SelectedShelf[];
+  queries: ResearchQuery[];
+  retrieval: {
+    mode: RetrievalMode;
+    k: number;
+  };
+  risks: ResearchRisk[];
+}
+
+export interface LedgerEntry {
+  source_id: string;
+  shelf: string;
+  relative_path: string | null;
+  line_range: { from: number; to: number } | null;
+  query: string;
+  retrieval_mode: RetrievalMode;
+  score: number | null;
+  excerpt: string;
+  source_kind: string | null;
+  source_generation: string | null;
+  risk_flags: string[];
+}
+
+export interface ResearchLedger {
+  schema_version: 'kb-research-ledger.v1';
+  question: string;
+  retrieval_mode: RetrievalMode;
+  entries: LedgerEntry[];
+  risks: ResearchRisk[];
+  search_failures: SearchFailureEvent[];
+}
+
+interface SearchFailureEvent {
+  query_id: string;
+  query: string;
+  shelf: string;
+  exit_code: number;
+  message: string;
+}
+
+interface SearchResult {
+  score?: number | null;
+  content?: string;
+  metadata?: Record<string, unknown>;
+  chunk_id?: string;
+  injection_signals?: unknown[];
+}
+
+interface SearchPayload {
+  mode?: string;
+  results?: SearchResult[];
+  retrievers?: {
+    lexical?: { failed?: number };
+  };
+  error?: { code?: string; message?: string };
+}
+
+interface SearchResponse {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+  payload: SearchPayload | null;
+}
+
+export interface ResearchDeps {
+  loadShelfDescriptions: () => Promise<ShelfDescription[]>;
+  loadStats: () => Promise<KbStatsPayload>;
+  searchHybrid: (input: { query: string; shelf: string; k: number }) => Promise<SearchResponse>;
+  now: () => Date;
+  stdout: (text: string) => void;
+  stderr: (text: string) => void;
+}
+
+const DEFAULT_DEPS: ResearchDeps = {
+  loadShelfDescriptions: loadShelfDescriptions,
+  loadStats: loadStats,
+  searchHybrid: defaultSearchHybrid,
+  now: () => new Date(),
+  stdout: (text) => process.stdout.write(text),
+  stderr: (text) => process.stderr.write(text),
+};
+
+export async function runResearch(
+  rest: string[],
+  deps: ResearchDeps = DEFAULT_DEPS,
+): Promise<number> {
+  let parsed: ResearchArgs;
+  try {
+    parsed = parseResearchArgs(rest);
+  } catch (err) {
+    deps.stderr(`kb research: ${(err as Error).message}\n`);
+    return 2;
+  }
+
+  try {
+    if (parsed.action === 'plan') {
+      const plan = await buildResearchPlan(parsed.question, parsed.k, deps);
+      deps.stdout(parsed.format === 'json'
+        ? `${JSON.stringify(plan, null, 2)}\n`
+        : formatPlanMarkdown(plan));
+      return 0;
+    }
+
+    const result = await collectResearch(parsed, deps);
+    deps.stdout(parsed.format === 'json'
+      ? `${JSON.stringify(result.summary, null, 2)}\n`
+      : formatCollectMarkdown(result.summary));
+    return result.exitCode;
+  } catch (err) {
+    deps.stderr(`kb research: ${(err as Error).message}\n`);
+    return 1;
+  }
+}
+
+export function parseResearchArgs(rest: string[]): ResearchArgs {
+  const action = rest[0];
+  if (action !== 'plan' && action !== 'collect') {
+    throw new Error("expected subcommand 'plan' or 'collect'");
+  }
+
+  let question: string | undefined;
+  let format: OutputFormat = 'md';
+  let runDir: string | undefined;
+  let k = 5;
+
+  for (let i = 1; i < rest.length; i++) {
+    const raw = rest[i];
+    if (raw === '--run-dir') {
+      const value = rest[++i];
+      if (!value || value.startsWith('--')) throw new Error('missing value for --run-dir');
+      runDir = value;
+      continue;
+    }
+    if (raw.startsWith('--run-dir=')) {
+      const value = raw.slice('--run-dir='.length);
+      if (value === '') throw new Error('empty --run-dir value');
+      runDir = value;
+      continue;
+    }
+    if (raw.startsWith('--format=')) {
+      const value = raw.slice('--format='.length);
+      if (value !== 'md' && value !== 'json') {
+        throw new Error(`invalid --format value '${value}' (expected md or json)`);
+      }
+      format = value;
+      continue;
+    }
+    if (raw.startsWith('--k=')) {
+      const value = Number(raw.slice('--k='.length));
+      if (!Number.isInteger(value) || value <= 0) throw new Error(`invalid --k: ${raw}`);
+      k = value;
+      continue;
+    }
+    if (raw.startsWith('--')) throw new Error(`unknown flag: ${raw}`);
+    if (question === undefined) {
+      question = raw;
+      continue;
+    }
+    throw new Error(`unexpected argument: ${raw}`);
+  }
+
+  if (question === undefined || question.trim() === '') {
+    throw new Error(`missing <question> for ${action}`);
+  }
+  if (action === 'collect' && (runDir === undefined || runDir.trim() === '')) {
+    throw new Error('collect requires --run-dir <path>');
+  }
+
+  return {
+    action,
+    question: question.trim(),
+    format,
+    ...(runDir !== undefined ? { runDir } : {}),
+    k,
+  };
+}
+
+export async function buildResearchPlan(
+  question: string,
+  k: number,
+  deps: Pick<ResearchDeps, 'loadShelfDescriptions' | 'loadStats'>,
+): Promise<ResearchPlan> {
+  const [descriptions, stats] = await Promise.all([
+    deps.loadShelfDescriptions(),
+    deps.loadStats(),
+  ]);
+  const selected = selectShelves(question, descriptions, stats.knowledge_bases);
+  const risks = selected.flatMap((shelf) => shelf.risks);
+  return {
+    schema_version: 'kb-research-plan.v1',
+    question,
+    selected_shelves: selected,
+    queries: buildQueries(question, selected),
+    retrieval: {
+      mode: 'hybrid',
+      k,
+    },
+    risks,
+  };
+}
+
+interface CollectResult {
+  exitCode: number;
+  summary: {
+    schema_version: 'kb-research-collect-summary.v1';
+    question: string;
+    run_dir: string;
+    status: 'complete' | 'failed';
+    artifact_paths: Record<string, string>;
+    evidence_count: number;
+    risk_count: number;
+    search_failure_count: number;
+  };
+}
+
+async function collectResearch(args: ResearchArgs, deps: ResearchDeps): Promise<CollectResult> {
+  if (!args.runDir) throw new Error('collect requires --run-dir <path>');
+  const runDir = path.resolve(args.runDir);
+  await fsp.mkdir(runDir, { recursive: true });
+  const eventsPath = path.join(runDir, 'events.jsonl');
+  await fsp.writeFile(eventsPath, '');
+
+  const startedAt = deps.now().toISOString();
+  await appendEvent(eventsPath, {
+    type: 'collect_started',
+    at: startedAt,
+    question: args.question,
+    run_dir: runDir,
+  });
+
+  const plan = await buildResearchPlan(args.question, args.k, deps);
+  await appendEvent(eventsPath, {
+    type: 'plan_created',
+    at: deps.now().toISOString(),
+    selected_shelves: plan.selected_shelves.map((shelf) => shelf.name),
+    queries: plan.queries.map((query) => query.text),
+  });
+
+  const entries: LedgerEntry[] = [];
+  const searchFailures: SearchFailureEvent[] = [];
+  const coverageRiskShelves = new Set(
+    plan.risks
+      .filter((risk) => risk.code === 'dense_index_empty_coverage' && risk.shelf)
+      .map((risk) => risk.shelf as string),
+  );
+
+  for (const query of plan.queries) {
+    for (const shelf of query.shelves) {
+      const response = await deps.searchHybrid({
+        query: query.text,
+        shelf,
+        k: plan.retrieval.k,
+      });
+      const searchFailureMessage = getSearchFailureMessage(response);
+      if (searchFailureMessage !== null) {
+        const failure = {
+          query_id: query.id,
+          query: query.text,
+          shelf,
+          exit_code: response.exitCode,
+          message: searchFailureMessage,
+        };
+        searchFailures.push(failure);
+        await appendEvent(eventsPath, { type: 'search_failure', at: deps.now().toISOString(), ...failure });
+        continue;
+      }
+      const results = response.payload?.results ?? [];
+      await appendEvent(eventsPath, {
+        type: 'search_completed',
+        at: deps.now().toISOString(),
+        query_id: query.id,
+        query: query.text,
+        shelf,
+        result_count: results.length,
+      });
+      results.forEach((result, index) => {
+        entries.push(toLedgerEntry({
+          result,
+          query: query.text,
+          shelf,
+          index,
+          coverageRisk: coverageRiskShelves.has(shelf),
+        }));
+      });
+    }
+  }
+
+  const ledger: ResearchLedger = {
+    schema_version: 'kb-research-ledger.v1',
+    question: args.question,
+    retrieval_mode: 'hybrid',
+    entries,
+    risks: plan.risks,
+    search_failures: searchFailures,
+  };
+
+  const status = searchFailures.length > 0 ? 'failed' : 'complete';
+  const artifactPaths = {
+    run: path.join(runDir, 'run.json'),
+    plan: path.join(runDir, 'plan.json'),
+    ledger: path.join(runDir, 'ledger.json'),
+    evidence_packet: path.join(runDir, 'evidence_packet.md'),
+    events: eventsPath,
+  };
+  const run = {
+    schema_version: 'kb-research-run.v1',
+    question: args.question,
+    command: 'kb research collect',
+    run_dir: runDir,
+    started_at: startedAt,
+    finished_at: deps.now().toISOString(),
+    status,
+    artifact_paths: artifactPaths,
+  };
+
+  await writeJsonAtomic(artifactPaths.run, run);
+  await writeJsonAtomic(artifactPaths.plan, plan);
+  await writeJsonAtomic(artifactPaths.ledger, ledger);
+  await writeTextAtomic(artifactPaths.evidence_packet, formatEvidencePacket(plan, ledger));
+  await appendEvent(eventsPath, {
+    type: 'artifacts_written',
+    at: deps.now().toISOString(),
+    status,
+    artifact_paths: artifactPaths,
+  });
+
+  return {
+    exitCode: searchFailures.length > 0 ? 1 : 0,
+    summary: {
+      schema_version: 'kb-research-collect-summary.v1',
+      question: args.question,
+      run_dir: runDir,
+      status,
+      artifact_paths: artifactPaths,
+      evidence_count: entries.length,
+      risk_count: ledger.risks.length,
+      search_failure_count: searchFailures.length,
+    },
+  };
+}
+
+function selectShelves(
+  question: string,
+  descriptions: ShelfDescription[],
+  statsRows: Record<string, KbStatsRow>,
+): SelectedShelf[] {
+  const questionTokens = tokenize(question);
+  const byName = new Map(descriptions.map((shelf) => [shelf.name, shelf.description]));
+  for (const name of Object.keys(statsRows)) {
+    if (!byName.has(name)) byName.set(name, '');
+  }
+
+  const shelves = [...byName.entries()].map(([name, description]) => {
+    const nameTokens = tokenize(name.replace(/[-_]/g, ' '));
+    const descriptionTokens = tokenize(description);
+    const nameOverlap = overlap(questionTokens, nameTokens);
+    const descriptionOverlap = overlap(questionTokens, descriptionTokens);
+    const exactNameHit = question.toLowerCase().includes(name.toLowerCase()) ? 1 : 0;
+    const stats = statsRows[name] ?? emptyStatsRow();
+    const score =
+      exactNameHit * 8 +
+      nameOverlap * 4 +
+      descriptionOverlap * 2;
+    const reasons = [
+      ...(exactNameHit ? ['question mentions shelf name'] : []),
+      ...(nameOverlap > 0 ? [`${nameOverlap} shelf-name token match${nameOverlap === 1 ? '' : 'es'}`] : []),
+      ...(descriptionOverlap > 0 ? [`${descriptionOverlap} description token match${descriptionOverlap === 1 ? '' : 'es'}`] : []),
+      ...(stats.file_count > 0 ? ['shelf has indexed-source files'] : []),
+    ];
+    const risks = buildShelfRisks(name, stats);
+    return {
+      name,
+      description,
+      file_count: stats.file_count,
+      chunk_count: stats.chunk_count,
+      score,
+      reasons,
+      risks,
+    };
+  });
+
+  const relevant = shelves
+    .filter((shelf) => shelf.score > 0 && shelf.file_count > 0)
+    .sort(compareShelves)
+    .slice(0, 5);
+  if (relevant.length > 0) return relevant;
+
+  return shelves
+    .filter((shelf) => shelf.file_count > 0)
+    .sort(compareShelves)
+    .slice(0, 3);
+}
+
+function buildShelfRisks(name: string, stats: KbStatsRow): ResearchRisk[] {
+  if (stats.file_count > 0 && stats.chunk_count === 0) {
+    return [{
+      code: 'dense_index_empty_coverage',
+      severity: 'warning',
+      shelf: name,
+      message: `${name} has ${stats.file_count} file(s) but 0 dense chunks; collect will still use hybrid search.`,
+    }];
+  }
+  return [];
+}
+
+function compareShelves(a: SelectedShelf, b: SelectedShelf): number {
+  return (
+    b.score - a.score ||
+    b.chunk_count - a.chunk_count ||
+    b.file_count - a.file_count ||
+    a.name.localeCompare(b.name)
+  );
+}
+
+function buildQueries(question: string, shelves: SelectedShelf[]): ResearchQuery[] {
+  const shelfNames = shelves.map((shelf) => shelf.name);
+  const keywords = tokenize(question).slice(0, 8).join(' ');
+  const shelfTerms = shelfNames.slice(0, 3).map((name) => name.replace(/[-_]/g, ' ')).join(' ');
+  const candidates = [
+    { text: question, purpose: 'original research question' },
+    { text: keywords || question, purpose: 'keyword-focused retrieval' },
+    { text: [question, shelfTerms].filter(Boolean).join(' '), purpose: 'question plus selected-shelf vocabulary' },
+  ];
+
+  const seen = new Set<string>();
+  const queries: ResearchQuery[] = [];
+  for (const candidate of candidates) {
+    const key = candidate.text.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    queries.push({
+      id: `q${queries.length + 1}`,
+      text: candidate.text,
+      purpose: candidate.purpose,
+      shelves: shelfNames,
+    });
+  }
+  return queries;
+}
+
+function tokenize(value: string): string[] {
+  const seen = new Set<string>();
+  const tokens: string[] = [];
+  for (const raw of value.toLowerCase().match(/[a-z0-9][a-z0-9-]{1,}/g) ?? []) {
+    const token = normalizeToken(raw.replace(/^-+|-+$/g, ''));
+    if (STOP_WORDS.has(token) || seen.has(token)) continue;
+    seen.add(token);
+    tokens.push(token);
+  }
+  return tokens;
+}
+
+function normalizeToken(token: string): string {
+  if (token.length > 4 && token.endsWith('ies')) return `${token.slice(0, -3)}y`;
+  if (
+    token.length > 3 &&
+    token.endsWith('s') &&
+    !token.endsWith('ss') &&
+    !token.endsWith('us') &&
+    !token.endsWith('ous') &&
+    !token.endsWith('is')
+  ) {
+    return token.slice(0, -1);
+  }
+  return token;
+}
+
+function overlap(left: string[], right: string[]): number {
+  const rightSet = new Set(right);
+  return left.filter((token) => rightSet.has(token)).length;
+}
+
+const STOP_WORDS = new Set([
+  'about', 'after', 'again', 'against', 'also', 'and', 'approach', 'are', 'as',
+  'between', 'can', 'could', 'does', 'end', 'for', 'from', 'have', 'how',
+  'into', 'its', 'over', 'research', 'should', 'that', 'the', 'their',
+  'then', 'there', 'this', 'through', 'use', 'using', 'what', 'when', 'where',
+  'which', 'with', 'would',
+]);
+
+function emptyStatsRow(): KbStatsRow {
+  return {
+    file_count: 0,
+    chunk_count: 0,
+    total_bytes_indexed: 0,
+    last_updated_at: null,
+  };
+}
+
+function toLedgerEntry(input: {
+  result: SearchResult;
+  query: string;
+  shelf: string;
+  index: number;
+  coverageRisk: boolean;
+}): LedgerEntry {
+  const metadata = input.result.metadata ?? {};
+  const shelf = inferShelf(metadata, input.shelf);
+  const relativePath = inferRelativePath(metadata, shelf);
+  const lineRange = inferLineRange(metadata, input.result.chunk_id);
+  const riskFlags = [
+    ...(input.coverageRisk ? ['dense_index_empty_coverage'] : []),
+    ...(lineRange === null ? ['missing_line_range'] : []),
+    ...(relativePath === null ? ['missing_relative_path'] : []),
+    ...((input.result.injection_signals?.length ?? 0) > 0 ? ['injection_signals'] : []),
+  ];
+  return {
+    source_id: input.result.chunk_id ?? fallbackSourceId(shelf, relativePath, lineRange, input.index),
+    shelf,
+    relative_path: relativePath,
+    line_range: lineRange,
+    query: input.query,
+    retrieval_mode: 'hybrid',
+    score: typeof input.result.score === 'number' ? input.result.score : null,
+    excerpt: excerpt(input.result.content ?? ''),
+    source_kind: inferSourceKind(metadata, relativePath),
+    source_generation: inferSourceGeneration(metadata),
+    risk_flags: riskFlags,
+  };
+}
+
+function getSearchFailureMessage(response: SearchResponse): string | null {
+  if (response.exitCode !== 0 || response.payload?.error) {
+    return response.payload?.error?.message ?? response.stderr.trim() ?? 'kb search failed';
+  }
+  const lexicalFailures = response.payload?.retrievers?.lexical?.failed;
+  if (typeof lexicalFailures === 'number' && lexicalFailures > 0) {
+    return response.stderr.trim() || `hybrid lexical leg failed for ${lexicalFailures} knowledge base(s)`;
+  }
+  return null;
+}
+
+function inferShelf(metadata: Record<string, unknown>, fallback: string): string {
+  const value = metadata.knowledgeBase;
+  if (typeof value === 'string' && value.trim() !== '') return value;
+  const relativePath = metadata.relativePath;
+  if (typeof relativePath === 'string' && relativePath.includes('/')) {
+    const [head] = relativePath.split('/');
+    if (head) return head;
+  }
+  return fallback;
+}
+
+function inferRelativePath(metadata: Record<string, unknown>, shelf: string): string | null {
+  const relativePath = metadata.relativePath;
+  if (typeof relativePath === 'string' && relativePath.trim() !== '') {
+    return stripShelfPrefix(relativePath.trim(), shelf);
+  }
+  const source = metadata.source;
+  if (typeof source === 'string' && source.trim() !== '') {
+    const normalized = source.split(path.sep).join('/');
+    const marker = `/${shelf}/`;
+    const index = normalized.indexOf(marker);
+    if (index >= 0) return normalized.slice(index + marker.length);
+    return stripShelfPrefix(normalized, shelf);
+  }
+  return null;
+}
+
+function stripShelfPrefix(value: string, shelf: string): string {
+  const normalized = value.split(path.sep).join('/');
+  return normalized.startsWith(`${shelf}/`) ? normalized.slice(shelf.length + 1) : normalized;
+}
+
+function inferLineRange(
+  metadata: Record<string, unknown>,
+  chunkId: string | undefined,
+): { from: number; to: number } | null {
+  const loc = metadata.loc;
+  if (loc && typeof loc === 'object') {
+    const lines = (loc as Record<string, unknown>).lines;
+    if (lines && typeof lines === 'object') {
+      const from = (lines as Record<string, unknown>).from;
+      const to = (lines as Record<string, unknown>).to;
+      if (isPositiveInteger(from)) {
+        return { from, to: isPositiveInteger(to) ? to : from };
+      }
+    }
+  }
+  const match = /#L(\d+)-L(\d+)$/.exec(chunkId ?? '');
+  if (!match) return null;
+  return { from: Number(match[1]), to: Number(match[2]) };
+}
+
+function inferSourceKind(metadata: Record<string, unknown>, relativePath: string | null): string | null {
+  const frontmatter = metadata.frontmatter;
+  if (frontmatter && typeof frontmatter === 'object') {
+    for (const key of ['source_kind', 'kind', 'type']) {
+      const value = (frontmatter as Record<string, unknown>)[key];
+      if (typeof value === 'string' && value.trim() !== '') return value;
+    }
+  }
+  if (!relativePath) return null;
+  const ext = path.extname(relativePath).toLowerCase();
+  if (ext === '.md' || ext === '.markdown') return 'markdown';
+  if (ext === '.pdf') return 'pdf';
+  if (ext === '.txt') return 'text';
+  return ext ? ext.slice(1) : null;
+}
+
+function inferSourceGeneration(metadata: Record<string, unknown>): string | null {
+  for (const key of ['source_generation', 'generation']) {
+    const value = metadata[key];
+    if (typeof value === 'string' && value.trim() !== '') return value;
+  }
+  const frontmatter = metadata.frontmatter;
+  if (frontmatter && typeof frontmatter === 'object') {
+    for (const key of ['source_generation', 'generation', 'generated_by']) {
+      const value = (frontmatter as Record<string, unknown>)[key];
+      if (typeof value === 'string' && value.trim() !== '') return value;
+    }
+  }
+  return null;
+}
+
+function fallbackSourceId(
+  shelf: string,
+  relativePath: string | null,
+  lineRange: { from: number; to: number } | null,
+  index: number,
+): string {
+  const location = lineRange ? `L${lineRange.from}-L${lineRange.to}` : `result-${index + 1}`;
+  return `${shelf}/${relativePath ?? 'unknown'}#${location}`;
+}
+
+function excerpt(content: string): string {
+  return content.trim().replace(/\s+/g, ' ').slice(0, 600);
+}
+
+function isPositiveInteger(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value > 0;
+}
+
+function formatPlanMarkdown(plan: ResearchPlan): string {
+  return [
+    '# KB Research Plan',
+    '',
+    `Question: ${plan.question}`,
+    '',
+    '## Selected Shelves',
+    '',
+    ...plan.selected_shelves.map((shelf) => (
+      `- ${shelf.name} (${shelf.file_count} files, ${shelf.chunk_count} chunks): ` +
+      `${shelf.reasons.join('; ') || 'fallback selection'}`
+    )),
+    '',
+    '## Queries',
+    '',
+    ...plan.queries.map((query) => `- ${query.id}: ${query.text}`),
+    '',
+    '## Risks',
+    '',
+    ...(plan.risks.length === 0
+      ? ['- None detected.']
+      : plan.risks.map((risk) => `- ${risk.code}: ${risk.message}`)),
+    '',
+  ].join('\n');
+}
+
+function formatCollectMarkdown(summary: CollectResult['summary']): string {
+  return [
+    '# KB Research Collect',
+    '',
+    `Status: ${summary.status}`,
+    `Run directory: ${summary.run_dir}`,
+    `Evidence entries: ${summary.evidence_count}`,
+    `Risks: ${summary.risk_count}`,
+    `Search failures: ${summary.search_failure_count}`,
+    '',
+  ].join('\n');
+}
+
+function formatEvidencePacket(plan: ResearchPlan, ledger: ResearchLedger): string {
+  const found = ledger.entries.slice(0, 50);
+  const sources = uniqueSources(ledger.entries);
+  return [
+    '# Evidence Packet',
+    '',
+    '## Question',
+    '',
+    plan.question,
+    '',
+    '## Selected Shelves',
+    '',
+    ...plan.selected_shelves.map((shelf) => (
+      `- ${shelf.name}: ${shelf.file_count} files, ${shelf.chunk_count} chunks` +
+      (shelf.description ? ` — ${shelf.description}` : '')
+    )),
+    '',
+    '## Queries',
+    '',
+    ...plan.queries.map((query) => `- ${query.id}: ${query.text}`),
+    '',
+    '## Evidence Found',
+    '',
+    ...(found.length === 0
+      ? ['- No evidence found.']
+      : found.map((entry, index) => (
+          `${index + 1}. ${formatSourceLabel(entry)} — score ${formatScore(entry.score)}\n\n` +
+          `   ${entry.excerpt || '(empty excerpt)'}`
+        ))),
+    '',
+    '## Evidence Gaps',
+    '',
+    ...formatEvidenceGaps(plan, ledger),
+    '',
+    '## Sources',
+    '',
+    ...(sources.length === 0 ? ['- None.'] : sources.map((source) => `- ${source}`)),
+    '',
+  ].join('\n');
+}
+
+function formatEvidenceGaps(plan: ResearchPlan, ledger: ResearchLedger): string[] {
+  const gaps: string[] = [];
+  if (ledger.entries.length === 0) {
+    gaps.push('- No retrieved passages were recorded.');
+  }
+  for (const risk of plan.risks) {
+    gaps.push(`- ${risk.code}: ${risk.message}`);
+  }
+  for (const failure of ledger.search_failures) {
+    gaps.push(`- search_failure: ${failure.shelf} / ${failure.query_id} exited ${failure.exit_code}: ${failure.message}`);
+  }
+  const queriesWithEvidence = new Set(ledger.entries.map((entry) => entry.query));
+  for (const query of plan.queries) {
+    if (!queriesWithEvidence.has(query.text)) {
+      gaps.push(`- no_evidence_for_query: ${query.id} (${query.text})`);
+    }
+  }
+  return gaps.length === 0 ? ['- None detected.'] : gaps;
+}
+
+function uniqueSources(entries: LedgerEntry[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const entry of entries) {
+    const source = formatSourceLabel(entry);
+    if (seen.has(source)) continue;
+    seen.add(source);
+    out.push(source);
+  }
+  return out;
+}
+
+function formatSourceLabel(entry: LedgerEntry): string {
+  const range = entry.line_range ? `#L${entry.line_range.from}-L${entry.line_range.to}` : '';
+  return `${entry.shelf}/${entry.relative_path ?? 'unknown'}${range}`;
+}
+
+function formatScore(score: number | null): string {
+  return score === null ? 'n/a' : String(Number(score.toFixed(4)));
+}
+
+async function appendEvent(filePath: string, event: Record<string, unknown>): Promise<void> {
+  await fsp.appendFile(filePath, `${JSON.stringify(event)}\n`);
+}
+
+async function writeJsonAtomic(filePath: string, value: unknown): Promise<void> {
+  await writeTextAtomic(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+async function writeTextAtomic(filePath: string, value: string): Promise<void> {
+  const tmp = `${filePath}.${process.pid}.${Date.now()}.tmp`;
+  await fsp.writeFile(tmp, value);
+  await fsp.rename(tmp, filePath);
+}
+
+async function loadShelfDescriptions(): Promise<ShelfDescription[]> {
+  const names = await listKnowledgeBases(KNOWLEDGE_BASES_ROOT_DIR);
+  const descriptions = await Promise.all(
+    names.map(async (name) => ({
+      name,
+      description: await describeKnowledgeBase(KNOWLEDGE_BASES_ROOT_DIR, name),
+    })),
+  );
+  return descriptions;
+}
+
+async function loadStats(): Promise<KbStatsPayload> {
+  await FaissIndexManager.bootstrapLayout();
+  const activeModelId = await resolveActiveModel();
+  const manager = await loadManagerForModel(activeModelId);
+  await loadWithJsonRetry(manager);
+  return computeKbStats(manager, {
+    serverVersion: readPackageVersion(),
+    startedAt: Date.now(),
+  });
+}
+
+async function defaultSearchHybrid(input: {
+  query: string;
+  shelf: string;
+  k: number;
+}): Promise<SearchResponse> {
+  const captured = await captureProcessOutput(() => runSearch([
+    input.query,
+    `--kb=${input.shelf}`,
+    '--mode=hybrid',
+    '--format=json',
+    `--k=${input.k}`,
+  ]));
+  let payload: SearchPayload | null = null;
+  if (captured.stdout.trim() !== '') {
+    try {
+      payload = JSON.parse(captured.stdout) as SearchPayload;
+    } catch {
+      payload = null;
+    }
+  }
+  return { ...captured, payload };
+}
+
+function readPackageVersion(): string {
+  try {
+    const here = realpathSync(process.argv[1] ?? path.join(process.cwd(), 'build', 'cli.js'));
+    const pkgPath = path.join(path.dirname(here), '..', 'package.json');
+    const raw = readFileSync(pkgPath, 'utf-8');
+    const parsed = JSON.parse(raw) as { version?: string };
+    return parsed.version ?? 'unknown';
+  } catch {
+    return 'unknown';
+  }
+}

--- a/src/cli-serve.ts
+++ b/src/cli-serve.ts
@@ -2,6 +2,7 @@ import * as http from 'node:http';
 import type { AddressInfo } from 'node:net';
 import { runList } from './cli-list.js';
 import { runSearch } from './cli-search.js';
+import { captureProcessOutput } from './cli-shared.js';
 import { runStats } from './cli-stats.js';
 import type { DaemonCommand, DaemonRunResult } from './daemon-client.js';
 
@@ -267,36 +268,6 @@ function readBody(req: http.IncomingMessage): Promise<string> {
     req.on('end', () => resolve(Buffer.concat(chunks).toString('utf-8')));
     req.on('error', reject);
   });
-}
-
-async function captureProcessOutput(fn: () => Promise<number>): Promise<DaemonRunResult> {
-  const stdoutChunks: string[] = [];
-  const stderrChunks: string[] = [];
-  const originalStdout = process.stdout.write;
-  const originalStderr = process.stderr.write;
-  process.stdout.write = ((chunk: unknown, ...args: unknown[]) => {
-    stdoutChunks.push(String(chunk));
-    const callback = args.find((arg): arg is (err?: Error) => void => typeof arg === 'function');
-    if (callback) callback();
-    return true;
-  }) as typeof process.stdout.write;
-  process.stderr.write = ((chunk: unknown, ...args: unknown[]) => {
-    stderrChunks.push(String(chunk));
-    const callback = args.find((arg): arg is (err?: Error) => void => typeof arg === 'function');
-    if (callback) callback();
-    return true;
-  }) as typeof process.stderr.write;
-  try {
-    const exitCode = await fn();
-    return {
-      exitCode,
-      stdout: stdoutChunks.join(''),
-      stderr: stderrChunks.join(''),
-    };
-  } finally {
-    process.stdout.write = originalStdout;
-    process.stderr.write = originalStderr;
-  }
 }
 
 function assertLoopbackHost(host: string): void {

--- a/src/cli-shared.ts
+++ b/src/cli-shared.ts
@@ -50,3 +50,41 @@ export async function loadWithJsonRetry(manager: FaissIndexManager): Promise<voi
     throw err;
   }
 }
+
+export interface CapturedProcessOutput {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+export async function captureProcessOutput(
+  fn: () => Promise<number>,
+): Promise<CapturedProcessOutput> {
+  const stdoutChunks: string[] = [];
+  const stderrChunks: string[] = [];
+  const originalStdout = process.stdout.write;
+  const originalStderr = process.stderr.write;
+  process.stdout.write = ((chunk: unknown, ...args: unknown[]) => {
+    stdoutChunks.push(Buffer.isBuffer(chunk) ? chunk.toString('utf-8') : String(chunk));
+    const callback = args.find((arg): arg is (err?: Error) => void => typeof arg === 'function');
+    if (callback) callback();
+    return true;
+  }) as typeof process.stdout.write;
+  process.stderr.write = ((chunk: unknown, ...args: unknown[]) => {
+    stderrChunks.push(Buffer.isBuffer(chunk) ? chunk.toString('utf-8') : String(chunk));
+    const callback = args.find((arg): arg is (err?: Error) => void => typeof arg === 'function');
+    if (callback) callback();
+    return true;
+  }) as typeof process.stderr.write;
+  try {
+    const exitCode = await fn();
+    return {
+      exitCode,
+      stdout: stdoutChunks.join(''),
+      stderr: stderrChunks.join(''),
+    };
+  } finally {
+    process.stdout.write = originalStdout;
+    process.stderr.write = originalStderr;
+  }
+}

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -51,6 +51,7 @@ describe('kb CLI — argv parsing and dispatch', () => {
       'serve',
       'ask',
       'remember',
+      'research',
       'capture',
       'compare',
       'doctor',
@@ -81,6 +82,7 @@ describe('kb CLI — argv parsing and dispatch', () => {
     ['serve', 'kb serve'],
     ['ask', 'kb ask'],
     ['remember', 'kb remember'],
+    ['research', 'kb research'],
     ['capture', 'kb capture'],
     ['compare', 'kb compare'],
     ['doctor', 'kb doctor'],
@@ -260,6 +262,12 @@ describe('kb CLI — argv parsing and dispatch', () => {
     const r = runCli(['explain', 'q', '--include-content']);
     expect(r.code).toBe(2);
     expect(r.stderr).toContain('--include-content requires --repro-bundle');
+  });
+
+  it('research without action dispatches to the research handler and exits 2', () => {
+    const r = runCli(['research']);
+    expect(r.code).toBe(2);
+    expect(r.stderr).toContain("kb research: expected subcommand 'plan' or 'collect'");
   });
 });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -21,6 +21,7 @@ import { MODELS_HELP, runModels } from './cli-models.js';
 import { PROMOTE_HELP, runPromote } from './cli-promote.js';
 import { QUARANTINE_HELP, runQuarantine } from './cli-quarantine.js';
 import { REMEMBER_HELP, runRemember } from './cli-remember.js';
+import { RESEARCH_HELP, runResearch } from './cli-research.js';
 import { SEARCH_HELP, runSearch } from './cli-search.js';
 import { SERVE_HELP, runServe } from './cli-serve.js';
 import { STALE_CHECK_HELP, runStaleCheck } from './cli-stale-check.js';
@@ -49,6 +50,7 @@ const SUBCOMMANDS: readonly Subcommand[] = [
   { name: 'serve',        summary: 'Run a localhost daemon for warm read-only CLI requests.',                 help: SERVE_HELP,        handler: runServe },
   { name: 'ask',          summary: 'Answer from retrieved KB context using a local LLM endpoint.',            help: ASK_HELP,          handler: runAsk },
   { name: 'remember',     summary: 'Suggest, create, or append knowledge-base notes (write path).',          help: REMEMBER_HELP,     handler: runRemember },
+  { name: 'research',     summary: 'Plan and collect read-only KB evidence packets.',                       help: RESEARCH_HELP,     handler: runResearch },
   { name: 'capture',      summary: 'Run a command and append its stdout to a KB note as a fenced block.',    help: CAPTURE_HELP,      handler: runCapture },
   { name: 'compare',      summary: 'Side-by-side rank/score table for two embedding models.',                help: COMPARE_HELP,      handler: runCompare },
   { name: 'doctor',       summary: 'Aggregate model / index / backend health report.',                       help: DOCTOR_HELP,       handler: runDoctor },


### PR DESCRIPTION
## Summary

- add `kb research plan` for deterministic read-only shelf/query planning from KB descriptions and stats
- add `kb research collect` to create `run.json`, `plan.json`, `ledger.json`, `evidence_packet.md`, and `events.jsonl`
- collect evidence through existing `kb search --mode=hybrid --format=json`; no LLM, LRA trigger, KB writes, or issue #450 advanced retrieval operators
- document the new JSON contracts and share CLI stdout/stderr capture with the serve daemon

## Command Shape

```bash
kb research plan "<question>" --format=json
kb research collect "<question>" --run-dir <path> --format=json
```

## Verification

- `npm run build`
- `npm test -- --runTestsByPath src/cli-research.test.ts`
- `npm test -- --runTestsByPath src/cli.test.ts`
- `npm test`
  - 82 suites passed
  - 1376 passed, 4 skipped, 1 todo
- After review fixes:
  - `npm run build`
  - `npm test -- --runTestsByPath src/cli-research.test.ts src/cli.test.ts src/cli-serve.test.ts`
  - 3 suites passed, 117 tests passed

## Pre-PR Review

- conventions specialist: addressed shared stdout/stderr capture, JSON contract docs, and CLI help wording
- correctness specialist: addressed hybrid lexical-leg failure detection and `--run-dir` missing-value parsing
- dead-code specialist: no dead code introduced
- test specialist: added non-help dispatch coverage and full query/shelf matrix assertions
- portability scan on added lines: clean
- `git diff --check`: clean

## Deferred

Issue #450 primitives remain deferred. This PR intentionally uses the stable hybrid search surface only.
