### PR TITLE
docs: clarify kb research dense coverage warnings

### DIFF
--- a/docs/cli-json-contracts.md
+++ b/docs/cli-json-contracts.md
@@ -351,7 +351,9 @@ Stable plan fields are `schema_version`, `question`, `selected_shelves`,
 `queries`, `retrieval`, and `risks`. `retrieval.mode` is currently `hybrid`.
 `selected_shelves[].risks` and top-level `risks` include
 `dense_index_empty_coverage` when a selected shelf has files but zero dense
-chunks; collection still uses hybrid search in that case.
+chunks; collection still uses hybrid search in that case, but evidence from
+that shelf may be lexical-heavy and lower confidence until the index is
+refreshed outside the read-only research command.
 
 Collect summary success envelope:
 

--- a/src/cli-research.test.ts
+++ b/src/cli-research.test.ts
@@ -3,6 +3,7 @@ import * as fsp from 'fs/promises';
 import * as os from 'os';
 import * as path from 'path';
 import {
+  RESEARCH_HELP,
   buildResearchPlan,
   parseResearchArgs,
   runResearch,
@@ -188,6 +189,12 @@ function lineRangeForQuery(query: string): { from: number; to: number } {
 }
 
 describe('kb research CLI', () => {
+  it('explains dense coverage warnings in command help', () => {
+    expect(RESEARCH_HELP).toContain('dense_index_empty_coverage');
+    expect(RESEARCH_HELP).toContain('lexical-heavy and lower confidence');
+    expect(RESEARCH_HELP).toContain('read-only command');
+  });
+
   it('parses plan and collect arguments', () => {
     expect(parseResearchArgs(['plan', 'agent evals', '--format=json'])).toMatchObject({
       action: 'plan',
@@ -302,6 +309,18 @@ describe('kb research CLI', () => {
     const parsed = JSON.parse(stdout.join(''));
     expect(parsed.schema_version).toBe('kb-research-plan.v1');
     expect(parsed.selected_shelves[0].name).toBe('llm-as-judge');
+    expect(deps.searchHybrid).not.toHaveBeenCalled();
+  });
+
+  it('prints dense coverage confidence guidance in markdown plan output', async () => {
+    const { deps, stdout, stderr } = makeDeps();
+
+    const code = await runResearch(['plan', 'autonomous agents as judges'], deps);
+
+    expect(code).toBe(0);
+    expect(stderr.join('')).toBe('');
+    expect(stdout.join('')).toContain('dense_index_empty_coverage');
+    expect(stdout.join('')).toContain('lexical-heavy and lower confidence');
     expect(deps.searchHybrid).not.toHaveBeenCalled();
   });
 
@@ -444,6 +463,28 @@ describe('kb research CLI', () => {
         (deps.searchHybrid as jest.Mock).mock.calls.map(([input]) => (input as { shelf: string }).shelf),
       );
       expect([...searchedShelves]).toEqual(['agent-task-lessons', 'llm-agents']);
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('prints dense coverage confidence guidance in markdown collect output', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-research-md-'));
+    const runDir = path.join(tempDir, 'run');
+    const { deps, stdout, stderr } = makeDeps();
+
+    try {
+      const code = await runResearch([
+        'collect',
+        'autonomous agents as judges',
+        '--run-dir',
+        runDir,
+      ], deps);
+
+      expect(code).toBe(0);
+      expect(stderr.join('')).toBe('');
+      expect(stdout.join('')).toContain('Coverage note: dense-index coverage warnings');
+      expect(stdout.join('')).toContain('lexical-heavy and lower confidence');
     } finally {
       await fsp.rm(tempDir, { recursive: true, force: true });
     }

--- a/src/cli-research.ts
+++ b/src/cli-research.ts
@@ -19,6 +19,11 @@ The workflow is deterministic: it reads KB descriptions and stats, selects
 likely shelves and queries, then collect uses existing hybrid search. It does
 not call an LLM, trigger local-research-agent, or write KB notes.
 
+If a selected shelf has files but 0 dense chunks, plan reports
+dense_index_empty_coverage. Collect still runs hybrid search, but evidence from
+that shelf may be lexical-heavy and lower confidence until the index is
+refreshed outside this read-only command.
+
 Commands:
   plan                  Print a deterministic retrieval plan.
   collect               Create run artifacts: run.json, plan.json, ledger.json,
@@ -565,7 +570,7 @@ function buildShelfRisks(name: string, stats: KbStatsRow): ResearchRisk[] {
       code: 'dense_index_empty_coverage',
       severity: 'warning',
       shelf: name,
-      message: `${name} has ${stats.file_count} file(s) but 0 dense chunks; collect will still use hybrid search.`,
+      message: `${name} has ${stats.file_count} file(s) but 0 dense chunks; collect will still use hybrid search, but evidence may be lexical-heavy and lower confidence until the index is refreshed.`,
     }];
   }
   return [];
@@ -902,6 +907,9 @@ function formatCollectMarkdown(summary: CollectResult['summary']): string {
     `Run directory: ${summary.run_dir}`,
     `Evidence entries: ${summary.evidence_count}`,
     `Risks: ${summary.risk_count}`,
+    ...(summary.risk_count > 0
+      ? ['Coverage note: dense-index coverage warnings mean evidence may be lexical-heavy and lower confidence; inspect evidence_packet.md for details.']
+      : []),
     `Search failures: ${summary.search_failure_count}`,
     '',
   ].join('\n');


### PR DESCRIPTION
## Summary

- explain dense_index_empty_coverage in kb research help text
- clarify that zero dense chunks can make evidence lexical-heavy and lower confidence
- surface the confidence note in markdown plan/collect output and JSON contract docs

Closes #454

## Verification

- npm test -- --runTestsByPath src/cli-research.test.ts
- npm run build
- npm run docs:check-anchors (exits 0 in warning mode; reports existing stale anchors outside this change)
- node build/cli.js help research | sed -n '1,80p'