### PR TITLE
feat(bench): add optional MLflow and Optuna hooks

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -215,6 +215,99 @@ benchmarks/results/compare-<id_a>-vs-<id_b>-<utc-stamp>.json  ← merged input +
 
 The HTML has six sections: summary table (with per-axis winner column), latency-distribution charts (single-query + batch p99 by concurrency), throughput-vs-concurrency line chart, on-disk storage stacked bar, query-level detail (collapsible top-5 per model with overlap highlighting), and a rule-based recommendation panel (fixed thresholds documented inline so a skeptical reader can disagree explicitly). Disclaimers section makes the "your-KB selection guidance, NOT MTEB" framing explicit.
 
+## Optional experiment tracking — MLflow
+
+The benchmark JSON and HTML files remain the canonical artifacts. MLflow is an
+optional side effect, enabled only when `BENCH_MLFLOW_*` is set. The normal
+`npm run bench` and `npm run bench:compare` paths do not import Python or
+require the `mlflow` package.
+
+Install the optional Python package when you want tracking:
+
+```bash
+python3 -m pip install mlflow
+```
+
+Log a plain benchmark run to a local MLflow store:
+
+```bash
+BENCH_PROVIDER=stub \
+BENCH_MLFLOW_URI=file:///tmp/kb-mlruns \
+BENCH_MLFLOW_EXPERIMENT=kb-benchmarks \
+npm run bench
+```
+
+Log a compare run with tags:
+
+```bash
+BENCH_MLFLOW_URI=http://127.0.0.1:5000 \
+BENCH_MLFLOW_EXPERIMENT=kb-compare \
+BENCH_MLFLOW_TAGS=suite=large,owner=local \
+npm run bench:compare -- \
+  --models=ollama__nomic-embed-text-latest,huggingface__BAAI-bge-small-en-v1.5 \
+  --fixture=large \
+  --yes
+```
+
+MLflow receives flattened params/metrics plus the benchmark artifacts:
+
+- `npm run bench`: the JSON report.
+- `npm run bench:compare`: the merged JSON and self-contained HTML report.
+
+Supported environment variables:
+
+| Variable | Meaning |
+|----------|---------|
+| `BENCH_MLFLOW_URI` | Tracking URI passed to `mlflow.set_tracking_uri`, e.g. `file:///tmp/kb-mlruns` or `http://host:5000`. |
+| `BENCH_MLFLOW_EXPERIMENT` | Experiment name. Defaults to `kb-benchmarks` when any MLflow env is set. |
+| `BENCH_MLFLOW_RUN_NAME` | Optional run name. |
+| `BENCH_MLFLOW_TAGS` | Comma-separated `key=value` tags. |
+| `BENCH_MLFLOW_PYTHON` | Python interpreter to use. Defaults to `python3`. |
+
+If MLflow env is set but the optional package is missing, the run fails with a
+setup message rather than silently dropping requested tracking.
+
+## Optional tuning — Optuna
+
+Optuna is also optional. The runner proposes environment-variable values,
+executes a benchmark command, reads the JSON artifact printed by that command,
+and optimizes the metric dot-path you name. It does not change the benchmark
+contract and it does not run unless invoked explicitly.
+
+Install the optional Python package:
+
+```bash
+python3 -m pip install optuna
+```
+
+Example: minimize warm-query p95 while sweeping fixture chunk size:
+
+```bash
+npm run bench:tune -- \
+  --trials=20 \
+  --direction=minimize \
+  --metric=scenarios.warm_query.p95_ms \
+  --param-int=BENCH_FIXTURE_CHUNK_CHARS=256:1536:128 \
+  -- npm run bench
+```
+
+Persist a study so repeated runs resume:
+
+```bash
+npm run bench:tune -- \
+  --storage=sqlite:///benchmarks/results/kb-optuna.db \
+  --study-name=chunk-size-latency \
+  --trials=50 \
+  --direction=minimize \
+  --metric=scenarios.warm_query.p95_ms \
+  --param-int=BENCH_FIXTURE_CHUNK_CHARS=256:1536:128 \
+  --param-int=BENCH_FIXTURE_CHUNKS_PER_FILE=3:10 \
+  -- npm run bench
+```
+
+You can combine Optuna with MLflow by exporting `BENCH_MLFLOW_*` before running
+`bench:tune`; each trial benchmark logs normally.
+
 ### Auto-clamping fixture chunk size to fit short-context models (#107)
 
 Before driving the bench legs, the orchestrator probes each model's `num_ctx`

