### PR TITLE
feat: paginate MCP resource listings

### DIFF
--- a/docs/mcp-resources.md
+++ b/docs/mcp-resources.md
@@ -5,7 +5,7 @@ The server exposes MCP resources for clients that want to enumerate and read sou
 | Surface | Use it for | What it returns |
 | --- | --- | --- |
 | `retrieve_knowledge` | Dense semantic or hybrid dense+BM25 search over indexed chunks. | Ranked markdown snippets with source metadata. |
-| `resources/list` | Discovering addressable files under the configured knowledge-base root. | One `kb://` URI per ingestable, non-quarantined file. |
+| `resources/list` | Discovering addressable files under the configured knowledge-base root. | One `kb://` URI per ingestable, non-quarantined file, with optional pagination. |
 | `resources/read` | Reading a known source document by URI. | The raw file content as text or a base64 blob. |
 
 Use resources when a client already knows which document it needs, or when it wants to let a user browse/read files. Use `retrieve_knowledge` when the client needs retrieval by meaning, keywords, filters, or ranking.
@@ -14,7 +14,16 @@ Use resources when a client already knows which document it needs, or when it wa
 
 `resources/list` walks every non-hidden knowledge base under `KNOWLEDGE_BASES_ROOT_DIR` and returns files that match the same ingest eligibility policy used by refresh/search indexing. Dot-prefixed files and directories are skipped, including `.index`, `.faiss`, and user-created draft folders. Built-in ingest exclusions, `INGEST_EXTRA_EXTENSIONS`, `INGEST_EXCLUDE_PATHS`, and per-KB ingest quarantine entries are also honored, so clients do not browse files the index would currently skip.
 
-Example response shape:
+The no-parameter request remains backward-compatible: it returns the full concrete resource list and no cursor. Clients browsing large roots can pass these optional params:
+
+| Param | Meaning |
+| --- | --- |
+| `cursor` | Standard MCP pagination cursor returned as `nextCursor`; it is opaque and includes the original filters and page size. |
+| `limit` or `pageSize` | Positive integer page size. Values above 1000 are capped to 1000. |
+| `kbName` | Restrict listing to one knowledge base. `knowledgeBase` and `knowledge_base_name` are accepted aliases. |
+| `prefix` | Restrict listing to KB-relative paths beginning with this prefix, such as `runbooks/` or `notes/2026-`. |
+
+Paginated response shape:
 
 ```json
 {
@@ -31,11 +40,12 @@ Example response shape:
       "description": "Document in knowledge base \"research\"",
       "mimeType": "text/html"
     }
-  ]
+  ],
+  "nextCursor": "kbres1.eyJ2IjoxLCJvZmZzZXQiOjEwMDAsInByZWZpeCI6IiIsImxpbWl0IjoxMDAwfQ"
 }
 ```
 
-The server also handles `resources/templates/list`, returning an empty `resourceTemplates` array. There are no URI templates today; clients should use the concrete URIs returned by `resources/list` or by retrieval citations.
+The server also handles `resources/templates/list`, returning a `kb://{kb}/{path}` URI template for clients that support templated discovery. Clients can use the template, concrete URIs returned by `resources/list`, or retrieval citations.
 
 ## `kb://` URI Format
 

--- a/src/KnowledgeBaseServer.test.ts
+++ b/src/KnowledgeBaseServer.test.ts
@@ -1015,6 +1015,118 @@ describe('KnowledgeBaseServer handlers', () => {
     );
   });
 
