### PR TITLE
feat: expose query cache telemetry

### DIFF
--- a/docs/cli-json-contracts.md
+++ b/docs/cli-json-contracts.md
@@ -136,7 +136,13 @@ Dense success envelope, including the default `--mode=dense`:
   "new_files": 0,
   "global_stale": false,
   "global_modified_files": 0,
-  "global_new_files": 0
+  "global_new_files": 0,
+  "query_cache": {
+    "enabled": true,
+    "outcome": "memory_hit",
+    "model_id": "ollama__nomic-embed-text-latest",
+    "elapsed_ms": 1
+  }
 }
 ```
 
@@ -154,6 +160,11 @@ Stable fields:
   that run.
 - `global_stale`, `global_modified_files`, `global_new_files`: staleness across
   all KBs.
+- `query_cache`: present for dense search when the FAISS vector-search path
+  exposes query-cache telemetry. `outcome` is one of `memory_hit`, `disk_hit`,
+  `miss`, `bypass`, or `disabled`; `model_id` is the embedding model id and
+  `elapsed_ms` is the bounded cache lookup/embedding time. The object never
+  includes raw query text or cache-key material.
 
 Optional stable fields:
 
@@ -183,7 +194,10 @@ Optional stable fields:
 - `auto_threshold`: present with `--threshold=auto`. Shape:
   `{"threshold": number, "knee_index": number|null, "kept": number}`.
 - `timing`: present with `--timing`; keys are elapsed millisecond counters and
-  mode labels. Treat the object as diagnostic, not a compatibility contract.
+  mode labels. Dense query-cache diagnostics use the flat keys
+  `query_cache`, `query_cache_enabled`, `query_cache_model_id`, and
+  `query_cache_elapsed_ms`. Treat the object as diagnostic, not a compatibility
+  contract.
   For dense and hybrid `--refresh` runs, the same diagnostic object may include
   refresh counters such as `refresh_embed_batches`,
   `refresh_embed_batches_total`, `refresh_embed_chunks`,

--- a/docs/operations/logs-reader.md
+++ b/docs/operations/logs-reader.md
@@ -88,6 +88,12 @@ kb logs show --request-id=req-7e2b --format=json | jq
       "took_ms": 42,
       "timings": { "embed_ms": 10, "faiss_ms": 20, "format_ms": 3 },
       "cache": "miss",
+      "query_cache": {
+        "enabled": true,
+        "outcome": "miss",
+        "model_id": "ollama__nomic-embed-text-latest",
+        "elapsed_ms": 10
+      },
       "result_count": 3,
       "top_sources": ["docs/a.md"]
     }
@@ -107,8 +113,9 @@ kb logs recent --limit=50 --format=json \
 ```
 
 A canonical log line carries everything `kb stats` would summarise *per
-request* — cache state, timings, top sources, error codes, recovery hints —
-so this kind of pull is enough for a quick performance sanity-check.
+request* — cache state, query-cache outcome metadata, timings, top sources,
+error codes, recovery hints — so this kind of pull is enough for a quick
+performance sanity-check.
 
 ## Group repeated queries
 

--- a/src/FaissIndexManager.ts
+++ b/src/FaissIndexManager.ts
@@ -82,7 +82,7 @@ import {
   type MetadataSidecar,
   type MetadataSidecarRow,
 } from './metadata-sidecar.js';
