### PR TITLE
test(ingest): add chaos fault suite

### DIFF
--- a/.github/workflows/chaos-nightly.yml
+++ b/.github/workflows/chaos-nightly.yml
@@ -1,0 +1,19 @@
+name: Chaos Tests
+
+on:
+  schedule:
+    - cron: '0 4 * * *'
+  workflow_dispatch:
+
+jobs:
+  chaos:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          cache: npm
+          node-version: 24
+      - run: npm ci
+      - run: npm run build
+      - run: npm run test:chaos

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "bench:compare": "npm run build && tsc -p tsconfig.bench.json && node build/benchmarks/compare/run.js",
     "docs:check-anchors": "node scripts/check-doc-anchors.mjs",
     "test": "jest --runInBand",
+    "test:chaos": "jest --runInBand --testMatch '**/tests/chaos/scenarios/**/*.test.ts'",
     "start": "node build/index.js",
     "dev": "nodemon src/index.ts",
     "dev:cli": "node --enable-source-maps --import tsx scripts/dev-cli.mjs",

--- a/tests/chaos/README.md
+++ b/tests/chaos/README.md
@@ -1,0 +1,24 @@
+# Ingest Chaos Test Suite
+
+This suite exercises deterministic ingest fault classes that are too broad or
+too timing-sensitive for the default per-PR Jest run.
+
+Run it locally with:
+
+```bash
+npm run test:chaos
+```
+
+The nightly workflow runs the suite on a small fixture KB and asserts that
+faults leave the dense index recoverable:
+
+| Scenario | Fault class | Recovery assertion |
+| --- | --- | --- |
+| save-complete interruption | process death after FAISS commit but before sidecar commit | `initialize()` replays the pending manifest and writes missing sidecars |
+| disk-full during save | `ENOSPC` while saving the versioned FAISS directory | no active index symlink is published and retry can clear orphan staging |
+| embedding timeout | provider timeout during `embedDocuments` | ingest summary fails in `indexing`, the file is quarantined, and canonical classification maps to provider recovery |
+| malformed embedding response | provider returns the wrong vector count | ingest fails before persistence and quarantines the source file |
+| contextual-preface timeout storm | repeated LLM timeout | per-file circuit breaker stops after five chunk-level timeouts and records failed sidecar entries |
+
+Keep this suite opt-in. New scenarios should prefer deterministic injection
+points over wall-clock sleeps or real signals.

