### PR TITLE
docs: refresh for RFC 017/018/019 and recent CLI additions

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ kb eval retrieval-eval.yml     # run fixture-driven retrieval checks
 kb eval-gate docs/testing/fixtures/rfc-018-gate-eval/queries.yml  # RFC 018 gate validation harness
 kb reindex --with-context     # rebuild the FAISS index with RFC 017 contextual prefaces
 kb reindex status --format=json  # ledger of recent / in-flight reindex passes (#417)
-kb logs --request-id=<id>     # read canonical request logs by id (#397)
-kb logs --tail=20 --format=json  # most recent canonical log entries
+kb logs show --request-id=<id>     # read canonical request logs by id (#397)
+kb logs recent --limit=20 --format=json  # most recent canonical log entries
 kb serve                      # start the loopback CLI daemon (warm reads); --port=17799 --idle-timeout-ms=300000
 kb serve status               # daemon liveness + degraded-mode diagnostics (#420)
 kb doctor                     # availability snapshot (index, embedding backend, LLM)
@@ -114,7 +114,7 @@ RFC 018 relevance gating is off by default. Enable it per process with `KB_RELEV
 
 `kb eval-gate <fixture.yml>` runs the RFC 018 relevance-gate validation harness end-to-end against a labelled-queries fixture (Stage A statistical floor + optional Stage B LLM judge) and reports per-stage precision, recall, and false-empty rate. Use it when you change `KB_GATE_*` tuning or the judge prompt before promoting changes to production. See [`docs/operations/eval-gate-harness.md`](docs/operations/eval-gate-harness.md).
 
-`kb logs` is the canonical reader for the structured request log emitted under `KB_LOG_FORMAT=canonical` or `both`. Filter by `--request-id=<id>` to pull every line of a specific retrieval, `--query-sha=<hash>` to follow recurring queries, `--since=<ISO|relative>` to scope a time window, and `--tail=<n>` for the most recent entries. `--format=json` produces one line per record for downstream tooling.
+`kb logs` is the canonical reader for the structured request log emitted under `KB_LOG_FORMAT=canonical` or `both`. Use `kb logs show --request-id=<id>` to pull every line of a specific retrieval, `kb logs show --query-sha=<hash>` to follow recurring queries, and `kb logs recent --limit=<n>` for the most recent entries. `--format=json` produces one line per record for downstream tooling.
 
 `kb serve` runs the loopback CLI daemon used by clients that pass `--daemon` for warm reads. The bare `kb serve [--host=127.0.0.1] [--port=17799] [--idle-timeout-ms=300000]` brings it up; `kb serve status [--json]` reports reachability, pid, idle timeout, and supported commands at the configured `KB_DAEMON_URL` (defaults to `http://127.0.0.1:17799`); SIGINT or SIGTERM stops it. CLI commands fall back to direct in-process execution when the daemon is unavailable. See [`docs/operations/daemon-lifecycle.md`](docs/operations/daemon-lifecycle.md).
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ kb list                       # list available knowledge bases
 kb stats                      # read-only index/corpus stats
 kb search "your query"                       # read-only dense search
 kb search "your query" --timing              # include retrieval-stage timings
+kb search "your query" --format=compact      # one-line-per-hit operator table (#446)
+printf '{"query":"q1"}\n{"query":"q2"}\n' | kb search --batch-jsonl  # batched JSONL stdin (#440)
 kb search "query" --refresh                  # also re-scan KB files (write path)
 kb search "query" --explain-empty            # opt-in deep diagnostics when results are empty (#328)
 kb search "INDEX_NOT_INITIALIZED" --mode=lexical --refresh   # BM25 debug surface (#206 stage 1)
@@ -55,13 +57,26 @@ printf '# Quarterly plan\n\n...' | kb remember --kb=work --title="Quarterly plan
 printf '\nFollow-up note.\n' | kb remember --kb=work --append=quarterly-plan.md --stdin --yes
 kb import-url --kb=research https://example.com/article   # snapshot a URL into a provenance-tagged note
 kb superseded --kb=work       # read-only review for obsolete/contradicted notes
+kb research plan "Compare RAG eval frameworks" --format=json  # deterministic shelf + query plan (#451)
+kb research collect "Compare RAG eval frameworks" --run-dir runs/rag-eval  # writes plan.json/ledger.json/evidence_packet.md/events.jsonl
+kb feedback add --kb=work --query="rollback procedure" --source=runbooks/deploy.md --verdict=relevant
+kb feedback promote --kb=work --query="rollback procedure" --fixture=docs/testing/feedback-fixture.yml --yes  # promote ledger entries into an eval fixture
 kb eval retrieval-eval.yml     # run fixture-driven retrieval checks
+kb eval-gate docs/testing/fixtures/rfc-018-gate-eval/queries.yml  # RFC 018 gate validation harness
+kb reindex --with-context     # rebuild the FAISS index with RFC 017 contextual prefaces
+kb reindex status --format=json  # ledger of recent / in-flight reindex passes (#417)
+kb logs --request-id=<id>     # read canonical request logs by id (#397)
+kb logs --tail=20 --format=json  # most recent canonical log entries
+kb serve                      # start the loopback CLI daemon (warm reads); --port=17799 --idle-timeout-ms=300000
+kb serve status               # daemon liveness + degraded-mode diagnostics (#420)
+kb doctor                     # availability snapshot (index, embedding backend, LLM)
+kb doctor --endpoints         # focused MCP/daemon/Ollama/LLM endpoint preflight
 kb --help                     # top-level command list
 kb help search                # per-command help (also: kb search --help)
 kb completion bash            # generate a bash shell completion script
 ```
 
-The `kb` bin shares the same env vars as the MCP server (`KNOWLEDGE_BASES_ROOT_DIR`, `FAISS_INDEX_PATH`, `EMBEDDING_PROVIDER`, `OLLAMA_*`, `OPENAI_*`, `HUGGINGFACE_*`). The consolidated operator matrix for retrieval flags, defaults, per-call overrides, rollout status, and validation commands lives in [docs/feature-flags.md](docs/feature-flags.md). `kb stats [--kb=<name>] [--format=md|json]` mirrors the MCP `kb_stats` payload for local shell use: per-KB file/chunk/byte counts, last indexed time, embedding model, index path, and version context. It is read-only and does not refresh the index. `kb search` also defaults to read-only dense retrieval — it loads the existing FAISS index but does not re-scan KB files. Pass `--refresh` to re-index. Use `--mode=hybrid` for explicit dense+BM25 rank fusion, or `--mode=auto` to keep dense for prose queries while selecting hybrid for code, path, flag, error-code, and issue-reference shaped queries. Add `--timing` to `kb search` or `kb ask` when you need per-stage elapsed milliseconds in either markdown or JSON output. Search output includes a freshness footer indicating whether the index is up-to-date relative to KB file mtimes.
+The `kb` bin shares the same env vars as the MCP server (`KNOWLEDGE_BASES_ROOT_DIR`, `FAISS_INDEX_PATH`, `EMBEDDING_PROVIDER`, `OLLAMA_*`, `OPENAI_*`, `HUGGINGFACE_*`). The consolidated operator matrix for retrieval flags, defaults, per-call overrides, rollout status, and validation commands lives in [docs/feature-flags.md](docs/feature-flags.md). `kb stats [--kb=<name>] [--format=md|json]` mirrors the MCP `kb_stats` payload for local shell use: per-KB file/chunk/byte counts, last indexed time, embedding model, index path, version context, contextual-preface cache/failure counters (when RFC 017 ingest is enabled), and remote-transport request/auth/backoff counters (when the HTTP or SSE transport is active). It is read-only and does not refresh the index. `kb search` also defaults to read-only dense retrieval — it loads the existing FAISS index but does not re-scan KB files. Pass `--refresh` to re-index. Use `--mode=hybrid` for explicit dense+BM25 rank fusion, or `--mode=auto` to keep dense for prose queries while selecting hybrid for code, path, flag, error-code, and issue-reference shaped queries. Add `--timing` to `kb search` or `kb ask` when you need per-stage elapsed milliseconds in either markdown or JSON output. `--format=compact` collapses each result to a single `score|kb|path:line` line for terse operator listings; `--batch-jsonl` reads `{"query":"…","kb":"…","k":N}` records from stdin and emits one JSON result envelope per line. Search output includes a freshness footer indicating whether the index is up-to-date relative to KB file mtimes.
 
 For local day-two operations with Ollama, llama-server, n8n, systemd user
 units, remote MCP transports, or `kb serve`, see the
@@ -76,6 +91,20 @@ RFC 018 relevance gating is off by default. Enable it per process with `KB_RELEV
 `kb import-url --kb=<name> <url>` snapshots a web page or PDF into one new KB note while preserving provenance. It fetches the URL over http(s), routes HTML and PDF responses through the same loaders the indexer uses, and writes a note whose YAML frontmatter records `source_url`, `fetched_at`, `content_sha256`, `content_type`, `http_status`, and `byte_count`. The fetch is guarded: only http/https schemes are allowed, redirects are followed manually and re-validated per hop (`--max-redirects`, default 5), responses are size-capped (`--max-bytes`, default 8 MiB) and time-bounded (`--timeout`, default 30000 ms), and private/loopback/link-local addresses are refused unless `--allow-local-network` is passed (SSRF guard). The note path defaults to a slug of the page title; pass `--note=<path.md>` to choose it, `--title` to override the title, and `--refresh` to re-index afterwards. It refuses to overwrite an existing note.
 
 `kb superseded --kb=<name>` is a read-only active-forgetting review. It scans markdown frontmatter for explicit contradiction, deprecated/dormant lifecycle status, stale verification dates, and low-confidence active notes, then uses the existing semantic index to add conservative newer-neighbor evidence when available. Use `--format=json` for agent workflows and `--include-clean` when you need a full inventory.
+
+`kb research plan "<question>"` reads KB descriptions and stats, then deterministically selects shelves and queries (no LLM calls). `kb research collect "<question>" --run-dir=<path>` runs the plan over hybrid search and writes a run directory containing `run.json`, `plan.json`, `ledger.json`, `evidence_packet.md` (the human-readable Sources-grouped packet), and `events.jsonl` so an agent can hand one coherent block of evidence to a follow-up `kb ask` or LLM call. See [`docs/operations/research-workflow.md`](docs/operations/research-workflow.md) for the operator walk-through.
+
+`kb feedback add --kb=<name> --query="<text>" --source=<kb-relative-path> --verdict=relevant|irrelevant|stale|misleading [--relevance=0..3] [--chunk-id=<id>]` appends a relevance judgment to the per-KB ledger (`<kb>/.index/relevance-feedback.jsonl`). `kb feedback list --kb=<name>` reviews recent entries, and `kb feedback promote --kb=<name> --query="<text>" --fixture=<path.yml> --yes` materialises every ledger row for a query into a retrieval-eval case so accumulated judgments become regression coverage. See [`docs/operations/feedback-workflow.md`](docs/operations/feedback-workflow.md).
+
+`kb eval-gate <fixture.yml>` runs the RFC 018 relevance-gate validation harness end-to-end against a labelled-queries fixture (Stage A statistical floor + optional Stage B LLM judge) and reports per-stage precision, recall, and false-empty rate. Use it when you change `KB_GATE_*` tuning or the judge prompt before promoting changes to production. See [`docs/operations/eval-gate-harness.md`](docs/operations/eval-gate-harness.md).
+
+`kb logs` is the canonical reader for the structured request log emitted under `KB_LOG_FORMAT=canonical` or `both`. Filter by `--request-id=<id>` to pull every line of a specific retrieval, `--query-sha=<hash>` to follow recurring queries, `--since=<ISO|relative>` to scope a time window, and `--tail=<n>` for the most recent entries. `--format=json` produces one line per record for downstream tooling.
+
+`kb serve` runs the loopback CLI daemon used by clients that pass `--daemon` for warm reads. The bare `kb serve [--host=127.0.0.1] [--port=17799] [--idle-timeout-ms=300000]` brings it up; `kb serve status [--json]` reports reachability, pid, idle timeout, and supported commands at the configured `KB_DAEMON_URL` (defaults to `http://127.0.0.1:17799`); SIGINT or SIGTERM stops it. CLI commands fall back to direct in-process execution when the daemon is unavailable. See [`docs/operations/daemon-lifecycle.md`](docs/operations/daemon-lifecycle.md).
+
+`kb reindex --with-context` rebuilds the FAISS index with RFC 017 contextual prefaces (requires `KB_CONTEXTUAL_RETRIEVAL=on` and an `KB_LLM_ENDPOINT`). `kb reindex status` reads the `.reindex.run.json` ledger and reports the current or most recent run (kb scope, model, started/finished timestamps, chunks processed, cache hit rate, and any failure code). The `--kb=<name>` flag is a guard/estimator hint only — the rebuild always covers the entire single-index-per-model FAISS layout (see RFC 017 §5).
+
+Retrieved chunks are passed through the **untrusted-content guard** (`KB_INJECTION_GUARD`, default `tag`). The guard scans chunk text for prompt-injection signals — system-role markers, instruction-override phrases, Unicode bidi/zero-width/tag controls — and either annotates metadata (`tag`), fences the content with sentinel strings (`wrap`), or both (`both`). Set `KB_INJECTION_GUARD=off` only on shelves you fully control, or use `KB_INJECTION_GUARD_BYPASS_KBS=trusted-kb,...` to opt specific shelves out without weakening the global default.
 
 `kb eval <fixture.yml|json>` runs retrieval checks from fixtures. Each case can set `query`, optional `kb`, `required_sources`, `forbidden_sources`, `expected_metadata`, `max_duplicate_groups`, `stale_policy`, and `gate`. Failing ungated cases print warnings and exit 0; failing gated cases exit 1 for CI.
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -22,11 +22,13 @@ If you've never seen this repo before, read top-to-bottom:
 3. [`c4-component.md`](./c4-component.md) — the TypeScript modules inside the server process and CLI, plus how they depend on each other.
 4. [`sequence-retrieve.md`](./sequence-retrieve.md) — `retrieve_knowledge` end-to-end, cold and warm.
 5. [`sequence-reindex.md`](./sequence-reindex.md) — what happens when `EMBEDDING_PROVIDER` or the model env var changes under an existing index.
