### PR TITLE
fix: tighten kb research planner selection

### DIFF
--- a/docs/cli-json-contracts.md
+++ b/docs/cli-json-contracts.md
@@ -302,11 +302,20 @@ Invocation:
 ```bash
 kb research plan "<question>" --format=json
 kb research collect "<question>" --run-dir <path> --format=json
+kb research plan "<question>" --include-kb=<name> --exclude-kb=<name> --max-shelves=<n>
 ```
 
 `kb research` is read-only. `plan` reads KB descriptions and stats, then
 deterministically selects shelves and queries. `collect` writes a local run
 directory and retrieves evidence using existing hybrid search.
+
+Planner controls are deterministic and do not trigger any model calls:
+`--kb=<name>` / `--include-kb=<name>` pins a shelf into the plan,
+`--exclude-kb=<name>` removes a shelf from consideration, and
+`--max-shelves=<n>` limits automatic shelf selection. The planner treats broad
+tokens such as `agent` as insufficient on their own, so domain shelves with
+specific matches rank ahead of operational shelves that only share generic
+wording.
 
 Plan success envelope:
 
@@ -379,7 +388,9 @@ Collect artifacts:
 - `ledger.json`: `kb-research-ledger.v1` with `question`, `retrieval_mode`,
   `entries`, `risks`, and `search_failures`.
 - `evidence_packet.md`: markdown packet with Question, Selected Shelves,
-  Queries, Evidence Found, Evidence Gaps, and Sources sections.
+  Queries, Evidence Found, Evidence Gaps, and Sources sections. Evidence Found
+  is grouped by source file so repeated passages from the same source are
+  easier to scan.
 - `events.jsonl`: structured event stream for collection progress.
 
 Ledger entries have stable `source_id`, `shelf`, `relative_path`,

--- a/src/cli-research.test.ts
+++ b/src/cli-research.test.ts
@@ -32,6 +32,18 @@ function statsPayload(overrides: Partial<KbStatsPayload> = {}): KbStatsPayload {
         total_bytes_indexed: 300,
         last_updated_at: null,
       },
+      'agent-task-lessons': {
+        file_count: 8,
+        chunk_count: 20,
+        total_bytes_indexed: 2000,
+        last_updated_at: null,
+      },
+      'job-search-agents': {
+        file_count: 7,
+        chunk_count: 18,
+        total_bytes_indexed: 1500,
+        last_updated_at: null,
+      },
     },
     quarantined: {},
     embedding: {
@@ -58,6 +70,8 @@ function statsPayload(overrides: Partial<KbStatsPayload> = {}): KbStatsPayload {
       sidecars_written: false,
       failure_count: 0,
       failures: [],
+      warning_count: 0,
+      warnings: [],
     },
     server: {
       version: 'test',
@@ -76,6 +90,23 @@ function statsPayload(overrides: Partial<KbStatsPayload> = {}): KbStatsPayload {
       l1_size: 0,
       disk_size_bytes: 0,
     },
+    relevance_gate: {
+      gated_queries: 0,
+      verdict_injected: 0,
+      verdict_no_relevant_context: 0,
+      verdict_empty_index: 0,
+      low_confidence_rate: 0,
+      drop_rate_A1: 0,
+      drop_rate_A2: 0,
+      drop_rate_B: 0,
+      judge_degrade_rate: 0,
+      judge_window: {
+        size: 0,
+        degraded: 0,
+        rate: 0,
+        warn_threshold: 0.1,
+      },
+    },
     ...overrides,
   };
 }
@@ -83,8 +114,10 @@ function statsPayload(overrides: Partial<KbStatsPayload> = {}): KbStatsPayload {
 function shelfDescriptions(): ShelfDescription[] {
   return [
     { name: 'llm-agents', description: 'Autonomous LLM agents, planning, tool use, and evaluation' },
-    { name: 'llm-as-judge', description: 'LLM judge evals, rubric design, and critic reliability' },
+    { name: 'llm-as-judge', description: 'LLM judge evals, rubric design, bias mitigation, and critic reliability' },
     { name: 'recipes', description: 'Cooking notes and kitchen experiments' },
+    { name: 'agent-task-lessons', description: 'Operational task lessons from coding agent runs' },
+    { name: 'job-search-agents', description: 'Job search agents, applications, and recruiting workflows' },
   ];
 }
 
@@ -108,11 +141,12 @@ function makeDeps(opts: {
           payload: { error: { code: 'INDEX_ERROR', message: 'fixture search failed' } },
         };
       }
+      const payload = opts.searchPayload ?? fixtureSearchPayload(shelf, input.query);
       return {
         exitCode: 0,
-        stdout: JSON.stringify(opts.searchPayload ?? fixtureSearchPayload(shelf)),
+        stdout: JSON.stringify(payload),
         stderr: '',
-        payload: opts.searchPayload ?? fixtureSearchPayload(shelf),
+        payload,
       };
     }),
     now: jest.fn(() => new Date('2026-05-21T09:30:00.000Z')),
