### PR TITLE
docs: document MCP resources usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,12 +431,14 @@ npm install -g @jeanibarz/knowledge-base-mcp-server@latest
 
 > **Writing notes that retrieve well?** See [`docs/authoring-knowledge.md`](docs/authoring-knowledge.md) — six-section guide on chunk-friendly markdown, frontmatter taxonomy that lifts into filters, content-boundary safety, and when to split a KB.
 
-The server exposes two tools:
+The core retrieval tools are:
 
 *   `list_knowledge_bases`: Lists the available knowledge bases.
 *   `retrieve_knowledge`: Retrieves similar chunks from the knowledge base based on a query. Optionally, if a knowledge base is specified, only that one is searched; otherwise, all available knowledge bases are considered. By default, at most 10 document chunks are returned with a score below a threshold of 2. A different threshold can optionally be provided using the `threshold` parameter.
 
 You can use these tools through the MCP interface.
+
+The server also exposes MCP resources for clients that want to enumerate and read source documents directly. `resources/list` returns `kb://<knowledge-base>/<encoded-relative-path>` URIs for visible files under `KNOWLEDGE_BASES_ROOT_DIR`, and `resources/read` returns the raw document content as text or a base64 PDF blob. See [`docs/mcp-resources.md`](docs/mcp-resources.md) for client-facing URI, MIME type, and percent-encoding details.
 
 The `retrieve_knowledge` tool performs a semantic search using a FAISS index. The index is automatically updated when the server starts or when a file in a knowledge base is modified.
 

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -26,6 +26,8 @@ For shell-driven workflows (REPL queries, scripted ingest checks, agent Bash-too
 
 For local empty-result, stale-index, active-model, provider, lock, or linked-checkout drift diagnosis, use the [`kb` troubleshooting runbook](./troubleshooting-local-kb.md).
 
+For clients that expose MCP resources, the server also supports `resources/list` and `resources/read` over `kb://` URIs. See [MCP resources and `kb://` URIs](./mcp-resources.md) for URI encoding, MIME behavior, and when to prefer resources over `retrieve_knowledge`.
+
 ## Multi-model setups (RFC 013, 0.3.0+)
 
 The default config in the snippets below resolves to a single embedding model via the legacy env vars (`EMBEDDING_PROVIDER` + `OLLAMA_MODEL`/`OPENAI_MODEL_NAME`/`HUGGINGFACE_MODEL_NAME`). On 0.3.0+, you can keep multiple models registered side-by-side and have the MCP server use any of them per-call.

--- a/docs/mcp-resources.md
+++ b/docs/mcp-resources.md
@@ -1,0 +1,117 @@
+# MCP Resources and `kb://` URIs
+
+The server exposes MCP resources for clients that want to enumerate and read source documents directly. Resources are different from the `retrieve_knowledge` tool:
+
+| Surface | Use it for | What it returns |
+| --- | --- | --- |
+| `retrieve_knowledge` | Dense semantic or hybrid dense+BM25 search over indexed chunks. | Ranked markdown snippets with source metadata. |
+| `resources/list` | Discovering addressable files under the configured knowledge-base root. | One `kb://` URI per visible file. |
+| `resources/read` | Reading a known source document by URI. | The raw file content as text or a base64 blob. |
+
+Use resources when a client already knows which document it needs, or when it wants to let a user browse/read files. Use `retrieve_knowledge` when the client needs retrieval by meaning, keywords, filters, or ranking.
+
+## Resource Listing
+
+`resources/list` walks every non-hidden knowledge base under `KNOWLEDGE_BASES_ROOT_DIR` and returns every non-hidden file below each knowledge base. Dot-prefixed files and directories are skipped, including `.index`, `.faiss`, and user-created draft folders.
+
+Example response shape:
+
+```json
+{
+  "resources": [
+    {
+      "uri": "kb://work/runbooks/deploy.md",
+      "name": "runbooks/deploy.md",
+      "description": "Document in knowledge base \"work\"",
+      "mimeType": "text/markdown"
+    },
+    {
+      "uri": "kb://research/papers/contextual-retrieval.pdf",
+      "name": "papers/contextual-retrieval.pdf",
+      "description": "Document in knowledge base \"research\"",
+      "mimeType": "application/pdf"
+    }
+  ]
+}
+```
+
+The server also handles `resources/templates/list`, returning an empty `resourceTemplates` array. There are no URI templates today; clients should use the concrete URIs returned by `resources/list` or by retrieval citations.
+
+## `kb://` URI Format
+
+Resource URIs use this form:
+
+```text
+kb://<knowledge-base>/<encoded-relative-path>
+```
+
+Examples:
+
+```text
+kb://work/runbooks/deploy.md
+kb://agent-task-lessons/reviews/pr%20%23123.md
+kb://research/papers/attention%20%26%20retrieval.pdf
+```
+
+Rules:
+
+- `<knowledge-base>` is the KB directory name, such as `work` or `research`.
+- KB names must be lowercase filesystem-safe names: letters, digits, dot, underscore, and hyphen, starting with a letter or digit.
+- The path is relative to that KB root.
+- Each path segment is percent-encoded independently. Reserved filename characters such as space, `#`, `?`, `&`, `+`, and `=` are encoded.
+- Literal or encoded path traversal is rejected. `..`, `%2f`, and `%5c` cannot be used to escape a KB root.
+- URI fragments may appear in retrieval citations, for example `kb://work/runbooks/deploy.md#L42-L78`. `resources/read` reads the file; line fragments are for client navigation and citation display.
+
+When constructing URIs manually, encode each path segment rather than the whole path so `/` remains the segment separator:
+
+```js
+const uri = `kb://${kbName}/${relativePath
+  .split("/")
+  .map((segment) => encodeURIComponent(segment))
+  .join("/")}`;
+```
+
+## Reading Resources
+
+`resources/read` accepts a `kb://` URI and returns one content item:
+
+```json
+{
+  "contents": [
+    {
+      "uri": "kb://work/runbooks/deploy.md",
+      "mimeType": "text/markdown",
+      "text": "# Deploy Runbook\n\n..."
+    }
+  ]
+}
+```
+
+PDF files are returned as base64 blobs:
+
+```json
+{
+  "contents": [
+    {
+      "uri": "kb://research/papers/contextual-retrieval.pdf",
+      "mimeType": "application/pdf",
+      "blob": "JVBERi0xLjQK..."
+    }
+  ]
+}
+```
+
+MIME type mapping is intentionally small and extension-based:
+
+| Extension | MIME type | Payload field |
+| --- | --- | --- |
+| `.md`, `.markdown` | `text/markdown` | `text` |
+| `.html`, `.htm` | `text/html` | `text` |
+| `.pdf` | `application/pdf` | `blob` |
+| `.txt` and other extensions | `text/plain` | `text` |
+
+## Security and Client Behavior
+
+Resources expose raw source documents under `KNOWLEDGE_BASES_ROOT_DIR`. They do not apply semantic retrieval thresholds, relevance gating, chunk packing, or search filters. Clients should treat returned document text as untrusted content when the KB contains material from outside the local user's trust boundary.
+
+For normal agent retrieval, prefer `retrieve_knowledge`. For explicit document browsing, file previews, citation expansion, or "open this source" actions, use `resources/list` and `resources/read`.


### PR DESCRIPTION
## Summary
- add a client-facing MCP resources guide for `resources/list`, `resources/read`, and `kb://` URI encoding
- link the guide from README usage docs and MCP client configuration docs
- clarify that MCP `retrieve_knowledge` supports dense and hybrid retrieval, not lexical-only mode

Closes #488

## Verification
- npm run build
- npm test
- npx jest src/mcp-resources.test.ts --runInBand
- node --input-type=module -e "import { checkDocAnchors } from './scripts/check-doc-anchors.mjs'; const report = await checkDocAnchors({ root: process.cwd(), docRoots: ['README.md', 'docs/clients.md', 'docs/mcp-resources.md'] }); console.log(JSON.stringify(report.totals)); if (report.totals.failures) process.exit(1);"

Note: `npm run docs:check-anchors -- --strict` currently fails on pre-existing stale anchors in docs/architecture and docs/rfcs outside this change.

## Pre-PR review
- conventions specialist: fixed sibling-link style nit
- correctness specialist: fixed retrieve_knowledge wording to dense/hybrid
- dead-code specialist: no dead/orphaned docs content
- test specialist: no test files in this docs-only PR