-import { queryEmbeddingCache, type QueryCacheLookupStatus } from './query-cache.js';
+import { queryEmbeddingCache, type QueryCacheLookupStatus, type QueryCacheTelemetry } from './query-cache.js';
 import { withSidecarLock } from './write-lock.js';
 import { FaissStoreAdapter } from './faiss-store-adapter.js';
 import {
@@ -314,6 +314,7 @@ export interface SimilaritySearchTiming {
   total_ms?: number;
   fetch_k?: number;
   query_cache?: QueryCacheLookupStatus | 'unavailable';
+  query_cache_telemetry?: QueryCacheTelemetry;
   /**
    * Issue #283 — outcome of the metadata-sidecar predicate-pushdown
    * fast-path. `unused` means the active filter did not benefit from the

--- a/src/KnowledgeBaseServer.test.ts
+++ b/src/KnowledgeBaseServer.test.ts
@@ -1,6 +1,7 @@
 import * as fsp from 'fs/promises';
 import * as os from 'os';
 import * as path from 'path';
+import type { SimilaritySearchTiming } from './FaissIndexManager.js';
 
 const initializeMock = jest.fn();
 const updateIndexMock = jest.fn();
@@ -1340,10 +1341,21 @@ describe('KnowledgeBaseServer handlers', () => {
     // Raw scores are chosen so the 2-decimal rounding in the handler
     // (score.toFixed(2)) produces a visibly different string than the raw
     // value — a regression that drops toFixed(2) would leak the raw digits.
-    similaritySearchMock.mockResolvedValue([
-      { pageContent: 'Alpha content', metadata: { source: '/kb/a.md' }, score: 0.129876 },
-      { pageContent: 'Beta content', metadata: { source: '/kb/b.md' }, score: 0.34567 },
-    ]);
+    similaritySearchMock.mockImplementation(async (...args: unknown[]) => {
+      const timing = args[5] as SimilaritySearchTiming;
+      timing.embed_query_ms = 3;
+      timing.faiss_search_ms = 5;
+      timing.query_cache_telemetry = {
+        enabled: true,
+        outcome: 'disk_hit',
+        model_id: 'huggingface__BAAI-bge-small-en-v1.5',
+        elapsed_ms: 2,
+      };
+      return [
+        { pageContent: 'Alpha content', metadata: { source: '/kb/a.md' }, score: 0.129876 },
+        { pageContent: 'Beta content', metadata: { source: '/kb/b.md' }, score: 0.34567 },
+      ];
+    });
 
     const server = await freshServer();
     const result = await server['handleRetrieveKnowledge']({ query: 'what is alpha' });
@@ -1487,10 +1499,21 @@ describe('KnowledgeBaseServer handlers', () => {
     process.env.LOG_FILE = logFile;
     process.env.KB_LOG_FORMAT = 'canonical';
     updateIndexMock.mockResolvedValue(undefined);
-    similaritySearchMock.mockResolvedValue([
-      { pageContent: 'Alpha content', metadata: { source: '/kb/a.md' }, score: 0.129876 },
-      { pageContent: 'Beta content', metadata: { source: '/kb/b.md' }, score: 0.34567 },
-    ]);
+    similaritySearchMock.mockImplementation(async (...args: unknown[]) => {
+      const timing = args[5] as SimilaritySearchTiming;
+      timing.embed_query_ms = 3;
+      timing.faiss_search_ms = 5;
+      timing.query_cache_telemetry = {
+        enabled: true,
+        outcome: 'disk_hit',
+        model_id: 'huggingface__BAAI-bge-small-en-v1.5',
+        elapsed_ms: 2,
+      };
+      return [
+        { pageContent: 'Alpha content', metadata: { source: '/kb/a.md' }, score: 0.129876 },
+        { pageContent: 'Beta content', metadata: { source: '/kb/b.md' }, score: 0.34567 },
+      ];
+    });
 
     const server = await freshServer();
     const result = await server['handleRetrieveKnowledge']({
@@ -1514,6 +1537,13 @@ describe('KnowledgeBaseServer handlers', () => {
       result_count: 2,
       top_score: 0.129876,
       top_sources: ['/kb/a.md', '/kb/b.md'],
+      cache: 'disk_hit',
+      query_cache: {
+        enabled: true,
+        outcome: 'disk_hit',
+        model_id: 'huggingface__BAAI-bge-small-en-v1.5',
+        elapsed_ms: 2,
+      },
     });
     expect(events[0].query_sha256).toMatch(/^[a-f0-9]{16}$/);
     expect(JSON.stringify(events[0])).not.toContain('raw private query');

--- a/src/KnowledgeBaseServer.ts
+++ b/src/KnowledgeBaseServer.ts
@@ -807,6 +807,8 @@ export class KnowledgeBaseServer {
       canonical.top_sources = topSourcesForCanonicalLog(similaritySearchResults);
       canonical.embed_ms = timing.embed_query_ms;
       canonical.faiss_ms = timing.faiss_search_ms ?? timing.query_search_ms;
+      canonical.cache = timing.query_cache_telemetry?.outcome;
+      canonical.query_cache = timing.query_cache_telemetry;
 
       // Build a nicely formatted markdown response including the similarity score.
       const formatStartedAt = Date.now();

--- a/src/canonical-log.test.ts
+++ b/src/canonical-log.test.ts
@@ -33,6 +33,13 @@ describe('canonical log line schema (#216)', () => {
       tool: 'retrieve_knowledge',
       took_ms: 5,
       top_sources: ['a.md', 'b.md', 'c.md', 'd.md'],
+      cache: 'memory_hit',
+      query_cache: {
+        enabled: true,
+        outcome: 'memory_hit',
+        model_id: 'fake__model',
+        elapsed_ms: 1,
+      },
     });
 
     const json = stableCanonicalJson(event);
@@ -44,9 +51,17 @@ describe('canonical log line schema (#216)', () => {
       tool: 'retrieve_knowledge',
       top_sources: ['a.md', 'b.md', 'c.md'],
       took_ms: 5,
+      cache: 'memory_hit',
+      query_cache: {
+        enabled: true,
+        outcome: 'memory_hit',
+        model_id: 'fake__model',
+        elapsed_ms: 1,
+      },
     });
     expect(json.indexOf('"schema_version"')).toBeLessThan(json.indexOf('"request_id"'));
     expect(json.indexOf('"top_sources"')).toBeLessThan(json.indexOf('"took_ms"'));
+    expect(json.indexOf('"cache"')).toBeLessThan(json.indexOf('"query_cache"'));
   });
 
   it('extracts error code and category from MCP tool error payloads', () => {

--- a/src/canonical-log.ts
+++ b/src/canonical-log.ts
@@ -2,11 +2,12 @@ import { createHash, randomBytes } from 'crypto';
 import { logger } from './logger.js';
 import { KBError, type KBErrorCode } from './errors.js';
 import { ActiveModelResolutionError } from './active-model.js';
+import type { QueryCacheOutcome, QueryCacheTelemetry } from './query-cache.js';
 
 export const CANONICAL_SCHEMA_VERSION = 'kb-canonical.v1';
 
 export type CanonicalProcess = 'mcp' | 'cli';
-export type CanonicalCacheStatus = 'hit_l1' | 'hit_disk' | 'miss';
+export type CanonicalCacheStatus = QueryCacheOutcome;
 export type CanonicalSearchMode = 'dense' | 'lexical' | 'hybrid' | 'auto';
 export type CanonicalErrorCategory =
   | 'configuration'
@@ -52,6 +53,7 @@ export interface CanonicalLogEvent {
   faiss_ms?: number;
   format_ms?: number;
   cache?: CanonicalCacheStatus;
+  query_cache?: QueryCacheTelemetry;
   error?: CanonicalError;
   recovery_hint?: string;
   rerank?: Record<string, unknown>;
@@ -94,6 +96,7 @@ const CANONICAL_FIELD_ORDER: readonly (keyof CanonicalLogEvent)[] = [
   'faiss_ms',
   'format_ms',
   'cache',
+  'query_cache',
   'error',
   'recovery_hint',
   'rerank',
@@ -141,6 +144,7 @@ export function normalizeCanonicalEvent(input: CanonicalLogInput): CanonicalLogE
   assignIfDefined(event, 'faiss_ms', roundNonNegative(input.faiss_ms));
   assignIfDefined(event, 'format_ms', roundNonNegative(input.format_ms));
   assignIfDefined(event, 'cache', input.cache);
+  assignIfDefined(event, 'query_cache', input.query_cache);
   assignIfDefined(event, 'error', input.error);
   assignIfDefined(event, 'recovery_hint', input.recovery_hint);
   assignIfDefined(event, 'rerank', input.rerank);

--- a/src/cli-logs.test.ts
+++ b/src/cli-logs.test.ts
@@ -91,7 +91,17 @@ describe('runLogs', () => {
     const { deps, stdout, stderr } = depsFor({
       '/repo/kb.log': [
         canonical({ request_id: 'req-1', query_sha256: 'old' }),
-        canonical({ request_id: 'req-2', query_sha256: 'new', result_count: 3 }),
+        canonical({
+          request_id: 'req-2',
+          query_sha256: 'new',
+          result_count: 3,
+          query_cache: {
+            enabled: true,
+            outcome: 'disk_hit',
+            model_id: 'fake__model',
+            elapsed_ms: 2,
+          },
+        }),
       ].join('\n'),
     }, { LOG_FILE: './kb.log' });
 
@@ -103,13 +113,28 @@ describe('runLogs', () => {
       schema_version: string;
       source: string;
       result_count: number;
-      events: Array<{ request_id: string; query_sha256: string; result_count?: number }>;
+      events: Array<{
+        request_id: string;
+        query_sha256: string;
+        result_count?: number;
+        query_cache?: unknown;
+      }>;
     };
     expect(payload.schema_version).toBe('kb.logs.v1');
     expect(payload.source).toBe('/repo/kb.log');
     expect(payload.result_count).toBe(1);
     expect(payload.events).toEqual([
-      expect.objectContaining({ request_id: 'req-2', query_sha256: 'new', result_count: 3 }),
+      expect.objectContaining({
+        request_id: 'req-2',
+        query_sha256: 'new',
+        result_count: 3,
+        query_cache: {
+          enabled: true,
+          outcome: 'disk_hit',
+          model_id: 'fake__model',
+          elapsed_ms: 2,
+        },
+      }),
     ]);
   });
 

--- a/src/cli-logs.ts
+++ b/src/cli-logs.ts
@@ -88,6 +88,7 @@ interface CanonicalLogSummary {
     format_ms?: number;
   };
   cache?: string;
+  query_cache?: unknown;
   result_count?: number;
   top_score?: number;
   top_sources?: string[];
@@ -355,6 +356,7 @@ function summarizeEvent(event: CanonicalLogRecord): CanonicalLogSummary {
       format_ms: numberField(event.format_ms),
     },
     cache: stringField(event.cache),
+    query_cache: event.query_cache,
     result_count: numberField(event.result_count),
     top_score: numberField(event.top_score),
     top_sources: stringArrayField(event.top_sources),

--- a/src/cli-search.test.ts
+++ b/src/cli-search.test.ts
@@ -10,6 +10,7 @@ import {
   parseSearchArgs,
   runSearch,
   shouldUsePicker,
+  takeLastSearchCanonicalTelemetry,
   type RunSearchDeps,
 } from './cli-search.js';
 import { KNOWLEDGE_BASES_ROOT_DIR } from './config/paths.js';
@@ -327,13 +328,24 @@ describe('runSearch timing guard (#331)', () => {
   it('runs dense JSONL batch rows while loading the model manager and index once', async () => {
     const { deps, manager } = makeDeps();
     manager.similaritySearch
-      .mockResolvedValueOnce([
-        {
-          pageContent: 'first result',
-          metadata: { source: '/kb/ops/first.md', chunkIndex: 0 },
-          score: 0.11,
-        },
-      ] as never)
+      .mockImplementationOnce(async (...args: unknown[]) => {
+        const timing = args[5] as SimilaritySearchTiming;
+        timing.embed_query_ms = 3;
+        timing.faiss_search_ms = 4;
+        timing.query_cache_telemetry = {
+          enabled: true,
+          outcome: 'bypass',
+          model_id: 'ollama__nomic-embed-text-latest',
+          elapsed_ms: 3,
+        };
+        return [
+          {
+            pageContent: 'first result',
+            metadata: { source: '/kb/ops/first.md', chunkIndex: 0 },
+            score: 0.11,
+          },
+        ] as never;
+      })
       .mockResolvedValueOnce([
         {
           pageContent: 'second result',
@@ -347,7 +359,7 @@ describe('runSearch timing guard (#331)', () => {
       '',
     ].join('\n');
 
-    const out = await captureSearchOutput(['--batch-jsonl', '--no-freshness'], deps, stdin);
+    const out = await captureSearchOutput(['--batch-jsonl', '--timing', '--no-freshness'], deps, stdin);
 
     expect(out.code).toBe(0);
     expect(out.stderr).toBe('');
@@ -388,6 +400,18 @@ describe('runSearch timing guard (#331)', () => {
       mode: 'dense',
       result: {
         freshness_omitted: true,
+        query_cache: {
+          enabled: true,
+          outcome: 'bypass',
+          model_id: 'ollama__nomic-embed-text-latest',
+          elapsed_ms: 3,
+        },
+        timing: {
+          query_cache: 'bypass',
+          query_cache_enabled: true,
+          query_cache_model_id: 'ollama__nomic-embed-text-latest',
+          query_cache_elapsed_ms: 3,
+        },
         results: [{ content: 'first result' }],
       },
     });
@@ -546,6 +570,79 @@ describe('runSearch timing guard (#331)', () => {
       freshness_omitted: true,
     });
     expect(payload).not.toHaveProperty('timing');
+  });
+
+  it('exposes query-cache telemetry in dense JSON, timing, and canonical metadata', async () => {
+    const { deps, manager } = makeDeps();
+    manager.similaritySearch.mockImplementationOnce(async (...args: unknown[]) => {
+      const denseTiming = args[5] as SimilaritySearchTiming;
+      denseTiming.embed_query_ms = 4;
+      denseTiming.faiss_search_ms = 6;
+      denseTiming.query_cache_telemetry = {
+        enabled: true,
+        outcome: 'memory_hit',
+        model_id: 'ollama__nomic-embed-text-latest',
+        elapsed_ms: 2,
+      };
+      return [{
+        pageContent: 'cached result',
+        metadata: { source: '/kb/ops/cache.md', relativePath: 'ops/cache.md', chunkIndex: 0 },
+        score: 0.12,
+      }] as never;
+    });
+
+    const out = await captureSearchOutput(['cache query', '--format=json', '--timing', '--no-freshness'], deps);
+
+    expect(out.code).toBe(0);
+    const payload = JSON.parse(out.stdout);
+    expect(payload.query_cache).toEqual({
+      enabled: true,
+      outcome: 'memory_hit',
+      model_id: 'ollama__nomic-embed-text-latest',
+      elapsed_ms: 2,
+    });
+    expect(payload.timing).toMatchObject({
+      query_cache: 'memory_hit',
+      query_cache_enabled: true,
+      query_cache_model_id: 'ollama__nomic-embed-text-latest',
+      query_cache_elapsed_ms: 2,
+    });
+    expect(takeLastSearchCanonicalTelemetry()).toMatchObject({
+      cache: 'memory_hit',
+      query_cache: payload.query_cache,
+      result_count: 1,
+      top_sources: ['/kb/ops/cache.md'],
+    });
+  });
+
+  it('records the computed threshold in canonical metadata for --threshold=auto', async () => {
+    const { deps, manager } = makeDeps();
+    manager.similaritySearch.mockResolvedValueOnce([
+      {
+        pageContent: 'first',
+        metadata: { source: '/kb/ops/first.md', relativePath: 'ops/first.md', chunkIndex: 0 },
+        score: 0.1,
+      },
+      {
+        pageContent: 'second',
+        metadata: { source: '/kb/ops/second.md', relativePath: 'ops/second.md', chunkIndex: 1 },
+        score: 0.2,
+      },
+    ] as never);
+
+    const out = await captureSearchOutput([
+      'auto threshold',
+      '--threshold=auto',
+      '--format=json',
+      '--no-freshness',
+    ], deps);
+
+    expect(out.code).toBe(0);
+    expect(JSON.parse(out.stdout).auto_threshold).toMatchObject({ threshold: 0.2 });
+    expect(takeLastSearchCanonicalTelemetry()).toMatchObject({
+      threshold: 0.2,
+      result_count: 2,
+    });
   });
 
   it('runs diverse search as read-only dense retrieval and emits JSON explanation metadata', async () => {

--- a/src/cli-search.ts
+++ b/src/cli-search.ts
@@ -115,6 +115,8 @@ import {
   type SearchMode,
   type Staleness,
 } from './search-core.js';
+import { hashQuery, type CanonicalLogInput } from './canonical-log.js';
+import type { QueryCacheTelemetry } from './query-cache.js';
 
 export const SEARCH_HELP = `kb search — semantic search across knowledge bases
 
@@ -230,6 +232,17 @@ Examples:
 
 export type SearchFormat = 'md' | 'json' | 'vimgrep' | 'compact';
 
+let lastSearchCanonicalTelemetry: Partial<CanonicalLogInput> | null = null;
+
+// `cli.ts` wraps `runSearch()` with canonical logging and drains this after
+// the command returns. Keep only redacted query fields here because daemon
+// handlers can call `runSearch()` directly without that wrapper.
+export function takeLastSearchCanonicalTelemetry(): Partial<CanonicalLogInput> | null {
+  const out = lastSearchCanonicalTelemetry;
+  lastSearchCanonicalTelemetry = null;
+  return out;
+}
+
 interface SearchArgs {
   query: string | null;
   kb?: string;
@@ -287,6 +300,7 @@ export async function runSearch(
   rest: string[],
   deps: RunSearchDeps = DEFAULT_RUN_SEARCH_DEPS,
 ): Promise<number> {
+  lastSearchCanonicalTelemetry = null;
   const totalStartedAt = nowMs();
   let parsed: SearchArgs;
   try {
@@ -551,6 +565,16 @@ export async function runSearch(
       : null;
 
   if (timing) timing.total_ms = elapsedMs(totalStartedAt);
+  recordDenseSearchCanonicalTelemetry({
+    query,
+    activeModelId,
+    scopedKb: parsed.kb,
+    k: parsed.k,
+    threshold: parsed.thresholdAuto ? autoThresholdDecision?.threshold : parsed.threshold,
+    searchMode: effectiveMode,
+    results,
+    denseTiming,
+  });
 
   if (shouldUsePicker(parsed)) {
     return runPicker({ results: results as ScoredDocument[] });
@@ -572,6 +596,7 @@ export async function runSearch(
       explainEmptyDiagnostics,
       gateVerdict,
       advancedRetrieval,
+      queryCache: denseTiming.query_cache_telemetry,
     });
     process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
   } else if (parsed.format === 'vimgrep') {
@@ -644,7 +669,7 @@ async function gatherExplainEmptyDiagnostics(input: {
   const allKbs = await listAvailableKbsForDiagnostics();
   return buildExplainEmptyDiagnostics({
     rawCandidates,
-    threshold: input.threshold,
+    threshold: input.threshold ?? 2,
     scopedKb: input.scopedKb,
     allKbs,
     staleness: input.staleness,
@@ -976,7 +1001,54 @@ function mergeDenseTiming(target: TimingPayload, source: SimilaritySearchTiming)
   if (source.post_filter_ms !== undefined) target.post_filter_ms = source.post_filter_ms;
   if (source.total_ms !== undefined) target.dense_total_ms = source.total_ms;
   if (source.fetch_k !== undefined) target.fetch_k = source.fetch_k;
-  if (source.query_cache !== undefined) target.query_cache = source.query_cache;
+  if (source.query_cache_telemetry !== undefined) {
+    target.query_cache = source.query_cache_telemetry.outcome;
+    target.query_cache_enabled = source.query_cache_telemetry.enabled;
+    target.query_cache_model_id = source.query_cache_telemetry.model_id;
+    target.query_cache_elapsed_ms = source.query_cache_telemetry.elapsed_ms;
+  } else if (source.query_cache !== undefined) {
+    target.query_cache = source.query_cache;
+  }
+}
+
+function recordDenseSearchCanonicalTelemetry(input: {
+  query: string;
+  activeModelId: string;
+  scopedKb: string | undefined;
+  k: number;
+  threshold: number | undefined;
+  searchMode: EffectiveSearchMode;
+  results: ScoredDocument[];
+  denseTiming: SimilaritySearchTiming;
+}): void {
+  const queryCache = input.denseTiming.query_cache_telemetry;
+  lastSearchCanonicalTelemetry = {
+    query_sha256: hashQuery(input.query),
+    query_len_chars: input.query.length,
+    model_id: input.activeModelId,
+    kb_scope: input.scopedKb ?? null,
+    k: input.k,
+    threshold: input.threshold,
+    search_mode: input.searchMode,
+    result_count: input.results.length,
+    top_score: input.results[0]?.score,
+    top_sources: topSourcesForCanonicalLog(input.results),
+    embed_ms: input.denseTiming.embed_query_ms,
+    faiss_ms: input.denseTiming.faiss_search_ms ?? input.denseTiming.query_search_ms,
+    cache: queryCache?.outcome,
+    query_cache: queryCache,
+  };
+}
+
+function topSourcesForCanonicalLog(results: readonly ScoredDocument[]): string[] {
+  const out: string[] = [];
+  for (const result of results) {
+    const source = (result.metadata as Record<string, unknown>).source;
+    if (typeof source !== 'string') continue;
+    out.push(source);
+    if (out.length >= 3) break;
+  }
+  return out;
 }
 
 async function computeStalenessWithTiming(
@@ -1020,6 +1092,7 @@ export interface DenseSearchJsonPayloadInput {
   explainEmptyDiagnostics?: ExplainEmptyDiagnostics | null;
   gateVerdict?: RelevanceGateVerdict;
   advancedRetrieval?: AdvancedRetrievalMetadata | null;
+  queryCache?: QueryCacheTelemetry;
 }
 
 export function buildDenseSearchJsonPayload(input: DenseSearchJsonPayloadInput): Record<string, unknown> {
@@ -1056,6 +1129,9 @@ export function buildDenseSearchJsonPayload(input: DenseSearchJsonPayloadInput):
   payload.gate_verdict = input.gateVerdict ?? defaultBypassedGateVerdict(input.results.length);
   if (input.advancedRetrieval !== undefined && input.advancedRetrieval !== null) {
     payload.advanced_retrieval = input.advancedRetrieval;
+  }
+  if (input.queryCache !== undefined) {
+    payload.query_cache = input.queryCache;
   }
   if (input.timing) {
     payload.timing = compactTimingPayload(input.timing);
@@ -1488,6 +1564,7 @@ async function runBatchJsonlSearch(
           timing,
           explainEmptyDiagnostics,
           gateVerdict: gate.verdict,
+          queryCache: denseTiming.query_cache_telemetry,
         }),
       });
     } catch (err) {

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -603,6 +603,64 @@ describe('kb CLI — argv parsing and dispatch', () => {
     }
   });
 
+  it('emits query-cache telemetry on the top-level kb search canonical event', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-cli-search-cache-log-'));
+    const logFile = path.join(tempDir, 'canonical.log');
+    const kbRoot = path.join(tempDir, 'kb');
+    const faissDir = path.join(tempDir, '.faiss');
+    const modelId = 'fake__bag-256d';
+
+    try {
+      await fsp.mkdir(path.join(kbRoot, 'ops'), { recursive: true });
+      await fsp.writeFile(path.join(kbRoot, 'ops', 'cache.md'), 'alpha cache telemetry runbook\n');
+      await fsp.mkdir(path.join(faissDir, 'models', modelId), { recursive: true });
+      await fsp.writeFile(path.join(faissDir, 'models', modelId, 'model_name.txt'), 'bag-256d');
+      await fsp.writeFile(path.join(faissDir, 'active.txt'), modelId);
+
+      const r = runCli([
+        'search',
+        'alpha cache',
+        '--refresh',
+        '--format=json',
+        '--timing',
+        '--no-freshness',
+      ], {
+        KNOWLEDGE_BASES_ROOT_DIR: kbRoot,
+        FAISS_INDEX_PATH: faissDir,
+        EMBEDDING_PROVIDER: 'fake',
+        KB_FAKE_DIM: '32',
+        KB_LOG_FORMAT: 'canonical',
+        LOG_FILE: logFile,
+      });
+
+      expect(r.code).toBe(0);
+      const payload = JSON.parse(r.stdout);
+      expect(payload.query_cache).toMatchObject({
+        enabled: true,
+        outcome: 'miss',
+        model_id: modelId,
+      });
+      const events = (await fsp.readFile(logFile, 'utf-8'))
+        .trim()
+        .split('\n')
+        .map((line) => JSON.parse(line));
+      const searchEvent = events.find((event) => event.cmd === 'kb search');
+      expect(searchEvent).toMatchObject({
+        process: 'cli',
+        cmd: 'kb search',
+        cache: 'miss',
+        query_cache: {
+          enabled: true,
+          outcome: 'miss',
+          model_id: modelId,
+        },
+      });
+      expect(JSON.stringify(searchEvent)).not.toContain('alpha cache');
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it('dispatches kb logs through the built CLI with default deps (#387)', async () => {
     const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-cli-logs-'));
     const logFile = path.join(tempDir, 'canonical.log');

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -31,7 +31,7 @@ import { QUARANTINE_HELP, runQuarantine } from './cli-quarantine.js';
 import { REINDEX_HELP, runReindexCli } from './cli-reindex.js';
 import { REMEMBER_HELP, runRemember } from './cli-remember.js';
 import { RESEARCH_HELP, runResearch } from './cli-research.js';
-import { SEARCH_HELP, parseSearchArgs, runSearch } from './cli-search.js';
+import { SEARCH_HELP, parseSearchArgs, runSearch, takeLastSearchCanonicalTelemetry } from './cli-search.js';
 import { SERVE_HELP, runServe } from './cli-serve.js';
 import { STALE_CHECK_HELP, runStaleCheck } from './cli-stale-check.js';
 import { STATS_HELP, runStats } from './cli-stats.js';
@@ -500,9 +500,13 @@ async function runSubcommandWithCanonicalLog(
   const startedAt = Date.now();
   try {
     const code = await operation();
+    const searchExtra = target.name === 'search'
+      ? takeLastSearchCanonicalTelemetry() ?? {}
+      : {};
     emitCanonicalLog({
       process: 'cli',
       cmd: `kb ${target.name}`,
+      ...searchExtra,
       took_ms: Date.now() - startedAt,
       error: code === 0 ? undefined : {
         code: `EXIT_${code}`,

--- a/src/faiss-store-adapter.test.ts
+++ b/src/faiss-store-adapter.test.ts
@@ -194,6 +194,12 @@ describe('FaissStoreAdapter', () => {
     const getQueryEmbedding = jest.fn(async () => ({
       embedding: [1, 2, 3],
       status: 'miss' as const,
+      telemetry: {
+        enabled: true,
+        outcome: 'miss' as const,
+        model_id: 'fake__model',
+        elapsed_ms: 4,
+      },
     }));
     const timing: FaissSearchTimingSink = {};
 
@@ -211,6 +217,12 @@ describe('FaissStoreAdapter', () => {
     expect(vectorSearch).toHaveBeenCalledWith([1, 2, 3], 5);
     expect(results[0][0].pageContent).toBe('hit');
     expect(timing.query_cache).toBe('miss');
+    expect(timing.query_cache_telemetry).toEqual({
+      enabled: true,
+      outcome: 'miss',
+      model_id: 'fake__model',
+      elapsed_ms: 4,
+    });
     expect(typeof timing.embed_query_ms).toBe('number');
     expect(typeof timing.faiss_search_ms).toBe('number');
   });

--- a/src/faiss-store-adapter.ts
+++ b/src/faiss-store-adapter.ts
@@ -3,7 +3,7 @@ import type { EmbeddingsInterface } from '@langchain/core/embeddings';
 import type { Document } from '@langchain/core/documents';
 import { embeddingText } from './contextual-preface.js';
 import { resolveFaissIndexType, type FaissIndexType } from './config/indexing.js';
-import type { QueryCacheLookupStatus } from './query-cache.js';
+import type { QueryCacheLookupStatus, QueryCacheTelemetry } from './query-cache.js';
 
 type ScoredFaissDocument = [Document, number];
 
@@ -137,6 +137,7 @@ function getVectorSearch(store: FaissStore): FaissStoreWithVectorSearch['similar
 export interface FaissSearchTimingSink {
   embed_query_ms?: number;
   query_cache?: QueryCacheLookupStatus | 'unavailable';
+  query_cache_telemetry?: QueryCacheTelemetry;
   faiss_search_ms?: number;
   query_search_ms?: number;
 }
@@ -144,6 +145,7 @@ export interface FaissSearchTimingSink {
 export interface QueryEmbeddingLookup {
   embedding: number[];
   status: QueryCacheLookupStatus;
+  telemetry: QueryCacheTelemetry;
 }
 
 /**
@@ -252,6 +254,9 @@ export class FaissStoreAdapter {
       }
       if (options.timing.query_cache === undefined) {
         options.timing.query_cache = cached.status;
+      }
+      if (options.timing.query_cache_telemetry === undefined) {
+        options.timing.query_cache_telemetry = cached.telemetry;
       }
     }
 

--- a/src/query-cache.test.ts
+++ b/src/query-cache.test.ts
@@ -29,6 +29,29 @@ describe('query embedding cache (#214)', () => {
         },
       });
       expect(miss.status).toBe('miss');
+      expect(miss.telemetry).toMatchObject({
+        enabled: true,
+        outcome: 'miss',
+        model_id: 'fake__one',
+      });
+      expect(typeof miss.telemetry.elapsed_ms).toBe('number');
+      expect(calls).toBe(1);
+
+      const memoryHit = await first.getOrCompute({
+        modelId: 'fake__one',
+        query: 'hello world',
+        embed: async () => {
+          calls += 1;
+          return [8, 8, 8];
+        },
+      });
+      expect(memoryHit.status).toBe('hit_l1');
+      expect(memoryHit.telemetry).toMatchObject({
+        enabled: true,
+        outcome: 'memory_hit',
+        model_id: 'fake__one',
+      });
+      expect(memoryHit.embedding).toEqual([1.25, 2.5, 3.75]);
       expect(calls).toBe(1);
 
       const second = new QueryEmbeddingCache({ indexPath, lruMax: 8 });
@@ -41,6 +64,7 @@ describe('query embedding cache (#214)', () => {
         },
       });
       expect(hit.status).toBe('hit_disk');
+      expect(hit.telemetry.outcome).toBe('disk_hit');
       expect(hit.embedding).toEqual([1.25, 2.5, 3.75]);
       expect(calls).toBe(1);
     } finally {
@@ -81,6 +105,7 @@ describe('query embedding cache (#214)', () => {
         embed: async () => [9],
       });
       expect(again.status).toBe('hit_disk');
+      expect(again.telemetry.outcome).toBe('disk_hit');
       expect(again.embedding).toEqual([1]);
       const stats = await cache.stats();
       expect(stats.l1_size).toBe(1);
@@ -140,6 +165,11 @@ describe('query embedding cache (#214)', () => {
         },
       });
       expect(bypassed.status).toBe('bypass');
+      expect(bypassed.telemetry).toMatchObject({
+        enabled: true,
+        outcome: 'bypass',
+        model_id: 'fake__one',
+      });
       expect(bypassed.embedding).toEqual([7]);
       expect(calls).toBe(1);
       expect((await cache.stats()).bypasses).toBe(1);
@@ -161,7 +191,7 @@ describe('query embedding cache (#214)', () => {
     try {
       let calls = 0;
       const cache = new QueryEmbeddingCache({ indexPath, enabled: false, lruMax: 8 });
-      await cache.getOrCompute({
+      const first = await cache.getOrCompute({
         modelId: 'fake__one',
         query: 'env off',
         embed: async () => {
@@ -169,13 +199,19 @@ describe('query embedding cache (#214)', () => {
           return [1];
         },
       });
-      await cache.getOrCompute({
+      const second = await cache.getOrCompute({
         modelId: 'fake__one',
         query: 'env off',
         embed: async () => {
           calls += 1;
           return [2];
         },
+      });
+      expect(first.status).toBe('disabled');
+      expect(second.telemetry).toMatchObject({
+        enabled: false,
+        outcome: 'disabled',
+        model_id: 'fake__one',
       });
       expect(calls).toBe(2);
       const stats = await cache.stats();

--- a/src/query-cache.ts
+++ b/src/query-cache.ts
@@ -16,7 +16,15 @@ import { isValidModelId } from './model-id.js';
 
 export const QUERY_CACHE_SCHEMA_VERSION = 'kb-query-cache.v1';
 
-export type QueryCacheLookupStatus = 'hit_l1' | 'hit_disk' | 'miss' | 'bypass';
+export type QueryCacheLookupStatus = 'hit_l1' | 'hit_disk' | 'miss' | 'bypass' | 'disabled';
+export type QueryCacheOutcome = 'memory_hit' | 'disk_hit' | 'miss' | 'bypass' | 'disabled';
+
+export interface QueryCacheTelemetry {
+  enabled: boolean;
+  outcome: QueryCacheOutcome;
+  model_id: string;
+  elapsed_ms: number;
+}
 
 export interface QueryCacheStats {
   hits: number;
@@ -34,6 +42,7 @@ export interface QueryCacheStats {
 interface QueryCacheRecord {
   embedding: number[];
   status: QueryCacheLookupStatus;
+  telemetry: QueryCacheTelemetry;
 }
 
 export interface QueryCacheOptions {
@@ -111,9 +120,31 @@ export class QueryEmbeddingCache {
     bypass?: boolean;
     embed: () => Promise<number[]>;
   }): Promise<QueryCacheRecord> {
-    if (args.bypass === true || !this.enabled) {
+    const startedAt = Date.now();
+    const record = (
+      embedding: number[],
+      status: QueryCacheLookupStatus,
+      outcome: QueryCacheOutcome,
+      enabled: boolean = this.enabled,
+    ): QueryCacheRecord => ({
+      embedding,
+      status,
+      telemetry: {
+        enabled,
+        outcome,
+        model_id: args.modelId,
+        elapsed_ms: Date.now() - startedAt,
+      },
+    });
+
+    if (!this.enabled) {
       this.bypasses += 1;
-      return { embedding: await args.embed(), status: 'bypass' };
+      return record(await args.embed(), 'disabled', 'disabled', false);
+    }
+
+    if (args.bypass === true) {
+      this.bypasses += 1;
+      return record(await args.embed(), 'bypass', 'bypass');
     }
 
     const paths = queryCachePaths({
@@ -125,14 +156,14 @@ export class QueryEmbeddingCache {
     const memoryHit = this.l1.get(paths.cacheKey);
     if (memoryHit !== null) {
       this.hitsL1 += 1;
-      return { embedding: memoryHit, status: 'hit_l1' };
+      return record(memoryHit, 'hit_l1', 'memory_hit');
     }
 
     const diskHit = await this.readDisk(paths);
     if (diskHit !== null) {
       this.hitsDisk += 1;
       this.l1.set(paths.cacheKey, diskHit);
-      return { embedding: diskHit.slice(), status: 'hit_disk' };
+      return record(diskHit.slice(), 'hit_disk', 'disk_hit');
     }
 
     this.misses += 1;
@@ -146,7 +177,7 @@ export class QueryEmbeddingCache {
     } catch (err) {
       logger.warn(`query embedding cache write skipped for ${args.modelId}: ${(err as Error).message}`);
     }
-    return { embedding: stableEmbedding, status: 'miss' };
+    return record(stableEmbedding, 'miss', 'miss');
   }
 
   async stats(): Promise<QueryCacheStats> {


### PR DESCRIPTION
## Summary
- expose bounded query-cache telemetry with public outcomes in dense search JSON and --timing output
- include query-cache metadata in CLI/MCP canonical logs and kb logs summaries
- document the new JSON/log fields and cover memory/disk/miss/bypass/disabled surfaces

## Verification
- npm run build
- npm test -- --runTestsByPath src/query-cache.test.ts src/cli-search.test.ts src/cli.test.ts src/canonical-log.test.ts src/cli-logs.test.ts src/faiss-store-adapter.test.ts src/KnowledgeBaseServer.test.ts
- npm test

Closes #491