--- a/tests/chaos/fault-harness.ts
+++ b/tests/chaos/fault-harness.ts
@@ -1,0 +1,119 @@
+import * as fsp from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+
+export const DEFAULT_MODEL_ID = 'huggingface__BAAI-bge-small-en-v1.5';
+
+export interface ChaosWorkspace {
+  tempDir: string;
+  kbRoot: string;
+  faissPath: string;
+  kbName: string;
+  kbPath: string;
+}
+
+const ENV_KEYS = [
+  'NODE_ENV',
+  'KNOWLEDGE_BASES_ROOT_DIR',
+  'FAISS_INDEX_PATH',
+  'EMBEDDING_PROVIDER',
+  'HUGGINGFACE_MODEL_NAME',
+  'HUGGINGFACE_API_KEY',
+  'KB_FAISS_INDEX_TYPE',
+  'KB_INDEX_VERSION_RETENTION',
+  'KB_CONTEXTUAL_RETRIEVAL',
+  'KB_LLM_ENDPOINT',
+] as const;
+
+export type SavedEnv = Record<typeof ENV_KEYS[number], string | undefined>;
+
+export function saveChaosEnv(): SavedEnv {
+  return Object.fromEntries(ENV_KEYS.map((key) => [key, process.env[key]])) as SavedEnv;
+}
+
+export function restoreChaosEnv(saved: SavedEnv): void {
+  for (const [key, value] of Object.entries(saved)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+}
+
+export async function createChaosWorkspace(): Promise<ChaosWorkspace> {
+  const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-ingest-chaos-'));
+  const kbRoot = path.join(tempDir, 'kbs');
+  const faissPath = path.join(tempDir, '.faiss');
+  const kbName = 'chaos';
+  const kbPath = path.join(kbRoot, kbName);
+  await fsp.mkdir(kbPath, { recursive: true });
+
+  process.env.NODE_ENV = 'test';
+  process.env.KNOWLEDGE_BASES_ROOT_DIR = kbRoot;
+  process.env.FAISS_INDEX_PATH = faissPath;
+  process.env.EMBEDDING_PROVIDER = 'huggingface';
+  process.env.HUGGINGFACE_MODEL_NAME = 'BAAI/bge-small-en-v1.5';
+  process.env.HUGGINGFACE_API_KEY = 'chaos-test-stub';
+  process.env.KB_FAISS_INDEX_TYPE = 'flat';
+  process.env.KB_INDEX_VERSION_RETENTION = '1';
+
+  return { tempDir, kbRoot, faissPath, kbName, kbPath };
+}
+
+export async function writeFixtureNote(
+  workspace: ChaosWorkspace,
+  relativePath = 'runbook.md',
+  body = '# Runbook\n\nRestart the queue worker when lag exceeds five minutes.\n',
+): Promise<string> {
+  const target = path.join(workspace.kbPath, relativePath);
+  await fsp.mkdir(path.dirname(target), { recursive: true });
+  await fsp.writeFile(target, body, 'utf-8');
+  return target;
+}
+
+export function modelDir(workspace: ChaosWorkspace): string {
+  return path.join(workspace.faissPath, 'models', DEFAULT_MODEL_ID);
+}
+
+export function activeIndexSymlink(workspace: ChaosWorkspace): string {
+  return path.join(modelDir(workspace), 'index');
+}
+
+export function pendingManifestPath(workspace: ChaosWorkspace): string {
+  return path.join(modelDir(workspace), 'pending-manifest.json');
+}
+
+export function hashSidecarPath(workspace: ChaosWorkspace, relativePath = 'runbook.md'): string {
+  return path.join(workspace.kbPath, '.index', relativePath);
+}
+
+export function chunkManifestPath(workspace: ChaosWorkspace, relativePath = 'runbook.md'): string {
+  return `${hashSidecarPath(workspace, relativePath)}.chunks.json`;
+}
+
+export async function pathExists(target: string): Promise<boolean> {
+  try {
+    await fsp.lstat(target);
+    return true;
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT' || code === 'ENOTDIR') return false;
+    throw error;
+  }
+}
+
+export async function readJson<T = unknown>(target: string): Promise<T> {
+  return JSON.parse(await fsp.readFile(target, 'utf-8')) as T;
+}
+
+export async function readQuarantineJsonl(workspace: ChaosWorkspace): Promise<Array<Record<string, unknown>>> {
+  const target = path.join(workspace.kbPath, '.index', 'quarantine.jsonl');
+  const raw = await fsp.readFile(target, 'utf-8');
+  return raw
+    .trim()
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
+export function fsError(code: string, message: string): NodeJS.ErrnoException {
+  return Object.assign(new Error(message), { code }) as NodeJS.ErrnoException;
+}

--- a/tests/chaos/scenarios/ingest-faults.test.ts
+++ b/tests/chaos/scenarios/ingest-faults.test.ts
@@ -1,0 +1,277 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import * as fsp from 'fs/promises';
+import * as path from 'path';
+import type { EmbeddingsInterface } from '@langchain/core/embeddings';
+import type { Document } from '@langchain/core/documents';
+import {
+  activeIndexSymlink,
+  chunkManifestPath,
+  createChaosWorkspace,
+  fsError,
+  hashSidecarPath,
+  modelDir,
+  pathExists,
+  pendingManifestPath,
+  readJson,
+  readQuarantineJsonl,
+  restoreChaosEnv,
+  saveChaosEnv,
+  writeFixtureNote,
+  type ChaosWorkspace,
+  type SavedEnv,
+} from '../fault-harness.js';
+
+type EmbeddingFault = 'none' | 'timeout' | 'wrong-count';
+type SaveFault = 'none' | 'disk-full';
+
+let mockEmbeddingFault: EmbeddingFault = 'none';
+let mockSaveFault: SaveFault = 'none';
+const mockEmbedDocuments = jest.fn(async (texts: string[]) => {
+  if (mockEmbeddingFault === 'timeout') {
+    throw fsError('PROVIDER_TIMEOUT', 'embedding provider timed out');
+  }
+  if (mockEmbeddingFault === 'wrong-count') {
+    return texts.slice(0, Math.max(0, texts.length - 1)).map(mockVectorForText);
+  }
+  return texts.map(mockVectorForText);
+});
+const mockEmbedQuery = jest.fn(async (text: string) => mockVectorForText(text));
+const mockSave = jest.fn();
+const mockAddVectors = jest.fn();
+const mockLoad = jest.fn();
+
+function mockVectorForText(text: string): number[] {
+  let hash = 0;
+  for (let i = 0; i < text.length; i += 1) {
+    hash = Math.imul(hash ^ text.charCodeAt(i), 16_777_619);
+  }
+  return [text.length, hash >>> 0];
+}
+
+class MockFaissStore {
+  public docstore = { _docs: new Map<string, Document>() };
+  public index = {
+    _n: 0,
+    ntotal: () => this.index._n,
+    getDimension: () => 2,
+  };
+
+  constructor(public embeddings: EmbeddingsInterface) {}
+
+  async addVectors(vectors: number[][], documents: Document[]): Promise<void> {
+    mockAddVectors(vectors, documents);
+    const expectedDimension = vectors[0]?.length ?? 0;
+    for (const vector of vectors) {
+      if (vector.length !== expectedDimension || vector.some((value) => !Number.isFinite(value))) {
+        throw fsError('EMBED_MALFORMED', 'embedding provider returned malformed vectors');
+      }
+    }
+    documents.forEach((document, i) => {
+      this.docstore._docs.set(`doc-${this.index._n + i}`, document);
+    });
+    this.index._n += documents.length;
+  }
+
+  async save(directory: string): Promise<void> {
+    mockSave(directory);
+    await fsp.mkdir(directory, { recursive: true });
+    await fsp.writeFile(path.join(directory, 'faiss.index'), `vectors=${this.index._n}\n`, 'utf-8');
+    if (mockSaveFault === 'disk-full') {
+      throw fsError('ENOSPC', 'no space left on device while writing docstore');
+    }
+    await fsp.writeFile(
+      path.join(directory, 'docstore.json'),
+      JSON.stringify(Array.from(this.docstore._docs.entries())),
+      'utf-8',
+    );
+  }
+
+  async similaritySearchWithScore(): Promise<[]> {
+    return [];
+  }
+
+  static async load(directory: string, embeddings: EmbeddingsInterface): Promise<MockFaissStore> {
+    mockLoad(directory, embeddings);
+    const store = new MockFaissStore(embeddings);
+    const raw = await fsp.readFile(path.join(directory, 'docstore.json'), 'utf-8');
+    const entries = JSON.parse(raw) as Array<[string, Document]>;
+    entries.forEach(([id, document]) => store.docstore._docs.set(id, document));
+    store.index._n = entries.length;
+    return store;
+  }
+}
+
+jest.mock('@langchain/community/embeddings/hf', () => ({
+  __esModule: true,
+  HuggingFaceInferenceEmbeddings: class MockEmbedding {
+    embedDocuments = mockEmbedDocuments;
+    embedQuery = mockEmbedQuery;
+  },
+}));
+
+jest.mock('@langchain/community/vectorstores/faiss', () => ({
+  __esModule: true,
+  FaissStore: MockFaissStore,
+}));
+
+describe('ingest chaos suite', () => {
+  let workspace: ChaosWorkspace;
+  let savedEnv: SavedEnv;
+
+  beforeEach(async () => {
+    savedEnv = saveChaosEnv();
+    mockEmbeddingFault = 'none';
+    mockSaveFault = 'none';
+    mockEmbedDocuments.mockClear();
+    mockEmbedQuery.mockClear();
+    mockSave.mockClear();
+    mockAddVectors.mockClear();
+    mockLoad.mockClear();
+    jest.resetModules();
+    workspace = await createChaosWorkspace();
+  });
+
+  afterEach(async () => {
+    restoreChaosEnv(savedEnv);
+    await fsp.rm(workspace.tempDir, { recursive: true, force: true });
+  });
+
+  async function runUpdate(): Promise<import('../../../src/FaissIndexManager.js').FaissIndexManager> {
+    const { FaissIndexManager } = await import('../../../src/FaissIndexManager.js');
+    const manager = new FaissIndexManager();
+    await manager.initialize();
+    await manager.updateIndex(workspace.kbName);
+    return manager;
+  }
+
+  it('recovers a save-complete interruption by replaying missing sidecars on initialize', async () => {
+    await writeFixtureNote(workspace);
+    await runUpdate();
+
+    const hashSidecar = hashSidecarPath(workspace);
+    const chunkSidecar = chunkManifestPath(workspace);
+    const hash = await fsp.readFile(hashSidecar, 'utf-8');
+    const manifest = await readJson(chunkSidecar);
+
+    await fsp.rm(hashSidecar, { force: true });
+    await fsp.rm(chunkSidecar, { force: true });
+    await fsp.writeFile(
+      pendingManifestPath(workspace),
+      JSON.stringify({
+        schema_version: 'kb.pending-sidecar-commit.v1',
+        phase: 'save-complete',
+        pending_hash_writes: [{ path: hashSidecar, hash }],
+        pending_chunk_manifest_writes: [{ path: chunkSidecar, manifest }],
+      }),
+      'utf-8',
+    );
+
+    jest.resetModules();
+    const { FaissIndexManager } = await import('../../../src/FaissIndexManager.js');
+    const recovered = new FaissIndexManager();
+    await recovered.initialize();
+
+    await expect(fsp.readFile(hashSidecar, 'utf-8')).resolves.toBe(hash);
+    await expect(readJson(chunkSidecar)).resolves.toEqual(manifest);
+    await expect(pathExists(pendingManifestPath(workspace))).resolves.toBe(false);
+    expect(recovered.hasLoadedIndex).toBe(true);
+  });
+
+  it('leaves no active index when disk fills during the versioned FAISS save', async () => {
+    await writeFixtureNote(workspace);
+    mockSaveFault = 'disk-full';
+
+    await expect(runUpdate()).rejects.toMatchObject({ code: 'ENOSPC' });
+
+    const summary = await readJson<{ summary: { status: string; failures: Array<{ phase: string; code: string }> } }>(
+      path.join(modelDir(workspace), 'last-index-update.json'),
+    );
+    expect(summary.summary.status).toBe('failed');
+    expect(summary.summary.failures).toEqual([
+      expect.objectContaining({ phase: 'save', code: 'ENOSPC' }),
+    ]);
+    await expect(pathExists(activeIndexSymlink(workspace))).resolves.toBe(false);
+    await expect(pathExists(hashSidecarPath(workspace))).resolves.toBe(false);
+
+    mockSaveFault = 'none';
+    jest.resetModules();
+    await runUpdate();
+    await expect(pathExists(activeIndexSymlink(workspace))).resolves.toBe(true);
+    await expect(pathExists(hashSidecarPath(workspace))).resolves.toBe(true);
+  });
+
+  it('quarantines an embedding-provider timeout and keeps the index unpublished', async () => {
+    await writeFixtureNote(workspace);
+    mockEmbeddingFault = 'timeout';
+
+    await expect(runUpdate()).rejects.toMatchObject({ code: 'PROVIDER_TIMEOUT' });
+
+    const records = await readQuarantineJsonl(workspace);
+    expect(records).toEqual([
+      expect.objectContaining({
+        relative_path: 'runbook.md',
+        error_code: 'PROVIDER_TIMEOUT',
+      }),
+    ]);
+    await expect(pathExists(activeIndexSymlink(workspace))).resolves.toBe(false);
+
+    const { KBError } = await import('../../../src/errors.js');
+    const { classifyKbSearchError } = await import('../../../src/search-errors-core.js');
+    expect(classifyKbSearchError(new KBError('PROVIDER_TIMEOUT', 'request timed out'))).toEqual(
+      expect.objectContaining({
+        category: 'provider',
+        next_action: expect.stringContaining('Retry once'),
+      }),
+    );
+  });
+
+  it('quarantines malformed embedding responses before any FAISS save is published', async () => {
+    await writeFixtureNote(workspace);
+    mockEmbeddingFault = 'wrong-count';
+
+    await expect(runUpdate()).rejects.toThrow(/Embedding provider returned 0 vector/);
+
+    const records = await readQuarantineJsonl(workspace);
+    expect(records).toEqual([
+      expect.objectContaining({
+        relative_path: 'runbook.md',
+        error_category: 'unknown',
+        message: expect.stringContaining('Embedding provider returned 0 vector'),
+      }),
+    ]);
+    expect(mockSave).not.toHaveBeenCalled();
+    await expect(pathExists(activeIndexSymlink(workspace))).resolves.toBe(false);
+  });
+
+  it('trips the contextual-preface circuit breaker after consecutive LLM timeouts', async () => {
+    process.env.KB_CONTEXTUAL_RETRIEVAL = 'on';
+    process.env.KB_LLM_ENDPOINT = 'http://127.0.0.1:0/v1/chat/completions';
+    const fetchMock = jest.fn(async () => {
+      throw Object.assign(new Error('timeout'), { name: 'AbortError' });
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const { resolveContextualPrefaces, sidecarPathFor } =
+      await import('../../../src/contextual-preface.js');
+    const source = path.join(workspace.kbPath, 'long.md');
+    const chunks = Array.from({ length: 8 }, (_, i) => `chunk ${i}`);
+
+    const resolved = await resolveContextualPrefaces({
+      source,
+      knowledgeBaseName: workspace.kbName,
+      documentHash: 'h-circuit',
+      documentBody: chunks.join('\n\n'),
+      chunks,
+    });
+
+    expect(resolved).toEqual(chunks.map(() => null));
+    expect(fetchMock).toHaveBeenCalledTimes(15);
+    const sidecar = await readJson<{ chunks: Array<{ preface: string | null; error_code: string }> }>(
+      sidecarPathFor(source, workspace.kbName),
+    );
+    expect(sidecar.chunks).toHaveLength(chunks.length);
+    expect(sidecar.chunks.every((chunk) =>
+      chunk.preface === null && chunk.error_code === 'llm_unreachable',
+    )).toBe(true);
+  }, 20_000);
+});


### PR DESCRIPTION
## Summary
- add an opt-in `npm run test:chaos` Jest suite for deterministic ingest fault injection
- cover pending sidecar recovery, disk-full save retry, provider timeout quarantine, malformed embedding quarantine, and contextual-preface timeout breaker behavior
- run the chaos suite nightly via GitHub Actions while keeping default `npm test` unchanged

## Verification
- npm run build
- npm run test:chaos
- npx jest --runInBand --testMatch '**/tests/chaos/scenarios/**/*.test.ts' tests/chaos/scenarios/ingest-faults.test.ts
- npm test

Closes #473