### PR TITLE
feat: add doctor bug report bundles

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ kb serve status               # daemon liveness + degraded-mode diagnostics (#42
 kb config validate            # static env-var schema validation before startup
 kb doctor                     # availability snapshot (index, embedding backend, LLM)
 kb doctor --endpoints         # focused MCP/daemon/Ollama/LLM endpoint preflight
+kb doctor --bug-report=/tmp   # write a redacted support bundle for issue reports
 kb --help                     # top-level command list
 kb help search                # per-command help (also: kb search --help)
 kb completion bash            # generate a bash shell completion script
@@ -518,11 +519,14 @@ When `kb search` (or the MCP `retrieve_knowledge` tool) is not returning results
 kb doctor                # human-readable report
 kb doctor --format=json  # machine-readable for agent shells
 kb doctor --endpoints    # focused bind/connect endpoint preflight
+kb doctor --bug-report=/tmp  # redacted support bundle directory
 ```
 
 The report covers active-model resolution, FAISS index version + mtime, the latest in-process index-update summary, per-KB stale counts, embedding-backend reachability (Ollama / HuggingFace / OpenAI), local LLM endpoint readiness, CLI version, and local git state. The command exits non-zero when any required retrieval check fails (active model unresolved, index missing, backend unreachable); LLM endpoint failures are WARN rows because search can remain healthy while `kb ask` is not ready.
 
 Use `kb doctor --endpoints` when you only need configured local endpoint readiness before starting or wiring clients. It checks MCP bind address/port availability, configured `KB_DAEMON_URL` health, configured Ollama embedding reachability, and configured `KB_LLM_ENDPOINT` or active LLM profile readiness without loading the full index health report.
+
+Use `kb doctor --bug-report[=<dir>]` when opening an issue or handing diagnostics to another operator. It writes a timestamped directory containing redacted `doctor.json`, `stats.json`, recent canonical log summaries, runtime/env metadata, and a README. The bundle does not include note contents or raw API keys; KB names, paths, model names, and log metadata can still be sensitive.
 
 ### Distinguishing search failure modes
 

--- a/docs/cli-json-contracts.md
+++ b/docs/cli-json-contracts.md
@@ -693,6 +693,8 @@ Invocation:
 ```bash
 kb doctor --format=json
 kb doctor --endpoints --format=json
+kb doctor --bug-report=/tmp --format=json
+kb doctor --bug-report=/tmp --include-command -- node -e 'process.exit(1)'
 ```
 
 Report envelope:
@@ -804,6 +806,44 @@ Stdout/stderr and exit codes:
 - There is no separate JSON error envelope; failing health checks are encoded in
   the report with `status: "error"`.
 - Argument errors print `kb doctor: ...` to stderr and exit `2`.
+
+`kb doctor --bug-report[=<dir>]` writes a timestamped support bundle directory
+under `<dir>` (default: current directory). The bundle contains:
+
+- `manifest.json`: schema `kb.doctor.bug_report.v1`, created timestamp, file
+  list, bundle path, and aggregate redaction counts.
+- `doctor.json`: redacted aggregate doctor report.
+- `stats.json`: captured `kb stats --format=json` payload or failure metadata.
+- `logs-recent.json`: recent canonical log summaries when a log file is
+  configured.
+- `runtime.json`: Node/package/platform metadata plus redacted relevant
+  environment settings.
+- `README.md`: human-readable explanation of the bundle contents and residual
+  sensitivity.
+- `command.json`: only when `--include-command -- <cmd>` is passed. Records the
+  support command, exit code, duration, stdout byte count, stderr byte count,
+  and redacted stderr tail. It does not persist stdout content.
+
+The command prints the bundle path in markdown mode. With `--format=json`, it
+prints the manifest shape:
+
+```json
+{
+  "schema_version": "kb.doctor.bug_report.v1",
+  "bundle_dir": "/tmp/kb-bug-report-20260522T010203Z",
+  "created_at": "2026-05-22T01:02:03.000Z",
+  "files": ["README.md", "doctor.json", "manifest.json", "runtime.json"],
+  "redaction_summary": {
+    "enabled": true,
+    "total": 1,
+    "by_type": { "provider_token": 1 }
+  }
+}
+```
+
+The bundle intentionally excludes knowledge-base note contents and raw API
+keys. KB names, paths, model names, and log metadata may remain sensitive and
+should be reviewed before public posting.
 
 `kb doctor --endpoints --format=json` emits the focused endpoint-readiness
 schema instead of the full report:

--- a/docs/troubleshooting-local-kb.md
+++ b/docs/troubleshooting-local-kb.md
@@ -12,11 +12,14 @@ Start with the read-only health check:
 kb doctor
 kb doctor --format=json
 kb doctor --endpoints
+kb doctor --bug-report=/tmp
 ```
 
 `kb doctor` reports active-model resolution, index path and version, stale file counts, embedding backend health, local LLM endpoint readiness for `kb ask`, CLI package and symlink state, git drift for linked checkouts, and the latest index-update summary. Use it before deleting index files, changing client configuration, or debugging local LLM answers.
 
 Use `kb doctor --endpoints` for the narrower port/URL preflight: MCP bind target availability, configured `KB_DAEMON_URL`, configured Ollama embedding endpoint, and configured `KB_LLM_ENDPOINT` or active LLM profile.
+
+Use `kb doctor --bug-report[=<dir>]` when preparing an issue-ready diagnostic bundle. The command writes a timestamped directory with redacted doctor/stats/log/runtime JSON plus a README, without note contents or raw API keys.
 
 ## Quick Symptom Table
 

