### PR TITLE
docs: document kb research evidence workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ kb open alpha/docs/deploy.md#L42-L78         # resolve a chunk id / kb:// URI / 
 kb llm use-endpoint http://127.0.0.1:8080/v1/chat/completions --profile=local-research-agent
 kb ask "what changed in the daemonization notes?" --timing   # retrieval + local LLM answer with timings
 kb ask "what changed?" --kb=work --save-transcript --title="Ask - daemon changes" --yes
+kb research plan "autonomous research agents and evals" --format=json
+kb research collect "autonomous research agents and evals" --run-dir runs/agents --format=json
 kb remember --suggest --kb=work --title="Quarterly plan"
 printf '# Quarterly plan\n\n...' | kb remember --kb=work --title="Quarterly plan" --stdin --yes
 printf '\nFollow-up note.\n' | kb remember --kb=work --append=quarterly-plan.md --stdin --yes
@@ -62,6 +64,21 @@ kb completion bash            # generate a bash shell completion script
 ```
 
 The `kb` bin shares the same env vars as the MCP server (`KNOWLEDGE_BASES_ROOT_DIR`, `FAISS_INDEX_PATH`, `EMBEDDING_PROVIDER`, `OLLAMA_*`, `OPENAI_*`, `HUGGINGFACE_*`). The consolidated operator matrix for retrieval flags, defaults, per-call overrides, rollout status, and validation commands lives in [docs/feature-flags.md](docs/feature-flags.md). `kb stats [--kb=<name>] [--format=md|json]` mirrors the MCP `kb_stats` payload for local shell use: per-KB file/chunk/byte counts, last indexed time, embedding model, index path, and version context. It is read-only and does not refresh the index. `kb search` also defaults to read-only dense retrieval — it loads the existing FAISS index but does not re-scan KB files. Pass `--refresh` to re-index. Use `--mode=hybrid` for explicit dense+BM25 rank fusion, or `--mode=auto` to keep dense for prose queries while selecting hybrid for code, path, flag, error-code, and issue-reference shaped queries. Add `--timing` to `kb search` or `kb ask` when you need per-stage elapsed milliseconds in either markdown or JSON output. Search output includes a freshness footer indicating whether the index is up-to-date relative to KB file mtimes.
+
+### Research evidence packets for agents
+
+`kb research` is a read-only workflow for agent shells that need a broad evidence pass before writing an answer, RFC, eval plan, or issue. It does not call an LLM, trigger local-research-agent, refresh indexes, or write KB notes.
+
+Run `plan` first to inspect the deterministic shelf/query plan, then run `collect` with a run directory:
+
+```bash
+kb research plan "synthesize an end-to-end approach for autonomous research agents and evals" --format=json
+kb research collect "synthesize an end-to-end approach for autonomous research agents and evals" \
+  --run-dir /tmp/kb-research-autonomous-agents-evals-20260521 \
+  --format=json
+```
+
+After `collect`, read the generated `evidence_packet.md` and synthesize manually. The run directory also contains `run.json`, `plan.json`, `ledger.json`, and `events.jsonl`; `ledger.json` stays lossless for audit/debug use, while `evidence_packet.md` is the human-scannable packet. The JSON contract and stable artifact fields are documented in [`docs/cli-json-contracts.md`](docs/cli-json-contracts.md#kb-research).
 
 For local day-two operations with Ollama, llama-server, n8n, systemd user
 units, remote MCP transports, or `kb serve`, see the

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ kb research collect "synthesize an end-to-end approach for autonomous research a
 
 After `collect`, read the generated `evidence_packet.md` and synthesize manually. The run directory also contains `run.json`, `plan.json`, `ledger.json`, and `events.jsonl`; `ledger.json` stays lossless for audit/debug use, while `evidence_packet.md` is the human-scannable packet. The JSON contract and stable artifact fields are documented in [`docs/cli-json-contracts.md`](docs/cli-json-contracts.md#kb-research).
 
+When `plan` reports `dense_index_empty_coverage`, the selected shelf has files but zero dense chunks. `collect` still runs hybrid search, but evidence from that shelf may be lexical-heavy and lower confidence until the index is refreshed outside the read-only research command.
+
 For local day-two operations with Ollama, llama-server, n8n, systemd user
 units, remote MCP transports, or `kb serve`, see the
 [local service operations runbook](docs/operations/local-services.md).

--- a/docs/cli-json-contracts.md
+++ b/docs/cli-json-contracts.md
@@ -351,7 +351,9 @@ Stable plan fields are `schema_version`, `question`, `selected_shelves`,
 `queries`, `retrieval`, and `risks`. `retrieval.mode` is currently `hybrid`.
 `selected_shelves[].risks` and top-level `risks` include
 `dense_index_empty_coverage` when a selected shelf has files but zero dense
-chunks; collection still uses hybrid search in that case.
+chunks; collection still uses hybrid search in that case, but evidence from
+that shelf may be lexical-heavy and lower confidence until the index is
+refreshed outside the read-only research command.
 
 Collect summary success envelope:
 

--- a/src/cli-research.test.ts
+++ b/src/cli-research.test.ts
@@ -3,6 +3,7 @@ import * as fsp from 'fs/promises';
 import * as os from 'os';
 import * as path from 'path';
 import {
+  RESEARCH_HELP,
   buildResearchPlan,
   parseResearchArgs,
   runResearch,
@@ -188,6 +189,12 @@ function lineRangeForQuery(query: string): { from: number; to: number } {
 }
 
 describe('kb research CLI', () => {
+  it('explains dense coverage warnings in command help', () => {
+    expect(RESEARCH_HELP).toContain('dense_index_empty_coverage');
+    expect(RESEARCH_HELP).toContain('lexical-heavy and lower confidence');
+    expect(RESEARCH_HELP).toContain('read-only command');
+  });
+
   it('parses plan and collect arguments', () => {
     expect(parseResearchArgs(['plan', 'agent evals', '--format=json'])).toMatchObject({
       action: 'plan',
@@ -305,6 +312,18 @@ describe('kb research CLI', () => {
     expect(deps.searchHybrid).not.toHaveBeenCalled();
   });
 
+  it('prints dense coverage confidence guidance in markdown plan output', async () => {
+    const { deps, stdout, stderr } = makeDeps();
+
+    const code = await runResearch(['plan', 'autonomous agents as judges'], deps);
+
+    expect(code).toBe(0);
+    expect(stderr.join('')).toBe('');
+    expect(stdout.join('')).toContain('dense_index_empty_coverage');
+    expect(stdout.join('')).toContain('lexical-heavy and lower confidence');
+    expect(deps.searchHybrid).not.toHaveBeenCalled();
+  });
+
   it('applies explicit shelf controls through the plan command path', async () => {
     const { deps, stdout, stderr } = makeDeps();
 
@@ -413,6 +432,28 @@ describe('kb research CLI', () => {
         shelf: 'llm-agents',
         k: 5,
       });
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('prints dense coverage confidence guidance in markdown collect output', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-research-md-'));
+    const runDir = path.join(tempDir, 'run');
+    const { deps, stdout, stderr } = makeDeps();
+
+    try {
+      const code = await runResearch([
+        'collect',
+        'autonomous agents as judges',
+        '--run-dir',
+        runDir,
+      ], deps);
+
+      expect(code).toBe(0);
+      expect(stderr.join('')).toBe('');
+      expect(stdout.join('')).toContain('Coverage note: dense-index coverage warnings');
+      expect(stdout.join('')).toContain('lexical-heavy and lower confidence');
     } finally {
       await fsp.rm(tempDir, { recursive: true, force: true });
     }

--- a/src/cli-research.ts
+++ b/src/cli-research.ts
@@ -19,6 +19,11 @@ The workflow is deterministic: it reads KB descriptions and stats, selects
 likely shelves and queries, then collect uses existing hybrid search. It does
 not call an LLM, trigger local-research-agent, or write KB notes.
 
+If a selected shelf has files but 0 dense chunks, plan reports
+dense_index_empty_coverage. Collect still runs hybrid search, but evidence from
+that shelf may be lexical-heavy and lower confidence until the index is
+refreshed outside this read-only command.
+
 Commands:
   plan                  Print a deterministic retrieval plan.
   collect               Create run artifacts: run.json, plan.json, ledger.json,
@@ -565,7 +570,7 @@ function buildShelfRisks(name: string, stats: KbStatsRow): ResearchRisk[] {
       code: 'dense_index_empty_coverage',
       severity: 'warning',
       shelf: name,
-      message: `${name} has ${stats.file_count} file(s) but 0 dense chunks; collect will still use hybrid search.`,
+      message: `${name} has ${stats.file_count} file(s) but 0 dense chunks; collect will still use hybrid search, but evidence may be lexical-heavy and lower confidence until the index is refreshed.`,
     }];
   }
   return [];
@@ -902,6 +907,9 @@ function formatCollectMarkdown(summary: CollectResult['summary']): string {
     `Run directory: ${summary.run_dir}`,
     `Evidence entries: ${summary.evidence_count}`,
     `Risks: ${summary.risk_count}`,
+    ...(summary.risk_count > 0
+      ? ['Coverage note: dense-index coverage warnings mean evidence may be lexical-heavy and lower confidence; inspect evidence_packet.md for details.']
+      : []),
     `Search failures: ${summary.search_failure_count}`,
     '',
   ].join('\n');


### PR DESCRIPTION
## Summary

- add `kb research plan` and `kb research collect` to the README CLI examples
- document the read-only agent evidence workflow and generated run artifacts
- cross-link the stable `kb research` JSON/artifact contract

Closes #453

## Verification

- `npm run docs:check-anchors` (exit 0; reports existing stale anchors in architecture/RFC docs outside this README change)
- `npm run build`
- `rm -rf build && npm run build && npm test` (106 suites, 1855 passing, 4 skipped, 1 todo)

## Pre-PR Review

- detected project type: npm
- type/build checks: passed after `npm ci` + clean build
- tests: passed
- bug reproduction: skipped (docs-only PR)
- diff review: done
- portability check: manual clean; `scripts/check-portability.sh` is absent in this repo
- reviewer specialists: skipped (small docs-only README change)
- OSS base-branch policy: skipped (same-repo PR)
- gate file: created