### PR TITLE
feat(index): add opt-in SQ8 FAISS indexes

### DIFF
--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -144,6 +144,7 @@ wrap-close vars below.
 | Splitter chunk size | `KB_CHUNK_SIZE` | `1000` | Ingest and refresh | Implemented | none | `KB_CHUNK_SIZE=500 kb search "query" --refresh` |
 | Splitter chunk overlap | `KB_CHUNK_OVERLAP` | `200` (auto-scales as `floor(chunkSize/5)` when only `KB_CHUNK_SIZE` is set) | Ingest and refresh | Implemented | none | `KB_CHUNK_SIZE=500 KB_CHUNK_OVERLAP=100 kb search "query" --refresh` |
 | Indexing batch size | `INDEXING_BATCH_SIZE` | `64` (Ollama: `16`) | Embedding ingest | Implemented | none | `INDEXING_BATCH_SIZE=32 kb search "query" --refresh` |
+| FAISS index type | `KB_INDEX_TYPE=flat\|sq8`, or `kb models add --index-type=flat\|sq8` | `flat` | Per-model FAISS index creation | Implemented, opt-in SQ8 | model registration flag | `KB_INDEX_TYPE=sq8 kb models add ollama nomic-embed-text --dry-run` |
 | Filesystem watcher | `KB_FS_WATCH` | off | KB root watcher (auto-refresh on file change) | Implemented, opt-in | none | `KB_FS_WATCH=1 node build/index.js` |
 | FS watcher debounce | `KB_FS_WATCH_DEBOUNCE_MS` | `250` | KB root watcher | Implemented | none | `KB_FS_WATCH=1 KB_FS_WATCH_DEBOUNCE_MS=500 node build/index.js` |
 | Index version retention | `KB_INDEX_VERSION_RETENTION` | `2` | FAISS version rotation | Implemented | none | `KB_INDEX_VERSION_RETENTION=4 kb reindex --with-context` |

--- a/docs/operations/index-quantization.md
+++ b/docs/operations/index-quantization.md
@@ -1,0 +1,40 @@
+# FAISS Index Quantization
+
+The default FAISS index type is `flat`, which preserves the existing exact
+IndexFlatL2 behavior. `sq8` is an opt-in scalar-quantized index for corpora
+where vector memory is the bottleneck and a small recall trade-off is
+acceptable.
+
+## Enable SQ8
+
+For a new model, use either the environment default:
+
+```bash
+KB_INDEX_TYPE=sq8 kb models add ollama nomic-embed-text --yes
+```
+
+or an explicit per-model registration flag:
+
+```bash
+kb models add ollama nomic-embed-text --index-type=sq8 --yes
+```
+
+Existing models keep their current index until rebuilt. To change an existing
+model, remove and re-add it or build a fresh model id, then run the same
+retrieval evaluation fixture against the flat and SQ8 versions before making it
+active.
+
+## Verify
+
+```bash
+kb stats
+kb stats --format=json
+```
+
+The stats payload exposes `embedding.index_type`; markdown output prints
+`Index type: flat` or `Index type: sq8`.
+
+Use `kb eval` on the same fixture before and after SQ8. Promote only if the
+Recall@K delta is acceptable for the shelf. SQ8 is most appropriate for large,
+memory-bound corpora; keep `flat` for small corpora or recall-sensitive
+retrieval.

