### PR TITLE
feat(security): add frontmatter sensitivity policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,11 @@ The MCP server (`knowledge-base-mcp-server` bin) is unchanged and still works wi
 
 `kb ask` keeps retrieval deterministic and adds a local OpenAI-compatible chat step on top. It resolves the LLM endpoint from `--endpoint`, `KB_LLM_ENDPOINT`, `--llm-profile`, the active `kb llm` profile, then finally the local-research-agent default on `127.0.0.1:8080`.
 
+Notes can opt out of LLM prompt packing with this YAML frontmatter:
+`kb_policy: { no_llm_context: true }`. Search can still return the chunk, but
+`kb ask` and MCP `ask_knowledge` skip it before calling the LLM and report
+`context_packing.policy_filtered_chunks`.
+
 For offline development, set `KB_LLM_FAKE=on` to route `kb ask`, RFC 018 relevance-gate judge calls, and RFC 017 contextual-preface generation to a deterministic in-process fake LLM. Use `npm run dev:mockllm -- --port=18080` when a client needs an OpenAI-compatible localhost endpoint instead. Rules can be customized with `KB_LLM_FAKE_RULES`; see [docs/testing/fake-llm.md](docs/testing/fake-llm.md).
 
 Add `--save-transcript --kb=<name> --yes` to persist the generated answer as a new markdown note in that KB. The saved record includes the question, answer, citations, source chunk ids, LLM endpoint/profile/model, retrieval model, and timing metadata when `--timing` is present. `--title=<title>` controls the note title and slug; existing transcript notes are never overwritten.

--- a/docs/authoring-knowledge.md
+++ b/docs/authoring-knowledge.md
@@ -54,6 +54,10 @@ confidence: 0.9
 manual_edits: true
 contradicted_by: ["doc-old.md"]
 tags: [retrieval, hybrid, bm25]
+kb_policy:
+  no_llm_context: true
+  resource_read: local_only
+  sensitivity: internal
 ---
 ```
 
@@ -62,6 +66,7 @@ Why it matters:
 - The MCP `retrieve_knowledge` tool accepts `extensions`, `path_glob`, and **`tags`** filters (`src/KnowledgeBaseServer.ts:107-122`). `tags` filter on the lifted frontmatter — chunks without `tags` in frontmatter will not match a `tags=[...]` filter. If you want a note findable as `tag:onboarding`, write `tags: [onboarding]`.
 - Non-whitelisted string keys land in `frontmatter.extras` (visible only when `FRONTMATTER_EXTRAS_WIRE_VISIBLE=1`). Use them for workflow-specific keys; don't expect filterability.
 - Non-string values for whitelisted keys (numbers, arrays, maps) are dropped silently *unless* the type is in the schema. Stick to scalars and short arrays.
+- `kb_policy` is a typed policy map. `no_llm_context: true` keeps matching chunks out of `kb ask` and MCP `ask_knowledge` prompt context, `resource_read: deny` blocks MCP `resources/read`, and `resource_read: local_only` allows stdio/local reads while blocking HTTP/SSE resource reads.
 - **Frontmatter doesn't help dense retrieval** unless you also put the same words in the body. A note with `tags: [rollback]` in frontmatter only is invisible to a query for "rollback" against the dense embedding — the embedder never saw it.
 
 ## 4. Content boundaries

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -21,6 +21,7 @@ verify the active behavior.
 | Fake LLM rules | `KB_LLM_FAKE_RULES` | unset | Fake LLM answers, prefaces, judge verdicts | Implemented | none | `KB_LLM_FAKE=on KB_LLM_FAKE_RULES=/path/to/rules.json kb ask "question"` |
 | Gate fallback LLM model id | `KB_LLM_MODEL` | endpoint default | Relevance gate fallback model | Implemented | none | `KB_RELEVANCE_GATE=on KB_LLM_MODEL=<model> kb search "query" --gate --task-context="current task"` |
 | Save generated answer | `kb ask --save-transcript --yes` | off | CLI ask write path | Implemented | `--save-transcript --kb=<name> --yes` | `kb ask "question" --kb=<name> --save-transcript --title="..." --yes` |
+| Frontmatter sensitivity policy | `kb_policy.no_llm_context`, `kb_policy.resource_read`, `kb_policy.sensitivity` | unset | `kb ask`, MCP `ask_knowledge`, MCP `resources/read` | Implemented, author-controlled | per-document frontmatter | add `kb_policy: { no_llm_context: true }` and run `kb ask ... --format=json` |
 
 ## Relevance Gate
 

--- a/docs/mcp-resources.md
+++ b/docs/mcp-resources.md
@@ -97,6 +97,19 @@ const uri = `kb://${kbName}/${relativePath
 }
 ```
 
+Markdown resources can opt into a frontmatter read policy:
+
+```yaml
+---
+kb_policy:
+  resource_read: local_only # allow | local_only | deny
+---
+```
+
+`deny` blocks `resources/read` for every transport. `local_only` allows the
+default stdio/local server but blocks HTTP/SSE reads (`MCP_TRANSPORT=http` or
+`sse`). This is a local authoring policy, not multi-user authorization.
+
 PDF files are returned as base64 blobs when `.pdf` is opted into ingest with `INGEST_EXTRA_EXTENSIONS=.pdf`:
 
 ```json
