### PR TITLE
feat: add SQ8 FAISS index option

### DIFF
--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -126,6 +126,7 @@ wrap-close vars below.
 |---|---|---:|---|---|---|---|
 | KB root | `KNOWLEDGE_BASES_ROOT_DIR` | `$HOME/knowledge_bases` | CLI and MCP | Implemented | none | `kb list` |
 | FAISS index path | `FAISS_INDEX_PATH` | `$KNOWLEDGE_BASES_ROOT_DIR/.faiss` | CLI and MCP | Implemented | none | `kb doctor --format=json` |
+| FAISS index type | `KB_INDEX_TYPE` | `flat` | Ingest and refresh | Implemented, opt-in (`flat` or `sq8`) | none | `KB_INDEX_TYPE=sq8 kb reindex --force && kb stats` |
 | Embedding provider | `EMBEDDING_PROVIDER` | `huggingface` | CLI and MCP retrieval/ingest | Implemented | register/query a model with `kb models` where available | `kb doctor` |
 | Ollama endpoint | `OLLAMA_BASE_URL` | `http://localhost:11434` | Ollama embedding provider | Implemented | none | `EMBEDDING_PROVIDER=ollama kb doctor` |
 | Ollama embedding model | `OLLAMA_MODEL` | `dengcao/Qwen3-Embedding-0.6B:Q8_0` | Ollama embedding provider | Implemented | active model selection through `kb models` | `EMBEDDING_PROVIDER=ollama kb models list` |

--- a/docs/operations/index-quantization.md
+++ b/docs/operations/index-quantization.md
@@ -1,0 +1,36 @@
+# FAISS Index Quantization
+
+`KB_INDEX_TYPE` controls the FAISS index created for a rebuilt model index.
+
+| Value | Behavior | Trade-off |
+| --- | --- | --- |
+| `flat` | Full-precision `IndexFlatL2` storage. This is the default and preserves existing behavior. | Highest memory use, exact search. |
+| `sq8` | Scalar-quantized 8-bit FAISS index created with the `SQ8` factory descriptor. | Lower vector memory, approximate distances. Validate recall before promoting. |
+
+The setting is read when `FaissIndexManager` is constructed and applies to the
+next index build. To convert an existing flat index to SQ8, run a forced global
+rebuild with the env var set:
+
+```bash
+KB_INDEX_TYPE=sq8 kb reindex --force
+kb stats
+```
+
+`kb stats` reports the active model's `embedding.index_type`, and the markdown
+view prints `Index type: flat|sq8`. Each versioned index directory also records
+the type in `integrity.json` as `index_type`, so retained versions remain
+self-describing.
+
+Before keeping SQ8 enabled for a corpus, compare it against the flat baseline:
+
+```bash
+KB_INDEX_TYPE=flat kb reindex --force
+kb eval --mode=dense docs/testing/fixtures/dogfood-frozen-core.yml
+
+KB_INDEX_TYPE=sq8 kb reindex --force
+kb eval --mode=dense docs/testing/fixtures/dogfood-frozen-core.yml
+```
+
+Promote SQ8 only when the Recall@K / MRR delta is acceptable for the target
+knowledge bases. Leave `KB_INDEX_TYPE` unset to return to `flat` on the next
+forced rebuild.

--- a/docs/requirements/INDEX.md
+++ b/docs/requirements/INDEX.md
@@ -57,6 +57,21 @@
 **Linked Tests:** TS-INDEX-281
 **Dependencies:** NFR-INDEX-236
 
+### FR-INDEX-468: SQ8 FAISS Index Type
+**Status:** Implemented
+**Priority:** Medium
+
+**Requirement:** The system shall support an opt-in `KB_INDEX_TYPE=sq8` FAISS index build for memory-bound corpora while keeping `flat` as the default.
+
+**Acceptance Criteria:**
+- [x] Given `KB_INDEX_TYPE` is unset, when an index is built, then the system shall use the existing full-precision flat FAISS index.
+- [x] Given `KB_INDEX_TYPE=sq8`, when a new index is built, then the system shall create and train an SQ8 FAISS index before adding vectors.
+- [x] Given an index is saved, then `integrity.json` shall record the active `index_type`.
+- [x] Given a user runs `kb stats`, then the active model's index type shall be visible in JSON and markdown output.
+
+**Linked Tests:** TS-INDEX-468
+**Dependencies:** FAISS versioned index layout, kb stats
+
 ## Observability
 
 ### FR-OBS-467: Deep Index Integrity Verification

--- a/docs/testing/INDEX.md
+++ b/docs/testing/INDEX.md
@@ -41,6 +41,15 @@
 - `normalizeChunkTextForEmbedding` shall collapse insignificant Unicode and whitespace differences before indexing dedupe.
 - `FaissIndexManager.updateIndex` shall call the embedding provider with unique normalized changed-file chunk text while preserving every duplicate source metadata entry in the FAISS insertion path.
 