-6. [`state-index.md`](./state-index.md) — the FAISS-index lifecycle (None → Loading → Loaded → Rebuilding → Recovering).
-7. [`data-model.md`](./data-model.md) — on-disk artifacts and the chunk metadata schema.
-8. [`qa-budgets.md`](./qa-budgets.md) — latency / memory / cost budgets and the current scale ceiling.
-9. [`threat-model.md`](./threat-model.md) — trust boundaries, provider keys, concurrency constraint, path-traversal plan.
-10. [`adr/`](./adr/) — five decisions in MADR 3.0 format (`0001` faiss-over-qdrant, `0002` per-file-hash-sidecars, `0003` stdio-only-transport, `0004` markdown-splitter-default, `0005` auto-rebuild-on-model-change).
+6. [`sequence-research-collect.md`](./sequence-research-collect.md) — `kb research collect` end-to-end: planner, per-shelf hybrid search loop, and atomic artifact writes.
+7. [`sequence-feedback-promote.md`](./sequence-feedback-promote.md) — `kb feedback add` (append to ledger) and `kb feedback promote` (materialise into a `kb eval` fixture).
+8. [`state-index.md`](./state-index.md) — the FAISS-index lifecycle (None → Loading → Loaded → Rebuilding → Recovering).
+9. [`data-model.md`](./data-model.md) — on-disk artifacts and the chunk metadata schema.
+10. [`qa-budgets.md`](./qa-budgets.md) — latency / memory / cost budgets and the current scale ceiling.
+11. [`threat-model.md`](./threat-model.md) — trust boundaries, provider keys, concurrency constraint, path-traversal plan.
+12. [`adr/`](./adr/) — five decisions in MADR 3.0 format (`0001` faiss-over-qdrant, `0002` per-file-hash-sidecars, `0003` stdio-only-transport, `0004` markdown-splitter-default, `0005` auto-rebuild-on-model-change).
 
 ## Conventions
 