@@ -122,17 +156,18 @@ function makeDeps(opts: {
   return { deps, stdout, stderr };
 }
 
-function fixtureSearchPayload(shelf: string): Record<string, unknown> {
+function fixtureSearchPayload(shelf: string, query: string): Record<string, unknown> {
+  const lines = lineRangeForQuery(query);
   return {
     mode: 'hybrid',
     results: [{
       score: 0.42,
       content: 'Agent evaluation evidence with rubric stability and tool-use traces.',
-      chunk_id: `${shelf}/papers/agent-evals.md#L10-L14`,
+      chunk_id: `${shelf}/papers/agent-evals.md#L${lines.from}-L${lines.to}`,
       metadata: {
         knowledgeBase: shelf,
         relativePath: `${shelf}/papers/agent-evals.md`,
-        loc: { lines: { from: 10, to: 14 } },
+        loc: { lines },
         frontmatter: {
           source_kind: 'paper-note',
           source_generation: 'lra',
@@ -146,6 +181,12 @@ function fixtureSearchPayload(shelf: string): Record<string, unknown> {
   };
 }
 
+function lineRangeForQuery(query: string): { from: number; to: number } {
+  if (query === 'autonomous agents judges') return { from: 20, to: 24 };
+  if (query.includes('llm as judge')) return { from: 30, to: 34 };
+  return { from: 10, to: 14 };
+}
+
 describe('kb research CLI', () => {
   it('parses plan and collect arguments', () => {
     expect(parseResearchArgs(['plan', 'agent evals', '--format=json'])).toMatchObject({
@@ -157,10 +198,28 @@ describe('kb research CLI', () => {
       action: 'collect',
       runDir: 'runs/a',
       k: 3,
+      maxShelves: 5,
+    });
+    expect(parseResearchArgs([
+      'plan',
+      'agent evals',
+      '--kb=llm-agents',
+      '--include-kb',
+      'llm-as-judge',
+      '--exclude-kb=recipes',
+      '--max-shelves=2',
+    ])).toMatchObject({
+      includeShelves: ['llm-agents', 'llm-as-judge'],
+      excludeShelves: ['recipes'],
+      maxShelves: 2,
     });
     expect(() => parseResearchArgs(['collect', 'agent evals'])).toThrow('collect requires --run-dir');
     expect(() => parseResearchArgs(['collect', 'agent evals', '--run-dir', '--format=json'])).toThrow(
       'missing value for --run-dir',
+    );
+    expect(() => parseResearchArgs(['plan', 'agent evals', '--max-shelves=0'])).toThrow('invalid --max-shelves');
+    expect(() => parseResearchArgs(['plan', 'agent evals', '--kb=llm-agents', '--exclude-kb=llm-agents'])).toThrow(
+      'cannot include and exclude the same shelf',
     );
   });
 
@@ -177,19 +236,60 @@ describe('kb research CLI', () => {
       retrieval: { mode: 'hybrid', k: 5 },
     });
     expect(first.selected_shelves.map((shelf) => shelf.name)).toEqual([
-      'llm-agents',
       'llm-as-judge',
+      'llm-agents',
     ]);
     expect(first.queries[0]).toMatchObject({
       id: 'q1',
       text: 'autonomous agents as judges and evals',
-      shelves: ['llm-agents', 'llm-as-judge'],
+      shelves: ['llm-as-judge', 'llm-agents'],
     });
     expect(first.risks).toContainEqual(expect.objectContaining({
       code: 'dense_index_empty_coverage',
       shelf: 'llm-as-judge',
     }));
     expect(deps.searchHybrid).not.toHaveBeenCalled();
+  });
+
+  it('ranks specific domain shelves ahead of broad agent shelves', async () => {
+    const { deps } = makeDeps();
+    const prompt = 'end-to-end approach for autonomous research agents and evals, including LLM-as-judge bias mitigation';
+
+    const plan = await buildResearchPlan(prompt, 5, deps);
+
+    expect(plan.selected_shelves.map((shelf) => shelf.name)).toEqual([
+      'llm-as-judge',
+      'llm-agents',
+    ]);
+    expect(plan.selected_shelves.map((shelf) => shelf.name)).not.toContain('agent-task-lessons');
+    expect(plan.selected_shelves.map((shelf) => shelf.name)).not.toContain('job-search-agents');
+    const queryTexts = plan.queries.map((query) => query.text);
+    expect(queryTexts).toEqual(expect.arrayContaining([
+      expect.stringContaining('bias'),
+    ]));
+    expect(queryTexts.every((text) => /\bbias\b/.test(text))).toBe(true);
+    expect(queryTexts.every((text) => !/\bbia\b/.test(text))).toBe(true);
+  });
+
+  it('supports explicit include, exclude, and max-shelves controls', async () => {
+    const { deps } = makeDeps();
+    const prompt = 'end-to-end approach for autonomous research agents and evals, including LLM-as-judge bias mitigation';
+
+    const included = await buildResearchPlan(prompt, 5, deps, {
+      includeShelves: ['agent-task-lessons'],
+      maxShelves: 2,
+    });
+    expect(included.selected_shelves.map((shelf) => shelf.name)).toEqual([
+      'agent-task-lessons',
+      'llm-as-judge',
+      'llm-agents',
+    ]);
+
+    const excluded = await buildResearchPlan(prompt, 5, deps, {
+      excludeShelves: ['llm-as-judge'],
+      maxShelves: 1,
+    });
+    expect(excluded.selected_shelves.map((shelf) => shelf.name)).toEqual(['llm-agents']);
   });
 
   it('prints plan JSON shape without running search', async () => {
@@ -201,7 +301,29 @@ describe('kb research CLI', () => {
     expect(stderr.join('')).toBe('');
     const parsed = JSON.parse(stdout.join(''));
     expect(parsed.schema_version).toBe('kb-research-plan.v1');
-    expect(parsed.selected_shelves[0].name).toBe('llm-agents');
+    expect(parsed.selected_shelves[0].name).toBe('llm-as-judge');
+    expect(deps.searchHybrid).not.toHaveBeenCalled();
+  });
+
+  it('applies explicit shelf controls through the plan command path', async () => {
+    const { deps, stdout, stderr } = makeDeps();
+
+    const code = await runResearch([
+      'plan',
+      'autonomous agents as judges',
+      '--include-kb=agent-task-lessons',
+      '--exclude-kb=llm-as-judge',
+      '--max-shelves=1',
+      '--format=json',
+    ], deps);
+
+    expect(code).toBe(0);
+    expect(stderr.join('')).toBe('');
+    const parsed = JSON.parse(stdout.join(''));
+    expect(parsed.selected_shelves.map((shelf: { name: string }) => shelf.name)).toEqual([
+      'agent-task-lessons',
+      'llm-agents',
+    ]);
     expect(deps.searchHybrid).not.toHaveBeenCalled();
   });
 
@@ -231,8 +353,8 @@ describe('kb research CLI', () => {
       expect(ledger.schema_version).toBe('kb-research-ledger.v1');
       expect(ledger.entries).toHaveLength(6);
       expect(ledger.entries[0]).toMatchObject({
-        source_id: 'llm-agents/papers/agent-evals.md#L10-L14',
-        shelf: 'llm-agents',
+        source_id: 'llm-as-judge/papers/agent-evals.md#L10-L14',
+        shelf: 'llm-as-judge',
         relative_path: 'papers/agent-evals.md',
         line_range: { from: 10, to: 14 },
         query: 'autonomous agents as judges',
@@ -251,40 +373,77 @@ describe('kb research CLI', () => {
       expect(packet).toContain('## Evidence Found');
       expect(packet).toContain('## Evidence Gaps');
       expect(packet).toContain('## Sources');
+      expect(packet).toContain('llm-agents/papers/agent-evals.md — 3 passages');
+      expect(packet).toContain('llm-as-judge/papers/agent-evals.md — 3 passages');
+      expect(packet.match(/papers\/agent-evals\.md — 3 passages/g)).toHaveLength(2);
+      expect(packet).toContain('L10-L14 via "autonomous agents as judges"');
+      expect(packet).toContain('L20-L24 via "autonomous agents judges"');
+      expect(packet).toContain('L30-L34 via "autonomous agents as judges llm as judge llm agents"');
 
       const events = parseJsonl(await fsp.readFile(path.join(runDir, 'events.jsonl'), 'utf-8'));
       expect(events.filter((event) => event.type === 'search_completed')).toHaveLength(6);
       expect(deps.searchHybrid).toHaveBeenCalledTimes(6);
       expect(deps.searchHybrid).toHaveBeenNthCalledWith(1, {
         query: 'autonomous agents as judges',
-        shelf: 'llm-agents',
+        shelf: 'llm-as-judge',
         k: 5,
       });
       expect(deps.searchHybrid).toHaveBeenNthCalledWith(2, {
         query: 'autonomous agents as judges',
-        shelf: 'llm-as-judge',
+        shelf: 'llm-agents',
         k: 5,
       });
       expect(deps.searchHybrid).toHaveBeenNthCalledWith(3, {
-        query: 'autonomous agent judge',
-        shelf: 'llm-agents',
+        query: 'autonomous agents judges',
+        shelf: 'llm-as-judge',
         k: 5,
       });
       expect(deps.searchHybrid).toHaveBeenNthCalledWith(4, {
-        query: 'autonomous agent judge',
-        shelf: 'llm-as-judge',
-        k: 5,
-      });
-      expect(deps.searchHybrid).toHaveBeenNthCalledWith(5, {
-        query: 'autonomous agents as judges llm agents llm as judge',
+        query: 'autonomous agents judges',
         shelf: 'llm-agents',
         k: 5,
       });
-      expect(deps.searchHybrid).toHaveBeenNthCalledWith(6, {
-        query: 'autonomous agents as judges llm agents llm as judge',
+      expect(deps.searchHybrid).toHaveBeenNthCalledWith(5, {
+        query: 'autonomous agents as judges llm as judge llm agents',
         shelf: 'llm-as-judge',
         k: 5,
       });
+      expect(deps.searchHybrid).toHaveBeenNthCalledWith(6, {
+        query: 'autonomous agents as judges llm as judge llm agents',
+        shelf: 'llm-agents',
+        k: 5,
+      });
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('applies explicit shelf controls through the collect command path', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-research-controls-'));
+    const runDir = path.join(tempDir, 'run');
+    const { deps, stdout, stderr } = makeDeps();
+
+    try {
+      const code = await runResearch([
+        'collect',
+        'autonomous agents as judges',
+        '--include-kb=agent-task-lessons',
+        '--exclude-kb=llm-as-judge',
+        '--max-shelves=1',
+        '--run-dir',
+        runDir,
+        '--format=json',
+      ], deps);
+
+      expect(code).toBe(0);
+      expect(stderr.join('')).toBe('');
+      const summary = JSON.parse(stdout.join(''));
+      expect(summary.status).toBe('complete');
+      expect(deps.searchHybrid).toHaveBeenCalledTimes(6);
+      const searchedShelves = new Set(
+        (deps.searchHybrid as jest.Mock).mock.calls.map(([input]) => (input as { shelf: string }).shelf),
+      );
+      expect([...searchedShelves]).toEqual(['agent-task-lessons', 'llm-agents']);
     } finally {
       await fsp.rm(tempDir, { recursive: true, force: true });
     }
@@ -311,7 +470,7 @@ describe('kb research CLI', () => {
 
       const ledger = JSON.parse(await fsp.readFile(path.join(runDir, 'ledger.json'), 'utf-8'));
       expect(ledger.search_failures[0]).toMatchObject({
-        shelf: 'llm-agents',
+        shelf: 'llm-as-judge',
         exit_code: 1,
         message: 'fixture search failed',
       });

--- a/src/cli-research.ts
+++ b/src/cli-research.ts
@@ -12,8 +12,8 @@ import { computeKbStats, type KbStatsPayload, type KbStatsRow } from './kb-stats
 export const RESEARCH_HELP = `kb research — read-only KB evidence planning and collection
 
 Usage:
-  kb research plan "<question>" [--format=md|json]
-  kb research collect "<question>" --run-dir <path> [--format=md|json]
+  kb research plan "<question>" [--format=md|json] [--include-kb=<name>] [--exclude-kb=<name>] [--max-shelves=<n>]
+  kb research collect "<question>" --run-dir <path> [--format=md|json] [--include-kb=<name>] [--exclude-kb=<name>] [--max-shelves=<n>]
 
 The workflow is deterministic: it reads KB descriptions and stats, selects
 likely shelves and queries, then collect uses existing hybrid search. It does
@@ -29,6 +29,10 @@ Options:
   --run-dir=<path>      Same as above.
   --format=md|json      Output format (default: md).
   --k=<int>             Results per query/shelf search during collect (default: 5).
+  --kb=<name>           Include a shelf explicitly (alias for --include-kb).
+  --include-kb=<name>   Include a shelf explicitly; repeatable.
+  --exclude-kb=<name>   Exclude a shelf; repeatable.
+  --max-shelves=<int>   Maximum automatically selected shelves (default: 5).
   --help, -h            Show this help.
 
 Examples:
@@ -46,6 +50,9 @@ interface ResearchArgs {
   format: OutputFormat;
   runDir?: string;
   k: number;
+  includeShelves: string[];
+  excludeShelves: string[];
+  maxShelves: number;
 }
 
 export interface ShelfDescription {
@@ -87,6 +94,18 @@ export interface ResearchPlan {
     k: number;
   };
   risks: ResearchRisk[];
+}
+
+interface ResearchPlanOptions {
+  includeShelves?: string[];
+  excludeShelves?: string[];
+  maxShelves?: number;
+}
+
+interface EvidenceSourceGroup {
+  label: string;
+  entries: LedgerEntry[];
+  bestScore: number | null;
 }
 
 export interface LedgerEntry {
@@ -176,7 +195,7 @@ export async function runResearch(
 
   try {
     if (parsed.action === 'plan') {
-      const plan = await buildResearchPlan(parsed.question, parsed.k, deps);
+      const plan = await buildResearchPlan(parsed.question, parsed.k, deps, researchPlanOptions(parsed));
       deps.stdout(parsed.format === 'json'
         ? `${JSON.stringify(plan, null, 2)}\n`
         : formatPlanMarkdown(plan));
@@ -204,6 +223,9 @@ export function parseResearchArgs(rest: string[]): ResearchArgs {
   let format: OutputFormat = 'md';
   let runDir: string | undefined;
   let k = 5;
+  const includeShelves: string[] = [];
+  const excludeShelves: string[] = [];
+  let maxShelves = 5;
 
   for (let i = 1; i < rest.length; i++) {
     const raw = rest[i];
@@ -233,6 +255,32 @@ export function parseResearchArgs(rest: string[]): ResearchArgs {
       k = value;
       continue;
     }
+    if (raw === '--kb' || raw === '--include-kb' || raw === '--exclude-kb') {
+      const value = rest[++i];
+      if (!value || value.startsWith('--')) throw new Error(`missing value for ${raw}`);
+      if (raw === '--exclude-kb') excludeShelves.push(value);
+      else includeShelves.push(value);
+      continue;
+    }
+    if (raw.startsWith('--kb=') || raw.startsWith('--include-kb=')) {
+      const flag = raw.startsWith('--kb=') ? '--kb' : '--include-kb';
+      const value = raw.slice(`${flag}=`.length).trim();
+      if (value === '') throw new Error(`empty ${flag} value`);
+      includeShelves.push(value);
+      continue;
+    }
+    if (raw.startsWith('--exclude-kb=')) {
+      const value = raw.slice('--exclude-kb='.length).trim();
+      if (value === '') throw new Error('empty --exclude-kb value');
+      excludeShelves.push(value);
+      continue;
+    }
+    if (raw.startsWith('--max-shelves=')) {
+      const value = Number(raw.slice('--max-shelves='.length));
+      if (!Number.isInteger(value) || value <= 0) throw new Error(`invalid --max-shelves: ${raw}`);
+      maxShelves = value;
+      continue;
+    }
     if (raw.startsWith('--')) throw new Error(`unknown flag: ${raw}`);
     if (question === undefined) {
       question = raw;
@@ -247,6 +295,10 @@ export function parseResearchArgs(rest: string[]): ResearchArgs {
   if (action === 'collect' && (runDir === undefined || runDir.trim() === '')) {
     throw new Error('collect requires --run-dir <path>');
   }
+  const conflicts = intersectNames(includeShelves, excludeShelves);
+  if (conflicts.length > 0) {
+    throw new Error(`cannot include and exclude the same shelf: ${conflicts.join(', ')}`);
+  }
 
   return {
     action,
@@ -254,6 +306,9 @@ export function parseResearchArgs(rest: string[]): ResearchArgs {
     format,
     ...(runDir !== undefined ? { runDir } : {}),
     k,
+    includeShelves: uniqueNames(includeShelves),
+    excludeShelves: uniqueNames(excludeShelves),
+    maxShelves,
   };
 }
 
@@ -261,12 +316,13 @@ export async function buildResearchPlan(
   question: string,
   k: number,
   deps: Pick<ResearchDeps, 'loadShelfDescriptions' | 'loadStats'>,
+  options: ResearchPlanOptions = {},
 ): Promise<ResearchPlan> {
   const [descriptions, stats] = await Promise.all([
     deps.loadShelfDescriptions(),
     deps.loadStats(),
   ]);
-  const selected = selectShelves(question, descriptions, stats.knowledge_bases);
+  const selected = selectShelves(question, descriptions, stats.knowledge_bases, options);
   const risks = selected.flatMap((shelf) => shelf.risks);
   return {
     schema_version: 'kb-research-plan.v1',
@@ -310,7 +366,7 @@ async function collectResearch(args: ResearchArgs, deps: ResearchDeps): Promise<
     run_dir: runDir,
   });
 
-  const plan = await buildResearchPlan(args.question, args.k, deps);
+  const plan = await buildResearchPlan(args.question, args.k, deps, researchPlanOptions(args));
   await appendEvent(eventsPath, {
     type: 'plan_created',
     at: deps.now().toISOString(),
@@ -425,28 +481,55 @@ function selectShelves(
   question: string,
   descriptions: ShelfDescription[],
   statsRows: Record<string, KbStatsRow>,
+  options: ResearchPlanOptions = {},
 ): SelectedShelf[] {
   const questionTokens = tokenize(question);
+  const questionText = canonicalPhrase(question);
+  const maxShelves = options.maxShelves ?? 5;
+  const includeNames = uniqueNames(options.includeShelves ?? []);
+  const excludeNames = new Set(uniqueNames(options.excludeShelves ?? []));
   const byName = new Map(descriptions.map((shelf) => [shelf.name, shelf.description]));
   for (const name of Object.keys(statsRows)) {
     if (!byName.has(name)) byName.set(name, '');
   }
+  const knownNames = new Set(byName.keys());
+  const unknownIncludes = includeNames.filter((name) => !knownNames.has(name));
+  if (unknownIncludes.length > 0) {
+    throw new Error(`unknown shelf in --include-kb/--kb: ${unknownIncludes.join(', ')}`);
+  }
+  const unknownExcludes = [...excludeNames].filter((name) => !knownNames.has(name));
+  if (unknownExcludes.length > 0) {
+    throw new Error(`unknown shelf in --exclude-kb: ${unknownExcludes.join(', ')}`);
+  }
+  const includeSet = new Set(includeNames);
 
   const shelves = [...byName.entries()].map(([name, description]) => {
     const nameTokens = tokenize(name.replace(/[-_]/g, ' '));
     const descriptionTokens = tokenize(description);
-    const nameOverlap = overlap(questionTokens, nameTokens);
-    const descriptionOverlap = overlap(questionTokens, descriptionTokens);
-    const exactNameHit = question.toLowerCase().includes(name.toLowerCase()) ? 1 : 0;
+    const nameMatches = matchedMeaningfulTokens(questionTokens, nameTokens);
+    const compoundNameMatch = matchedCompoundNameTokens(questionTokens, nameTokens);
+    const descriptionMatches = matchedMeaningfulTokens(questionTokens, descriptionTokens);
+    const exactNameHit = questionText.includes(canonicalPhrase(name)) ? 1 : 0;
     const stats = statsRows[name] ?? emptyStatsRow();
+    const explicitlyIncluded = includeSet.has(name);
     const score =
-      exactNameHit * 8 +
-      nameOverlap * 4 +
-      descriptionOverlap * 2;
+      exactNameHit * 12 +
+      compoundNameMatch.score +
+      nameMatches.length * 5 +
+      descriptionMatches.length * 2 +
+      (explicitlyIncluded ? 100 : 0);
     const reasons = [
+      ...(explicitlyIncluded ? ['explicitly included by operator'] : []),
       ...(exactNameHit ? ['question mentions shelf name'] : []),
-      ...(nameOverlap > 0 ? [`${nameOverlap} shelf-name token match${nameOverlap === 1 ? '' : 'es'}`] : []),
-      ...(descriptionOverlap > 0 ? [`${descriptionOverlap} description token match${descriptionOverlap === 1 ? '' : 'es'}`] : []),
+      ...(nameMatches.length > 0
+        ? [`${nameMatches.length} shelf-name token match${nameMatches.length === 1 ? '' : 'es'} (${nameMatches.join(', ')})`]
+        : []),
+      ...(compoundNameMatch.tokens.length > 0
+        ? [`compound shelf-name match (${compoundNameMatch.tokens.join(', ')})`]
+        : []),
+      ...(descriptionMatches.length > 0
+        ? [`${descriptionMatches.length} description token match${descriptionMatches.length === 1 ? '' : 'es'} (${descriptionMatches.join(', ')})`]
+        : []),
       ...(stats.file_count > 0 ? ['shelf has indexed-source files'] : []),
     ];
     const risks = buildShelfRisks(name, stats);
@@ -461,16 +544,19 @@ function selectShelves(
     };
   });
 
-  const relevant = shelves
-    .filter((shelf) => shelf.score > 0 && shelf.file_count > 0)
+  const available = shelves.filter((shelf) => shelf.file_count > 0 && !excludeNames.has(shelf.name));
+  const included = available
+    .filter((shelf) => includeSet.has(shelf.name))
+    .sort(compareShelves);
+  const relevant = available
+    .filter((shelf) => !includeSet.has(shelf.name) && shelf.score >= 2)
     .sort(compareShelves)
-    .slice(0, 5);
-  if (relevant.length > 0) return relevant;
+    .slice(0, maxShelves);
+  if (included.length > 0 || relevant.length > 0) return [...included, ...relevant];
 
-  return shelves
-    .filter((shelf) => shelf.file_count > 0)
+  return available
     .sort(compareShelves)
-    .slice(0, 3);
+    .slice(0, Math.min(maxShelves, 3));
 }
 
 function buildShelfRisks(name: string, stats: KbStatsRow): ResearchRisk[] {
@@ -496,7 +582,7 @@ function compareShelves(a: SelectedShelf, b: SelectedShelf): number {
 
 function buildQueries(question: string, shelves: SelectedShelf[]): ResearchQuery[] {
   const shelfNames = shelves.map((shelf) => shelf.name);
-  const keywords = tokenize(question).slice(0, 8).join(' ');
+  const keywords = tokenizeForQuery(question).slice(0, 8).join(' ');
   const shelfTerms = shelfNames.slice(0, 3).map((name) => name.replace(/[-_]/g, ' ')).join(' ');
   const candidates = [
     { text: question, purpose: 'original research question' },
@@ -524,15 +610,24 @@ function tokenize(value: string): string[] {
   const seen = new Set<string>();
   const tokens: string[] = [];
   for (const raw of value.toLowerCase().match(/[a-z0-9][a-z0-9-]{1,}/g) ?? []) {
-    const token = normalizeToken(raw.replace(/^-+|-+$/g, ''));
-    if (STOP_WORDS.has(token) || seen.has(token)) continue;
-    seen.add(token);
-    tokens.push(token);
+    addSelectionToken(raw.replace(/^-+|-+$/g, ''), seen, tokens);
+    for (const part of raw.split('-')) {
+      addSelectionToken(part.replace(/^-+|-+$/g, ''), seen, tokens);
+    }
   }
   return tokens;
 }
 
+function addSelectionToken(raw: string, seen: Set<string>, tokens: string[]): void {
+  if (raw === '') return;
+  const token = normalizeToken(raw);
+  if (STOP_WORDS.has(token) || seen.has(token)) return;
+  seen.add(token);
+  tokens.push(token);
+}
+
 function normalizeToken(token: string): string {
+  if (token === 'evals' || token === 'evaluations' || token === 'evaluation') return 'eval';
   if (token.length > 4 && token.endsWith('ies')) return `${token.slice(0, -3)}y`;
   if (
     token.length > 3 &&
@@ -540,17 +635,77 @@ function normalizeToken(token: string): string {
     !token.endsWith('ss') &&
     !token.endsWith('us') &&
     !token.endsWith('ous') &&
-    !token.endsWith('is')
+    !token.endsWith('is') &&
+    !token.endsWith('ias')
   ) {
     return token.slice(0, -1);
   }
   return token;
 }
 
-function overlap(left: string[], right: string[]): number {
-  const rightSet = new Set(right);
-  return left.filter((token) => rightSet.has(token)).length;
+function tokenizeForQuery(value: string): string[] {
+  const seen = new Set<string>();
+  const tokens: string[] = [];
+  for (const raw of value.toLowerCase().match(/[a-z0-9][a-z0-9-]{1,}/g) ?? []) {
+    const token = raw.replace(/^-+|-+$/g, '');
+    if (token === '') continue;
+    const normalized = normalizeToken(token);
+    if (STOP_WORDS.has(normalized) || seen.has(token)) continue;
+    seen.add(token);
+    tokens.push(token);
+  }
+  return tokens;
 }
+
+function matchedMeaningfulTokens(left: string[], right: string[]): string[] {
+  const rightSet = new Set(right);
+  return left.filter((token) => rightSet.has(token) && !BROAD_SELECTION_TOKENS.has(token));
+}
+
+function matchedCompoundNameTokens(questionTokens: string[], nameTokens: string[]): { tokens: string[]; score: number } {
+  const uniqueNameTokens = [...new Set(nameTokens)].filter((token) => !STOP_WORDS.has(token));
+  if (uniqueNameTokens.length < 2) return { tokens: [], score: 0 };
+  const questionSet = new Set(questionTokens);
+  const matched = uniqueNameTokens.filter((token) => questionSet.has(token));
+  if (matched.length !== uniqueNameTokens.length) return { tokens: [], score: 0 };
+  return {
+    tokens: matched,
+    score: matched.includes('llm') ? 10 : 4,
+  };
+}
+
+function canonicalPhrase(value: string): string {
+  return ` ${value.toLowerCase().replace(/[^a-z0-9]+/g, ' ').trim().replace(/\s+/g, ' ')} `;
+}
+
+function uniqueNames(names: string[]): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const raw of names) {
+    const name = raw.trim();
+    if (name === '' || seen.has(name)) continue;
+    seen.add(name);
+    out.push(name);
+  }
+  return out;
+}
+
+function intersectNames(left: string[], right: string[]): string[] {
+  const rightSet = new Set(uniqueNames(right));
+  return uniqueNames(left).filter((name) => rightSet.has(name));
+}
+
+function researchPlanOptions(args: Pick<ResearchArgs, 'includeShelves' | 'excludeShelves' | 'maxShelves'>): ResearchPlanOptions {
+  return {
+    includeShelves: args.includeShelves,
+    excludeShelves: args.excludeShelves,
+    maxShelves: args.maxShelves,
+  };
+}
+
+const BROAD_SELECTION_TOKENS = new Set([
+  'agent', 'llm', 'task', 'lesson', 'job', 'search', 'note', 'notes', 'tool', 'workflow',
+]);
 
 const STOP_WORDS = new Set([
   'about', 'after', 'again', 'against', 'also', 'and', 'approach', 'are', 'as',
@@ -753,7 +908,7 @@ function formatCollectMarkdown(summary: CollectResult['summary']): string {
 }
 
 function formatEvidencePacket(plan: ResearchPlan, ledger: ResearchLedger): string {
-  const found = ledger.entries.slice(0, 50);
+  const found = groupEvidenceBySource(ledger.entries).slice(0, 50);
   const sources = uniqueSources(ledger.entries);
   return [
     '# Evidence Packet',
@@ -777,9 +932,13 @@ function formatEvidencePacket(plan: ResearchPlan, ledger: ResearchLedger): strin
     '',
     ...(found.length === 0
       ? ['- No evidence found.']
-      : found.map((entry, index) => (
-          `${index + 1}. ${formatSourceLabel(entry)} — score ${formatScore(entry.score)}\n\n` +
-          `   ${entry.excerpt || '(empty excerpt)'}`
+      : found.map((group, index) => (
+          `${index + 1}. ${group.label} — ${group.entries.length} passage${group.entries.length === 1 ? '' : 's'}, ` +
+          `best score ${formatScore(group.bestScore)}\n\n` +
+          group.entries.slice(0, 3).map((entry) => (
+            `   - ${formatLineRange(entry)} via "${entry.query}": ${entry.excerpt || '(empty excerpt)'}`
+          )).join('\n') +
+          (group.entries.length > 3 ? `\n   - ... ${group.entries.length - 3} more passage(s) from this source` : '')
         ))),
     '',
     '## Evidence Gaps',
@@ -817,7 +976,7 @@ function uniqueSources(entries: LedgerEntry[]): string[] {
   const seen = new Set<string>();
   const out: string[] = [];
   for (const entry of entries) {
-    const source = formatSourceLabel(entry);
+    const source = formatSourceGroupLabel(entry);
     if (seen.has(source)) continue;
     seen.add(source);
     out.push(source);
@@ -828,6 +987,40 @@ function uniqueSources(entries: LedgerEntry[]): string[] {
 function formatSourceLabel(entry: LedgerEntry): string {
   const range = entry.line_range ? `#L${entry.line_range.from}-L${entry.line_range.to}` : '';
   return `${entry.shelf}/${entry.relative_path ?? 'unknown'}${range}`;
+}
+
+function formatSourceGroupLabel(entry: LedgerEntry): string {
+  return `${entry.shelf}/${entry.relative_path ?? 'unknown'}`;
+}
+
+function formatLineRange(entry: LedgerEntry): string {
+  if (!entry.line_range) return formatSourceLabel(entry);
+  return `L${entry.line_range.from}-L${entry.line_range.to}`;
+}
+
+function groupEvidenceBySource(entries: LedgerEntry[]): EvidenceSourceGroup[] {
+  const groups = new Map<string, { label: string; entries: LedgerEntry[]; bestScore: number | null; seen: Set<string> }>();
+  for (const entry of entries) {
+    const label = formatSourceGroupLabel(entry);
+    const key = label;
+    let group = groups.get(key);
+    if (!group) {
+      group = { label, entries: [], bestScore: null, seen: new Set<string>() };
+      groups.set(key, group);
+    }
+    const dedupeKey = `${formatSourceLabel(entry)}\0${entry.query}\0${entry.excerpt}`;
+    if (group.seen.has(dedupeKey)) continue;
+    group.seen.add(dedupeKey);
+    group.entries.push(entry);
+    if (entry.score !== null && (group.bestScore === null || entry.score > group.bestScore)) {
+      group.bestScore = entry.score;
+    }
+  }
+  return [...groups.values()].map(({ label, entries: groupedEntries, bestScore }) => ({
+    label,
+    entries: groupedEntries,
+    bestScore,
+  }));
 }
 
 function formatScore(score: number | null): string {

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -195,6 +195,7 @@ describe('kb CLI — argv parsing and dispatch', () => {
       'serve',
       'ask',
       'remember',
+      'research',
       'capture',
       'import-url',
       'compare',


### PR DESCRIPTION
## Summary
- tighten deterministic `kb research` shelf selection so specific domain shelves beat broad token matches
- add minimal operator steering controls: `--kb` / `--include-kb`, `--exclude-kb`, and `--max-shelves`
- preserve query terms such as `bias` by separating selection normalization from generated query text
- group evidence packet entries by source file to reduce repeated-source noise
- update CLI JSON docs and the help manifest test for the existing `research` command

## Selection behavior
Before this patch, broad normalized token overlap could select operational or unrelated shelves such as `agent-task-lessons` and `job-search-agents` from generic `agent` matches, and query generation could truncate `bias` to `bia`.

After this patch, broad tokens such as `agent` and `llm` are insufficient alone. Exact shelf-name and compound name matches rank higher, so the dogfood prompt selects `llm-as-judge` and `llm-agents` in focused tests while excluding the broad agent shelves by default. A live read-only plan check with `--max-shelves=2` selected exactly `llm-as-judge` and `llm-agents` and preserved `bias` in generated queries.

## Verification
- `npm install`
- `npm test -- --runTestsByPath src/cli-research.test.ts`
- `npm test -- --runTestsByPath src/cli-json-contracts.test.ts`
- `npm run build`
- `node build/cli.js research plan "end-to-end approach for autonomous research agents and evals, including LLM-as-judge bias mitigation" --format=json`
- `node build/cli.js research plan "end-to-end approach for autonomous research agents and evals, including LLM-as-judge bias mitigation" --format=json --max-shelves=2`
- Pre-PR specialist review: conventions, correctness, dead-code, and test specialists; follow-up findings were addressed.
- Final focused gate after review fixes: `npm test -- --runTestsByPath src/cli-research.test.ts src/cli.test.ts src/cli-json-contracts.test.ts` (164 passed)
- Final full gate after review fixes: `npm test` (106 suites passed; 1852 passed, 4 skipped, 1 todo)
- `git diff --check`

## Notes
This remains read-only for `plan`; `collect` only writes local run artifacts and delegates to existing hybrid search. No LLM, LRA, or advanced retrieval operators are introduced.
