### PR TITLE
feat(search): add optional pager output

### DIFF
--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -111,6 +111,7 @@ wrap-close vars below.
 | Frontmatter extras on wire | `FRONTMATTER_EXTRAS_WIRE_VISIBLE` | `false` | MCP and CLI JSON retrieval output | Implemented | none | `FRONTMATTER_EXTRAS_WIRE_VISIBLE=true kb search "query" --format=json` |
 | CLI timing | `--timing` | off | CLI search and ask | Implemented | `--timing` | `kb search "query" --timing` |
 | Compact search output | `kb search --format=compact` | `md` | CLI search | Implemented | `--format=compact` | `kb search "query" --format=compact` |
+| Search pager | `KB_PAGER`, `kb search --pager` | off; `less -R` when enabled without a pager env | CLI search markdown/compact output on TTY stdout | Implemented, opt-in | `--pager`, `--no-pager` | `KB_PAGER='less -R' kb search "query" --pager --k=30` |
 | Batch JSONL search input | `kb search --batch-jsonl` | off | CLI search | Implemented | `--batch-jsonl < queries.jsonl` | `printf '{"query":"q1"}\n{"query":"q2"}\n' \| kb search --batch-jsonl` |
 | Canonical log format | `KB_LOG_FORMAT` | `both` | Process logs | Implemented | none | `KB_LOG_FORMAT=canonical kb search "query"` |
 | Verbose MCP server tracing | `KB_LOG_VERBOSE` | unset | `KnowledgeBaseServer` lifecycle logs | Implemented, opt-in | none | `KB_LOG_VERBOSE=1 node build/index.js` |