--- a/src/FaissIndexManager.ts
+++ b/src/FaissIndexManager.ts
@@ -27,7 +27,9 @@ import {
   resolveRefreshQuiesceMs,
 } from './config/ingest.js';
 import {
+  resolveFaissIndexType,
   resolveIndexingBatchSize,
+  type FaissIndexType,
 } from './config/indexing.js';
 import { casRootForIndexPath } from './docstore-cas.js';
 import {
@@ -35,6 +37,7 @@ import {
   computeLegacyEnvModelSpec,
   modelDir,
   modelNameFilePath,
+  writeIndexTypeAtomic,
 } from './active-model.js';
 import { deriveModelId, EmbeddingProvider } from './model-id.js';
 import { logger } from './logger.js';
@@ -215,6 +218,7 @@ function totalFileCount(
 export interface FaissIndexManagerOptions {
   provider: EmbeddingProvider;
   modelName: string;
+  indexType?: FaissIndexType;
 }
 
 export interface IndexUpdateProgress {
@@ -540,6 +544,7 @@ export class FaissIndexManager {
   readonly modelDir: string;
   readonly modelNameFile: string;
   private readonly indexingBatchSize: number;
+  private readonly indexType: FaissIndexType;
   private lastIndexUpdateSummary: IndexUpdateSummary;
   // Issue #283 — cached metadata sidecar so we don't re-parse the JSONL
   // file on every query. Invalidated whenever updateIndex rewrites it,
@@ -574,6 +579,7 @@ export class FaissIndexManager {
     this.modelDir = modelDir(this.modelId);
     this.modelNameFile = modelNameFilePath(this.modelId);
     this.indexingBatchSize = resolveIndexingBatchSize(this.embeddingProvider);
+    this.indexType = opts?.indexType ?? resolveFaissIndexType();
     this.lastIndexUpdateSummary = createNeverRunIndexUpdateSummary(this.modelId);
 
     // Issue #59 — embeddings are constructed lazily inside initialize() so
@@ -751,6 +757,7 @@ export class FaissIndexManager {
       if (!readOnly) {
         try {
           await writeModelNameAtomic(this.modelNameFile, this.modelName);
+          await writeIndexTypeAtomic(this.modelId, this.indexType);
         } catch (error) {
           handleFsOperationError('persist embedding model metadata in', this.modelNameFile, error);
         }
@@ -1162,6 +1169,7 @@ export class FaissIndexManager {
       modelDir: this.modelDir,
       modelId: this.modelId,
       swapCounter: this.swapCounter,
+      indexType: this.indexType,
       casRoot: casRootForIndexPath(FAISS_INDEX_PATH),
       onCommitted: opts.onCommitted,
     });
@@ -1205,6 +1213,7 @@ export class FaissIndexManager {
         this.faissIndex = await FaissStoreAdapter.fromDocuments(
           batch,
           indexingEmbeddings,
+          { indexType: this.indexType },
         );
         // The store must keep the real client for query embeddings and later
         // operations; the deduper is only an insertion-time wrapper.
@@ -2641,14 +2650,15 @@ export class FaissIndexManager {
     totalChunks: number;
     chunkCountsByKb: Record<string, number>;
     dim: number | null;
+    indexType: FaissIndexType;
   } {
     if (!this.faissIndex) {
-      return { totalChunks: 0, chunkCountsByKb: {}, dim: null };
+      return { totalChunks: 0, chunkCountsByKb: {}, dim: null, indexType: this.indexType };
     }
     const totalChunks = this.faissIndex.totalVectors();
     const dim = this.faissIndex.vectorDimension();
     const chunkCountsByKb = this.faissIndex.chunkCountsByKnowledgeBase();
-    return { totalChunks, chunkCountsByKb, dim };
+    return { totalChunks, chunkCountsByKb, dim, indexType: this.indexType };
   }
 
   private getDocstoreDocuments(): Document[] {

--- a/src/active-model.test.ts
+++ b/src/active-model.test.ts
@@ -83,6 +83,19 @@ describe('active-model: writeActiveModelAtomic / robust reader', () => {
     await expect(writeActiveModelAtomic('Invalid Model')).rejects.toThrow(/invalid model_id/i);
   });
 
+  it('stores per-model index type and defaults old models to flat', async () => {
+    jest.resetModules();
+    const { readStoredIndexType, writeIndexTypeAtomic } = await import('./active-model.js');
+    await seedRegistered(faissDir);
+
+    expect(await readStoredIndexType(REGISTERED_ID)).toBe('flat');
+
+    await writeIndexTypeAtomic(REGISTERED_ID, 'sq8');
+    expect(await fsp.readFile(path.join(faissDir, 'models', REGISTERED_ID, 'index-type.txt'), 'utf-8'))
+      .toBe('sq8\n');
+    expect(await readStoredIndexType(REGISTERED_ID)).toBe('sq8');
+  });
+
   it('robust reader strips trailing newline / CRLF', async () => {
     jest.resetModules();
     const { resolveActiveModel } = await import('./active-model.js');

--- a/src/active-model.ts
+++ b/src/active-model.ts
@@ -28,6 +28,7 @@ import {
   parseIndexVersionDirName,
   resolveIndexVersionRetention,
 } from './faiss-store-layout.js';
+import { resolveFaissIndexType, type FaissIndexType } from './config/indexing.js';
 
 const ACTIVE_FILE = path.join(FAISS_INDEX_PATH, 'active.txt');
 const MODELS_DIR = path.join(FAISS_INDEX_PATH, 'models');
@@ -180,6 +181,10 @@ async function directorySizeBytes(dir: string): Promise<number> {
 
 export function modelNameFilePath(modelId: string): string {
   return path.join(modelDir(modelId), 'model_name.txt');
+}
+
+export function indexTypeFilePath(modelId: string): string {
+  return path.join(modelDir(modelId), 'index-type.txt');
 }
 
 export function addingSentinelPath(modelId: string): string {
@@ -411,6 +416,22 @@ export async function readStoredModelName(modelId: string): Promise<string | nul
     if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null;
     throw err;
   }
+}
+
+export async function readStoredIndexType(modelId: string): Promise<FaissIndexType> {
+  try {
+    return resolveFaissIndexType(await fsp.readFile(indexTypeFilePath(modelId), 'utf-8'));
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return 'flat';
+    throw err;
+  }
+}
+
+export async function writeIndexTypeAtomic(modelId: string, indexType: FaissIndexType): Promise<void> {
+  const target = indexTypeFilePath(modelId);
+  const tmp = `${target}.${process.pid}.tmp`;
+  await fsp.writeFile(tmp, `${indexType}\n`, 'utf-8');
+  await fsp.rename(tmp, target);
 }
 
 /**

--- a/src/cli-models.ts
+++ b/src/cli-models.ts
@@ -13,6 +13,7 @@ import {
   writeAddingSentinel,
   writeActiveModelAtomic,
 } from './active-model.js';
+import { resolveFaissIndexType, type FaissIndexType } from './config/indexing.js';
 import { deriveModelId, type EmbeddingProvider } from './model-id.js';
 import { KNOWLEDGE_BASES_ROOT_DIR } from './config/paths.js';
 import { enumerateIngestableKbFiles, listKnowledgeBases } from './kb-fs.js';
@@ -24,7 +25,7 @@ export const MODELS_HELP = `kb models — manage embedding models (RFC 013)
 
 Usage:
   kb models list
-  kb models add <provider> <model> [--yes] [--dry-run] [--recover]
+  kb models add <provider> <model> [--index-type=flat|sq8] [--yes] [--dry-run] [--recover]
   kb models set-active <id>
   kb models remove <id>
 
@@ -57,6 +58,8 @@ Options for \`add\`:
   --recover             When a previous add left a stale .adding sentinel
                         whose writer PID is dead, delete that incomplete
                         model directory before retrying. Requires --yes.
+  --index-type=flat|sq8 Select the FAISS index type for this model. Default
+                        is KB_INDEX_TYPE when set, otherwise flat.
 
 Global:
   --help, -h            Show this help.
@@ -127,10 +130,22 @@ async function runModelsAdd(rest: string[]): Promise<number> {
   let yes = false;
   let dryRun = false;
   let recover = false;
+  let indexType: FaissIndexType = resolveFaissIndexType();
   for (const raw of rest) {
     if (raw === '--yes') { yes = true; continue; }
     if (raw === '--dry-run') { dryRun = true; continue; }
     if (raw === '--recover') { recover = true; continue; }
+    if (raw.startsWith('--index-type=')) {
+      const value = raw.slice('--index-type='.length);
+      const normalized = value.trim().toLowerCase();
+      const parsed = resolveFaissIndexType(value);
+      if (normalized !== parsed) {
+        process.stderr.write(`kb models add: invalid --index-type: ${raw}\n`);
+        return 2;
+      }
+      indexType = parsed;
+      continue;
+    }
     if (raw.startsWith('--')) {
       process.stderr.write(`kb models add: unknown flag: ${raw}\n`);
       return 2;
@@ -221,6 +236,7 @@ async function runModelsAdd(rest: string[]): Promise<number> {
                 : estChunks * 0.3;
   process.stderr.write(
     `Adding model: ${modelId} (provider=${provider}, model=${modelName})\n` +
+    `Index type: ${indexType}\n` +
     `Will embed: ${fileCount} files (~${estChunks} chunks, ~${(totalBytes / 1024).toFixed(0)} KB of text, ~${(estTokens / 1000).toFixed(0)}k tokens)\n` +
     costLine +
     `Estimated wall time: ~${wallSec < 60 ? wallSec.toFixed(0) + ' s' : (wallSec / 60).toFixed(1) + ' min'} (HTTP latency dominated)\n`,
@@ -256,6 +272,7 @@ async function runModelsAdd(rest: string[]): Promise<number> {
       const manager = new FaissIndexManager({
         provider: provider as EmbeddingProvider,
         modelName,
+        indexType,
       });
       await manager.initialize();
       await manager.updateIndex();

--- a/src/cli-shared.ts
+++ b/src/cli-shared.ts
@@ -1,5 +1,5 @@
 import { FaissIndexManager } from './FaissIndexManager.js';
-import { parseModelId, readStoredModelName } from './active-model.js';
+import { parseModelId, readStoredIndexType, readStoredModelName } from './active-model.js';
 import type { EmbeddingProvider } from './model-id.js';
 import { logger } from './logger.js';
 
@@ -19,6 +19,7 @@ export async function loadManagerForModel(modelId: string): Promise<FaissIndexMa
   return new FaissIndexManager({
     provider: provider as EmbeddingProvider,
     modelName,
+    indexType: await readStoredIndexType(modelId),
   });
 }
 

--- a/src/cli-stats.test.ts
+++ b/src/cli-stats.test.ts
@@ -192,6 +192,7 @@ describe('kb stats CLI', () => {
     expect(out).toContain('| beta | 1 | 3 | 100 | never |');
     expect(out).toContain('- Provider: ollama');
     expect(out).toContain('- Model: nomic-embed-text:latest');
+    expect(out).toContain('- Index type: flat');
     expect(out).toContain('- Index path: `/tmp/kb-index`');
     expect(out).toContain('## Relevance Gate');
     expect(out).toContain('- Gated queries: 0');

--- a/src/cli-stats.ts
+++ b/src/cli-stats.ts
@@ -158,6 +158,7 @@ export function formatStatsMarkdown(payload: KbStatsPayload): string {
     `- Provider: ${payload.embedding.provider}`,
     `- Model: ${payload.embedding.model}`,
     `- Dimensions: ${dim}`,
+    `- Index type: ${payload.embedding.index_type ?? 'flat'}`,
     `- Index path: \`${payload.index_path}\``,
     `- Server version: ${payload.server.version}`,
     `- Uptime: ${formatInteger(uptimeMs)} ms`,

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -2219,9 +2219,34 @@ describe('kb search — active-model resolution (RFC 013 §4.7)', () => {
       });
       expect(r.code).toBe(0);
       expect(r.stderr).toContain('Adding model: ollama__nomic-embed-text');
+      expect(r.stderr).toContain('Index type: flat');
       expect(r.stderr).toContain('Will embed:');
       expect(r.stderr).toContain('--dry-run');
       // No directory created.
+      await expect(fsp.access(path.join(faissDir, 'models'))).rejects.toMatchObject({ code: 'ENOENT' });
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('kb models add accepts an SQ8 index type override', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-cli-add-sq8-dryrun-'));
+    try {
+      const faissDir = path.join(tempDir, '.faiss');
+      await fsp.mkdir(faissDir, { recursive: true });
+      const kbDir = path.join(tempDir, 'kb');
+      await fsp.mkdir(path.join(kbDir, 'sample'), { recursive: true });
+      await fsp.writeFile(path.join(kbDir, 'sample', 'doc.md'), '# t\n\nbody');
+
+      const r = runCli(['models', 'add', 'ollama', 'nomic-embed-text', '--index-type=SQ8', '--dry-run'], {
+        KNOWLEDGE_BASES_ROOT_DIR: kbDir,
+        FAISS_INDEX_PATH: faissDir,
+        EMBEDDING_PROVIDER: 'ollama',
+        OLLAMA_MODEL: 'nomic-embed-text',
+      });
+
+      expect(r.code).toBe(0);
+      expect(r.stderr).toContain('Index type: sq8');
       await expect(fsp.access(path.join(faissDir, 'models'))).rejects.toMatchObject({ code: 'ENOENT' });
     } finally {
       await fsp.rm(tempDir, { recursive: true, force: true });

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -4,6 +4,7 @@ import {
   parseKbMaxFileBytes,
 } from './config/ingest.js';
 import {
+  resolveFaissIndexType,
   resolveChunkSize,
   resolveIndexingBatchSize,
 } from './config/indexing.js';
@@ -87,6 +88,19 @@ describe('resolveIndexingBatchSize (issue #236 — INDEXING_BATCH_SIZE)', () => 
 
     process.env.INDEXING_BATCH_SIZE = '0';
     expect(resolveIndexingBatchSize('ollama')).toBe(16);
+  });
+});
+
+describe('resolveFaissIndexType (#468 — KB_INDEX_TYPE)', () => {
+  it('defaults to flat for unset, blank, and unknown values', () => {
+    expect(resolveFaissIndexType(undefined)).toBe('flat');
+    expect(resolveFaissIndexType('')).toBe('flat');
+    expect(resolveFaissIndexType('ivfpq')).toBe('flat');
+  });
+
+  it('accepts flat and sq8 case-insensitively', () => {
+    expect(resolveFaissIndexType('flat')).toBe('flat');
+    expect(resolveFaissIndexType(' SQ8 ')).toBe('sq8');
   });
 });
 

--- a/src/config/indexing.ts
+++ b/src/config/indexing.ts
@@ -7,6 +7,8 @@ import { EMBEDDING_PROVIDER } from './provider.js';
 const DEFAULT_INDEXING_BATCH_SIZE = 64;
 const DEFAULT_OLLAMA_INDEXING_BATCH_SIZE = 16;
 const MAX_INDEXING_BATCH_SIZE = 512;
+export const KB_INDEX_TYPE_ENV = 'KB_INDEX_TYPE';
+export type FaissIndexType = 'flat' | 'sq8';
 
 export function resolveIndexingBatchSize(
   provider: string = EMBEDDING_PROVIDER,
@@ -26,6 +28,15 @@ export function resolveIndexingBatchSize(
 }
 
 export const INDEXING_BATCH_SIZE: number = resolveIndexingBatchSize();
+
+export function resolveFaissIndexType(
+  raw: string | undefined = process.env[KB_INDEX_TYPE_ENV],
+): FaissIndexType {
+  const normalized = raw?.trim().toLowerCase();
+  if (normalized === undefined || normalized === '') return 'flat';
+  if (normalized === 'flat' || normalized === 'sq8') return normalized;
+  return 'flat';
+}
 
 // ---------------------------------------------------------------------------
 // Chunking configuration (#107 follow-up).

--- a/src/faiss-store-adapter.test.ts
+++ b/src/faiss-store-adapter.test.ts
@@ -170,6 +170,25 @@ describe('FaissStoreAdapter', () => {
     ).rejects.toThrow(/index\/docstore divergence/);
   });
 
+  it('pre-creates and trains an SQ8 index before adding the first vector batch', async () => {
+    const embeddings = {
+      embedDocuments: jest.fn(async () => [[1, 0], [0, 1]]),
+      embedQuery: jest.fn(),
+    };
+
+    const adapter = await FaissStoreAdapter.fromDocuments(
+      [
+        { pageContent: 'a', metadata: {} },
+        { pageContent: 'b', metadata: {} },
+      ] as never,
+      embeddings as never,
+      { indexType: 'sq8' },
+    );
+
+    expect(adapter.totalVectors()).toBe(2);
+    expect(adapter.vectorDimension()).toBe(2);
+  });
+
   it('uses vector-first search when LangChain exposes it', async () => {
     const vectorSearch = jest.fn(async () => [[{ pageContent: 'hit', metadata: {} }, 0.1]]);
     const getQueryEmbedding = jest.fn(async () => ({

--- a/src/faiss-store-adapter.ts
+++ b/src/faiss-store-adapter.ts
@@ -2,6 +2,7 @@ import { FaissStore, type FaissLibArgs } from '@langchain/community/vectorstores
 import type { EmbeddingsInterface } from '@langchain/core/embeddings';
 import type { Document } from '@langchain/core/documents';
 import { embeddingText } from './contextual-preface.js';
+import { resolveFaissIndexType, type FaissIndexType } from './config/indexing.js';
 import type { QueryCacheLookupStatus } from './query-cache.js';
 
 type ScoredFaissDocument = [Document, number];
@@ -20,6 +21,17 @@ type FaissStoreWithVectorSearch = FaissStore & {
 type FaissIndexHandle = {
   ntotal: () => number;
   getDimension: () => number;
+  isTrained?: () => boolean;
+  train?: (vectors: number[]) => void;
+};
+
+type FaissNodeModule = {
+  Index: {
+    fromFactory: (dims: number, descriptor: string, metric?: number) => FaissIndexHandle;
+  };
+  MetricType: {
+    METRIC_L2: number;
+  };
 };
 
 function describeShape(value: unknown): string {
@@ -57,6 +69,31 @@ function getIndexHandle(store: FaissStore): FaissIndexHandle {
     throw new Error('FAISS store index is missing getDimension()');
   }
   return index as FaissIndexHandle;
+}
+
+async function importFaissNode(): Promise<FaissNodeModule> {
+  const mod = await import('faiss-node') as unknown as { default: FaissNodeModule };
+  return mod.default;
+}
+
+function flattenVectors(vectors: readonly number[][]): number[] {
+  return vectors.flatMap((vector) => vector);
+}
+
+async function createIndexForVectors(
+  vectors: readonly number[][],
+  indexType: FaissIndexType,
+): Promise<FaissIndexHandle | undefined> {
+  const dimension = vectors[0]?.length;
+  if (dimension === undefined) return undefined;
+  if (indexType === 'flat') return undefined;
+
+  const faiss = await importFaissNode();
+  const index = faiss.Index.fromFactory(dimension, 'SQ8', faiss.MetricType.METRIC_L2);
+  if (index.isTrained?.() === false) {
+    index.train?.(flattenVectors(vectors));
+  }
+  return index;
 }
 
 /**
@@ -127,6 +164,7 @@ export class FaissStoreAdapter {
   static async fromDocuments(
     documents: readonly Document[],
     embeddings: EmbeddingsInterface,
+    options: { indexType?: FaissIndexType } = {},
   ): Promise<FaissStoreAdapter> {
     // RFC 017 §3 — the embedding-input text MAY differ from the docstore
     // text. When `metadata.contextual_preface` is present, `embeddingText`
@@ -141,13 +179,9 @@ export class FaissStoreAdapter {
         `Embedding provider returned ${vectors.length} vector(s) for ${documents.length} document(s)`,
       );
     }
-    // `new FaissStore(embeddings, {})` is the documented way to create an
-    // empty store without an index; `addVectors` lazy-initializes the
-    // IndexFlatL2 on first call (see node_modules faiss.js:84-87).
-    // FaissLibArgs has all-optional fields; an empty object yields a store
-    // whose `index` is undefined. `addVectors` lazy-initializes the
-    // IndexFlatL2 on first call (faiss.js:84-87 in node_modules).
-    const store = new FaissStore(embeddings, {} as FaissLibArgs);
+    const indexType = options.indexType ?? resolveFaissIndexType();
+    const index = await createIndexForVectors(vectors, indexType);
+    const store = new FaissStore(embeddings, { ...(index ? { index } : {}) } as FaissLibArgs);
     await store.addVectors(vectors, [...documents]);
     // Post-batch invariant: the FaissStore.addVectors call must produce a
     // 1:1 docstore-to-vector ratio. RFC 017 §3 mandates this check to catch

--- a/src/faiss-store-layout.ts
+++ b/src/faiss-store-layout.ts
@@ -8,6 +8,7 @@ import {
   type DedupOutcome,
 } from './docstore-cas.js';
 import { calculateSHA256, pathExists } from './file-utils.js';
+import { resolveFaissIndexType, type FaissIndexType } from './config/indexing.js';
 import { logger } from './logger.js';
 
 export const INDEX_VERSION_RETENTION_ENV = 'KB_INDEX_VERSION_RETENTION';
@@ -22,6 +23,7 @@ export interface IndexIntegrityManifest {
   schema_version: typeof INDEX_INTEGRITY_MANIFEST_SCHEMA_VERSION;
   written_at: string;
   model_id: string;
+  index_type: FaissIndexType;
   files: {
     'faiss.index': { sha256: string };
     'docstore.json': { sha256: string };
@@ -291,6 +293,7 @@ export async function saveFaissStoreAtomic(options: {
   modelDir: string;
   modelId: string;
   swapCounter: number;
+  indexType?: FaissIndexType;
   /**
    * RFC 016 — when provided, the per-model `docstore.json` written by
    * `FaissStore.save` is canonicalized and hardlinked to a shared payload
@@ -311,6 +314,7 @@ export async function saveFaissStoreAtomic(options: {
     modelDir,
     modelId,
     swapCounter,
+    indexType = resolveFaissIndexType(),
     casRoot = null,
     onCommitted,
   } = options;
@@ -333,7 +337,7 @@ export async function saveFaissStoreAtomic(options: {
   if (casRoot !== null) {
     dedup = await dedupeDocstoreOnSave({ stagingDir, casRoot, swapCounter });
   }
-  await writeIndexIntegrityManifest(stagingDir, modelId);
+  await writeIndexIntegrityManifest(stagingDir, modelId, indexType);
 
   const tmpLink = path.join(
     modelDir,
@@ -368,11 +372,13 @@ export async function saveFaissStoreAtomic(options: {
 export async function writeIndexIntegrityManifest(
   versionDir: string,
   modelId: string,
+  indexType: FaissIndexType = resolveFaissIndexType(),
 ): Promise<IndexIntegrityManifest> {
   const manifest: IndexIntegrityManifest = {
     schema_version: INDEX_INTEGRITY_MANIFEST_SCHEMA_VERSION,
     written_at: new Date().toISOString(),
     model_id: modelId,
+    index_type: indexType,
     files: {
       'faiss.index': {
         sha256: await calculateSHA256(path.join(versionDir, 'faiss.index')),

--- a/src/kb-stats.ts
+++ b/src/kb-stats.ts
@@ -42,6 +42,7 @@ import {
   type RelevanceGateMetricsSnapshot,
 } from './relevance-gate-metrics.js';
 import type { TransportRuntimeStatsSnapshot } from './transport-runtime-stats.js';
+import type { FaissIndexType } from './config/indexing.js';
 
 export interface KbStatsRow {
   file_count: number;
@@ -87,7 +88,7 @@ export interface KbStatsContextualFailureBlock {
 export interface KbStatsPayload {
   knowledge_bases: Record<string, KbStatsRow>;
   quarantined: Record<string, number>;
-  embedding: { provider: string; model: string; dim: number | null };
+  embedding: { provider: string; model: string; dim: number | null; index_type?: FaissIndexType };
   index_path: string;
   last_index_update: IndexUpdateSummary;
   server: { version: string; uptime_ms: number };
@@ -217,6 +218,7 @@ export async function computeKbStats(
       provider: manager.embeddingProvider,
       model: manager.modelName,
       dim: indexStats.dim,
+      index_type: indexStats.indexType,
     },
     index_path: FAISS_INDEX_PATH,
     last_index_update: lastIndexUpdate,


### PR DESCRIPTION
## Summary
- add KB_INDEX_TYPE=flat|sq8 and kb models add --index-type=flat|sq8
- create and train FAISS SQ8 indexes before the first addVectors batch
- persist index_type in model metadata and integrity manifests, and show it in kb stats
- document SQ8 rollout and eval guidance

Closes #468

## Tests
- npm run build
- npm test -- --runTestsByPath src/active-model.test.ts src/config.test.ts src/faiss-store-adapter.test.ts src/cli-stats.test.ts src/kb-stats.test.ts src/atomic-save.test.ts
- npm test -- --runTestsByPath src/cli.test.ts -t "kb models add"

Note: attempted full cli.test.ts in the larger slice, but it hung in an unrelated kb remember --lesson child process; stopped that run and used the targeted models-add slice for this change.