### PR TITLE
docs: diagnose zero dense chunk shelves

### DIFF
--- a/docs/troubleshooting-local-kb.md
+++ b/docs/troubleshooting-local-kb.md
@@ -24,6 +24,7 @@ Use `kb doctor --endpoints` for the narrower port/URL preflight: MCP bind target
 | --- | --- | --- | --- |
 | `kb search` returns zero results for content you know exists | Querying the wrong KB, stale index, or no index yet | `kb doctor` | Confirm `KNOWLEDGE_BASES_ROOT_DIR`, then run `kb search "known phrase" --kb=<name> --refresh`. |
 | Search output footer says the selected KB or global index is stale | Source files changed after the last refresh | `kb stats --kb=<name>` | Run `kb search "known phrase" --kb=<name> --refresh`; omit `--kb` only when you intend to refresh every KB. |
+| `kb research` or `kb stats` shows shelves with files but 0 dense chunks | The active dense index may only cover a scoped refresh, or those shelves have not been refreshed for the active embedding model | `kb stats` or `kb stats --format=json` | Inspect `last_index_update.scope`; refresh one affected shelf with `kb search "known phrase" --kb=<name> --refresh`, or omit `--kb` only for an intentional global refresh. |
 | MCP client returns old results but shell `kb` is fresh | Client process still has an older package/env, or uses `npx` cache | `kb doctor` in the same shell/env as the client when possible | Restart the client, prefer `@latest` in `npx` args, or point the client at the intended linked checkout. |
 | `ACTIVE_MODEL_UNRESOLVED` or doctor shows no active model | `${FAISS_INDEX_PATH}/active.txt` points at a missing model, `KB_ACTIVE_MODEL` is wrong, or no model is registered | `kb models list` | Add or select a model with `kb models add ...` or `kb models set-active <id>`. |
 | `PROVIDER_UNAVAILABLE`, `PROVIDER_TIMEOUT`, or backend check is unhealthy | Ollama is down, remote provider is unreachable, or API credentials are missing/invalid | `kb doctor` | Start the backend, fix API keys/env, then retry the search. |
@@ -78,6 +79,30 @@ Use the footer this way:
 | Fresh but result quality is poor | Index freshness is not the problem | Try `--mode=hybrid`, a narrower `--kb`, or a query phrase closer to the document wording. |
 
 Refresh writes index state. Avoid running broad refreshes from multiple shells at the same time.
+
+## Files But Zero Dense Chunks
+
+`file_count` and `chunk_count` answer different questions. `file_count` is the
+number of ingestable source files on disk. `chunk_count` is the number of chunks
+currently present in the active dense index for the active embedding model.
+
+When a shelf has files but `0` dense chunks, read it as an index coverage
+diagnostic, not as proof that the shelf is empty. This commonly happens after a
+scoped refresh: `last_index_update.status` can be `success` while
+`last_index_update.scope` names a different shelf. In that state, read-only
+commands such as `kb research` are correct to report
+`dense_index_empty_coverage` and continue with hybrid/lexical evidence; they do
+not refresh indexes themselves.
+
+Use this sequence:
+
+```bash
+kb stats
+kb stats --format=json
+kb search "known phrase from the affected shelf" --kb=<name> --refresh
+```
+
+Only omit `--kb` when you intentionally want to refresh every registered shelf.
 
 ## Linked Checkout and Global Bin Drift
 