--- a/src/cli-pager.test.ts
+++ b/src/cli-pager.test.ts
@@ -1,0 +1,144 @@
+import { Writable } from 'stream';
+import { describe, expect, it } from '@jest/globals';
+import {
+  buildDaemonSearchArgs,
+  resolveSearchPager,
+  writeMaybePagedOutput,
+} from './cli-pager.js';
+
+class CaptureStream extends Writable {
+  private chunks: Buffer[] = [];
+
+  override _write(
+    chunk: Buffer | string,
+    _encoding: BufferEncoding,
+    callback: (error?: Error | null) => void,
+  ): void {
+    this.chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    callback();
+  }
+
+  text(): string {
+    return Buffer.concat(this.chunks).toString('utf-8');
+  }
+}
+
+describe('search pager resolution (#471)', () => {
+  it('keeps pager disabled by default', async () => {
+    await expect(resolveSearchPager({
+      flag: null,
+      format: 'md',
+      env: { PATH: process.env.PATH },
+      stdoutIsTTY: true,
+    })).resolves.toBeNull();
+  });
+
+  it('uses KB_PAGER as both opt-in and command override', async () => {
+    await expect(resolveSearchPager({
+      flag: null,
+      format: 'md',
+      env: { PATH: process.env.PATH, KB_PAGER: `${process.execPath} -e "process.stdin.pipe(process.stdout)"` },
+      stdoutIsTTY: true,
+    })).resolves.toMatchObject({
+      command: process.execPath,
+      args: ['-e', 'process.stdin.pipe(process.stdout)'],
+    });
+  });
+
+  it('lets --pager fall back to PAGER before less -R', async () => {
+    await expect(resolveSearchPager({
+      flag: true,
+      format: 'compact',
+      env: { PATH: process.env.PATH, PAGER: `${process.execPath} -e "process.stdin.pipe(process.stdout)"` },
+      stdoutIsTTY: true,
+    })).resolves.toMatchObject({
+      command: process.execPath,
+    });
+  });
+
+  it('keeps structured output and non-TTY stdout direct', async () => {
+    await expect(resolveSearchPager({
+      flag: true,
+      format: 'json',
+      env: { PATH: process.env.PATH, PAGER: process.execPath },
+      stdoutIsTTY: true,
+    })).resolves.toBeNull();
+    await expect(resolveSearchPager({
+      flag: true,
+      format: 'md',
+      env: { PATH: process.env.PATH, PAGER: process.execPath },
+      stdoutIsTTY: false,
+    })).resolves.toBeNull();
+  });
+
+  it('treats --no-pager, cat, NO_COLOR, and TERM=dumb as direct output', async () => {
+    for (const input of [
+      { flag: false as const, env: { PATH: process.env.PATH, KB_PAGER: process.execPath } },
+      { flag: true as const, env: { PATH: process.env.PATH, PAGER: 'cat' } },
+      { flag: true as const, env: { PATH: process.env.PATH, PAGER: process.execPath, NO_COLOR: '1' } },
+      { flag: true as const, env: { PATH: process.env.PATH, PAGER: process.execPath, TERM: 'dumb' } },
+    ]) {
+      await expect(resolveSearchPager({
+        ...input,
+        format: 'md',
+        stdoutIsTTY: true,
+      })).resolves.toBeNull();
+    }
+  });
+});
+
+describe('writeMaybePagedOutput (#471)', () => {
+  it('pipes output through the configured pager when enabled on a TTY', async () => {
+    const stdout = new CaptureStream();
+    await writeMaybePagedOutput('paged output\n', {
+      flag: null,
+      format: 'md',
+      env: { PATH: process.env.PATH, KB_PAGER: `${process.execPath} -e "process.stdin.pipe(process.stdout)"` },
+      stdoutIsTTY: true,
+      stdout,
+      capturePagerStdout: true,
+    });
+
+    expect(stdout.text()).toBe('paged output\n');
+  });
+
+  it('falls back to direct stdout when the pager command is not present', async () => {
+    const stdout = new CaptureStream();
+    await writeMaybePagedOutput('direct output\n', {
+      flag: true,
+      format: 'md',
+      env: { PATH: '/definitely/not/a/real/bin', PAGER: 'missing-kb-pager' },
+      stdoutIsTTY: true,
+      stdout,
+      capturePagerStdout: true,
+    });
+
+    expect(stdout.text()).toBe('direct output\n');
+  });
+
+  it('does not fail when the pager exits before consuming stdin', async () => {
+    const stdout = new CaptureStream();
+    await expect(writeMaybePagedOutput('ignored output\n', {
+      flag: null,
+      format: 'md',
+      env: { PATH: process.env.PATH, KB_PAGER: `${process.execPath} -e "process.exit(0)"` },
+      stdoutIsTTY: true,
+      stdout,
+      capturePagerStdout: true,
+    })).resolves.toBeUndefined();
+  });
+});
+
+describe('daemon search pager args (#471)', () => {
+  it('strips pager flags and disables daemon-side env paging', () => {
+    expect(buildDaemonSearchArgs(['query', '--pager', '--format=compact'])).toEqual([
+      'query',
+      '--format=compact',
+      '--no-pager',
+    ]);
+    expect(buildDaemonSearchArgs(['query', '--no-pager'])).toEqual([
+      'query',
+      '--no-pager',
+    ]);
+  });
+});

