### PR TITLE
feat: expose OpenMetrics endpoint

### DIFF
--- a/docs/architecture/qa-budgets.md
+++ b/docs/architecture/qa-budgets.md
@@ -104,4 +104,4 @@ The bench harness above measures budgets offline. **At runtime**, the same wall-
 - a regression against the latency budgets above (compare live `provider_calls.<model_id>.latency_ms.p95` to the bench baseline);
 - a sudden error-rate spike from the embedding provider (network blip, expired token, model decommission).
 
-The histogram is bounded — 10 log-spaced latency buckets in [1 ms, 30 s] plus an overflow bucket — and labelled only by `model_id`, so memory cost stays at ~200 bytes per model in the registered set. No on-disk state, no `/metrics` endpoint, no per-query labels.
+The histogram is bounded — 10 log-spaced latency buckets in [1 ms, 30 s] plus an overflow bucket — and labelled only by `model_id`, so memory cost stays at ~200 bytes per model in the registered set. No on-disk state, no per-query labels. `KB_METRICS_EXPORT=on` can additionally expose the bounded live counters through the authenticated `/metrics` endpoint documented in `docs/operations/metrics-export.md`.

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -118,6 +118,7 @@ wrap-close vars below.
 | Log file | `LOG_FILE` | unset | Process logs | Implemented | none | `LOG_FILE=/tmp/kb.log kb doctor` |
 | Canonical log reader | `kb logs show --request-id=<id>` | reads configured canonical log | `kb logs` | Implemented | none | `kb logs recent --limit=20 --format=json` |
 | Mutation audit log | `KB_MUTATION_AUDIT_LOG` | unset | KB write paths | Implemented, opt-in | none | `KB_MUTATION_AUDIT_LOG=/tmp/kb-mutations.jsonl kb remember --kb=<name> --title="..." --stdin --yes` |
+| OpenMetrics export | `KB_METRICS_EXPORT` | `off` | `kb serve` and HTTP/SSE transport `/metrics` | Implemented, opt-in | none | `KB_METRICS_EXPORT=on kb serve` then `curl http://127.0.0.1:17799/metrics` |
 | Tool description overrides | `RETRIEVE_KNOWLEDGE_DESCRIPTION`, `LIST_KNOWLEDGE_BASES_DESCRIPTION`, `LIST_MODELS_DESCRIPTION`, `KB_STATS_DESCRIPTION` | built-in descriptions | MCP server tool metadata | Implemented | none; set before server start | restart MCP server and inspect tool descriptions |
 
 ## Ingest and Storage

--- a/docs/operations/metrics-export.md
+++ b/docs/operations/metrics-export.md
@@ -1,0 +1,69 @@
+# Metrics Export
+
+`KB_METRICS_EXPORT=on` exposes an OpenMetrics text endpoint for scrape-based
+monitoring:
+
+- `kb serve`: `GET /metrics` on the loopback daemon URL.
+- `MCP_TRANSPORT=http|sse`: `GET /metrics` on the remote transport host, behind
+  the same bearer-token and origin checks as MCP requests.
+
+The endpoint is disabled by default. It includes KB names and model ids, so do
+not expose it on an untrusted interface. Remote transports already require
+`MCP_AUTH_TOKEN`; the local `kb serve` daemon remains loopback-only.
+
+## Enable
+
+```bash
+KB_METRICS_EXPORT=on kb serve
+curl -s http://127.0.0.1:17799/metrics
+```
+
+For authenticated HTTP transport:
+
+```bash
+MCP_TRANSPORT=http \
+MCP_AUTH_TOKEN="$MCP_AUTH_TOKEN" \
+KB_METRICS_EXPORT=on \
+node build/index.js
+
+curl -s \
+  -H "Authorization: Bearer $MCP_AUTH_TOKEN" \
+  http://127.0.0.1:8765/metrics
+```
+
+## Label Contract
+
+The v1 exporter keeps labels bounded:
+
+| Label | Metrics | Cardinality bound |
+|---|---|---|
+| `kb` | `kb_knowledge_base_*` | registered knowledge bases |
+| `model_id` | `kb_provider_*` | registered embedding models observed by the process |
+
+There are no query text, file path, user, request id, source URL, or raw error
+labels.
+
+## Metric Groups
+
+| Prefix | Meaning |
+|---|---|
+| `kb_knowledge_base_*` | file counts, chunk counts, indexed bytes, quarantine counts by KB |
+| `kb_provider_*` | provider call counts, errors, token totals when reported, p50/p95/p99 latency |
+| `kb_query_cache_*` | query embedding cache hits, misses, bypasses, disk usage |
+| `kb_relevance_gate_*` | relevance gate query and verdict counters |
+| `kb_remote_transport_*` | HTTP/SSE sessions, requests, auth failures, origin denials, status buckets |
+| `kb_server_uptime_ms` | process uptime for the serving process |
+| `kb_index_embedding_dimensions` | active dense index dimensionality, or `0` when unknown |
+
+## Prometheus Scrape
+
+```yaml
+scrape_configs:
+  - job_name: knowledge-base-mcp-server
+    metrics_path: /metrics
+    static_configs:
+      - targets: ['127.0.0.1:17799']
+```
+
+For authenticated MCP HTTP/SSE transport, configure your scraper to send the
+same bearer token used by MCP clients.

--- a/docs/testing/INDEX.md
+++ b/docs/testing/INDEX.md
@@ -225,6 +225,14 @@
 - `computeKbStats` shall include a `remote_transport` block with request, auth-failure, and backoff counters when the HTTP or SSE transport is active.
 - The block shall be omitted under stdio transport.
 
