### PR TITLE
feat: add doctor lock diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ kb serve status               # daemon liveness + degraded-mode diagnostics (#42
 kb config validate            # static env-var schema validation before startup
 kb doctor                     # availability snapshot (index, embedding backend, LLM)
 kb doctor --endpoints         # focused MCP/daemon/Ollama/LLM endpoint preflight
+kb doctor --locks             # write-lock owner and stale-lock diagnosis
 kb doctor --bug-report=/tmp   # write a redacted support bundle for issue reports
 kb --help                     # top-level command list
 kb help search                # per-command help (also: kb search --help)
@@ -521,12 +522,15 @@ When `kb search` (or the MCP `retrieve_knowledge` tool) is not returning results
 kb doctor                # human-readable report
 kb doctor --format=json  # machine-readable for agent shells
 kb doctor --endpoints    # focused bind/connect endpoint preflight
+kb doctor --locks        # model write-lock owner/stale diagnosis
 kb doctor --bug-report=/tmp  # redacted support bundle directory
 ```
 
 The report covers active-model resolution, FAISS index version + mtime, the latest in-process index-update summary, per-KB stale counts, embedding-backend reachability (Ollama / HuggingFace / OpenAI), local LLM endpoint readiness, CLI version, and local git state. The command exits non-zero when any required retrieval check fails (active model unresolved, index missing, backend unreachable); LLM endpoint failures are WARN rows because search can remain healthy while `kb ask` is not ready.
 
 Use `kb doctor --endpoints` when you only need configured local endpoint readiness before starting or wiring clients. It checks MCP bind address/port availability, configured `KB_DAEMON_URL` health, configured Ollama embedding reachability, and configured `KB_LLM_ENDPOINT` or active LLM profile readiness without loading the full index health report.
+
+Use `kb doctor --locks` when refresh or model writes report lock contention. It scans per-model `.kb-write.lock` paths, reports lock age, recorded owner PID/command for new locks, stale suspicion, and conservative next actions without deleting any lock file.
 
 Use `kb doctor --bug-report[=<dir>]` when opening an issue or handing diagnostics to another operator. It writes a timestamped directory containing redacted `doctor.json`, `stats.json`, recent canonical log summaries, runtime/env metadata, and a README. The bundle does not include note contents or raw API keys; KB names, paths, model names, and log metadata can still be sensitive.
 

--- a/docs/cli-json-contracts.md
+++ b/docs/cli-json-contracts.md
@@ -707,6 +707,7 @@ Invocation:
 ```bash
 kb doctor --format=json
 kb doctor --endpoints --format=json
+kb doctor --locks --format=json
 kb doctor --bug-report=/tmp --format=json
 kb doctor --bug-report=/tmp --include-command -- node -e 'process.exit(1)'
 ```
@@ -820,6 +821,71 @@ Stdout/stderr and exit codes:
 - There is no separate JSON error envelope; failing health checks are encoded in
   the report with `status: "error"`.
 - Argument errors print `kb doctor: ...` to stderr and exit `2`.
+
+`kb doctor --locks --format=json` emits a focused lock report without running
+the aggregate backend/index checks:
+
+```json
+{
+  "schema_version": "kb.doctor.locks.v1",
+  "status": "warn",
+  "faiss_index_path": "/path/to/.faiss",
+  "models_root": "/path/to/.faiss/models",
+  "generated_at": "2026-05-22T00:00:00.000Z",
+  "stale_threshold_ms": 10000,
+  "summary": {
+    "total": 1,
+    "held": 0,
+    "stale_suspected": 1,
+    "unknown": 0
+  },
+  "locks": [
+    {
+      "kind": "model_write",
+      "model_id": "ollama__nomic-embed-text-latest",
+      "model_name": "nomic-embed-text:latest",
+      "resource_path": "/path/to/.faiss/models/ollama__nomic-embed-text-latest",
+      "lock_path": "/path/to/.faiss/models/ollama__nomic-embed-text-latest/.kb-write.lock",
+      "owner_path": "/path/to/.faiss/models/ollama__nomic-embed-text-latest/.kb-write.lock.owner.json",
+      "present": true,
+      "lock_kind": "directory",
+      "mtime": "2026-05-22T00:00:00.000Z",
+      "age_ms": 60000,
+      "stale_threshold_ms": 10000,
+      "stale_suspected": true,
+      "owner": {
+        "pid": 12345,
+        "live": false,
+        "command": "kb search --refresh docs",
+        "cwd": "/workspace",
+        "hostname": "host",
+        "started_at": "2026-05-22T00:00:00.000Z",
+        "source": "metadata",
+        "detail": null
+      },
+      "status": "stale",
+      "next_action": "The recorded owner PID is no longer live; verify no writer is running before removing the lock path.",
+      "warnings": []
+    }
+  ]
+}
+```
+
+Stable lock-report fields:
+
+- `schema_version`: currently `kb.doctor.locks.v1`.
+- `status`: `ok`, `warn`, or `error`. Suspected stale locks are `warn`;
+  unreadable or malformed lock paths are `error`.
+- `summary`: counts scanned model dirs, actively held locks, suspected stale
+  locks, and unknown lock states.
+- `locks[]`: one `model_write` entry per model directory. `present` and
+  `lock_kind` describe the lock path; `age_ms` is the lock heartbeat age;
+  `stale_suspected` is true when the heartbeat is older than the stale
+  threshold or the recorded owner PID is dead.
+- `owner`: best-effort owner metadata. New write locks record PID, command,
+  cwd, hostname, and start time beside the lock; older locks may report
+  `source: "none"`.
+- `next_action`: conservative guidance. The command never deletes locks.
 
 `kb doctor --bug-report[=<dir>]` writes a timestamped support bundle directory
 under `<dir>` (default: current directory). The bundle contains:

--- a/docs/troubleshooting-local-kb.md
+++ b/docs/troubleshooting-local-kb.md
@@ -12,12 +12,15 @@ Start with the read-only health check:
 kb doctor
 kb doctor --format=json
 kb doctor --endpoints
+kb doctor --locks
 kb doctor --bug-report=/tmp
 ```
 
 `kb doctor` reports active-model resolution, index path and version, stale file counts, embedding backend health, local LLM endpoint readiness for `kb ask`, CLI package and symlink state, git drift for linked checkouts, and the latest index-update summary. Use it before deleting index files, changing client configuration, or debugging local LLM answers.
 
 Use `kb doctor --endpoints` for the narrower port/URL preflight: MCP bind target availability, configured `KB_DAEMON_URL`, configured Ollama embedding endpoint, and configured `KB_LLM_ENDPOINT` or active LLM profile.