--- a/benchmarks/compare/run.ts
+++ b/benchmarks/compare/run.ts
@@ -27,6 +27,7 @@ import {
   largeCorpusQueryLines,
   type LargeCorpusCache,
 } from '../fixtures/large-corpus.js';
+import { logCompareToMlflow } from '../observability/mlflow.js';
 // Type duplicated locally rather than imported from src/ — tsconfig.bench.json's
 // rootDir scopes types to the benchmarks/ tree (src/ files are out of scope even
 // for type-only imports). All src-side runtime values are loaded via dynamic
@@ -234,16 +235,19 @@ async function main(): Promise<void> {
   const jsonPath = path.join(outDir, `${outBase}.json`);
 
   await fsp.writeFile(htmlPath, html, 'utf-8');
-  await fsp.writeFile(jsonPath, JSON.stringify({
+  const compareJson = {
     modelA: { id: modelA.id, provider: modelA.provider, name: modelA.name },
     modelB: { id: modelB.id, provider: modelB.provider, name: modelB.name },
+    fixture: { profile: flags.fixture, chunks: reportA.scenarios.cold_index.chunks },
     reportA,
     reportB,
     crossModel,
     goldenQuality,
     cost,
     generatedAt: new Date().toISOString(),
-  }, null, 2) + '\n', 'utf-8');
+  };
+  await fsp.writeFile(jsonPath, JSON.stringify(compareJson, null, 2) + '\n', 'utf-8');
+  await logCompareToMlflow({ compareJson, jsonPath, htmlPath, repoRoot });
 
   // Cleanup orchestrator tmpdir on success; preserve on failure for debugging.
   try {

--- a/benchmarks/observability/mlflow.test.ts
+++ b/benchmarks/observability/mlflow.test.ts
@@ -1,0 +1,49 @@
+import { flattenMetrics, flattenParams, readMlflowConfig } from './mlflow.js';
+
+describe('benchmark MLflow observability', () => {
+  it('stays disabled unless MLflow env is configured', () => {
+    expect(readMlflowConfig({})).toBeUndefined();
+  });
+
+  it('parses optional MLflow config from env', () => {
+    expect(readMlflowConfig({
+      BENCH_MLFLOW_URI: 'file:/tmp/mlruns',
+      BENCH_MLFLOW_EXPERIMENT: 'kb-local',
+      BENCH_MLFLOW_RUN_NAME: 'trial-1',
+      BENCH_MLFLOW_TAGS: 'suite=beir,dataset=scifact',
+      BENCH_MLFLOW_PYTHON: '/opt/venv/bin/python',
+    })).toEqual({
+      trackingUri: 'file:/tmp/mlruns',
+      experimentName: 'kb-local',
+      runName: 'trial-1',
+      tags: { suite: 'beir', dataset: 'scifact' },
+      python: '/opt/venv/bin/python',
+    });
+  });
+
+  it('flattens numeric benchmark values into MLflow metrics', () => {
+    expect(flattenMetrics({
+      warm_query: { p50_ms: 12, p95_ms: 21 },
+      batch_query: { runs: [{ concurrency: 1, qps_p50: 3.5 }] },
+      ignored: 'not-a-metric',
+    })).toEqual({
+      'warm_query.p50_ms': 12,
+      'warm_query.p95_ms': 21,
+      'batch_query.runs.0.concurrency': 1,
+      'batch_query.runs.0.qps_p50': 3.5,
+    });
+  });
+
+  it('flattens scalar params but skips object arrays', () => {
+    expect(flattenParams({
+      provider: 'stub',
+      version: 1,
+      models: ['a', 'b'],
+      cases: [{ name: 'not scalar' }],
+    })).toEqual({
+      provider: 'stub',
+      version: '1',
+      models: 'a,b',
+    });
+  });
+});

--- a/benchmarks/observability/mlflow.ts
+++ b/benchmarks/observability/mlflow.ts
@@ -1,0 +1,236 @@
+import { spawn } from 'child_process';
+import * as fsp from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import type { BenchmarkReport } from '../types.js';
+
+export interface MlflowConfig {
+  trackingUri?: string;
+  experimentName: string;
+  runName?: string;
+  tags: Record<string, string>;
+  python: string;
+}
+
+export interface MlflowPayload {
+  tracking_uri?: string;
+  experiment_name: string;
+  run_name?: string;
+  tags: Record<string, string>;
+  params: Record<string, string>;
+  metrics: Record<string, number>;
+  artifacts: string[];
+}
+
+export interface MlflowBenchmarkInput {
+  report: BenchmarkReport;
+  reportPath: string;
+  repoRoot: string;
+}
+
+export interface MlflowCompareInput {
+  compareJson: unknown;
+  jsonPath: string;
+  htmlPath: string;
+  repoRoot: string;
+}
+
+const DEFAULT_EXPERIMENT = 'kb-benchmarks';
+
+export function readMlflowConfig(env: NodeJS.ProcessEnv = process.env): MlflowConfig | undefined {
+  const hasConfig = Boolean(
+    env.BENCH_MLFLOW_URI
+      || env.BENCH_MLFLOW_EXPERIMENT
+      || env.BENCH_MLFLOW_RUN_NAME
+      || env.BENCH_MLFLOW_TAGS,
+  );
+  if (!hasConfig) return undefined;
+
+  return {
+    trackingUri: emptyToUndefined(env.BENCH_MLFLOW_URI),
+    experimentName: emptyToUndefined(env.BENCH_MLFLOW_EXPERIMENT) ?? DEFAULT_EXPERIMENT,
+    runName: emptyToUndefined(env.BENCH_MLFLOW_RUN_NAME),
+    tags: parseTags(env.BENCH_MLFLOW_TAGS),
+    python: emptyToUndefined(env.BENCH_MLFLOW_PYTHON) ?? 'python3',
+  };
+}
+
+export async function logBenchmarkToMlflow(
+  input: MlflowBenchmarkInput,
+  config = readMlflowConfig(),
+): Promise<void> {
+  if (!config) return;
+  const payload: MlflowPayload = {
+    ...basePayload(config),
+    params: flattenParams({
+      arch: input.report.arch,
+      git_sha: input.report.git_sha,
+      model_id: input.report.model_id,
+      model_name: input.report.model_name,
+      node_version: input.report.node_version,
+      os: input.report.os,
+      provider: input.report.provider,
+      version: input.report.version,
+    }),
+    metrics: flattenMetrics(input.report.scenarios),
+    artifacts: [input.reportPath],
+  };
+  await runMlflowLogger(payload, input.repoRoot, config.python);
+}
+
+export async function logCompareToMlflow(
+  input: MlflowCompareInput,
+  config = readMlflowConfig(),
+): Promise<void> {
+  if (!config) return;
+  const record = isRecord(input.compareJson) ? input.compareJson : {};
+  const params = flattenParams({
+    kind: 'compare',
+    modelA: pickNested(record, ['modelA']),
+    modelB: pickNested(record, ['modelB']),
+    fixture: pickNested(record, ['fixture']),
+    generatedAt: pickNested(record, ['generatedAt']),
+  });
+  const metrics = flattenMetrics({
+    reportA: pickNested(record, ['reportA', 'scenarios']),
+    reportB: pickNested(record, ['reportB', 'scenarios']),
+    crossModel: pickNested(record, ['crossModel']),
+    goldenQuality: pickNested(record, ['goldenQuality']),
+    cost: pickNested(record, ['cost']),
+  });
+  await runMlflowLogger({
+    ...basePayload(config),
+    params,
+    metrics,
+    artifacts: [input.jsonPath, input.htmlPath],
+  }, input.repoRoot, config.python);
+}
+
+export function flattenMetrics(value: unknown, prefix = ''): Record<string, number> {
+  const out: Record<string, number> = {};
+  collectMetrics(out, value, prefix);
+  return out;
+}
+
+export function flattenParams(value: unknown, prefix = ''): Record<string, string> {
+  const out: Record<string, string> = {};
+  collectParams(out, value, prefix);
+  return out;
+}
+
+function basePayload(config: MlflowConfig): Omit<MlflowPayload, 'params' | 'metrics' | 'artifacts'> {
+  return {
+    ...(config.trackingUri ? { tracking_uri: config.trackingUri } : {}),
+    experiment_name: config.experimentName,
+    ...(config.runName ? { run_name: config.runName } : {}),
+    tags: config.tags,
+  };
+}
+
+async function runMlflowLogger(payload: MlflowPayload, repoRoot: string, python: string): Promise<void> {
+  const payloadPath = path.join(os.tmpdir(), `kb-mlflow-${process.pid}-${Date.now()}.json`);
+  await fsp.writeFile(payloadPath, `${JSON.stringify(payload, null, 2)}\n`, 'utf-8');
+  try {
+    const scriptPath = path.join(repoRoot, 'benchmarks', 'observability', 'mlflow_log.py');
+    await spawnPython(python, [scriptPath, payloadPath], repoRoot);
+  } finally {
+    await fsp.rm(payloadPath, { force: true });
+  }
+}
+
+function spawnPython(python: string, args: string[], cwd: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(python, args, {
+      cwd,
+      stdio: ['ignore', 'inherit', 'inherit'],
+    });
+    child.on('error', reject);
+    child.on('exit', (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`MLflow logger exited with code ${code}`));
+    });
+  });
+}
+
+function collectMetrics(out: Record<string, number>, value: unknown, prefix: string): void {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    if (prefix) out[metricKey(prefix)] = value;
+    return;
+  }
+  if (Array.isArray(value)) {
+    value.forEach((entry, index) => collectMetrics(out, entry, joinKey(prefix, String(index))));
+    return;
+  }
+  if (!isRecord(value)) return;
+  for (const [key, nested] of Object.entries(value)) {
+    collectMetrics(out, nested, joinKey(prefix, key));
+  }
+}
+
+function collectParams(out: Record<string, string>, value: unknown, prefix: string): void {
+  if (value === undefined || value === null) return;
+  if (typeof value === 'string' || typeof value === 'boolean' || typeof value === 'number') {
+    if (prefix) out[paramKey(prefix)] = String(value);
+    return;
+  }
+  if (Array.isArray(value)) {
+    const scalar = value.every((entry) => (
+      entry === null
+        || typeof entry === 'string'
+        || typeof entry === 'boolean'
+        || typeof entry === 'number'
+    ));
+    if (scalar && prefix) {
+      out[paramKey(prefix)] = value.map((entry) => String(entry)).join(',');
+    }
+    return;
+  }
+  if (!isRecord(value)) return;
+  for (const [key, nested] of Object.entries(value)) {
+    collectParams(out, nested, joinKey(prefix, key));
+  }
+}
+
+function parseTags(raw: string | undefined): Record<string, string> {
+  if (!raw) return {};
+  const tags: Record<string, string> = {};
+  for (const pair of raw.split(',')) {
+    const trimmed = pair.trim();
+    if (!trimmed) continue;
+    const index = trimmed.indexOf('=');
+    if (index <= 0) continue;
+    const key = trimmed.slice(0, index).trim();
+    const value = trimmed.slice(index + 1).trim();
+    if (key) tags[key] = value;
+  }
+  return tags;
+}
+
+function metricKey(value: string): string {
+  return value.replace(/[^A-Za-z0-9_.-]/g, '_').slice(0, 250);
+}
+
+function paramKey(value: string): string {
+  return value.replace(/[^A-Za-z0-9_.-]/g, '_').slice(0, 250);
+}
+
+function joinKey(prefix: string, key: string): string {
+  return prefix ? `${prefix}.${key}` : key;
+}
+
+function emptyToUndefined(value: string | undefined): string | undefined {
+  return value && value.trim() ? value.trim() : undefined;
+}
+
+function pickNested(value: Record<string, unknown>, pathParts: string[]): unknown {
+  let cursor: unknown = value;
+  for (const part of pathParts) {
+    if (!isRecord(cursor)) return undefined;
+    cursor = cursor[part];
+  }
+  return cursor;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/benchmarks/observability/mlflow_log.py
+++ b/benchmarks/observability/mlflow_log.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Optional MLflow bridge for kb benchmark runs.
+
+This script is intentionally imported only when BENCH_MLFLOW_* is set. The
+normal benchmark path has no Python or MLflow dependency.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: mlflow_log.py <payload.json>", file=sys.stderr)
+        return 2
+
+    try:
+        import mlflow  # type: ignore
+    except ModuleNotFoundError:
+        print(
+            "MLflow logging requested, but the optional Python package is not installed. "
+            "Install it with `python3 -m pip install mlflow` or unset BENCH_MLFLOW_*.",
+            file=sys.stderr,
+        )
+        return 2
+
+    payload = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+    tracking_uri = payload.get("tracking_uri")
+    if tracking_uri:
+        mlflow.set_tracking_uri(tracking_uri)
+
+    mlflow.set_experiment(payload["experiment_name"])
+    with mlflow.start_run(run_name=payload.get("run_name")):
+        tags: dict[str, str] = payload.get("tags", {})
+        if tags:
+            mlflow.set_tags(tags)
+
+        params: dict[str, str] = payload.get("params", {})
+        if params:
+            mlflow.log_params(params)
+
+        metrics: dict[str, float] = payload.get("metrics", {})
+        for key, value in metrics.items():
+            if isinstance(value, (int, float)):
+                mlflow.log_metric(key, float(value))
+
+        for artifact in payload.get("artifacts", []):
+            path = Path(artifact)
+            if path.exists():
+                mlflow.log_artifact(str(path))
+
+        mlflow.log_dict(_compact_payload(payload), "kb_benchmark_payload.json")
+
+    return 0
+
+
+def _compact_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "experiment_name": payload.get("experiment_name"),
+        "run_name": payload.get("run_name"),
+        "tracking_uri": payload.get("tracking_uri"),
+        "tags": payload.get("tags", {}),
+        "params": payload.get("params", {}),
+        "metric_count": len(payload.get("metrics", {})),
+        "artifacts": payload.get("artifacts", []),
+    }
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/optuna_tune.py
+++ b/benchmarks/optuna_tune.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Optional Optuna runner for kb benchmarks.
+
+The runner is deliberately generic: it proposes environment variables, runs a
+benchmark command, reads the emitted JSON artifact, and returns one metric to
+Optuna. Optuna is only imported when this script is invoked.
+
+Example:
+  python3 benchmarks/optuna_tune.py \
+    --trials=20 \
+    --direction=minimize \
+    --metric=scenarios.warm_query.p95_ms \
+    --param-int=BENCH_FIXTURE_CHUNK_CHARS=256:1536:128 \
+    -- npm run bench
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def main() -> int:
+    args = parse_args()
+
+    try:
+        import optuna  # type: ignore
+    except ModuleNotFoundError:
+        print(
+            "Optuna tuning requested, but the optional Python package is not installed. "
+            "Install it with `python3 -m pip install optuna`.",
+            file=sys.stderr,
+        )
+        return 2
+
+    if not args.command:
+        print("bench:optuna: missing benchmark command after `--`", file=sys.stderr)
+        return 2
+
+    study = optuna.create_study(
+        direction=args.direction,
+        study_name=args.study_name,
+        storage=args.storage,
+        load_if_exists=True,
+    )
+
+    def objective(trial: Any) -> float:
+        env = os.environ.copy()
+        env["BENCH_RESULTS_PREFIX"] = f"optuna-trial-{trial.number}"
+        env["BENCH_OPTUNA_TRIAL"] = str(trial.number)
+        for spec in args.param_int:
+            name, low, high, step = parse_int_spec(spec)
+            env[name] = str(trial.suggest_int(name, low, high, step=step))
+        for spec in args.param_float:
+            name, low, high = parse_float_spec(spec)
+            env[name] = str(trial.suggest_float(name, low, high))
+        for spec in args.param_categorical:
+            name, choices = parse_categorical_spec(spec)
+            env[name] = str(trial.suggest_categorical(name, choices))
+
+        completed = subprocess.run(
+            args.command,
+            env=env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        if completed.returncode != 0:
+            raise RuntimeError(
+                f"benchmark command exited {completed.returncode}\n"
+                f"stdout:\n{completed.stdout}\n"
+                f"stderr:\n{completed.stderr}"
+            )
+
+        artifact_path = find_json_artifact(completed.stdout)
+        report = json.loads(artifact_path.read_text(encoding="utf-8"))
+        value = read_metric(report, args.metric)
+        trial.set_user_attr("artifact", str(artifact_path))
+        for key, val in env.items():
+            if key.startswith(("BENCH_", "KB_")) and key in trial.params:
+                trial.set_user_attr(key, val)
+        return value
+
+    study.optimize(objective, n_trials=args.trials)
+    print(f"study: {study.study_name}")
+    print(f"best_trial: {study.best_trial.number}")
+    print(f"best_value: {study.best_value}")
+    print(f"best_params: {json.dumps(study.best_params, sort_keys=True)}")
+    return 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Tune kb benchmark environment parameters with optional Optuna.",
+    )
+    parser.add_argument("--trials", type=int, default=20)
+    parser.add_argument("--direction", choices=["minimize", "maximize"], default="maximize")
+    parser.add_argument("--metric", required=True, help="Dot path in benchmark JSON, e.g. scenarios.warm_query.p95_ms")
+    parser.add_argument("--study-name", default="kb-bench")
+    parser.add_argument("--storage", help="Optuna storage URL, e.g. sqlite:///benchmarks/results/optuna.db")
+    parser.add_argument("--param-int", action="append", default=[], metavar="NAME=LOW:HIGH[:STEP]")
+    parser.add_argument("--param-float", action="append", default=[], metavar="NAME=LOW:HIGH")
+    parser.add_argument("--param-categorical", action="append", default=[], metavar="NAME=A,B,C")
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    parsed = parser.parse_args()
+    if parsed.command and parsed.command[0] == "--":
+        parsed.command = parsed.command[1:]
+    return parsed
+
+
+def parse_int_spec(spec: str) -> tuple[str, int, int, int]:
+    name, raw = split_spec(spec)
+    parts = raw.split(":")
+    if len(parts) not in (2, 3):
+        raise ValueError(f"invalid --param-int {spec!r}; expected NAME=LOW:HIGH[:STEP]")
+    low = int(parts[0])
+    high = int(parts[1])
+    step = int(parts[2]) if len(parts) == 3 else 1
+    return name, low, high, step
+
+
+def parse_float_spec(spec: str) -> tuple[str, float, float]:
+    name, raw = split_spec(spec)
+    parts = raw.split(":")
+    if len(parts) != 2:
+        raise ValueError(f"invalid --param-float {spec!r}; expected NAME=LOW:HIGH")
+    return name, float(parts[0]), float(parts[1])
+
+
+def parse_categorical_spec(spec: str) -> tuple[str, list[str]]:
+    name, raw = split_spec(spec)
+    choices = [part for part in raw.split(",") if part]
+    if not choices:
+        raise ValueError(f"invalid --param-categorical {spec!r}; expected NAME=A,B,C")
+    return name, choices
+
+
+def split_spec(spec: str) -> tuple[str, str]:
+    if "=" not in spec:
+        raise ValueError(f"invalid parameter spec {spec!r}; expected NAME=...")
+    name, raw = spec.split("=", 1)
+    if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", name):
+        raise ValueError(f"invalid environment variable name {name!r}")
+    return name, raw
+
+
+def find_json_artifact(stdout: str) -> Path:
+    candidates: list[str] = []
+    for line in stdout.splitlines():
+        text = line.strip()
+        if text.startswith("JSON:"):
+            candidates.append(text.split("JSON:", 1)[1].strip())
+        elif text.endswith(".json"):
+            candidates.append(text)
+    for candidate in reversed(candidates):
+        path = Path(candidate)
+        if path.exists():
+            return path
+    raise RuntimeError(f"benchmark command did not print a readable JSON artifact path\nstdout:\n{stdout}")
+
+
+def read_metric(report: Any, metric_path: str) -> float:
+    cursor = report
+    for part in metric_path.split("."):
+        if isinstance(cursor, list):
+            cursor = cursor[int(part)]
+        elif isinstance(cursor, dict):
+            cursor = cursor[part]
+        else:
+            raise KeyError(metric_path)
+    if not isinstance(cursor, (int, float)):
+        raise TypeError(f"metric {metric_path!r} resolved to non-numeric value {cursor!r}")
+    return float(cursor)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/run.ts
+++ b/benchmarks/run.ts
@@ -12,6 +12,7 @@ import { runMemoryScenario } from './scenarios/memory.js';
 import { runRetrievalQualityScenario } from './scenarios/retrieval-quality.js';
 import { runWarmQueryScenario } from './scenarios/warm-query.js';
 import { ensureDirectory, gitSha, resultFileName, writeJsonFile } from './utils.js';