+### TS-STATS-469: OpenMetrics Export
+**Requirement:** FR-STATS-469
+
+**Test Cases:**
+- The OpenMetrics formatter shall serialize KB, provider-call, query-cache, relevance-gate, and remote-transport stats with bounded labels and a terminal `# EOF`.
+- `kb serve` shall mount `GET /metrics` only when `KB_METRICS_EXPORT=on`.
+- HTTP and SSE transports shall mount `GET /metrics` behind the existing bearer-token auth gate when `KB_METRICS_EXPORT=on`.
+
 ## Reindex
 
 ### TS-REINDEX-407: Reindex Status Ledger

--- a/src/KnowledgeBaseServer.test.ts
+++ b/src/KnowledgeBaseServer.test.ts
@@ -512,6 +512,48 @@ describe('KnowledgeBaseServer handlers', () => {
     expect(payload.remote_transport).toEqual(remoteTransportStats);
   });
 
+  it('handleMetricsExport renders production stats with remote transport counters', async () => {
+    const tempDir = await setRetrieveEnv();
+    await fsp.mkdir(path.join(tempDir, 'alpha'));
+    await fsp.writeFile(path.join(tempDir, 'alpha', 'a.md'), 'aaa');
+
+    getStatsMock.mockReturnValue({
+      totalChunks: 2,
+      chunkCountsByKb: { alpha: 2 },
+      dim: 384,
+    });
+
+    const server = await freshServer();
+    server['transportMode'] = 'http';
+    server['httpHost'] = {
+      getRuntimeStats: () => ({
+        transport: 'http' as const,
+        sessions_opened: 1,
+        sessions_closed: 0,
+        current_sessions: 1,
+        in_flight_requests: 0,
+        requests_total: 3,
+        response_status_buckets: {
+          '1xx': 0,
+          '2xx': 2,
+          '3xx': 0,
+          '4xx': 1,
+          '5xx': 0,
+        },
+        auth_failures: 1,
+        origin_denials: 0,
+        last_error: null,
+      }),
+    } as any;
+
+    const text = await server['handleMetricsExport']();
+
+    expect(text).toContain('kb_knowledge_base_chunks{kb="alpha"} 2');
+    expect(text).toContain('# TYPE kb_remote_transport_requests counter');
+    expect(text).toContain('kb_remote_transport_requests_total 3');
+    expect(text.endsWith('# EOF\n')).toBe(true);
+  });
+
   it('handleKbStats with unknown knowledge_base_name returns KB_NOT_FOUND error', async () => {
     const tempDir = await setRetrieveEnv();
     await fsp.mkdir(path.join(tempDir, 'alpha'));

--- a/src/KnowledgeBaseServer.ts
+++ b/src/KnowledgeBaseServer.ts
@@ -95,6 +95,7 @@ import {
   emitCanonicalLog,
   type CanonicalLogInput,
 } from './canonical-log.js';
+import { formatKbStatsOpenMetrics } from './prometheus-export.js';
 import {
   formatDiffIndexMarkdown,
   resolveIndexVersionPath,
@@ -1023,6 +1024,7 @@ export class KnowledgeBaseServer {
     const host = new SseHost({
       config,
       createMcpServer: () => this.buildMcpServer(),
+      metricsExporter: () => this.handleMetricsExport(),
     });
     this.sseHost = host;
     this.installHttpShutdown();
@@ -1039,6 +1041,7 @@ export class KnowledgeBaseServer {
     const host = new StreamableHttpHost({
       config,
       createMcpServer: () => this.buildMcpServer(),
+      metricsExporter: () => this.handleMetricsExport(),
     });
     this.httpHost = host;
     this.installHttpShutdown();
@@ -1053,6 +1056,17 @@ export class KnowledgeBaseServer {
     if (this.transportMode === 'sse') return this.sseHost?.getRuntimeStats();
     if (this.transportMode === 'http') return this.httpHost?.getRuntimeStats();
     return undefined;
+  }
+
+  private async handleMetricsExport(): Promise<string> {
+    const activeModelId = await resolveActiveModel();
+    const manager = await this.managers.getOrCreate(activeModelId);
+    const payload = await computeKbStats(manager, {
+      serverVersion: SERVER_VERSION,
+      startedAt: this.startedAt,
+      remoteTransportStats: this.getRemoteTransportStats(),
+    });
+    return formatKbStatsOpenMetrics(payload);
   }
 
   /**

--- a/src/cli-serve.test.ts
+++ b/src/cli-serve.test.ts
@@ -1,7 +1,13 @@
 import { afterEach, describe, expect, it } from '@jest/globals';
 import * as http from 'node:http';
-import { parseServeArgs, runServeStatus, startDaemonServer } from './cli-serve.js';
+import {
+  formatStatsRunResultAsOpenMetrics,
+  parseServeArgs,
+  runServeStatus,
+  startDaemonServer,
+} from './cli-serve.js';
 import type { DaemonRunResult } from './daemon-client.js';
+import type { KbStatsPayload } from './kb-stats.js';
 
 interface RawResponse {
   statusCode: number;
@@ -37,6 +43,13 @@ function request(
 }
 
 describe('kb serve daemon', () => {
+  const originalMetricsExport = process.env.KB_METRICS_EXPORT;
+
+  afterEach(() => {
+    if (originalMetricsExport === undefined) delete process.env.KB_METRICS_EXPORT;
+    else process.env.KB_METRICS_EXPORT = originalMetricsExport;
+  });
+
   it('serves health and dispatches read-only commands through handlers', async () => {
     const calls: Array<{ command: string; args: string[] }> = [];
     const ok = (stdout: string): DaemonRunResult => ({ exitCode: 0, stdout, stderr: '' });
@@ -100,8 +113,123 @@ describe('kb serve daemon', () => {
     }
   });
 
+  it('exposes OpenMetrics text only when KB_METRICS_EXPORT is enabled', async () => {
+    const daemon = await startDaemonServer({
+      port: 0,
+      idleTimeoutMs: 0,
+      metricsHandler: async () => '# TYPE kb_server_uptime_ms gauge\nkb_server_uptime_ms 1\n# EOF\n',
+    });
+    try {
+      const disabled = await request(daemon.url, { path: '/metrics' });
+      expect(disabled.statusCode).toBe(404);
+
+      process.env.KB_METRICS_EXPORT = 'on';
+      const enabled = await request(daemon.url, { path: '/metrics' });
+      expect(enabled.statusCode).toBe(200);
+      expect(enabled.body).toContain('kb_server_uptime_ms 1');
+    } finally {
+      await daemon.stop();
+    }
+  });
+
   it('keeps serve binding loopback-only', () => {
     expect(() => parseServeArgs(['--host=0.0.0.0'])).toThrow(/non-loopback/);
+  });
+});
+
+describe('kb serve metrics formatting', () => {
+  it('formats the default kb stats daemon result as OpenMetrics text', () => {
+    const payload: KbStatsPayload = {
+      knowledge_bases: {
+        alpha: {
+          file_count: 1,
+          chunk_count: 2,
+          total_bytes_indexed: 3,
+          last_updated_at: null,
+        },
+      },
+      quarantined: {},
+      embedding: {
+        provider: 'huggingface',
+        model: 'BAAI/bge-small-en-v1.5',
+        dim: 384,
+      },
+      index_path: '/tmp/faiss',
+      last_index_update: {
+        status: 'never_run',
+        scope: null,
+        model_id: 'huggingface__BAAI-bge-small-en-v1.5',
+        started_at: null,
+        finished_at: null,
+        duration_ms: null,
+        files_scanned: 0,
+        files_changed: 0,
+        files_unchanged: 0,
+        files_skipped: 0,
+        chunks_attempted: 0,
+        chunks_added: 0,
+        index_mutated: false,
+        saved: false,
+        sidecars_written: false,
+        warning_count: 0,
+        warnings: [],
+        failure_count: 0,
+        failures: [],
+      },
+      server: {
+        version: '0.0.0-test',
+        uptime_ms: 1,
+      },
+      provider_calls: {},
+      query_cache: {
+        hits: 0,
+        misses: 0,
+        hit_ratio: 0,
+        l1_hits: 0,
+        disk_hits: 0,
+        bypasses: 0,
+        writes: 0,
+        corruptions: 0,
+        l1_size: 0,
+        disk_size_bytes: 0,
+      },
+      relevance_gate: {
+        gated_queries: 0,
+        verdict_injected: 0,
+        verdict_no_relevant_context: 0,
+        verdict_empty_index: 0,
+        low_confidence_rate: 0,
+        drop_rate_A1: 0,
+        drop_rate_A2: 0,
+        drop_rate_B: 0,
+        judge_degrade_rate: 0,
+        judge_window: {
+          size: 0,
+          degraded: 0,
+          rate: 0,
+          warn_threshold: 0.1,
+        },
+      },
+    };
+
+    const text = formatStatsRunResultAsOpenMetrics({
+      exitCode: 0,
+      stdout: JSON.stringify(payload),
+      stderr: '',
+    });
+
+    expect(text).toContain('kb_knowledge_base_chunks{kb="alpha"} 2');
+    expect(text).toContain('# TYPE kb_query_cache_hits counter');
+    expect(text).toContain('kb_query_cache_hits_total 0');
+    expect(text.endsWith('# EOF\n')).toBe(true);
+  });
+
+  it('surfaces kb stats failures from the default metrics path', () => {
+    expect(() => formatStatsRunResultAsOpenMetrics({
+      exitCode: 1,
+      stdout: '',
+      stderr: 'stats unavailable\n',
+    })).toThrow('stats unavailable');
   });
 });
 

--- a/src/cli-serve.ts
+++ b/src/cli-serve.ts
@@ -5,12 +5,18 @@ import { runSearch } from './cli-search.js';
 import { captureProcessOutput } from './cli-shared.js';
 import { runStats } from './cli-stats.js';
 import {
+  isMetricsExportEnabled,
+  OPENMETRICS_CONTENT_TYPE,
+} from './config/metrics-export.js';
+import {
   daemonUrlFromEnv,
   tryFetchDaemonHealth,
   type DaemonCommand,
   type DaemonHealth,
   type DaemonRunResult,
 } from './daemon-client.js';
+import { formatKbStatsOpenMetrics } from './prometheus-export.js';
+import type { KbStatsPayload } from './kb-stats.js';
 
 export const SERVE_HELP = `kb serve — resident local daemon for warm CLI reads
 
@@ -38,6 +44,8 @@ Environment:
   KB_DAEMON_URL             Daemon URL queried by \`kb serve status\` and
                             \`kb search --daemon\` (default
                             http://127.0.0.1:17799).
+  KB_METRICS_EXPORT         Set to \`on\` to expose OpenMetrics text at
+                            \`GET /metrics\` on the loopback daemon.
 
 Exit codes:
   0   daemon started, or \`kb serve status\` found a reachable daemon
@@ -63,6 +71,7 @@ export interface DaemonCommandHandlers {
 
 export interface StartDaemonServerOptions extends Partial<ServeArgs> {
   handlers?: DaemonCommandHandlers;
+  metricsHandler?: () => Promise<string>;
 }
 
 export interface ResidentDaemon {
@@ -199,6 +208,7 @@ export async function startDaemonServer(
   };
   assertLoopbackHost(parsed.host);
   const handlers = options.handlers ?? defaultHandlers();
+  const metricsHandler = options.metricsHandler ?? defaultMetricsHandler;
   let idleTimer: NodeJS.Timeout | undefined;
   let queue: Promise<void> = Promise.resolve();
   const startedAt = Date.now();
@@ -220,7 +230,7 @@ export async function startDaemonServer(
 
   const server = http.createServer((req, res) => {
     resetIdleTimer();
-    void handleRequest(req, res, handlers, buildHealth, (job) => {
+    void handleRequest(req, res, handlers, metricsHandler, buildHealth, (job) => {
       queue = queue.then(job, job);
       return queue;
     });
@@ -317,14 +327,20 @@ async function handleRequest(
   req: http.IncomingMessage,
   res: http.ServerResponse,
   handlers: DaemonCommandHandlers,
+  metricsHandler: () => Promise<string>,
   buildHealth: () => DaemonHealth,
   enqueue: (job: () => Promise<void>) => Promise<void>,
 ): Promise<void> {
-  if (req.method === 'GET' && req.url === '/health') {
+  const url = new URL(req.url ?? '/', 'http://placeholder');
+  if (req.method === 'GET' && url.pathname === '/health') {
     writeJson(res, 200, buildHealth());
     return;
   }
-  if (req.method !== 'POST' || req.url !== '/v1/run') {
+  if (url.pathname === '/metrics') {
+    await handleMetricsRequest(req, res, metricsHandler, enqueue);
+    return;
+  }
+  if (req.method !== 'POST' || url.pathname !== '/v1/run') {
     writeJson(res, 404, { error: 'not_found' });
     return;
   }
@@ -376,6 +392,54 @@ function readArgs(payload: unknown): string[] | null {
 function writeJson(res: http.ServerResponse, statusCode: number, payload: unknown): void {
   res.writeHead(statusCode, { 'Content-Type': 'application/json' });
   res.end(`${JSON.stringify(payload)}\n`);
+}
+
+async function handleMetricsRequest(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  metricsHandler: () => Promise<string>,
+  enqueue: (job: () => Promise<void>) => Promise<void>,
+): Promise<void> {
+  if (!isMetricsExportEnabled()) {
+    writeJson(res, 404, { error: 'not_found' });
+    return;
+  }
+  const method = req.method ?? 'GET';
+  if (method !== 'GET' && method !== 'HEAD') {
+    res.setHeader('Allow', 'GET, HEAD');
+    writeJson(res, 405, { error: 'method_not_allowed' });
+    return;
+  }
+
+  await enqueue(async () => {
+    try {
+      const body = await metricsHandler();
+      res.writeHead(200, {
+        'Content-Type': OPENMETRICS_CONTENT_TYPE,
+        'Cache-Control': 'no-store',
+      });
+      if (method === 'GET') res.end(body);
+      else res.end();
+    } catch (err) {
+      writeJson(res, 500, {
+        error: 'metrics_unavailable',
+        message: (err as Error).message,
+      });
+    }
+  });
+}
+
+async function defaultMetricsHandler(): Promise<string> {
+  const result = await defaultHandlers().stats(['--format=json']);
+  return formatStatsRunResultAsOpenMetrics(result);
+}
+
+export function formatStatsRunResultAsOpenMetrics(result: DaemonRunResult): string {
+  if (result.exitCode !== 0) {
+    throw new Error(result.stderr.trim() || 'kb stats failed');
+  }
+  const payload = JSON.parse(result.stdout) as KbStatsPayload;
+  return formatKbStatsOpenMetrics(payload);
 }
 
 function readBody(req: http.IncomingMessage): Promise<string> {

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,6 +3,7 @@ export * from './config/ingest.js';
 export * from './config/indexing.js';
 export * from './config/logging.js';
 export * from './config/mcp-descriptions.js';
+export * from './config/metrics-export.js';
 export * from './config/paths.js';
 export * from './config/provider.js';
 export * from './config/retrieval.js';

--- a/src/config/metrics-export.ts
+++ b/src/config/metrics-export.ts
@@ -1,0 +1,9 @@
+export function isMetricsExportEnabled(
+  raw: string | undefined = process.env.KB_METRICS_EXPORT,
+): boolean {
+  const value = (raw ?? '').trim().toLowerCase();
+  return value === 'on' || value === 'true' || value === '1' || value === 'yes';
+}
+
+export const OPENMETRICS_CONTENT_TYPE =
+  'application/openmetrics-text; version=1.0.0; charset=utf-8';

--- a/src/prometheus-export.test.ts
+++ b/src/prometheus-export.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from '@jest/globals';
+import type { KbStatsPayload } from './kb-stats.js';
+import { formatKbStatsOpenMetrics } from './prometheus-export.js';
+
+describe('formatKbStatsOpenMetrics', () => {
+  it('renders bounded-label OpenMetrics text from kb stats payloads', () => {
+    const payload = samplePayload();
+    const text = formatKbStatsOpenMetrics(payload);
+
+    expect(text).toContain('# TYPE kb_knowledge_base_chunks gauge');
+    expect(text).toContain('# TYPE kb_provider_calls counter');
+    expect(text).not.toContain('# TYPE kb_provider_calls_total counter');
+    expect(text).toContain('kb_knowledge_base_chunks{kb="ops\\\\team\\"a\\nline"} 7');
+    expect(text).toContain('kb_provider_calls_total{model_id="ollama__nomic-embed-text-latest"} 11');
+    expect(text).not.toContain('kb_provider_tokens_in_total');
+    expect(text).toContain('kb_provider_call_latency_p95_ms{model_id="ollama__nomic-embed-text-latest"} 123.4');
+    expect(text).toContain('kb_remote_transport_requests_total 9');
+    expect(text).toContain('# TYPE kb_remote_transport_responses_4xx counter');
+    expect(text).toContain('kb_remote_transport_responses_4xx_total 2');
+    expect(text.endsWith('# EOF\n')).toBe(true);
+  });
+
+  it('emits provider token counters only when the provider reports token usage', () => {
+    const payload = samplePayload();
+    payload.provider_calls['ollama__nomic-embed-text-latest'].tokens_in = 42;
+
+    const text = formatKbStatsOpenMetrics(payload);
+
+    expect(text).toContain('# TYPE kb_provider_tokens_in counter');
+    expect(text).toContain('kb_provider_tokens_in_total{model_id="ollama__nomic-embed-text-latest"} 42');
+  });
+});
+
+function samplePayload(): KbStatsPayload {
+  return {
+    knowledge_bases: {
+      'ops\\team"a\nline': {
+        file_count: 3,
+        chunk_count: 7,
+        total_bytes_indexed: 2048,
+        last_updated_at: '2026-05-21T00:00:00.000Z',
+      },
+    },
+    quarantined: {
+      'ops\\team"a\nline': 1,
+    },
+    embedding: {
+      provider: 'ollama',
+      model: 'nomic-embed-text:latest',
+      dim: 768,
+    },
+    index_path: '/tmp/faiss',
+    last_index_update: {
+      status: 'success',
+      scope: 'global',
+      model_id: 'ollama__nomic-embed-text-latest',
+      started_at: '2026-05-21T00:00:00.000Z',
+      finished_at: '2026-05-21T00:00:01.000Z',
+      duration_ms: 1000,
+      files_scanned: 3,
+      files_changed: 1,
+      files_unchanged: 2,
+      files_skipped: 0,
+      chunks_attempted: 7,
+      chunks_added: 7,
+      index_mutated: true,
+      saved: true,
+      sidecars_written: true,
+      warning_count: 0,
+      warnings: [],
+      failure_count: 0,
+      failures: [],
+    },
+    server: {
+      version: '0.0.0-test',
+      uptime_ms: 42,
+    },
+    provider_calls: {
+      'ollama__nomic-embed-text-latest': {
+        count: 11,
+        errors: 2,
+        tokens_in: null,
+        latency_ms: {
+          p50: 12.3,
+          p95: 123.4,
+          p99: 300,
+        },
+        since_started_at: '2026-05-21T00:00:00.000Z',
+      },
+    },
+    query_cache: {
+      hits: 5,
+      misses: 6,
+      hit_ratio: 5 / 11,
+      l1_hits: 4,
+      disk_hits: 1,
+      bypasses: 0,
+      writes: 6,
+      corruptions: 0,
+      l1_size: 4,
+      disk_size_bytes: 1024,
+    },
+    relevance_gate: {
+      gated_queries: 2,
+      verdict_injected: 1,
+      verdict_no_relevant_context: 1,
+      verdict_empty_index: 0,
+      low_confidence_rate: 0,
+      drop_rate_A1: 0,
+      drop_rate_A2: 0,
+      drop_rate_B: 0,
+      judge_degrade_rate: 0,
+      judge_window: {
+        size: 2,
+        degraded: 0,
+        rate: 0,
+        warn_threshold: 0.1,
+      },
+    },
+    remote_transport: {
+      transport: 'http',
+      sessions_opened: 2,
+      sessions_closed: 1,
+      current_sessions: 1,
+      in_flight_requests: 0,
+      requests_total: 9,
+      response_status_buckets: {
+        '1xx': 0,
+        '2xx': 7,
+        '3xx': 0,
+        '4xx': 2,
+        '5xx': 0,
+      },
+      auth_failures: 1,
+      origin_denials: 1,
+      last_error: null,
+    },
+  };
+}

--- a/src/prometheus-export.ts
+++ b/src/prometheus-export.ts
@@ -1,0 +1,300 @@
+import type { KbStatsPayload } from './kb-stats.js';
+
+interface MetricSample {
+  name: string;
+  value: number;
+  labels?: Record<string, string>;
+}
+
+interface MetricDefinition {
+  name: string;
+  help: string;
+  type: 'counter' | 'gauge';
+  samples: MetricSample[];
+}
+
+export function formatKbStatsOpenMetrics(payload: KbStatsPayload): string {
+  const metrics: MetricDefinition[] = [
+    {
+      name: 'kb_knowledge_base_files',
+      help: 'Number of ingestable source files by knowledge base.',
+      type: 'gauge',
+      samples: Object.entries(payload.knowledge_bases).map(([kb, row]) => ({
+        name: 'kb_knowledge_base_files',
+        labels: { kb },
+        value: row.file_count,
+      })),
+    },
+    {
+      name: 'kb_knowledge_base_chunks',
+      help: 'Number of dense index chunks by knowledge base.',
+      type: 'gauge',
+      samples: Object.entries(payload.knowledge_bases).map(([kb, row]) => ({
+        name: 'kb_knowledge_base_chunks',
+        labels: { kb },
+        value: row.chunk_count,
+      })),
+    },
+    {
+      name: 'kb_knowledge_base_indexed_bytes',
+      help: 'Total bytes from ingestable files by knowledge base.',
+      type: 'gauge',
+      samples: Object.entries(payload.knowledge_bases).map(([kb, row]) => ({
+        name: 'kb_knowledge_base_indexed_bytes',
+        labels: { kb },
+        value: row.total_bytes_indexed,
+      })),
+    },
+    {
+      name: 'kb_knowledge_base_quarantined_chunks',
+      help: 'Number of quarantined chunks by knowledge base.',
+      type: 'gauge',
+      samples: Object.entries(payload.quarantined).map(([kb, count]) => ({
+        name: 'kb_knowledge_base_quarantined_chunks',
+        labels: { kb },
+        value: count,
+      })),
+    },
+    {
+      name: 'kb_server_uptime_ms',
+      help: 'Process uptime in milliseconds for the serving process.',
+      type: 'gauge',
+      samples: [{ name: 'kb_server_uptime_ms', value: payload.server.uptime_ms }],
+    },
+    {
+      name: 'kb_index_embedding_dimensions',
+      help: 'Embedding dimension of the active FAISS index, or 0 when unknown.',
+      type: 'gauge',
+      samples: [{
+        name: 'kb_index_embedding_dimensions',
+        value: payload.embedding.dim ?? 0,
+      }],
+    },
+    {
+      name: 'kb_provider_calls_total',
+      help: 'Embedding provider calls by model id.',
+      type: 'counter',
+      samples: Object.entries(payload.provider_calls).map(([modelId, snapshot]) => ({
+        name: 'kb_provider_calls_total',
+        labels: { model_id: modelId },
+        value: snapshot.count,
+      })),
+    },
+    {
+      name: 'kb_provider_call_errors_total',
+      help: 'Embedding provider call errors by model id.',
+      type: 'counter',
+      samples: Object.entries(payload.provider_calls).map(([modelId, snapshot]) => ({
+        name: 'kb_provider_call_errors_total',
+        labels: { model_id: modelId },
+        value: snapshot.errors,
+      })),
+    },
+    {
+      name: 'kb_provider_tokens_in_total',
+      help: 'Reported input tokens consumed by embedding provider calls.',
+      type: 'counter',
+      samples: Object.entries(payload.provider_calls)
+        .filter(([, snapshot]) => snapshot.tokens_in !== null)
+        .map(([modelId, snapshot]) => ({
+          name: 'kb_provider_tokens_in_total',
+          labels: { model_id: modelId },
+          value: snapshot.tokens_in ?? 0,
+        })),
+    },
+    ...providerLatencyMetrics(payload),
+    {
+      name: 'kb_query_cache_hits_total',
+      help: 'Query embedding cache hits.',
+      type: 'counter',
+      samples: [{ name: 'kb_query_cache_hits_total', value: payload.query_cache.hits }],
+    },
+    {
+      name: 'kb_query_cache_misses_total',
+      help: 'Query embedding cache misses.',
+      type: 'counter',
+      samples: [{ name: 'kb_query_cache_misses_total', value: payload.query_cache.misses }],
+    },
+    {
+      name: 'kb_query_cache_bypasses_total',
+      help: 'Query embedding cache bypasses.',
+      type: 'counter',
+      samples: [{ name: 'kb_query_cache_bypasses_total', value: payload.query_cache.bypasses }],
+    },
+    {
+      name: 'kb_query_cache_disk_size_bytes',
+      help: 'Query embedding cache disk usage in bytes.',
+      type: 'gauge',
+      samples: [{ name: 'kb_query_cache_disk_size_bytes', value: payload.query_cache.disk_size_bytes }],
+    },
+    {
+      name: 'kb_relevance_gate_queries_total',
+      help: 'Relevance-gated retrieval queries.',
+      type: 'counter',
+      samples: [{ name: 'kb_relevance_gate_queries_total', value: payload.relevance_gate.gated_queries }],
+    },
+    {
+      name: 'kb_relevance_gate_verdict_injected_total',
+      help: 'Relevance gate injected-context verdict count.',
+      type: 'counter',
+      samples: [{
+        name: 'kb_relevance_gate_verdict_injected_total',
+        value: payload.relevance_gate.verdict_injected,
+      }],
+    },
+    {
+      name: 'kb_relevance_gate_verdict_no_relevant_context_total',
+      help: 'Relevance gate no-relevant-context verdict count.',
+      type: 'counter',
+      samples: [{
+        name: 'kb_relevance_gate_verdict_no_relevant_context_total',
+        value: payload.relevance_gate.verdict_no_relevant_context,
+      }],
+    },
+    {
+      name: 'kb_relevance_gate_verdict_empty_index_total',
+      help: 'Relevance gate empty-index verdict count.',
+      type: 'counter',
+      samples: [{
+        name: 'kb_relevance_gate_verdict_empty_index_total',
+        value: payload.relevance_gate.verdict_empty_index,
+      }],
+    },
+    ...remoteTransportMetrics(payload),
+  ];
+
+  const lines: string[] = [];
+  for (const metric of metrics) {
+    if (metric.samples.length === 0) continue;
+    const familyName = metricFamilyName(metric);
+    lines.push(`# HELP ${familyName} ${metric.help}`);
+    lines.push(`# TYPE ${familyName} ${metric.type}`);
+    for (const sample of metric.samples) {
+      lines.push(`${sample.name}${formatLabels(sample.labels)} ${formatNumber(sample.value)}`);
+    }
+  }
+  lines.push('# EOF');
+  return `${lines.join('\n')}\n`;
+}
+
+function metricFamilyName(metric: MetricDefinition): string {
+  if (metric.type !== 'counter') return metric.name;
+  return metric.name.endsWith('_total') ? metric.name.slice(0, -'_total'.length) : metric.name;
+}
+
+function providerLatencyMetrics(payload: KbStatsPayload): MetricDefinition[] {
+  const quantiles = [
+    ['p50', 'p50'] as const,
+    ['p95', 'p95'] as const,
+    ['p99', 'p99'] as const,
+  ];
+  return quantiles.map(([suffix, field]) => ({
+    name: `kb_provider_call_latency_${suffix}_ms`,
+    help: `Embedding provider call latency ${suffix} by model id, in milliseconds.`,
+    type: 'gauge' as const,
+    samples: Object.entries(payload.provider_calls).map(([modelId, snapshot]) => ({
+      name: `kb_provider_call_latency_${suffix}_ms`,
+      labels: { model_id: modelId },
+      value: snapshot.latency_ms[field],
+    })),
+  }));
+}
+
+function remoteTransportMetrics(payload: KbStatsPayload): MetricDefinition[] {
+  const stats = payload.remote_transport;
+  if (stats === undefined) return [];
+  return [
+    {
+      name: 'kb_remote_transport_requests_total',
+      help: 'Remote HTTP/SSE transport requests.',
+      type: 'counter',
+      samples: [{ name: 'kb_remote_transport_requests_total', value: stats.requests_total }],
+    },
+    {
+      name: 'kb_remote_transport_sessions_opened_total',
+      help: 'Remote HTTP/SSE transport sessions opened.',
+      type: 'counter',
+      samples: [{
+        name: 'kb_remote_transport_sessions_opened_total',
+        value: stats.sessions_opened,
+      }],
+    },
+    {
+      name: 'kb_remote_transport_sessions_closed_total',
+      help: 'Remote HTTP/SSE transport sessions closed.',
+      type: 'counter',
+      samples: [{
+        name: 'kb_remote_transport_sessions_closed_total',
+        value: stats.sessions_closed,
+      }],
+    },
+    {
+      name: 'kb_remote_transport_current_sessions',
+      help: 'Current remote HTTP/SSE transport sessions.',
+      type: 'gauge',
+      samples: [{
+        name: 'kb_remote_transport_current_sessions',
+        value: stats.current_sessions,
+      }],
+    },
+    {
+      name: 'kb_remote_transport_in_flight_requests',
+      help: 'Current in-flight remote HTTP/SSE transport requests.',
+      type: 'gauge',
+      samples: [{
+        name: 'kb_remote_transport_in_flight_requests',
+        value: stats.in_flight_requests,
+      }],
+    },
+    {
+      name: 'kb_remote_transport_auth_failures_total',
+      help: 'Remote HTTP/SSE transport authentication failures.',
+      type: 'counter',
+      samples: [{
+        name: 'kb_remote_transport_auth_failures_total',
+        value: stats.auth_failures,
+      }],
+    },
+    {
+      name: 'kb_remote_transport_origin_denials_total',
+      help: 'Remote HTTP/SSE transport CORS origin denials.',
+      type: 'counter',
+      samples: [{
+        name: 'kb_remote_transport_origin_denials_total',
+        value: stats.origin_denials,
+      }],
+    },
+    ...Object.entries(stats.response_status_buckets).map(([bucket, count]) => ({
+      name: `kb_remote_transport_responses_${bucket}_total`,
+      help: `Remote HTTP/SSE transport ${bucket} responses.`,
+      type: 'counter' as const,
+      samples: [{
+        name: `kb_remote_transport_responses_${bucket}_total`,
+        value: count,
+      }],
+    })),
+  ];
+}
+
+function formatLabels(labels: Record<string, string> | undefined): string {
+  if (labels === undefined || Object.keys(labels).length === 0) return '';
+  const body = Object.entries(labels)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([key, value]) => `${key}="${escapeLabelValue(value)}"`)
+    .join(',');
+  return `{${body}}`;
+}
+
+function escapeLabelValue(value: string): string {
+  return value
+    .replace(/\\/g, '\\\\')
+    .replace(/\n/g, '\\n')
+    .replace(/"/g, '\\"');
+}
+
+function formatNumber(value: number): string {
+  if (Number.isNaN(value)) return '0';
+  if (value === Infinity) return '+Inf';
+  if (value === -Infinity) return '-Inf';
+  return String(value);
+}

--- a/src/transport/base-http-host.ts
+++ b/src/transport/base-http-host.ts
@@ -23,6 +23,10 @@ import { timingSafeEqual } from 'node:crypto';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 import {
+  isMetricsExportEnabled,
+  OPENMETRICS_CONTENT_TYPE,
+} from '../config/metrics-export.js';
+import {
   DEFAULT_MCP_AUTH_BACKOFF_MAX_ENTRIES,
   DEFAULT_MCP_AUTH_BACKOFF_MS,
   DEFAULT_MCP_AUTH_BACKOFF_THRESHOLD,
@@ -47,6 +51,7 @@ const SHUTDOWN_POLL_INTERVAL_MS = 50;
 export interface BaseHttpHostOptions {
   config: TransportConfig;
   createMcpServer: () => McpServer;
+  metricsExporter?: () => Promise<string>;
 }
 
 export interface BaseSessionEntry<TTransport> {
@@ -382,7 +387,15 @@ export abstract class BaseHttpHost<TTransport extends { close(): Promise<void> }
       this.setCorsResponseHeaders(res, originHeader);
     }
 
-    // 7. Subclass routing.
+    // 7. Optional OpenMetrics route. Kept behind the same auth/origin gates
+    // as MCP routes so KB names and model ids are not exposed accidentally.
+    if (path === '/metrics') {
+      const metricsStatus = await this.handleMetricsExport(method, res);
+      finalize(metricsStatus);
+      return;
+    }
+
+    // 8. Subclass routing.
     const status = await this.handleAuthenticatedRequest(req, res, url);
     finalize(status);
   }
@@ -434,6 +447,44 @@ export abstract class BaseHttpHost<TTransport extends { close(): Promise<void> }
       res.end();
     }
     return 200;
+  }
+
+  private async handleMetricsExport(
+    method: string,
+    res: http.ServerResponse,
+  ): Promise<number> {
+    if (!isMetricsExportEnabled() || this.options.metricsExporter === undefined) {
+      respond(res, 404, 'Not Found');
+      return 404;
+    }
+    if (method !== 'GET' && method !== 'HEAD') {
+      res.setHeader('Allow', 'GET, HEAD');
+      respond(res, 405, 'Method Not Allowed');
+      return 405;
+    }
+
+    this.inFlight += 1;
+    try {
+      const body = await this.options.metricsExporter();
+      const buf = Buffer.from(body, 'utf8');
+      res.setHeader('Content-Type', OPENMETRICS_CONTENT_TYPE);
+      res.setHeader('Content-Length', String(buf.length));
+      res.setHeader('Cache-Control', 'no-store');
+      res.writeHead(200);
+      if (method === 'GET') {
+        res.end(buf);
+      } else {
+        res.end();
+      }
+      return 200;
+    } catch (err) {
+      this.recordTransportError(err as Error);
+      logger.warn(`[${this.logPrefix}] metrics export failed: ${(err as Error).message}`);
+      respond(res, 500, 'Metrics unavailable');
+      return 500;
+    } finally {
+      this.inFlight -= 1;
+    }
   }
 
   protected setCorsResponseHeaders(res: http.ServerResponse, origin: string): void {

--- a/src/transport/http.test.ts
+++ b/src/transport/http.test.ts
@@ -34,6 +34,7 @@ async function startHost(opts: {
   authToken?: string;
   allowedOrigins?: string[];
   authBackoff?: AuthBackoffConfig;
+  metricsExporter?: () => Promise<string>;
 }): Promise<{ host: StreamableHttpHost; port: number; stop: () => Promise<void> }> {
   const host = new StreamableHttpHost({
     config: {
@@ -45,6 +46,7 @@ async function startHost(opts: {
       authBackoff: opts.authBackoff,
     },
     createMcpServer: freshFactory(),
+    metricsExporter: opts.metricsExporter,
   });
   const server = await host.start();
   const addr = server.address() as AddressInfo;
@@ -143,12 +145,15 @@ function sendMalformedHttpRequest(port: number): Promise<void> {
 
 describe('StreamableHttpHost — endpoints', () => {
   let stop: (() => Promise<void>) | undefined;
+  const originalMetricsExport = process.env.KB_METRICS_EXPORT;
 
   afterEach(async () => {
     if (stop) {
       await stop();
       stop = undefined;
     }
+    if (originalMetricsExport === undefined) delete process.env.KB_METRICS_EXPORT;
+    else process.env.KB_METRICS_EXPORT = originalMetricsExport;
   });
 
   it('GET /health returns 200 JSON {"status":"ok"} without auth', async () => {
@@ -158,6 +163,25 @@ describe('StreamableHttpHost — endpoints', () => {
     expect(res.statusCode).toBe(200);
     expect(res.headers['content-type']).toMatch(/application\/json/);
     expect(JSON.parse(res.body)).toEqual({ status: 'ok' });
+  });
+
+  it('serves authenticated OpenMetrics text at GET /metrics when enabled', async () => {
+    process.env.KB_METRICS_EXPORT = 'on';
+    const started = await startHost({
+      metricsExporter: async () => '# TYPE kb_server_uptime_ms gauge\nkb_server_uptime_ms 5\n# EOF\n',
+    });
+    stop = started.stop;
+
+    const unauthenticated = await request(started.port, { path: '/metrics' });
+    expect(unauthenticated.statusCode).toBe(401);
+
+    const authenticated = await request(started.port, {
+      path: '/metrics',
+      headers: { Authorization: `Bearer ${VALID_TOKEN}` },
+    });
+    expect(authenticated.statusCode).toBe(200);
+    expect(authenticated.headers['content-type']).toMatch(/openmetrics-text/);
+    expect(authenticated.body).toContain('kb_server_uptime_ms 5');
   });
 
   it('request without Authorization gets 401 with WWW-Authenticate', async () => {

--- a/src/transport/sse.test.ts
+++ b/src/transport/sse.test.ts
@@ -33,6 +33,7 @@ async function startHost(opts: {
   authToken?: string;
   allowedOrigins?: string[];
   authBackoff?: AuthBackoffConfig;
+  metricsExporter?: () => Promise<string>;
 }): Promise<{ host: SseHost; port: number; stop: () => Promise<void> }> {
   const host = new SseHost({
     config: {
@@ -44,6 +45,7 @@ async function startHost(opts: {
       authBackoff: opts.authBackoff,
     },
     createMcpServer: freshFactory(),
+    metricsExporter: opts.metricsExporter,
   });
   const server = await host.start();
   const addr = server.address() as AddressInfo;
@@ -265,12 +267,15 @@ describe('loadTransportConfig validation', () => {
 
 describe('SseHost — endpoints', () => {
   let stop: (() => Promise<void>) | undefined;
+  const originalMetricsExport = process.env.KB_METRICS_EXPORT;
 
   afterEach(async () => {
     if (stop) {
       await stop();
       stop = undefined;
     }
+    if (originalMetricsExport === undefined) delete process.env.KB_METRICS_EXPORT;
+    else process.env.KB_METRICS_EXPORT = originalMetricsExport;
   });
 
   it('exposes process-lifetime SSE transport counters', async () => {
@@ -310,6 +315,25 @@ describe('SseHost — endpoints', () => {
     expect(stats.response_status_buckets['4xx']).toBe(2);
     expect(stats.auth_failures).toBe(1);
     expect(stats.origin_denials).toBe(1);
+  });
+
+  it('serves authenticated OpenMetrics text at GET /metrics when enabled', async () => {
+    process.env.KB_METRICS_EXPORT = 'on';
+    const started = await startHost({
+      metricsExporter: async () => '# TYPE kb_server_uptime_ms gauge\nkb_server_uptime_ms 8\n# EOF\n',
+    });
+    stop = started.stop;
+
+    const unauthenticated = await request(started.port, { path: '/metrics' });
+    expect(unauthenticated.statusCode).toBe(401);
+
+    const authenticated = await request(started.port, {
+      path: '/metrics',
+      headers: { Authorization: `Bearer ${VALID_TOKEN}` },
+    });
+    expect(authenticated.statusCode).toBe(200);
+    expect(authenticated.headers['content-type']).toMatch(/openmetrics-text/);
+    expect(authenticated.body).toContain('kb_server_uptime_ms 8');
   });
 
   it('(e) GET /health returns 200 JSON {"status":"ok"} without auth (RFC 008 §6.8: no fingerprinting)', async () => {


### PR DESCRIPTION
## Summary
- add opt-in KB_METRICS_EXPORT /metrics support for kb serve and remote HTTP/SSE transports
- serialize kb_stats as bounded-label OpenMetrics 1.0 text, including remote transport counters
- document the feature flag, operator usage, and testing coverage

## Verification
- npm test -- --runTestsByPath src/prometheus-export.test.ts src/cli-serve.test.ts src/KnowledgeBaseServer.test.ts src/transport/http.test.ts src/transport/sse.test.ts
- npm run build
- npm test (passed before final reviewer-driven coverage patches)

Closes #469