+  it('resources/list supports KB and prefix filters with cursor pagination', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-server-resources-page-'));
+    await fsp.mkdir(path.join(tempDir, 'alpha', 'docs'), { recursive: true });
+    await fsp.mkdir(path.join(tempDir, 'alpha', 'notes'), { recursive: true });
+    await fsp.mkdir(path.join(tempDir, 'beta', 'docs'), { recursive: true });
+    await fsp.writeFile(path.join(tempDir, 'alpha', 'docs', 'guide.md'), '# Guide\n');
+    await fsp.writeFile(path.join(tempDir, 'alpha', 'docs', 'glossary.md'), '# Glossary\n');
+    await fsp.writeFile(path.join(tempDir, 'alpha', 'docs', 'plan.md'), '# Plan\n');
+    await fsp.writeFile(path.join(tempDir, 'alpha', 'notes', 'general.md'), '# General\n');
+    await fsp.writeFile(path.join(tempDir, 'beta', 'docs', 'guide.md'), '# Beta\n');
+
+    process.env.KNOWLEDGE_BASES_ROOT_DIR = tempDir;
+    process.env.FAISS_INDEX_PATH = path.join(tempDir, '.faiss');
+    process.env.EMBEDDING_PROVIDER = 'huggingface';
+    process.env.HUGGINGFACE_API_KEY = 'test-key';
+
+    const server = await freshServer();
+    const firstPage = await server['handleListResources']({
+      kbName: 'alpha',
+      prefix: 'docs/g',
+      limit: 1,
+    });
+
+    expect(firstPage.resources.map((resource: { uri: string }) => resource.uri)).toEqual([
+      'kb://alpha/docs/glossary.md',
+    ]);
+    expect(firstPage.nextCursor).toEqual(expect.any(String));
+
+    const secondPage = await server['handleListResources']({ cursor: firstPage.nextCursor });
+
+    expect(secondPage.resources.map((resource: { uri: string }) => resource.uri)).toEqual([
+      'kb://alpha/docs/guide.md',
+    ]);
+    expect(secondPage.nextCursor).toBeUndefined();
+  });
+
+  it('resources/list keeps full listing as the no-parameter default', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-server-resources-default-'));
+    await fsp.mkdir(path.join(tempDir, 'alpha', 'docs'), { recursive: true });
+    await fsp.mkdir(path.join(tempDir, 'beta', 'docs'), { recursive: true });
+    await fsp.writeFile(path.join(tempDir, 'alpha', 'docs', 'a.md'), '# A\n');
+    await fsp.writeFile(path.join(tempDir, 'alpha', 'docs', 'b.md'), '# B\n');
+    await fsp.writeFile(path.join(tempDir, 'beta', 'docs', 'c.md'), '# C\n');
+
+    process.env.KNOWLEDGE_BASES_ROOT_DIR = tempDir;
+    process.env.FAISS_INDEX_PATH = path.join(tempDir, '.faiss');
+    process.env.EMBEDDING_PROVIDER = 'huggingface';
+    process.env.HUGGINGFACE_API_KEY = 'test-key';
+
+    const server = await freshServer();
+    const result = await server['handleListResources']();
+
+    expect(result.resources.map((resource: { uri: string }) => resource.uri).sort()).toEqual([
+      'kb://alpha/docs/a.md',
+      'kb://alpha/docs/b.md',
+      'kb://beta/docs/c.md',
+    ]);
+    expect(result.nextCursor).toBeUndefined();
+  });
+
+  it('resources/list paginates the unfiltered listing across KB boundaries', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-server-resources-unfiltered-page-'));
+    await fsp.mkdir(path.join(tempDir, 'alpha', 'docs'), { recursive: true });
+    await fsp.mkdir(path.join(tempDir, 'beta', 'docs'), { recursive: true });
+    await fsp.writeFile(path.join(tempDir, 'alpha', 'docs', 'a.md'), '# A\n');
+    await fsp.writeFile(path.join(tempDir, 'beta', 'docs', 'b.md'), '# B\n');
+
+    process.env.KNOWLEDGE_BASES_ROOT_DIR = tempDir;
+    process.env.FAISS_INDEX_PATH = path.join(tempDir, '.faiss');
+    process.env.EMBEDDING_PROVIDER = 'huggingface';
+    process.env.HUGGINGFACE_API_KEY = 'test-key';
+
+    const server = await freshServer();
+    const firstPage = await server['handleListResources']({ limit: 1 });
+
+    expect(firstPage.resources.map((resource: { uri: string }) => resource.uri)).toEqual([
+      'kb://alpha/docs/a.md',
+    ]);
+    expect(firstPage.nextCursor).toEqual(expect.any(String));
+
+    const secondPage = await server['handleListResources']({ cursor: firstPage.nextCursor });
+
+    expect(secondPage.resources.map((resource: { uri: string }) => resource.uri)).toEqual([
+      'kb://beta/docs/b.md',
+    ]);
+    expect(secondPage.nextCursor).toBeUndefined();
+  });
+
+  it('resources/list rejects client-forged cursors with unsafe filters', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-server-resources-forged-cursor-'));
+    await fsp.mkdir(path.join(tempDir, 'alpha'), { recursive: true });
+    await fsp.writeFile(path.join(tempDir, 'alpha', 'safe.md'), '# Safe\n');
+
+    process.env.KNOWLEDGE_BASES_ROOT_DIR = tempDir;
+    process.env.FAISS_INDEX_PATH = path.join(tempDir, '.faiss');
+    process.env.EMBEDDING_PROVIDER = 'huggingface';
+    process.env.HUGGINGFACE_API_KEY = 'test-key';
+
+    const server = await freshServer();
+    const forgedCursor = `kbres1.${Buffer.from(JSON.stringify({
+      v: 1,
+      offset: 0,
+      kbName: '../outside',
+      prefix: '',
+      limit: 10,
+    }), 'utf-8').toString('base64url')}`;
+
+    await expect(server['handleListResources']({ cursor: forgedCursor })).rejects.toThrow(
+      /invalid resources\/list cursor/,
+    );
+  });
+
   it('resources/read returns markdown text for an existing file', async () => {
     const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-server-resources-read-'));
     await fsp.mkdir(path.join(tempDir, 'alpha', 'docs'), { recursive: true });

--- a/src/KnowledgeBaseServer.ts
+++ b/src/KnowledgeBaseServer.ts
@@ -5,6 +5,7 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { z } from 'zod';
 import {
   type CallToolResult,
+  type ListResourcesRequest,
   type ListResourcesResult,
   type ReadResourceResult,
   type TextContent,
@@ -392,8 +393,10 @@ export class KnowledgeBaseServer {
   // handler bodies. These remain on the class as thin delegates so the
   // existing private-method test surface (KnowledgeBaseServer.test.ts) keeps
   // working without re-plumbing.
-  private async handleListResources(): Promise<ListResourcesResult> {
-    return listResources();
+  private async handleListResources(
+    params?: ListResourcesRequest['params'],
+  ): Promise<ListResourcesResult> {
+    return listResources(params);
   }
 
   private async handleReadResource(uri: string): Promise<ReadResourceResult> {

--- a/src/mcp-resources.test.ts
+++ b/src/mcp-resources.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it } from '@jest/globals';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { ListResourceTemplatesRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import {
   buildResourceUri,
+  listResourceTemplates,
   mimeTypeForResource,
   parseKnowledgeBaseResourceUri,
+  registerResources,
 } from './mcp-resources.js';
 
 // Issue #157 step 2 — direct tests for the pure URI/MIME helpers extracted
@@ -111,5 +115,40 @@ describe('parseKnowledgeBaseResourceUri', () => {
     const uri = buildResourceUri('alpha', `issues/${filename}`);
     const parsed = parseKnowledgeBaseResourceUri(uri);
     expect(parsed.relativePath).toBe(`issues/${filename}`);
+  });
+});
+
+describe('listResourceTemplates', () => {
+  it('advertises the kb:// document URI template', () => {
+    expect(listResourceTemplates()).toEqual({
+      resourceTemplates: [
+        expect.objectContaining({
+          uriTemplate: 'kb://{kb}/{path}',
+          name: 'kb-document',
+        }),
+      ],
+    });
+  });
+
+  it('registers the resources/templates/list handler with the template response', async () => {
+    const handlers: Array<{ schema: unknown; handler: () => unknown }> = [];
+    const mcp = {
+      server: {
+        registerCapabilities: () => undefined,
+        setRequestHandler: (schema: unknown, handler: () => unknown) => {
+          handlers.push({ schema, handler });
+        },
+      },
+    };
+
+    registerResources(mcp as unknown as McpServer);
+
+    const registered = handlers.find(
+      (entry) => entry.schema === ListResourceTemplatesRequestSchema,
+    );
+    expect(registered).toBeDefined();
+    await expect(Promise.resolve(registered!.handler())).resolves.toEqual(
+      listResourceTemplates(),
+    );
   });
 });

--- a/src/mcp-resources.ts
+++ b/src/mcp-resources.ts
@@ -14,6 +14,8 @@ import {
   ListResourcesRequestSchema,
   ListResourceTemplatesRequestSchema,
   ReadResourceRequestSchema,
+  type ListResourceTemplatesResult,
+  type ListResourcesRequest,
   type ListResourcesResult,
   type ReadResourceResult,
   type Resource,
@@ -22,10 +24,44 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { INGEST_EXCLUDE_PATHS, INGEST_EXTRA_EXTENSIONS } from './config/ingest.js';
 import { KNOWLEDGE_BASES_ROOT_DIR } from './config/paths.js';
 import { toError } from './error-utils.js';
+import { getFilesRecursively } from './file-utils.js';
 import { filterIngestablePaths } from './ingest-filter.js';
 import { listIngestQuarantine } from './ingest-quarantine.js';
-import { enumerateIngestableKbFiles, listKnowledgeBases, resolveKbPath } from './kb-fs.js';
+import {
+  assertNoTraversal,
+  enumerateIngestableKbFiles,
+  listKnowledgeBases,
+  resolveKbPath,
+} from './kb-fs.js';
 import { isValidKbName } from './kb-paths.js';
+
+export interface ListResourcesOptions {
+  cursor?: string;
+  kbName?: string;
+  knowledgeBase?: string;
+  knowledge_base_name?: string;
+  prefix?: string;
+  limit?: number;
+  pageSize?: number;
+}
+
+interface NormalizedListResourcesOptions {
+  kbName?: string;
+  prefix: string;
+  limit?: number;
+  offset: number;
+}
+
+interface ListResourcesCursor {
+  v: 1;
+  offset: number;
+  kbName?: string;
+  prefix: string;
+  limit: number;
+}
+
+const LIST_RESOURCES_CURSOR_PREFIX = 'kbres1.';
+const LIST_RESOURCES_MAX_PAGE_SIZE = 1000;
 
 export function mimeTypeForResource(filePath: string): string {
   const ext = path.extname(filePath).toLowerCase();
@@ -121,45 +157,297 @@ export function parseKnowledgeBaseResourceUri(uri: string): { kbName: string; re
   return { kbName, relativePath };
 }
 
-/**
- * `resources/list` body. Walks every registered KB under
- * `KNOWLEDGE_BASES_ROOT_DIR` and emits one `Resource` per ingestable,
- * non-quarantined file with a percent-encoded `kb://` URI and a
- * content-type-by-extension mime hint.
- */
-export async function listResources(): Promise<ListResourcesResult> {
-  const resources: Resource[] = [];
-  const knowledgeBases = (await listKnowledgeBases(KNOWLEDGE_BASES_ROOT_DIR)).sort();
-  const enumerations = await enumerateIngestableKbFiles(
-    KNOWLEDGE_BASES_ROOT_DIR,
-    knowledgeBases.filter(isValidKbName),
-    {
-      extraExtensions: INGEST_EXTRA_EXTENSIONS,
-      excludePaths: INGEST_EXCLUDE_PATHS,
-    },
-  );
+function encodeListResourcesCursor(cursor: ListResourcesCursor): string {
+  return `${LIST_RESOURCES_CURSOR_PREFIX}${Buffer.from(JSON.stringify(cursor), 'utf-8').toString('base64url')}`;
+}
 
-  for (const { kbName, kbPath, filePaths } of enumerations) {
-    const quarantined = new Set(
-      (await listIngestQuarantine(kbPath)).map((record) => record.relative_path),
+function decodeListResourcesCursor(raw: string): ListResourcesCursor {
+  if (!raw.startsWith(LIST_RESOURCES_CURSOR_PREFIX)) {
+    throw new Error('invalid resources/list cursor');
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(
+      Buffer.from(raw.slice(LIST_RESOURCES_CURSOR_PREFIX.length), 'base64url').toString('utf-8'),
     );
-    for (const filePath of filePaths.sort()) {
-      const relativePath = path
-        .relative(kbPath, filePath)
-        .split(path.sep)
-        .join('/');
-      if (quarantined.has(relativePath)) continue;
+  } catch (error: unknown) {
+    throw new Error(`invalid resources/list cursor: ${toError(error).message}`);
+  }
 
-      resources.push({
-        uri: buildResourceUri(kbName, relativePath),
-        name: relativePath,
-        description: `Document in knowledge base "${kbName}"`,
-        mimeType: mimeTypeForResource(filePath),
-      });
+  if (
+    typeof parsed !== 'object' ||
+    parsed === null ||
+    (parsed as { v?: unknown }).v !== 1 ||
+    !Number.isInteger((parsed as { offset?: unknown }).offset) ||
+    (parsed as { offset: number }).offset < 0 ||
+    typeof (parsed as { prefix?: unknown }).prefix !== 'string' ||
+    !Number.isInteger((parsed as { limit?: unknown }).limit) ||
+    (parsed as { limit: number }).limit <= 0
+  ) {
+    throw new Error('invalid resources/list cursor');
+  }
+
+  const kbName = (parsed as { kbName?: unknown }).kbName;
+  if (kbName !== undefined && typeof kbName !== 'string') {
+    throw new Error('invalid resources/list cursor');
+  }
+  if (kbName !== undefined && !isValidKbName(kbName)) {
+    throw new Error('invalid resources/list cursor');
+  }
+
+  const prefix = (parsed as { prefix: string }).prefix;
+  if (prefix.includes('\0')) {
+    throw new Error('invalid resources/list cursor');
+  }
+  if (prefix.length > 0) {
+    try {
+      assertNoTraversal(prefix);
+    } catch {
+      throw new Error('invalid resources/list cursor');
     }
   }
 
-  return { resources };
+  const limit = (parsed as { limit: number }).limit;
+  if (limit > LIST_RESOURCES_MAX_PAGE_SIZE) {
+    throw new Error('invalid resources/list cursor');
+  }
+
+  return {
+    v: 1,
+    offset: (parsed as { offset: number }).offset,
+    kbName,
+    prefix,
+    limit,
+  };
+}
+
+function readStringOption(options: ListResourcesOptions | undefined, key: keyof ListResourcesOptions): string | undefined {
+  const value = options?.[key];
+  return typeof value === 'string' ? value : undefined;
+}
+
+function normalizeListResourcesOptions(
+  options: ListResourcesOptions | undefined,
+): NormalizedListResourcesOptions {
+  const explicitKbName =
+    readStringOption(options, 'kbName') ??
+    readStringOption(options, 'knowledgeBase') ??
+    readStringOption(options, 'knowledge_base_name');
+  const explicitPrefix = readStringOption(options, 'prefix') ?? '';
+  const explicitLimit = options?.limit ?? options?.pageSize;
+
+  if (explicitKbName !== undefined && !isValidKbName(explicitKbName)) {
+    throw new Error('invalid KB name in resources/list filter');
+  }
+  if (explicitPrefix.includes('\0')) {
+    throw new Error('resources/list prefix contains null byte');
+  }
+  if (explicitPrefix.length > 0) {
+    assertNoTraversal(explicitPrefix);
+  }
+  if (explicitLimit !== undefined && (!Number.isInteger(explicitLimit) || explicitLimit <= 0)) {
+    throw new Error('resources/list limit must be a positive integer');
+  }
+
+  if (options?.cursor === undefined) {
+    return {
+      kbName: explicitKbName,
+      prefix: explicitPrefix,
+      limit:
+        explicitLimit === undefined
+          ? undefined
+          : Math.min(explicitLimit, LIST_RESOURCES_MAX_PAGE_SIZE),
+      offset: 0,
+    };
+  }
+
+  const cursor = decodeListResourcesCursor(options.cursor);
+  if (explicitKbName !== undefined && explicitKbName !== cursor.kbName) {
+    throw new Error('resources/list cursor does not match kbName filter');
+  }
+  if (explicitPrefix !== '' && explicitPrefix !== cursor.prefix) {
+    throw new Error('resources/list cursor does not match prefix filter');
+  }
+  if (explicitLimit !== undefined && Math.min(explicitLimit, LIST_RESOURCES_MAX_PAGE_SIZE) !== cursor.limit) {
+    throw new Error('resources/list cursor does not match limit');
+  }
+
+  return {
+    kbName: cursor.kbName,
+    prefix: cursor.prefix,
+    limit: cursor.limit,
+    offset: cursor.offset,
+  };
+}
+
+function normalizeRelativePath(filePath: string, kbPath: string): string {
+  return path
+    .relative(kbPath, filePath)
+    .split(path.sep)
+    .join('/');
+}
+
+async function listCandidatePathsForPrefix(kbPath: string, prefix: string): Promise<string[]> {
+  const normalizedPrefix = prefix.replace(/\\/g, '/');
+  const prefixSegments = normalizedPrefix.split('/').filter((segment) => segment.length > 0);
+  let searchRelativeDir = '';
+  if (normalizedPrefix.endsWith('/')) {
+    searchRelativeDir = prefixSegments.join('/');
+  } else if (prefixSegments.length > 1) {
+    searchRelativeDir = prefixSegments.slice(0, -1).join('/');
+  }
+
+  const searchRoot = path.join(kbPath, searchRelativeDir);
+  let stat;
+  try {
+    stat = await fsp.stat(searchRoot);
+  } catch (error: unknown) {
+    const code = (error as NodeJS.ErrnoException | undefined)?.code;
+    if (code === 'ENOENT' || code === 'ENOTDIR') {
+      return [];
+    }
+    throw error;
+  }
+  if (!stat.isDirectory()) {
+    return [];
+  }
+
+  return getFilesRecursively(searchRoot);
+}
+
+async function listResourcesForKb(
+  kbName: string,
+  prefix: string,
+): Promise<Resource[]> {
+  const kbPath = path.join(KNOWLEDGE_BASES_ROOT_DIR, kbName);
+  const candidates = await listCandidatePathsForPrefix(kbPath, prefix);
+  const filePaths = filterIngestablePaths(candidates, kbPath, {
+    extraExtensions: INGEST_EXTRA_EXTENSIONS,
+    excludePaths: INGEST_EXCLUDE_PATHS,
+  });
+  const quarantined = new Set(
+    (await listIngestQuarantine(kbPath)).map((record) => record.relative_path),
+  );
+  const resources: Resource[] = [];
+
+  for (const filePath of filePaths.sort()) {
+    const relativePath = normalizeRelativePath(filePath, kbPath);
+    if (prefix.length > 0 && !relativePath.startsWith(prefix)) continue;
+    if (quarantined.has(relativePath)) continue;
+
+    resources.push({
+      uri: buildResourceUri(kbName, relativePath),
+      name: relativePath,
+      description: `Document in knowledge base "${kbName}"`,
+      mimeType: mimeTypeForResource(filePath),
+    });
+  }
+
+  return resources;
+}
+
+/**
+ * `resources/list` body. No-option calls preserve the original full listing:
+ * every registered KB under `KNOWLEDGE_BASES_ROOT_DIR` contributes one
+ * `Resource` per ingestable, non-quarantined file. Optional KB/prefix filters
+ * and MCP cursors narrow/page that same deterministic listing.
+ */
+export async function listResources(options?: ListResourcesOptions): Promise<ListResourcesResult> {
+  const normalizedOptions = normalizeListResourcesOptions(options);
+  const resources: Resource[] = [];
+  let matchedCount = 0;
+  const appendResource = (resource: Resource): void => {
+    if (normalizedOptions.limit === undefined) {
+      resources.push(resource);
+      return;
+    }
+    if (
+      matchedCount >= normalizedOptions.offset &&
+      resources.length <= normalizedOptions.limit
+    ) {
+      resources.push(resource);
+    }
+    matchedCount += 1;
+  };
+  const pageHasLookahead = (): boolean =>
+    normalizedOptions.limit !== undefined && resources.length > normalizedOptions.limit;
+
+  const knowledgeBases = normalizedOptions.kbName === undefined
+    ? (await listKnowledgeBases(KNOWLEDGE_BASES_ROOT_DIR)).sort().filter(isValidKbName)
+    : [normalizedOptions.kbName];
+
+  if (normalizedOptions.prefix.length === 0) {
+    for (const kbName of knowledgeBases) {
+      const [enumeration] = await enumerateIngestableKbFiles(
+        KNOWLEDGE_BASES_ROOT_DIR,
+        [kbName],
+        {
+          extraExtensions: INGEST_EXTRA_EXTENSIONS,
+          excludePaths: INGEST_EXCLUDE_PATHS,
+        },
+      );
+      if (enumeration === undefined) continue;
+      const { kbPath, filePaths } = enumeration;
+      const quarantined = new Set(
+        (await listIngestQuarantine(kbPath)).map((record) => record.relative_path),
+      );
+      for (const filePath of filePaths.sort()) {
+        const relativePath = normalizeRelativePath(filePath, kbPath);
+        if (quarantined.has(relativePath)) continue;
+
+        appendResource({
+          uri: buildResourceUri(kbName, relativePath),
+          name: relativePath,
+          description: `Document in knowledge base "${kbName}"`,
+          mimeType: mimeTypeForResource(filePath),
+        });
+        if (pageHasLookahead()) break;
+      }
+      if (pageHasLookahead()) break;
+    }
+  } else {
+    for (const kbName of knowledgeBases) {
+      const kbResources = await listResourcesForKb(kbName, normalizedOptions.prefix);
+      for (const resource of kbResources) {
+        appendResource(resource);
+        if (pageHasLookahead()) break;
+      }
+      if (pageHasLookahead()) break;
+    }
+  }
+
+  if (normalizedOptions.limit === undefined) {
+    return { resources };
+  }
+
+  const pageResources = resources.slice(0, normalizedOptions.limit);
+  const nextOffset = normalizedOptions.offset + pageResources.length;
+  const nextCursor = pageHasLookahead()
+    ? encodeListResourcesCursor({
+      v: 1,
+      offset: nextOffset,
+      kbName: normalizedOptions.kbName,
+      prefix: normalizedOptions.prefix,
+      limit: normalizedOptions.limit,
+    })
+    : undefined;
+
+  return nextCursor === undefined
+    ? { resources: pageResources }
+    : { resources: pageResources, nextCursor };
+}
+
+export function listResourceTemplates(): ListResourceTemplatesResult {
+  return {
+    resourceTemplates: [
+      {
+        uriTemplate: 'kb://{kb}/{path}',
+        name: 'kb-document',
+        description: 'Read an ingestable, non-quarantined knowledge-base document by KB name and relative path.',
+      },
+    ],
+  };
 }
 
 /**
@@ -209,10 +497,8 @@ export async function readResource(uri: string): Promise<ReadResourceResult> {
 
 /**
  * Wire the resources surface onto an `McpServer`. Registers
- * `resources/list`, `resources/read`, and an empty
- * `resources/templates/list` (the server has no templates; clients that
- * probe for them must get an empty response, not a method-not-found
- * error). Called once from `KnowledgeBaseServer.buildMcpServer`.
+ * `resources/list`, `resources/read`, and `resources/templates/list`.
+ * Called once from `KnowledgeBaseServer.buildMcpServer`.
  */
 export function registerResources(mcp: McpServer): void {
   mcp.server.registerCapabilities({
@@ -221,10 +507,10 @@ export function registerResources(mcp: McpServer): void {
     },
   });
 
-  mcp.server.setRequestHandler(ListResourcesRequestSchema, async () => listResources());
-  mcp.server.setRequestHandler(ListResourceTemplatesRequestSchema, async () => ({
-    resourceTemplates: [],
-  }));
+  mcp.server.setRequestHandler(ListResourcesRequestSchema, async (request: ListResourcesRequest) =>
+    listResources(request.params),
+  );
+  mcp.server.setRequestHandler(ListResourceTemplatesRequestSchema, async () => listResourceTemplates());
   mcp.server.setRequestHandler(ReadResourceRequestSchema, async (request) =>
     readResource(request.params.uri),
   );


### PR DESCRIPTION
## Summary
- add MCP resources/list pagination using opaque cursors and limit/pageSize
- support kbName and prefix filters while preserving the full no-param listing
- advertise kb://{kb}/{path} resource templates and document the listing params

Closes #490

## Verification
- npx jest --runInBand src/mcp-resources.test.ts src/KnowledgeBaseServer.test.ts
- npm run build
- npm test
- git diff --check
- local-path scan of changed files (no machine-local paths found; repository has no scripts/check-portability.sh)
