### PR TITLE
feat(cli): suggest typo fixes for commands and flags

### DIFF
--- a/src/cli-llm.ts
+++ b/src/cli-llm.ts
@@ -26,7 +26,7 @@ Usage:
   kb llm status [--profile=<name>] [--format=md|json]
   kb llm probe [--endpoint=<url>]
   kb llm use-endpoint <url> [--profile=<name>]
-  kb llm install --profile=<name> --runner=llama-server --bin=<path> --model=<gguf-path> [--port=8091] [--ctx=32768] [--ngl=99] [--start]
+  kb llm install --profile=<name> --runner=llama-server --bin=<path> --model=<gguf-path> [--port=8091] [--ctx=32768] [--ngl=99] [--runner-arg=<arg>] [--start]
   kb llm start [--profile=<name>]
   kb llm stop [--profile=<name>]
   kb llm restart [--profile=<name>]

--- a/src/cli-search.ts
+++ b/src/cli-search.ts
@@ -196,6 +196,8 @@ Output:
   --pager               Page markdown/compact output through KB_PAGER, PAGER,
                         or less -R when stdout is a TTY.
   --no-pager            Disable KB_PAGER for this search.
+  --daemon              Use the local read-only daemon when available; falls
+                        back to direct search when unreachable.
   --no-freshness        Skip the staleness scan and omit freshness output.
   --explain-empty       Opt-in deep diagnostics for empty results: pre/post
                         filter candidate counts, per-filter drops, scope,

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -254,6 +254,10 @@ describe('kb CLI — argv parsing and dispatch', () => {
         value: '<name>',
       }),
       expect.objectContaining({
+        flags: ['--runner-arg'],
+        value: '<arg>',
+      }),
+      expect.objectContaining({
         flags: ['--all'],
         value: null,
       }),
