### PR TITLE
feat: add fake LLM dev fixture

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ The MCP server (`knowledge-base-mcp-server` bin) is unchanged and still works wi
 
 `kb ask` keeps retrieval deterministic and adds a local OpenAI-compatible chat step on top. It resolves the LLM endpoint from `--endpoint`, `KB_LLM_ENDPOINT`, `--llm-profile`, the active `kb llm` profile, then finally the local-research-agent default on `127.0.0.1:8080`.
 
+For offline development, set `KB_LLM_FAKE=on` to route `kb ask`, RFC 018 relevance-gate judge calls, and RFC 017 contextual-preface generation to a deterministic in-process fake LLM. Use `npm run dev:mockllm -- --port=18080` when a client needs an OpenAI-compatible localhost endpoint instead. Rules can be customized with `KB_LLM_FAKE_RULES`; see [docs/testing/fake-llm.md](docs/testing/fake-llm.md).
+
 Add `--save-transcript --kb=<name> --yes` to persist the generated answer as a new markdown note in that KB. The saved record includes the question, answer, citations, source chunk ids, LLM endpoint/profile/model, retrieval model, and timing metadata when `--timing` is present. `--title=<title>` controls the note title and slug; existing transcript notes are never overwritten.
 
 ```bash

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -17,6 +17,8 @@ verify the active behavior.
 | Query cache memory limit | `KB_QUERY_CACHE_LRU_MAX` | `256` | CLI and MCP retrieval | Implemented | none | `kb doctor --format=json` |
 | Query cache disk budget | `KB_QUERY_CACHE_DISK_MAX_MB` | `64` | CLI and MCP retrieval | Implemented | none | `kb doctor --format=json` |
 | Local LLM endpoint | `KB_LLM_ENDPOINT` | active `kb llm` profile, then local-research-agent default for `kb ask`; unset for contextual ingest unless supplied | `kb ask`, contextual ingest, gate fallback endpoint | Implemented | `kb ask --endpoint=...`, `--llm-profile=...` | `kb llm status` |
+| Fake LLM | `KB_LLM_FAKE` | `off` | `kb ask`, contextual ingest, relevance-gate Stage B | Implemented, dev/test fixture | none | `KB_LLM_FAKE=on kb ask "question" --kb=<name>` |
+| Fake LLM rules | `KB_LLM_FAKE_RULES` | unset | Fake LLM answers, prefaces, judge verdicts | Implemented | none | `KB_LLM_FAKE=on KB_LLM_FAKE_RULES=/path/to/rules.json kb ask "question"` |
 | Gate fallback LLM model id | `KB_LLM_MODEL` | endpoint default | Relevance gate fallback model | Implemented | none | `KB_RELEVANCE_GATE=on KB_LLM_MODEL=<model> kb search "query" --gate --task-context="current task"` |
 | Save generated answer | `kb ask --save-transcript --yes` | off | CLI ask write path | Implemented | `--save-transcript --kb=<name> --yes` | `kb ask "question" --kb=<name> --save-transcript --title="..." --yes` |
 

--- a/docs/testing/INDEX.md
+++ b/docs/testing/INDEX.md
@@ -2,6 +2,7 @@
 
 - [Retrieval eval command](retrieval-eval.md)
 - [Retrieval eval methodology](retrieval-eval-methodology.md)
+- [Fake LLM fixture](fake-llm.md)
 - [Fixtures](fixtures/README.md)
 - RFC test surfaces:
   [RFC 017 contextual retrieval](../rfcs/017-contextual-retrieval.md),
@@ -122,6 +123,16 @@
 - `formatFreshnessFooter` and JSON payload tests shall verify scoped fields remain distinct from global fields.
 
 ## Relevance Gate (RFC 018)
+
+### TS-LLM-465: Fake LLM Fixture
+**Requirement:** FR-LLM-465
+
+**Test Cases:**
+- `KB_LLM_FAKE=on` shall route `callChatCompletion` to the in-process fake LLM without invoking `fetch`.
+- The fake LLM shall produce deterministic Stage B relevance judge JSON that preserves the existing judge parser contract.
+- The fake LLM shall generate deterministic contextual prefaces without `KB_LLM_ENDPOINT`.
+- `kb ask` shall resolve a fake LLM target and answer from packed snippets without a live server.
+- `npm run dev:mockllm` shall serve OpenAI-compatible `/v1/chat/completions` and `/health` endpoints.
 
 ### TS-GATE-EVAL-369: M0 Gate Validation Harness
 **Requirement:** FR-GATE-EVAL-369

--- a/docs/testing/fake-llm.md
+++ b/docs/testing/fake-llm.md
@@ -1,0 +1,70 @@
+# Fake LLM Fixture
+
+Use the fake LLM when developing LLM-dependent paths without a local model:
+
+```bash
+KB_LLM_FAKE=on kb ask "Who approves rollback?" --kb=ops
+KB_LLM_FAKE=on KB_RELEVANCE_GATE=on kb search "rollback approval" --gate --task-context="answer an operations question"
+KB_LLM_FAKE=on KB_CONTEXTUAL_RETRIEVAL=on kb reindex --with-context
+```
+
+`KB_LLM_FAKE=on` routes every `callChatCompletion` call to an in-process
+deterministic responder and ignores `KB_LLM_ENDPOINT`. It covers:
+
+- RFC 018 relevance-gate Stage B judge calls.
+- RFC 017 contextual-preface generation.
+- `kb ask` final-answer calls.
+
+The fake also has a standalone OpenAI-compatible server for end-to-end clients
+that need a real HTTP endpoint:
+
+```bash
+npm run dev:mockllm -- --port=18080
+KB_LLM_ENDPOINT=http://127.0.0.1:18080/v1/chat/completions kb ask "Who approves rollback?"
+```
+
+The server implements:
+
+- `GET /health`
+- `POST /v1/chat/completions`
+
+## Rules File
+
+Set `KB_LLM_FAKE_RULES=/path/to/rules.json` or pass
+`npm run dev:mockllm -- --rules=/path/to/rules.json`.
+
+```json
+{
+  "answers": [
+    {
+      "question_contains": "rollback",
+      "answer": "Rollback approval requires the release lead. Source: ops/runbooks/rollback.md."
+    }
+  ],
+  "prefaces": [
+    {
+      "chunk_contains": "release lead",
+      "preface": "In section \"Rollback\", this chunk explains approval ownership."
+    }
+  ],
+  "judge": [
+    {
+      "query_contains": "rollback",
+      "keep_contains": ["rollback", "release lead"],
+      "overall": "relevant"
+    }
+  ],
+  "responses": [
+    {
+      "user_contains": "health check",
+      "content": "ok"
+    }
+  ],
+  "default_response": "Fake LLM response from kb-fake-llm."
+}
+```
+
+Rules are matched case-insensitively. Defaults are deterministic: the judge
+keeps candidates whose content overlaps query/task terms, contextual prefaces
+use the nearest Markdown heading, and `kb ask` answers from the first packed
+snippet or abstains when no snippets are present.

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "dev": "nodemon src/index.ts",
     "dev:cli": "node --enable-source-maps --import tsx scripts/dev-cli.mjs",
     "dev:fixture": "node --enable-source-maps --import tsx scripts/dev-fixture.mjs",
+    "dev:mockllm": "node --enable-source-maps --import tsx scripts/dev-mockllm.mjs",
     "dev:remote": "node --enable-source-maps --import tsx scripts/dev-remote.mjs",
     "dev:setup": "bash scripts/dev-setup.sh"
   },

--- a/scripts/dev-mockllm.mjs
+++ b/scripts/dev-mockllm.mjs
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+import http from 'node:http';
+import * as fsp from 'node:fs/promises';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SCRIPT_PATH = fileURLToPath(import.meta.url);
+const DEFAULT_PORT = 18080;
+const DEFAULT_BIND = '127.0.0.1';
+const MAX_BODY_BYTES = 1024 * 1024;
+
+const HELP = `npm run dev:mockllm — run a deterministic OpenAI-compatible fake LLM
+
+Usage:
+  npm run dev:mockllm -- [--bind=<host>] [--port=<int>] [--rules=<path>] [--help]
+
+Starts a tiny localhost server for offline LLM-dependent development. It
+implements GET /health and POST /v1/chat/completions. The chat route uses the
+same deterministic fake responder as KB_LLM_FAKE=on.
+
+Options:
+  --bind=<host>         Bind address (default: ${DEFAULT_BIND}).
+  --port=<int>          Port 1-65535 (default: ${DEFAULT_PORT}).
+  --rules=<path>        Optional JSON rules file, same schema as KB_LLM_FAKE_RULES.
+  --help, -h            Show this help.
+`;
+
+function parseArgs(argv) {
+  const out = { bind: DEFAULT_BIND, port: DEFAULT_PORT, rules: null, help: false };
+  for (const arg of argv) {
+    if (arg === '--help' || arg === '-h') {
+      out.help = true;
+    } else if (arg.startsWith('--bind=')) {
+      const value = arg.slice('--bind='.length).trim();
+      if (!value) throw new Error('--bind requires a non-empty host');
+      out.bind = value;
+    } else if (arg.startsWith('--port=')) {
+      const raw = arg.slice('--port='.length);
+      const value = Number(raw);
+      if (!Number.isInteger(value) || value <= 0 || value > 65535) {
+        throw new Error(`--port must be an integer from 1 to 65535, got: ${raw}`);
+      }
+      out.port = value;
+    } else if (arg.startsWith('--rules=')) {
+      const value = arg.slice('--rules='.length).trim();
+      if (!value) throw new Error('--rules requires a non-empty path');
+      out.rules = path.resolve(value);
+    } else {
+      throw new Error(`unknown argument: ${arg} (use --help to see options)`);
+    }
+  }
+  return out;
+}
+
+async function run(argv, deps = {}) {
+  let args;
+  try {
+    args = parseArgs(argv);
+  } catch (err) {
+    process.stderr.write(`dev:mockllm: ${err.message}\n`);
+    return 2;
+  }
+
+  if (args.help) {
+    process.stdout.write(HELP);
+    return 0;
+  }
+
+  const fakeModuleUrl = new URL('../src/llm-fake-stub.ts', import.meta.url);
+  const { fakeOpenAiChatCompletionResponse } = await import(fakeModuleUrl.href);
+  const rules = args.rules === null
+    ? {}
+    : JSON.parse(await fsp.readFile(args.rules, 'utf-8'));
+
+  const server = (deps.createServer ?? http.createServer)((req, res) => {
+    void handleRequest(req, res, fakeOpenAiChatCompletionResponse, rules);
+  });
+
+  await new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(args.port, args.bind, resolve);
+  });
+
+  const endpoint = `http://${formatHost(args.bind)}:${args.port}/v1/chat/completions`;
+  process.stdout.write([
+    '',
+    'Fake LLM server ready.',
+    `  endpoint: ${endpoint}`,
+    `  health:   http://${formatHost(args.bind)}:${args.port}/health`,
+    args.rules ? `  rules:    ${args.rules}` : '  rules:    defaults',
+    '',
+    'Use it with:',
+    `  KB_LLM_ENDPOINT=${endpoint} kb ask 'What changed?'`,
+    `  KB_LLM_ENDPOINT=${endpoint} KB_RELEVANCE_GATE=on kb search 'rollback' --gate --task-context='answer an operations question'`,
+    '',
+  ].join('\n'));
+  return new Promise(() => {});
+}
+
+async function handleRequest(req, res, fakeOpenAiChatCompletionResponse, rules) {
+  if (req.method === 'GET' && req.url === '/health') {
+    writeJson(res, 200, { status: 'ok', provider: 'fake' });
+    return;
+  }
+  if (req.method !== 'POST' || req.url !== '/v1/chat/completions') {
+    writeJson(res, 404, { error: { message: 'not found' } });
+    return;
+  }
+
+  let body;
+  try {
+    body = await readRequestBody(req, MAX_BODY_BYTES);
+  } catch (err) {
+    writeJson(res, 413, { error: { message: err.message } });
+    return;
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    writeJson(res, 400, { error: { message: 'request body must be JSON' } });
+    return;
+  }
+
+  writeJson(res, 200, fakeOpenAiChatCompletionResponse(parsed, rules));
+}
+
+function readRequestBody(req, maxBytes) {
+  return new Promise((resolve, reject) => {
+    let size = 0;
+    const chunks = [];
+    req.on('data', (chunk) => {
+      size += chunk.length;
+      if (size > maxBytes) {
+        req.destroy();
+        reject(new Error(`request body exceeds ${maxBytes} bytes`));
+        return;
+      }
+      chunks.push(chunk);
+    });
+    req.on('end', () => resolve(Buffer.concat(chunks).toString('utf-8')));
+    req.on('error', reject);
+  });
+}
+
+function writeJson(res, status, payload) {
+  const body = JSON.stringify(payload);
+  res.writeHead(status, {
+    'Content-Type': 'application/json',
+    'Content-Length': Buffer.byteLength(body),
+  });
+  res.end(body);
+}
+
+function formatHost(host) {
+  return host.includes(':') ? `[${host}]` : host;
+}
+
+const isDirectInvocation = process.argv[1] && path.resolve(process.argv[1]) === SCRIPT_PATH;
+if (isDirectInvocation) {
+  try {
+    const result = await run(process.argv.slice(2));
+    if (typeof result === 'number') process.exitCode = result;
+  } catch (err) {
+    const msg = err instanceof Error && err.stack ? err.stack : String(err);
+    process.stderr.write(`dev:mockllm: fatal: ${msg}\n`);
+    process.exitCode = 1;
+  }
+}
+
+export { HELP, DEFAULT_PORT, parseArgs, run };

