### PR TITLE
fix: deduplicate kb research evidence packet passages

### DIFF
--- a/docs/cli-json-contracts.md
+++ b/docs/cli-json-contracts.md
@@ -390,7 +390,8 @@ Collect artifacts:
 - `evidence_packet.md`: markdown packet with Question, Selected Shelves,
   Queries, Evidence Found, Evidence Gaps, and Sources sections. Evidence Found
   is grouped by source file so repeated passages from the same source are
-  easier to scan.
+  easier to scan. Duplicate passages from the same source are shown once with
+  the query ids that retrieved them.
 - `events.jsonl`: structured event stream for collection progress.
 
 Ledger entries have stable `source_id`, `shelf`, `relative_path`,

--- a/src/cli-research.test.ts
+++ b/src/cli-research.test.ts
@@ -181,6 +181,27 @@ function fixtureSearchPayload(shelf: string, query: string): Record<string, unkn
   };
 }
 
+function repeatedPassagePayload(shelf: string): Record<string, unknown> {
+  const lines = { from: 10, to: 14 };
+  return {
+    mode: 'hybrid',
+    results: [{
+      score: 0.42,
+      content: 'Repeated passage about agent evaluation and evidence packet readability.',
+      chunk_id: `${shelf}/papers/repeated.md#L${lines.from}-L${lines.to}`,
+      metadata: {
+        knowledgeBase: shelf,
+        relativePath: `${shelf}/papers/repeated.md`,
+        loc: { lines },
+      },
+    }],
+    retrievers: {
+      dense: { fetched: 1, model: 'ollama__nomic-embed-text-latest' },
+      lexical: { fetched: 1, refreshed: 0, failed: 0 },
+    },
+  };
+}
+
 function lineRangeForQuery(query: string): { from: number; to: number } {
   if (query === 'autonomous agents judges') return { from: 20, to: 24 };
   if (query.includes('llm as judge')) return { from: 30, to: 34 };
@@ -376,9 +397,9 @@ describe('kb research CLI', () => {
       expect(packet).toContain('llm-agents/papers/agent-evals.md — 3 passages');
       expect(packet).toContain('llm-as-judge/papers/agent-evals.md — 3 passages');
       expect(packet.match(/papers\/agent-evals\.md — 3 passages/g)).toHaveLength(2);
-      expect(packet).toContain('L10-L14 via "autonomous agents as judges"');
-      expect(packet).toContain('L20-L24 via "autonomous agents judges"');
-      expect(packet).toContain('L30-L34 via "autonomous agents as judges llm as judge llm agents"');
+      expect(packet).toContain('L10-L14 via q1');
+      expect(packet).toContain('L20-L24 via q2');
+      expect(packet).toContain('L30-L34 via q3');
 
       const events = parseJsonl(await fsp.readFile(path.join(runDir, 'events.jsonl'), 'utf-8'));
       expect(events.filter((event) => event.type === 'search_completed')).toHaveLength(6);
@@ -413,6 +434,43 @@ describe('kb research CLI', () => {
         shelf: 'llm-agents',
         k: 5,
       });
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('deduplicates repeated packet passages while keeping the ledger lossless', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-research-dedupe-'));
+    const runDir = path.join(tempDir, 'run');
+    const { deps, stdout, stderr } = makeDeps();
+    deps.searchHybrid = jest.fn(async (input: { query: string; shelf: string; k: number }) => ({
+      exitCode: 0,
+      stdout: JSON.stringify(repeatedPassagePayload(input.shelf)),
+      stderr: '',
+      payload: repeatedPassagePayload(input.shelf),
+    }));
+
+    try {
+      const code = await runResearch([
+        'collect',
+        'autonomous agents as judges',
+        '--run-dir',
+        runDir,
+        '--format=json',
+      ], deps);
+
+      expect(code).toBe(0);
+      expect(stderr.join('')).toBe('');
+      expect(JSON.parse(stdout.join('')).status).toBe('complete');
+
+      const ledger = JSON.parse(await fsp.readFile(path.join(runDir, 'ledger.json'), 'utf-8'));
+      expect(ledger.entries).toHaveLength(6);
+
+      const packet = await fsp.readFile(path.join(runDir, 'evidence_packet.md'), 'utf-8');
+      expect(packet).toContain('llm-agents/papers/repeated.md — 1 unique passage, 3 retrieval matches');
+      expect(packet).toContain('llm-as-judge/papers/repeated.md — 1 unique passage, 3 retrieval matches');
+      expect(packet.match(/via q1, q2, q3/g)).toHaveLength(2);
+      expect(packet.match(/Repeated passage about agent evaluation/g)).toHaveLength(2);
     } finally {
       await fsp.rm(tempDir, { recursive: true, force: true });
     }

--- a/src/cli-research.ts
+++ b/src/cli-research.ts
@@ -108,6 +108,13 @@ interface EvidenceSourceGroup {
   bestScore: number | null;
 }
 
+interface EvidencePassageGroup {
+  entry: LedgerEntry;
+  queryLabels: string[];
+  matchCount: number;
+  bestScore: number | null;
+}
+
 export interface LedgerEntry {
   source_id: string;
   shelf: string;
@@ -910,6 +917,7 @@ function formatCollectMarkdown(summary: CollectResult['summary']): string {
 function formatEvidencePacket(plan: ResearchPlan, ledger: ResearchLedger): string {
   const found = groupEvidenceBySource(ledger.entries).slice(0, 50);
   const sources = uniqueSources(ledger.entries);
+  const queryLabelByText = new Map(plan.queries.map((query) => [query.text, query.id]));
   return [
     '# Evidence Packet',
     '',
@@ -932,14 +940,7 @@ function formatEvidencePacket(plan: ResearchPlan, ledger: ResearchLedger): strin
     '',
     ...(found.length === 0
       ? ['- No evidence found.']
-      : found.map((group, index) => (
-          `${index + 1}. ${group.label} — ${group.entries.length} passage${group.entries.length === 1 ? '' : 's'}, ` +
-          `best score ${formatScore(group.bestScore)}\n\n` +
-          group.entries.slice(0, 3).map((entry) => (
-            `   - ${formatLineRange(entry)} via "${entry.query}": ${entry.excerpt || '(empty excerpt)'}`
-          )).join('\n') +
-          (group.entries.length > 3 ? `\n   - ... ${group.entries.length - 3} more passage(s) from this source` : '')
-        ))),
+      : found.map((group, index) => formatEvidenceSourceGroup(index, group, queryLabelByText))),
     '',
     '## Evidence Gaps',
     '',
@@ -950,6 +951,25 @@ function formatEvidencePacket(plan: ResearchPlan, ledger: ResearchLedger): strin
     ...(sources.length === 0 ? ['- None.'] : sources.map((source) => `- ${source}`)),
     '',
   ].join('\n');
+}
+
+function formatEvidenceSourceGroup(index: number, group: EvidenceSourceGroup, queryLabelByText: Map<string, string>): string {
+  const passages = groupPassagesByIdentity(group.entries, queryLabelByText);
+  const summary = formatPassageSummary(passages.length, group.entries.length);
+  return (
+    `${index + 1}. ${group.label} — ${summary}, best score ${formatScore(group.bestScore)}\n\n` +
+    passages.slice(0, 3).map((passage) => (
+      `   - ${formatLineRange(passage.entry)} via ${passage.queryLabels.join(', ')}: ` +
+      `${passage.entry.excerpt || '(empty excerpt)'}`
+    )).join('\n') +
+    (passages.length > 3 ? `\n   - ... ${passages.length - 3} more unique passage(s) from this source` : '')
+  );
+}
+
+function formatPassageSummary(uniqueCount: number, matchCount: number): string {
+  const uniqueLabel = `${uniqueCount} passage${uniqueCount === 1 ? '' : 's'}`;
+  if (uniqueCount === matchCount) return uniqueLabel;
+  return `${uniqueCount} unique passage${uniqueCount === 1 ? '' : 's'}, ${matchCount} retrieval matches`;
 }
 
 function formatEvidenceGaps(plan: ResearchPlan, ledger: ResearchLedger): string[] {
@@ -1021,6 +1041,40 @@ function groupEvidenceBySource(entries: LedgerEntry[]): EvidenceSourceGroup[] {
     entries: groupedEntries,
     bestScore,
   }));
+}
+
+function groupPassagesByIdentity(entries: LedgerEntry[], queryLabelByText: Map<string, string>): EvidencePassageGroup[] {
+  const groups = new Map<string, EvidencePassageGroup & { seenQueries: Set<string> }>();
+  for (const entry of entries) {
+    const key = `${formatSourceLabel(entry)}\0${entry.excerpt}`;
+    const queryLabel = queryLabelByText.get(entry.query) ?? `"${entry.query}"`;
+    let group = groups.get(key);
+    if (!group) {
+      group = {
+        entry,
+        queryLabels: [],
+        matchCount: 0,
+        bestScore: entry.score,
+        seenQueries: new Set<string>(),
+      };
+      groups.set(key, group);
+    }
+    group.matchCount += 1;
+    if (!group.seenQueries.has(queryLabel)) {
+      group.seenQueries.add(queryLabel);
+      group.queryLabels.push(queryLabel);
+    }
+    if (entry.score !== null && (group.bestScore === null || entry.score > group.bestScore)) {
+      group.bestScore = entry.score;
+      group.entry = entry;
+    }
+  }
+  return [...groups.values()]
+    .sort((a, b) => (
+      (b.bestScore ?? Number.NEGATIVE_INFINITY) - (a.bestScore ?? Number.NEGATIVE_INFINITY) ||
+      formatSourceLabel(a.entry).localeCompare(formatSourceLabel(b.entry))
+    ))
+    .map(({ seenQueries: _seenQueries, ...group }) => group);
 }
 
 function formatScore(score: number | null): string {


### PR DESCRIPTION
## Summary

- keep kb research ledger entries lossless for every retrieved result
- group repeated evidence packet passages by source/line/excerpt
- show query-id provenance for grouped passages

Closes #456

## Tests

- npm test -- --runTestsByPath src/cli-research.test.ts
- npm run build
- npm run docs:check-anchors (exits 0 in warning mode; reports existing stale anchors outside this change)
