### PR TITLE
feat: quarantine secret-bearing ingest chunks

### DIFF
--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -140,6 +140,7 @@ wrap-close vars below.
 | HuggingFace API key | `HUGGINGFACE_API_KEY` | required for HuggingFace | HuggingFace embedding provider | Implemented | none | `EMBEDDING_PROVIDER=huggingface kb doctor` |
 | Extra ingest extensions | `INGEST_EXTRA_EXTENSIONS` | empty | Ingest and refresh | Implemented | none | `INGEST_EXTRA_EXTENSIONS=.pdf kb search "known phrase" --refresh` |
 | Extra ingest exclusions | `INGEST_EXCLUDE_PATHS` | empty | Ingest and refresh | Implemented | none | `INGEST_EXCLUDE_PATHS="drafts/**" kb search "known phrase" --refresh` |
+| Ingest secret scan | `KB_INGEST_SECRET_SCAN` | `off` | Ingest and refresh | Implemented, opt-in | `KB_SECRET_SCAN_BYPASS_KBS=<csv>` | `KB_INGEST_SECRET_SCAN=on kb search "query" --refresh` |
 | Refresh quiescence guard | `KB_REFRESH_QUIESCE_MS` | `0` | Ingest and refresh | Implemented, opt-in | none | `KB_REFRESH_QUIESCE_MS=1000 kb search "query" --refresh` |
 | Maximum raw file size | `KB_MAX_FILE_BYTES` | `104857600` | Ingest and refresh | Implemented | none | `KB_MAX_FILE_BYTES=1048576 kb search "query" --refresh` |
 | Maximum extracted text size | `KB_MAX_EXTRACTED_TEXT_BYTES` | `16777216` | Ingest and refresh | Implemented | none | `KB_MAX_EXTRACTED_TEXT_BYTES=1048576 kb search "query" --refresh` |

--- a/docs/operations/secret-scan.md
+++ b/docs/operations/secret-scan.md
@@ -1,0 +1,18 @@
+# Ingest Secret Scan
+
+`KB_INGEST_SECRET_SCAN=on` scans chunks after loading and splitting, but before
+contextual prefaces or embeddings are produced. If a chunk contains a
+high-confidence credential shape, the whole source file is quarantined with
+`error_category: "secret_detected"` and no chunks from that file are added to
+FAISS.
+
+The scanner detects common provider keys, GitHub tokens, JWT-shaped strings,
+SSH private-key blocks, bearer headers, password/token assignments, and
+high-entropy standalone tokens. It records only categories, chunk indexes, and
+file paths; matched secret text is never written to logs or quarantine
+metadata.
+
+Use `KB_SECRET_SCAN_BYPASS_KBS=<kb-a>,<kb-b>` for shelves that intentionally
+store secret examples, such as auth cookbooks. Existing vectors are not
+retroactively removed; run a force reindex with the flag enabled to rebuild an
+index under the scanner.