--- a/src/cli-pager.ts
+++ b/src/cli-pager.ts
@@ -1,0 +1,187 @@
+import { spawn } from 'child_process';
+import { constants as fsConstants } from 'fs';
+import * as fsp from 'fs/promises';
+import * as path from 'path';
+import type { Writable } from 'stream';
+
+export type PagerFlag = boolean | null;
+
+export interface SearchPagerOptions {
+  flag: PagerFlag;
+  format: 'md' | 'compact' | 'json' | 'vimgrep';
+  env?: NodeJS.ProcessEnv;
+  stdoutIsTTY?: boolean;
+  stdout?: Writable;
+  stderr?: Writable;
+  capturePagerStdout?: boolean;
+}
+
+export interface PagerResolution {
+  command: string;
+  args: string[];
+}
+
+const DEFAULT_PAGER = 'less -R';
+const DISABLED_PAGER_VALUES = new Set(['', '0', 'false', 'off', 'none', 'no']);
+
+export async function writeMaybePagedOutput(
+  output: string,
+  options: SearchPagerOptions,
+): Promise<void> {
+  const stdout: Writable = options.stdout ?? process.stdout;
+  const pager = await resolveSearchPager(options);
+  if (pager === null) {
+    writeChunk(stdout, output);
+    return;
+  }
+
+  const usedPager = await writeToPager(output, pager, options);
+  if (!usedPager) {
+    writeChunk(stdout, output);
+  }
+}
+
+export async function resolveSearchPager(
+  options: SearchPagerOptions,
+): Promise<PagerResolution | null> {
+  if (options.format !== 'md' && options.format !== 'compact') return null;
+  if (options.flag === false) return null;
+
+  const env = options.env ?? process.env;
+  const stdoutIsTTY = options.stdoutIsTTY ?? process.stdout.isTTY === true;
+  if (!stdoutIsTTY) return null;
+  if (env.TERM === 'dumb') return null;
+  if (env.NO_COLOR !== undefined && env.NO_COLOR !== '') return null;
+
+  const kbPager = env.KB_PAGER;
+  const envEnabled = kbPager !== undefined && kbPager.trim() !== '';
+  if (options.flag !== true && !envEnabled) return null;
+
+  const raw = (envEnabled ? kbPager : (env.PAGER && env.PAGER.trim() !== '' ? env.PAGER : DEFAULT_PAGER)) ?? DEFAULT_PAGER;
+  if (isPagerDisabledValue(raw)) return null;
+
+  const argv = splitPagerCommand(raw);
+  if (argv.length === 0) return null;
+  const [command, ...args] = argv;
+  if (isCatPager(command)) return null;
+  if (!(await commandExists(command, env))) return null;
+  return { command, args };
+}
+
+export function buildDaemonSearchArgs(args: readonly string[]): string[] {
+  const out = args.filter((arg) => arg !== '--pager' && arg !== '--no-pager');
+  out.push('--no-pager');
+  return out;
+}
+
+async function writeToPager(
+  output: string,
+  pager: PagerResolution,
+  options: SearchPagerOptions,
+): Promise<boolean> {
+  const stderr = options.stderr ?? process.stderr;
+  const stdout: Writable = options.stdout ?? process.stdout;
+  const child = spawn(pager.command, pager.args, {
+    stdio: ['pipe', options.capturePagerStdout ? 'pipe' : stdout, stderr],
+  });
+
+  if (child.stdout) {
+    child.stdout.on('data', (chunk) => {
+      writeChunk(stdout, chunk);
+    });
+  }
+
+  let spawnFailed = false;
+  child.on('error', () => {
+    spawnFailed = true;
+  });
+
+  await Promise.all([
+    new Promise<void>((resolve) => {
+      if (child.stdin === null) {
+        resolve();
+        return;
+      }
+      child.stdin.on('error', () => resolve());
+      child.stdin.end(output, () => resolve());
+    }),
+    new Promise<void>((resolve) => {
+      child.on('close', () => resolve());
+      child.on('error', () => resolve());
+    }),
+  ]);
+
+  return !spawnFailed;
+}
+
+function writeChunk(stream: Writable, chunk: string | Buffer): void {
+  stream.write(chunk);
+}
+
+function isPagerDisabledValue(value: string): boolean {
+  return DISABLED_PAGER_VALUES.has(value.trim().toLowerCase());
+}
+
+function isCatPager(command: string): boolean {
+  return path.basename(command).toLowerCase() === 'cat';
+}
+
+function splitPagerCommand(commandLine: string): string[] {
+  const out: string[] = [];
+  let current = '';
+  let quote: '"' | "'" | null = null;
+  let escaping = false;
+
+  for (const char of commandLine.trim()) {
+    if (escaping) {
+      current += char;
+      escaping = false;
+      continue;
+    }
+    if (char === '\\' && quote !== "'") {
+      escaping = true;
+      continue;
+    }
+    if ((char === '"' || char === "'") && quote === null) {
+      quote = char;
+      continue;
+    }
+    if (quote === char) {
+      quote = null;
+      continue;
+    }
+    if (/\s/.test(char) && quote === null) {
+      if (current !== '') {
+        out.push(current);
+        current = '';
+      }
+      continue;
+    }
+    current += char;
+  }
+
+  if (escaping) current += '\\';
+  if (current !== '') out.push(current);
+  return out;
+}
+
+async function commandExists(command: string, env: NodeJS.ProcessEnv): Promise<boolean> {
+  if (command.includes(path.sep)) {
+    return isExecutable(command);
+  }
+  const pathEnv = env.PATH ?? process.env.PATH ?? '';
+  for (const dir of pathEnv.split(path.delimiter)) {
+    if (dir === '') continue;
+    if (await isExecutable(path.join(dir, command))) return true;
+  }
+  return false;
+}
+
+async function isExecutable(file: string): Promise<boolean> {
+  try {
+    await fsp.access(file, fsConstants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/cli-search.test.ts
+++ b/src/cli-search.test.ts
@@ -142,6 +142,17 @@ describe('parseSearchArgs freshness', () => {
   });
 });
 
+describe('parseSearchArgs pager (#471)', () => {
+  it('defaults to env-driven pager resolution', () => {
+    expect(parseSearchArgs(['query'])).toMatchObject({ pager: null });
+  });
+
+  it('accepts explicit pager opt-in and opt-out', () => {
+    expect(parseSearchArgs(['query', '--pager'])).toMatchObject({ pager: true });
+    expect(parseSearchArgs(['query', '--no-pager'])).toMatchObject({ pager: false });
+  });
+});
+
 describe('parseSearchArgs --explain-empty (#328)', () => {
   it('defaults to false so the inline #335 guidance keeps its current behaviour', () => {
     expect(parseSearchArgs(['query'])).toMatchObject({ explainEmpty: false });
@@ -275,6 +286,43 @@ describe('runSearch timing guard (#331)', () => {
       stderrSpy.mockRestore();
     }
   }
+
+  it('routes dense markdown output through the pager writer at the runSearch boundary', async () => {
+    const { deps, manager } = makeDeps();
+    const writeOutput = jest.fn(async () => {});
+    deps.writeOutput = writeOutput;
+    manager.similaritySearch.mockResolvedValueOnce([
+      {
+        pageContent: 'pager result',
+        metadata: { source: '/kb/ops/pager.md', chunkIndex: 0 },
+        score: 0.1,
+      },
+    ] as never);
+    const originalIsTTY = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY');
+    Object.defineProperty(process.stdout, 'isTTY', { configurable: true, value: true });
+
+    try {
+      const out = await captureSearchOutput(['pager query', '--pager', '--no-freshness'], deps);
+
+      expect(out.code).toBe(0);
+      expect(out.stdout).toBe('');
+      expect(writeOutput).toHaveBeenCalledTimes(1);
+      expect(writeOutput).toHaveBeenCalledWith(
+        expect.stringContaining('pager result'),
+        expect.objectContaining({
+          flag: true,
+          format: 'md',
+          stdoutIsTTY: true,
+        }),
+      );
+    } finally {
+      if (originalIsTTY) {
+        Object.defineProperty(process.stdout, 'isTTY', originalIsTTY);
+      } else {
+        delete (process.stdout as { isTTY?: boolean }).isTTY;
+      }
+    }
+  });
 
   it('runs dense JSONL batch rows while loading the model manager and index once', async () => {
     const { deps, manager } = makeDeps();

--- a/src/cli-search.ts
+++ b/src/cli-search.ts
@@ -83,6 +83,7 @@ import {
   type RerankOverride,
   type RerankerConfig,
 } from './reranker.js';
+import { writeMaybePagedOutput, type PagerFlag } from './cli-pager.js';
 import {
   inspectTaskContext,
   resolveTaskContextArgvMax,
@@ -190,6 +191,9 @@ Output:
                         in markdown output. With \`--format=json\`, adds a
                         \`grouped_results\` field alongside raw results.
   --timing              Include elapsed milliseconds for retrieval stages.
+  --pager               Page markdown/compact output through KB_PAGER, PAGER,
+                        or less -R when stdout is a TTY.
+  --no-pager            Disable KB_PAGER for this search.
   --no-freshness        Skip the staleness scan and omit freshness output.
   --explain-empty       Opt-in deep diagnostics for empty results: pre/post
                         filter candidate counts, per-filter drops, scope,
@@ -239,6 +243,7 @@ interface SearchArgs {
   groupBySource: boolean;
   mode: SearchMode;
   timing: boolean;
+  pager: PagerFlag;
   interactive: boolean;
   batchJsonl: boolean;
   noCache: boolean;
@@ -261,6 +266,7 @@ export interface RunSearchDeps {
   resolveActiveModel: typeof resolveActiveModel;
   loadManagerForModel: typeof loadManagerForModel;
   loadWithJsonRetry: typeof loadWithJsonRetry;
+  writeOutput?: typeof writeMaybePagedOutput;
   computeStaleness?: typeof computeStaleness;
   listLexicalKbs?: typeof listLexicalKbs;
   loadLexicalIndex?: typeof LexicalIndex.load;
@@ -572,7 +578,7 @@ export async function runSearch(
     const out = formatRetrievalAsVimgrep(results);
     if (out !== '') process.stdout.write(`${out}\n`);
   } else if (parsed.format === 'compact') {
-    process.stdout.write(formatDenseSearchCompactOutput({
+    await writeSearchOutput(parsed, deps, formatDenseSearchCompactOutput({
       results,
       mode: effectiveMode,
       staleness,
@@ -581,7 +587,7 @@ export async function runSearch(
       timing,
     }));
   } else {
-    process.stdout.write(formatDenseSearchMarkdownOutput({
+    await writeSearchOutput(parsed, deps, formatDenseSearchMarkdownOutput({
       results,
       groupBySource: parsed.groupBySource,
       staleness,
@@ -599,6 +605,21 @@ export async function runSearch(
   }
 
   return 0;
+}
+
+async function writeSearchOutput(
+  parsed: SearchArgs,
+  deps: RunSearchDeps,
+  output: string,
+): Promise<void> {
+  await (deps.writeOutput ?? writeMaybePagedOutput)(output, {
+    flag: parsed.pager,
+    format: parsed.format,
+    env: process.env,
+    stdoutIsTTY: process.stdout.isTTY === true,
+    stdout: process.stdout,
+    stderr: process.stderr,
+  });
 }
 
 /**
@@ -717,6 +738,7 @@ export function parseSearchArgs(rest: string[]): SearchArgs {
     groupBySource: false,
     mode: 'dense',
     timing: false,
+    pager: null,
     interactive: false,
     batchJsonl: false,
     noCache: false,
@@ -733,6 +755,8 @@ export function parseSearchArgs(rest: string[]): SearchArgs {
     if (raw === '--stdin')   { out.stdin = true; continue; }
     if (raw === '--group-by-source') { out.groupBySource = true; continue; }
     if (raw === '--timing') { out.timing = true; continue; }
+    if (raw === '--pager') { out.pager = true; continue; }
+    if (raw === '--no-pager') { out.pager = false; continue; }
     if (raw === '--no-cache') { out.noCache = true; continue; }
     if (raw === '--gate') { out.gateOverride = 'on'; continue; }
     if (raw === '--no-gate') { out.gateOverride = 'off'; continue; }
@@ -1921,32 +1945,31 @@ async function runLexicalSearch(
     const out = formatRetrievalAsVimgrep(formatted as never);
     if (out !== '') process.stdout.write(`${out}\n`);
   } else if (parsed.format === 'compact') {
+    let output = '';
     if (autoModeDecision) {
-      process.stdout.write(formatAutoModeHeader(autoModeDecision));
-      process.stdout.write('\n\n');
+      output += `${formatAutoModeHeader(autoModeDecision)}\n\n`;
     }
-    process.stdout.write(`${formatRetrievalAsCompactTable(formatted as never, {
+    output += `${formatRetrievalAsCompactTable(formatted as never, {
       mode: 'lexical',
       gate: 'bypassed',
       width: process.stdout.columns,
-    })}\n`);
+    })}\n`;
     const summary = `${perKb.length} KB(s), ${errors.length} error(s)`;
-    process.stdout.write(`> _Lexical status: ${summary}._\n`);
+    output += `> _Lexical status: ${summary}._\n`;
     if (timing) {
-      process.stdout.write(formatTimingFooter('Timing', timing));
-      process.stdout.write('\n');
+      output += `${formatTimingFooter('Timing', timing)}\n`;
     }
+    await writeSearchOutput(parsed, deps, output);
   } else {
+    let output = '';
     if (autoModeDecision) {
-      process.stdout.write(formatAutoModeHeader(autoModeDecision));
-      process.stdout.write('\n\n');
+      output += `${formatAutoModeHeader(autoModeDecision)}\n\n`;
     }
-    process.stdout.write(`> _Mode: lexical (BM25). Stage 1 — debug surface; see #206._\n\n`);
+    output += `> _Mode: lexical (BM25). Stage 1 — debug surface; see #206._\n\n`;
     if (formatted.length === 0) {
-      process.stdout.write(`_No matches._\n\n`);
+      output += `_No matches._\n\n`;
     } else {
-      process.stdout.write(formatRetrievalAsMarkdown(formatted as never, FRONTMATTER_EXTRAS_WIRE_VISIBLE, KB_EDITOR_URI));
-      process.stdout.write('\n\n');
+      output += `${formatRetrievalAsMarkdown(formatted as never, FRONTMATTER_EXTRAS_WIRE_VISIBLE, KB_EDITOR_URI)}\n\n`;
     }
     const summaryLines = perKb.map((r) => {
       if (r.error) return `- ${r.kbName}: error — ${r.error.message}`;
@@ -1959,12 +1982,11 @@ async function runLexicalSearch(
         : '(no refresh this run)';
       return `- ${r.kbName}: ${counts}`;
     });
-    process.stdout.write(`> _Lexical index status:_\n${summaryLines.join('\n')}\n`);
+    output += `> _Lexical index status:_\n${summaryLines.join('\n')}\n`;
     if (timing) {
-      process.stdout.write(`\n`);
-      process.stdout.write(formatTimingFooter('Timing', timing));
-      process.stdout.write('\n');
+      output += `\n${formatTimingFooter('Timing', timing)}\n`;
     }
+    await writeSearchOutput(parsed, deps, output);
   }
 
   return errors.length > 0 ? 1 : 0;
@@ -2177,65 +2199,56 @@ async function runHybridSearch(
     const out = formatRetrievalAsVimgrep(ranked as never);
     if (out !== '') process.stdout.write(`${out}\n`);
   } else if (parsed.format === 'compact') {
+    let output = '';
     if (autoModeDecision) {
-      process.stdout.write(formatAutoModeHeader(autoModeDecision));
-      process.stdout.write('\n\n');
+      output += `${formatAutoModeHeader(autoModeDecision)}\n\n`;
     }
-    process.stdout.write(`${formatRetrievalAsCompactTable(ranked as never, {
+    output += `${formatRetrievalAsCompactTable(ranked as never, {
       mode: 'hybrid',
       gate: compactGateMarker(gateVerdict),
       width: process.stdout.columns,
-    })}\n`);
-    process.stdout.write(
-      `> _Hybrid status: dense ${denseResults.length}, lexical ${lexicalResults.length}, refreshed ${lexicalResultsRow.refreshed}, failed ${lexicalResultsRow.failed}, RRF c=${HYBRID_RRF_C}._\n`,
-    );
+    })}\n`;
+    output += `> _Hybrid status: dense ${denseResults.length}, lexical ${lexicalResults.length}, refreshed ${lexicalResultsRow.refreshed}, failed ${lexicalResultsRow.failed}, RRF c=${HYBRID_RRF_C}._\n`;
     if (rerankResult.candidatesIn > 0) {
       const degraded = rerankResult.degraded ? '; degraded to fused order' : '';
-      process.stdout.write(
-        `> _Rerank: ${rerankResult.model}; rescored ${rerankResult.candidatesIn} candidate(s), cache hits ${rerankResult.cacheHits}${degraded}._\n`,
-      );
+      output += `> _Rerank: ${rerankResult.model}; rescored ${rerankResult.candidatesIn} candidate(s), cache hits ${rerankResult.cacheHits}${degraded}._\n`;
     }
     if (gateVerdict.state !== 'bypassed') {
-      process.stdout.write(`${formatGateVerdictFooter(gateVerdict)}\n`);
+      output += `${formatGateVerdictFooter(gateVerdict)}\n`;
     }
     if (parsed.explain) {
-      process.stdout.write(`${formatGateDroppedList(gateVerdict)}\n`);
+      output += `${formatGateDroppedList(gateVerdict)}\n`;
     }
     if (timing) {
-      process.stdout.write(formatTimingFooter('Timing', timing));
-      process.stdout.write('\n');
+      output += `${formatTimingFooter('Timing', timing)}\n`;
     }
+    await writeSearchOutput(parsed, deps, output);
   } else {
+    let output = '';
     if (autoModeDecision) {
-      process.stdout.write(formatAutoModeHeader(autoModeDecision));
-      process.stdout.write('\n\n');
+      output += `${formatAutoModeHeader(autoModeDecision)}\n\n`;
     }
-    process.stdout.write(`> _Mode: hybrid (RRF c=${HYBRID_RRF_C}). Stage 2 - dense + lexical; see #206._\n\n`);
+    output += `> _Mode: hybrid (RRF c=${HYBRID_RRF_C}). Stage 2 - dense + lexical; see #206._\n\n`;
     if (ranked.length === 0) {
-      process.stdout.write(`_No matches._\n\n`);
+      output += `_No matches._\n\n`;
     } else {
-      process.stdout.write(formatRetrievalAsMarkdown(ranked as never, FRONTMATTER_EXTRAS_WIRE_VISIBLE, KB_EDITOR_URI));
-      process.stdout.write('\n\n');
+      output += `${formatRetrievalAsMarkdown(ranked as never, FRONTMATTER_EXTRAS_WIRE_VISIBLE, KB_EDITOR_URI)}\n\n`;
     }
-    process.stdout.write(
-      `> _Hybrid status: dense fetched ${denseResults.length}, lexical fetched ${lexicalResults.length} (refreshed ${lexicalResultsRow.refreshed}, ${lexicalResultsRow.failed} failed); fused via RRF (c=${HYBRID_RRF_C}, fetch_k=${fetchK})._\n`,
-    );
+    output += `> _Hybrid status: dense fetched ${denseResults.length}, lexical fetched ${lexicalResults.length} (refreshed ${lexicalResultsRow.refreshed}, ${lexicalResultsRow.failed} failed); fused via RRF (c=${HYBRID_RRF_C}, fetch_k=${fetchK})._\n`;
     if (rerankResult.candidatesIn > 0) {
       const degraded = rerankResult.degraded ? '; degraded to fused order' : '';
-      process.stdout.write(
-        `> _Rerank: ${rerankResult.model}; rescored ${rerankResult.candidatesIn} candidate(s), cache hits ${rerankResult.cacheHits}${degraded}._\n`,
-      );
+      output += `> _Rerank: ${rerankResult.model}; rescored ${rerankResult.candidatesIn} candidate(s), cache hits ${rerankResult.cacheHits}${degraded}._\n`;
     }
     if (gateVerdict.state !== 'bypassed') {
-      process.stdout.write(`${formatGateVerdictFooter(gateVerdict)}\n`);
+      output += `${formatGateVerdictFooter(gateVerdict)}\n`;
     }
     if (parsed.explain) {
-      process.stdout.write(`${formatGateDroppedList(gateVerdict)}\n`);
+      output += `${formatGateDroppedList(gateVerdict)}\n`;
     }
     if (timing) {
-      process.stdout.write(formatTimingFooter('Timing', timing));
-      process.stdout.write('\n');
+      output += `${formatTimingFooter('Timing', timing)}\n`;
     }
+    await writeSearchOutput(parsed, deps, output);
   }
 
   return 0;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -31,7 +31,7 @@ import { QUARANTINE_HELP, runQuarantine } from './cli-quarantine.js';
 import { REINDEX_HELP, runReindexCli } from './cli-reindex.js';
 import { REMEMBER_HELP, runRemember } from './cli-remember.js';
 import { RESEARCH_HELP, runResearch } from './cli-research.js';
-import { SEARCH_HELP, runSearch } from './cli-search.js';
+import { SEARCH_HELP, parseSearchArgs, runSearch } from './cli-search.js';
 import { SERVE_HELP, runServe } from './cli-serve.js';
 import { STALE_CHECK_HELP, runStaleCheck } from './cli-stale-check.js';
 import { STATS_HELP, runStats } from './cli-stats.js';
@@ -40,6 +40,7 @@ import { VERIFY_HELP, runVerify } from './cli-verify.js';
 import { WHERE_HELP, runWhere } from './cli-where.js';
 import { daemonUrlFromEnv, tryRunDaemonCommand } from './daemon-client.js';
 import { emitCanonicalLog } from './canonical-log.js';
+import { buildDaemonSearchArgs, resolveSearchPager } from './cli-pager.js';
 
 // ----- Subcommand registry --------------------------------------------------
 
@@ -151,6 +152,7 @@ Environment:
   EMBEDDING_PROVIDER        ollama | openai | huggingface
   KB_ACTIVE_MODEL           Override the active model for this process (RFC 013 §4.7).
   KB_DAEMON_URL             URL for \`kb search --daemon\` (default http://127.0.0.1:17799).
+  KB_PAGER                  Pager command and opt-in for human-readable \`kb search\` output.
   KB_LLM_ENDPOINT           OpenAI-compatible endpoint used by \`kb ask\`.
   LOG_FILE                  Optional file used by \`kb logs\` and by runtime logging.
   KB_LOG_FORMAT             text | canonical | both (default both).
@@ -529,9 +531,12 @@ async function runSearchMaybeViaDaemon(rest: string[]): Promise<number> {
   if (directRest.includes('--refresh')) {
     return runSearch(directRest);
   }
+  if (await shouldRunSearchLocallyForPager(directRest)) {
+    return runSearch(directRest);
+  }
 
   const startedAt = Date.now();
-  const daemonResult = await tryRunDaemonCommand('search', directRest);
+  const daemonResult = await tryRunDaemonCommand('search', buildDaemonSearchArgs(directRest));
   if (daemonResult === null) {
     // The daemon was unreachable: tell the operator the search still ran,
     // just directly, and how long the daemon probe cost before falling back.
@@ -544,6 +549,20 @@ async function runSearchMaybeViaDaemon(rest: string[]): Promise<number> {
   if (daemonResult.stdout !== '') process.stdout.write(daemonResult.stdout);
   if (daemonResult.stderr !== '') process.stderr.write(daemonResult.stderr);
   return daemonResult.exitCode;
+}
+
+async function shouldRunSearchLocallyForPager(rest: string[]): Promise<boolean> {
+  try {
+    const parsed = parseSearchArgs(rest);
+    return await resolveSearchPager({
+      flag: parsed.pager,
+      format: parsed.format,
+      env: process.env,
+      stdoutIsTTY: process.stdout.isTTY === true,
+    }) !== null;
+  } catch {
+    return false;
+  }
 }
 
 /** ` at <url>` for the fallback notice, or '' when the daemon URL is unset. */


### PR DESCRIPTION
## Summary
- add `kb search --pager` / `--no-pager` plus `KB_PAGER` support for human-readable search output
- route markdown and compact search output through a configurable pager only when stdout is a TTY
- keep JSON/vimgrep, non-TTY, disabled/cat/missing pager, `NO_COLOR`, and `TERM=dumb` paths direct
- keep daemon-backed search from paging inside daemon capture; pager-enabled searches run locally and daemon requests receive `--no-pager`
- document the pager knob in CLI help and feature flags

Closes #471

## Tests
- `npm run build`
- `npm test -- --runTestsByPath src/cli-pager.test.ts src/cli-search.test.ts`
- `npm test -- --runTestsByPath src/cli-json-contracts.test.ts src/cli.test.ts -t "help|search"`
- `npm test -- --runTestsByPath src/cli-pager.test.ts src/cli-search.test.ts src/cli-json-contracts.test.ts src/cli.test.ts -t "pager|help|search"`
- `npm test -- --runTestsByPath src/cli-pager.test.ts src/cli-search.test.ts src/cli.test.ts -t "pager|daemon|search"`
- `npm test -- --runTestsByPath src/cli-json-contracts.test.ts src/cli.test.ts -t "help|daemon|search|pager"`
- `npm test`