--- a/src/cli-stats.test.ts
+++ b/src/cli-stats.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, jest } from '@jest/globals';
 import {
+  formatDenseCoverageSection,
   formatContextualSection,
   formatRemoteTransportSection,
   runStats,
@@ -194,6 +195,53 @@ describe('kb stats CLI', () => {
     expect(out).toContain('- Index path: `/tmp/kb-index`');
     expect(out).toContain('## Relevance Gate');
     expect(out).toContain('- Gated queries: 0');
+  });
+
+  it('diagnoses shelves with files but zero dense chunks in markdown stats', async () => {
+    const scoped = payload();
+    scoped.knowledge_bases.beta.chunk_count = 0;
+    scoped.last_index_update = {
+      ...scoped.last_index_update,
+      status: 'success',
+      scope: 'alpha',
+      chunks_added: 4,
+      finished_at: '2026-05-21T09:00:00.000Z',
+    };
+    const { deps, stdout } = makeDeps({ payload: scoped });
+
+    const code = await runStats([], deps);
+
+    expect(code).toBe(0);
+    const out = stdout.join('');
+    expect(out).toContain('## Dense Coverage');
+    expect(out).toContain('Knowledge bases with files but 0 dense chunks: `beta` (1 file).');
+    expect(out).toContain('Last index update: status=success, scope=kb:alpha, chunks_added=4');
+    expect(out).toContain('latest refresh was scoped outside these knowledge bases');
+    expect(out).toContain('likely index-scope state rather than missing source files');
+    expect(out).toContain('kb search "known phrase" --kb=<name> --refresh');
+  });
+
+  it('uses the generic dense coverage interpretation when the latest refresh was not scoped elsewhere', () => {
+    const scoped = payload();
+    scoped.knowledge_bases.beta.chunk_count = 0;
+    scoped.last_index_update = {
+      ...scoped.last_index_update,
+      status: 'success',
+      scope: 'global',
+      chunks_added: 4,
+      finished_at: '2026-05-21T09:00:00.000Z',
+    };
+
+    const lines = formatDenseCoverageSection(scoped);
+
+    expect(lines.join('\n')).toContain(
+      'source files exist on disk, but the active dense index has no chunks for these knowledge bases',
+    );
+    expect(lines.join('\n')).not.toContain('latest refresh was scoped outside');
+  });
+
+  it('omits the dense coverage section when every file-backed shelf has chunks', () => {
+    expect(formatDenseCoverageSection(payload())).toEqual([]);
   });
 
   it('renders a Remote Transport section when HTTP/SSE counters are present (#430)', async () => {

--- a/src/cli-stats.ts
+++ b/src/cli-stats.ts
@@ -162,6 +162,7 @@ export function formatStatsMarkdown(payload: KbStatsPayload): string {
     `- Server version: ${payload.server.version}`,
     `- Uptime: ${formatInteger(uptimeMs)} ms`,
     '',
+    ...formatDenseCoverageSection(payload),
     '## Relevance Gate',
     '',
     `- Gated queries: ${formatInteger(payload.relevance_gate.gated_queries)}`,
@@ -179,6 +180,41 @@ export function formatStatsMarkdown(payload: KbStatsPayload): string {
     ...formatRemoteTransportSection(payload),
     ...formatContextualSection(payload),
   ].join('\n');
+}
+
+export function formatDenseCoverageSection(payload: KbStatsPayload): string[] {
+  const emptyDenseShelves = Object.entries(payload.knowledge_bases)
+    .filter(([, row]) => row.file_count > 0 && row.chunk_count === 0)
+    .sort(([a], [b]) => a.localeCompare(b));
+  if (emptyDenseShelves.length === 0) return [];
+
+  const lastUpdate = payload.last_index_update;
+  const scopedElsewhere =
+    (lastUpdate.status === 'success' || lastUpdate.status === 'partial') &&
+    lastUpdate.scope !== null &&
+    lastUpdate.scope !== 'global' &&
+    !emptyDenseShelves.some(([name]) => name === lastUpdate.scope);
+  const shelfSummary = emptyDenseShelves
+    .map(([name, row]) => `\`${name}\` (${formatInteger(row.file_count)} file${row.file_count === 1 ? '' : 's'})`)
+    .join(', ');
+  const updateParts = [
+    `status=${lastUpdate.status}`,
+    `scope=${formatIndexUpdateScope(lastUpdate.scope)}`,
+    `chunks_added=${formatInteger(lastUpdate.chunks_added)}`,
+    `finished_at=${lastUpdate.finished_at ?? 'never'}`,
+  ];
+
+  return [
+    '## Dense Coverage',
+    '',
+    `- Knowledge bases with files but 0 dense chunks: ${shelfSummary}.`,
+    `- Last index update: ${updateParts.join(', ')}.`,
+    scopedElsewhere
+      ? '- Interpretation: the latest refresh was scoped outside these knowledge bases, so this is likely index-scope state rather than missing source files.'
+      : '- Interpretation: source files exist on disk, but the active dense index has no chunks for these knowledge bases.',
+    '- Next action: refresh a chosen knowledge base with `kb search "known phrase" --kb=<name> --refresh`; omit `--kb` only when you intend a global refresh.',
+    '',
+  ];
 }
 
 export function formatRemoteTransportSection(payload: KbStatsPayload): string[] {
@@ -269,6 +305,11 @@ function formatInteger(value: number): string {
 
 function formatRate(value: number): string {
   return `${(value * 100).toFixed(1)}%`;
+}
+
+function formatIndexUpdateScope(scope: KbStatsPayload['last_index_update']['scope']): string {
+  if (scope === null) return 'none';
+  return scope === 'global' ? 'global' : `kb:${scope}`;
 }
 
 function readPackageVersion(): string {


### PR DESCRIPTION
## Summary

- add a `kb stats` Dense Coverage markdown section for knowledge bases with files but 0 dense chunks
- explain scoped-index interpretation and explicit refresh remediation
- document the same files-vs-chunks diagnostic in the local troubleshooting runbook

Closes #455

## Verification

- npm test -- --runTestsByPath src/cli-stats.test.ts
- npm run build
- npm run docs:check-anchors (exits 0 in warning mode; reports existing stale anchors outside this change)

## Pre-PR Review

- detected project type: npm
- type/build checks: passed (`npm run build`)
- tests: passed (`npm test -- --runTestsByPath src/cli-stats.test.ts`)
- bug reproduction: skipped (docs/diagnostic enhancement, not a `fix:` PR)
- diff review: done
- portability check: manual clean; `scripts/check-portability.sh` is absent in this repo
- reviewer specialists: run; conventions/test suggestions addressed, correctness/dead-code clean
- OSS base-branch policy: skipped (same-repo PR)
- gate file: created