@@ -123,5 +136,10 @@ MIME type mapping is intentionally small and extension-based:
 ## Security and Client Behavior
 
 Resources expose raw source documents under `KNOWLEDGE_BASES_ROOT_DIR`. They do not apply semantic retrieval thresholds, relevance gating, chunk packing, or search filters. Clients should treat returned document text as untrusted content when the KB contains material from outside the local user's trust boundary.
+
+`resources/read` does apply `kb_policy.resource_read` from Markdown
+frontmatter. `resources/list` may still reveal the existence and path of a
+policy-protected document; use ingest exclusions for documents that should not
+be discoverable as resources at all.
 
 For normal agent retrieval, prefer `retrieve_knowledge`. For explicit document browsing, file previews, citation expansion, or "open this source" actions, use `resources/list` and `resources/read`.

--- a/docs/testing/INDEX.md
+++ b/docs/testing/INDEX.md
@@ -154,6 +154,16 @@
 - `kb ask` shall resolve a fake LLM target and answer from packed snippets without a live server.
 - `npm run dev:mockllm` shall serve OpenAI-compatible `/v1/chat/completions` and `/health` endpoints.
 
+### TS-POLICY-494: Frontmatter Sensitivity Policy
+**Requirement:** FR-POLICY-494
+
+**Test Cases:**
+- Ingest shall lift typed `kb_policy.no_llm_context`, `kb_policy.resource_read`, and `kb_policy.sensitivity` frontmatter into chunk metadata.
+- `kb ask` and MCP `ask_knowledge` shall exclude chunks marked `frontmatter.kb_policy.no_llm_context: true` from LLM prompt context and report `context_packing.policy_filtered_chunks`.
+- `kb ask` and MCP `ask_knowledge` shall hydrate current source-file `kb_policy` frontmatter before LLM prompt packing so stale indexes do not leak newly marked sensitive notes.
+- `resources/read` shall reject Markdown resources with `kb_policy.resource_read: deny`.
+- `resources/read` shall reject `kb_policy.resource_read: local_only` when the MCP transport is HTTP/SSE and allow it for local stdio reads.
+
 ### TS-GATE-EVAL-369: M0 Gate Validation Harness
 **Requirement:** FR-GATE-EVAL-369
 

--- a/src/ask-core.ts
+++ b/src/ask-core.ts
@@ -1,7 +1,10 @@
+import * as fsp from 'fs/promises';
 import type { FaissIndexManager, SimilaritySearchTiming } from './FaissIndexManager.js';
+import type { SearchResultDocument } from './FaissIndexManager.js';
 import type { resolveActiveModel } from './active-model.js';
 import { FRONTMATTER_EXTRAS_WIRE_VISIBLE } from './config/retrieval.js';
 import { formatRetrievalAsJson, type RetrievalJsonResult } from './formatter.js';