--- a/src/FaissIndexManager.test.ts
+++ b/src/FaissIndexManager.test.ts
@@ -392,12 +392,15 @@ describe('FaissIndexManager permission handling', () => {
     KB_CHUNK_SIZE: process.env.KB_CHUNK_SIZE,
     KB_CHUNK_OVERLAP: process.env.KB_CHUNK_OVERLAP,
     KB_REFRESH_QUIESCE_MS: process.env.KB_REFRESH_QUIESCE_MS,
+    KB_INGEST_SECRET_SCAN: process.env.KB_INGEST_SECRET_SCAN,
+    KB_SECRET_SCAN_BYPASS_KBS: process.env.KB_SECRET_SCAN_BYPASS_KBS,
   };
 
 
   beforeEach(() => {
     saveMock.mockReset();
     addDocumentsMock.mockReset();
+    addVectorsMock.mockReset();
     fromTextsMock.mockReset();
     loadMock.mockReset();
     similaritySearchMock.mockReset();
@@ -1506,6 +1509,53 @@ describe('FaissIndexManager permission handling', () => {
     await manager.updateIndex('default');
     expect(fromTextsMock).toHaveBeenCalledTimes(1);
     await expect(listIngestQuarantine(defaultKb)).resolves.toEqual([]);
+  });
+
+  it('quarantines secret-bearing chunks before embedding when ingest secret scan is enabled', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-faiss-secret-scan-'));
+    const kbDir = path.join(tempDir, 'kb');
+    const defaultKb = path.join(kbDir, 'default');
+    await fsp.mkdir(defaultKb, { recursive: true });
+    const docPath = path.join(defaultKb, 'secret.md');
+    await fsp.writeFile(docPath, '# Secret\n\npassword=abcDEF1234567890!\n', 'utf-8');
+
+    process.env.KNOWLEDGE_BASES_ROOT_DIR = kbDir;
+    process.env.FAISS_INDEX_PATH = path.join(tempDir, '.faiss');
+    process.env.EMBEDDING_PROVIDER = 'huggingface';
+    process.env.HUGGINGFACE_API_KEY = 'test-key';
+    process.env.KB_INGEST_SECRET_SCAN = 'on';
+
+    jest.resetModules();
+    const { FaissIndexManager } = await import('./FaissIndexManager.js');
+    const { listIngestQuarantine } = await import('./ingest-quarantine.js');
+    const manager = new FaissIndexManager();
+    await manager.initialize();
+
+    await manager.updateIndex('default');
+
+    expect(fromTextsMock).not.toHaveBeenCalled();
+    expect(addVectorsMock).not.toHaveBeenCalled();
+    expect(manager.getLastIndexUpdateSummary()).toMatchObject({
+      status: 'partial',
+      files_scanned: 1,
+      files_changed: 1,
+      files_skipped: 1,
+      chunks_attempted: 0,
+      failure_count: 1,
+      failures: [expect.objectContaining({
+        relative_path: 'secret.md',
+        phase: 'indexing',
+        code: 'KB_INGEST_SECRET_DETECTED',
+      })],
+    });
+    await expect(listIngestQuarantine(defaultKb)).resolves.toEqual([
+      expect.objectContaining({
+        relative_path: 'secret.md',
+        error_category: 'secret_detected',
+        error_code: 'KB_INGEST_SECRET_DETECTED',
+        message: expect.stringContaining('key_value_secret'),
+      }),
+    ]);
   });
 
   it('sanitizes absolute file paths in update failure summaries', async () => {

--- a/src/FaissIndexManager.ts
+++ b/src/FaissIndexManager.ts
@@ -3,6 +3,7 @@ import * as fsp from 'fs/promises';
 import * as path from 'path';
 import type { EmbeddingsInterface } from '@langchain/core/embeddings';
 import { Document } from "@langchain/core/documents";
+import { emitCanonicalLog, type CanonicalProcess } from './canonical-log.js';
 import { createEmbeddingsClient, type EmbeddingsClient } from './embedding-provider.js';
 import { handleFsOperationError, toError } from './error-utils.js';
 import { calculateSHA256, pathExists } from './file-utils.js';
@@ -89,6 +90,7 @@ import {
   recordIngestSuccess,
   shouldRetryIngest,
 } from './ingest-quarantine.js';
+import { IngestSecretDetectedError } from './secret-scanner.js';
 
 export { MigrationRefusedError } from './layout-bootstrap.js';
 
@@ -100,6 +102,10 @@ async function writeModelNameAtomic(modelNameFile: string, modelName: string): P
   const tmp = `${modelNameFile}.${process.pid}.tmp`;
   await fsp.writeFile(tmp, modelName, 'utf-8');
   await fsp.rename(tmp, modelNameFile);
+}
+
+function canonicalProcessFromArgv(): CanonicalProcess {
+  return process.argv.some((entry) => /(?:^|[/\\])cli\.(?:js|ts|mjs)$/.test(entry)) ? 'cli' : 'mcp';
 }
 
 // ---------------------------------------------------------------------------
@@ -1293,6 +1299,21 @@ export class FaissIndexManager {
       sourceHash: string | null,
       error: unknown,
     ): Promise<void> => {
+      if (error instanceof IngestSecretDetectedError) {
+        emitCanonicalLog({
+          process: canonicalProcessFromArgv(),
+          event: 'secret_detected',
+          level: 'warn',
+          kb_scope: path.basename(kbPath),
+          top_sources: [relativePath],
+          took_ms: 0,
+          error: { code: error.code, category: 'input' },
+          secret_scan: {
+            categories: error.categories,
+            chunk_indexes: error.chunkIndexes,
+          },
+        });
+      }
       try {
         await recordIngestFailure({
           kbPath,

--- a/src/canonical-log.ts
+++ b/src/canonical-log.ts
@@ -56,6 +56,7 @@ export interface CanonicalLogEvent {
   recovery_hint?: string;
   rerank?: Record<string, unknown>;
   gate?: Record<string, unknown>;
+  secret_scan?: Record<string, unknown>;
   llm_provider?: string;
 }
 
@@ -97,6 +98,7 @@ const CANONICAL_FIELD_ORDER: readonly (keyof CanonicalLogEvent)[] = [
   'recovery_hint',
   'rerank',
   'gate',
+  'secret_scan',
   'llm_provider',
 ];
 
@@ -143,6 +145,7 @@ export function normalizeCanonicalEvent(input: CanonicalLogInput): CanonicalLogE
   assignIfDefined(event, 'recovery_hint', input.recovery_hint);
   assignIfDefined(event, 'rerank', input.rerank);
   assignIfDefined(event, 'gate', input.gate);
+  assignIfDefined(event, 'secret_scan', input.secret_scan);
   assignIfDefined(event, 'llm_provider', input.llm_provider);
 
   return event;

--- a/src/config/ingest.ts
+++ b/src/config/ingest.ts
@@ -6,6 +6,11 @@ function parseCommaSeparatedList(raw: string | undefined): string[] {
     .filter((entry) => entry.length > 0);
 }
 
+function parseOnOff(raw: string | undefined): boolean {
+  const normalized = raw?.trim().toLowerCase();
+  return normalized === 'on' || normalized === '1' || normalized === 'true' || normalized === 'yes';
+}
+
 // ---------------------------------------------------------------------------
 // Ingest filter configuration (RFC 011 section5.2.3).
 // Operator-extensible extras; the base allowlist and exclusion rules in
@@ -78,4 +83,22 @@ export function parseRefreshQuiesceMs(raw: string | undefined): number {
 
 export function resolveRefreshQuiesceMs(): number {
   return parseRefreshQuiesceMs(process.env.KB_REFRESH_QUIESCE_MS);
+}
+
+// ---------------------------------------------------------------------------
+// Ingest secret scan (#472).
+// ---------------------------------------------------------------------------
+
+export interface IngestSecretScanOptions {
+  enabled: boolean;
+  bypassKnowledgeBases: string[];
+}
+
+export function resolveIngestSecretScanOptions(
+  env: NodeJS.ProcessEnv = process.env,
+): IngestSecretScanOptions {
+  return {
+    enabled: parseOnOff(env.KB_INGEST_SECRET_SCAN),
+    bypassKnowledgeBases: parseCommaSeparatedList(env.KB_SECRET_SCAN_BYPASS_KBS),
+  };
 }

--- a/src/file-ingest.ts
+++ b/src/file-ingest.ts
@@ -33,6 +33,7 @@ import { parseFrontmatter } from './frontmatter.js';
 import { detectSiblingPdfPath, liftFrontmatter } from './frontmatter-lift.js';
 import { applyExtractedTextLimit } from './loaders.js';
 import { logger } from './logger.js';
+import { assertNoIngestSecrets } from './secret-scanner.js';
 import { withSidecarLock } from './write-lock.js';
 
 export interface PendingSidecarWrite {
@@ -243,6 +244,11 @@ export async function buildChunkDocuments(
     [body],
     [{ source: filePath }],
   );
+
+  assertNoIngestSecrets(documents.map((document) => document.pageContent), {
+    relativePath,
+    knowledgeBaseName,
+  });
 
   // RFC 017 — contextual-retrieval prefaces. Gated off by default; when
   // enabled, we call the LLM once per chunk (cached) to produce a short

--- a/src/ingest-quarantine.ts
+++ b/src/ingest-quarantine.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import { classifyKbSearchError, type SearchFailureCategory } from './search-errors-core.js';
 import { toError } from './error-utils.js';
 import { assertNoTraversal } from './kb-fs.js';
+import { IngestSecretDetectedError } from './secret-scanner.js';
 import { withSidecarLock } from './write-lock.js';
 
 export const INGEST_QUARANTINE_SCHEMA_VERSION = 'ingest-quarantine.v1';
@@ -14,7 +15,7 @@ export const DEFAULT_INGEST_QUARANTINE_MAX_ENTRIES = 1000;
 const BASE_RETRY_DELAY_MS = 60_000;
 const MAX_RETRY_DELAY_MS = 24 * 60 * 60_000;
 
-export type IngestQuarantineCategory = SearchFailureCategory;
+export type IngestQuarantineCategory = SearchFailureCategory | 'secret_detected';
 
 export interface IngestQuarantineRecord {
   schema_version: typeof INGEST_QUARANTINE_SCHEMA_VERSION;
@@ -201,6 +202,13 @@ function classifyIngestError(error: unknown): {
   code: string;
   message: string;
 } {
+  if (error instanceof IngestSecretDetectedError) {
+    return {
+      category: 'secret_detected',
+      code: error.code,
+      message: error.message,
+    };
+  }
   const classified = classifyKbSearchError(error);
   const fsCode = (error as NodeJS.ErrnoException | undefined)?.code;
   if (typeof fsCode === 'string' && fsCode.length > 0) {

--- a/src/secret-scanner.test.ts
+++ b/src/secret-scanner.test.ts
@@ -1,0 +1,71 @@
+import {
+  IngestSecretDetectedError,
+  assertNoIngestSecrets,
+  detectSecretsInText,
+} from './secret-scanner.js';
+
+describe('ingest secret scanner', () => {
+  it('detects curated credential shapes without returning matched payloads', () => {
+    const cases = [
+      ['aws_access_key', 'export AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE'],
+      ['gcp_api_key', 'AIzaSyD-1234567890abcdefghijklmnopqrstu'],
+      ['github_token', 'ghp_1234567890abcdefghijklmnopqrstuvwxyzABCD'],
+      [
+        'jwt',
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.vJ8eQhVZl2w5uXqO78Fpm_4ZcYc8-Ma5zJ5PpQ',
+      ],
+      ['ssh_private_key', '-----BEGIN OPENSSH PRIVATE KEY-----'],
+      ['bearer_token', 'Authorization: Bearer abcDEF1234567890abcDEF1234567890'],
+      ['azure_storage_key', 'AccountKey=abcDEF1234567890abcDEF1234567890abcDEF1234567890=='],
+      ['key_value_secret', 'password=abcDEF1234567890!'],
+    ] as const;
+
+    for (const [category, text] of cases) {
+      expect(detectSecretsInText(text)).toEqual(expect.arrayContaining([
+        expect.objectContaining({ category, chunkIndex: 0 }),
+      ]));
+    }
+  });
+
+  it('throws only when the feature is enabled and the KB is not bypassed', () => {
+    const chunks = ['ordinary runbook text', 'token=abcDEF1234567890!'];
+
+    expect(() => assertNoIngestSecrets(chunks, {
+      relativePath: 'alpha/secret.md',
+      knowledgeBaseName: 'alpha',
+      scanOptions: { enabled: false, bypassKnowledgeBases: [] },
+    })).not.toThrow();
+
+    expect(() => assertNoIngestSecrets(chunks, {
+      relativePath: 'alpha/secret.md',
+      knowledgeBaseName: 'alpha',
+      scanOptions: { enabled: true, bypassKnowledgeBases: ['alpha'] },
+    })).not.toThrow();
+
+    expect(() => assertNoIngestSecrets(chunks, {
+      relativePath: 'alpha/secret.md',
+      knowledgeBaseName: 'alpha',
+      scanOptions: { enabled: true, bypassKnowledgeBases: [] },
+    })).toThrow(IngestSecretDetectedError);
+  });
+
+  it('deduplicates categories and reports chunk indexes only', () => {
+    try {
+      assertNoIngestSecrets(
+        ['password=abcDEF1234567890!', 'Bearer abcDEF1234567890abcDEF1234567890'],
+        {
+          relativePath: 'alpha/secret.md',
+          knowledgeBaseName: 'alpha',
+          scanOptions: { enabled: true, bypassKnowledgeBases: [] },
+        },
+      );
+      throw new Error('expected scanner to throw');
+    } catch (error) {
+      expect(error).toBeInstanceOf(IngestSecretDetectedError);
+      const secretError = error as IngestSecretDetectedError;
+      expect(secretError.categories).toEqual(['bearer_token', 'key_value_secret']);
+      expect(secretError.chunkIndexes).toEqual([0, 1]);
+      expect(secretError.message).not.toContain('abcDEF');
+    }
+  });
+});

--- a/src/secret-scanner.ts
+++ b/src/secret-scanner.ts
@@ -1,0 +1,153 @@
+import { resolveIngestSecretScanOptions, type IngestSecretScanOptions } from './config/ingest.js';
+
+export type SecretFindingCategory =
+  | 'aws_access_key'
+  | 'gcp_api_key'
+  | 'github_token'
+  | 'jwt'
+  | 'ssh_private_key'
+  | 'bearer_token'
+  | 'azure_storage_key'
+  | 'key_value_secret'
+  | 'high_entropy';
+
+export interface SecretScanFinding {
+  category: SecretFindingCategory;
+  chunkIndex: number;
+}
+
+export class IngestSecretDetectedError extends Error {
+  readonly code = 'KB_INGEST_SECRET_DETECTED';
+  readonly categories: SecretFindingCategory[];
+  readonly chunkIndexes: number[];
+
+  constructor(relativePath: string, findings: readonly SecretScanFinding[]) {
+    const categories = uniqueSorted(findings.map((finding) => finding.category));
+    const chunkIndexes = uniqueSortedNumbers(findings.map((finding) => finding.chunkIndex));
+    super(
+      `secret-like content detected in ${relativePath} ` +
+        `(${categories.join(', ')}); file quarantined before embedding`,
+    );
+    this.name = 'IngestSecretDetectedError';
+    this.categories = categories;
+    this.chunkIndexes = chunkIndexes;
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+const SECRET_PATTERNS: ReadonlyArray<{
+  category: SecretFindingCategory;
+  pattern: RegExp;
+  entropyCheck?: boolean;
+}> = [
+  { category: 'aws_access_key', pattern: /\b(?:A3T[A-Z0-9]|AKIA|ASIA|AGPA|AIDA|AROA|AIPA|ANPA)[A-Z0-9]{16}\b/g },
+  { category: 'gcp_api_key', pattern: /\bAIza[0-9A-Za-z_-]{35}\b/g },
+  { category: 'github_token', pattern: /\bgh[opsu]_[A-Za-z0-9_]{36,}\b/g },
+  { category: 'jwt', pattern: /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/g },
+  { category: 'ssh_private_key', pattern: /-----BEGIN (?:OPENSSH|RSA|DSA|EC|PRIVATE) PRIVATE KEY-----/g },
+  { category: 'bearer_token', pattern: /\bBearer\s+[A-Za-z0-9._~+/=-]{20,}\b/gi, entropyCheck: true },
+  { category: 'azure_storage_key', pattern: /\bAccountKey=[A-Za-z0-9+/=]{40,}\b/gi, entropyCheck: true },
+  {
+    category: 'key_value_secret',
+    pattern: /\b(?:password|passwd|pwd|api[_-]?key|secret|token)\s*[:=]\s*['"]?([A-Za-z0-9._~+/=-]{12,})/gi,
+    entropyCheck: true,
+  },
+];
+
+const HIGH_ENTROPY_TOKEN = /\b[A-Za-z0-9._~+/=-]{40,}\b/g;
+const MIN_SECRET_ENTROPY = 3.5;
+const MIN_STANDALONE_ENTROPY = 4.2;
+
+export function detectSecretsInText(
+  text: string,
+  chunkIndex = 0,
+): SecretScanFinding[] {
+  const findings: SecretScanFinding[] = [];
+  const seen = new Set<string>();
+
+  for (const { category, pattern, entropyCheck } of SECRET_PATTERNS) {
+    pattern.lastIndex = 0;
+    for (const match of text.matchAll(pattern)) {
+      const value = match[1] ?? match[0];
+      if (entropyCheck === true && shannonEntropy(value) < MIN_SECRET_ENTROPY) {
+        continue;
+      }
+      addFinding(findings, seen, { category, chunkIndex });
+      break;
+    }
+  }
+
+  HIGH_ENTROPY_TOKEN.lastIndex = 0;
+  for (const match of text.matchAll(HIGH_ENTROPY_TOKEN)) {
+    const token = match[0];
+    if (looksLikeStandaloneSecret(token) && shannonEntropy(token) >= MIN_STANDALONE_ENTROPY) {
+      addFinding(findings, seen, { category: 'high_entropy', chunkIndex });
+      break;
+    }
+  }
+
+  return findings;
+}
+
+export function assertNoIngestSecrets(
+  chunks: ReadonlyArray<string>,
+  options: {
+    relativePath: string;
+    knowledgeBaseName: string;
+    scanOptions?: IngestSecretScanOptions;
+  },
+): void {
+  const scanOptions = options.scanOptions ?? resolveIngestSecretScanOptions();
+  if (!scanOptions.enabled || scanOptions.bypassKnowledgeBases.includes(options.knowledgeBaseName)) {
+    return;
+  }
+
+  const findings = chunks.flatMap((chunk, chunkIndex) => detectSecretsInText(chunk, chunkIndex));
+  if (findings.length > 0) {
+    throw new IngestSecretDetectedError(options.relativePath, findings);
+  }
+}
+
+function looksLikeStandaloneSecret(token: string): boolean {
+  if (/^https?:\/\//i.test(token)) return false;
+  if (/^[0-9a-f]{40,}$/i.test(token)) return false;
+  return (
+    /[a-z]/.test(token) &&
+    /[A-Z]/.test(token) &&
+    /\d/.test(token) &&
+    /[._~+/=-]/.test(token)
+  );
+}
+
+function shannonEntropy(value: string): number {
+  if (value.length === 0) return 0;
+  const counts = new Map<string, number>();
+  for (const char of value) {
+    counts.set(char, (counts.get(char) ?? 0) + 1);
+  }
+  let entropy = 0;
+  for (const count of counts.values()) {
+    const probability = count / value.length;
+    entropy -= probability * Math.log2(probability);
+  }
+  return entropy;
+}
+
+function addFinding(
+  findings: SecretScanFinding[],
+  seen: Set<string>,
+  finding: SecretScanFinding,
+): void {
+  const key = `${finding.category}:${finding.chunkIndex}`;
+  if (seen.has(key)) return;
+  seen.add(key);
+  findings.push(finding);
+}
+
+function uniqueSorted(values: readonly SecretFindingCategory[]): SecretFindingCategory[] {
+  return Array.from(new Set(values)).sort();
+}
+
+function uniqueSortedNumbers(values: readonly number[]): number[] {
+  return Array.from(new Set(values)).sort((a, b) => a - b);
+}


### PR DESCRIPTION
Closes #472.

## Summary
- add an opt-in `KB_INGEST_SECRET_SCAN=on` scanner for common credential shapes and high-entropy tokens
- scan split chunks before contextual prefaces or embedding, quarantine the source file with `secret_detected`, and emit a payload-free canonical `secret_detected` event
- document the flag, bypass list, and operational limits

## Verification
- `npm run build`
- `npm test` on rebased branch before final base advanced: 116 suites passed, 1934 passing, 4 skipped, 1 todo
- post-final-rebase hook build passed
- post-final-rebase `npx jest src/secret-scanner.test.ts src/FaissIndexManager.test.ts --runInBand --testNamePattern='ingest secret scanner|quarantines secret-bearing chunks'`\n- `git diff --check origin/main..HEAD`\n- portability: helper absent; manual added-line scan clean\n\n## Pre-PR review\n- project type: npm\n- build: passed\n- tests: passed as above\n- scope: one commit, ten issue #472 files only\n- reviewer specialists: skipped because this Codex session exposes no Agent/spawn_agent tool; manual diff review completed\n