+### TS-INDEX-468: SQ8 FAISS Index Option
+**Requirement:** FR-INDEX-468
+
+**Test Cases:**
+- `KB_INDEX_TYPE` shall default to `flat`, accept `sq8`, and reject unknown values.
+- `FaissStoreAdapter.fromDocuments` shall create and train an SQ8 FAISS index before adding vectors.
+- `saveFaissStoreAtomic` shall persist the active index type in `integrity.json`.
+- `kb stats` shall expose the active model index type in JSON and markdown output.
+
 ## Observability
 
 ### TS-OBS-467: Deep Index Integrity Verification

--- a/src/FaissIndexManager.test.ts
+++ b/src/FaissIndexManager.test.ts
@@ -392,6 +392,7 @@ describe('FaissIndexManager permission handling', () => {
     KB_CHUNK_SIZE: process.env.KB_CHUNK_SIZE,
     KB_CHUNK_OVERLAP: process.env.KB_CHUNK_OVERLAP,
     KB_REFRESH_QUIESCE_MS: process.env.KB_REFRESH_QUIESCE_MS,
+    KB_INDEX_TYPE: process.env.KB_INDEX_TYPE,
   };
 
 
@@ -645,6 +646,54 @@ describe('FaissIndexManager permission handling', () => {
     }
     await expect(fsp.stat(pendingManifestPathIn(process.env.FAISS_INDEX_PATH!)))
       .rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('persists and reports the active SQ8 index type across reloads (#468)', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-faiss-sq8-manager-'));
+    const kbDir = path.join(tempDir, 'kb');
+    const defaultKb = path.join(kbDir, 'default');
+    await fsp.mkdir(defaultKb, { recursive: true });
+    await fsp.writeFile(
+      path.join(defaultKb, 'doc.md'),
+      '# SQ8\n\nManager-level SQ8 persistence and stats coverage.',
+    );
+
+    const faissDir = path.join(tempDir, '.faiss');
+    process.env.KNOWLEDGE_BASES_ROOT_DIR = kbDir;
+    process.env.FAISS_INDEX_PATH = faissDir;
+    process.env.EMBEDDING_PROVIDER = 'huggingface';
+    process.env.HUGGINGFACE_API_KEY = 'test-key';
+    process.env.KB_INDEX_TYPE = 'sq8';
+
+    jest.resetModules();
+    const { FaissIndexManager } = await import('./FaissIndexManager.js');
+    const firstManager = new FaissIndexManager();
+    await firstManager.initialize();
+    await firstManager.updateIndex();
+
+    const integrityManifest = JSON.parse(
+      await fsp.readFile(path.join(versionedIndexPathIn(faissDir), 'integrity.json'), 'utf-8'),
+    ) as { index_type: string };
+    expect(integrityManifest.index_type).toBe('sq8');
+    expect(firstManager.getStats().indexType).toBe('sq8');
+
+    // The reloaded manager deliberately uses the default configured type.
+    // Stats must reflect the active index manifest, not the new process env.
+    process.env.KB_INDEX_TYPE = 'flat';
+    loadMock.mockClear();
+    jest.resetModules();
+    const { FaissIndexManager: ReloadedFaissIndexManager } = await import('./FaissIndexManager.js');
+    const { computeKbStats } = await import('./kb-stats.js');
+    const reloadedManager = new ReloadedFaissIndexManager();
+    await reloadedManager.initialize();
+
+    expect(loadMock).toHaveBeenCalledWith(versionedIndexPathIn(faissDir), expect.anything());
+    expect(reloadedManager.getStats().indexType).toBe('sq8');
+    const statsPayload = await computeKbStats(reloadedManager, {
+      serverVersion: 'test',
+      startedAt: Date.now(),
+    });
+    expect(statsPayload.embedding.index_type).toBe('sq8');
   });
 
   it('recovers a save-complete pending manifest by finishing hash and chunk sidecars', async () => {

--- a/src/FaissIndexManager.ts
+++ b/src/FaissIndexManager.ts
@@ -48,9 +48,14 @@ import { mapBounded, resolveFsConcurrency } from './bounded-concurrency.js';
 import {
   loadFaissStoreAtomic,
   loadFaissStoreFromVersionDir,
+  readIndexTypeFromVersionDir,
   resolveActiveIndexFilePath as resolveActiveIndexFilePathFromLayout,
   saveFaissStoreAtomic,
 } from './faiss-store-layout.js';
+import {
+  resolveFaissIndexType,
+  type FaissIndexType,
+} from './config/index-type.js';
 import {
   freshnessManifestPath,
   readFreshnessManifest,
@@ -540,6 +545,8 @@ export class FaissIndexManager {
   readonly modelDir: string;
   readonly modelNameFile: string;
   private readonly indexingBatchSize: number;
+  private readonly configuredIndexType: FaissIndexType;
+  private activeIndexType: FaissIndexType;
   private lastIndexUpdateSummary: IndexUpdateSummary;
   // Issue #283 — cached metadata sidecar so we don't re-parse the JSONL
   // file on every query. Invalidated whenever updateIndex rewrites it,
@@ -574,6 +581,8 @@ export class FaissIndexManager {
     this.modelDir = modelDir(this.modelId);
     this.modelNameFile = modelNameFilePath(this.modelId);
     this.indexingBatchSize = resolveIndexingBatchSize(this.embeddingProvider);
+    this.configuredIndexType = resolveFaissIndexType();
+    this.activeIndexType = this.configuredIndexType;
     this.lastIndexUpdateSummary = createNeverRunIndexUpdateSummary(this.modelId);
 
     // Issue #59 — embeddings are constructed lazily inside initialize() so
@@ -1082,14 +1091,21 @@ export class FaissIndexManager {
    * file is required — the filesystem is the single source of truth.
    */
   private async loadAtomic(opts: { repairCorrupt?: boolean } = {}): Promise<FaissStoreAdapter | null> {
-    const store = await loadFaissStoreAtomic({
+    const loaded = await loadFaissStoreAtomic({
       modelDir: this.modelDir,
       modelId: this.modelId,
       embeddings: this.embeddings,
       handleFsOperationError,
       repairCorrupt: opts.repairCorrupt,
     });
-    return store === null ? null : FaissStoreAdapter.fromStore(store);
+    if (loaded === null) {
+      this.activeIndexType = this.configuredIndexType;
+      return null;
+    }
+    this.activeIndexType = loaded.versionDir === null
+      ? 'flat'
+      : await readIndexTypeFromVersionDir(loaded.versionDir);
+    return FaissStoreAdapter.fromStore(loaded.store);
   }
 
   /**
@@ -1126,6 +1142,7 @@ export class FaissIndexManager {
       embeddings: this.embeddings,
     });
     this.faissIndex = FaissStoreAdapter.fromStore(store);
+    this.activeIndexType = await readIndexTypeFromVersionDir(versionDir);
     // Metadata sidecars are keyed to the active model directory, not to an
     // arbitrary historical index.vN directory. Disable the fast-path after a
     // direct version load so scoped diff/eval searches fall back to
@@ -1161,6 +1178,7 @@ export class FaissIndexManager {
       store: this.faissStoreForPersistence(),
       modelDir: this.modelDir,
       modelId: this.modelId,
+      indexType: this.activeIndexType,
       swapCounter: this.swapCounter,
       casRoot: casRootForIndexPath(FAISS_INDEX_PATH),
       onCommitted: opts.onCommitted,
@@ -1205,7 +1223,9 @@ export class FaissIndexManager {
         this.faissIndex = await FaissStoreAdapter.fromDocuments(
           batch,
           indexingEmbeddings,
+          { indexType: this.configuredIndexType },
         );
+        this.activeIndexType = this.configuredIndexType;
         // The store must keep the real client for query embeddings and later
         // operations; the deduper is only an insertion-time wrapper.
         this.faissIndex.restoreEmbeddings(this.embeddings);
@@ -2641,14 +2661,20 @@ export class FaissIndexManager {
     totalChunks: number;
     chunkCountsByKb: Record<string, number>;
     dim: number | null;
+    indexType: FaissIndexType;
   } {
     if (!this.faissIndex) {
-      return { totalChunks: 0, chunkCountsByKb: {}, dim: null };
+      return {
+        totalChunks: 0,
+        chunkCountsByKb: {},
+        dim: null,
+        indexType: this.activeIndexType,
+      };
     }
     const totalChunks = this.faissIndex.totalVectors();
     const dim = this.faissIndex.vectorDimension();
     const chunkCountsByKb = this.faissIndex.chunkCountsByKnowledgeBase();
-    return { totalChunks, chunkCountsByKb, dim };
+    return { totalChunks, chunkCountsByKb, dim, indexType: this.activeIndexType };
   }
 
   private getDocstoreDocuments(): Document[] {

--- a/src/KnowledgeBaseServer.test.ts
+++ b/src/KnowledgeBaseServer.test.ts
@@ -14,6 +14,7 @@ const getStatsMock = jest.fn(() => ({
   totalChunks: 0,
   chunkCountsByKb: {} as Record<string, number>,
   dim: null as number | null,
+  indexType: 'flat' as const,
 }));
 const getLastIndexUpdateSummaryMock = jest.fn(() => ({
   status: 'never_run',
@@ -97,7 +98,12 @@ describe('KnowledgeBaseServer handlers', () => {
     hasLoadedIndexMock.mockReset();
     hasLoadedIndexMock.mockReturnValue(true);
     getStatsMock.mockReset();
-    getStatsMock.mockReturnValue({ totalChunks: 0, chunkCountsByKb: {}, dim: null });
+    getStatsMock.mockReturnValue({
+      totalChunks: 0,
+      chunkCountsByKb: {},
+      dim: null,
+      indexType: 'flat',
+    });
     process.env.KB_LOG_FORMAT = 'text';
     getLastIndexUpdateSummaryMock.mockReset();
     getLastIndexUpdateSummaryMock.mockReturnValue({
@@ -394,6 +400,7 @@ describe('KnowledgeBaseServer handlers', () => {
       totalChunks: 7,
       chunkCountsByKb: { alpha: 4, beta: 3 },
       dim: 384,
+      indexType: 'flat',
     });
 
     const server = await freshServer();
@@ -416,6 +423,7 @@ describe('KnowledgeBaseServer handlers', () => {
       provider: 'huggingface',
       model: 'BAAI/bge-small-en-v1.5',
       dim: 384,
+      index_type: 'flat',
     });
     expect(payload.index_path).toBe(process.env.FAISS_INDEX_PATH);
     expect(payload.last_index_update.status).toBe('never_run');
@@ -439,6 +447,7 @@ describe('KnowledgeBaseServer handlers', () => {
       // there is also a `beta` entry — kb_stats with a name MUST scope.
       chunkCountsByKb: { alpha: 5, beta: 4 },
       dim: 768,
+      indexType: 'flat',
     });
 
     const server = await freshServer();
@@ -462,6 +471,7 @@ describe('KnowledgeBaseServer handlers', () => {
       totalChunks: 0,
       chunkCountsByKb: {},
       dim: null,
+      indexType: 'flat',
     });
 
     const server = await freshServer();

--- a/src/atomic-save.test.ts
+++ b/src/atomic-save.test.ts
@@ -229,10 +229,12 @@ describe('RFC 014 atomic save — atomicity smoke', () => {
     ) as {
       schema_version: string;
       model_id: string;
+      index_type: string;
       files: Record<string, { sha256: string }>;
     };
     expect(integrityManifest.schema_version).toBe('kb.index-integrity.v1');
     expect(integrityManifest.model_id).toBe(DEFAULT_MODEL_ID);
+    expect(integrityManifest.index_type).toBe('flat');
     expect(integrityManifest.files['faiss.index'].sha256).toMatch(/^[0-9a-f]{64}$/);
     expect(integrityManifest.files['docstore.json'].sha256).toMatch(/^[0-9a-f]{64}$/);
 

--- a/src/cli-research.test.ts
+++ b/src/cli-research.test.ts
@@ -51,6 +51,7 @@ function statsPayload(overrides: Partial<KbStatsPayload> = {}): KbStatsPayload {
       provider: 'ollama',
       model: 'nomic-embed-text:latest',
       dim: 768,
+      index_type: 'flat',
     },
     index_path: '/tmp/kb-index',
     last_index_update: {

--- a/src/cli-stats.test.ts
+++ b/src/cli-stats.test.ts
@@ -34,6 +34,7 @@ function payload(): KbStatsPayload {
       provider: 'ollama',
       model: 'nomic-embed-text:latest',
       dim: 768,
+      index_type: 'flat',
     },
     index_path: '/tmp/kb-index',
     last_index_update: {
@@ -192,6 +193,7 @@ describe('kb stats CLI', () => {
     expect(out).toContain('| beta | 1 | 3 | 100 | never |');
     expect(out).toContain('- Provider: ollama');
     expect(out).toContain('- Model: nomic-embed-text:latest');
+    expect(out).toContain('- Index type: flat');
     expect(out).toContain('- Index path: `/tmp/kb-index`');
     expect(out).toContain('## Relevance Gate');
     expect(out).toContain('- Gated queries: 0');

--- a/src/cli-stats.ts
+++ b/src/cli-stats.ts
@@ -158,6 +158,7 @@ export function formatStatsMarkdown(payload: KbStatsPayload): string {
     `- Provider: ${payload.embedding.provider}`,
     `- Model: ${payload.embedding.model}`,
     `- Dimensions: ${dim}`,
+    `- Index type: ${payload.embedding.index_type}`,
     `- Index path: \`${payload.index_path}\``,
     `- Server version: ${payload.server.version}`,
     `- Uptime: ${formatInteger(uptimeMs)} ms`,

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -8,6 +8,10 @@ import {
   resolveIndexingBatchSize,
 } from './config/indexing.js';
 import {
+  parseFaissIndexType,
+  resolveFaissIndexType,
+} from './config/index-type.js';
+import {
   parseKBLogFormat,
 } from './config/logging.js';
 import {
@@ -87,6 +91,30 @@ describe('resolveIndexingBatchSize (issue #236 — INDEXING_BATCH_SIZE)', () => 
 
     process.env.INDEXING_BATCH_SIZE = '0';
     expect(resolveIndexingBatchSize('ollama')).toBe(16);
+  });
+});
+
+describe('resolveFaissIndexType (#468 — KB_INDEX_TYPE)', () => {
+  const saved = process.env.KB_INDEX_TYPE;
+
+  afterEach(() => {
+    if (saved === undefined) delete process.env.KB_INDEX_TYPE;
+    else process.env.KB_INDEX_TYPE = saved;
+  });
+
+  it('defaults to the full-precision flat index', () => {
+    delete process.env.KB_INDEX_TYPE;
+    expect(resolveFaissIndexType()).toBe('flat');
+    expect(parseFaissIndexType('')).toBe('flat');
+  });
+
+  it('accepts flat and sq8 case-insensitively', () => {
+    expect(parseFaissIndexType('flat')).toBe('flat');
+    expect(parseFaissIndexType(' SQ8 ')).toBe('sq8');
+  });
+
+  it('rejects unknown index types with an actionable env-var name', () => {
+    expect(() => parseFaissIndexType('pq')).toThrow(/KB_INDEX_TYPE.*flat, sq8/);
   });
 });
 

--- a/src/config/index-type.ts
+++ b/src/config/index-type.ts
@@ -1,0 +1,24 @@
+export const KB_INDEX_TYPE_ENV = 'KB_INDEX_TYPE';
+
+export type FaissIndexType = 'flat' | 'sq8';
+
+export const DEFAULT_FAISS_INDEX_TYPE: FaissIndexType = 'flat';
+
+export function parseFaissIndexType(raw: string | undefined): FaissIndexType {
+  const normalized = raw?.trim().toLowerCase();
+  if (normalized === undefined || normalized === '') {
+    return DEFAULT_FAISS_INDEX_TYPE;
+  }
+  if (normalized === 'flat' || normalized === 'sq8') {
+    return normalized;
+  }
+  throw new Error(
+    `${KB_INDEX_TYPE_ENV} must be one of: flat, sq8; got ${JSON.stringify(raw)}`,
+  );
+}
+
+export function resolveFaissIndexType(
+  raw: string | undefined = process.env[KB_INDEX_TYPE_ENV],
+): FaissIndexType {
+  return parseFaissIndexType(raw);
+}

--- a/src/faiss-store-adapter.test.ts
+++ b/src/faiss-store-adapter.test.ts
@@ -1,3 +1,4 @@
+import { Document } from '@langchain/core/documents';
 import { FaissStoreAdapter, type FaissSearchTimingSink } from './faiss-store-adapter.js';
 
 function adapterFor(store: Record<string, unknown>): FaissStoreAdapter {
@@ -5,6 +6,37 @@ function adapterFor(store: Record<string, unknown>): FaissStoreAdapter {
 }
 
 describe('FaissStoreAdapter', () => {
+  it('builds a trained SQ8 index and keeps vector search usable (#468)', async () => {
+    const docs = [
+      new Document({ pageContent: 'alpha', metadata: { source: 'alpha.md', knowledgeBase: 'kb' } }),
+      new Document({ pageContent: 'beta', metadata: { source: 'beta.md', knowledgeBase: 'kb' } }),
+      new Document({ pageContent: 'gamma', metadata: { source: 'gamma.md', knowledgeBase: 'kb' } }),
+    ];
+    const embeddings = {
+      embedDocuments: jest.fn(async () => [
+        [1, 0, 0],
+        [0, 1, 0],
+        [0, 0, 1],
+      ]),
+      embedQuery: jest.fn(async () => [1, 0, 0]),
+    };
+
+    const adapter = await FaissStoreAdapter.fromDocuments(
+      docs,
+      embeddings as never,
+      { indexType: 'sq8' },
+    );
+
+    expect(adapter.totalVectors()).toBe(3);
+    expect(adapter.vectorDimension()).toBe(3);
+    const results = await adapter.similaritySearchUsingBestPath({
+      query: 'alpha',
+      k: 1,
+      getQueryEmbedding: async () => ({ embedding: [1, 0, 0], status: 'miss' }),
+    });
+    expect(results[0]?.[0].metadata.source).toBe('alpha.md');
+  });
+
   it('guards raw index access before reading totals', () => {
     expect(() => adapterFor({}).totalVectors()).toThrow(
       'FAISS store index must be an object; got undefined',

--- a/src/faiss-store-adapter.ts
+++ b/src/faiss-store-adapter.ts
@@ -1,6 +1,8 @@
 import { FaissStore, type FaissLibArgs } from '@langchain/community/vectorstores/faiss';
 import type { EmbeddingsInterface } from '@langchain/core/embeddings';
 import type { Document } from '@langchain/core/documents';
+import type { Index } from 'faiss-node';
+import type { FaissIndexType } from './config/index-type.js';
 import { embeddingText } from './contextual-preface.js';
 import type { QueryCacheLookupStatus } from './query-cache.js';
 
@@ -20,6 +22,8 @@ type FaissStoreWithVectorSearch = FaissStore & {
 type FaissIndexHandle = {
   ntotal: () => number;
   getDimension: () => number;
+  isTrained?: () => boolean;
+  train?: (vectors: number[]) => void;
 };
 
 function describeShape(value: unknown): string {
@@ -57,6 +61,52 @@ function getIndexHandle(store: FaissStore): FaissIndexHandle {
     throw new Error('FAISS store index is missing getDimension()');
   }
   return index as FaissIndexHandle;
+}
+
+function flattenVectors(vectors: readonly number[][]): number[] {
+  return vectors.flatMap((vector) => vector);
+}
+
+async function createIndexForVectors(
+  vectors: readonly number[][],
+  indexType: FaissIndexType,
+): Promise<Index> {
+  const first = vectors[0];
+  if (first === undefined) {
+    throw new Error('Cannot create a FAISS index without at least one vector');
+  }
+  const dimension = first.length;
+  const faissModule = await import('faiss-node') as unknown as
+    typeof import('faiss-node') & { default?: typeof import('faiss-node') };
+  const faiss = faissModule.default ?? faissModule;
+  if (indexType === 'flat') {
+    return new faiss.IndexFlatL2(dimension) as unknown as Index;
+  }
+
+  const index = faiss.Index.fromFactory(
+    dimension,
+    'SQ8',
+    faiss.MetricType.METRIC_L2,
+  );
+  trainIndexIfNeeded(index, vectors, 'FaissStoreAdapter.createIndexForVectors');
+  return index;
+}
+
+function trainIndexIfNeeded(
+  index: FaissIndexHandle,
+  vectors: readonly number[][],
+  label: string,
+): void {
+  if (typeof index.isTrained !== 'function' || index.isTrained()) {
+    return;
+  }
+  if (typeof index.train !== 'function') {
+    throw new Error(`${label}: FAISS index requires training but has no train() method`);
+  }
+  index.train(flattenVectors(vectors));
+  if (!index.isTrained()) {
+    throw new Error(`${label}: FAISS index training did not complete`);
+  }
 }
 
 /**
@@ -127,6 +177,7 @@ export class FaissStoreAdapter {
   static async fromDocuments(
     documents: readonly Document[],
     embeddings: EmbeddingsInterface,
+    options: { indexType?: FaissIndexType } = {},
   ): Promise<FaissStoreAdapter> {
     // RFC 017 §3 — the embedding-input text MAY differ from the docstore
     // text. When `metadata.contextual_preface` is present, `embeddingText`
@@ -141,13 +192,8 @@ export class FaissStoreAdapter {
         `Embedding provider returned ${vectors.length} vector(s) for ${documents.length} document(s)`,
       );
     }
-    // `new FaissStore(embeddings, {})` is the documented way to create an
-    // empty store without an index; `addVectors` lazy-initializes the
-    // IndexFlatL2 on first call (see node_modules faiss.js:84-87).
-    // FaissLibArgs has all-optional fields; an empty object yields a store
-    // whose `index` is undefined. `addVectors` lazy-initializes the
-    // IndexFlatL2 on first call (faiss.js:84-87 in node_modules).
-    const store = new FaissStore(embeddings, {} as FaissLibArgs);
+    const index = await createIndexForVectors(vectors, options.indexType ?? 'flat');
+    const store = new FaissStore(embeddings, { index } as unknown as FaissLibArgs);
     await store.addVectors(vectors, [...documents]);
     // Post-batch invariant: the FaissStore.addVectors call must produce a
     // 1:1 docstore-to-vector ratio. RFC 017 §3 mandates this check to catch
@@ -188,6 +234,11 @@ export class FaissStoreAdapter {
         `Embedding provider returned ${vectors.length} vector(s) for ${documents.length} document(s)`,
       );
     }
+    trainIndexIfNeeded(
+      getIndexHandle(this.store),
+      vectors,
+      'FaissStoreAdapter.addDocumentsWithEmbeddings',
+    );
     await this.store.addVectors(vectors, [...documents]);
     assertIndexDocstoreParity(this.store, 'FaissStoreAdapter.addDocumentsWithEmbeddings');
   }

--- a/src/faiss-store-layout.ts
+++ b/src/faiss-store-layout.ts
@@ -9,6 +9,11 @@ import {
 } from './docstore-cas.js';
 import { calculateSHA256, pathExists } from './file-utils.js';
 import { logger } from './logger.js';
+import {
+  DEFAULT_FAISS_INDEX_TYPE,
+  parseFaissIndexType,
+  type FaissIndexType,
+} from './config/index-type.js';
 
 export const INDEX_VERSION_RETENTION_ENV = 'KB_INDEX_VERSION_RETENTION';
 export const DEFAULT_PREVIOUS_INDEX_VERSION_RETENTION = 2;
@@ -22,6 +27,7 @@ export interface IndexIntegrityManifest {
   schema_version: typeof INDEX_INTEGRITY_MANIFEST_SCHEMA_VERSION;
   written_at: string;
   model_id: string;
+  index_type: FaissIndexType;
   files: {
     'faiss.index': { sha256: string };
     'docstore.json': { sha256: string };
@@ -175,13 +181,18 @@ export async function loadFaissStoreFromVersionDir(options: {
   return FaissStore.load(versionDir, embeddings);
 }
 
+export interface LoadedFaissStoreAtomic {
+  store: FaissStore;
+  versionDir: string | null;
+}
+
 export async function loadFaissStoreAtomic(options: {
   modelDir: string;
   modelId: string;
   embeddings: EmbeddingsInterface;
   handleFsOperationError: FsOperationErrorHandler;
   repairCorrupt?: boolean;
-}): Promise<FaissStore | null> {
+}): Promise<LoadedFaissStoreAtomic | null> {
   const {
     modelDir,
     modelId,
@@ -249,7 +260,7 @@ export async function loadFaissStoreAtomic(options: {
       );
     }
 
-    return store;
+    return { store, versionDir: resolved };
   }
 
   if (await pathExists(legacyPath)) {
@@ -258,7 +269,8 @@ export async function loadFaissStoreAtomic(options: {
         `Loading legacy FAISS index for model ${modelId} from faiss.index/. ` +
           `First save will create versioned layout (${SYMLINK_NAME} -> index.v0).`,
       );
-      return await FaissStore.load(legacyPath, embeddings);
+      const store = await FaissStore.load(legacyPath, embeddings);
+      return { store, versionDir: null };
     } catch (err) {
       if (!repairCorrupt) {
         throw new Error(
@@ -291,6 +303,7 @@ export async function saveFaissStoreAtomic(options: {
   modelDir: string;
   modelId: string;
   swapCounter: number;
+  indexType?: FaissIndexType;
   /**
    * RFC 016 — when provided, the per-model `docstore.json` written by
    * `FaissStore.save` is canonicalized and hardlinked to a shared payload
@@ -311,6 +324,7 @@ export async function saveFaissStoreAtomic(options: {
     modelDir,
     modelId,
     swapCounter,
+    indexType = DEFAULT_FAISS_INDEX_TYPE,
     casRoot = null,
     onCommitted,
   } = options;
@@ -333,7 +347,7 @@ export async function saveFaissStoreAtomic(options: {
   if (casRoot !== null) {
     dedup = await dedupeDocstoreOnSave({ stagingDir, casRoot, swapCounter });
   }
-  await writeIndexIntegrityManifest(stagingDir, modelId);
+  await writeIndexIntegrityManifest(stagingDir, modelId, indexType);
 
   const tmpLink = path.join(
     modelDir,
@@ -368,11 +382,13 @@ export async function saveFaissStoreAtomic(options: {
 export async function writeIndexIntegrityManifest(
   versionDir: string,
   modelId: string,
+  indexType: FaissIndexType = DEFAULT_FAISS_INDEX_TYPE,
 ): Promise<IndexIntegrityManifest> {
   const manifest: IndexIntegrityManifest = {
     schema_version: INDEX_INTEGRITY_MANIFEST_SCHEMA_VERSION,
     written_at: new Date().toISOString(),
     model_id: modelId,
+    index_type: indexType,
     files: {
       'faiss.index': {
         sha256: await calculateSHA256(path.join(versionDir, 'faiss.index')),
@@ -388,6 +404,29 @@ export async function writeIndexIntegrityManifest(
     { encoding: 'utf-8', mode: 0o600 },
   );
   return manifest;
+}
+
+export async function readIndexTypeFromVersionDir(
+  versionDir: string,
+): Promise<FaissIndexType> {
+  const manifestPath = path.join(versionDir, INDEX_INTEGRITY_MANIFEST_FILENAME);
+  try {
+    const parsed = JSON.parse(await fsp.readFile(manifestPath, 'utf-8')) as {
+      index_type?: unknown;
+    };
+    return typeof parsed.index_type === 'string'
+      ? parseFaissIndexType(parsed.index_type)
+      : DEFAULT_FAISS_INDEX_TYPE;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code !== 'ENOENT' && code !== 'ENOTDIR') {
+      logger.warn(
+        `Could not read FAISS index type from ${manifestPath}; assuming ${DEFAULT_FAISS_INDEX_TYPE}: ` +
+          `${(err as Error).message}`,
+      );
+    }
+    return DEFAULT_FAISS_INDEX_TYPE;
+  }
 }
 
 export async function resolveActiveIndexFilePath(modelDir: string): Promise<string | null> {

--- a/src/kb-stats.test.ts
+++ b/src/kb-stats.test.ts
@@ -16,6 +16,7 @@ interface FakeManager {
     totalChunks: number;
     chunkCountsByKb: Record<string, number>;
     dim: number | null;
+    indexType: 'flat' | 'sq8';
   };
   getLastIndexUpdateSummary(): unknown;
 }
@@ -26,6 +27,7 @@ function makeManager(opts: {
   modelId?: string;
   chunkCountsByKb?: Record<string, number>;
   dim?: number | null;
+  indexType?: 'flat' | 'sq8';
   lastIndexUpdateSummary?: unknown;
 }): FakeManager {
   const modelId = opts.modelId ?? 'huggingface__BAAI-bge-small-en-v1.5';
@@ -37,6 +39,7 @@ function makeManager(opts: {
       totalChunks: Object.values(opts.chunkCountsByKb ?? {}).reduce((s, n) => s + n, 0),
       chunkCountsByKb: opts.chunkCountsByKb ?? {},
       dim: opts.dim ?? null,
+      indexType: opts.indexType ?? 'flat',
     }),
     getLastIndexUpdateSummary: () => opts.lastIndexUpdateSummary ?? ({
       status: 'never_run',
@@ -147,6 +150,7 @@ describe('computeKbStats', () => {
       provider: 'huggingface',
       model: 'BAAI/bge-small-en-v1.5',
       dim: 384,
+      index_type: 'flat',
     });
     expect(payload.index_path).toBe(path.join(tempDir, '.faiss'));
     expect(payload.last_index_update).toMatchObject({

--- a/src/kb-stats.ts
+++ b/src/kb-stats.ts
@@ -17,6 +17,7 @@ import {
   isContextualRetrievalEnabled,
   type ContextualErrorCode,
 } from './config/contextual-preface.js';
+import type { FaissIndexType } from './config/index-type.js';
 import { FaissIndexManager, type IndexUpdateSummary } from './FaissIndexManager.js';
 import {
   FAISS_INDEX_PATH,
@@ -87,7 +88,12 @@ export interface KbStatsContextualFailureBlock {
 export interface KbStatsPayload {
   knowledge_bases: Record<string, KbStatsRow>;
   quarantined: Record<string, number>;
-  embedding: { provider: string; model: string; dim: number | null };
+  embedding: {
+    provider: string;
+    model: string;
+    dim: number | null;
+    index_type: FaissIndexType;
+  };
   index_path: string;
   last_index_update: IndexUpdateSummary;
   server: { version: string; uptime_ms: number };
@@ -217,6 +223,7 @@ export async function computeKbStats(
       provider: manager.embeddingProvider,
       model: manager.modelName,
       dim: indexStats.dim,
+      index_type: indexStats.indexType,
     },
     index_path: FAISS_INDEX_PATH,
     last_index_update: lastIndexUpdate,


### PR DESCRIPTION
## Summary
- add KB_INDEX_TYPE=flat|sq8 config with flat as the default
- build and train SQ8 FAISS indexes before insertion, then persist index_type in integrity.json
- expose the active index type in kb stats JSON/markdown and document operational usage

## Review
- pre-PR reviewer specialists ran: conventions, correctness, dead-code, tests
- addressed conventions doc placement/table feedback, the loader symlink race, and manager-level SQ8 coverage

## Verification
- npm run build
- npx jest --runInBand src/config.test.ts src/faiss-store-adapter.test.ts src/atomic-save.test.ts src/kb-stats.test.ts src/cli-stats.test.ts
- npx jest --runInBand src/KnowledgeBaseServer.test.ts -t handleKbStats
- npx jest --runInBand src/FaissIndexManager.test.ts -t "persists and reports the active SQ8 index type|saves the FAISS index exactly once"
- npx jest --runInBand src/FaissIndexManager.test.ts src/config.test.ts src/faiss-store-adapter.test.ts src/atomic-save.test.ts src/kb-stats.test.ts src/cli-stats.test.ts
- npm test

Closes #468