+import { logBenchmarkToMlflow } from './observability/mlflow.js';
 
 const provider = parseProvider(process.env.BENCH_PROVIDER);
 const repoRoot = process.cwd();
@@ -117,6 +118,7 @@ async function main(): Promise<void> {
   };
 
   await writeJsonFile(outputPath, report);
+  await logBenchmarkToMlflow({ report, reportPath: outputPath, repoRoot });
   process.stdout.write(`${outputPath}\n`);
 }
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "build": "tsc -p tsconfig.json && chmod +x build/index.js build/cli.js",
     "bench": "npm run build && tsc -p tsconfig.bench.json && node build/benchmarks/run.js",
     "bench:compare": "npm run build && tsc -p tsconfig.bench.json && node build/benchmarks/compare/run.js",
+    "bench:tune": "python3 benchmarks/optuna_tune.py",
     "docs:check-anchors": "node scripts/check-doc-anchors.mjs",
     "test": "jest --runInBand",
     "test:chaos": "jest --runInBand --testMatch '**/tests/chaos/scenarios/**/*.test.ts'",


### PR DESCRIPTION
## Summary
- add optional MLflow logging for bench and bench:compare via BENCH_MLFLOW_* env vars
- add optional Optuna tuning runner exposed as npm run bench:tune
- document optional setup and keep normal benchmark JSON/HTML artifacts canonical

## Verification
- npx tsc -p tsconfig.bench.json --noEmit
- npx jest benchmarks/observability/mlflow.test.ts --runInBand
- BENCH_PROVIDER=stub BENCH_FIXTURE_FILES=2 BENCH_FIXTURE_CHUNKS_PER_FILE=2 BENCH_INCLUDE_BATCH_QUERY=0 BENCH_INCLUDE_INDEX_STORAGE=0 BENCH_RESULTS_DIR=/tmp/kb-bench-smoke npm run bench
- python3 -m py_compile benchmarks/optuna_tune.py benchmarks/observability/mlflow_log.py
- python3 benchmarks/optuna_tune.py --metric=scenarios.warm_query.p95_ms -- npm run bench (verified missing optional optuna package reports setup guidance)