### PR TITLE
feat: align MCP resources with ingest policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,7 +438,7 @@ The core retrieval tools are:
 
 You can use these tools through the MCP interface.
 
-The server also exposes MCP resources for clients that want to enumerate and read source documents directly. `resources/list` returns `kb://<knowledge-base>/<encoded-relative-path>` URIs for visible files under `KNOWLEDGE_BASES_ROOT_DIR`, and `resources/read` returns the raw document content as text or a base64 PDF blob. See [`docs/mcp-resources.md`](docs/mcp-resources.md) for client-facing URI, MIME type, and percent-encoding details.
+The server also exposes MCP resources for clients that want to enumerate and read source documents directly. `resources/list` returns `kb://<knowledge-base>/<encoded-relative-path>` URIs for ingestable, non-quarantined files under `KNOWLEDGE_BASES_ROOT_DIR`, and `resources/read` returns the raw document content as text or, when `.pdf` is opted into ingest, a base64 PDF blob. See [`docs/mcp-resources.md`](docs/mcp-resources.md) for client-facing URI, MIME type, and percent-encoding details.
 
 The `retrieve_knowledge` tool performs a semantic search using a FAISS index. The index is automatically updated when the server starts or when a file in a knowledge base is modified.
 

--- a/docs/mcp-resources.md
+++ b/docs/mcp-resources.md
@@ -5,14 +5,14 @@ The server exposes MCP resources for clients that want to enumerate and read sou
 | Surface | Use it for | What it returns |
 | --- | --- | --- |
 | `retrieve_knowledge` | Dense semantic or hybrid dense+BM25 search over indexed chunks. | Ranked markdown snippets with source metadata. |
-| `resources/list` | Discovering addressable files under the configured knowledge-base root. | One `kb://` URI per visible file. |
+| `resources/list` | Discovering addressable files under the configured knowledge-base root. | One `kb://` URI per ingestable, non-quarantined file. |
 | `resources/read` | Reading a known source document by URI. | The raw file content as text or a base64 blob. |
 
 Use resources when a client already knows which document it needs, or when it wants to let a user browse/read files. Use `retrieve_knowledge` when the client needs retrieval by meaning, keywords, filters, or ranking.
 
 ## Resource Listing
 
-`resources/list` walks every non-hidden knowledge base under `KNOWLEDGE_BASES_ROOT_DIR` and returns every non-hidden file below each knowledge base. Dot-prefixed files and directories are skipped, including `.index`, `.faiss`, and user-created draft folders.
+`resources/list` walks every non-hidden knowledge base under `KNOWLEDGE_BASES_ROOT_DIR` and returns files that match the same ingest eligibility policy used by refresh/search indexing. Dot-prefixed files and directories are skipped, including `.index`, `.faiss`, and user-created draft folders. Built-in ingest exclusions, `INGEST_EXTRA_EXTENSIONS`, `INGEST_EXCLUDE_PATHS`, and per-KB ingest quarantine entries are also honored, so clients do not browse files the index would currently skip.
 
 Example response shape:
 
@@ -26,10 +26,10 @@ Example response shape:
       "mimeType": "text/markdown"
     },
     {
-      "uri": "kb://research/papers/contextual-retrieval.pdf",
-      "name": "papers/contextual-retrieval.pdf",
+      "uri": "kb://research/notes/contextual-retrieval.html",
+      "name": "notes/contextual-retrieval.html",
       "description": "Document in knowledge base \"research\"",
-      "mimeType": "application/pdf"
+      "mimeType": "text/html"
     }
   ]
 }
@@ -50,7 +50,7 @@ Examples:
 ```text
 kb://work/runbooks/deploy.md
 kb://agent-task-lessons/reviews/pr%20%23123.md
-kb://research/papers/attention%20%26%20retrieval.pdf
+kb://research/notes/attention%20%26%20retrieval.html
 ```
 
 Rules:
@@ -87,7 +87,7 @@ const uri = `kb://${kbName}/${relativePath
 }
 ```
 