--- a/src/cli-bug-report.test.ts
+++ b/src/cli-bug-report.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, it } from '@jest/globals';
+import * as fsp from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { createDoctorBugReportBundle } from './cli-bug-report.js';
+import type { DoctorReport } from './cli-doctor.js';
+
+function minimalDoctorReport(): DoctorReport {
+  return {
+    status: 'ok',
+    checks: [],
+    active_model: { model_id: 'fake__model', provider: 'fake', model_name: 'model' },
+    index: {
+      path: '/tmp/faiss',
+      binary_path: null,
+      version: null,
+      mtime: null,
+      storage: {
+        active_version_bytes: null,
+        inactive_version_count: 0,
+        inactive_version_bytes: 0,
+        total_version_bytes: 0,
+        retention_previous_versions: 0,
+      },
+    },
+    index_security: {
+      permission_check: 'checked',
+      ownership_check: 'checked',
+      entries: [],
+    },
+    stale_counts_by_kb: {},
+    quarantine_counts_by_kb: {},
+    age_budgets: {},
+    age_budget_config_errors: [],
+    incomplete_models: [],
+    backend: { provider: 'fake', healthy: true, detail: 'ok' },
+    llm_endpoint: {
+      status: 'ok',
+      endpoint: null,
+      health_url: null,
+      endpoint_source: 'unresolved',
+      profile_name: null,
+      profile_mode: null,
+      managed_by: null,
+      unit_name: null,
+      health_ok: false,
+      chat_ok: false,
+      detail: 'not configured',
+      next_action: null,
+    },
+    reranker: {
+      enabled: false,
+      model: 'reranker',
+      top_n: 40,
+      status: 'ok',
+      cache_path: null,
+      detail: 'off',
+    },
+    cli: {
+      version: 'test',
+      package_root: '/tmp/repo',
+      invoked_path: null,
+      symlinked_checkout_path: null,
+    },
+    git: null,
+    last_index_update: {
+      status: 'never_run',
+      scope: null,
+      model_id: null,
+      started_at: null,
+      finished_at: null,
+      duration_ms: null,
+      files_scanned: 0,
+      files_changed: 0,
+      files_unchanged: 0,
+      files_skipped: 0,
+      chunks_attempted: 0,
+      chunks_added: 0,
+      index_mutated: false,
+      saved: false,
+      sidecars_written: false,
+      warning_count: 0,
+      warnings: [],
+      failure_count: 0,
+      failures: [],
+    },
+    reindex_trigger: {
+      status: 'ok',
+      enabled: false,
+      poll_ms: 0,
+      poll_ms_source: 'default',
+      poll_ms_raw: null,
+      path: '/tmp/trigger',
+      path_source: 'default',
+      path_raw: null,
+      kb_fs_watch_enabled: false,
+      trigger_file: {
+        exists: false,
+        kind: 'missing',
+        mtime: null,
+        age_ms: null,
+        size_bytes: null,
+        stat_error: null,
+      },
+      parent: {
+        path: '/tmp',
+        exists: true,
+        writable: true,
+        access_error: null,
+      },
+      freshness: {
+        index_mtime: null,
+        trigger_mtime: null,
+        trigger_newer_than_index: null,
+      },
+      warnings: [],
+      limitation: 'test',
+    },
+    provider_calls: {},
+    integrity: null,
+  };
+}
+
+describe('doctor bug-report bundle', () => {
+  it('writes a timestamped redacted support bundle without raw secrets', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-bug-report-test-'));
+    try {
+      const result = await createDoctorBugReportBundle({
+        outputParentDir: tempDir,
+        now: new Date('2026-05-22T01:02:03.000Z'),
+        env: {
+          OPENAI_API_KEY: 'sk-proj-secretsecretsecretsecret',
+          KB_LLM_ENDPOINT: 'http://127.0.0.1:8080/v1/chat/completions',
+        },
+        buildDoctorReport: async () => minimalDoctorReport(),
+        runStats: async () => {
+          process.stdout.write('{"stats_secret":"Bearer abcdefghijklmnop"}\n');
+          return 0;
+        },
+        runLogs: async () => {
+          process.stdout.write('{"events":[{"authorization":"Bearer abcdefghijklmnop"}]}\n');
+          return 0;
+        },
+      });
+
+      expect(path.basename(result.bundle_dir)).toBe('kb-bug-report-20260522T010203Z');
+      expect(result.files).toEqual([
+        'README.md',
+        'doctor.json',
+        'logs-recent.json',
+        'manifest.json',
+        'runtime.json',
+        'stats.json',
+      ]);
+      const runtime = await fsp.readFile(path.join(result.bundle_dir, 'runtime.json'), 'utf-8');
+      expect(runtime).toContain('"name": "OPENAI_API_KEY"');
+      expect(runtime).toContain('[REDACTED]');
+      const bundleText = await readBundleText(result.bundle_dir, result.files);
+      expect(bundleText).not.toContain('sk-proj-secretsecretsecretsecret');
+      expect(bundleText).not.toContain('abcdefghijklmnop');
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('records optional command exit metadata and redacted stderr tail only', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-bug-report-cmd-'));
+    try {
+      const result = await createDoctorBugReportBundle({
+        outputParentDir: tempDir,
+        buildDoctorReport: async () => minimalDoctorReport(),
+        runStats: async () => 0,
+        runLogs: async () => 0,
+        command: [
+          process.execPath,
+          '-e',
+          'console.log(Buffer.from("cmF3IHN0ZG91dCBzZWNyZXQ=", "base64").toString("utf8")); console.error("Authorization: Bearer abcdefghijklmnop"); process.exit(7)',
+          '--',
+          '--token',
+          'plainsecret123456789',
+          '--api-key=anothersecret123456789',
+        ],
+      });
+
+      expect(result.files).toContain('command.json');
+      const commandText = await fsp.readFile(path.join(result.bundle_dir, 'command.json'), 'utf-8');
+      const command = JSON.parse(commandText) as {
+        command: string[];
+        exit_code: number;
+        stderr_tail: string;
+        stdout_bytes: number;
+      };
+      expect(command.exit_code).toBe(7);
+      expect(command.stdout_bytes).toBe(0);
+      expect(command.command).toContain('[REDACTED]');
+      expect(command.command).toContain('--api-key=[REDACTED]');
+      expect(commandText).not.toContain('raw stdout secret');
+      expect(commandText).not.toContain('plainsecret123456789');
+      expect(commandText).not.toContain('anothersecret123456789');
+      expect(command.stderr_tail).toContain('Authorization: Bearer [REDACTED]');
+      expect(command.stderr_tail).not.toContain('abcdefghijklmnop');
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+});
+
+async function readBundleText(bundleDir: string, files: string[]): Promise<string> {
+  const contents = await Promise.all(
+    files.map((file) => fsp.readFile(path.join(bundleDir, file), 'utf-8')),
+  );
+  return contents.join('\n');
+}

--- a/src/cli-bug-report.ts
+++ b/src/cli-bug-report.ts
@@ -1,0 +1,361 @@
+import { spawn } from 'child_process';
+import { readFileSync } from 'fs';
+import * as fsp from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { runLogs } from './cli-logs.js';
+import { runStats } from './cli-stats.js';
+import { captureProcessOutput } from './cli-shared.js';
+import {
+  REDACTION_PLACEHOLDER,
+  combineRedactionSummaries,
+  emptyRedactionSummary,
+  redactSecrets,
+  type RedactionSummary,
+} from './redaction.js';
+import type { DoctorReport } from './cli-doctor.js';
+
+const BUG_REPORT_SCHEMA_VERSION = 'kb.doctor.bug_report.v1';
+const DEFAULT_LOG_LIMIT = 50;
+const COMMAND_STDERR_TAIL_BYTES = 16 * 1024;
+
+export interface DoctorBugReportOptions {
+  outputParentDir?: string;
+  now?: Date;
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  command?: string[];
+  buildDoctorReport?: () => Promise<DoctorReport>;
+  runStats?: (args: string[]) => Promise<number>;
+  runLogs?: (args: string[]) => Promise<number>;
+}
+
+export interface DoctorBugReportResult {
+  schema_version: typeof BUG_REPORT_SCHEMA_VERSION;
+  bundle_dir: string;
+  created_at: string;
+  files: string[];
+  redaction_summary: RedactionSummary;
+}
+
+interface WrittenFile {
+  name: string;
+  redaction: RedactionSummary;
+}
+
+interface CommandBundleResult {
+  command: string[];
+  exit_code: number;
+  signal: NodeJS.Signals | null;
+  duration_ms: number;
+  stdout_bytes: number;
+  stderr_bytes: number;
+  stderr_tail: string;
+  stderr_truncated: boolean;
+}
+
+export async function createDoctorBugReportBundle(
+  options: DoctorBugReportOptions = {},
+): Promise<DoctorBugReportResult> {
+  const now = options.now ?? new Date();
+  const createdAt = now.toISOString();
+  const parentDir = path.resolve(options.cwd ?? process.cwd(), options.outputParentDir ?? '.');
+  const bundleDir = path.join(parentDir, `kb-bug-report-${formatBundleTimestamp(now)}`);
+  await fsp.mkdir(bundleDir, { recursive: false });
+
+  const written: WrittenFile[] = [];
+  const writeJson = async (name: string, value: unknown): Promise<void> => {
+    const redacted = redactJsonValue(value);
+    await fsp.writeFile(
+      path.join(bundleDir, name),
+      `${JSON.stringify(redacted.value, null, 2)}\n`,
+      'utf-8',
+    );
+    written.push({ name, redaction: redacted.redaction });
+  };
+  const writeText = async (name: string, text: string): Promise<void> => {
+    const redacted = redactSecrets(text);
+    await fsp.writeFile(path.join(bundleDir, name), redacted.text, 'utf-8');
+    written.push({ name, redaction: redacted.summary });
+  };
+
+  await writeJson('doctor.json', await (options.buildDoctorReport ?? defaultBuildDoctorReport)());
+  await writeCapturedJson(
+    'stats.json',
+    async () => captureProcessOutput(() => (options.runStats ?? runStats)(['--format=json'])),
+    writeJson,
+  );
+  await writeCapturedJson(
+    'logs-recent.json',
+    async () => captureProcessOutput(() => (options.runLogs ?? runLogs)([
+      'recent',
+      `--limit=${DEFAULT_LOG_LIMIT}`,
+      '--format=json',
+    ])),
+    writeJson,
+  );
+  await writeJson('runtime.json', buildRuntimeSummary(options.env ?? process.env));
+
+  if (options.command !== undefined) {
+    await writeJson('command.json', await runSupportCommand(options.command));
+  }
+
+  const manifestRedaction = combineRedactionSummaries(
+    true,
+    ...written.map((file) => file.redaction),
+  );
+  const manifest: DoctorBugReportResult = {
+    schema_version: BUG_REPORT_SCHEMA_VERSION,
+    bundle_dir: bundleDir,
+    created_at: createdAt,
+    files: [],
+    redaction_summary: manifestRedaction,
+  };
+  await writeText('README.md', buildReadme(createdAt, options.command !== undefined));
+  manifest.files = [...written.map((file) => file.name), 'manifest.json'].sort();
+  await fsp.writeFile(
+    path.join(bundleDir, 'manifest.json'),
+    `${JSON.stringify(manifest, null, 2)}\n`,
+    'utf-8',
+  );
+
+  return manifest;
+}
+
+async function defaultBuildDoctorReport(): Promise<DoctorReport> {
+  const { buildDoctorReport } = await import('./cli-doctor.js');
+  return buildDoctorReport();
+}
+
+function redactJsonValue(value: unknown): { value: unknown; redaction: RedactionSummary } {
+  if (typeof value === 'string') {
+    const redacted = redactSecrets(value);
+    return { value: redacted.text, redaction: redacted.summary };
+  }
+  if (Array.isArray(value)) {
+    const items = value.map((item) => redactJsonValue(item));
+    return {
+      value: items.map((item) => item.value),
+      redaction: combineRedactionSummaries(true, ...items.map((item) => item.redaction)),
+    };
+  }
+  if (value !== null && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    const summaries: RedactionSummary[] = [];
+    for (const [key, child] of Object.entries(value)) {
+      const redacted = redactJsonValue(child);
+      out[key] = redacted.value;
+      summaries.push(redacted.redaction);
+    }
+    return {
+      value: out,
+      redaction: combineRedactionSummaries(true, ...summaries),
+    };
+  }
+  return { value, redaction: emptyRedactionSummary(true) };
+}
+
+async function writeCapturedJson(
+  fileName: string,
+  run: () => Promise<{ exitCode: number; stdout: string; stderr: string }>,
+  writeJson: (name: string, value: unknown) => Promise<void>,
+): Promise<void> {
+  const captured = await run();
+  const parsed = parseJsonOrNull(captured.stdout);
+  await writeJson(fileName, {
+    command_exit_code: captured.exitCode,
+    payload: parsed,
+    parse_error: parsed === null && captured.stdout.trim() !== ''
+      ? 'command did not emit valid JSON'
+      : null,
+    stderr_tail: tailString(captured.stderr, COMMAND_STDERR_TAIL_BYTES),
+  });
+}
+
+function parseJsonOrNull(text: string): unknown {
+  const trimmed = text.trim();
+  if (trimmed === '') return null;
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return null;
+  }
+}
+
+function buildRuntimeSummary(env: NodeJS.ProcessEnv): unknown {
+  return {
+    node: process.version,
+    platform: process.platform,
+    arch: process.arch,
+    release: os.release(),
+    cwd: process.cwd(),
+    package: readPackageMetadata(),
+    env: summarizeEnv(env),
+  };
+}
+
+function readPackageMetadata(): { name: string | null; version: string | null } {
+  const candidates = [
+    ...(process.argv[1] === undefined
+      ? []
+      : [
+          path.join(path.dirname(process.argv[1]), '..', 'package.json'),
+          path.join(path.dirname(process.argv[1]), 'package.json'),
+        ]),
+    path.join(process.cwd(), 'package.json'),
+  ];
+  for (const candidate of candidates) {
+    try {
+      const parsed = JSON.parse(requireText(candidate)) as { name?: string; version?: string };
+      return { name: parsed.name ?? null, version: parsed.version ?? null };
+    } catch {
+      // Try the next likely package location.
+    }
+  }
+  return { name: null, version: null };
+}
+
+function requireText(filePath: string): string {
+  return readFileSync(filePath, 'utf-8');
+}
+
+function summarizeEnv(env: NodeJS.ProcessEnv): Array<{ name: string; value: string }> {
+  const prefixes = [
+    'KB_',
+    'KNOWLEDGE_',
+    'FAISS_',
+    'EMBEDDING_',
+    'OLLAMA_',
+    'OPENAI_',
+    'HUGGINGFACE_',
+    'MCP_',
+    'LOG_',
+    'REINDEX_',
+  ];
+  return Object.keys(env)
+    .filter((name) => prefixes.some((prefix) => name.startsWith(prefix)))
+    .sort()
+    .map((name) => ({
+      name,
+      value: redactEnvValue(name, env[name] ?? ''),
+    }));
+}
+
+function redactEnvValue(name: string, value: string): string {
+  if (isSensitiveEnvName(name)) return REDACTION_PLACEHOLDER;
+  return redactSecrets(value).text;
+}
+
+function isSensitiveEnvName(name: string): boolean {
+  return /(?:API_?KEY|ACCESS_?TOKEN|AUTH_?TOKEN|REFRESH_?TOKEN|SESSION_?TOKEN|PRIVATE_?KEY|CLIENT_?SECRET|SECRET|PASSWORD|PASSWD|COOKIE|AUTHORIZATION)/i
+    .test(name);
+}
+
+async function runSupportCommand(command: string[]): Promise<CommandBundleResult> {
+  if (command.length === 0) {
+    throw new Error('bug-report support command is empty');
+  }
+  const started = Date.now();
+  return new Promise((resolve, reject) => {
+    const [cmd, ...args] = command;
+    const child = spawn(cmd, args, { shell: false, stdio: ['ignore', 'ignore', 'pipe'] });
+    const stderrChunks: Buffer[] = [];
+    let stderrBytes = 0;
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderrBytes += chunk.length;
+      stderrChunks.push(chunk);
+      trimTailBuffers(stderrChunks, COMMAND_STDERR_TAIL_BYTES);
+    });
+    child.on('error', reject);
+    child.on('close', (code, signal) => {
+      const rawStderrTail = Buffer.concat(stderrChunks).toString('utf-8');
+      resolve({
+        command: redactCommandArguments(command),
+        exit_code: code ?? 1,
+        signal,
+        duration_ms: Math.max(0, Date.now() - started),
+        stdout_bytes: 0,
+        stderr_bytes: stderrBytes,
+        stderr_tail: redactSecrets(rawStderrTail).text,
+        stderr_truncated: stderrBytes > COMMAND_STDERR_TAIL_BYTES,
+      });
+    });
+  });
+}
+
+function redactCommandArguments(command: string[]): string[] {
+  let redactNext = false;
+  return command.map((arg) => {
+    if (redactNext) {
+      redactNext = false;
+      return REDACTION_PLACEHOLDER;
+    }
+
+    const equalsIndex = arg.indexOf('=');
+    if (equalsIndex > 0) {
+      const flag = arg.slice(0, equalsIndex);
+      if (isSensitiveCommandValueFlag(flag)) {
+        return `${flag}=${REDACTION_PLACEHOLDER}`;
+      }
+    }
+
+    if (isSensitiveCommandValueFlag(arg)) {
+      redactNext = true;
+    }
+    return redactSecrets(arg).text;
+  });
+}
+
+function isSensitiveCommandValueFlag(arg: string): boolean {
+  const flag = arg.replace(/^-+/, '').toLowerCase();
+  return /(?:^|[-_])(?:token|api[-_]?key|access[-_]?token|auth[-_]?token|refresh[-_]?token|session[-_]?token|private[-_]?key|client[-_]?secret|secret|password|passwd|cookie|authorization)$/
+    .test(flag);
+}
+
+function trimTailBuffers(chunks: Buffer[], maxBytes: number): void {
+  let total = chunks.reduce((sum, chunk) => sum + chunk.length, 0);
+  while (total > maxBytes && chunks.length > 0) {
+    const first = chunks[0];
+    const excess = total - maxBytes;
+    if (first.length <= excess) {
+      chunks.shift();
+      total -= first.length;
+    } else {
+      chunks[0] = first.subarray(excess);
+      total -= excess;
+    }
+  }
+}
+
+function tailString(text: string, maxBytes: number): string {
+  const buffer = Buffer.from(text, 'utf-8');
+  if (buffer.length <= maxBytes) return text;
+  return buffer.subarray(buffer.length - maxBytes).toString('utf-8');
+}
+
+function buildReadme(createdAt: string, includedCommand: boolean): string {
+  return [
+    '# kb doctor bug report',
+    '',
+    `Created: ${createdAt}`,
+    '',
+    'This support bundle contains redacted diagnostics for a local `kb` installation.',
+    'It intentionally excludes knowledge-base note contents and raw API keys.',
+    'KB names, filesystem paths, model names, and log metadata can still be sensitive.',
+    '',
+    'Included files:',
+    '- `manifest.json` - bundle schema, file list, and redaction counts.',
+    '- `doctor.json` - aggregate `kb doctor` health report.',
+    '- `stats.json` - captured `kb stats --format=json` result or error metadata.',
+    '- `logs-recent.json` - recent canonical log summaries when a log file is configured.',
+    '- `runtime.json` - Node/package/platform and redacted relevant environment settings.',
+    ...(includedCommand
+      ? ['- `command.json` - optional support command exit metadata and redacted stderr tail.']
+      : []),
+    '',
+  ].join('\n');
+}
+
+function formatBundleTimestamp(date: Date): string {
+  return date.toISOString().replace(/[-:]/g, '').replace(/\.\d{3}Z$/, 'Z');
+}

--- a/src/cli-capture.ts
+++ b/src/cli-capture.ts
@@ -22,6 +22,12 @@ import {
   sha256OfFileOrNull,
   type RefreshStatus,
 } from './audit-log.js';
+import {
+  REDACTION_PLACEHOLDER,
+  combineRedactionSummaries,
+  maybeRedact,
+  type RedactionSummary,
+} from './redaction.js';
 
 interface CaptureArgs {
   kb?: string;
@@ -42,14 +48,7 @@ interface CommandResult {
   exitCode: number;
 }
 
-interface RedactionSummary {
-  enabled: boolean;
-  total: number;
-  by_type: Record<string, number>;
-}
-
 const DEFAULT_MAX_BYTES = 64 * 1024;
-const REDACTION_PLACEHOLDER = '[REDACTED]';
 
 const LANGUAGE_BY_EXT: Record<string, string> = {
   json: 'json',
@@ -340,109 +339,6 @@ async function runCommand(command: string[], maxBytes: number): Promise<CommandR
       });
     });
   });