--- a/docs/architecture/sequence-feedback-promote.md
+++ b/docs/architecture/sequence-feedback-promote.md
@@ -1,0 +1,97 @@
+# Sequence — `kb feedback` (add + promote)
+
+`kb feedback` has three actions; this diagram covers the two that mutate
+state. `list` is a trivial read of the JSONL ledger and is not diagrammed
+separately.
+
+The CLI entrypoint is `runFeedback` at `src/cli-feedback.ts:95-140`, which
+dispatches to `appendFeedbackEntry` (add) or
+`buildPromotedEvalFixture` + `appendPromotedCaseToFixtureFile` (promote).
+
+## Add a judgment
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant Op as Operator/agent
+  participant Cli as runFeedback<br/>src/cli-feedback.ts:95-140
+  participant Ledger as appendFeedbackEntry<br/>src/feedback-ledger.ts:61-67
+  participant KbFs as resolveKnowledgeBaseDir<br/>src/kb-fs.ts
+  participant FS as &lt;kb&gt;/.index/relevance-feedback.jsonl
+
+  Op->>Cli: kb feedback add --kb=<name> --query=<text><br/>--source=<rel-path> [verdict flags]
+  Cli->>KbFs: resolveKnowledgeBaseDir(KB_ROOT, kb)<br/>:106
+  KbFs-->>Cli: <kb> absolute path
+  Note over Cli: parseFeedbackArgs validates required fields<br/>:142-166
+  Cli->>Ledger: appendFeedbackEntry(kbDir, input)<br/>:114
+  Ledger->>Ledger: buildFeedbackEntry → ULID id,<br/>created_at, SHA-256 of task_context<br/>:97-118
+  Ledger->>FS: fsp.appendFile JSONL line
+  FS-->>Ledger: ok
+  Ledger-->>Cli: FeedbackLedgerEntry
+  Cli-->>Op: { ledger_path, entry } (JSON)<br/>:253-269<br/>exit 0
+```
+
+Stable guarantees:
+
+- The ledger file is append-only. If a prior process held it open with a
+  pending write, the new line still appends cleanly thanks to POSIX
+  `O_APPEND` semantics.
+- `task_context_sha256` is computed at `buildFeedbackEntry` time; raw task
+  context never reaches disk.
+- `verdict` and `relevance` defaults are applied in `buildFeedbackEntry`,
+  not in the CLI parser — direct programmatic callers get the same defaults
+  as the CLI.
+
+## Promote into an eval fixture
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant Op as Operator/agent
+  participant Cli as runFeedback<br/>src/cli-feedback.ts:95-140
+  participant Read as readFeedbackLedger<br/>src/feedback-ledger.ts:69-79
+  participant Build as buildPromotedEvalFixture<br/>:120-171
+  participant Append as appendPromotedCaseToFixtureFile<br/>:177-210
+  participant FS as fixture.yml
+
+  Op->>Cli: kb feedback promote --kb=<name><br/>--query=<text> [--fixture=<path> --yes]
+  Cli->>Read: readFeedbackLedger(kbDir)<br/>:127
+  Read->>Read: parse JSONL,<br/>filter by --query<br/>:81-95
+  Read-->>Cli: FeedbackLedgerEntry[]
+  Cli->>Build: buildPromotedEvalFixture(entries, parsed)<br/>:128
+  Build-->>Cli: { gate, cases: [one case for the query] }
+
+  alt --fixture && --yes (write mode)
+    Cli->>Append: appendPromotedCaseToFixtureFile(path, fixture)<br/>:130
+    Append->>Append: load existing YAML or create new
+    Append->>FS: write merged YAML atomically
+    Append-->>Cli: { caseCount, created }
+    Cli-->>Op: { fixture_path, wrote:true, created, case_count }<br/>:307-326<br/>exit 0
+  else preview (default)
+    Cli->>Cli: dumpPromotedEvalFixture(fixture)<br/>:294
+    Cli-->>Op: { wrote:false, fixture_yaml }<br/>:289-305<br/>exit 0
+  end
+```
+
+## Key invariants
+
+- **Preview by default.** Without both `--fixture` and `--yes`, no file is
+  touched. The `wrote: false` envelope carries the rendered YAML so the
+  operator can review.
+- **One case per promotion.** Each `promote` call emits exactly one `kb eval`
+  case for the target query (the case includes every ledger row that
+  matches). Re-running promotion appends another case rather than mutating
+  the previous one, so fixture history is monotonic.
+- **Idempotency boundary.** Adding the same judgment twice via `kb feedback
+  add` produces two ledger rows (different ULIDs). Operator-driven
+  retraction is by hand-editing the JSONL file — there is no `remove`.
+
+## Related
+
+- Operator walk-through: [`docs/operations/feedback-workflow.md`](../operations/feedback-workflow.md)
+- JSON contract: [`docs/cli-json-contracts.md`](../cli-json-contracts.md#kb-feedback)
+- Upstream: `kb research` (this diagram's sibling) produces the candidate
+  evidence operators typically judge — see
+  [`sequence-research-collect.md`](sequence-research-collect.md).
+- Downstream: the promoted fixture is consumed by `kb eval`
+  (`docs/cli-json-contracts.md#kb-eval`).

--- a/docs/architecture/sequence-research-collect.md
+++ b/docs/architecture/sequence-research-collect.md
@@ -1,0 +1,88 @@
+# Sequence — `kb research collect`
+
+End-to-end flow for `kb research collect "<question>" --run-dir=<path>`. The
+entrypoint is `runResearch` at `src/cli-research.ts:184-214`, which dispatches
+to `collectResearch` at `src/cli-research.ts:354-484` when the action is
+`collect`.
+
+The collector is deterministic and stateless across invocations: it never
+calls an LLM, never writes KB content, and uses the existing CLI hybrid
+search through a `deps.searchHybrid` seam so testing can mock the retrieval
+boundary.
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant Op as Operator/agent
+  participant Cli as runResearch<br/>src/cli-research.ts:184-214
+  participant Collect as collectResearch<br/>:354-484
+  participant Plan as buildResearchPlan<br/>:315-338
+  participant Stats as deps.loadStats / loadShelfDescriptions
+  participant Search as deps.searchHybrid<br/>(kb search --mode=hybrid)
+  participant FS as $RUN_DIR
+
+  Op->>Cli: kb research collect "<question>"<br/>--run-dir=<path>
+  Cli->>Collect: collectResearch(args, deps)
+  Collect->>FS: mkdir -p <run-dir><br/>:357
+  Collect->>FS: touch events.jsonl<br/>:358-359
+  Collect->>FS: appendEvent collect_started<br/>:362-367
+
+  Collect->>Plan: buildResearchPlan(question, k)<br/>:369
+  Plan->>Stats: loadShelfDescriptions() + loadStats()<br/>:321-324
+  Stats-->>Plan: shelf names + descriptions + file/chunk counts
+  Note over Plan: deterministic shelf scoring +<br/>query generation (:325-336)
+  Plan-->>Collect: kb-research-plan.v1
+  Collect->>FS: appendEvent plan_created<br/>:370-375
+
+  loop for each (query, shelf) in plan.queries
+    Collect->>Search: searchHybrid({query, shelf, k})<br/>:387-391
+    alt search_failure
+      Search-->>Collect: exitCode != 0
+      Collect->>FS: appendEvent search_failure<br/>:401-403
+    else search_completed
+      Search-->>Collect: results[]
+      Collect->>FS: appendEvent search_completed<br/>:406-413
+      Note over Collect: toLedgerEntry per result<br/>:414-422
+    end
+  end
+
+  Collect->>FS: writeJsonAtomic run.json<br/>:454
+  Collect->>FS: writeJsonAtomic plan.json<br/>:455
+  Collect->>FS: writeJsonAtomic ledger.json<br/>:456
+  Collect->>FS: writeTextAtomic evidence_packet.md<br/>:457
+  Collect->>FS: appendEvent artifacts_written<br/>:458-463
+  Collect-->>Cli: { exitCode, summary }<br/>:465-484
+  Cli-->>Op: kb-research-collect-summary.v1 (stdout)<br/>exit 0 (complete) or 1 (failed)
+```
+
+## Key invariants
+
+- **No LLM call.** `collectResearch` calls only `deps.loadShelfDescriptions`,
+  `deps.loadStats`, and `deps.searchHybrid`. None of those touch a language
+  model.
+- **Atomic per-artifact writes.** `writeJsonAtomic` / `writeTextAtomic`
+  (`src/cli-research.ts` near :454-457) write to a temp file then rename, so
+  a SIGINT mid-collect leaves either the previous file or no file — never a
+  truncated one.
+- **Events.jsonl is the audit trail.** Every state change (`collect_started`,
+  `plan_created`, `search_completed`, `search_failure`, `artifacts_written`)
+  appends a line. Replay it to reconstruct exactly what the collector saw.
+- **Status mirrors search outcomes.** `status: failed` (exit `1`) means at
+  least one `searchHybrid` call returned a non-zero exit. The successful
+  shelf entries are still in the ledger; this is *partial failure*, not
+  data loss.
+
+## Cost profile
+
+For `Q` queries × `S` shelves with `k` results each: one cold hybrid search
+per `(query, shelf)` cell when called without `--daemon`, plus the constant
+overhead of the planner (two parallel `loadShelfDescriptions` + `loadStats`
+calls). With `kb serve` running and `--daemon` propagated, every shelf
+search is warm.
+
+## Related
+
+- Operator walk-through: [`docs/operations/research-workflow.md`](../operations/research-workflow.md)
+- JSON contract: [`docs/cli-json-contracts.md`](../cli-json-contracts.md#kb-research)
+- Downstream: ledger entries feed [`kb feedback`](../operations/feedback-workflow.md)
+  when an operator judges them.

--- a/docs/cli-json-contracts.md
+++ b/docs/cli-json-contracts.md
@@ -944,6 +944,255 @@ Source and test anchors: `src/cli-eval.ts:136-142`,
 `src/retrieval-eval.ts:140-153`, `src/retrieval-eval.test.ts:38-74`,
 `src/retrieval-eval.test.ts:140-156`.
 
+## `kb eval-gate`
+
+The RFC 018 relevance-gate validation harness. Two modes, gated by `--m1`:
+
+- **M0 (default)** — "validate before build". Answers each query twice (raw
+  top-k vs. gate-simulated top-k via threshold surgery) and grades both for
+  downstream quality. Live with `--endpoint` (and optionally `--model`), or
+  simulation with `--dry-run` / when no endpoint is reachable.
+- **M1 (`--m1`)** — canary against the real gate (`KB_RELEVANCE_GATE=on`,
+  Stage B judge live). Requires a reachable endpoint. Reports downstream
+  answer quality, recall on known-good fixtures, position-swap probe,
+  `KB_GATE_SCORE_FLOOR` sweep, BM25-veto calibration, and go/no-go.
+
+Invocation:
+
+```bash
+kb eval-gate <fixture.yml|json> --format=json [--endpoint=<url>] [--model=<id>]
+             [--dry-run] [--calibration=<path>] [--out=<path>]
+kb eval-gate <fixture.yml|json> --m1 --format=json --endpoint=<url>
+             [--model=<id>] [--score-floor=<n>] [--floor-sweep=lo:hi:step]
+             [--calibration=<path>] [--out=<path>]
+```
+
+M0 report envelope:
+
+```json
+{
+  "meta": {
+    "fixturePath": "docs/testing/fixtures/rfc-018-gate-eval/queries.yml",
+    "mode": "live",
+    "answererModel": "llama-3.1",
+    "graderModel": "llama-3.1",
+    "generatedAt": "2026-05-21T08:30:00.000Z"
+  },
+  "summary": {
+    "case_count": 24,
+    "kb_names": ["operating-environment"],
+    "has_answer_count": 18,
+    "no_good_answer_count": 6,
+    "no_good_answer_ratio": 0.25,
+    "directional_pass": true,
+    "epsilon": 0.05,
+    "no_good_answer_delta": -0.08,
+    "has_answer_delta": -0.02,
+    "empty_verdict_fire_rate": 0.12,
+    "empty_verdict_fire_count": 3,
+    "per_chunk_drop_no_good_answer_delta": -0.04,
+    "per_chunk_drop_has_answer_delta": -0.01,
+    "answer_present_but_distant_count": 2,
+    "judge_false_empty_count": 0,
+    "judge_false_empty_rate": 0,
+    "grader_admissibility": null
+  },
+  "cases": [
+    {
+      "name": "deployment runbook",
+      "kb": "operating-environment",
+      "bucket": "has_answer",
+      "fixture_class": "in_kb",
+      "gated_verdict": "kept",
+      "empty_fired": false,
+      "conditions": [
+        { "label": "raw", "outcome": "answered_correctly", "passages": 5 },
+        { "label": "gated", "outcome": "answered_correctly", "passages": 3 }
+      ]
+    }
+  ]
+}
+```
+
+Stable fields:
+
+- `meta.mode` is `"live"` or `"simulation"`.
+- `summary.directional_pass` is the pre-registered RFC 018 M0 go/no-go boolean.
+- `summary.empty_verdict_fire_rate`, `summary.per_chunk_drop_no_good_answer_delta`,
+  `summary.judge_false_empty_rate` are the three pre-registered M0 numbers.
+- `cases[].bucket` is `"has_answer"` or `"no_good_answer"`.
+- `cases[].fixture_class` is `"in_kb"`, `"adjacent"`, or `"out_of_kb"`.
+
+The M1 (`--m1`) JSON report has a different shape (canary measurements, sweep
+points, recommendation). See `src/relevance-gate-m1.ts:toM1JsonReport` and
+`docs/rfcs/018-m1-canary-report.md` for the field list.
+
+Stdout/stderr and exit codes:
+
+- JSON report on stdout, plus `--out=<path>` mirrors the report to a file.
+- Exit `0` always for M0 (the harness "runs straight through" by design).
+- Exit `2` for argv/fixture errors and for `--m1` without a reachable endpoint.
+- Exit `1` only for an M1 run that fails after the endpoint probe succeeded.
+
+Source and test anchors: `src/cli-eval-gate.ts:58-138`,
+`src/cli-eval-gate.ts:163-237`, `src/cli-eval-gate.ts:244-303`,
+`src/cli-eval-gate.ts:493-529`, `src/relevance-gate-m1.ts:822-940`,
+`src/cli-json-contracts.test.ts` (eval-gate goldens).
+
+## `kb feedback`
+
+Records and promotes per-KB relevance judgments. The ledger lives in
+`<kb>/.index/relevance-feedback.jsonl`. Promotion converts every ledger row
+for a single query into a `kb eval` fixture case, so accumulated judgments
+become regression coverage.
+
+Invocation:
+
+```bash
+kb feedback add --kb=<name> --query=<text> --source=<rel-path>
+                [--chunk-id=<id>] [--verdict=relevant|irrelevant|stale|misleading]
+                [--relevance=0..3] [--task-context=<text>] [--note=<text>]
+                [--group=<label>]... --format=json
+kb feedback list --kb=<name> [--query=<text>] [--limit=<int>] --format=json
+kb feedback promote --kb=<name> --query=<text> [--name=<case-name>]
+                    [--k=<int>] [--mode=dense|lexical|hybrid|auto] [--gate]
+                    [--fixture=<path> --yes] --format=json
+```
+
+`add` envelope:
+
+```json
+{
+  "ledger_path": "/home/jean/knowledge_bases/work/.index/relevance-feedback.jsonl",
+  "entry": {
+    "id": "01HVT7C0DXFG2MJC9Y4N9YEH3R",
+    "kb": "work",
+    "created_at": "2026-05-21T09:15:00.000Z",
+    "query": "rollback procedure",
+    "source": "runbooks/deploy.md",
+    "chunk_id": "work/runbooks/deploy.md#L42-L78",
+    "verdict": "relevant",
+    "relevance": 3,
+    "task_context_sha256": "0123…",
+    "note": "matches step 3 in deploy.md",
+    "groups": ["runbook"]
+  }
+}
+```
+
+`list` envelope:
+
+```json
+{
+  "ledger_path": "/home/jean/knowledge_bases/work/.index/relevance-feedback.jsonl",
+  "entries": [
+    { "id": "…", "kb": "work", "created_at": "…", "query": "…", "source": "…", "verdict": "relevant", "relevance": 3 }
+  ]
+}
+```
+
+`promote` envelopes:
+
+```json
+{
+  "query": "rollback procedure",
+  "fixture_path": null,
+  "wrote": false,
+  "fixture_yaml": "gate: false\ncases:\n  - name: rollback procedure\n    ...\n"
+}
+```
+
+```json
+{
+  "fixture_path": "docs/testing/feedback-fixture.yml",
+  "wrote": true,
+  "created": false,
+  "case_count": 7
+}
+```
+
+Stable fields:
+
+- Every envelope includes the ledger path; `add` returns the new `entry`.
+- `entry.verdict` is one of `relevant`, `irrelevant`, `stale`, `misleading`.
+- `entry.relevance` is `0..3`. Non-relevant verdicts default to `0`; `relevant`
+  defaults to `3` unless `--relevance` overrides.
+- `entry.task_context_sha256` is present only when `--task-context` was passed;
+  the raw text is never stored.
+- `promote` is read-only without `--fixture --yes`; the preview includes the
+  full `fixture_yaml` so an operator can review before writing.
+- Promote-with-write returns `case_count` (the fixture's case count after the
+  append) and `created` (`true` if the fixture file did not exist).
+
+Stdout/stderr and exit codes:
+
+- Reports on stdout. Errors print `kb feedback: <message>` to stderr.
+- Exit `0` on success.
+- Exit `2` on argv errors and missing KB.
+- Exit `1` on ledger I/O or fixture-write failures.
+
+Source and test anchors: `src/cli-feedback.ts:56-140`,
+`src/cli-feedback.ts:253-326`, `src/feedback-ledger.ts`,
+`src/cli-feedback.test.ts`.
+
+## `kb serve status`
+
+A read-only lifecycle probe for the resident `kb serve` daemon. Queries
+`GET /health` at the configured `KB_DAEMON_URL` (defaults to
+`http://127.0.0.1:17799`) and reports reachability without starting or
+stopping a daemon.
+
+Invocation:
+
+```bash
+kb serve status [--json]
+```
+
+Reachable envelope:
+
+```json
+{
+  "reachable": true,
+  "url": "http://127.0.0.1:17799/",
+  "daemon": {
+    "url": "http://127.0.0.1:17799/",
+    "pid": 41234,
+    "uptime_ms": 124500,
+    "idle_timeout_ms": 300000,
+    "commands": ["search", "list", "stats"]
+  }
+}
+```
+
+Not-reachable envelope:
+
+```json
+{
+  "reachable": false,
+  "url": "http://127.0.0.1:17799/"
+}
+```
+
+Stable fields:
+
+- `reachable`, `url` always present.
+- `daemon.commands` always lists the read-only commands the daemon accepts.
+- `daemon.pid`, `daemon.uptime_ms`, `daemon.idle_timeout_ms` are present when
+  the daemon's `/health` payload supplies them.
+
+Stdout/stderr and exit codes:
+
+- JSON envelope on stdout. The default (non-`--json`) markdown output goes to
+  stdout too.
+- Exit `0` when a daemon is reachable.
+- Exit `2` for invalid arguments or environment (bad `KB_DAEMON_URL`).
+- Exit `3` when no daemon is reachable at the configured URL (this is the
+  "happy idle" state, distinct from errors).
+- Exit `1` when a daemon answered but the `/health` payload was unusable.
+
+Source and test anchors: `src/cli-serve.ts:114-166`,
+`src/daemon-client.ts:46-122`, `src/cli-serve.test.ts:109-180`.
+
 ## `kb list`
 
 Invocation:

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -83,6 +83,23 @@ provider load or scoring failures degrade to the fused order.
 | Reranker model | `KB_RERANK_MODEL` | `Xenova/ms-marco-MiniLM-L-6-v2` | Local `@huggingface/transformers` provider | Implemented | none | `KB_RERANK=on kb doctor --format=json` |
 | Rerank candidate count | `KB_RERANK_TOP_N` | `40` | Reranker stage | Implemented | none | `KB_RERANK_TOP_N=20 KB_RERANK=on kb search "query" --mode=hybrid --timing` |
 
+## Untrusted Content Hardening
+
+Retrieved chunk text is treated as untrusted by default — the injection guard
+detects prompt-injection signals (system-role markers, instruction overrides,
+bidi controls, zero-width chars, unicode tag chars) and either tags or wraps
+the offending content before it reaches the agent. The default mode is `tag`,
+which adds a metadata signal without altering content. `wrap` and `both`
+additionally fence content with sentinel strings derived from the wrap-open and
+wrap-close vars below.
+
+| Feature | Env var or flag | Default | Surfaces | Status | Per-call override | Validation command |
+|---|---|---:|---|---|---|---|
+| Untrusted-content guard mode | `KB_INJECTION_GUARD` | `tag` | MCP and CLI retrieval output | Implemented | none | `KB_INJECTION_GUARD=both kb search "query" --format=json` |
+| Guard bypass list | `KB_INJECTION_GUARD_BYPASS_KBS` | empty | Retrieval guard | Implemented | none | `KB_INJECTION_GUARD_BYPASS_KBS=trusted-runbook kb search "query"` |
+| Wrap-open sentinel | `KB_INJECTION_GUARD_WRAP_OPEN` | `<untrusted-doc src="{source}">` | Retrieval guard wrap modes | Implemented | none | `KB_INJECTION_GUARD=wrap KB_INJECTION_GUARD_WRAP_OPEN='<<UNTRUSTED:{source}>>' kb search "query"` |
+| Wrap-close sentinel | `KB_INJECTION_GUARD_WRAP_CLOSE` | `</untrusted-doc>` | Retrieval guard wrap modes | Implemented | none | `KB_INJECTION_GUARD=wrap KB_INJECTION_GUARD_WRAP_CLOSE='<<END>>' kb search "query"` |
+
 ## Output, Diagnostics, and Logging
 
 | Feature | Env var or flag | Default | Surfaces | Status | Per-call override | Validation command |
@@ -90,9 +107,13 @@ provider load or scoring failures degrade to the fused order.
 | Editor URI links | `KB_EDITOR_URI` | `none` | CLI and MCP retrieval output | Implemented | none | `KB_EDITOR_URI=cursor kb search "query" --format=json` |
 | Frontmatter extras on wire | `FRONTMATTER_EXTRAS_WIRE_VISIBLE` | `false` | MCP and CLI JSON retrieval output | Implemented | none | `FRONTMATTER_EXTRAS_WIRE_VISIBLE=true kb search "query" --format=json` |
 | CLI timing | `--timing` | off | CLI search and ask | Implemented | `--timing` | `kb search "query" --timing` |
+| Compact search output | `kb search --format=compact` | `md` | CLI search | Implemented | `--format=compact` | `kb search "query" --format=compact` |
+| Batch JSONL search input | `kb search --batch-jsonl` | off | CLI search | Implemented | `--batch-jsonl < queries.jsonl` | `printf '{"query":"q1"}\n{"query":"q2"}\n' \| kb search --batch-jsonl` |
 | Canonical log format | `KB_LOG_FORMAT` | `both` | Process logs | Implemented | none | `KB_LOG_FORMAT=canonical kb search "query"` |
+| Verbose MCP server tracing | `KB_LOG_VERBOSE` | unset | `KnowledgeBaseServer` lifecycle logs | Implemented, opt-in | none | `KB_LOG_VERBOSE=1 node build/index.js` |
 | Log level | `LOG_LEVEL` | `info` | Process logs | Implemented | none | `LOG_LEVEL=debug kb doctor` |
 | Log file | `LOG_FILE` | unset | Process logs | Implemented | none | `LOG_FILE=/tmp/kb.log kb doctor` |
+| Canonical log reader | `kb logs --request-id=<id>` | tails active log | `kb logs` | Implemented | none | `kb logs --tail=20 --format=json` |
 | Mutation audit log | `KB_MUTATION_AUDIT_LOG` | unset | KB write paths | Implemented, opt-in | none | `KB_MUTATION_AUDIT_LOG=/tmp/kb-mutations.jsonl kb remember --kb=<name> --title="..." --stdin --yes` |
 | Tool description overrides | `RETRIEVE_KNOWLEDGE_DESCRIPTION`, `LIST_KNOWLEDGE_BASES_DESCRIPTION`, `LIST_MODELS_DESCRIPTION`, `KB_STATS_DESCRIPTION` | built-in descriptions | MCP server tool metadata | Implemented | none; set before server start | restart MCP server and inspect tool descriptions |
 
@@ -117,6 +138,13 @@ provider load or scoring failures degrade to the fused order.
 | Maximum raw file size | `KB_MAX_FILE_BYTES` | `104857600` | Ingest and refresh | Implemented | none | `KB_MAX_FILE_BYTES=1048576 kb search "query" --refresh` |
 | Maximum extracted text size | `KB_MAX_EXTRACTED_TEXT_BYTES` | `16777216` | Ingest and refresh | Implemented | none | `KB_MAX_EXTRACTED_TEXT_BYTES=1048576 kb search "query" --refresh` |
 | Large-file policy | `KB_LARGE_FILE_POLICY` | `skip` | Ingest and refresh | Implemented | none | `KB_LARGE_FILE_POLICY=error kb search "query" --refresh` |
+| Splitter chunk size | `KB_CHUNK_SIZE` | `1000` | Ingest and refresh | Implemented | none | `KB_CHUNK_SIZE=500 kb search "query" --refresh` |
+| Splitter chunk overlap | `KB_CHUNK_OVERLAP` | `200` (auto-scales as `floor(chunkSize/5)` when only `KB_CHUNK_SIZE` is set) | Ingest and refresh | Implemented | none | `KB_CHUNK_SIZE=500 KB_CHUNK_OVERLAP=100 kb search "query" --refresh` |
+| Indexing batch size | `INDEXING_BATCH_SIZE` | `64` (Ollama: `16`) | Embedding ingest | Implemented | none | `INDEXING_BATCH_SIZE=32 kb search "query" --refresh` |
+| Filesystem watcher | `KB_FS_WATCH` | off | KB root watcher (auto-refresh on file change) | Implemented, opt-in | none | `KB_FS_WATCH=1 node build/index.js` |
+| FS watcher debounce | `KB_FS_WATCH_DEBOUNCE_MS` | `250` | KB root watcher | Implemented | none | `KB_FS_WATCH=1 KB_FS_WATCH_DEBOUNCE_MS=500 node build/index.js` |
+| Index version retention | `KB_INDEX_VERSION_RETENTION` | `2` | FAISS version rotation | Implemented | none | `KB_INDEX_VERSION_RETENTION=4 kb reindex --with-context` |
+| Per-KB age budget | `KB_AGE_BUDGET_HOURS_<KB>` or `KB_AGE_BUDGET_HOURS` (global fallback) | unset | `kb doctor`, search freshness footer | Implemented, opt-in | none | `KB_AGE_BUDGET_HOURS=24 kb doctor --format=json` |
 
 ## Remote Transport
 
@@ -130,6 +158,29 @@ provider load or scoring failures degrade to the fused order.
 | Failed auth backoff threshold | `MCP_AUTH_BACKOFF_THRESHOLD` | `5` | HTTP/SSE MCP server | Implemented | none | `MCP_TRANSPORT=http MCP_AUTH_TOKEN=<32+ chars> MCP_AUTH_BACKOFF_THRESHOLD=3 node build/index.js` |
 | Failed auth backoff window | `MCP_AUTH_BACKOFF_MS` | `30000` | HTTP/SSE MCP server | Implemented | none | `MCP_TRANSPORT=http MCP_AUTH_TOKEN=<32+ chars> MCP_AUTH_BACKOFF_MS=60000 node build/index.js` |
 | Failed auth backoff address cap | `MCP_AUTH_BACKOFF_MAX_ENTRIES` | `1024` | HTTP/SSE MCP server | Implemented | none | `MCP_TRANSPORT=http MCP_AUTH_TOKEN=<32+ chars> MCP_AUTH_BACKOFF_MAX_ENTRIES=2048 node build/index.js` |
+
+## Daemon and CLI Fast-Path
+
+`kb serve` runs a long-lived CLI helper process. CLI commands that opt in (and
+`kb serve status`) reach it over loopback HTTP, avoiding cold-start overhead.
+
+| Feature | Env var or flag | Default | Surfaces | Status | Per-call override | Validation command |
+|---|---|---:|---|---|---|---|
+| Daemon URL | `KB_DAEMON_URL` | composed from `KB_DAEMON_HOST` (default `127.0.0.1`) and `KB_DAEMON_PORT` (default `17799`) when unset | `kb serve` clients, `kb doctor --endpoints`, `kb serve status` | Implemented | none | `KB_DAEMON_URL=http://127.0.0.1:17799 kb serve status` |
+| Daemon host | `KB_DAEMON_HOST` | `127.0.0.1` | Daemon URL composition | Implemented | none | `KB_DAEMON_HOST=127.0.0.1 KB_DAEMON_PORT=17799 kb serve` |
+| Daemon port | `KB_DAEMON_PORT` | `17799` | Daemon URL composition | Implemented | none | `KB_DAEMON_PORT=18888 kb serve` |
+
+## Managed LLM Profiles
+
+`kb llm` writes profile configuration, lease state, and managed systemd unit
+files under platform-appropriate paths. Operators can redirect any of the three
+without changing source.
+
+| Feature | Env var or flag | Default | Surfaces | Status | Per-call override | Validation command |
+|---|---|---:|---|---|---|---|
+| LLM profile config dir | `KB_LLM_CONFIG_DIR` | `$XDG_CONFIG_HOME/kb-llm` or `~/.config/kb-llm` | `kb llm` profile files | Implemented | none | `KB_LLM_CONFIG_DIR=/tmp/kb-llm kb llm status` |
+| LLM lease/state dir | `KB_LLM_STATE_DIR` | `$XDG_STATE_HOME/kb-llm` or `~/.local/state/kb-llm` | `kb llm` lease files and managed-runner stdout/stderr | Implemented | none | `KB_LLM_STATE_DIR=/tmp/kb-llm-state kb llm status` |
+| Managed systemd unit dir | `KB_LLM_SYSTEMD_USER_DIR` | `~/.config/systemd/user` | `kb llm install` / `uninstall` for `kb-llm@<profile>.service` | Implemented | none | `KB_LLM_SYSTEMD_USER_DIR=$HOME/.config/systemd/user kb llm install --profile=qwen ...` |
 
 ## Rollout Checklist
 

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -114,7 +114,7 @@ wrap-close vars below.
 | Verbose MCP server tracing | `KB_LOG_VERBOSE` | unset | `KnowledgeBaseServer` lifecycle logs | Implemented, opt-in | none | `KB_LOG_VERBOSE=1 node build/index.js` |
 | Log level | `LOG_LEVEL` | `info` | Process logs | Implemented | none | `LOG_LEVEL=debug kb doctor` |
 | Log file | `LOG_FILE` | unset | Process logs | Implemented | none | `LOG_FILE=/tmp/kb.log kb doctor` |
-| Canonical log reader | `kb logs --request-id=<id>` | tails active log | `kb logs` | Implemented | none | `kb logs --tail=20 --format=json` |
+| Canonical log reader | `kb logs show --request-id=<id>` | reads configured canonical log | `kb logs` | Implemented | none | `kb logs recent --limit=20 --format=json` |
 | Mutation audit log | `KB_MUTATION_AUDIT_LOG` | unset | KB write paths | Implemented, opt-in | none | `KB_MUTATION_AUDIT_LOG=/tmp/kb-mutations.jsonl kb remember --kb=<name> --title="..." --stdin --yes` |
 | Tool description overrides | `RETRIEVE_KNOWLEDGE_DESCRIPTION`, `LIST_KNOWLEDGE_BASES_DESCRIPTION`, `LIST_MODELS_DESCRIPTION`, `KB_STATS_DESCRIPTION` | built-in descriptions | MCP server tool metadata | Implemented | none; set before server start | restart MCP server and inspect tool descriptions |
 

--- a/docs/operations/daemon-lifecycle.md
+++ b/docs/operations/daemon-lifecycle.md
@@ -1,0 +1,158 @@
+# `kb serve` — Local CLI Daemon Lifecycle
+
+`kb serve` runs a loopback-only HTTP daemon that serves read-only `kb search`,
+`kb list`, and `kb stats` requests from CLI clients. The point is *warm
+reads*: the daemon keeps the FAISS index, model adapter, and lexical store
+loaded in memory so each CLI invocation skips the cold-start cost.
+
+CLI clients use the daemon when they pass `--daemon`. If the daemon is not
+reachable, they print a one-line notice on stderr and fall back to direct
+in-process execution.
+
+## When to run it
+
+- You issue `kb search` more than once or twice an hour — cold start
+  dominates wall time for the first call.
+- You wire `kb search` into an editor, agent shell, or pre-commit hook and
+  want predictable latency.
+- You are debugging retrieval latency: daemon timings expose embed/search/format
+  splits without the index-load tax.
+
+## Start the daemon
+
+```bash
+kb serve [--host=127.0.0.1] [--port=17799] [--idle-timeout-ms=300000]
+```
+
+Defaults:
+
+- `--host=127.0.0.1` (loopback only; non-loopback bind is rejected)
+- `--port=17799`
+- `--idle-timeout-ms=300000` (5 minutes; `0` disables auto-exit)
+
+The process logs `kb serve: listening on http://127.0.0.1:17799/` to stdout
+and stays in the foreground. SIGINT / SIGTERM stops it cleanly. Run it under
+a terminal multiplexer, or wrap it in a systemd user unit for hands-off
+operation:
+
+```ini
+# ~/.config/systemd/user/kb-serve.service
+[Unit]
+Description=kb serve — local CLI daemon
+
+[Service]
+ExecStart=%h/.local/share/npm/bin/kb serve --idle-timeout-ms=0
+Restart=on-failure
+
+[Install]
+WantedBy=default.target
+```
+
+```bash
+systemctl --user enable --now kb-serve.service
+```
+
+## Probe with `kb serve status`
+
+`kb serve status` is a strict read-only probe — it queries `GET /health` at
+the configured URL and reports reachability. It never starts or stops a
+daemon.
+
+```bash
+kb serve status            # human-readable
+kb serve status --json     # machine-readable
+```
+
+Exit codes are deliberately distinct:
+
+| Exit | Meaning | Operator next step |
+| --- | --- | --- |
+| `0` | Daemon reachable | Continue. |
+| `1` | Daemon answered with an unusable `/health` payload | Restart the daemon; the version may be stale. |
+| `2` | Invalid argument or environment (bad `KB_DAEMON_URL`) | Fix the configuration. |
+| `3` | No daemon listening at the configured URL | Start one with `kb serve`. **Not an error in itself** — this is the normal idle state when CLI clients are expected to fall back. |
+
+`--json` output:
+
+```jsonc
+// Reachable
+{
+  "reachable": true,
+  "url": "http://127.0.0.1:17799/",
+  "daemon": {
+    "url": "http://127.0.0.1:17799/",
+    "pid": 41234,
+    "uptime_ms": 124500,
+    "idle_timeout_ms": 300000,
+    "commands": ["search", "list", "stats"]
+  }
+}
+
+// Unreachable
+{ "reachable": false, "url": "http://127.0.0.1:17799/" }
+```
+
+## Configure the daemon URL
+
+CLI clients and `kb serve status` resolve the daemon URL in this order:
+
+1. `KB_DAEMON_URL` (explicit, used verbatim — must include scheme)
+2. `KB_DAEMON_HOST` + `KB_DAEMON_PORT` (composed)
+3. Default `http://127.0.0.1:17799/`
+
+For a non-default port:
+
+```bash
+export KB_DAEMON_PORT=18888
+kb serve &
+kb serve status
+# kb serve: daemon running at http://127.0.0.1:18888/
+```
+
+For a per-user instance on a multi-tenant host, run on a unique port and
+export `KB_DAEMON_URL` in the user's shell profile so every CLI call hits the
+right daemon.
+
+## Use the daemon from CLI clients
+
+Any CLI subcommand that supports `--daemon` will use the daemon when set:
+
+```bash
+kb search "your query" --daemon --format=json
+```
+
+Without `--daemon` the CLI runs in-process. If you want daemon-first by
+default, alias it: `alias kb-d='kb --daemon'` — there is no global switch (the
+fallback is intentionally explicit).
+
+## Limits
+
+- Read-only commands only: `search`, `list`, `stats`. Writes (`remember`,
+  `capture`, `import-url`, `reindex`) always run in-process.
+- One daemon per `FAISS_INDEX_PATH`. Multiple daemons against the same index
+  is unsupported and would race the read-only refresh path.
+- Loopback only. To expose CLI-shaped retrieval over the network, use the
+  MCP HTTP transport — see [RFC 008](../rfcs/008-remote-transport.md).
+
+## Diagnose
+
+- **`kb search --daemon` falls back silently**: run `kb serve status`. If exit
+  `3`, start the daemon. If exit `1`, the daemon is misconfigured.
+- **Daemon exits after 5 minutes**: that's the default idle timeout. Set
+  `--idle-timeout-ms=0` to disable, or wrap in systemd with `Restart=`.
+- **`Address already in use`**: another daemon (or other process) holds the
+  port. Pick a free one with `--port=`, or stop the conflicting process.
+- **CLI ignores the daemon**: confirm `kb serve status` returns reachable
+  and the client passes `--daemon`. The fallback is by design — there is no
+  warning when the client chose in-process.
+
+## JSON contract
+
+See [`docs/cli-json-contracts.md`](../cli-json-contracts.md#kb-serve-status)
+for the stable `kb serve status` envelope.
+
+## Related
+
+- [`docs/feature-flags.md` — Daemon and CLI Fast-Path](../feature-flags.md#daemon-and-cli-fast-path)
+- [`docs/operations/local-services.md`](local-services.md) for the broader
+  local stack (Ollama, llama-server, n8n).

--- a/docs/operations/eval-gate-harness.md
+++ b/docs/operations/eval-gate-harness.md
@@ -1,0 +1,110 @@
+# `kb eval-gate` — RFC 018 Relevance-Gate Validation Harness
+
+`kb eval-gate` is the measurement tool for the RFC 018 relevance gate. It
+answers a simple operator question: *does turning the gate on make my
+downstream answers better, worse, or roughly the same?*
+
+The harness has two modes:
+
+| Mode | When | What it measures |
+| --- | --- | --- |
+| **M0** (default) | Before turning the gate on in production | Simulated gate via threshold surgery vs. raw top-k. Always emits a report — falls back to an offline causal model when no endpoint is reachable. |
+| **M1** (`--m1`) | After the gate is wired up, before promoting tuning changes | The *real* gate with `KB_RELEVANCE_GATE=on` and Stage B judge live. Requires a reachable endpoint. |
+
+Both modes consume a labelled-queries fixture and emit a stable JSON or
+markdown report. M0 always exits `0` (it is a measurement, not a gate); M1
+exits non-zero when the endpoint is unreachable or the run cannot complete.
+
+## M0 — validate before build
+
+Use M0 to decide whether the gate is worth enabling at all for your KB shape.
+It does not require a live LLM; the offline causal model treats the gate
+keep/drop decision as the thing under test.
+
+```bash
+# Offline (always works, simulation mode):
+kb eval-gate docs/testing/fixtures/rfc-018-gate-eval/queries.yml --dry-run --format=md
+
+# Live (uses the local llama-server / Ollama / OpenAI-compatible endpoint):
+KB_LLM_ENDPOINT=http://127.0.0.1:8080/v1/chat/completions \
+kb eval-gate docs/testing/fixtures/rfc-018-gate-eval/queries.yml --format=json
+```
+
+The report's `summary` block carries three pre-registered numbers from
+RFC 018:
+
+| Field | What to look at |
+| --- | --- |
+| `empty_verdict_fire_rate` | How often the gate decides "no answer". Too high = recall regression. |
+| `per_chunk_drop_no_good_answer_delta` | Whether the gate's *chunk* dropping (separate from the empty verdict) helps. Negative is better — fewer wrong answers. |
+| `judge_false_empty_rate` | How often Stage B incorrectly returns empty. The gate's tail risk. |
+| `directional_pass` | The single pre-registered go/no-go boolean. `true` means the M0 result clears the bar to keep iterating. |
+
+When `directional_pass` is `false`, the gate is not worth enabling on this
+KB *yet*. Tune `KB_GATE_SCORE_FLOOR`, re-run, and compare.
+
+## M1 — real-gate canary
+
+Use M1 when M0 said yes, after the Stage B judge is wired up, and you want
+ground-truth numbers before promoting a `KB_GATE_*` tuning change.
+
+```bash
+KB_LLM_ENDPOINT=http://127.0.0.1:8080/v1/chat/completions \
+kb eval-gate docs/testing/fixtures/rfc-018-gate-eval/queries.yml \
+  --m1 \
+  --calibration=docs/testing/fixtures/rfc-018-gate-eval/grader-calibration.yml \
+  --floor-sweep=0.85:1.00:0.025 \
+  --format=json \
+  --out=runs/rfc-018-m1-$(date -u +%Y%m%dT%H%M%SZ).json
+```
+
+The M1 report adds (see `docs/rfcs/018-m1-canary-report.md` for the full
+field list):
+
+- Per-floor sweep points showing how recall and false-empty rate trade.
+- A position-swap probe (RFC §5) showing whether the gate's ranking is
+  stable when candidates are reordered.
+- BM25-veto calibration against the grader fixture.
+- A `recommendation` with a clear go/no-go and the recommended floor.
+
+M1 *does not* fall back to simulation. If the endpoint is not reachable it
+exits with code `2` — that is by design: a simulated M1 would be misleading.
+
+## Fixture layout
+
+`docs/testing/fixtures/rfc-018-gate-eval/` ships the reference fixture:
+
+| File | Purpose |
+| --- | --- |
+| `queries.yml` | The labelled-queries fixture. Each case has `query`, `kb`, optional `task_context`, and a `gate_sim` block (the threshold surgery to apply). |
+| `grader-calibration.yml` | Grader/human agreement fixture used as an admissibility threshold for live M0 and M1 runs. |
+
+Use the shipped fixture as a starting point and add your own cases as the gate
+matures.
+
+## Tuning loop
+
+1. **M0 baseline** — run `kb eval-gate <fixture> --dry-run` and record the
+   three pre-registered numbers.
+2. **Wire the gate** — set `KB_RELEVANCE_GATE=on` and verify behavior with
+   `kb search --gate --task-context="…"`.
+3. **M1 canary** — `kb eval-gate <fixture> --m1 --endpoint=…` and review the
+   recommendation. Adjust `KB_GATE_SCORE_FLOOR`, `KB_GATE_JUDGE_INPUT`, or
+   the judge prompt.
+4. **Promote** — once M1 recommends go, update the operator-default env vars
+   (see [`docs/feature-flags.md`](../feature-flags.md#relevance-gate)).
+5. **Lock in** — promote any newly-judged borderline queries through
+   [`kb feedback`](feedback-workflow.md) so the next M1 has more coverage.
+
+## JSON contract
+
+See [`docs/cli-json-contracts.md`](../cli-json-contracts.md#kb-eval-gate) for
+the stable M0 envelope. The M1 envelope is documented in
+[`docs/rfcs/018-m1-canary-report.md`](../rfcs/018-m1-canary-report.md).
+
+## Related
+
+- [RFC 018 — Context Relevance Gating](../rfcs/018-context-relevance-gating.md)
+- [`docs/feature-flags.md` — Relevance Gate](../feature-flags.md#relevance-gate)
+- [`kb feedback`](feedback-workflow.md) for accumulating gate-relevant
+  judgments.

--- a/docs/operations/feedback-workflow.md
+++ b/docs/operations/feedback-workflow.md
@@ -1,0 +1,138 @@
+# `kb feedback` — Relevance Ledger and Eval Promotion
+
+`kb feedback` is a per-KB ledger for relevance judgments. It exists to close
+the loop between *retrieving* and *measuring*: every judgment you record
+becomes a potential regression case for `kb eval`, so an irrelevant result you
+flag today turns into a CI gate tomorrow.
+
+The ledger lives at `<kb>/.index/relevance-feedback.jsonl` — alongside the
+hash sidecars, one JSON record per line, append-only.
+
+## When to use it
+
+- You just ran a `kb search` or `kb research collect` and noticed a result
+  that should rank higher (or shouldn't appear at all).
+- You want a query to become an `kb eval` regression case once you have a few
+  judgments on it.
+- You are iterating on retrieval (reranker, gate floor, contextual ingest)
+  and want a growing labelled set without inventing fixtures from scratch.
+
+## Three actions
+
+```bash
+kb feedback add     --kb=<name> --query=<text> --source=<rel-path> [judgement flags] --format=json
+kb feedback list    --kb=<name> [--query=<text>] [--limit=<int>]                       --format=json
+kb feedback promote --kb=<name> --query=<text> [--fixture=<path> --yes]               --format=json
+```
+
+### Record a judgment
+
+```bash
+kb feedback add \
+  --kb=work \
+  --query="rollback procedure" \
+  --source=runbooks/deploy.md \
+  --chunk-id="work/runbooks/deploy.md#L42-L78" \
+  --verdict=relevant \
+  --relevance=3 \
+  --group=runbook \
+  --note="matches step 3 in deploy.md"
+```
+
+Fields:
+
+- `--verdict` — one of `relevant`, `irrelevant`, `stale`, `misleading`. Non-
+  relevant verdicts default to `relevance=0`; `relevant` defaults to `3`.
+- `--relevance=0..3` — graded relevance (NDCG-friendly). Override the default.
+- `--chunk-id` — paste from `kb search --format=json` if you want to bind the
+  judgment to the exact chunk rather than the file.
+- `--group=<label>` — intent / topic label for diversity metrics. Repeatable.
+- `--task-context=<text>` — captured as a SHA-256 hash only. The raw text is
+  never persisted.
+- `--note=<text>` — short reviewer note stored verbatim.
+
+### List recent judgments
+
+```bash
+kb feedback list --kb=work --query="rollback procedure" --limit=20 --format=json
+```
+
+Entries are sorted newest-first. `--query` is an exact match; omit it to see
+the entire ledger.
+
+### Promote into an eval fixture
+
+The default `promote` is read-only — it prints the YAML it *would* append:
+
+```bash
+kb feedback promote --kb=work --query="rollback procedure" --format=md
+```
+
+Pipe-review the YAML. When it looks right, write it:
+
+```bash
+kb feedback promote \
+  --kb=work \
+  --query="rollback procedure" \
+  --name="deploy rollback runbook" \
+  --gate \
+  --fixture=docs/testing/feedback-fixture.yml \
+  --yes
+```
+
+Repeated promotions for the same query append further cases (the fixture
+keeps growing). Add `--mode=hybrid` and `--k=10` to lock retrieval settings
+into the case.
+
+## Loop into CI
+
+The promoted fixture is a standard `kb eval` input:
+
+```bash
+kb eval docs/testing/feedback-fixture.yml --format=json
+```
+
+Gated cases (`gate: true` in the fixture, or `--gate` at promotion) fail the
+command (`exit 1`) if `required_sources` are missing or `forbidden_sources`
+appear. Wire that into CI so reverted retrieval regressions surface
+immediately.
+
+## What the ledger stores
+
+```jsonc
+{
+  "id": "01HVT7C0DXFG2MJC9Y4N9YEH3R",   // ULID
+  "kb": "work",
+  "created_at": "2026-05-21T09:15:00.000Z",
+  "query": "rollback procedure",
+  "source": "runbooks/deploy.md",
+  "chunk_id": "work/runbooks/deploy.md#L42-L78",
+  "verdict": "relevant",
+  "relevance": 3,
+  "task_context_sha256": "0123…",
+  "note": "matches step 3 in deploy.md",
+  "groups": ["runbook"]
+}
+```
+
+The file is append-only and human-readable. If you need to retract an entry,
+edit the file in place and remove the offending line; there is no
+`kb feedback remove` because promotion already reflects only the *current*
+ledger snapshot.
+
+## Backup
+
+The ledger is git-friendly. Commit `<kb>/.index/relevance-feedback.jsonl`
+alongside the KB content if you want history. For private notes, route it
+through your usual secrets-aware backup.
+
+## JSON contract
+
+See [`docs/cli-json-contracts.md`](../cli-json-contracts.md#kb-feedback) for
+the stable envelopes for `add`, `list`, and `promote` (preview and write).
+
+## Related
+
+- `kb research collect` to generate candidate evidence to judge — see
+  [`research-workflow.md`](research-workflow.md).
+- `kb eval` to run the promoted fixture as a regression check.

--- a/docs/operations/logs-reader.md
+++ b/docs/operations/logs-reader.md
@@ -1,0 +1,137 @@
+# `kb logs` — Canonical Log Reader
+
+`kb logs` is a structured reader for the canonical request log emitted under
+`KB_LOG_FORMAT=canonical` or `both`. It exists so an operator (or an agent
+shell) can answer "what happened in request X?" or "what queries fired in
+the last hour?" without grepping mixed-format text logs by hand.
+
+The reader consumes `kb-canonical.v1` JSON lines from a single log file and
+ignores everything else, so you can point it at a log file that also contains
+free-text lines without false matches.
+
+## When to use it
+
+- A `kb search` or `kb ask` returned an empty result or a slow timing and
+  you want the full canonical envelope for that request.
+- You are auditing recent retrieval activity (cache hit rate, top-source
+  drift, error categories).
+- You are wiring a downstream tool (Loki/Vector/Grafana) and want the same
+  envelope shape over a one-shot pull rather than a streaming tail.
+
+For *live* tailing, use your usual log-pipe tool against the file directly;
+`kb logs` is a point-in-time reader.
+
+## Two actions
+
+```bash
+kb logs recent [--limit=<n>] [--file=<path>] --format=md|json
+kb logs show   --request-id=<id> [--file=<path>] --format=md|json
+kb logs show   --query-sha=<hash> [--file=<path>] --format=md|json
+```
+
+`recent` returns the most recent canonical events (default limit `10`).
+`show` filters by a stable id — `request_id` (one request) or `query_sha256`
+(every request for the same query).
+
+## Log-file resolution
+
+`kb logs` resolves the source file in this order:
+
+1. `--file=<path>` (explicit)
+2. `$LOG_FILE`
+3. Existing well-known local default paths
+
+If nothing is discoverable, the command exits `2` with a JSON error envelope
+(`schema_version: "kb.logs.v1"`).
+
+## Enable canonical logging
+
+The reader only sees lines emitted in the `kb-canonical.v1` shape. Turn that
+shape on for the producing process:
+
+```bash
+export KB_LOG_FORMAT=both   # 'canonical' (JSON only) or 'both' (text + canonical)
+export LOG_FILE=/tmp/kb.log # the file the producer writes
+```
+
+`both` is the safer default during rollout — you keep human-readable text
+and gain machine-readable JSON in the same file. Switch to `canonical` once
+your downstream consumers are wired up.
+
+## Read a single request
+
+When `kb search --format=json` includes a `request_id` in its error or
+timing envelope, fetch the matching canonical line:
+
+```bash
+kb logs show --request-id=req-7e2b --format=json | jq
+```
+
+```jsonc
+{
+  "schema_version": "kb.logs.v1",
+  "action": "show",
+  "source": "/tmp/kb.log",
+  "filters": { "request_id": "req-7e2b" },
+  "scanned_line_count": 1247,
+  "canonical_event_count": 412,
+  "ignored_line_count": 835,
+  "malformed_canonical_line_count": 0,
+  "result_count": 1,
+  "events": [
+    {
+      "ts": "2026-05-21T08:30:00.000Z",
+      "request_id": "req-7e2b",
+      "process": "cli",
+      "cmd": "kb search",
+      "query_sha256": "ab12…",
+      "took_ms": 42,
+      "timings": { "embed_ms": 10, "faiss_ms": 20, "format_ms": 3 },
+      "cache": "miss",
+      "result_count": 3,
+      "top_sources": ["docs/a.md"]
+    }
+  ]
+}
+```
+
+`scanned_line_count` minus `canonical_event_count` is the count of plain-text
+log lines the reader skipped over. A high `malformed_canonical_line_count` is
+a producer bug worth raising.
+
+## Audit recent activity
+
+```bash
+kb logs recent --limit=50 --format=json \
+  | jq -r '.events[] | "\(.ts) \(.took_ms)ms \(.cmd) \(.cache // "-") rc=\(.result_count // "-") err=\(.error.code // "-")"'
+```
+
+A canonical log line carries everything `kb stats` would summarise *per
+request* — cache state, timings, top sources, error codes, recovery hints —
+so this kind of pull is enough for a quick performance sanity-check.
+
+## Group repeated queries
+
+`query_sha256` is stable across runs of the same query string, so `show
+--query-sha=<hash>` returns every historical hit for that query. Use it to
+trace a query whose results changed after a reindex or model swap.
+
+## Diagnose
+
+- **`result_count: 0`** — no events matched. Check the filter; for
+  `--request-id`, the id must be the exact value from the producer.
+- **Exit `2` with a JSON error envelope** — the reader couldn't find a log
+  file. Set `LOG_FILE` and re-run the producer first.
+- **High `malformed_canonical_line_count`** — the producer is emitting
+  invalid JSON. File an issue with the bad line.
+
+## JSON contract
+
+See [`docs/cli-json-contracts.md`](../cli-json-contracts.md#kb-logs) for the
+stable `recent` / `show` envelopes and event field list.
+
+## Related
+
+- [`docs/feature-flags.md` — Output, Diagnostics, and Logging](../feature-flags.md#output-diagnostics-and-logging)
+- [RFC 009 — Error Taxonomy](../rfcs/009-error-taxonomy.md) for the
+  `error.code` / `error.category` shape carried in canonical events.

--- a/docs/operations/research-workflow.md
+++ b/docs/operations/research-workflow.md
@@ -1,0 +1,121 @@
+# `kb research` — Evidence Planning and Collection
+
+`kb research` is a read-only, deterministic workflow for collecting evidence
+from your knowledge bases for a research question. It is not an autonomous
+agent: it does not call an LLM, does not write KB notes, and does not trigger
+local-research-agent. The output is a self-contained run directory that an
+agent or operator can then hand to `kb ask` or any LLM as a coherent context
+block.
+
+## When to use it
+
+- You have a focused research question and want a vetted, reproducible
+  evidence set across multiple shelves.
+- You want `kb ask` to answer from a *curated* packet rather than the raw
+  top-k of a single query.
+- You want a durable artifact (the run directory) you can re-run, version,
+  attach to a PR, or feed to another tool.
+
+If you only need one quick answer, prefer `kb ask` directly. `kb research` is
+the right tool when the question deserves multi-query coverage.
+
+## Two-phase contract
+
+```bash
+kb research plan    "<question>" [--format=md|json] [planner options]
+kb research collect "<question>" --run-dir=<path>   [--format=md|json] [planner options]
+```
+
+`plan` is the *dry-run*: it reads KB descriptions and `kb stats`, picks the
+likely shelves, generates a deterministic set of query candidates, and emits a
+`kb-research-plan.v1` envelope. No retrieval runs. Inspect the plan before
+committing to a collection.
+
+`collect` re-runs the same planner, then executes every query through the
+existing hybrid retrieval surface (`kb search --mode=hybrid`), deduplicates
+hits across queries, and writes five artifacts under `--run-dir`:
+
+| File | Contents |
+| --- | --- |
+| `run.json` | Run metadata (command, started/finished timestamps, status, artifact paths) |
+| `plan.json` | The planner output — same shape as `plan --format=json` |
+| `ledger.json` | `kb-research-ledger.v1` — every hit with shelf, path, line range, score, query id, source kind |
+| `evidence_packet.md` | Human-readable packet: Question, Selected Shelves, Queries, Evidence Found (grouped by source file), Evidence Gaps, Sources |
+| `events.jsonl` | Structured event stream from the collection (one record per shelf search) |
+
+`evidence_packet.md` is what you typically hand to a downstream LLM or paste
+into a follow-up `kb ask --task-context-file=…`. `ledger.json` is the
+machine-readable contract for any tooling on top.
+
+## Planner controls
+
+The planner is deterministic. The flags below shape its decisions but never
+add non-determinism:
+
+- `--include-kb=<name>` (alias `--kb=<name>`, repeatable): pin a shelf into
+  the plan even if its score is low.
+- `--exclude-kb=<name>` (repeatable): drop a shelf from consideration.
+- `--max-shelves=<n>` (default `5`): cap automatic shelf selection.
+- `--k=<int>` (default `5`): hits per query/shelf during collection.
+
+The planner intentionally treats broad tokens (`agent`, `system`) as
+insufficient on their own — domain shelves with specific matches rank ahead
+of operational shelves that only share generic wording (#452).
+
+## Read the plan first
+
+```bash
+kb research plan "Compare RAG eval frameworks" --format=json | jq '.queries[].text'
+```
+
+If the planned queries look thin or off-target, refine the question or pin the
+right shelves with `--include-kb`. Re-running `plan` is free.
+
+## Collect into a run directory
+
+```bash
+kb research collect "Compare RAG eval frameworks" \
+  --run-dir=runs/rag-eval \
+  --format=json
+```
+
+`status: complete` means every planned hybrid search returned. `status:
+failed` means at least one shelf-search failed (the ledger still includes the
+successful entries and the failure record). Exit codes mirror the status: `0`
+for complete, `1` for failed, `2` for argv errors.
+
+## Hand the packet to `kb ask`
+
+```bash
+kb ask "$(cat runs/rag-eval/evidence_packet.md)" \
+  --task-context-file=runs/rag-eval/evidence_packet.md \
+  --save-transcript --kb=research --title="RAG eval comparison" --yes
+```
+
+The packet is markdown-safe (grouped by source so the same passage is not
+repeated for every matching query). When the answer is good, save the
+transcript so the cited synthesis becomes a durable KB note.
+
+## Diagnose
+
+- **Empty `selected_shelves`**: no shelf description matched. Add a `--include-kb`
+  pin, or improve the shelf's `README.md` so the planner has something to
+  weight on.
+- **`dense_index_empty_coverage` risk**: a selected shelf has files but no
+  dense chunks. Hybrid search still works (it falls back to lexical), but a
+  `kb reindex` is overdue.
+- **`status: failed`**: open the `events.jsonl` to see which shelf failed.
+  Usually a `KB_NOT_FOUND` or `PROVIDER_TIMEOUT` — fix the underlying issue
+  and re-collect into a fresh `--run-dir`.
+
+## JSON contract
+
+See [`docs/cli-json-contracts.md`](../cli-json-contracts.md#kb-research) for
+the stable plan and collect envelopes, plus per-entry ledger fields.
+
+## Related
+
+- `kb feedback` to record judgments on collected evidence — see
+  [`feedback-workflow.md`](feedback-workflow.md).
+- `kb ask --save-transcript` to persist the synthesised answer.
+- `kb eval` to turn promoted feedback rows back into regression cases.

--- a/docs/requirements/INDEX.md
+++ b/docs/requirements/INDEX.md
@@ -2,6 +2,10 @@
 
 - [Retrieval eval command](retrieval-eval.md)
 - [Reranker](reranker.md)
+- Source RFCs:
+  [RFC 017 contextual retrieval](../rfcs/017-contextual-retrieval.md),
+  [RFC 018 relevance gating](../rfcs/018-context-relevance-gating.md),
+  [RFC 019 cross-encoder reranker](../rfcs/019-cross-encoder-reranker.md)
 
 ## Indexing
 
@@ -178,6 +182,183 @@
 
 **Linked Tests:** TS-SEARCH-192
 **Dependencies:** RFC005
+
+## Relevance Gate (RFC 018)
+
+### FR-GATE-EVAL-369: Gate Validation Harness
+**Status:** Implemented
+**Priority:** High
+
+**Requirement:** The system shall provide `kb eval-gate` as a fixture-driven harness that measures whether the RFC 018 relevance gate improves downstream answer quality before and after enabling it in production.
+
+**Acceptance Criteria:**
+- [x] Given a valid gate-eval fixture, when `kb eval-gate` runs, then the harness emits a stable report with the three pre-registered numbers (`empty_verdict_fire_rate`, `per_chunk_drop_no_good_answer_delta`, `judge_false_empty_rate`).
+- [x] Given no reachable LLM endpoint, when `kb eval-gate` runs without `--m1`, then the harness falls back to the offline causal model and still produces a report.
+- [x] Given `--m1`, when no endpoint is reachable, then the harness exits non-zero rather than producing a misleading simulated canary report.
+
+**Linked Tests:** TS-GATE-EVAL-369
+**Dependencies:** RFC018
+
+### FR-GATE-379: Stage A Floor and Stage B LLM Judge
+**Status:** Implemented
+**Priority:** High
+
+**Requirement:** The system shall apply a configurable Stage A statistical floor and an optional Stage B LLM judge to retrieval results when `KB_RELEVANCE_GATE=on` or `--gate` is set, fail-soft on judge failures, and only fire an empty verdict when `KB_GATE_EMPTY_VERDICT=on`.
+
+**Acceptance Criteria:**
+- [x] Given the gate is off, when retrieval runs, then the gate shall not invoke any LLM call and shall not alter the result set.
+- [x] Given Stage A is on, when a candidate scores strictly below `KB_GATE_SCORE_FLOOR`, then it shall be dropped from the gated candidate set.
+- [x] Given Stage B is eligible, when the LLM judge times out or returns an invalid verdict, then the gate shall degrade to retrieval and emit a `gate.degraded` canonical event.
+- [x] Given `KB_GATE_EMPTY_VERDICT=off`, when the gate's terminal verdict is empty, then the search shall return the pre-gate top-k instead of an empty result.
+
+**Linked Tests:** TS-GATE-379
+**Dependencies:** RFC018
+
+### FR-GATE-422: Untrusted Task-Context Policy
+**Status:** Implemented
+**Priority:** High
+
+**Requirement:** The system shall apply a configurable `KB_GATE_TASK_CONTEXT_MODE` policy to argv-supplied task context that blocks or warns when content is suspicious (long argv, prompt-injection signals).
+
+**Acceptance Criteria:**
+- [x] Given the default `warn` mode, when argv task context is long or carries injection signals, then `kb search` shall log a warning to stderr but continue.
+- [x] Given `strict` mode, when argv task context carries injection signals, then `kb search` shall exit 2.
+- [x] Given `--task-context-file=<path>`, when the file content is large, then the argv-length check shall not apply.
+
+**Linked Tests:** TS-GATE-422
+**Dependencies:** FR-GATE-379
+
+## Research
+
+### FR-RESEARCH-451: Evidence Plan and Collect
+**Status:** Implemented
+**Priority:** Medium
+
+**Requirement:** The system shall provide `kb research plan` and `kb research collect` so an agent can split research into a vetted plan step and a single deterministic evidence-collection step.
+
+**Acceptance Criteria:**
+- [x] Given a research question, when `kb research plan` runs, then the system shall return a schema-versioned plan listing the query candidates the collector would run.
+- [x] Given a research plan, when `kb research collect` runs, then the system shall execute the queries, deduplicate hits across query candidates, and return a single ranked evidence packet with stable per-hit fields.
+- [x] Given per-query and total caps, when the collector runs, then the returned packet shall not exceed them.
+
+**Linked Tests:** TS-RESEARCH-451
+**Dependencies:** FR-SEARCH-374
+
+### FR-RESEARCH-452: Planner Selection Tightening
+**Status:** Implemented
+**Priority:** Medium
+
+**Requirement:** The research planner shall refuse to propose query candidates that contain prompt-injection signals or fail the minimum-task-token threshold.
+
+**Acceptance Criteria:**
+- [x] Given a question carrying injection signals, when the planner runs, then no candidate referencing the injected text shall appear in the plan envelope.
+- [x] Given a degenerate question, when the planner runs, then non-actionable query candidates shall be omitted with a clear `skipped` reason in the report.
+
+**Linked Tests:** TS-RESEARCH-452
+**Dependencies:** FR-RESEARCH-451
+
+## Feedback
+
+### FR-FEEDBACK-436: Relevance Feedback Ledger
+**Status:** Implemented
+**Priority:** Medium
+
+**Requirement:** The system shall record per-KB relevance judgments through `kb feedback add` and let operators promote accumulated judgments for a query into a `kb eval` fixture case via `kb feedback promote`.
+
+**Acceptance Criteria:**
+- [x] Given a relevance judgment, when `kb feedback add` runs, then the system shall append a `relevance-feedback.v1` row to `<kb>/.index/relevance-feedback.jsonl` and return the new entry id.
+- [x] Given recorded judgments, when `kb feedback list` runs, then the system shall return entries sorted by `created_at` descending and honor `--query` and `--limit`.
+- [x] Given recorded judgments, when `kb feedback promote --fixture --yes` runs, then the system shall append one `kb eval` case for the target query to the fixture file.
+- [x] Given `--task-context`, when the ledger row is written, then only the SHA-256 of the task context shall be persisted.
+
+**Linked Tests:** TS-FEEDBACK-436
+**Dependencies:** FR-RETRIEVAL-EVAL
+
+## Logging and Observability
+
+### FR-LOGS-397: Canonical Log Reader
+**Status:** Implemented
+**Priority:** Medium
+
+**Requirement:** The system shall provide `kb logs` as a structured reader over `kb-canonical.v1` log lines so operators can retrieve events by request id, query hash, or recency without parsing raw log files by hand.
+
+**Acceptance Criteria:**
+- [x] Given a log file containing canonical events, when `kb logs recent --format=json` runs, then the system shall return the latest events with stable scan counts.
+- [x] Given a request id or query SHA, when `kb logs show` runs with the matching filter, then the system shall return every matching event in chronological order.
+- [x] Given a missing log file, when `kb logs` runs, then the system shall emit a JSON error envelope with `schema_version: "kb.logs.v1"` and exit code 2.
+
+**Linked Tests:** TS-LOGS-397
+**Dependencies:** RFC009
+
+### FR-STATS-419: Contextual Preface Stats
+**Status:** Implemented
+**Priority:** Medium
+
+**Requirement:** The `kb_stats` payload shall include `contextual_preface` cache and failure counters when RFC 017 ingest is enabled and shall omit the block otherwise.
+
+**Acceptance Criteria:**
+- [x] Given `KB_CONTEXTUAL_RETRIEVAL=on` and at least one ingest pass, when stats are requested, then the payload shall include `contextual_preface.cache_hits`, `cache_misses`, `failures`, and `last_failure_code`.
+- [x] Given the contextual flag is off, when stats are requested, then the `contextual_preface` block shall be absent and the prior payload shape preserved.
+
+**Linked Tests:** TS-STATS-419
+**Dependencies:** RFC017
+
+### FR-STATS-442: Remote Transport Stats
+**Status:** Implemented
+**Priority:** Medium
+
+**Requirement:** The `kb_stats` payload shall include a `remote_transport` counter block when the HTTP or SSE transport is active and shall omit the block under stdio.
+
+**Acceptance Criteria:**
+- [x] Given HTTP or SSE transport, when stats are requested, then the payload shall include `remote_transport.request_count`, `auth_failure_count`, and `backoff_active_count`.
+- [x] Given stdio transport, when stats are requested, then the `remote_transport` block shall be absent.
+
+**Linked Tests:** TS-STATS-442
+**Dependencies:** RFC008
+
+## Reindex
+
+### FR-REINDEX-407: Reindex Status Ledger
+**Status:** Implemented
+**Priority:** Medium
+
+**Requirement:** The system shall expose `kb reindex status` as a read-only reader over the `.reindex.run.json` ledger so operators can inspect the current or most recent contextual-reindex pass.
+
+**Acceptance Criteria:**
+- [x] Given an existing `.reindex.run.json`, when `kb reindex status --format=json` runs, then the system shall report `kb_scope`, `model`, `started_at`, `finished_at`, chunk counters, cache hit rate, and any failure code.
+- [x] Given a missing ledger, when the command runs, then the system shall report a clearly-typed "no runs" envelope rather than failing.
+
+**Linked Tests:** TS-REINDEX-407
+**Dependencies:** RFC017
+
+### FR-REINDEX-408: Cache-Aware Reindex Estimate
+**Status:** Implemented
+**Priority:** Medium
+
+**Requirement:** The contextual-reindex estimator shall subtract chunks already present in the preface cache from its wall-clock estimate so re-runs after partial failures report realistic remaining work.
+
+**Acceptance Criteria:**
+- [x] Given a populated preface cache, when the estimator runs, then the reported chunk-to-embed count shall exclude cache hits.
+- [x] Given an empty cache, when the estimator runs, then the reported count shall equal the total ingestable chunks.
+
+**Linked Tests:** TS-REINDEX-408
+**Dependencies:** RFC017
+
+## Serve / Daemon
+
+### FR-SERVE-410: Daemon Lifecycle Probe
+**Status:** Implemented
+**Priority:** Medium
+
+**Requirement:** The system shall provide `kb serve status` as a read-only probe that reports whether the resident daemon is reachable at the configured `KB_DAEMON_URL` and never starts or stops the daemon itself.
+
+**Acceptance Criteria:**
+- [x] Given a reachable daemon, when the probe runs, then the system shall exit 0 with the daemon's pid, uptime, idle timeout, and command list when supplied by `/health`.
+- [x] Given no daemon is listening, when the probe runs, then the system shall exit 3 with a clear "no daemon at <url>" message.
+- [x] Given a daemon answers with an unusable `/health` payload, when the probe runs, then the system shall exit 1.
+- [x] Given an invalid `KB_DAEMON_URL`, when the probe runs, then the system shall exit 2.
+
+**Linked Tests:** TS-SERVE-410
 
 ## Stats
 

--- a/docs/testing/INDEX.md
+++ b/docs/testing/INDEX.md
@@ -1,6 +1,14 @@
 # Testing
 
 - [Retrieval eval command](retrieval-eval.md)
+- [Retrieval eval methodology](retrieval-eval-methodology.md)
+- [Fixtures](fixtures/README.md)
+- RFC test surfaces:
+  [RFC 017 contextual retrieval](../rfcs/017-contextual-retrieval.md),
+  [RFC 018 relevance gating](../rfcs/018-context-relevance-gating.md)
+  ([M1 canary report](../rfcs/018-m1-canary-report.md)),
+  [RFC 019 cross-encoder reranker](../rfcs/019-cross-encoder-reranker.md)
+  ([M0b reranker report](../rfcs/019-m0b-reranker-report.md))
 
 ## Indexing
 
@@ -112,6 +120,116 @@
 - `computeStaleness` shall count modified and new files in the selected KB separately from other KBs.
 - `computeStaleness` shall preserve global modified and new file counts for unscoped searches.
 - `formatFreshnessFooter` and JSON payload tests shall verify scoped fields remain distinct from global fields.
+
+## Relevance Gate (RFC 018)
+
+### TS-GATE-EVAL-369: M0 Gate Validation Harness
+**Requirement:** FR-GATE-EVAL-369
+
+**Test Cases:**
+- `kb eval-gate` shall parse the gate-eval fixture and emit a stable `kb.eval-gate.v1`-shaped JSON or markdown report.
+- `kb eval-gate --dry-run` and `kb eval-gate` without a reachable endpoint shall fall back to the offline causal model and still produce a report.
+- `kb eval-gate --m1` shall require a reachable endpoint and exit non-zero when no endpoint is configured.
+- The aggregated summary shall include the three pre-registered numbers: `empty_verdict_fire_rate`, `per_chunk_drop_no_good_answer_delta`, `judge_false_empty_rate`.
+
+### TS-GATE-379: Stage A Statistical Floor + Stage B LLM Judge
+**Requirement:** FR-GATE-379
+
+**Test Cases:**
+- `applyRelevanceGate` shall short-circuit when `KB_RELEVANCE_GATE=off` and emit `gate.skipped` canonical events when on.
+- The Stage A floor (`KB_GATE_SCORE_FLOOR`) shall drop candidates strictly below the configured distance.
+- The Stage B LLM judge shall be invoked only when `KB_GATE_LLM_ENDPOINT` (or `KB_LLM_ENDPOINT` fallback) resolves, task context meets `KB_GATE_MIN_TASK_TOKENS`, and Stage A retained ≥ 1 candidate.
+- Judge failures (timeout, non-JSON, bad model id) shall degrade to retrieval rather than failing the search.
+- `KB_GATE_EMPTY_VERDICT=on` shall let the gate return an empty set; the default `off` shall fall back to the pre-gate top-k.
+
+### TS-GATE-422: Untrusted Task-Context Policy
+**Requirement:** FR-GATE-422
+
+**Test Cases:**
+- `KB_GATE_TASK_CONTEXT_MODE=warn` (default) shall log on stderr but accept long or injection-bearing argv task context.
+- `KB_GATE_TASK_CONTEXT_MODE=strict` shall refuse injection-signal-bearing argv task context with exit code 2.
+- `KB_GATE_TASK_CONTEXT_MODE=off` shall apply neither check.
+- `--task-context-file=<path>` shall always bypass the argv length check.
+
+## Research
+
+### TS-RESEARCH-451: Evidence Plan and Collect
+**Requirement:** FR-RESEARCH-451
+
+**Test Cases:**
+- `kb research plan` shall emit a `kb.research.v1` plan envelope with a vetted set of query candidates and `--format=json` validation.
+- `kb research collect` shall execute the plan, deduplicate hits across query candidates, and return a single ranked evidence packet with chunk-id, score, source-query, and KB fields.
+- The collector shall enforce per-query result caps and total-evidence caps via `--max-per-query` and `--max-total`.
+
+### TS-RESEARCH-452: Planner Selection Tightening
+**Requirement:** FR-RESEARCH-452
+
+**Test Cases:**
+- `kb research plan` shall reject queries containing prompt-injection signals and shall not echo them in the plan envelope.
+- The planner shall skip non-actionable / generic queries that fail the minimum-task-token threshold.
+
+## Feedback
+
+### TS-FEEDBACK-436: Relevance Feedback Ledger
+**Requirement:** FR-FEEDBACK-436
+
+**Test Cases:**
+- `kb feedback add` shall append a `relevance-feedback.v1` entry to `<kb>/.index/relevance-feedback.jsonl` with stable id, timestamp, query, source, verdict, and graded relevance.
+- `kb feedback list` shall return entries sorted by `created_at` descending and honor `--query` and `--limit`.
+- `kb feedback promote` shall produce a YAML preview without `--fixture --yes` and shall append a `kb eval` case to the target fixture when both are supplied.
+- The ledger shall store `task_context_sha256` (never the raw text) when `--task-context` is supplied.
+
+## Logging and Observability
+
+### TS-LOGS-397: Canonical Log Reader
+**Requirement:** FR-LOGS-397
+
+**Test Cases:**
+- `kb logs recent --format=json` shall return the latest `kb-canonical.v1` events from the discovered log file.
+- `kb logs show --request-id=<id>` and `--query-sha=<hash>` shall return matching events with stable counts of scanned, ignored, and malformed lines.
+- The reader shall ignore non-canonical text lines and shall not write to stdout when no events match (returns `result_count: 0`).
+- File-resolution order shall be `--file` → `LOG_FILE` → existing local default paths.
+
+### TS-STATS-419: Contextual Preface Stats
+**Requirement:** FR-STATS-419
+
+**Test Cases:**
+- `computeKbStats` shall include `contextual_preface` cache hit/miss/failure counters when RFC 017 ingest is enabled.
+- The block shall be omitted when the contextual-retrieval flag is off, preserving the prior payload shape.
+
+### TS-STATS-442: Remote Transport Stats
+**Requirement:** FR-STATS-442
+
+**Test Cases:**
+- `computeKbStats` shall include a `remote_transport` block with request, auth-failure, and backoff counters when the HTTP or SSE transport is active.
+- The block shall be omitted under stdio transport.
+
+## Reindex
+
+### TS-REINDEX-407: Reindex Status Ledger
+**Requirement:** FR-REINDEX-407
+
+**Test Cases:**
+- `kb reindex status --format=json` shall read the `.reindex.run.json` ledger and report current or most recent runs with `kb_scope`, `model`, timestamps, chunk counters, cache hit-rate, and any failure code.
+- The reader shall report a clearly-typed "no runs" envelope when the ledger is missing rather than failing.
+
+### TS-REINDEX-408: Cache-Aware Estimate
+**Requirement:** FR-REINDEX-408
+
+**Test Cases:**
+- The contextual-reindex estimator shall subtract chunks already present in the preface cache from the total chunk count before producing the wall-clock estimate.
+
+## Serve / Daemon
+
+### TS-SERVE-410: kb serve status
+**Requirement:** FR-SERVE-410
+
+**Test Cases:**
+- `kb serve status` shall query `GET /health` at `KB_DAEMON_URL` and never start or stop a daemon.
+- Reachable daemons shall produce exit code 0 with PID, uptime, idle-timeout, and command-list fields when the `/health` payload supplies them.
+- An unreachable daemon shall produce exit code 3 with a clear "no daemon at <url>" message.
+- A daemon answering with an unusable `/health` payload shall produce exit code 1.
+- Invalid `KB_DAEMON_URL` shall produce exit code 2.
 
 ## Stats
 

--- a/docs/testing/INDEX.md
+++ b/docs/testing/INDEX.md
@@ -158,8 +158,8 @@
 
 **Test Cases:**
 - `kb research plan` shall emit a `kb.research.v1` plan envelope with a vetted set of query candidates and `--format=json` validation.
-- `kb research collect` shall execute the plan, deduplicate hits across query candidates, and return a single ranked evidence packet with chunk-id, score, source-query, and KB fields.
-- The collector shall enforce per-query result caps and total-evidence caps via `--max-per-query` and `--max-total`.
+- `kb research collect` shall execute the plan and write `run.json`, `plan.json`, `ledger.json`, `evidence_packet.md`, and `events.jsonl`.
+- The collector shall honor `--k=<int>` as the per-query/shelf retrieval cap, keep `ledger.json` lossless, and group duplicate passages in `evidence_packet.md` with query provenance.
 
 ### TS-RESEARCH-452: Planner Selection Tightening
 **Requirement:** FR-RESEARCH-452


### PR DESCRIPTION
## Summary

Closes the documentation gap that accumulated over the ~30 PRs since the last RFC-017 docs pass (commits since 2026-05-15). README, feature-flags matrix, JSON contracts, requirements/testing indexes, plus 5 new operator guides and 2 new architecture sequence diagrams.

- **README:** registers 6 new CLI commands (\`kb research\`, \`kb feedback\`, \`kb eval-gate\`, \`kb logs\`, \`kb reindex status\`, \`kb serve status\`), 2 new search flags (\`--format=compact\` #446, \`--batch-jsonl\` #440), and updated \`kb stats\` output (contextual_preface #419 + remote_transport #442). Adds narrative sections for each new feature and the untrusted-content guard.
- **\`docs/feature-flags.md\`:** new sections for Untrusted Content Hardening (\`KB_INJECTION_GUARD*\`), Daemon and CLI Fast-Path (\`KB_DAEMON_*\`), and Managed LLM Profiles (\`KB_LLM_CONFIG_DIR/STATE_DIR/SYSTEMD_USER_DIR\`); fills in \`KB_CHUNK_SIZE/OVERLAP\`, \`INDEXING_BATCH_SIZE\`, \`KB_FS_WATCH*\`, \`KB_INDEX_VERSION_RETENTION\`, \`KB_AGE_BUDGET_HOURS*\`, \`KB_LOG_VERBOSE\`, and the new search/log flags.
- **\`docs/cli-json-contracts.md\`:** adds stable JSON envelopes for \`kb eval-gate\` (M0 + M1), \`kb feedback\` (add/list/promote preview + write), and \`kb serve status\`.
- **\`docs/operations/\` (new):** \`research-workflow.md\`, \`feedback-workflow.md\`, \`eval-gate-harness.md\`, \`daemon-lifecycle.md\`, \`logs-reader.md\`.
- **\`docs/architecture/\` (new):** \`sequence-research-collect.md\` and \`sequence-feedback-promote.md\`, mermaid + line-anchored to current \`src/\`; both registered in \`architecture/README.md\` reading order.
- **\`docs/testing/INDEX.md\` & \`docs/requirements/INDEX.md\`:** test-spec and requirement stubs for the new commands and the RFC 018/019 surfaces; top-of-file RFC cross-links.

Total: 13 files, +1485 lines.

## Test plan

- [x] \`npm run docs:check-anchors\` — 0 new stale anchors (the 59 pre-existing warnings are all in RFC 011 / RFC 014 and predate this PR)
- [x] All internal markdown links in the 7 new doc files resolve to existing paths
- [x] Spot-check rendered mermaid in the two new sequence diagrams on GitHub
- [x] Cross-check feature-flags table entries against \`src/config/*.ts\` and \`src/*.ts\` definitions for accuracy (defaults, validation commands)
- [x] Cross-check \`cli-json-contracts.md\` envelopes against the actual JSON shapes returned by \`src/cli-feedback.ts\`, \`src/cli-eval-gate.ts\`, \`src/cli-serve.ts\`
- [ ] Reviewer sanity check: open the README in the GitHub renderer and skim the new CLI command list + new narrative paragraphs

🤖 Generated with [Claude Code](https://claude.com/claude-code)