+import { parseFrontmatter } from './frontmatter.js';
 import { resolveInjectionGuardOptions } from './injection-guard.js';
 import { FAKE_LLM_ENDPOINT, isFakeLlmEnabled } from './llm-fake-stub.js';
 import {
@@ -27,6 +30,11 @@ import {
   nowMs,
   type TimingPayload,
 } from './timing-core.js';
+import {
+  excludesLlmContext,
+  normalizeKbSensitivityPolicy,
+  sensitivityPolicyFromMetadata,
+} from './sensitivity-policy.js';
 
 export const DEFAULT_ASK_CONTEXT_BUDGET_TOKENS = 6000;
 export const MIN_ASK_CONTEXT_BUDGET_TOKENS = 64;
@@ -90,6 +98,7 @@ export interface AskRetrievalPayload {
 export interface AskPackedChunkPayload {
   index: number;
   status: 'included' | 'excluded';
+  excluded_reason?: 'token_budget' | 'policy_no_llm_context';
   estimated_tokens: number;
   included_tokens: number;
   truncated: boolean;
@@ -104,6 +113,7 @@ export interface AskContextPackingPayload {
   included_chunks: number;
   excluded_chunks: number;
   truncated_chunks: number;
+  policy_filtered_chunks: number;
   chunks: AskPackedChunkPayload[];
 }
 
@@ -217,20 +227,28 @@ export async function executeAsk(
       undefined,
       timing ? denseTiming : undefined,
     );
+    results = await hydrateSensitivityPoliciesFromSource(results);
     if (args.gate !== undefined || args.taskContext !== undefined) {
       const denseDistanceById = new Map<string, number>();
-      for (const result of results) {
+      const policyExcluded = results.filter((result) =>
+        excludesLlmContext(result.metadata as Record<string, unknown>),
+      );
+      let gateCandidates = results.filter((result) =>
+        !excludesLlmContext(result.metadata as Record<string, unknown>),
+      );
+      for (const result of gateCandidates) {
         denseDistanceById.set(chunkIdFromMetadata(result.metadata as Record<string, unknown>), result.score);
       }
       const gate = await applyRelevanceGate({
         query: args.question,
         taskContext: args.taskContext,
-        candidates: results,
+        candidates: gateCandidates,
         denseDistanceById,
         gateOverride: args.gate,
         process: 'mcp',
       });
-      results = gate.results;
+      gateCandidates = gate.results;
+      results = [...gateCandidates, ...policyExcluded];
       emitRelevanceGateDecision({
         process: 'mcp',
         query: args.question,
@@ -323,6 +341,55 @@ export async function executeAsk(
   };
 }
 
+async function hydrateSensitivityPoliciesFromSource(
+  results: SearchResultDocument[],
+): Promise<SearchResultDocument[]> {
+  const policyBySource = new Map<string, ReturnType<typeof normalizeKbSensitivityPolicy>>();
+
+  return Promise.all(results.map(async (result) => {
+    const metadata = result.metadata as Record<string, unknown>;
+    if (sensitivityPolicyFromMetadata(metadata) !== undefined) {
+      return result;
+    }
+
+    const source = metadata.source;
+    if (typeof source !== 'string' || source.length === 0) {
+      return result;
+    }
+
+    let policy = policyBySource.get(source);
+    if (!policyBySource.has(source)) {
+      try {
+        const content = await fsp.readFile(source, 'utf-8');
+        policy = normalizeKbSensitivityPolicy(parseFrontmatter(content).frontmatter.kb_policy);
+      } catch {
+        policy = undefined;
+      }
+      policyBySource.set(source, policy);
+    }
+
+    if (policy === undefined) {
+      return result;
+    }
+
+    const frontmatter = metadata.frontmatter;
+    const frontmatterObject =
+      frontmatter && typeof frontmatter === 'object' && !Array.isArray(frontmatter)
+        ? frontmatter as Record<string, unknown>
+        : {};
+    return {
+      ...result,
+      metadata: {
+        ...metadata,
+        frontmatter: {
+          ...frontmatterObject,
+          kb_policy: policy,
+        },
+      },
+    };
+  }));
+}
+
 async function resolveLlmTarget(args: Pick<AskExecutionArgs, 'endpoint' | 'llmProfile'>): Promise<LlmTarget> {
   if (isFakeLlmEnabled()) {
     return { profile: await createExternalProfile('fake', FAKE_LLM_ENDPOINT, 'kb-fake-llm'), source: 'fake' };
@@ -371,8 +438,30 @@ export function packAskContext(
   let estimatedTokens = 0;
   let excludedChunks = 0;
   let truncatedChunks = 0;
+  let policyFilteredChunks = 0;
 
   retrieval.forEach((result, index) => {
+    const pathValue = stringMetadata(result.metadata, 'relativePath')
+      ?? stringMetadata(result.metadata, 'source')
+      ?? '(unknown source)';
+    const policyExcluded = excludesLlmContext(result.metadata);
+    if (policyExcluded) {
+      excludedChunks++;
+      policyFilteredChunks++;
+      chunks.push({
+        index: index + 1,
+        status: 'excluded',
+        excluded_reason: 'policy_no_llm_context',
+        estimated_tokens: 0,
+        included_tokens: 0,
+        truncated: false,
+        knowledge_base: stringMetadata(result.metadata, 'knowledgeBase'),
+        path: pathValue,
+        ...(result.chunk_id ? { chunk_id: result.chunk_id } : {}),
+      });
+      return;
+    }
+
     const fullSnippet = buildAskSnippet(result, index + 1, result.content);
     const fullTokens = estimateTokens(fullSnippet);
     const separatorTokens = included.length === 0 ? 0 : estimateTokens(ASK_SNIPPET_SEPARATOR);
@@ -403,12 +492,10 @@ export function packAskContext(
       }
     }
 
-    const pathValue = stringMetadata(result.metadata, 'relativePath')
-      ?? stringMetadata(result.metadata, 'source')
-      ?? '(unknown source)';
     const chunkPayload: AskPackedChunkPayload = {
       index: index + 1,
       status: snippetText === null ? 'excluded' : 'included',
+      ...(snippetText === null ? { excluded_reason: 'token_budget' as const } : {}),
       estimated_tokens: fullTokens,
       included_tokens: includedTokens,
       truncated,
@@ -439,6 +526,7 @@ export function packAskContext(
       included_chunks: included.length,
       excluded_chunks: excludedChunks,
       truncated_chunks: truncatedChunks,
+      policy_filtered_chunks: policyFilteredChunks,
       chunks,
     },
   };

--- a/src/cli-ask.test.ts
+++ b/src/cli-ask.test.ts
@@ -150,6 +150,37 @@ describe('packAskContext', () => {
       else process.env.KB_INJECTION_GUARD_WRAP_CLOSE = previousClose;
     }
   });
+
+  it('excludes no_llm_context chunks before prompt packing and reports the policy count', () => {
+    const packed = packAskContext([
+      retrievalResult('public.md', 'public deployment context'),
+      {
+        ...retrievalResult('sensitive.md', 'DO_NOT_SEND_TO_LLM private context'),
+        metadata: {
+          knowledgeBase: 'ops',
+          relativePath: 'sensitive.md',
+          frontmatter: {
+            kb_policy: {
+              no_llm_context: true,
+              sensitivity: 'confidential',
+            },
+          },
+        },
+      },
+    ], 600);
+
+    expect(packed.payload).toMatchObject({
+      included_chunks: 1,
+      excluded_chunks: 1,
+      policy_filtered_chunks: 1,
+    });
+    expect(packed.payload.chunks[1]).toMatchObject({
+      status: 'excluded',
+      excluded_reason: 'policy_no_llm_context',
+      path: 'sensitive.md',
+    });
+    expect(packed.included.map((snippet) => snippet.text).join('\n')).not.toContain('DO_NOT_SEND_TO_LLM');
+  });
 });
 
 describe('ask transcript records', () => {
@@ -789,13 +820,158 @@ describe('kb ask grounding fixtures', () => {
       await harness.cleanup();
     }
   });
+
+  it('does not send no_llm_context snippets to the answer LLM', async () => {
+    const harness = createAskFixtureHarness({
+      results: [
+        retrievalResult(
+          'runbooks/public.md',
+          'Rollback approval requires the release lead.',
+          'ops/runbooks/public.md#L1-L3',
+        ),
+        {
+          ...retrievalResult(
+            'runbooks/private.md',
+            'PRIVATE_ESCALATION_PHONE must never enter LLM context.',
+            'ops/runbooks/private.md#L4-L6',
+          ),
+          metadata: {
+            knowledgeBase: 'ops',
+            relativePath: 'runbooks/private.md',
+            frontmatter: { kb_policy: { no_llm_context: true } },
+          },
+        },
+      ],
+      answer: ({ userContent }) => {
+        expect(userContent).toContain('runbooks/public.md');
+        expect(userContent).not.toContain('PRIVATE_ESCALATION_PHONE');
+        expect(userContent).not.toContain('runbooks/private.md');
+        return 'Rollback approval requires the release lead.';
+      },
+    });
+
+    try {
+      const { code, stdout, stderr } = await harness.run([
+        'Who approves rollback?',
+        '--kb=ops',
+        '--format=json',
+      ]);
+
+      expect(code).toBe(0);
+      expect(stderr).toBe('');
+      const payload = JSON.parse(stdout) as {
+        citations: Array<{ path: string }>;
+        context_packing: {
+          included_chunks: number;
+          excluded_chunks: number;
+          policy_filtered_chunks: number;
+          chunks: Array<{ path: string; excluded_reason?: string }>;
+        };
+      };
+      expect(payload.citations.map((citation) => citation.path)).toEqual(['runbooks/public.md']);
+      expect(payload.context_packing).toMatchObject({
+        included_chunks: 1,
+        excluded_chunks: 1,
+        policy_filtered_chunks: 1,
+      });
+      expect(payload.context_packing.chunks[1]).toMatchObject({
+        path: 'runbooks/private.md',
+        excluded_reason: 'policy_no_llm_context',
+      });
+    } finally {
+      await harness.cleanup();
+    }
+  });
+
+  it('hydrates no_llm_context from source files when indexed metadata is stale', async () => {
+    const root = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-ask-policy-source-'));
+    const previousEndpoint = process.env.KB_LLM_ENDPOINT;
+    try {
+      process.env.KB_LLM_ENDPOINT = 'http://127.0.0.1:8080/v1/chat/completions';
+      const privatePath = path.join(root, 'ops', 'private.md');
+      await fsp.mkdir(path.dirname(privatePath), { recursive: true });
+      await fsp.writeFile(privatePath, [
+        '---',
+        'kb_policy:',
+        '  no_llm_context: true',
+        '---',
+        '# Private',
+        '',
+        'PRIVATE_ESCALATION_PHONE must never enter LLM context.',
+      ].join('\n'), 'utf-8');
+
+      const manager = {
+        modelDir: path.join(root, '.faiss', 'models', 'ollama__nomic'),
+        similaritySearch: jest.fn(async () => [
+          {
+            pageContent: 'Rollback approval requires the release lead.',
+            metadata: { knowledgeBase: 'ops', relativePath: 'runbooks/public.md' },
+            score: 0.1,
+          },
+          {
+            pageContent: 'PRIVATE_ESCALATION_PHONE must never enter LLM context.',
+            metadata: {
+              knowledgeBase: 'ops',
+              relativePath: 'private.md',
+              source: privatePath,
+            },
+            score: 0.2,
+          },
+        ]),
+      };
+      const callChatCompletion = jest.fn(async (call: Parameters<RunAskDeps['callChatCompletion']>[0]) => {
+        const userContent = call.messages.find((message) => message.role === 'user')?.content ?? '';
+        expect(userContent).toContain('runbooks/public.md');
+        expect(userContent).not.toContain('PRIVATE_ESCALATION_PHONE');
+        expect(userContent).not.toContain('private.md');
+        return {
+          content: 'Rollback approval requires the release lead.',
+          model: 'fake-grounding-llm',
+          raw: { fixture: true },
+        };
+      });
+
+      const result = await askKnowledge({
+        query: 'Who approves rollback?',
+        knowledge_base_name: 'ops',
+      }, {
+        bootstrapLayout: jest.fn(async () => {}),
+        resolveActiveModel: jest.fn(async () => 'ollama__nomic-embed-text-latest'),
+        loadManagerForModel: jest.fn(async () => manager as never),
+        loadReadOnlyIndex: jest.fn(async () => {}),
+        withWriteLock: jest.fn(async <T>(_resource: string, action: () => Promise<T>) => action()) as RunAskDeps['withWriteLock'],
+        callChatCompletion,
+      });
+
+      expect(result.context_packing).toMatchObject({
+        included_chunks: 1,
+        excluded_chunks: 1,
+        policy_filtered_chunks: 1,
+      });
+      expect(result.context_packing.chunks[1]).toMatchObject({
+        path: 'private.md',
+        excluded_reason: 'policy_no_llm_context',
+      });
+      expect(result.citations.map((citation) => citation.path)).toEqual(['runbooks/public.md']);
+      expect(callChatCompletion).toHaveBeenCalledTimes(1);
+    } finally {
+      if (previousEndpoint === undefined) delete process.env.KB_LLM_ENDPOINT;
+      else process.env.KB_LLM_ENDPOINT = previousEndpoint;
+      await fsp.rm(root, { recursive: true, force: true });
+    }
+  });
 });
 
 function retrievalResult(
   relativePath: string,
   content: string,
   chunkId?: string,
-) {
+): {
+  score: number;
+  content: string;
+  metadata: Record<string, unknown>;
+  chunk_id?: string;
+} {
   const lineRange = chunkId?.match(/#L(\d+)-L(\d+)$/);
   return {
     score: 0.1,

--- a/src/file-ingest.test.ts
+++ b/src/file-ingest.test.ts
@@ -97,6 +97,10 @@ describe('buildChunkDocuments → metadata-sidecar contract (#283)', () => {
       '  - oncall',
       'title: On-call runbook',
       'status: active',
+      'kb_policy:',
+      '  no_llm_context: true',
+      '  resource_read: local_only',
+      '  sensitivity: internal',
       '---',
       '',
       '# On-call runbook',
@@ -120,7 +124,15 @@ describe('buildChunkDocuments → metadata-sidecar contract (#283)', () => {
       relativePath: expectedRelativePath,
       extension: '.md',
       tags: expect.arrayContaining(['ops', 'oncall']),
-      frontmatter: expect.objectContaining({ title: 'On-call runbook', status: 'active' }),
+      frontmatter: expect.objectContaining({
+        title: 'On-call runbook',
+        status: 'active',
+        kb_policy: {
+          no_llm_context: true,
+          resource_read: 'local_only',
+          sensitivity: 'internal',
+        },
+      }),
     }));
 
     const row = buildSidecarRowFromDocument('vec-0', first);

--- a/src/frontmatter-lift.ts
+++ b/src/frontmatter-lift.ts
@@ -2,6 +2,10 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { KNOWLEDGE_BASES_ROOT_DIR } from './config/paths.js';
 import { logger } from './logger.js';
+import {
+  normalizeKbSensitivityPolicy,
+  type KbSensitivityPolicy,
+} from './sensitivity-policy.js';
 
 // -----------------------------------------------------------------------------
 // RFC 011 §5.4 — whitelisted frontmatter lift + sibling PDF detection.
@@ -51,6 +55,7 @@ export interface LiftedFrontmatter {
   tier?: string;
   confidence?: number;
   last_verified_at?: string;
+  kb_policy?: KbSensitivityPolicy;
   /** Other string-valued frontmatter keys (e.g. workflow-specific additions). */
   extras?: Record<string, string>;
 }
@@ -124,6 +129,17 @@ export function liftFrontmatter(
         hasAny = true;
       } else {
         logger.debug(`Dropping non-string-list frontmatter key "contradicted_by" from ${filePath}`);
+      }
+      continue;
+    }
+
+    if (key === 'kb_policy') {
+      const parsed = normalizeKbSensitivityPolicy(value);
+      if (parsed !== undefined) {
+        lifted.kb_policy = parsed;
+        hasAny = true;
+      } else {
+        logger.debug(`Dropping invalid frontmatter key "kb_policy" from ${filePath}`);
       }
       continue;
     }

--- a/src/mcp-resources.test.ts
+++ b/src/mcp-resources.test.ts
@@ -1,11 +1,15 @@
-import { describe, expect, it } from '@jest/globals';
+import { afterEach, describe, expect, it } from '@jest/globals';
+import * as fsp from 'fs/promises';
+import * as path from 'path';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { ListResourceTemplatesRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import { KNOWLEDGE_BASES_ROOT_DIR } from './config/paths.js';
 import {
   buildResourceUri,
   listResourceTemplates,
   mimeTypeForResource,
   parseKnowledgeBaseResourceUri,
+  readResource,
   registerResources,
 } from './mcp-resources.js';
 
@@ -150,5 +154,71 @@ describe('listResourceTemplates', () => {
     await expect(Promise.resolve(registered!.handler())).resolves.toEqual(
       listResourceTemplates(),
     );
+  });
+});
+
+describe('readResource sensitivity policy', () => {
+  const kbName = `resource-policy-${process.pid}`;
+  const kbDir = path.join(KNOWLEDGE_BASES_ROOT_DIR, kbName);
+
+  afterEach(async () => {
+    await fsp.rm(kbDir, { recursive: true, force: true });
+  });
+
+  it('blocks resource_read=deny for local and remote reads', async () => {
+    await fsp.mkdir(kbDir, { recursive: true });
+    await fsp.writeFile(path.join(kbDir, 'deny.md'), [
+      '---',
+      'kb_policy:',
+      '  resource_read: deny',
+      '---',
+      '# Private',
+    ].join('\n'), 'utf-8');
+
+    await expect(readResource(buildResourceUri(kbName, 'deny.md'), { access: 'local' }))
+      .rejects.toThrow(/resource blocked by kb_policy\.resource_read/);
+    await expect(readResource(buildResourceUri(kbName, 'deny.md'), { access: 'remote' }))
+      .rejects.toThrow(/resource blocked by kb_policy\.resource_read/);
+  });
+
+  it('allows local_only resources locally but blocks them over remote MCP transports', async () => {
+    await fsp.mkdir(kbDir, { recursive: true });
+    await fsp.writeFile(path.join(kbDir, 'local.md'), [
+      '---',
+      'kb_policy:',
+      '  resource_read: local_only',
+      '---',
+      '# Local',
+      '',
+      'Operator-only note.',
+    ].join('\n'), 'utf-8');
+
+    await expect(readResource(buildResourceUri(kbName, 'local.md'), { access: 'local' }))
+      .resolves.toMatchObject({
+        contents: [{ text: expect.stringContaining('Operator-only note.') }],
+      });
+    await expect(readResource(buildResourceUri(kbName, 'local.md'), { access: 'remote' }))
+      .rejects.toThrow(/local_only/);
+  });
+
+  it('derives remote resource access from MCP_TRANSPORT by default', async () => {
+    const previousTransport = process.env.MCP_TRANSPORT;
+    try {
+      await fsp.mkdir(kbDir, { recursive: true });
+      await fsp.writeFile(path.join(kbDir, 'transport.md'), [
+        '---',
+        'kb_policy:',
+        '  resource_read: local_only',
+        '---',
+        '# Remote',
+      ].join('\n'), 'utf-8');
+
+      process.env.MCP_TRANSPORT = 'http';
+      await expect(readResource(buildResourceUri(kbName, 'transport.md')))
+        .rejects.toThrow(/local_only/);
+    } finally {
+      if (previousTransport === undefined) delete process.env.MCP_TRANSPORT;
+      else process.env.MCP_TRANSPORT = previousTransport;
+    }
   });
 });

--- a/src/mcp-resources.ts
+++ b/src/mcp-resources.ts
@@ -25,6 +25,7 @@ import { INGEST_EXCLUDE_PATHS, INGEST_EXTRA_EXTENSIONS } from './config/ingest.j
 import { KNOWLEDGE_BASES_ROOT_DIR } from './config/paths.js';
 import { toError } from './error-utils.js';
 import { getFilesRecursively } from './file-utils.js';
+import { parseFrontmatter } from './frontmatter.js';
 import { filterIngestablePaths } from './ingest-filter.js';
 import { listIngestQuarantine } from './ingest-quarantine.js';
 import {
@@ -34,6 +35,12 @@ import {
   resolveKbPath,
 } from './kb-fs.js';
 import { isValidKbName } from './kb-paths.js';
+import {
+  decideResourceRead,
+  normalizeKbSensitivityPolicy,
+  resolveResourceReadAccess,
+  type KbResourceReadAccess,
+} from './sensitivity-policy.js';
 
 export interface ListResourcesOptions {
   cursor?: string;
@@ -43,6 +50,10 @@ export interface ListResourcesOptions {
   prefix?: string;
   limit?: number;
   pageSize?: number;
+}
+
+export interface ReadResourceOptions {
+  access?: KbResourceReadAccess;
 }
 
 interface NormalizedListResourcesOptions {
@@ -457,7 +468,10 @@ export function listResourceTemplates(): ListResourceTemplatesResult {
  * returns either a base64 blob (PDF) or UTF-8 text (markdown, HTML,
  * plain text).
  */
-export async function readResource(uri: string): Promise<ReadResourceResult> {
+export async function readResource(
+  uri: string,
+  options: ReadResourceOptions = {},
+): Promise<ReadResourceResult> {
   const { kbName, relativePath } = parseKnowledgeBaseResourceUri(uri);
   const kbPath = path.join(KNOWLEDGE_BASES_ROOT_DIR, kbName);
   const requestedPath = path.join(kbPath, relativePath);
@@ -490,9 +504,31 @@ export async function readResource(uri: string): Promise<ReadResourceResult> {
   }
 
   const text = await fsp.readFile(filePath, 'utf-8');
+  assertResourceReadPolicy({
+    text,
+    relativePath,
+    access: options.access ?? resolveResourceReadAccess(),
+  });
+
   return {
     contents: [{ uri, mimeType, text }],
   };
+}
+
+function assertResourceReadPolicy(input: {
+  text: string;
+  relativePath: string;
+  access: KbResourceReadAccess;
+}): void {
+  const parsed = parseFrontmatter(input.text);
+  const policy = normalizeKbSensitivityPolicy(parsed.frontmatter.kb_policy);
+  const decision = decideResourceRead(policy, input.access);
+  if (decision.allowed) return;
+
+  const detail = decision.reason === 'resource_read_local_only'
+    ? 'resource is marked local_only and the MCP transport is remote'
+    : 'resource is marked deny';
+  throw new Error(`resource blocked by kb_policy.resource_read: ${JSON.stringify(input.relativePath)} (${detail})`);
 }
 
 /**

--- a/src/sensitivity-policy.ts
+++ b/src/sensitivity-policy.ts
@@ -1,0 +1,96 @@
+export type KbResourceReadPolicy = 'allow' | 'local_only' | 'deny';
+export type KbResourceReadAccess = 'local' | 'remote';
+
+export interface KbSensitivityPolicy {
+  no_llm_context?: boolean;
+  resource_read?: KbResourceReadPolicy;
+  sensitivity?: string;
+}
+
+export interface KbResourceReadDecision {
+  allowed: boolean;
+  reason?: 'resource_read_deny' | 'resource_read_local_only';
+}
+
+export function normalizeKbSensitivityPolicy(
+  value: unknown,
+): KbSensitivityPolicy | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return undefined;
+  }
+  const raw = value as Record<string, unknown>;
+  const policy: KbSensitivityPolicy = {};
+
+  const noLlmContext = parseBoolean(raw.no_llm_context);
+  if (noLlmContext !== undefined) {
+    policy.no_llm_context = noLlmContext;
+  }
+
+  const resourceRead = parseResourceReadPolicy(raw.resource_read);
+  if (resourceRead !== undefined) {
+    policy.resource_read = resourceRead;
+  }
+
+  if (typeof raw.sensitivity === 'string') {
+    const sensitivity = raw.sensitivity.trim();
+    if (sensitivity.length > 0) {
+      policy.sensitivity = sensitivity;
+    }
+  }
+
+  return Object.keys(policy).length > 0 ? policy : undefined;
+}
+
+export function sensitivityPolicyFromMetadata(
+  metadata: Record<string, unknown> | undefined,
+): KbSensitivityPolicy | undefined {
+  const frontmatter = metadata?.frontmatter;
+  if (!frontmatter || typeof frontmatter !== 'object' || Array.isArray(frontmatter)) {
+    return undefined;
+  }
+  const policy = (frontmatter as Record<string, unknown>).kb_policy;
+  return normalizeKbSensitivityPolicy(policy);
+}
+
+export function excludesLlmContext(metadata: Record<string, unknown> | undefined): boolean {
+  return sensitivityPolicyFromMetadata(metadata)?.no_llm_context === true;
+}
+
+export function decideResourceRead(
+  policy: KbSensitivityPolicy | undefined,
+  access: KbResourceReadAccess,
+): KbResourceReadDecision {
+  if (policy?.resource_read === 'deny') {
+    return { allowed: false, reason: 'resource_read_deny' };
+  }
+  if (policy?.resource_read === 'local_only' && access === 'remote') {
+    return { allowed: false, reason: 'resource_read_local_only' };
+  }
+  return { allowed: true };
+}
+
+export function resolveResourceReadAccess(
+  env: NodeJS.ProcessEnv = process.env,
+): KbResourceReadAccess {
+  return env.MCP_TRANSPORT === 'http' || env.MCP_TRANSPORT === 'sse'
+    ? 'remote'
+    : 'local';
+}
+
+function parseBoolean(value: unknown): boolean | undefined {
+  if (typeof value === 'boolean') return value;
+  if (typeof value !== 'string') return undefined;
+  const normalized = value.trim().toLowerCase();
+  if (normalized === 'true') return true;
+  if (normalized === 'false') return false;
+  return undefined;
+}
+
+function parseResourceReadPolicy(value: unknown): KbResourceReadPolicy | undefined {
+  if (typeof value !== 'string') return undefined;
+  const normalized = value.trim().toLowerCase().replace(/-/g, '_');
+  if (normalized === 'allow' || normalized === 'local_only' || normalized === 'deny') {
+    return normalized;
+  }
+  return undefined;
+}


### PR DESCRIPTION
## Summary
- lift typed `kb_policy` frontmatter into chunk metadata
- exclude `kb_policy.no_llm_context` chunks from `kb ask` / MCP `ask_knowledge` LLM prompt packing with structured counts, including source-file hydration for stale indexes
- enforce `kb_policy.resource_read` for MCP `resources/read` (`deny`, `local_only`) and document the policy

Closes #494

## Verification
- `npm run build`
- `npm test -- --runTestsByPath src/cli-ask.test.ts src/mcp-resources.test.ts src/file-ingest.test.ts`
- `npm test`

## Pre-PR review
- conventions-specialist: docs syntax/taxonomy issues fixed
- correctness-specialist: stale-index no_llm_context leak fixed by source hydration before gate/context packing
- deadcode-specialist: no dead code introduced
- test-specialist: remote deny/default transport coverage added