-}
-
-function maybeRedact(text: string, enabled: boolean): { text: string; summary: RedactionSummary } {
-  if (!enabled) {
-    return { text, summary: emptyRedactionSummary(false) };
-  }
-  return redactSecrets(text);
-}
-
-function redactSecrets(input: string): { text: string; summary: RedactionSummary } {
-  let text = input;
-  const byType: Record<string, number> = {};
-
-  const apply = (
-    type: string,
-    pattern: RegExp,
-    replacer: (...args: string[]) => string,
-  ): void => {
-    let count = 0;
-    text = text.replace(pattern, (...args: string[]) => {
-      count++;
-      return replacer(...args);
-    });
-    if (count > 0) byType[type] = (byType[type] ?? 0) + count;
-  };
-
-  apply(
-    'credential_url',
-    /\b([a-z][a-z0-9+.-]*:\/\/)([^/\s:@]+):([^/\s@]+)@/gi,
-    (_match, scheme) => `${scheme}${REDACTION_PLACEHOLDER}@`,
-  );
-  apply(
-    'authorization_header',
-    /\b(Authorization\s*:\s*(?:Bearer|Basic)\s+)([^\s"'`,;]+)/gi,
-    (_match, prefix) => `${prefix}${REDACTION_PLACEHOLDER}`,
-  );
-  apply(
-    'cookie_header',
-    /^([ \t]*(?:Cookie|Set-Cookie)\s*:\s*)[^\r\n]+/gim,
-    (_match, prefix) => `${prefix}${REDACTION_PLACEHOLDER}`,
-  );
-  apply(
-    'json_secret',
-    /("[A-Za-z0-9_-]*(?:(?:api|access|refresh|auth|session)[_-]?token|api[_-]?key|client[_-]?secret|password|passwd|secret|cookie|authorization)[A-Za-z0-9_-]*"\s*:\s*")([^"]+)(")/gi,
-    (_match, prefix, _value, suffix) => `${prefix}${REDACTION_PLACEHOLDER}${suffix}`,
-  );
-  apply(
-    'dotenv_secret',
-    /^([ \t]*(?:export\s+)?[A-Za-z_][A-Za-z0-9_]*(?:API_KEY|ACCESS_TOKEN|AUTH_TOKEN|REFRESH_TOKEN|SESSION_TOKEN|PRIVATE_KEY|CLIENT_SECRET|SECRET|PASSWORD|PASSWD|COOKIE)[A-Za-z0-9_]*\s*=\s*)(['"]?)([^\r\n'"]+)(\2)/gim,
-    (_match, prefix, quote, _value, suffix) => `${prefix}${quote}${REDACTION_PLACEHOLDER}${suffix}`,
-  );
-  apply(
-    'key_value_secret',
-    /\b([A-Za-z_][A-Za-z0-9_]*(?:(?:api|access|refresh|auth|session)[_-]?token|api[_-]?key|client[_-]?secret|password|passwd|secret|cookie)[A-Za-z0-9_]*\s*[:=]\s*)(['"]?)(?!\[REDACTED\])([^\s'",}]+)(\2)/gi,
-    (_match, prefix, quote, _value, suffix) => `${prefix}${quote}${REDACTION_PLACEHOLDER}${suffix}`,
-  );
-  apply(
-    'bearer_token',
-    /\b(Bearer\s+)([A-Za-z0-9._~+/-]{12,})\b/g,
-    (_match, prefix) => `${prefix}${REDACTION_PLACEHOLDER}`,
-  );
-  apply(
-    'provider_token',
-    /\b(?:sk-(?:proj-)?[A-Za-z0-9_-]{20,}|gh[pousr]_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]{20,}|AKIA[0-9A-Z]{16}|xox[abprs]-[A-Za-z0-9-]{10,})\b/g,
-    () => REDACTION_PLACEHOLDER,
-  );
-
-  return {
-    text,
-    summary: {
-      enabled: true,
-      total: Object.values(byType).reduce((sum, count) => sum + count, 0),
-      by_type: byType,
-    },
-  };
-}
-
-function emptyRedactionSummary(enabled: boolean): RedactionSummary {
-  return {
-    enabled,
-    total: 0,
-    by_type: {},
-  };
-}
-
-function combineRedactionSummaries(
-  enabled: boolean,
-  ...summaries: RedactionSummary[]
-): RedactionSummary {
-  if (!enabled) return emptyRedactionSummary(false);
-
-  const byType: Record<string, number> = {};
-  for (const summary of summaries) {
-    for (const [type, count] of Object.entries(summary.by_type)) {
-      byType[type] = (byType[type] ?? 0) + count;
-    }
-  }
-
-  return {
-    enabled: true,
-    total: Object.values(byType).reduce((sum, count) => sum + count, 0),
-    by_type: byType,
-  };
 }
 
 interface BlockOptions {

--- a/src/cli-doctor.test.ts
+++ b/src/cli-doctor.test.ts
@@ -1130,32 +1130,67 @@ describe('kb doctor', () => {
       reindexTrigger: false,
       endpoints: false,
       integrity: false,
+      bugReport: null,
     });
     expect(parseDoctorArgs(['--reindex-trigger'])).toEqual({
       format: 'md',
       reindexTrigger: true,
       endpoints: false,
       integrity: false,
+      bugReport: null,
     });
     expect(parseDoctorArgs(['--endpoints', '--format=json'])).toEqual({
       format: 'json',
       reindexTrigger: false,
       endpoints: true,
       integrity: false,
+      bugReport: null,
     });
     expect(parseDoctorArgs(['--reindex-trigger', '--format=json'])).toEqual({
       format: 'json',
       reindexTrigger: true,
       endpoints: false,
       integrity: false,
+      bugReport: null,
     });
     expect(parseDoctorArgs([])).toEqual({
       format: 'md',
       reindexTrigger: false,
       endpoints: false,
       integrity: false,
+      bugReport: null,
+    });
+    expect(parseDoctorArgs(['--bug-report=/tmp/out'])).toEqual({
+      format: 'md',
+      reindexTrigger: false,
+      endpoints: false,
+      integrity: false,
+      bugReport: {
+        outputParentDir: '/tmp/out',
+        includeCommand: false,
+        command: undefined,
+      },
+    });
+    expect(parseDoctorArgs([
+      '--bug-report',
+      '--include-command',
+      '--',
+      'node',
+      '-e',
+      'process.exit(1)',
+    ])).toEqual({
+      format: 'md',
+      reindexTrigger: false,
+      endpoints: false,
+      integrity: false,
+      bugReport: {
+        outputParentDir: undefined,
+        includeCommand: true,
+        command: ['node', '-e', 'process.exit(1)'],
+      },
     });
     expect(() => parseDoctorArgs(['--format=yaml'])).toThrow(/invalid --format/);
+    expect(() => parseDoctorArgs(['--bug-report', '--include-command'])).toThrow(/requires/);
   });
 
   describe('age budgets (issue #218)', () => {

--- a/src/cli-doctor.ts
+++ b/src/cli-doctor.ts
@@ -81,6 +81,7 @@ import {
   verifyIntegrity,
   type IntegrityReport,
 } from './cli-verify.js';
+import { createDoctorBugReportBundle } from './cli-bug-report.js';
 
 /**
  * Issue #210 — error-rate threshold above which the doctor surfaces a
@@ -99,6 +100,7 @@ export const DOCTOR_HELP = `kb doctor — aggregate model / index / backend heal
 
 Usage:
   kb doctor [--format=md|json] [--reindex-trigger] [--endpoints] [--integrity|--slow]
+  kb doctor --bug-report[=<dir>] [--include-command -- <cmd> [args...]]
 
 Composes existing read-only checks (env vars, registered models, active
 model, FAISS index presence + mtime, knowledge-base count, embedding
@@ -118,6 +120,13 @@ Options:
   --endpoints           Check only configured local bind/connect endpoint
                         readiness (MCP bind target, KB_DAEMON_URL,
                         Ollama embedding endpoint, and KB_LLM_ENDPOINT/profile).
+  --bug-report[=<dir>]  Write a timestamped redacted support bundle under
+                        <dir> (default: current directory). Includes doctor,
+                        stats, recent canonical logs, runtime metadata, and
+                        a README. Does not include note contents or raw keys.
+  --include-command -- <cmd> [args...]
+                        With --bug-report, run a support command and record
+                        exit code plus redacted stderr tail.
   --integrity           Include slow \`kb verify --integrity\` checks.
   --slow                Alias for --integrity.
   --help, -h            Show this help.
@@ -133,6 +142,11 @@ export interface DoctorArgs {
   reindexTrigger: boolean;
   endpoints: boolean;
   integrity: boolean;
+  bugReport: {
+    outputParentDir?: string;
+    includeCommand: boolean;
+    command?: string[];
+  } | null;
 }
 
 export type HealthStatus = 'ok' | 'warn' | 'error';
@@ -376,6 +390,20 @@ export async function runDoctor(rest: string[]): Promise<number> {
     return report.status === 'error' ? 1 : 0;
   }
 
+  if (parsed.bugReport !== null) {
+    const result = await createDoctorBugReportBundle({
+      outputParentDir: parsed.bugReport.outputParentDir,
+      command: parsed.bugReport.command,
+      buildDoctorReport: () => buildDoctorReport({ integrity: parsed.integrity }),
+    });
+    if (parsed.format === 'json') {
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    } else {
+      process.stdout.write(`Bug report bundle: ${result.bundle_dir}\n`);
+    }
+    return 0;
+  }
+
   const report = await buildDoctorReport({ integrity: parsed.integrity });
   if (parsed.format === 'json') {
     process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
@@ -386,8 +414,25 @@ export async function runDoctor(rest: string[]): Promise<number> {
 }
 
 export function parseDoctorArgs(rest: string[]): DoctorArgs {
-  const out: DoctorArgs = { format: 'md', reindexTrigger: false, endpoints: false, integrity: false };
-  for (const raw of rest) {
+  const out: DoctorArgs = {
+    format: 'md',
+    reindexTrigger: false,
+    endpoints: false,
+    integrity: false,
+    bugReport: null,
+  };
+  let sawBugReport = false;
+  for (let i = 0; i < rest.length; i++) {
+    const raw = rest[i];
+    if (raw === '--') {
+      if (out.bugReport?.includeCommand !== true) {
+        throw new Error('unexpected "--"; use --include-command before command arguments');
+      }
+      const command = rest.slice(i + 1);
+      if (command.length === 0) throw new Error('missing command after "--"');
+      out.bugReport.command = command;
+      break;
+    }
     if (raw.startsWith('--format=')) {
       const value = raw.slice('--format='.length);
       if (value !== 'md' && value !== 'json') {
@@ -404,12 +449,42 @@ export function parseDoctorArgs(rest: string[]): DoctorArgs {
       out.endpoints = true;
       continue;
     }
+    if (raw === '--bug-report' || raw.startsWith('--bug-report=')) {
+      sawBugReport = true;
+      const outputParentDir = raw.includes('=')
+        ? raw.slice('--bug-report='.length)
+        : undefined;
+      if (outputParentDir === '') throw new Error('empty --bug-report value');
+      out.bugReport = {
+        outputParentDir,
+        includeCommand: out.bugReport?.includeCommand ?? false,
+        command: out.bugReport?.command,
+      };
+      continue;
+    }
+    if (raw === '--include-command') {
+      out.bugReport = {
+        outputParentDir: out.bugReport?.outputParentDir,
+        includeCommand: true,
+        command: out.bugReport?.command,
+      };
+      continue;
+    }
     if (raw === '--integrity' || raw === '--slow') {
       out.integrity = true;
       continue;
     }
     if (raw.startsWith('--')) throw new Error(`unknown flag: ${raw}`);
     throw new Error(`unexpected argument: ${JSON.stringify(raw)}`);
+  }
+  if (out.bugReport?.includeCommand === true && out.bugReport.command === undefined) {
+    throw new Error('--include-command requires "--" followed by a command');
+  }
+  if (out.bugReport?.includeCommand === true && !sawBugReport) {
+    throw new Error('--include-command requires --bug-report');
+  }
+  if (out.bugReport !== null && out.endpoints) {
+    throw new Error('--bug-report cannot be combined with --endpoints');
   }
   return out;
 }

--- a/src/cli-json-contracts.test.ts
+++ b/src/cli-json-contracts.test.ts
@@ -213,7 +213,7 @@ const docAssertions: Record<DocumentedCommand, (examples: unknown[]) => void> = 
     expect(record(examples[1])).toEqual({ recommended_kb: null, results: [] });
   },
   'kb doctor': (examples) => {
-    expect(examples).toHaveLength(2);
+    expect(examples).toHaveLength(3);
     expect(record(examples[0])).toMatchObject({
       status: expect.any(String),
       checks: expect.any(Array),
@@ -224,6 +224,13 @@ const docAssertions: Record<DocumentedCommand, (examples: unknown[]) => void> = 
       last_index_update: expect.any(Object),
     });
     expect(record(examples[1])).toMatchObject({
+      schema_version: 'kb.doctor.bug_report.v1',
+      bundle_dir: expect.any(String),
+      created_at: expect.any(String),
+      files: expect.any(Array),
+      redaction_summary: expect.any(Object),
+    });
+    expect(record(examples[2])).toMatchObject({
       schema_version: 'kb.doctor.endpoints.v1',
       status: expect.any(String),
       endpoints: expect.arrayContaining([

--- a/src/redaction.test.ts
+++ b/src/redaction.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from '@jest/globals';
+import { redactSecrets } from './redaction.js';
+
+describe('redactSecrets', () => {
+  it('redacts common support-bundle secret shapes', () => {
+    const input = [
+      'OPENAI_API_KEY=sk-proj-abcdefghijklmnopqrstuvwxyz',
+      'Authorization: Bearer abcdefghijklmnop',
+      '{"github_token":"ghp_abcdefghijklmnopqrstuvwxyz"}',
+      'https://user:password@example.com/path',
+    ].join('\n');
+
+    const result = redactSecrets(input);
+
+    expect(result.text).toContain('OPENAI_API_KEY=[REDACTED]');
+    expect(result.text).toContain('Authorization: Bearer [REDACTED]');
+    expect(result.text).toContain('"github_token":"[REDACTED]"');
+    expect(result.text).toContain('https://[REDACTED]@example.com/path');
+    expect(result.summary.total).toBeGreaterThanOrEqual(4);
+  });
+});

--- a/src/redaction.ts
+++ b/src/redaction.ts
@@ -1,0 +1,110 @@
+export interface RedactionSummary {
+  enabled: boolean;
+  total: number;
+  by_type: Record<string, number>;
+}
+
+export const REDACTION_PLACEHOLDER = '[REDACTED]';
+
+export function maybeRedact(text: string, enabled: boolean): { text: string; summary: RedactionSummary } {
+  if (!enabled) {
+    return { text, summary: emptyRedactionSummary(false) };
+  }
+  return redactSecrets(text);
+}
+
+export function redactSecrets(input: string): { text: string; summary: RedactionSummary } {
+  let text = input;
+  const byType: Record<string, number> = {};
+
+  const apply = (
+    type: string,
+    pattern: RegExp,
+    replacer: (...args: string[]) => string,
+  ): void => {
+    let count = 0;
+    text = text.replace(pattern, (...args: string[]) => {
+      count++;
+      return replacer(...args);
+    });
+    if (count > 0) byType[type] = (byType[type] ?? 0) + count;
+  };
+
+  apply(
+    'credential_url',
+    /\b([a-z][a-z0-9+.-]*:\/\/)([^/\s:@]+):([^/\s@]+)@/gi,
+    (_match, scheme) => `${scheme}${REDACTION_PLACEHOLDER}@`,
+  );
+  apply(
+    'authorization_header',
+    /\b(Authorization\s*:\s*(?:Bearer|Basic)\s+)([^\s"'`,;]+)/gi,
+    (_match, prefix) => `${prefix}${REDACTION_PLACEHOLDER}`,
+  );
+  apply(
+    'cookie_header',
+    /^([ \t]*(?:Cookie|Set-Cookie)\s*:\s*)[^\r\n]+/gim,
+    (_match, prefix) => `${prefix}${REDACTION_PLACEHOLDER}`,
+  );
+  apply(
+    'json_secret',
+    /("[A-Za-z0-9_-]*(?:(?:api|access|refresh|auth|session)[_-]?token|api[_-]?key|client[_-]?secret|password|passwd|secret|cookie|authorization)[A-Za-z0-9_-]*"\s*:\s*")([^"]+)(")/gi,
+    (_match, prefix, _value, suffix) => `${prefix}${REDACTION_PLACEHOLDER}${suffix}`,
+  );
+  apply(
+    'dotenv_secret',
+    /^([ \t]*(?:export\s+)?[A-Za-z_][A-Za-z0-9_]*(?:API_KEY|ACCESS_TOKEN|AUTH_TOKEN|REFRESH_TOKEN|SESSION_TOKEN|PRIVATE_KEY|CLIENT_SECRET|SECRET|PASSWORD|PASSWD|COOKIE)[A-Za-z0-9_]*\s*=\s*)(['"]?)([^\r\n'"]+)(\2)/gim,
+    (_match, prefix, quote, _value, suffix) => `${prefix}${quote}${REDACTION_PLACEHOLDER}${suffix}`,
+  );
+  apply(
+    'key_value_secret',
+    /\b([A-Za-z_][A-Za-z0-9_]*(?:(?:api|access|refresh|auth|session)[_-]?token|api[_-]?key|client[_-]?secret|password|passwd|secret|cookie)[A-Za-z0-9_]*\s*[:=]\s*)(['"]?)(?!\[REDACTED\])([^\s'",}]+)(\2)/gi,
+    (_match, prefix, quote, _value, suffix) => `${prefix}${quote}${REDACTION_PLACEHOLDER}${suffix}`,
+  );
+  apply(
+    'bearer_token',
+    /\b(Bearer\s+)([A-Za-z0-9._~+/-]{12,})\b/g,
+    (_match, prefix) => `${prefix}${REDACTION_PLACEHOLDER}`,
+  );
+  apply(
+    'provider_token',
+    /\b(?:sk-(?:proj-)?[A-Za-z0-9_-]{20,}|gh[pousr]_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]{20,}|AKIA[0-9A-Z]{16}|xox[abprs]-[A-Za-z0-9-]{10,})\b/g,
+    () => REDACTION_PLACEHOLDER,
+  );
+
+  return {
+    text,
+    summary: {
+      enabled: true,
+      total: Object.values(byType).reduce((sum, count) => sum + count, 0),
+      by_type: byType,
+    },
+  };
+}
+
+export function emptyRedactionSummary(enabled: boolean): RedactionSummary {
+  return {
+    enabled,
+    total: 0,
+    by_type: {},
+  };
+}
+
+export function combineRedactionSummaries(
+  enabled: boolean,
+  ...summaries: RedactionSummary[]
+): RedactionSummary {
+  if (!enabled) return emptyRedactionSummary(false);
+
+  const byType: Record<string, number> = {};
+  for (const summary of summaries) {
+    for (const [type, count] of Object.entries(summary.by_type)) {
+      byType[type] = (byType[type] ?? 0) + count;
+    }
+  }
+
+  return {
+    enabled: true,
+    total: Object.values(byType).reduce((sum, count) => sum + count, 0),
+    by_type: byType,
+  };
+}


### PR DESCRIPTION
## Summary
- Add `kb doctor --bug-report[=<dir>]` to create timestamped redacted support bundles with doctor, stats, recent logs, runtime metadata, manifest, and README files.
- Share capture redaction through `src/redaction.ts` and keep optional support-command output limited to exit metadata plus redacted stderr tail.
- Redact support-command argv values following sensitive flags such as `--token value` and `--api-key=value`.
- Document the new bundle contract and update CLI JSON contract coverage.

Closes #487

## Verification
- `npm run build`
- `npx jest --runInBand src/redaction.test.ts src/cli-bug-report.test.ts src/cli-doctor.test.ts`
- `npx jest --runInBand src/cli.test.ts`
- `npx jest --runInBand src/cli-json-contracts.test.ts`
- `npx jest --runInBand src/cli-bug-report.test.ts src/cli-doctor.test.ts src/redaction.test.ts src/cli-json-contracts.test.ts`
- `npm run docs:check-anchors` (exits 0; reports existing stale anchor warnings outside this change)
- `node build/cli.js doctor --bug-report=/tmp --format=json`
- `git diff --check`

## Pre-PR Review
- Manual diff review completed; no added machine-local paths or whitespace errors found.
- Specialist reviews completed with correctness, conventions, dead-code, and test passes. The correctness reviewer found a blocking argv-redaction gap for `--token value`; fixed before PR creation. The test reviewer suggested full-bundle secret absence assertions and command stdout absence assertions; added before PR creation.
- Codex exec sandbox had to be bypassed for specialist reviews because read-only bubblewrap was unavailable in this environment; prompts were read-only and no reviewer modified files.