@@ -564,6 +568,31 @@ describe('kb CLI — argv parsing and dispatch', () => {
     const r = runCli(['notacommand']);
     expect(r.code).toBe(2);
     expect(r.stderr).toContain("unknown subcommand 'notacommand'");
+    expect(r.stderr).not.toContain('Did you mean');
+  });
+
+  it('unknown subcommand suggests the nearest registered command', () => {
+    const r = runCli(['serach']);
+    expect(r.code).toBe(2);
+    expect(r.stderr).toContain("unknown subcommand 'serach'");
+    expect(r.stderr).toContain('Did you mean kb search?');
+    expect(r.stderr).toContain('Available commands:');
+  });
+
+  it('kb help unknown command suggests the nearest registered command', () => {
+    const r = runCli(['help', 'docter']);
+    expect(r.code).toBe(2);
+    expect(r.stderr).toContain("unknown command 'docter'");
+    expect(r.stderr).toContain('Did you mean kb help doctor?');
+    expect(r.stdout).toBe('');
+  });
+
+  it('unknown long flags suggest the nearest flag for that subcommand', () => {
+    const r = runCli(['search', 'rollback', '--formt=json']);
+    expect(r.code).toBe(2);
+    expect(r.stderr).toContain('kb search: unknown flag: --formt=json');
+    expect(r.stderr).toContain('Did you mean --format?');
+    expect(r.stdout).toBe('');
   });
 
   it('search without query (and no --stdin) exits 2', () => {
@@ -722,6 +751,12 @@ describe('kb CLI — argv parsing and dispatch', () => {
     const r = runCli(['search', 'q', '--zzz=1']);
     expect(r.code).toBe(2);
     expect(r.stderr).toContain('unknown flag');
+    expect(r.stderr).not.toContain('Did you mean');
+  });
+
+  it('search accepts dash-prefixed queries as positional input', () => {
+    const r = runCli(['search', '-x', '--format=json']);
+    expect(r.stderr).not.toContain('unknown flag: -x');
   });
 
   it('search with invalid --threshold exits 2', () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -180,6 +180,16 @@ function wantsHelp(args: readonly string[]): boolean {
   return args.some((a) => a === '--help' || a === '-h');
 }
 
+interface ClosestSuggestion {
+  value: string;
+  distance: number;
+}
+
+interface UnknownFlagSuggestion {
+  raw: string;
+  suggestion: string;
+}
+
 export async function main(argv: string[]): Promise<number> {
   // Strip the conventional argv[0]/argv[1] before delegating.
   const args = argv.slice(2);
@@ -216,7 +226,9 @@ export async function main(argv: string[]): Promise<number> {
     }
     const target = SUBCOMMANDS.find((s) => s.name === helpArgs.command);
     if (!target) {
-      process.stderr.write(`kb help: unknown command '${helpArgs.command}'\n`);
+      process.stderr.write(
+        `kb help: unknown command '${helpArgs.command}'\n${formatCommandSuggestion(helpArgs.command, 'help')}`,
+      );
       return 2;
     }
     if (helpArgs.format === 'json') {
@@ -232,7 +244,7 @@ export async function main(argv: string[]): Promise<number> {
 
   const target = SUBCOMMANDS.find((s) => s.name === sub);
   if (!target) {
-    process.stderr.write(`kb: unknown subcommand '${sub}'\n${HELP}`);
+    process.stderr.write(`kb: unknown subcommand '${sub}'\n${formatCommandSuggestion(sub, 'run')}${HELP}`);
     return 2;
   }
 
@@ -245,12 +257,95 @@ export async function main(argv: string[]): Promise<number> {
     return target.handler(rest);
   }
 
-  return runSubcommandWithCanonicalLog(
-    target,
-    sub === 'search'
+  const unknownFlag = findUnknownFlag(rest, buildCommandHelpManifest(target).options);
+  const operation = unknownFlag !== null
+    ? async () => {
+        process.stderr.write(formatUnknownFlagMessage(target.name, unknownFlag));
+        return 2;
+      }
+    : sub === 'search'
       ? () => runSearchMaybeViaDaemon(rest)
-      : () => target.handler(rest),
-  );
+      : () => target.handler(rest);
+  return runSubcommandWithCanonicalLog(target, operation);
+}
+
+function formatCommandSuggestion(input: string, mode: 'help' | 'run'): string {
+  const suggestion = closestSuggestion(input, SUBCOMMANDS.map((command) => command.name));
+  if (suggestion === undefined) return '';
+  const command = mode === 'help' ? `kb help ${suggestion.value}` : `kb ${suggestion.value}`;
+  return `Did you mean ${command}?\n`;
+}
+
+function findUnknownFlag(
+  args: readonly string[],
+  options: readonly HelpManifestOption[],
+): UnknownFlagSuggestion | null {
+  const validFlags = new Set(options.flatMap((option) => option.flags));
+  const candidates = [...validFlags].filter((flag) => flag !== '--');
+
+  for (const raw of args) {
+    if (raw === '--') return null;
+    const flag = flagNameFromArg(raw);
+    if (flag === null || validFlags.has(flag)) continue;
+    const suggestion = closestSuggestion(flag, candidates)?.value;
+    if (suggestion === undefined) continue;
+    return {
+      raw,
+      suggestion,
+    };
+  }
+  return null;
+}
+
+function flagNameFromArg(raw: string): string | null {
+  if (!raw.startsWith('--')) return null;
+  const eqIndex = raw.indexOf('=');
+  return eqIndex === -1 ? raw : raw.slice(0, eqIndex);
+}
+
+function formatUnknownFlagMessage(command: string, unknown: UnknownFlagSuggestion): string {
+  return `kb ${command}: unknown flag: ${unknown.raw}\nDid you mean ${unknown.suggestion}?\n`;
+}
+
+function closestSuggestion(input: string, candidates: readonly string[]): ClosestSuggestion | undefined {
+  let best: ClosestSuggestion | undefined;
+  for (const candidate of candidates) {
+    const distance = levenshteinDistance(input, candidate);
+    if (
+      best === undefined
+      || distance < best.distance
+      || (distance === best.distance && candidate.length < best.value.length)
+      || (distance === best.distance && candidate.length === best.value.length && candidate < best.value)
+    ) {
+      best = { value: candidate, distance };
+    }
+  }
+  if (best === undefined || best.distance > suggestionDistanceThreshold(input)) return undefined;
+  return best;
+}
+
+function suggestionDistanceThreshold(input: string): number {
+  return Math.max(1, Math.floor(input.length / 3));
+}
+
+function levenshteinDistance(a: string, b: string): number {
+  const rows = a.length + 1;
+  const cols = b.length + 1;
+  const dp = Array.from({ length: rows }, () => new Array<number>(cols).fill(0));
+  for (let i = 0; i < rows; i++) dp[i][0] = i;
+  for (let j = 0; j < cols; j++) dp[0][j] = j;
+
+  for (let i = 1; i < rows; i++) {
+    for (let j = 1; j < cols; j++) {
+      const substitutionCost = a[i - 1] === b[j - 1] ? 0 : 1;
+      dp[i][j] = Math.min(
+        dp[i - 1][j] + 1,
+        dp[i][j - 1] + 1,
+        dp[i - 1][j - 1] + substitutionCost,
+      );
+    }
+  }
+  return dp[a.length][b.length];
 }
 
 function parseHelpArgs(rest: readonly string[]): HelpArgs {


### PR DESCRIPTION
## Summary
- add conservative Did you mean suggestions for unknown kb subcommands and kb help command typos
- suggest nearest known per-command long flag when an option typo has a close match
- keep help-derived option metadata aligned with accepted search and llm flags

## Verification
- npm run build
- npx jest src/cli.test.ts --runInBand

## Pre-PR review
- conventions, correctness, dead-code, and test specialists ran
- addressed reviewer findings for help-copy intent, dash-prefixed search queries, llm --runner-arg metadata, unreachable no-suggestion branch, and far-away flag fallback coverage

Closes #493