--- a/src/canonical-log.ts
+++ b/src/canonical-log.ts
@@ -56,6 +56,7 @@ export interface CanonicalLogEvent {
   recovery_hint?: string;
   rerank?: Record<string, unknown>;
   gate?: Record<string, unknown>;
+  llm_provider?: string;
 }
 
 export type CanonicalLogInput = Omit<
@@ -96,6 +97,7 @@ const CANONICAL_FIELD_ORDER: readonly (keyof CanonicalLogEvent)[] = [
   'recovery_hint',
   'rerank',
   'gate',
+  'llm_provider',
 ];
 
 export function createCanonicalRequestId(): string {
@@ -141,6 +143,7 @@ export function normalizeCanonicalEvent(input: CanonicalLogInput): CanonicalLogE
   assignIfDefined(event, 'recovery_hint', input.recovery_hint);
   assignIfDefined(event, 'rerank', input.rerank);
   assignIfDefined(event, 'gate', input.gate);
+  assignIfDefined(event, 'llm_provider', input.llm_provider);
 
   return event;
 }

--- a/src/cli-ask.test.ts
+++ b/src/cli-ask.test.ts
@@ -11,6 +11,7 @@ import {
   runAsk,
   type RunAskDeps,
 } from './cli-ask.js';
+import { callChatCompletion } from './llm-client.js';
 
 describe('parseAskArgs', () => {
   it('parses retrieval and LLM options', () => {
@@ -405,6 +406,75 @@ describe('ask transcript records', () => {
       stderrSpy.mockRestore();
       if (previousEndpoint === undefined) delete process.env.KB_LLM_ENDPOINT;
       else process.env.KB_LLM_ENDPOINT = previousEndpoint;
+    }
+  });
+
+  it('answers through KB_LLM_FAKE without KB_LLM_ENDPOINT or a live server', async () => {
+    const previousFake = process.env.KB_LLM_FAKE;
+    const previousEndpoint = process.env.KB_LLM_ENDPOINT;
+    const previousLogFormat = process.env.KB_LOG_FORMAT;
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const stdoutSpy = jest.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+      stdout.push(String(chunk));
+      return true;
+    });
+    const stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation((chunk) => {
+      stderr.push(String(chunk));
+      return true;
+    });
+
+    try {
+      process.env.KB_LLM_FAKE = 'on';
+      process.env.KB_LOG_FORMAT = 'text';
+      delete process.env.KB_LLM_ENDPOINT;
+      const manager = {
+        modelDir: '/tmp/kb-ask-model',
+        initialize: jest.fn(async () => {}),
+        updateIndex: jest.fn(async () => {}),
+        similaritySearch: jest.fn(async () => [
+          {
+            pageContent: 'Rollback approval requires the release lead.',
+            metadata: { knowledgeBase: 'ops', relativePath: 'runbooks/rollback.md' },
+            score: 0.1,
+          },
+        ]),
+      };
+      const deps: RunAskDeps = {
+        bootstrapLayout: jest.fn(async () => {}),
+        resolveActiveModel: jest.fn(async () => 'ollama__nomic-embed-text-latest'),
+        loadManagerForModel: jest.fn(async () => manager as never),
+        loadWithJsonRetry: jest.fn(async () => {}),
+        withWriteLock: jest.fn(async <T>(_resource: string, action: () => Promise<T>) => action()) as RunAskDeps['withWriteLock'],
+        callChatCompletion,
+        createTranscriptNote: createAskTranscriptNote,
+        knowledgeBasesRootDir: '/tmp/kb-ask-root',
+      };
+
+      const code = await runAsk(['Who approves rollback?', '--kb=ops', '--format=json'], deps);
+
+      expect(code).toBe(0);
+      expect(stderr.join('')).toContain('"llm_provider":"fake"');
+      const payload = JSON.parse(stdout.join('')) as {
+        answer: string;
+        llm: { profile: string; source: string; model: string | null; endpoint: string };
+      };
+      expect(payload.answer).toContain('Rollback approval requires the release lead.');
+      expect(payload.llm).toMatchObject({
+        profile: 'fake',
+        source: 'fake',
+        model: 'kb-fake-llm',
+        endpoint: 'mock://kb-llm-fake/v1/chat/completions',
+      });
+    } finally {
+      stdoutSpy.mockRestore();
+      stderrSpy.mockRestore();
+      if (previousFake === undefined) delete process.env.KB_LLM_FAKE;
+      else process.env.KB_LLM_FAKE = previousFake;
+      if (previousEndpoint === undefined) delete process.env.KB_LLM_ENDPOINT;
+      else process.env.KB_LLM_ENDPOINT = previousEndpoint;
+      if (previousLogFormat === undefined) delete process.env.KB_LOG_FORMAT;
+      else process.env.KB_LOG_FORMAT = previousLogFormat;
     }
   });
 

--- a/src/cli-ask.ts
+++ b/src/cli-ask.ts
@@ -27,6 +27,7 @@ import { FRONTMATTER_EXTRAS_WIRE_VISIBLE } from './config/retrieval.js';
 import { formatRetrievalAsJson, type RetrievalJsonResult } from './formatter.js';
 import { resolveInjectionGuardOptions } from './injection-guard.js';
 import { callChatCompletion } from './llm-client.js';
+import { FAKE_LLM_ENDPOINT, isFakeLlmEnabled } from './llm-fake-stub.js';
 import {
   createExternalProfile,
   resolveProfile,
@@ -89,7 +90,7 @@ interface AskArgs {
 
 interface LlmTarget {
   profile: LlmProfile;
-  source: 'flag' | 'env' | 'profile' | 'default';
+  source: 'flag' | 'env' | 'profile' | 'default' | 'fake';
 }
 
 interface AskCitation {
@@ -490,6 +491,9 @@ export function parseAskArgs(rest: string[]): AskArgs {
 }
 
 async function resolveLlmTarget(args: AskArgs): Promise<LlmTarget> {
+  if (isFakeLlmEnabled()) {
+    return { profile: await createExternalProfile('fake', FAKE_LLM_ENDPOINT, 'kb-fake-llm'), source: 'fake' };
+  }
   if (args.endpoint) {
     return { profile: await createExternalProfile('adhoc', args.endpoint), source: 'flag' };
   }

--- a/src/config/contextual-preface.ts
+++ b/src/config/contextual-preface.ts
@@ -1,3 +1,5 @@
+import { FAKE_LLM_ENDPOINT, isFakeLlmEnabled } from '../llm-fake-stub.js';
+
 // RFC 017 — Contextual Retrieval at Ingest.
 //
 // Config knobs live here so the rest of the module can read them via a
@@ -27,6 +29,7 @@ export function resolveContextualMaxTokens(): number {
 }
 
 export function resolveContextualLlmEndpoint(): string | null {
+  if (isFakeLlmEnabled()) return FAKE_LLM_ENDPOINT;
   const raw = process.env.KB_LLM_ENDPOINT;
   if (raw === undefined || raw.trim() === '') return null;
   return raw.trim();

--- a/src/config/relevance-gate.ts
+++ b/src/config/relevance-gate.ts
@@ -1,3 +1,5 @@
+import { FAKE_LLM_ENDPOINT, isFakeLlmEnabled } from '../llm-fake-stub.js';
+
 export interface RelevanceGateConfig {
   enabled: boolean;
   emptyVerdictEnabled: boolean;
@@ -12,6 +14,7 @@ export interface RelevanceGateConfig {
 export function resolveRelevanceGateConfig(
   env: NodeJS.ProcessEnv = process.env,
 ): RelevanceGateConfig {
+  const fakeLlm = isFakeLlmEnabled(env);
   return {
     enabled: parseOnOff(env.KB_RELEVANCE_GATE, false),
     // RFC 018 M0 (#369) observed a high false-empty rate. Keep the terminal
@@ -20,7 +23,7 @@ export function resolveRelevanceGateConfig(
     scoreFloor: parseFinite(env.KB_GATE_SCORE_FLOOR, 0.95),
     judgeInputLimit: parsePositiveInt(env.KB_GATE_JUDGE_INPUT, 10),
     judgeTimeoutMs: parsePositiveInt(env.KB_GATE_LLM_TIMEOUT_MS, 8000),
-    judgeEndpoint: firstNonEmpty(env.KB_GATE_LLM_ENDPOINT, env.KB_LLM_ENDPOINT),
+    judgeEndpoint: fakeLlm ? FAKE_LLM_ENDPOINT : firstNonEmpty(env.KB_GATE_LLM_ENDPOINT, env.KB_LLM_ENDPOINT),
     judgeModel: firstNonEmpty(env.KB_GATE_LLM_MODEL, env.KB_LLM_MODEL),
     minTaskContextTokens: parsePositiveInt(env.KB_GATE_MIN_TASK_TOKENS, 8),
   };

--- a/src/contextual-preface.test.ts
+++ b/src/contextual-preface.test.ts
@@ -39,6 +39,8 @@ beforeEach(async () => {
     KNOWLEDGE_BASES_ROOT_DIR: process.env.KNOWLEDGE_BASES_ROOT_DIR,
     KB_CONTEXTUAL_RETRIEVAL: process.env.KB_CONTEXTUAL_RETRIEVAL,
     KB_LLM_ENDPOINT: process.env.KB_LLM_ENDPOINT,
+    KB_LLM_FAKE: process.env.KB_LLM_FAKE,
+    KB_LOG_FORMAT: process.env.KB_LOG_FORMAT,
     KB_CONTEXTUAL_MAX_TOKENS: process.env.KB_CONTEXTUAL_MAX_TOKENS,
   };
   // Set BEFORE the dynamic import so config/paths.ts reads the right
@@ -104,6 +106,32 @@ describe('resolveContextualPrefaces — LLM call + sidecar', () => {
       chunks: ['c1', 'c2'],
     });
     expect(result).toEqual([null, null]);
+    expect(FETCH_MOCK).not.toHaveBeenCalled();
+  });
+
+  it('generates deterministic prefaces with KB_LLM_FAKE without a real endpoint', async () => {
+    setEnv('KB_LLM_ENDPOINT', undefined);
+    setEnv('KB_LLM_FAKE', 'on');
+    setEnv('KB_LOG_FORMAT', 'text');
+    const { resolveContextualPrefaces } = await loadModule();
+
+    const result = await resolveContextualPrefaces({
+      source: '/tmp/alpha/runbook.md',
+      knowledgeBaseName: 'alpha',
+      documentHash: 'doc-hash-fake',
+      documentBody: [
+        '# Operations Runbook',
+        '',
+        '## Rollback',
+        '',
+        'Rollback approval requires the release lead.',
+      ].join('\n'),
+      chunks: ['Rollback approval requires the release lead.'],
+    });
+
+    expect(result).toEqual([
+      'In section "Rollback", this chunk discusses Rollback approval requires the release lead.',
+    ]);
     expect(FETCH_MOCK).not.toHaveBeenCalled();
   });
 

--- a/src/dev-mockllm-script.test.ts
+++ b/src/dev-mockllm-script.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from '@jest/globals';
+import { spawn, spawnSync, type ChildProcessWithoutNullStreams } from 'child_process';
+import * as net from 'net';
+import * as path from 'path';
+
+const SCRIPT_PATH = path.join(process.cwd(), 'scripts', 'dev-mockllm.mjs');
+
+function runScript(args: string[]): ReturnType<typeof spawnSync> {
+  return spawnSync(
+    process.execPath,
+    ['--enable-source-maps', '--import', 'tsx', SCRIPT_PATH, ...args],
+    { encoding: 'utf-8', env: process.env },
+  );
+}
+
+describe('npm run dev:mockllm script', () => {
+  it('prints help without starting a server', () => {
+    const result = runScript(['--help']);
+    if (result.error) throw result.error;
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('npm run dev:mockllm');
+    expect(result.stdout).toContain('/v1/chat/completions');
+    expect(result.stdout).toContain('--rules=<path>');
+  });
+
+  it('exposes the help path through the package script', () => {
+    const result = spawnSync('npm', ['run', 'dev:mockllm', '--', '--help'], {
+      encoding: 'utf-8',
+      env: process.env,
+    });
+    if (result.error) throw result.error;
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('npm run dev:mockllm');
+    expect(result.stdout).toContain('/v1/chat/completions');
+  });
+
+  it('rejects invalid options', () => {
+    const badPort = runScript(['--port=70000']);
+    if (badPort.error) throw badPort.error;
+    expect(badPort.status).toBe(2);
+    expect(badPort.stderr).toContain('--port must be an integer');
+
+    const badFlag = runScript(['--nope']);
+    if (badFlag.error) throw badFlag.error;
+    expect(badFlag.status).toBe(2);
+    expect(badFlag.stderr).toContain('unknown argument');
+  });
+
+  it('serves health and OpenAI-compatible chat responses', async () => {
+    const port = await getFreePort();
+    const child = spawn(
+      process.execPath,
+      ['--enable-source-maps', '--import', 'tsx', SCRIPT_PATH, `--port=${port}`],
+      { env: process.env },
+    );
+    try {
+      await waitForReady(child);
+      const health = await fetch(`http://127.0.0.1:${port}/health`);
+      expect(health.status).toBe(200);
+      await expect(health.json()).resolves.toMatchObject({ status: 'ok', provider: 'fake' });
+
+      const chat = await fetch(`http://127.0.0.1:${port}/v1/chat/completions`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          messages: [
+            { role: 'system', content: 'Reply with exactly: ok' },
+            { role: 'user', content: 'health check' },
+          ],
+        }),
+      });
+      expect(chat.status).toBe(200);
+      const payload = await chat.json() as { choices: Array<{ message: { content: string } }> };
+      expect(payload.choices[0].message.content).toBe('ok');
+    } finally {
+      child.kill('SIGTERM');
+    }
+  }, 15_000);
+});
+
+function getFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (address === null || typeof address === 'string') {
+        server.close(() => reject(new Error('failed to allocate a TCP port')));
+        return;
+      }
+      server.close(() => resolve(address.port));
+    });
+  });
+}
+
+function waitForReady(child: ChildProcessWithoutNullStreams): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let stdout = '';
+    let stderr = '';
+    const timeout = setTimeout(() => {
+      reject(new Error(`dev:mockllm did not become ready\nstdout:\n${stdout}\nstderr:\n${stderr}`));
+    }, 10_000);
+    child.stdout.on('data', (chunk) => {
+      stdout += String(chunk);
+      if (stdout.includes('Fake LLM server ready.')) {
+        clearTimeout(timeout);
+        resolve();
+      }
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += String(chunk);
+    });
+    child.on('error', (err) => {
+      clearTimeout(timeout);
+      reject(err);
+    });
+    child.on('exit', (code) => {
+      if (!stdout.includes('Fake LLM server ready.')) {
+        clearTimeout(timeout);
+        reject(new Error(`dev:mockllm exited before ready with ${code}\nstderr:\n${stderr}`));
+      }
+    });
+  });
+}