-PDF files are returned as base64 blobs:
+PDF files are returned as base64 blobs when `.pdf` is opted into ingest with `INGEST_EXTRA_EXTENSIONS=.pdf`:
 
 ```json
 {
@@ -107,7 +107,7 @@ MIME type mapping is intentionally small and extension-based:
 | --- | --- | --- |
 | `.md`, `.markdown` | `text/markdown` | `text` |
 | `.html`, `.htm` | `text/html` | `text` |
-| `.pdf` | `application/pdf` | `blob` |
+| `.pdf` when allowed by ingest config | `application/pdf` | `blob` |
 | `.txt` and other extensions | `text/plain` | `text` |
 
 ## Security and Client Behavior

--- a/src/KnowledgeBaseServer.test.ts
+++ b/src/KnowledgeBaseServer.test.ts
@@ -88,6 +88,8 @@ describe('KnowledgeBaseServer handlers', () => {
     ASK_KNOWLEDGE_DESCRIPTION: process.env.ASK_KNOWLEDGE_DESCRIPTION,
     RETRIEVE_KNOWLEDGE_DESCRIPTION: process.env.RETRIEVE_KNOWLEDGE_DESCRIPTION,
     LIST_KNOWLEDGE_BASES_DESCRIPTION: process.env.LIST_KNOWLEDGE_BASES_DESCRIPTION,
+    INGEST_EXTRA_EXTENSIONS: process.env.INGEST_EXTRA_EXTENSIONS,
+    INGEST_EXCLUDE_PATHS: process.env.INGEST_EXCLUDE_PATHS,
   };
 
   beforeEach(() => {
@@ -979,7 +981,7 @@ describe('KnowledgeBaseServer handlers', () => {
 
   // --- MCP Resources (#49) --------------------------------------------------
 
-  it('resources/list returns kb:// URIs across multiple KBs', async () => {
+  it('resources/list returns kb:// URIs across multiple KBs for ingestable files', async () => {
     const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-server-resources-list-'));
     await fsp.mkdir(path.join(tempDir, 'alpha', 'docs'), { recursive: true });
     await fsp.mkdir(path.join(tempDir, 'beta'), { recursive: true });
@@ -1000,18 +1002,17 @@ describe('KnowledgeBaseServer handlers', () => {
       'kb://alpha/docs/guide.md',
       'kb://alpha/notes.txt',
       'kb://beta/page.html',
-      'kb://beta/paper.pdf',
     ]);
     expect(result.resources.find((resource: { uri: string }) => resource.uri === 'kb://alpha/docs/guide.md')).toMatchObject({
       name: 'docs/guide.md',
       mimeType: 'text/markdown',
     });
-    expect(result.resources.find((resource: { uri: string }) => resource.uri === 'kb://beta/paper.pdf')).toMatchObject({
-      mimeType: 'application/pdf',
-    });
     expect(result.resources.find((resource: { uri: string }) => resource.uri === 'kb://beta/page.html')).toMatchObject({
       mimeType: 'text/html',
     });
+    expect(result.resources.map((resource: { uri: string }) => resource.uri)).not.toContain(
+      'kb://beta/paper.pdf',
+    );
   });
 
   it('resources/read returns markdown text for an existing file', async () => {
@@ -1046,8 +1047,17 @@ describe('KnowledgeBaseServer handlers', () => {
     process.env.FAISS_INDEX_PATH = path.join(tempDir, '.faiss');
     process.env.EMBEDDING_PROVIDER = 'huggingface';
     process.env.HUGGINGFACE_API_KEY = 'test-key';
+    process.env.INGEST_EXTRA_EXTENSIONS = '.pdf';
 
     const server = await freshServer();
+    const listResult = await server['handleListResources']();
+    expect(listResult.resources).toContainEqual({
+      uri: 'kb://alpha/paper.pdf',
+      name: 'paper.pdf',
+      description: 'Document in knowledge base "alpha"',
+      mimeType: 'application/pdf',
+    });
+
     const result = await server['handleReadResource']('kb://alpha/paper.pdf');
 
     expect(result.contents).toHaveLength(1);
@@ -1056,6 +1066,56 @@ describe('KnowledgeBaseServer handlers', () => {
     expect(content.mimeType).toBe('application/pdf');
     expect('blob' in content ? content.blob : undefined).toBe(pdfBytes.toString('base64'));
     expect('text' in content ? content.text : undefined).toBeUndefined();
+  });
+
+  it('resources/list and resources/read honor ingest filters and quarantine state', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-server-resources-ingest-policy-'));
+    const kbPath = path.join(tempDir, 'alpha');
+    await fsp.mkdir(path.join(kbPath, 'docs'), { recursive: true });
+    await fsp.mkdir(path.join(kbPath, 'drafts'), { recursive: true });
+    await fsp.mkdir(path.join(kbPath, 'logs'), { recursive: true });
+    await fsp.writeFile(path.join(kbPath, 'docs', 'guide.md'), '# Guide\n');
+    await fsp.writeFile(path.join(kbPath, 'docs', 'quarantined.md'), '# Broken\n');
+    await fsp.writeFile(path.join(kbPath, 'drafts', 'hidden.md'), '# Draft\n');
+    await fsp.writeFile(path.join(kbPath, 'logs', 'today.md'), '# Logs\n');
+    await fsp.writeFile(path.join(kbPath, 'paper.pdf'), Buffer.from('%PDF-1.4\n'));
+    await fsp.symlink('../docs/guide.md', path.join(kbPath, 'drafts', 'guide-link.md'));
+    const { recordIngestFailure } = await import('./ingest-quarantine.js');
+    await recordIngestFailure({
+      kbPath,
+      relativePath: 'docs/quarantined.md',
+      error: new Error('loader rejected file'),
+    });
+
+    process.env.KNOWLEDGE_BASES_ROOT_DIR = tempDir;
+    process.env.FAISS_INDEX_PATH = path.join(tempDir, '.faiss');
+    process.env.EMBEDDING_PROVIDER = 'huggingface';
+    process.env.HUGGINGFACE_API_KEY = 'test-key';
+    process.env.INGEST_EXCLUDE_PATHS = 'drafts/**';
+
+    const server = await freshServer();
+    const result = await server['handleListResources']();
+    const uris = result.resources.map((resource: { uri: string }) => resource.uri).sort();
+
+    expect(uris).toEqual(['kb://alpha/docs/guide.md']);
+    await expect(server['handleReadResource']('kb://alpha/docs/guide.md')).resolves.toMatchObject({
+      contents: [{ uri: 'kb://alpha/docs/guide.md', text: '# Guide\n' }],
+    });
+    await expect(server['handleReadResource']('kb://alpha/docs/quarantined.md')).rejects.toThrow(
+      /resource quarantined by ingest pipeline: "docs\/quarantined\.md"/,
+    );
+    await expect(server['handleReadResource']('kb://alpha/drafts/hidden.md')).rejects.toThrow(
+      /resource excluded by ingest filters: "drafts\/hidden\.md"/,
+    );
+    await expect(server['handleReadResource']('kb://alpha/drafts/guide-link.md')).rejects.toThrow(
+      /resource excluded by ingest filters: "drafts\/guide-link\.md"/,
+    );
+    await expect(server['handleReadResource']('kb://alpha/logs/today.md')).rejects.toThrow(
+      /resource excluded by ingest filters: "logs\/today\.md"/,
+    );
+    await expect(server['handleReadResource']('kb://alpha/paper.pdf')).rejects.toThrow(
+      /resource excluded by ingest filters: "paper\.pdf"/,
+    );
   });
 
   it('resources/list and resources/read round-trip filenames with reserved URI characters', async () => {

--- a/src/mcp-resources.ts
+++ b/src/mcp-resources.ts
@@ -19,10 +19,12 @@ import {
   type Resource,
 } from '@modelcontextprotocol/sdk/types.js';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { INGEST_EXCLUDE_PATHS, INGEST_EXTRA_EXTENSIONS } from './config/ingest.js';
 import { KNOWLEDGE_BASES_ROOT_DIR } from './config/paths.js';
 import { toError } from './error-utils.js';
-import { getFilesRecursively } from './file-utils.js';
-import { listKnowledgeBases, resolveKbPath } from './kb-fs.js';
+import { filterIngestablePaths } from './ingest-filter.js';
+import { listIngestQuarantine } from './ingest-quarantine.js';
+import { enumerateIngestableKbFiles, listKnowledgeBases, resolveKbPath } from './kb-fs.js';
 import { isValidKbName } from './kb-paths.js';
 
 export function mimeTypeForResource(filePath: string): string {
@@ -121,22 +123,32 @@ export function parseKnowledgeBaseResourceUri(uri: string): { kbName: string; re
 
 /**
  * `resources/list` body. Walks every registered KB under
- * `KNOWLEDGE_BASES_ROOT_DIR` and emits one `Resource` per file with a
- * percent-encoded `kb://` URI and a content-type-by-extension mime hint.
+ * `KNOWLEDGE_BASES_ROOT_DIR` and emits one `Resource` per ingestable,
+ * non-quarantined file with a percent-encoded `kb://` URI and a
+ * content-type-by-extension mime hint.
  */
 export async function listResources(): Promise<ListResourcesResult> {
   const resources: Resource[] = [];
   const knowledgeBases = (await listKnowledgeBases(KNOWLEDGE_BASES_ROOT_DIR)).sort();
+  const enumerations = await enumerateIngestableKbFiles(
+    KNOWLEDGE_BASES_ROOT_DIR,
+    knowledgeBases.filter(isValidKbName),
+    {
+      extraExtensions: INGEST_EXTRA_EXTENSIONS,
+      excludePaths: INGEST_EXCLUDE_PATHS,
+    },
+  );
 
-  for (const kbName of knowledgeBases) {
-    if (!isValidKbName(kbName)) continue;
-    const kbPath = path.join(KNOWLEDGE_BASES_ROOT_DIR, kbName);
-    const filePaths = (await getFilesRecursively(kbPath)).sort();
-    for (const filePath of filePaths) {
+  for (const { kbName, kbPath, filePaths } of enumerations) {
+    const quarantined = new Set(
+      (await listIngestQuarantine(kbPath)).map((record) => record.relative_path),
+    );
+    for (const filePath of filePaths.sort()) {
       const relativePath = path
         .relative(kbPath, filePath)
         .split(path.sep)
         .join('/');
+      if (quarantined.has(relativePath)) continue;
 
       resources.push({
         uri: buildResourceUri(kbName, relativePath),
@@ -153,17 +165,33 @@ export async function listResources(): Promise<ListResourcesResult> {
 /**
  * `resources/read` body. Parses the `kb://` URI, resolves the document
  * under `KNOWLEDGE_BASES_ROOT_DIR` (which rejects traversal escapes),
- * and returns either a base64 blob (PDF) or UTF-8 text (markdown,
- * HTML, plain text).
+ * rejects files the ingest pipeline would skip or has quarantined, and
+ * returns either a base64 blob (PDF) or UTF-8 text (markdown, HTML,
+ * plain text).
  */
 export async function readResource(uri: string): Promise<ReadResourceResult> {
   const { kbName, relativePath } = parseKnowledgeBaseResourceUri(uri);
+  const kbPath = path.join(KNOWLEDGE_BASES_ROOT_DIR, kbName);
+  const requestedPath = path.join(kbPath, relativePath);
   const filePath = await resolveKbPath(
     KNOWLEDGE_BASES_ROOT_DIR,
     kbName,
     relativePath,
     { mustExist: true },
   );
+  const ingestable = filterIngestablePaths([requestedPath], kbPath, {
+    extraExtensions: INGEST_EXTRA_EXTENSIONS,
+    excludePaths: INGEST_EXCLUDE_PATHS,
+  });
+  if (ingestable.length === 0) {
+    throw new Error(`resource excluded by ingest filters: ${JSON.stringify(relativePath)}`);
+  }
+
+  const quarantined = await listIngestQuarantine(kbPath);
+  if (quarantined.some((record) => record.relative_path === relativePath)) {
+    throw new Error(`resource quarantined by ingest pipeline: ${JSON.stringify(relativePath)}`);
+  }
+
   const mimeType = mimeTypeForResource(filePath);
 
   if (mimeType === 'application/pdf') {


### PR DESCRIPTION
## Summary
- make MCP resources/list enumerate only ingestable, non-quarantined files
- make resources/read reject files excluded by ingest filters or ingest quarantine, including excluded symlink paths
- update resource docs for ingest-policy parity and PDF opt-in behavior

## Tests
- npm run build
- npm test -- --runTestsByPath src/KnowledgeBaseServer.test.ts src/mcp-resources.test.ts
- npm test

Closes #489