+
+Use `kb doctor --locks` for write-lock contention. It reports per-model lock path, age, recorded owner PID/command when available, whether that PID is still live, stale suspicion, and the next safe action. It never removes lock files.
 
 Use `kb doctor --bug-report[=<dir>]` when preparing an issue-ready diagnostic bundle. The command writes a timestamped directory with redacted doctor/stats/log/runtime JSON plus a README, without note contents or raw API keys.
 
@@ -199,7 +202,7 @@ After fixing env for an MCP client, restart that client so the child process rec
 When you see `REFRESH_LOCK_BUSY`:
 
 ```bash
-kb doctor
+kb doctor --locks
 kb search "known phrase" --k=5
 ```
 

--- a/src/cli-doctor.test.ts
+++ b/src/cli-doctor.test.ts
@@ -389,6 +389,72 @@ describe('kb doctor', () => {
     }
   });
 
+  it('reports stale model write locks with owner metadata and recovery guidance', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-doctor-locks-'));
+    try {
+      const rootDir = path.join(tempDir, 'kbs');
+      const faissDir = path.join(tempDir, '.faiss');
+      await fsp.mkdir(rootDir, { recursive: true });
+      const modelDir = await seedRegisteredModel(faissDir);
+      const lockPath = path.join(modelDir, '.kb-write.lock');
+      const ownerPath = path.join(modelDir, '.kb-write.lock.owner.json');
+      await fsp.mkdir(lockPath);
+      await fsp.writeFile(ownerPath, JSON.stringify({
+        schema_version: 'kb.write-lock-owner.v1',
+        pid: 999999999,
+        command: 'kb search --refresh stale',
+        cwd: tempDir,
+        hostname: 'test-host',
+        started_at: '2026-05-22T00:00:00.000Z',
+      }));
+      const oldMs = Date.now() - 60_000;
+      await fsp.utimes(lockPath, oldMs / 1000, oldMs / 1000);
+
+      const { buildDoctorLocksReport, formatDoctorLocksMarkdown } = await freshDoctor({
+        KNOWLEDGE_BASES_ROOT_DIR: rootDir,
+        FAISS_INDEX_PATH: faissDir,
+        EMBEDDING_PROVIDER: 'huggingface',
+        HUGGINGFACE_MODEL_NAME: MODEL_NAME,
+      });
+
+      const report = await buildDoctorLocksReport();
+
+      expect(report).toMatchObject({
+        schema_version: 'kb.doctor.locks.v1',
+        status: 'warn',
+        summary: {
+          total: 1,
+          held: 0,
+          stale_suspected: 1,
+          unknown: 0,
+        },
+      });
+      expect(report.locks).toEqual([
+        expect.objectContaining({
+          model_id: MODEL_ID,
+          model_name: MODEL_NAME,
+          present: true,
+          lock_kind: 'directory',
+          stale_suspected: true,
+          status: 'stale',
+          owner: expect.objectContaining({
+            pid: 999999999,
+            live: false,
+            command: 'kb search --refresh stale',
+            source: 'metadata',
+          }),
+          next_action: expect.stringContaining('recorded owner PID is no longer live'),
+        }),
+      ]);
+      const markdown = formatDoctorLocksMarkdown(report);
+      expect(markdown).toContain('Status: WARN');
+      expect(markdown).toContain('STALE huggingface__BAAI-bge-small-en-v1.5');
+      expect(markdown).toContain('owner: pid=999999999, live=no');
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it('reports active external LLM profile readiness in JSON and markdown', async () => {
     const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-doctor-llm-external-'));
     try {
@@ -1123,12 +1189,40 @@ describe('kb doctor', () => {
     }
   });
 
-  it('parses --format=json, --endpoints, and rejects unsupported formats', async () => {
+  it('routes --locks through runDoctor with JSON output', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-doctor-run-locks-'));
+    try {
+      const { runDoctor } = await freshDoctor({
+        KNOWLEDGE_BASES_ROOT_DIR: path.join(tempDir, 'kbs'),
+        FAISS_INDEX_PATH: path.join(tempDir, '.faiss'),
+        EMBEDDING_PROVIDER: 'huggingface',
+        HUGGINGFACE_MODEL_NAME: MODEL_NAME,
+      });
+
+      const ok = await captureStdout(() => runDoctor(['--locks', '--format=json']));
+      expect(ok.code).toBe(0);
+      expect(JSON.parse(ok.stdout)).toMatchObject({
+        schema_version: 'kb.doctor.locks.v1',
+        status: 'ok',
+        summary: {
+          total: 0,
+          held: 0,
+          stale_suspected: 0,
+          unknown: 0,
+        },
+      });
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('parses --format=json, --endpoints, --locks, and rejects unsupported formats', async () => {
     const { parseDoctorArgs } = await freshDoctor({});
     expect(parseDoctorArgs(['--format=json'])).toEqual({
       format: 'json',
       reindexTrigger: false,
       endpoints: false,
+      locks: false,
       integrity: false,
       bugReport: null,
     });
@@ -1136,6 +1230,7 @@ describe('kb doctor', () => {
       format: 'md',
       reindexTrigger: true,
       endpoints: false,
+      locks: false,
       integrity: false,
       bugReport: null,
     });
@@ -1143,6 +1238,15 @@ describe('kb doctor', () => {
       format: 'json',
       reindexTrigger: false,
       endpoints: true,
+      locks: false,
+      integrity: false,
+      bugReport: null,
+    });
+    expect(parseDoctorArgs(['--locks', '--format=json'])).toEqual({
+      format: 'json',
+      reindexTrigger: false,
+      endpoints: false,
+      locks: true,
       integrity: false,
       bugReport: null,
     });
@@ -1150,6 +1254,7 @@ describe('kb doctor', () => {
       format: 'json',
       reindexTrigger: true,
       endpoints: false,
+      locks: false,
       integrity: false,
       bugReport: null,
     });
@@ -1157,6 +1262,7 @@ describe('kb doctor', () => {
       format: 'md',
       reindexTrigger: false,
       endpoints: false,
+      locks: false,
       integrity: false,
       bugReport: null,
     });
@@ -1164,6 +1270,7 @@ describe('kb doctor', () => {
       format: 'md',
       reindexTrigger: false,
       endpoints: false,
+      locks: false,
       integrity: false,
       bugReport: {
         outputParentDir: '/tmp/out',
@@ -1182,6 +1289,7 @@ describe('kb doctor', () => {
       format: 'md',
       reindexTrigger: false,
       endpoints: false,
+      locks: false,
       integrity: false,
       bugReport: {
         outputParentDir: undefined,
@@ -1191,6 +1299,7 @@ describe('kb doctor', () => {
     });
     expect(() => parseDoctorArgs(['--format=yaml'])).toThrow(/invalid --format/);
     expect(() => parseDoctorArgs(['--bug-report', '--include-command'])).toThrow(/requires/);
+    expect(() => parseDoctorArgs(['--endpoints', '--locks'])).toThrow(/cannot be combined/);
   });
 
   describe('age budgets (issue #218)', () => {

--- a/src/cli-doctor.ts
+++ b/src/cli-doctor.ts
@@ -13,6 +13,7 @@ import {
   ActiveModelResolutionError,
   listIncompleteModelStates,
   listRegisteredModels,
+  modelsRoot,
   parseModelId,
   readModelIndexStorage,
   resolveActiveModel,
@@ -82,6 +83,13 @@ import {
   type IntegrityReport,
 } from './cli-verify.js';
 import { createDoctorBugReportBundle } from './cli-bug-report.js';
+import {
+  WRITE_LOCK_OWNER_SCHEMA_VERSION,
+  WRITE_LOCK_STALE_MS,
+  writeLockOwnerPathFor,
+  writeLockPathFor,
+  type WriteLockOwnerMetadata,
+} from './write-lock.js';
 
 /**
  * Issue #210 — error-rate threshold above which the doctor surfaces a
@@ -99,7 +107,7 @@ const execFileAsync = promisify(execFile);
 export const DOCTOR_HELP = `kb doctor — aggregate model / index / backend health report
 
 Usage:
-  kb doctor [--format=md|json] [--reindex-trigger] [--endpoints] [--integrity|--slow]
+  kb doctor [--format=md|json] [--reindex-trigger] [--endpoints] [--locks] [--integrity|--slow]
   kb doctor --bug-report[=<dir>] [--include-command -- <cmd> [args...]]
 
 Composes existing read-only checks (env vars, registered models, active
@@ -120,6 +128,8 @@ Options:
   --endpoints           Check only configured local bind/connect endpoint
                         readiness (MCP bind target, KB_DAEMON_URL,
                         Ollama embedding endpoint, and KB_LLM_ENDPOINT/profile).
+  --locks               Check only FAISS/model write-lock paths, including
+                        owner metadata when available and stale-lock guidance.
   --bug-report[=<dir>]  Write a timestamped redacted support bundle under
                         <dir> (default: current directory). Includes doctor,
                         stats, recent canonical logs, runtime metadata, and
@@ -141,6 +151,7 @@ export interface DoctorArgs {
   format: 'md' | 'json';
   reindexTrigger: boolean;
   endpoints: boolean;
+  locks: boolean;
   integrity: boolean;
   bugReport: {
     outputParentDir?: string;
@@ -166,6 +177,52 @@ export interface EndpointReadinessReport {
   schema_version: 'kb.doctor.endpoints.v1';
   status: HealthStatus;
   endpoints: EndpointReadinessEntry[];
+}
+
+export interface DoctorLockOwner {
+  pid: number | null;
+  live: boolean | null;
+  command: string | null;
+  cwd: string | null;
+  hostname: string | null;
+  started_at: string | null;
+  source: 'metadata' | 'none' | 'invalid';
+  detail: string | null;
+}
+
+export interface DoctorLockEntry {
+  kind: 'model_write';
+  model_id: string;
+  model_name: string | null;
+  resource_path: string;
+  lock_path: string;
+  owner_path: string;
+  present: boolean;
+  lock_kind: 'directory' | 'file' | 'other' | 'missing' | 'unknown';
+  mtime: string | null;
+  age_ms: number | null;
+  stale_threshold_ms: number;
+  stale_suspected: boolean;
+  owner: DoctorLockOwner;
+  status: 'ok' | 'held' | 'stale' | 'unknown';
+  next_action: string;
+  warnings: string[];
+}
+
+export interface DoctorLocksReport {
+  schema_version: 'kb.doctor.locks.v1';
+  status: HealthStatus;
+  faiss_index_path: string;
+  models_root: string;
+  generated_at: string;
+  stale_threshold_ms: number;
+  locks: DoctorLockEntry[];
+  summary: {
+    total: number;
+    held: number;
+    stale_suspected: number;
+    unknown: number;
+  };
 }
 
 export interface DoctorIndexSecurityEntry {
@@ -390,6 +447,16 @@ export async function runDoctor(rest: string[]): Promise<number> {
     return report.status === 'error' ? 1 : 0;
   }
 
+  if (parsed.locks) {
+    const report = await buildDoctorLocksReport();
+    if (parsed.format === 'json') {
+      process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    } else {
+      process.stdout.write(formatDoctorLocksMarkdown(report));
+    }
+    return report.status === 'error' ? 1 : 0;
+  }
+
   if (parsed.bugReport !== null) {
     const result = await createDoctorBugReportBundle({
       outputParentDir: parsed.bugReport.outputParentDir,
@@ -418,6 +485,7 @@ export function parseDoctorArgs(rest: string[]): DoctorArgs {
     format: 'md',
     reindexTrigger: false,
     endpoints: false,
+    locks: false,
     integrity: false,
     bugReport: null,
   };
@@ -447,6 +515,10 @@ export function parseDoctorArgs(rest: string[]): DoctorArgs {
     }
     if (raw === '--endpoints') {
       out.endpoints = true;
+      continue;
+    }
+    if (raw === '--locks') {
+      out.locks = true;
       continue;
     }
     if (raw === '--bug-report' || raw.startsWith('--bug-report=')) {
@@ -485,6 +557,12 @@ export function parseDoctorArgs(rest: string[]): DoctorArgs {
   }
   if (out.bugReport !== null && out.endpoints) {
     throw new Error('--bug-report cannot be combined with --endpoints');
+  }
+  if (out.bugReport !== null && out.locks) {
+    throw new Error('--bug-report cannot be combined with --locks');
+  }
+  if (out.endpoints && out.locks) {
+    throw new Error('--endpoints cannot be combined with --locks');
   }
   return out;
 }
@@ -831,6 +909,275 @@ export function formatEndpointReadinessMarkdown(report: EndpointReadinessReport)
       `  ${entry.status.toUpperCase().padEnd(7)} ${entry.name}: ${target} ` +
       `(${entry.kind}, ${entry.source}, ${configured}) - ${entry.detail}`,
     );
+  }
+  return lines.join('\n') + '\n';
+}
+
+export async function buildDoctorLocksReport(): Promise<DoctorLocksReport> {
+  const generatedAt = new Date();
+  const modelRows = await listDoctorLockModelRows();
+  const locks = await Promise.all(modelRows.map((row) => readDoctorModelWriteLock(row, generatedAt)));
+  const summary = {
+    total: locks.length,
+    held: locks.filter((entry) => entry.status === 'held').length,
+    stale_suspected: locks.filter((entry) => entry.stale_suspected).length,
+    unknown: locks.filter((entry) => entry.status === 'unknown').length,
+  };
+  const status: HealthStatus = summary.unknown > 0
+    ? 'error'
+    : summary.stale_suspected > 0
+      ? 'warn'
+      : 'ok';
+  return {
+    schema_version: 'kb.doctor.locks.v1',
+    status,
+    faiss_index_path: FAISS_INDEX_PATH,
+    models_root: modelsRoot(),
+    generated_at: generatedAt.toISOString(),
+    stale_threshold_ms: WRITE_LOCK_STALE_MS,
+    locks,
+    summary,
+  };
+}
+
+async function listDoctorLockModelRows(): Promise<Array<{
+  model_id: string;
+  model_name: string | null;
+  resource_path: string;
+}>> {
+  const byId = new Map<string, { model_id: string; model_name: string | null; resource_path: string }>();
+  try {
+    for (const model of await listRegisteredModels()) {
+      byId.set(model.model_id, {
+        model_id: model.model_id,
+        model_name: model.model_name,
+        resource_path: path.join(modelsRoot(), model.model_id),
+      });
+    }
+  } catch {
+    // Fall back to the filesystem walk below.
+  }
+
+  try {
+    const entries = await fsp.readdir(modelsRoot(), { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      if (byId.has(entry.name)) continue;
+      byId.set(entry.name, {
+        model_id: entry.name,
+        model_name: null,
+        resource_path: path.join(modelsRoot(), entry.name),
+      });
+    }
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+  }
+
+  return [...byId.values()].sort((a, b) => a.model_id.localeCompare(b.model_id));
+}
+
+async function readDoctorModelWriteLock(
+  row: { model_id: string; model_name: string | null; resource_path: string },
+  now: Date,
+): Promise<DoctorLockEntry> {
+  const lockPath = writeLockPathFor(row.resource_path);
+  const ownerPath = writeLockOwnerPathFor(row.resource_path);
+  const warnings: string[] = [];
+  let present = false;
+  let lockKind: DoctorLockEntry['lock_kind'] = 'missing';
+  let mtime: string | null = null;
+  let ageMs: number | null = null;
+
+  try {
+    const st = await fsp.lstat(lockPath);
+    present = true;
+    lockKind = st.isDirectory() ? 'directory' : st.isFile() ? 'file' : 'other';
+    mtime = new Date(st.mtimeMs).toISOString();
+    ageMs = Math.max(0, now.getTime() - st.mtimeMs);
+    if (lockKind !== 'directory') {
+      warnings.push(`unexpected lock path kind: ${lockKind}`);
+    }
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code !== 'ENOENT' && code !== 'ENOTDIR') {
+      lockKind = 'unknown';
+      warnings.push(`stat_failed: ${(err as Error).message}`);
+    }
+  }
+
+  const owner = present ? await readDoctorLockOwner(ownerPath) : emptyDoctorLockOwner();
+  if (owner.source === 'invalid' && owner.detail !== null) {
+    warnings.push(owner.detail);
+  }
+
+  const ownerDead = owner.pid !== null && owner.live === false;
+  const heartbeatStale = ageMs !== null && ageMs > WRITE_LOCK_STALE_MS;
+  const staleSuspected = present && (ownerDead || (heartbeatStale && owner.live !== true));
+  const status: DoctorLockEntry['status'] = !present
+    ? 'ok'
+    : lockKind !== 'directory'
+      ? 'unknown'
+      : staleSuspected
+        ? 'stale'
+        : 'held';
+
+  return {
+    kind: 'model_write',
+    model_id: row.model_id,
+    model_name: row.model_name,
+    resource_path: row.resource_path,
+    lock_path: lockPath,
+    owner_path: ownerPath,
+    present,
+    lock_kind: lockKind,
+    mtime,
+    age_ms: ageMs === null ? null : Math.round(ageMs),
+    stale_threshold_ms: WRITE_LOCK_STALE_MS,
+    stale_suspected: staleSuspected,
+    owner,
+    status,
+    next_action: formatDoctorLockNextAction(status, owner, heartbeatStale),
+    warnings,
+  };
+}
+
+async function readDoctorLockOwner(ownerPath: string): Promise<DoctorLockOwner> {
+  let raw: string;
+  try {
+    raw = await fsp.readFile(ownerPath, 'utf-8');
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return emptyDoctorLockOwner();
+    return {
+      ...emptyDoctorLockOwner(),
+      source: 'invalid',
+      detail: `owner metadata read failed: ${(err as Error).message}`,
+    };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return {
+      ...emptyDoctorLockOwner(),
+      source: 'invalid',
+      detail: 'owner metadata is not valid JSON',
+    };
+  }
+  if (!isWriteLockOwnerMetadata(parsed)) {
+    return {
+      ...emptyDoctorLockOwner(),
+      source: 'invalid',
+      detail: `owner metadata does not match ${WRITE_LOCK_OWNER_SCHEMA_VERSION}`,
+    };
+  }
+
+  return {
+    pid: parsed.pid,
+    live: isPidLive(parsed.pid),
+    command: parsed.command,
+    cwd: parsed.cwd,
+    hostname: parsed.hostname,
+    started_at: parsed.started_at,
+    source: 'metadata',
+    detail: null,
+  };
+}
+
+function isWriteLockOwnerMetadata(value: unknown): value is WriteLockOwnerMetadata {
+  if (value === null || typeof value !== 'object') return false;
+  const candidate = value as Partial<WriteLockOwnerMetadata>;
+  return candidate.schema_version === WRITE_LOCK_OWNER_SCHEMA_VERSION
+    && Number.isSafeInteger(candidate.pid)
+    && typeof candidate.pid === 'number'
+    && candidate.pid > 0
+    && typeof candidate.command === 'string'
+    && (candidate.cwd === null || typeof candidate.cwd === 'string')
+    && typeof candidate.hostname === 'string'
+    && typeof candidate.started_at === 'string'
+    && !Number.isNaN(Date.parse(candidate.started_at));
+}
+
+function emptyDoctorLockOwner(): DoctorLockOwner {
+  return {
+    pid: null,
+    live: null,
+    command: null,
+    cwd: null,
+    hostname: null,
+    started_at: null,
+    source: 'none',
+    detail: null,
+  };
+}
+
+function isPidLive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === 'EPERM';
+  }
+}
+
+function formatDoctorLockNextAction(
+  status: DoctorLockEntry['status'],
+  owner: DoctorLockOwner,
+  heartbeatStale: boolean,
+): string {
+  if (status === 'ok') return 'No write lock is present for this model.';
+  if (status === 'unknown') {
+    return 'Inspect the lock path before retrying; do not remove it until its type and owner are understood.';
+  }
+  if (status === 'stale') {
+    if (owner.pid !== null && owner.live === false) {
+      return 'The recorded owner PID is no longer live; verify no writer is running before removing the lock path.';
+    }
+    return 'The lock heartbeat is older than the stale threshold; verify no writer is running before removing the lock path.';
+  }
+  if (owner.pid !== null && owner.live === true) {
+    return 'A writer appears active; wait for it to finish or inspect the recorded command before restarting services.';
+  }
+  if (heartbeatStale) {
+    return 'The heartbeat is old but no owner is known; inspect running kb processes before removing the lock path.';
+  }
+  return 'A write lock is present; wait and retry before considering manual recovery.';
+}
+
+export function formatDoctorLocksMarkdown(report: DoctorLocksReport): string {
+  const lines: string[] = [];
+  lines.push(`Status: ${report.status.toUpperCase()}`);
+  lines.push(`FAISS index path: ${report.faiss_index_path}`);
+  lines.push(`Models root: ${report.models_root}`);
+  lines.push(
+    `Summary: ${report.summary.held} held, ` +
+    `${report.summary.stale_suspected} stale suspected, ` +
+    `${report.summary.unknown} unknown across ${report.summary.total} model(s)`,
+  );
+  lines.push('');
+  lines.push('Write locks:');
+  if (report.locks.length === 0) {
+    lines.push('  (no model directories found)');
+  } else {
+    for (const entry of report.locks) {
+      const modelName = entry.model_name === null ? '' : ` (${entry.model_name})`;
+      const age = entry.age_ms === null ? 'n/a' : `${entry.age_ms}ms`;
+      lines.push(`  ${entry.status.toUpperCase()} ${entry.model_id}${modelName}`);
+      lines.push(`    lock: ${entry.lock_path}`);
+      lines.push(`    present: ${entry.present ? 'yes' : 'no'}, kind: ${entry.lock_kind}, age: ${age}`);
+      if (entry.owner.pid !== null) {
+        lines.push(
+          `    owner: pid=${entry.owner.pid}, live=${formatNullableBoolean(entry.owner.live)}, ` +
+          `source=${entry.owner.source}, command=${entry.owner.command ?? '<unknown>'}`,
+        );
+      } else {
+        lines.push(`    owner: ${entry.owner.source}`);
+      }
+      if (entry.warnings.length > 0) {
+        for (const warning of entry.warnings) lines.push(`    WARN ${warning}`);
+      }
+      lines.push(`    next: ${entry.next_action}`);
+    }
   }
   return lines.join('\n') + '\n';
 }

--- a/src/cli-json-contracts.test.ts
+++ b/src/cli-json-contracts.test.ts
@@ -213,7 +213,7 @@ const docAssertions: Record<DocumentedCommand, (examples: unknown[]) => void> = 
     expect(record(examples[1])).toEqual({ recommended_kb: null, results: [] });
   },
   'kb doctor': (examples) => {
-    expect(examples).toHaveLength(3);
+    expect(examples).toHaveLength(4);
     expect(record(examples[0])).toMatchObject({
       status: expect.any(String),
       checks: expect.any(Array),
@@ -224,13 +224,27 @@ const docAssertions: Record<DocumentedCommand, (examples: unknown[]) => void> = 
       last_index_update: expect.any(Object),
     });
     expect(record(examples[1])).toMatchObject({
+      schema_version: 'kb.doctor.locks.v1',
+      status: expect.any(String),
+      faiss_index_path: expect.any(String),
+      models_root: expect.any(String),
+      stale_threshold_ms: expect.any(Number),
+      summary: expect.objectContaining({
+        total: expect.any(Number),
+        held: expect.any(Number),
+        stale_suspected: expect.any(Number),
+        unknown: expect.any(Number),
+      }),
+      locks: expect.any(Array),
+    });
+    expect(record(examples[2])).toMatchObject({
       schema_version: 'kb.doctor.bug_report.v1',
       bundle_dir: expect.any(String),
       created_at: expect.any(String),
       files: expect.any(Array),
       redaction_summary: expect.any(Object),
     });
-    expect(record(examples[2])).toMatchObject({
+    expect(record(examples[3])).toMatchObject({
       schema_version: 'kb.doctor.endpoints.v1',
       status: expect.any(String),
       endpoints: expect.arrayContaining([

--- a/src/write-lock.test.ts
+++ b/src/write-lock.test.ts
@@ -28,21 +28,28 @@ describe('withWriteLock', () => {
 
   it('acquires the lock, runs fn, releases', async () => {
     jest.resetModules();
-    const { withWriteLock } = await import('./write-lock.js');
+    const { withWriteLock, writeLockOwnerPathFor } = await import('./write-lock.js');
 
-    let observed: { lockedDuringFn: boolean } = { lockedDuringFn: false };
+    let observed: { lockedDuringFn: boolean; ownerPid: number | null } = {
+      lockedDuringFn: false,
+      ownerPid: null,
+    };
     const result = await withWriteLock(tempDir, async () => {
       // Lock dir should exist while fn runs.
       observed.lockedDuringFn = await fsp
         .stat(lockPath)
         .then(() => true)
         .catch(() => false);
+      const owner = JSON.parse(await fsp.readFile(writeLockOwnerPathFor(tempDir), 'utf-8')) as { pid: number };
+      observed.ownerPid = owner.pid;
       return 'value';
     });
     expect(result).toBe('value');
     expect(observed.lockedDuringFn).toBe(true);
+    expect(observed.ownerPid).toBe(process.pid);
     // Lock released after fn.
     await expect(fsp.stat(lockPath)).rejects.toMatchObject({ code: 'ENOENT' });
+    await expect(fsp.stat(writeLockOwnerPathFor(tempDir))).rejects.toMatchObject({ code: 'ENOENT' });
   });
 
   it('serializes concurrent callers (second waits for the first)', async () => {

--- a/src/write-lock.ts
+++ b/src/write-lock.ts
@@ -12,10 +12,13 @@
 // concurrent operations on different models.
 
 import * as fsp from 'fs/promises';
+import * as os from 'os';
 import * as path from 'path';
 import * as properLockfile from 'proper-lockfile';
 import { FAISS_INDEX_PATH } from './config/paths.js';
 import { logger } from './logger.js';
+
+export const WRITE_LOCK_STALE_MS = 10_000;
 
 const WRITE_LOCK_OPTS_BASE: Omit<properLockfile.LockOptions, 'lockfilePath'> = {
   // Heartbeat keeps the lock alive across long-running updateIndex calls
@@ -24,13 +27,24 @@ const WRITE_LOCK_OPTS_BASE: Omit<properLockfile.LockOptions, 'lockfilePath'> = {
   // false-positive as stale at the 10s default and another writer could
   // acquire.
   update: 5000,
-  stale: 10_000,
+  stale: WRITE_LOCK_STALE_MS,
   // Brief retry budget for fast-path contention (MCP and CLI both want
   // the lock for ~280 ms). Slow-path (model-switch re-embed) callers will
   // exhaust this and error with a clear message — that's the documented
   // RFC 012 §4.8.3 slow-path behavior.
   retries: { retries: 5, factor: 1.5, minTimeout: 100, maxTimeout: 1000 },
 };
+
+export const WRITE_LOCK_OWNER_SCHEMA_VERSION = 'kb.write-lock-owner.v1';
+
+export interface WriteLockOwnerMetadata {
+  schema_version: typeof WRITE_LOCK_OWNER_SCHEMA_VERSION;
+  pid: number;
+  command: string;
+  cwd: string | null;
+  hostname: string;
+  started_at: string;
+}
 
 const SIDECAR_LOCK_OPTS_BASE: Omit<properLockfile.LockOptions, 'lockfilePath'> = {
   stale: 30_000,
@@ -78,6 +92,7 @@ export async function withWriteLock<T>(resource: string, fn: () => Promise<T>): 
   await fsp.mkdir(resource, { recursive: true });
 
   const lockfilePath = path.join(resource, '.kb-write.lock');
+  const ownerPath = writeLockOwnerPathFor(resource);
   let release: () => Promise<void>;
   try {
     release = await properLockfile.lock(resource, {
@@ -94,9 +109,15 @@ export async function withWriteLock<T>(resource: string, fn: () => Promise<T>): 
     }
     throw err;
   }
+  await writeLockOwnerMetadata(ownerPath);
   try {
     return await fn();
   } finally {
+    try {
+      await fsp.rm(ownerPath, { force: true });
+    } catch (err) {
+      logger.warn(`Error removing write lock owner metadata: ${(err as Error).message}`);
+    }
     try {
       await release();
     } catch (err) {
@@ -112,6 +133,34 @@ export async function withWriteLock<T>(resource: string, fn: () => Promise<T>): 
  */
 export function writeLockPathFor(resource: string): string {
   return path.join(resource, '.kb-write.lock');
+}
+
+export function writeLockOwnerPathFor(resource: string): string {
+  return path.join(resource, '.kb-write.lock.owner.json');
+}
+
+async function writeLockOwnerMetadata(ownerPath: string): Promise<void> {
+  const metadata: WriteLockOwnerMetadata = {
+    schema_version: WRITE_LOCK_OWNER_SCHEMA_VERSION,
+    pid: process.pid,
+    command: process.argv.join(' '),
+    cwd: safeCwd(),
+    hostname: os.hostname(),
+    started_at: new Date().toISOString(),
+  };
+  try {
+    await fsp.writeFile(ownerPath, `${JSON.stringify(metadata, null, 2)}\n`, 'utf-8');
+  } catch (err) {
+    logger.warn(`Error writing write lock owner metadata: ${(err as Error).message}`);
+  }
+}
+
+function safeCwd(): string | null {
+  try {
+    return process.cwd();
+  } catch {
+    return null;
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- add `kb doctor --locks` focused JSON/markdown diagnostics for model write locks
- write best-effort owner metadata beside newly acquired write locks
- document the lock diagnostics contract and troubleshooting path

## Verification
- npm run build
- npx jest src/cli-doctor.test.ts src/write-lock.test.ts --runInBand
- npx jest src/cli-json-contracts.test.ts --runInBand
- node build/cli.js doctor --locks --format=json >/tmp/kb-doctor-locks-smoke.json && jq '{schema_version,status,summary}' /tmp/kb-doctor-locks-smoke.json\n- npm test\n\nPre-PR review: build/test/diff/portability checks completed; reviewer specialist subagents unavailable in this Codex session, manual specialist checklist applied.\n\nCloses #492