--- a/src/llm-client.test.ts
+++ b/src/llm-client.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from '@jest/globals';
+import { afterEach, describe, expect, it } from '@jest/globals';
 import {
   callChatCompletion,
   deriveHealthUrl,
@@ -7,6 +7,16 @@ import {
 } from './llm-client.js';
 
 describe('llm-client', () => {
+  const savedFake = process.env.KB_LLM_FAKE;
+  const savedLogFormat = process.env.KB_LOG_FORMAT;
+
+  afterEach(() => {
+    if (savedFake === undefined) delete process.env.KB_LLM_FAKE;
+    else process.env.KB_LLM_FAKE = savedFake;
+    if (savedLogFormat === undefined) delete process.env.KB_LOG_FORMAT;
+    else process.env.KB_LOG_FORMAT = savedLogFormat;
+  });
+
   it('normalizes base URLs to chat-completions endpoints', () => {
     expect(normalizeChatEndpoint('http://127.0.0.1:8080')).toBe('http://127.0.0.1:8080/v1/chat/completions');
     expect(normalizeChatEndpoint('http://127.0.0.1:8080/v1/chat/completions')).toBe('http://127.0.0.1:8080/v1/chat/completions');
@@ -28,6 +38,24 @@ describe('llm-client', () => {
     expect(result.model).toBe('local-model');
     const calls = fetchMock.mock.calls as unknown as Array<[string, RequestInit]>;
     expect(calls[0][0]).toBe('http://127.0.0.1:8080/v1/chat/completions');
+  });
+
+  it('uses the in-process fake LLM and skips fetch when KB_LLM_FAKE is on', async () => {
+    process.env.KB_LLM_FAKE = 'on';
+    process.env.KB_LOG_FORMAT = 'text';
+    const fetchMock = jest.fn();
+
+    const result = await callChatCompletion({
+      endpoint: 'http://127.0.0.1:9',
+      messages: [
+        { role: 'system', content: 'Reply with exactly: ok' },
+        { role: 'user', content: 'health check' },
+      ],
+    }, fetchMock as unknown as typeof fetch);
+
+    expect(result.content).toBe('ok');
+    expect(result.model).toBe('kb-fake-llm');
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it('probes health and chat completion', async () => {

--- a/src/llm-client.ts
+++ b/src/llm-client.ts
@@ -1,3 +1,5 @@
+import { callFakeChatCompletion, isFakeLlmEnabled } from './llm-fake-stub.js';
+
 export interface LlmChatMessage {
   role: 'system' | 'user' | 'assistant';
   content: string;
@@ -54,6 +56,10 @@ export async function callChatCompletion(
   options: ChatCompletionOptions,
   fetchImpl: FetchLike = fetch,
 ): Promise<ChatCompletionResult> {
+  if (isFakeLlmEnabled()) {
+    return callFakeChatCompletion(options);
+  }
+
   const endpoint = normalizeChatEndpoint(options.endpoint);
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), options.timeoutMs ?? 180_000);

--- a/src/llm-fake-stub.test.ts
+++ b/src/llm-fake-stub.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from '@jest/globals';
+import * as fsp from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  callFakeChatCompletion,
+  fakeOpenAiChatCompletionResponse,
+  generateFakeChatContent,
+  isFakeLlmEnabled,
+} from './llm-fake-stub.js';
+
+describe('llm fake stub', () => {
+  it('parses on/off environment values', () => {
+    expect(isFakeLlmEnabled({ KB_LLM_FAKE: 'on' } as NodeJS.ProcessEnv)).toBe(true);
+    expect(isFakeLlmEnabled({ KB_LLM_FAKE: 'true' } as NodeJS.ProcessEnv)).toBe(true);
+    expect(isFakeLlmEnabled({ KB_LLM_FAKE: '1' } as NodeJS.ProcessEnv)).toBe(true);
+    expect(isFakeLlmEnabled({ KB_LLM_FAKE: 'off' } as NodeJS.ProcessEnv)).toBe(false);
+  });
+
+  it('returns deterministic relevance judge JSON from prompt content', () => {
+    const content = generateFakeChatContent([
+      {
+        role: 'system',
+        content: 'You judge whether retrieved knowledge-base chunks are relevant to the user task.',
+      },
+      {
+        role: 'user',
+        content: [
+          'Task context:',
+          'answer a deployment rollback question',
+          '',
+          'Query:',
+          'rollback approval',
+          '',
+          'Candidates:',
+          'Candidate 1',
+          'id: ops.md#0',
+          'source: ops.md',
+          'content:',
+          'Rollback approval requires the release lead.',
+          '',
+          '---',
+          '',
+          'Candidate 2',
+          'id: dns.md#0',
+          'source: dns.md',
+          'content:',
+          'DNS cutovers use a 300 second TTL.',
+          '',
+          'JSON shape: {"overall":"relevant|partial|no-relevant-context","verdicts":[]}',
+        ].join('\n'),
+      },
+    ]);
+
+    expect(JSON.parse(content)).toEqual({
+      overall: 'relevant',
+      verdicts: [
+        { id: 'ops.md#0', decision: 'keep', reason: 'rollback match' },
+        { id: 'dns.md#0', decision: 'drop', reason: 'dns lacks query match' },
+      ],
+    });
+  });
+
+  it('derives contextual prefaces from the nearest markdown heading', () => {
+    const content = generateFakeChatContent([
+      {
+        role: 'system',
+        content: 'You generate short retrieval-aware context strings. Reply with the context only.',
+      },
+      {
+        role: 'user',
+        content: [
+          '<document>',
+          '# Runbook',
+          '',
+          '## Rollback',
+          '',
+          'Rollback approval requires the release lead.',
+          '</document>',
+          '',
+          'Here is one chunk from the document above:',
+          '<chunk>',
+          'Rollback approval requires the release lead.',
+          '</chunk>',
+        ].join('\n'),
+      },
+    ]);
+
+    expect(content).toBe('In section "Rollback", this chunk discusses Rollback approval requires the release lead.');
+  });
+
+  it('returns an OpenAI-compatible response envelope for the mock server', () => {
+    const response = fakeOpenAiChatCompletionResponse({
+      messages: [
+        { role: 'system', content: 'Reply with exactly: ok' },
+        { role: 'user', content: 'health check' },
+      ],
+    });
+
+    expect(response).toMatchObject({
+      object: 'chat.completion',
+      model: 'kb-fake-llm',
+      choices: [
+        {
+          message: { role: 'assistant', content: 'ok' },
+        },
+      ],
+    });
+  });
+
+  it('loads KB_LLM_FAKE_RULES overrides for fake chat completions', async () => {
+    const dir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-fake-llm-rules-'));
+    try {
+      const rulesPath = path.join(dir, 'rules.json');
+      await fsp.writeFile(rulesPath, JSON.stringify({
+        answers: [
+          { question_contains: 'release owner', answer: 'The release owner is Ada.' },
+        ],
+      }));
+
+      const result = await callFakeChatCompletion({
+        endpoint: 'mock://ignored',
+        model: 'ignored',
+        messages: [
+          {
+            role: 'system',
+            content: 'Answer only from the provided knowledge-base snippets.',
+          },
+          {
+            role: 'user',
+            content: [
+              'Question:',
+              'Who is the release owner?',
+              '',
+              'Retrieved snippets:',
+              'Snippet 1',
+              'Score: 0.9',
+              'Metadata: {"relativePath":"runbook.md"}',
+              'Content:',
+              'The fallback owner is Grace.',
+            ].join('\n'),
+          },
+        ],
+      }, { KB_LLM_FAKE_RULES: rulesPath } as NodeJS.ProcessEnv);
+
+      expect(result.content).toBe('The release owner is Ada.');
+    } finally {
+      await fsp.rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/llm-fake-stub.ts
+++ b/src/llm-fake-stub.ts
@@ -1,0 +1,415 @@
+import * as fsp from 'fs/promises';
+import { emitCanonicalLog } from './canonical-log.js';
+import type {
+  ChatCompletionOptions,
+  ChatCompletionResult,
+  LlmChatMessage,
+} from './llm-client.js';
+
+export const FAKE_LLM_ENDPOINT = 'mock://kb-llm-fake/v1/chat/completions';
+const FAKE_LLM_MODEL = 'kb-fake-llm';
+
+interface FakeResponseRule {
+  contains?: string;
+  system_contains?: string;
+  user_contains?: string;
+  content: string;
+}
+
+interface FakeAnswerRule {
+  question_contains: string;
+  answer: string;
+}
+
+interface FakePrefaceRule {
+  chunk_contains: string;
+  preface: string;
+}
+
+interface FakeJudgeRule {
+  query_contains: string;
+  overall?: 'relevant' | 'partial' | 'no-relevant-context';
+  keep_contains?: string[];
+  drop_contains?: string[];
+}
+
+export interface FakeLlmRules {
+  responses?: FakeResponseRule[];
+  answers?: FakeAnswerRule[];
+  prefaces?: FakePrefaceRule[];
+  judge?: FakeJudgeRule[];
+  default_response?: string;
+}
+
+interface FakeOpenAiRequest {
+  model?: unknown;
+  messages?: unknown;
+  temperature?: unknown;
+}
+
+interface ParsedCandidate {
+  id: string;
+  content: string;
+}
+
+const STOP_WORDS = new Set([
+  'about',
+  'after',
+  'again',
+  'also',
+  'answer',
+  'chunk',
+  'context',
+  'does',
+  'from',
+  'have',
+  'into',
+  'only',
+  'please',
+  'query',
+  'retrieved',
+  'snippets',
+  'that',
+  'their',
+  'there',
+  'this',
+  'with',
+  'would',
+]);
+
+export function isFakeLlmEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const raw = env.KB_LLM_FAKE?.trim().toLowerCase();
+  return raw === 'on' || raw === 'true' || raw === '1' || raw === 'yes';
+}
+
+export async function callFakeChatCompletion(
+  options: ChatCompletionOptions,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<ChatCompletionResult> {
+  const startedAt = Date.now();
+  const rules = await loadFakeLlmRules(env);
+  const content = generateFakeChatContent(options.messages, rules);
+  const raw = fakeOpenAiChatCompletionResponse({
+    model: options.model ?? FAKE_LLM_MODEL,
+    messages: options.messages,
+    temperature: options.temperature,
+  }, rules);
+  emitCanonicalLog({
+    process: 'cli',
+    event: 'llm.fake.chat',
+    cmd: 'llm.fake.chat',
+    model_id: FAKE_LLM_MODEL,
+    llm_provider: 'fake',
+    took_ms: Date.now() - startedAt,
+  });
+  return {
+    content,
+    model: FAKE_LLM_MODEL,
+    raw,
+  };
+}
+
+async function loadFakeLlmRules(env: NodeJS.ProcessEnv = process.env): Promise<FakeLlmRules> {
+  const rulesPath = env.KB_LLM_FAKE_RULES?.trim();
+  if (!rulesPath) return {};
+  const raw = await fsp.readFile(rulesPath, 'utf-8');
+  const parsed = JSON.parse(raw) as unknown;
+  if (!isFakeLlmRules(parsed)) {
+    throw new Error(`invalid KB_LLM_FAKE_RULES file: ${rulesPath}`);
+  }
+  return parsed;
+}
+
+export function fakeOpenAiChatCompletionResponse(
+  request: FakeOpenAiRequest,
+  rules: FakeLlmRules = {},
+): Record<string, unknown> {
+  const messages = parseMessages(request.messages);
+  const content = generateFakeChatContent(messages, rules);
+  return {
+    id: 'chatcmpl-kb-fake',
+    object: 'chat.completion',
+    created: 0,
+    model: FAKE_LLM_MODEL,
+    choices: [
+      {
+        index: 0,
+        finish_reason: 'stop',
+        message: {
+          role: 'assistant',
+          content,
+        },
+      },
+    ],
+    usage: {
+      prompt_tokens: estimateTokens(messages.map((message) => message.content).join('\n')),
+      completion_tokens: estimateTokens(content),
+      total_tokens: estimateTokens(messages.map((message) => message.content).join('\n')) + estimateTokens(content),
+    },
+  };
+}
+
+export function generateFakeChatContent(
+  messages: readonly LlmChatMessage[],
+  rules: FakeLlmRules = {},
+): string {
+  const system = messages.filter((message) => message.role === 'system').map((message) => message.content).join('\n');
+  const user = [...messages].reverse().find((message) => message.role === 'user')?.content ?? '';
+  const combined = `${system}\n${user}`;
+
+  const responseOverride = matchResponseOverride(rules.responses ?? [], system, user, combined);
+  if (responseOverride !== null) return responseOverride;
+
+  if (/reply with exactly:\s*ok/i.test(combined)) return 'ok';
+  if (/judge whether retrieved knowledge-base chunks are relevant/i.test(system)) {
+    return JSON.stringify(buildJudgeResponse(user, rules));
+  }
+  if (/generate short retrieval-aware context strings/i.test(system) || user.includes('<chunk>')) {
+    return buildPrefaceResponse(user, rules);
+  }
+  if (/Answer only from the provided knowledge-base snippets/i.test(system) || user.includes('Retrieved snippets:')) {
+    return buildAskResponse(user, rules);
+  }
+  return rules.default_response ?? 'Fake LLM response from kb-fake-llm.';
+}
+
+function matchResponseOverride(
+  rules: FakeResponseRule[],
+  system: string,
+  user: string,
+  combined: string,
+): string | null {
+  for (const rule of rules) {
+    if (rule.contains !== undefined && !includesFolded(combined, rule.contains)) continue;
+    if (rule.system_contains !== undefined && !includesFolded(system, rule.system_contains)) continue;
+    if (rule.user_contains !== undefined && !includesFolded(user, rule.user_contains)) continue;
+    return rule.content;
+  }
+  return null;
+}
+
+function buildJudgeResponse(user: string, rules: FakeLlmRules): {
+  overall: 'relevant' | 'partial' | 'no-relevant-context';
+  verdicts: Array<{ id: string; decision: 'keep' | 'drop'; reason: string }>;
+} {
+  const query = extractSection(user, 'Query:', 'Candidates:');
+  const taskContext = extractSection(user, 'Task context:', 'Query:');
+  const queryHaystack = `${taskContext}\n${query}`;
+  const candidates = parseJudgeCandidates(user);
+  const rule = (rules.judge ?? []).find((entry) => includesFolded(queryHaystack, entry.query_contains));
+  const terms = importantTerms(queryHaystack);
+  let kept = 0;
+
+  const verdicts = candidates.map((candidate) => {
+    const contentLower = candidate.content.toLowerCase();
+    const ruleDecision = ruleDecisionForCandidate(rule, contentLower);
+    const matchedTerm = terms.find((term) => contentLower.includes(term));
+    const keep = ruleDecision ?? (matchedTerm !== undefined || terms.length === 0);
+    if (keep) kept += 1;
+    return {
+      id: candidate.id,
+      decision: keep ? 'keep' as const : 'drop' as const,
+      reason: keep
+        ? `${matchedTerm ?? firstContentTerm(candidate.content) ?? 'content'} match`
+        : `${firstContentTerm(candidate.content) ?? 'content'} lacks query match`,
+    };
+  });
+
+  const overall = rule?.overall ?? (
+    kept === 0
+      ? 'no-relevant-context'
+      : 'relevant'
+  );
+  return { overall, verdicts };
+}
+
+function ruleDecisionForCandidate(rule: FakeJudgeRule | undefined, contentLower: string): boolean | undefined {
+  if (rule === undefined) return undefined;
+  if (rule.keep_contains && rule.keep_contains.length > 0) {
+    return rule.keep_contains.some((term) => contentLower.includes(term.toLowerCase()));
+  }
+  if (rule.drop_contains && rule.drop_contains.length > 0) {
+    return !rule.drop_contains.some((term) => contentLower.includes(term.toLowerCase()));
+  }
+  return true;
+}
+
+function parseJudgeCandidates(user: string): ParsedCandidate[] {
+  const rows: ParsedCandidate[] = [];
+  const regex = /id:\s*([^\n]+)\nsource:\s*[^\n]*\ncontent:\n([\s\S]*?)(?=\n\n---\n\nCandidate \d+|\n\nJSON shape:|$)/g;
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(user)) !== null) {
+    rows.push({
+      id: match[1].trim(),
+      content: match[2].trim(),
+    });
+  }
+  return rows;
+}
+
+function buildPrefaceResponse(user: string, rules: FakeLlmRules): string {
+  const chunk = extractTagged(user, 'chunk');
+  const rule = (rules.prefaces ?? []).find((entry) => includesFolded(chunk, entry.chunk_contains));
+  if (rule !== undefined) return rule.preface;
+
+  const documentBody = extractTagged(user, 'document');
+  const heading = nearestHeading(documentBody, chunk);
+  const topic = firstSentence(chunk) ?? firstContentTerm(chunk) ?? 'the selected passage';
+  const punctuation = /[.!?]$/.test(topic) ? '' : '.';
+  return `In ${heading}, this chunk discusses ${topic}${punctuation}`;
+}
+
+function buildAskResponse(user: string, rules: FakeLlmRules): string {
+  const question = extractSection(user, 'Question:', 'Retrieved snippets:');
+  const answerRule = (rules.answers ?? []).find((entry) => includesFolded(question, entry.question_contains));
+  if (answerRule !== undefined) return answerRule.answer;
+  if (user.includes('(no snippets retrieved)')) {
+    return 'I do not have enough retrieved context to answer that from the knowledge base.';
+  }
+  const snippet = parseFirstAskSnippet(user);
+  if (snippet === null) {
+    return 'I do not have enough retrieved context to answer that from the knowledge base.';
+  }
+  const sentence = firstSentence(snippet.content) ?? snippet.content.slice(0, 160).trim();
+  const source = snippet.path === null ? 'the retrieved snippet' : snippet.path;
+  return `Fake answer: ${sentence} Source: ${source}.`;
+}
+
+function parseFirstAskSnippet(user: string): { path: string | null; content: string } | null {
+  const match = user.match(/Snippet 1\nScore:[^\n]*\nMetadata:\s*([^\n]+)\nContent:\n([\s\S]*?)(?=\n\n---\n\nSnippet \d+|$)/);
+  if (match === null) return null;
+  let pathValue: string | null = null;
+  try {
+    const metadata = JSON.parse(match[1]) as { relativePath?: unknown; source?: unknown; knowledgeBase?: unknown };
+    const path = typeof metadata.relativePath === 'string'
+      ? metadata.relativePath
+      : typeof metadata.source === 'string'
+        ? metadata.source
+        : null;
+    pathValue = typeof metadata.knowledgeBase === 'string' && path !== null
+      ? `${metadata.knowledgeBase}:${path}`
+      : path;
+  } catch {
+    pathValue = null;
+  }
+  return { path: pathValue, content: match[2].trim() };
+}
+
+function nearestHeading(documentBody: string, chunk: string): string {
+  const index = chunk.trim() === '' ? -1 : documentBody.indexOf(chunk);
+  const prefix = index >= 0 ? documentBody.slice(0, index) : documentBody;
+  const headings = [...prefix.matchAll(/^#{1,6}\s+(.+)$/gm)].map((match) => match[1].trim());
+  const heading = headings.at(-1) ?? [...documentBody.matchAll(/^#{1,6}\s+(.+)$/gm)].at(0)?.[1]?.trim();
+  return heading ? `section "${heading}"` : 'the source document';
+}
+
+function extractSection(input: string, startMarker: string, endMarker: string): string {
+  const start = input.indexOf(startMarker);
+  if (start < 0) return '';
+  const contentStart = start + startMarker.length;
+  const end = input.indexOf(endMarker, contentStart);
+  return (end < 0 ? input.slice(contentStart) : input.slice(contentStart, end)).trim();
+}
+
+function extractTagged(input: string, tag: string): string {
+  const match = input.match(new RegExp(`<${tag}>\\n([\\s\\S]*?)\\n</${tag}>`));
+  return match?.[1]?.trim() ?? '';
+}
+
+function parseMessages(value: unknown): LlmChatMessage[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((entry): LlmChatMessage[] => {
+    if (typeof entry !== 'object' || entry === null) return [];
+    const role = (entry as { role?: unknown }).role;
+    const content = (entry as { content?: unknown }).content;
+    if ((role !== 'system' && role !== 'user' && role !== 'assistant') || typeof content !== 'string') {
+      return [];
+    }
+    return [{ role, content }];
+  });
+}
+
+function isFakeLlmRules(value: unknown): value is FakeLlmRules {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+  const v = value as Record<string, unknown>;
+  return (
+    optionalArray(v.responses, isFakeResponseRule) &&
+    optionalArray(v.answers, isFakeAnswerRule) &&
+    optionalArray(v.prefaces, isFakePrefaceRule) &&
+    optionalArray(v.judge, isFakeJudgeRule) &&
+    (v.default_response === undefined || typeof v.default_response === 'string')
+  );
+}
+
+function isFakeResponseRule(value: unknown): value is FakeResponseRule {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.content === 'string' &&
+    (v.contains === undefined || typeof v.contains === 'string') &&
+    (v.system_contains === undefined || typeof v.system_contains === 'string') &&
+    (v.user_contains === undefined || typeof v.user_contains === 'string')
+  );
+}
+
+function isFakeAnswerRule(value: unknown): value is FakeAnswerRule {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return typeof v.question_contains === 'string' && typeof v.answer === 'string';
+}
+
+function isFakePrefaceRule(value: unknown): value is FakePrefaceRule {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return typeof v.chunk_contains === 'string' && typeof v.preface === 'string';
+}
+
+function isFakeJudgeRule(value: unknown): value is FakeJudgeRule {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.query_contains === 'string' &&
+    (v.overall === undefined || v.overall === 'relevant' || v.overall === 'partial' || v.overall === 'no-relevant-context') &&
+    optionalStringArray(v.keep_contains) &&
+    optionalStringArray(v.drop_contains)
+  );
+}
+
+function optionalArray<T>(value: unknown, guard: (entry: unknown) => entry is T): boolean {
+  return value === undefined || (Array.isArray(value) && value.every(guard));
+}
+
+function optionalStringArray(value: unknown): boolean {
+  return value === undefined || (Array.isArray(value) && value.every((entry) => typeof entry === 'string'));
+}
+
+function includesFolded(haystack: string, needle: string): boolean {
+  return haystack.toLowerCase().includes(needle.toLowerCase());
+}
+
+function importantTerms(input: string): string[] {
+  return input
+    .replace(/<[^>]+>/g, ' ')
+    .toLowerCase()
+    .match(/[a-z0-9_/-]{3,}/g)
+    ?.filter((term) => !STOP_WORDS.has(term)) ?? [];
+}
+
+function firstContentTerm(input: string): string | null {
+  return importantTerms(input)[0] ?? null;
+}
+
+function firstSentence(input: string): string | null {
+  const cleaned = input
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (cleaned === '') return null;
+  const match = cleaned.match(/^(.{1,220}?[.!?])(?:\s|$)/);
+  return (match?.[1] ?? cleaned.slice(0, 180)).trim();
+}
+
+function estimateTokens(input: string): number {
+  const trimmed = input.trim();
+  return trimmed === '' ? 0 : Math.max(1, Math.ceil(trimmed.length / 4));
+}

--- a/src/relevance-gate.test.ts
+++ b/src/relevance-gate.test.ts
@@ -200,6 +200,52 @@ describe('relevance gate', () => {
     expect(result.verdict.judge.reason).toContain('degraded to A2');
   });
 
+  it('uses KB_LLM_FAKE as an offline Stage B judge without a configured endpoint', async () => {
+    const previousFake = process.env.KB_LLM_FAKE;
+    const previousEndpoint = process.env.KB_LLM_ENDPOINT;
+    const previousGateEndpoint = process.env.KB_GATE_LLM_ENDPOINT;
+    const previousLogFormat = process.env.KB_LOG_FORMAT;
+    try {
+      process.env.KB_LLM_FAKE = 'on';
+      process.env.KB_LOG_FORMAT = 'text';
+      delete process.env.KB_LLM_ENDPOINT;
+      delete process.env.KB_GATE_LLM_ENDPOINT;
+
+      const rows = [
+        candidate('/kb/rollback.md', 0, 0.1, 'rollback approval requires the release lead'),
+        candidate('/kb/dns.md', 0, 0.1, 'dns cutovers use a 300 second ttl'),
+      ];
+      const result = await applyRelevanceGate({
+        query: 'offline fake judge rollback approval',
+        taskContext: 'answer a deployment rollback approval question with precise operational context',
+        candidates: rows,
+        gateOverride: 'on',
+      });
+
+      expect(result.results).toEqual([rows[0]]);
+      expect(result.verdict.judge).toMatchObject({
+        status: 'succeeded',
+        model: 'kb-fake-llm',
+      });
+      expect(result.verdict.dropped).toEqual([
+        {
+          id: '/kb/dns.md#0',
+          stage: 'B-judge',
+          reason: 'dns lacks query match',
+        },
+      ]);
+    } finally {
+      if (previousFake === undefined) delete process.env.KB_LLM_FAKE;
+      else process.env.KB_LLM_FAKE = previousFake;
+      if (previousEndpoint === undefined) delete process.env.KB_LLM_ENDPOINT;
+      else process.env.KB_LLM_ENDPOINT = previousEndpoint;
+      if (previousGateEndpoint === undefined) delete process.env.KB_GATE_LLM_ENDPOINT;
+      else process.env.KB_GATE_LLM_ENDPOINT = previousGateEndpoint;
+      if (previousLogFormat === undefined) delete process.env.KB_LOG_FORMAT;
+      else process.env.KB_LOG_FORMAT = previousLogFormat;
+    }
+  });
+
   it('parses fenced JSON, keeps partial verdicts, and downgrades contentless drops', async () => {
     const rows = [
       candidate('/kb/a.md', 0, 0.1, 'contains timeout retry budget'),


### PR DESCRIPTION
Closes #465.

## Summary
- add KB_LLM_FAKE=on in-process fake chat-completions responder shared by relevance gate, contextual prefaces, and kb ask
- add npm run dev:mockllm standalone OpenAI-compatible mock server
- document fake rules and add targeted coverage for judge, preface, ask, and server paths

## Verification
- npm run build
- npx jest --runInBand src/llm-fake-stub.test.ts src/llm-client.test.ts src/relevance-gate.test.ts src/contextual-preface.test.ts src/cli-ask.test.ts src/dev-mockllm-script.test.ts
- npm test