### PR TITLE
feat(bench): add BEIR SciFact benchmark runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,24 @@ cases:
 
 The MCP server (`knowledge-base-mcp-server` bin) is unchanged and still works with all the configurations in [docs/clients.md](docs/clients.md). The CLI is additive.
 
+### Local retrieval benchmarks
+
+Use `npm run bench:beir` to run a local BEIR/SciFact benchmark with
+credential-free lexical retrieval:
+
+```bash
+npm run bench:beir -- --dataset=scifact --split=test --mode=lexical --output-dir=/tmp/kb-beir-scifact
+```
+
+The runner builds a temporary KB root, emits metrics JSON plus a TREC run file,
+and records reproduction metadata such as git SHA, command, dataset checksum,
+runtime versions, chunking config, and latency percentiles. These are local
+benchmark artifacts, not official BEIR leaderboard submissions; the current
+lexical path is scored at document level by benchmark-only chunk collapse while
+normal `kb search --mode=lexical` remains chunk-level. See
+[benchmarks/README.md](benchmarks/README.md#beirscifact-local-retrieval-benchmark)
+for smoke-test commands and caveats.
+
 ### Local LLM answers (RFC 015)
 
 `kb ask` keeps retrieval deterministic and adds a local OpenAI-compatible chat step on top. It resolves the LLM endpoint from `--endpoint`, `KB_LLM_ENDPOINT`, `--llm-profile`, the active `kb llm` profile, then finally the local-research-agent default on `127.0.0.1:8080`.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -26,6 +26,49 @@ Optional environment variables:
 - `BENCH_CLI_SEARCH_REPETITIONS` sets the per-variant repetition count for `cli_search`. Defaults to 5.
 - `BENCH_CLI_SEARCH_PROFILE=matrix` expands `cli_search` from the compact default profile to a broader local matrix across retrieval modes, scopes, formats, grouping, query shapes, and `k` values.
 
+## BEIR/SciFact local retrieval benchmark
+
+`bench:beir` runs a reproducible local BEIR benchmark, starting with SciFact
+test. It downloads the BEIR zip to a cache, expands `corpus.jsonl`,
+`queries.jsonl`, and `qrels/test.tsv`, converts the corpus into a temporary
+KB root, runs the selected `kb` retrieval primitive, and writes three
+artifacts:
+
+- metrics JSON with `nDCG@10`, `MAP@100`, `Recall@10`, `Recall@100`, latency
+  percentiles, git SHA, dataset checksum/source URL, command, runtime, and
+  chunking metadata
+- a TREC-format run file for external scoring tools
+- a short Markdown report
+
+Lexical mode requires no provider credentials:
+
+```bash
+npm run bench:beir -- \
+  --dataset=scifact \
+  --split=test \
+  --mode=lexical \
+  --output-dir=/tmp/kb-beir-scifact
+```
+
+For a fast deterministic smoke test, limit the query set:
+
+```bash
+npm run bench:beir -- \
+  --dataset=scifact \
+  --split=test \
+  --mode=lexical \
+  --max-queries=3 \
+  --output-dir=/tmp/kb-beir-scifact-smoke
+```
+
+The runner uses `LexicalIndex` chunk BM25 and collapses chunk hits to BEIR
+document IDs by max chunk score before writing TREC rows. That collapse is
+benchmark-only; normal `kb search --mode=lexical` behavior remains chunk-level.
+Reports should be described as a **local BEIR/SciFact benchmark**, not an
+official BEIR leaderboard result. Optional MLflow logging is not required for
+the JSON/TREC artifacts and can be layered in by the separate bench
+observability hook.
+
 ## Result file naming
 
 Reports are written to `benchmarks/results/` with this naming pattern:

--- a/benchmarks/beir/metrics.test.ts
+++ b/benchmarks/beir/metrics.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+  aggregateQueryMetrics,
+  formatTrecRun,
+  parseQrelsTsv,
+  scoreQuery,
+  summarizeLatencies,
+} from './metrics.js';
+
+describe('BEIR benchmark metrics', () => {
+  it('scores BEIR-style qrels with graded nDCG and binary recall/MAP', () => {
+    const qrels = parseQrelsTsv([
+      'query-id corpus-id score',
+      'q1 d1 2',
+      'q1 d2 1',
+      'q1 d3 0',
+      'q2 d9 1',
+    ].join('\n'));
+
+    const scored = scoreQuery('q1', [
+      { docId: 'd2', score: 12 },
+      { docId: 'd3', score: 11 },
+      { docId: 'd1', score: 10 },
+    ], qrels);
+
+    expect(scored).toMatchObject({
+      queryId: 'q1',
+      relevant: 2,
+      retrieved: 3,
+      recallAt10: 1,
+      recallAt100: 1,
+    });
+    expect(scored?.mapAt100).toBeCloseTo(0.833333, 6);
+    expect(scored?.ndcgAt10).toBeCloseTo(0.688529, 6);
+    expect(scored?.ndcgAt10).toBeLessThan(1);
+  });
+
+  it('aggregates query metrics and latency percentiles deterministically', () => {
+    const aggregate = aggregateQueryMetrics([
+      {
+        queryId: 'q1',
+        relevant: 1,
+        retrieved: 1,
+        ndcgAt10: 1,
+        mapAt100: 1,
+        recallAt10: 1,
+        recallAt100: 1,
+      },
+      {
+        queryId: 'q2',
+        relevant: 2,
+        retrieved: 1,
+        ndcgAt10: 0.5,
+        mapAt100: 0.25,
+        recallAt10: 0.5,
+        recallAt100: 0.5,
+      },
+    ]);
+
+    expect(aggregate).toEqual({
+      judgedQueries: 2,
+      ndcgAt10: 0.75,
+      mapAt100: 0.625,
+      recallAt10: 0.75,
+      recallAt100: 0.75,
+    });
+    expect(summarizeLatencies([7, 1, 3, 9, 5])).toEqual({
+      queries: 5,
+      p50Ms: 5,
+      p95Ms: 9,
+      p99Ms: 9,
+      meanMs: 5,
+    });
+  });
+
+  it('emits TREC run rows with stable ranks and score formatting', () => {
+    expect(formatTrecRun([
+      {
+        queryId: 'q1',
+        ranking: [
+          { docId: 'd1', score: 1.23456789 },
+          { docId: 'd2', score: 0 },
+        ],
+      },
+    ], 'kb-lexical')).toBe('q1 Q0 d1 1 1.234568 kb-lexical\nq1 Q0 d2 2 0.000000 kb-lexical\n');
+  });
+});

--- a/benchmarks/beir/metrics.ts
+++ b/benchmarks/beir/metrics.ts
@@ -1,0 +1,197 @@
+export interface Qrels {
+  byQuery: Map<string, Map<string, number>>;
+}
+
+export interface RankedDocument {
+  docId: string;
+  score: number;
+}
+
+export interface QueryMetric {
+  queryId: string;
+  relevant: number;
+  retrieved: number;
+  ndcgAt10: number;
+  mapAt100: number;
+  recallAt10: number;
+  recallAt100: number;
+}
+
+export interface AggregateMetrics {
+  judgedQueries: number;
+  ndcgAt10: number;
+  mapAt100: number;
+  recallAt10: number;
+  recallAt100: number;
+}
+
+export interface LatencySummary {
+  queries: number;
+  p50Ms: number;
+  p95Ms: number;
+  p99Ms: number;
+  meanMs: number;
+}
+
+export function parseQrelsTsv(raw: string): Qrels {
+  const byQuery = new Map<string, Map<string, number>>();
+  const lines = raw.split(/\r?\n/);
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const parts = trimmed.split(/\s+/);
+    if (parts.length < 3) continue;
+    if (parts[0] === 'query-id' || parts[0] === 'query_id') continue;
+
+    const queryId = parts[0];
+    const docId = parts[1];
+    const relevance = Number(parts[2]);
+    if (!Number.isFinite(relevance)) {
+      continue;
+    }
+    let docs = byQuery.get(queryId);
+    if (docs === undefined) {
+      docs = new Map();
+      byQuery.set(queryId, docs);
+    }
+    docs.set(docId, relevance);
+  }
+  return { byQuery };
+}
+
+export function scoreQuery(
+  queryId: string,
+  ranking: readonly RankedDocument[],
+  qrels: Qrels,
+): QueryMetric | null {
+  const labels = qrels.byQuery.get(queryId);
+  if (labels === undefined) {
+    return null;
+  }
+  const relevantEntries = [...labels.entries()].filter(([, relevance]) => relevance > 0);
+  if (relevantEntries.length === 0) {
+    return null;
+  }
+
+  const relevantDocIds = new Set(relevantEntries.map(([docId]) => docId));
+  const relevanceByDoc = new Map(relevantEntries);
+  const uniqueRanking = dedupeRanking(ranking);
+  return {
+    queryId,
+    relevant: relevantDocIds.size,
+    retrieved: uniqueRanking.length,
+    ndcgAt10: roundMetric(ndcgAt(uniqueRanking, relevanceByDoc, 10)),
+    mapAt100: roundMetric(averagePrecisionAt(uniqueRanking, relevantDocIds, 100)),
+    recallAt10: roundMetric(recallAt(uniqueRanking, relevantDocIds, 10)),
+    recallAt100: roundMetric(recallAt(uniqueRanking, relevantDocIds, 100)),
+  };
+}
+
+export function aggregateQueryMetrics(metrics: readonly QueryMetric[]): AggregateMetrics {
+  return {
+    judgedQueries: metrics.length,
+    ndcgAt10: roundMetric(mean(metrics.map((metric) => metric.ndcgAt10))),
+    mapAt100: roundMetric(mean(metrics.map((metric) => metric.mapAt100))),
+    recallAt10: roundMetric(mean(metrics.map((metric) => metric.recallAt10))),
+    recallAt100: roundMetric(mean(metrics.map((metric) => metric.recallAt100))),
+  };
+}
+
+export function summarizeLatencies(latenciesMs: readonly number[]): LatencySummary {
+  return {
+    queries: latenciesMs.length,
+    p50Ms: percentile(latenciesMs, 50),
+    p95Ms: percentile(latenciesMs, 95),
+    p99Ms: percentile(latenciesMs, 99),
+    meanMs: roundMetric(mean(latenciesMs)),
+  };
+}
+
+export function formatTrecRun(
+  rows: ReadonlyArray<{ queryId: string; ranking: readonly RankedDocument[] }>,
+  runTag: string,
+): string {
+  const lines: string[] = [];
+  for (const row of rows) {
+    row.ranking.forEach((doc, index) => {
+      const score = Number.isFinite(doc.score) ? doc.score : 0;
+      lines.push(`${row.queryId} Q0 ${doc.docId} ${index + 1} ${score.toFixed(6)} ${runTag}`);
+    });
+  }
+  return `${lines.join('\n')}${lines.length > 0 ? '\n' : ''}`;
+}
+
+function dedupeRanking(ranking: readonly RankedDocument[]): RankedDocument[] {
+  const seen = new Set<string>();
+  const out: RankedDocument[] = [];
+  for (const item of ranking) {
+    if (seen.has(item.docId)) continue;
+    seen.add(item.docId);
+    out.push(item);
+  }
+  return out;
+}
+
+function recallAt(ranking: readonly RankedDocument[], relevantDocIds: Set<string>, k: number): number {
+  if (relevantDocIds.size === 0) return 0;
+  let hits = 0;
+  for (const item of ranking.slice(0, k)) {
+    if (relevantDocIds.has(item.docId)) hits += 1;
+  }
+  return hits / relevantDocIds.size;
+}
+
+function averagePrecisionAt(
+  ranking: readonly RankedDocument[],
+  relevantDocIds: Set<string>,
+  k: number,
+): number {
+  if (relevantDocIds.size === 0) return 0;
+  let hits = 0;
+  let precisionSum = 0;
+  ranking.slice(0, k).forEach((item, index) => {
+    if (!relevantDocIds.has(item.docId)) return;
+    hits += 1;
+    precisionSum += hits / (index + 1);
+  });
+  return precisionSum / relevantDocIds.size;
+}
+
+function ndcgAt(
+  ranking: readonly RankedDocument[],
+  relevanceByDoc: Map<string, number>,
+  k: number,
+): number {
+  const dcg = ranking.slice(0, k).reduce((sum, item, index) => {
+    const relevance = relevanceByDoc.get(item.docId) ?? 0;
+    return sum + discountedGain(relevance, index + 1);
+  }, 0);
+  const ideal = [...relevanceByDoc.values()]
+    .sort((left, right) => right - left)
+    .slice(0, k)
+    .reduce((sum, relevance, index) => sum + discountedGain(relevance, index + 1), 0);
+  return ideal === 0 ? 0 : dcg / ideal;
+}
+
+function discountedGain(relevance: number, rank: number): number {
+  return (2 ** relevance - 1) / Math.log2(rank + 1);
+}
+
+function percentile(values: readonly number[], percentileValue: number): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((left, right) => left - right);
+  const index = Math.min(
+    sorted.length - 1,
+    Math.max(0, Math.ceil((percentileValue / 100) * sorted.length) - 1),
+  );
+  return roundMetric(sorted[index]);
+}
+
+function mean(values: readonly number[]): number {
+  if (values.length === 0) return 0;
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+function roundMetric(value: number): number {
+  return Number(value.toFixed(6));
+}

--- a/benchmarks/beir/run.test.ts
+++ b/benchmarks/beir/run.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from '@jest/globals';
+import * as fsp from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  parseArgs,
+  runBeirBenchmark,
+  type LexicalIndexLike,
+} from './run.js';
+
+async function writeTinyBeirDataset(root: string): Promise<string> {
+  const datasetDir = path.join(root, 'tiny');
+  await fsp.mkdir(path.join(datasetDir, 'qrels'), { recursive: true });
+  await fsp.writeFile(path.join(datasetDir, 'corpus.jsonl'), [
+    JSON.stringify({ _id: 'doc-alpha', title: 'Alpha', text: 'Alpha benchmark evidence.' }),
+    JSON.stringify({ _id: 'doc-beta', title: 'Beta', text: 'Beta benchmark evidence.' }),
+    '',
+  ].join('\n'), 'utf-8');
+  await fsp.writeFile(path.join(datasetDir, 'queries.jsonl'), [
+    JSON.stringify({ _id: 'q1', text: 'alpha evidence' }),
+    '',
+  ].join('\n'), 'utf-8');
+  await fsp.writeFile(path.join(datasetDir, 'qrels', 'test.tsv'), [
+    'query-id corpus-id score',
+    'q1 doc-alpha 1',
+    '',
+  ].join('\n'), 'utf-8');
+  return datasetDir;
+}
+
+describe('BEIR benchmark runner', () => {
+  it('writes metrics JSON, TREC, and Markdown artifacts for a tiny local dataset', async () => {
+    const root = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-beir-run-test-'));
+    const datasetDir = await writeTinyBeirDataset(root);
+    const outputDir = path.join(root, 'out');
+    const workspaceRoot = path.join(root, 'kb-beir-workspace');
+
+    const args = parseArgs([
+      '--dataset=tiny',
+      `--dataset-dir=${datasetDir}`,
+      '--split=test',
+      '--mode=lexical',
+      `--output-dir=${outputDir}`,
+      `--workspace-root=${workspaceRoot}`,
+      '--k=10',
+      '--chunk-k=10',
+    ]);
+
+    const result = await runBeirBenchmark(args, {
+      gitSha: async () => 'test-sha',
+      now: () => new Date('2026-05-27T12:00:00.000Z'),
+      pythonVersion: async () => 'Python 3.test',
+      silenceServerLogger: async () => undefined,
+      loadLexicalIndex: async (_buildRoot, _kbName, kbPath): Promise<LexicalIndexLike> => {
+        const files = await fsp.readdir(kbPath);
+        const alphaFile = files.find((file) => file.includes('doc-alpha'));
+        if (alphaFile === undefined) {
+          throw new Error('tiny dataset did not produce a doc-alpha markdown file');
+        }
+        return {
+          refresh: async () => ({
+            added: 2,
+            updated: 0,
+            removed: 0,
+            failed: 0,
+            totalFiles: 2,
+            totalChunks: 2,
+          }),
+          save: async () => undefined,
+          query: async () => [{
+            metadata: { source: path.join(kbPath, alphaFile) },
+            score: 42,
+          }],
+          numChunks: () => 2,
+          numFiles: () => 2,
+        };
+      },
+    });
+
+    const json = JSON.parse(await fsp.readFile(result.jsonPath, 'utf-8')) as {
+      git_sha: string;
+      metrics: { ndcgAt10: number; mapAt100: number; recallAt10: number; recallAt100: number };
+      dataset: { corpus_documents: number; queries_evaluated: number };
+    };
+    expect(json.git_sha).toBe('test-sha');
+    expect(json.dataset).toMatchObject({ corpus_documents: 2, queries_evaluated: 1 });
+    expect(json.metrics).toMatchObject({
+      ndcgAt10: 1,
+      mapAt100: 1,
+      recallAt10: 1,
+      recallAt100: 1,
+    });
+    await expect(fsp.readFile(result.trecPath, 'utf-8')).resolves.toBe(
+      'q1 Q0 doc-alpha 1 42.000000 kb-tiny-lexical-docrank\n',
+    );
+    await expect(fsp.readFile(result.reportPath, 'utf-8')).resolves.toContain(
+      'This is a local BEIR benchmark run, not an official leaderboard submission.',
+    );
+    await expect(fsp.stat(workspaceRoot)).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('refuses to use the repository checkout as a destructive workspace root', async () => {
+    const args = parseArgs([
+      '--dataset=scifact',
+      `--workspace-root=${process.cwd()}`,
+      `--output-dir=${path.join(os.tmpdir(), 'kb-beir-safe-workspace-out')}`,
+    ]);
+
+    await expect(runBeirBenchmark(args, {
+      gitSha: async () => 'unused',
+      loadLexicalIndex: async () => {
+        throw new Error('should not load lexical index');
+      },
+      now: () => new Date('2026-05-27T12:00:00.000Z'),
+      pythonVersion: async () => null,
+      silenceServerLogger: async () => undefined,
+    })).rejects.toThrow('--workspace-root must not be the repository root or one of its parents');
+  });
+});

--- a/benchmarks/beir/run.ts
+++ b/benchmarks/beir/run.ts
@@ -1,0 +1,655 @@
+import * as crypto from 'crypto';
+import * as fsp from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import { pathToFileURL } from 'url';
+import {
+  aggregateQueryMetrics,
+  formatTrecRun,
+  parseQrelsTsv,
+  scoreQuery,
+  summarizeLatencies,
+  type Qrels,
+  type RankedDocument,
+  type QueryMetric,
+} from './metrics.js';
+import { durationMs, ensureDirectory, gitSha, resetDirectory, writeJsonFile } from '../utils.js';
+
+const execFileAsync = promisify(execFile);
+
+const DATASET_URLS: Record<string, string> = {
+  scifact: 'https://public.ukp.informatik.tu-darmstadt.de/thakur/BEIR/datasets/scifact.zip',
+};
+
+const BENCHMARK_SCHEMA_VERSION = 'kb.beir-benchmark.v1';
+
+interface Args {
+  dataset: string;
+  split: string;
+  mode: 'lexical';
+  outputDir: string;
+  cacheDir: string;
+  workspaceRoot: string;
+  datasetDir?: string;
+  datasetUrl?: string;
+  k: number;
+  chunkK: number;
+  maxQueries?: number;
+  keepWorkspace: boolean;
+}
+
+interface BeirCorpusRow {
+  _id: string;
+  title?: string;
+  text?: string;
+}
+
+interface BeirQueryRow {
+  _id: string;
+  text: string;
+}
+
+interface CorpusPreparation {
+  kbName: string;
+  kbPath: string;
+  docIdByRelativePath: Map<string, string>;
+  documents: number;
+}
+
+export interface LexicalIndexLike {
+  refresh(): Promise<{ added: number; updated: number; removed: number; failed: number; totalFiles: number; totalChunks: number }>;
+  save(): Promise<void>;
+  query(query: string, k: number): Promise<Array<{ metadata: Record<string, unknown>; score: number }>>;
+  numChunks(): number;
+  numFiles(): number;
+}
+
+interface LexicalIndexModule {
+  LexicalIndex: {
+    load(kbName: string, kbPath: string): Promise<LexicalIndexLike>;
+  };
+}
+
+interface BeirBenchmarkReport {
+  schema_version: typeof BENCHMARK_SCHEMA_VERSION;
+  generated_at: string;
+  git_sha: string;
+  command: string;
+  dataset: {
+    name: string;
+    split: string;
+    source_url: string | null;
+    checksum_sha256: string;
+    corpus_documents: number;
+    queries_total: number;
+    qrels_queries: number;
+    queries_evaluated: number;
+  };
+  mode: Args['mode'];
+  ranking: {
+    unit: 'document';
+    implementation: string;
+    trec_run: string;
+    k: number;
+    chunk_candidate_k: number;
+  };
+  chunking: {
+    KB_CHUNK_SIZE: string | null;
+    KB_CHUNK_OVERLAP: string | null;
+  };
+  runtime: {
+    node_version: string;
+    python_version: string | null;
+    os: string;
+    arch: string;
+  };
+  indexing: {
+    ms: number;
+    refresh: Awaited<ReturnType<LexicalIndexLike['refresh']>>;
+    files: number;
+    chunks: number;
+  };
+  metrics: ReturnType<typeof aggregateQueryMetrics>;
+  latency: ReturnType<typeof summarizeLatencies>;
+  per_query: QueryMetric[];
+  caveats: string[];
+}
+
+export interface BeirBenchmarkRunResult {
+  jsonPath: string;
+  trecPath: string;
+  reportPath: string;
+  report: BeirBenchmarkReport;
+}
+
+interface RunDependencies {
+  gitSha(repoRoot: string): Promise<string>;
+  loadLexicalIndex(buildRoot: string, kbName: string, kbPath: string): Promise<LexicalIndexLike>;
+  now(): Date;
+  pythonVersion(): Promise<string | null>;
+  silenceServerLogger(buildRoot: string): Promise<void>;
+}
+
+const defaultRunDependencies: RunDependencies = {
+  gitSha,
+  loadLexicalIndex,
+  now: () => new Date(),
+  pythonVersion,
+  silenceServerLogger,
+};
+
+async function main(): Promise<void> {
+  const result = await runBeirBenchmark(parseArgs(process.argv.slice(2)));
+  process.stdout.write(`${result.jsonPath}\n${result.trecPath}\n${result.reportPath}\n`);
+}
+
+export async function runBeirBenchmark(
+  args: Args,
+  dependencies: RunDependencies = defaultRunDependencies,
+): Promise<BeirBenchmarkRunResult> {
+  await assertSafeWorkspaceRoot(args.workspaceRoot, args.outputDir);
+  await ensureDirectory(args.outputDir);
+  await resetDirectory(args.workspaceRoot);
+
+  const dataset = await ensureDataset(args);
+  const queries = await readJsonlFile<BeirQueryRow>(path.join(dataset.datasetDir, 'queries.jsonl'));
+  const qrelsPath = path.join(dataset.datasetDir, 'qrels', `${args.split}.tsv`);
+  const qrels = parseQrelsTsv(await fsp.readFile(qrelsPath, 'utf-8'));
+  const selectedQueries = selectQueries(queries, qrels, args.maxQueries);
+
+  const knowledgeBasesRootDir = path.join(args.workspaceRoot, 'knowledge-bases');
+  const faissIndexPath = path.join(args.workspaceRoot, '.faiss');
+  const prepared = await prepareCorpus({
+    datasetName: args.dataset,
+    datasetDir: dataset.datasetDir,
+    knowledgeBasesRootDir,
+  });
+
+  configureBenchmarkEnvironment(knowledgeBasesRootDir, faissIndexPath);
+  await dependencies.silenceServerLogger(path.join(process.cwd(), 'build'));
+  const lexicalIndex = await dependencies.loadLexicalIndex(path.join(process.cwd(), 'build'), prepared.kbName, prepared.kbPath);
+  const indexStarted = process.hrtime.bigint();
+  const refresh = await lexicalIndex.refresh();
+  await lexicalIndex.save();
+  const indexMs = durationMs(indexStarted, process.hrtime.bigint());
+
+  const queryRows: Array<{ queryId: string; ranking: RankedDocument[] }> = [];
+  const perQuery: QueryMetric[] = [];
+  const latenciesMs: number[] = [];
+
+  for (const query of selectedQueries) {
+    const started = process.hrtime.bigint();
+    const chunks = await lexicalIndex.query(query.text, args.chunkK);
+    const latency = durationMs(started, process.hrtime.bigint());
+    latenciesMs.push(latency);
+    const ranking = collapseChunksToDocuments(chunks, prepared.docIdByRelativePath, args.k);
+    queryRows.push({ queryId: query._id, ranking });
+    const scored = scoreQuery(query._id, ranking, qrels);
+    if (scored !== null) {
+      perQuery.push(scored);
+    }
+  }
+
+  const runTag = `kb-${args.dataset}-${args.mode}-docrank`;
+  const trecPath = path.join(args.outputDir, `${runTag}-run.trec`);
+  const jsonPath = path.join(args.outputDir, `${runTag}-results.json`);
+  const reportPath = path.join(args.outputDir, `${runTag}-report.md`);
+  await fsp.writeFile(trecPath, formatTrecRun(queryRows, runTag), 'utf-8');
+
+  const report: BeirBenchmarkReport = {
+    schema_version: BENCHMARK_SCHEMA_VERSION,
+    generated_at: dependencies.now().toISOString(),
+    git_sha: await dependencies.gitSha(process.cwd()),
+    command: ['node', ...process.argv.slice(1)].join(' '),
+    dataset: {
+      name: args.dataset,
+      split: args.split,
+      source_url: dataset.sourceUrl,
+      checksum_sha256: dataset.checksumSha256,
+      corpus_documents: prepared.documents,
+      queries_total: queries.length,
+      qrels_queries: qrels.byQuery.size,
+      queries_evaluated: selectedQueries.length,
+    },
+    mode: args.mode,
+    ranking: {
+      unit: 'document',
+      implementation: 'LexicalIndex chunk BM25 collapsed by BEIR document id using max chunk score',
+      trec_run: trecPath,
+      k: args.k,
+      chunk_candidate_k: args.chunkK,
+    },
+    chunking: {
+      KB_CHUNK_SIZE: process.env.KB_CHUNK_SIZE ?? null,
+      KB_CHUNK_OVERLAP: process.env.KB_CHUNK_OVERLAP ?? null,
+    },
+    runtime: {
+      node_version: process.version,
+      python_version: await dependencies.pythonVersion(),
+      os: os.platform(),
+      arch: os.arch(),
+    },
+    indexing: {
+      ms: Number(indexMs.toFixed(3)),
+      refresh,
+      files: lexicalIndex.numFiles(),
+      chunks: lexicalIndex.numChunks(),
+    },
+    metrics: aggregateQueryMetrics(perQuery),
+    latency: summarizeLatencies(latenciesMs),
+    per_query: perQuery,
+    caveats: [
+      'This is a local BEIR/SciFact benchmark, not an official leaderboard submission.',
+      'Lexical mode requires no provider credentials.',
+      'Scores are document-level after benchmark-only chunk collapse; normal kb search lexical output remains chunk-level.',
+      'MLflow logging is not required for JSON/TREC artifacts; optional logging is expected to come from the bench observability hook.',
+    ],
+  };
+
+  await writeJsonFile(jsonPath, report);
+  await fsp.writeFile(reportPath, formatMarkdownReport(report, trecPath, jsonPath), 'utf-8');
+
+  if (!args.keepWorkspace) {
+    await fsp.rm(args.workspaceRoot, { recursive: true, force: true });
+  }
+
+  return { jsonPath, trecPath, reportPath, report };
+}
+
+export function parseArgs(argv: string[]): Args {
+  const repoRoot = process.cwd();
+  const args: Args = {
+    dataset: 'scifact',
+    split: 'test',
+    mode: 'lexical',
+    outputDir: path.join(repoRoot, 'benchmarks', 'results'),
+    cacheDir: process.env.BEIR_CACHE_DIR ?? path.join(os.tmpdir(), 'kb-beir-cache'),
+    workspaceRoot: path.join(os.tmpdir(), `kb-beir-${process.pid}-${Date.now()}`),
+    k: 100,
+    chunkK: 1000,
+    keepWorkspace: false,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    const [flag, inlineValue] = token.includes('=') ? token.split(/=(.*)/s, 2) : [token, undefined];
+    const readValue = (): string => {
+      if (inlineValue !== undefined) return inlineValue;
+      i += 1;
+      const value = argv[i];
+      if (value === undefined || value.startsWith('--')) {
+        throw new Error(`${flag} requires a value`);
+      }
+      return value;
+    };
+
+    if (flag === '--dataset') {
+      args.dataset = readValue();
+    } else if (flag === '--split') {
+      args.split = readValue();
+    } else if (flag === '--mode') {
+      const mode = readValue();
+      if (mode !== 'lexical') throw new Error('BEIR benchmark currently supports --mode=lexical only');
+      args.mode = mode;
+    } else if (flag === '--dataset-dir') {
+      args.datasetDir = path.resolve(readValue());
+    } else if (flag === '--dataset-url') {
+      args.datasetUrl = readValue();
+    } else if (flag === '--output-dir') {
+      args.outputDir = path.resolve(readValue());
+    } else if (flag === '--cache-dir') {
+      args.cacheDir = path.resolve(readValue());
+    } else if (flag === '--workspace-root') {
+      args.workspaceRoot = path.resolve(readValue());
+    } else if (flag === '--k') {
+      args.k = parsePositiveInteger(readValue(), '--k');
+    } else if (flag === '--chunk-k') {
+      args.chunkK = parsePositiveInteger(readValue(), '--chunk-k');
+    } else if (flag === '--max-queries') {
+      args.maxQueries = parsePositiveInteger(readValue(), '--max-queries');
+    } else if (flag === '--keep-workspace') {
+      args.keepWorkspace = true;
+    } else if (flag === '--help' || flag === '-h') {
+      process.stdout.write(helpText());
+      process.exit(0);
+    } else {
+      throw new Error(`unknown argument: ${token}`);
+    }
+  }
+
+  if (!Object.hasOwn(DATASET_URLS, args.dataset) && args.datasetDir === undefined && args.datasetUrl === undefined) {
+    throw new Error(`unsupported dataset "${args.dataset}"; pass --dataset-dir or --dataset-url for custom BEIR data`);
+  }
+  args.chunkK = Math.max(args.chunkK, args.k);
+  return args;
+}
+
+async function ensureDataset(args: Args): Promise<{ datasetDir: string; sourceUrl: string | null; checksumSha256: string }> {
+  if (args.datasetDir !== undefined) {
+    await assertDatasetShape(args.datasetDir, args.split);
+    return {
+      datasetDir: args.datasetDir,
+      sourceUrl: null,
+      checksumSha256: await hashDatasetFiles(args.datasetDir, args.split),
+    };
+  }
+
+  const sourceUrl = args.datasetUrl ?? DATASET_URLS[args.dataset];
+  const datasetDir = path.join(args.cacheDir, datasetCacheKey(args.dataset, sourceUrl, args.datasetUrl !== undefined));
+  if (await datasetExists(datasetDir, args.split)) {
+    return {
+      datasetDir,
+      sourceUrl,
+      checksumSha256: await hashDatasetFiles(datasetDir, args.split),
+    };
+  }
+
+  await ensureDirectory(args.cacheDir);
+  const zipPath = path.join(args.cacheDir, `${args.dataset}.zip`);
+  const zipBytes = await downloadBytes(sourceUrl);
+  await fsp.writeFile(zipPath, zipBytes);
+  await unzip(zipPath, args.cacheDir);
+  await assertDatasetShape(datasetDir, args.split);
+  return {
+    datasetDir,
+    sourceUrl,
+    checksumSha256: await hashDatasetFiles(datasetDir, args.split),
+  };
+}
+
+function datasetCacheKey(dataset: string, sourceUrl: string, customUrl: boolean): string {
+  if (!customUrl) return dataset;
+  const sourceHash = crypto.createHash('sha1').update(sourceUrl).digest('hex').slice(0, 12);
+  return `${dataset}-${sourceHash}`;
+}
+
+async function assertSafeWorkspaceRoot(workspaceRoot: string, outputDir: string): Promise<void> {
+  const resolvedWorkspace = path.resolve(workspaceRoot);
+  const resolvedOutput = path.resolve(outputDir);
+  const repoRoot = process.cwd();
+  if (resolvedWorkspace === path.parse(resolvedWorkspace).root) {
+    throw new Error('--workspace-root must not be a filesystem root');
+  }
+  if (resolvedWorkspace === repoRoot || isAncestorPath(resolvedWorkspace, repoRoot)) {
+    throw new Error('--workspace-root must not be the repository root or one of its parents');
+  }
+  if (resolvedWorkspace === resolvedOutput || isAncestorPath(resolvedWorkspace, resolvedOutput)) {
+    throw new Error('--workspace-root must not contain --output-dir because it is removed after the run');
+  }
+
+  let stat;
+  try {
+    stat = await fsp.stat(resolvedWorkspace);
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT') return;
+    throw error;
+  }
+  if (!stat.isDirectory()) {
+    throw new Error('--workspace-root must be a directory or a path that does not exist yet');
+  }
+
+  const entries = await fsp.readdir(resolvedWorkspace);
+  if (entries.length > 0 && !path.basename(resolvedWorkspace).startsWith('kb-beir-')) {
+    throw new Error('--workspace-root already exists and is not empty; use an empty directory or a kb-beir-* temp directory');
+  }
+}
+
+function isAncestorPath(parent: string, child: string): boolean {
+  const relative = path.relative(parent, child);
+  return relative !== '' && !relative.startsWith('..') && !path.isAbsolute(relative);
+}
+
+async function prepareCorpus(options: {
+  datasetName: string;
+  datasetDir: string;
+  knowledgeBasesRootDir: string;
+}): Promise<CorpusPreparation> {
+  const kbName = options.datasetName;
+  const kbPath = path.join(options.knowledgeBasesRootDir, kbName);
+  await resetDirectory(kbPath);
+  const corpus = await readJsonlFile<BeirCorpusRow>(path.join(options.datasetDir, 'corpus.jsonl'));
+  const docIdByRelativePath = new Map<string, string>();
+  let index = 0;
+  for (const row of corpus) {
+    const fileName = safeDocFileName(row._id, index);
+    const relativePath = `${kbName}/${fileName}`;
+    docIdByRelativePath.set(relativePath, row._id);
+    const body = [
+      '---',
+      `title: ${yamlScalar(row.title ?? row._id)}`,
+      '---',
+      '',
+      row.title ? `# ${row.title}` : `# ${row._id}`,
+      '',
+      row.text ?? '',
+      '',
+    ].join('\n');
+    await fsp.writeFile(path.join(kbPath, fileName), body, 'utf-8');
+    index += 1;
+  }
+  return { kbName, kbPath, docIdByRelativePath, documents: corpus.length };
+}
+
+function selectQueries(queries: readonly BeirQueryRow[], qrels: Qrels, maxQueries?: number): BeirQueryRow[] {
+  const selected = queries.filter((query) => qrels.byQuery.has(query._id));
+  return maxQueries === undefined ? selected : selected.slice(0, maxQueries);
+}
+
+function collapseChunksToDocuments(
+  chunks: ReadonlyArray<{ metadata: Record<string, unknown>; score: number }>,
+  docIdByRelativePath: Map<string, string>,
+  k: number,
+): RankedDocument[] {
+  const best = new Map<string, number>();
+  for (const chunk of chunks) {
+    const docId = docIdFromMetadata(chunk.metadata, docIdByRelativePath);
+    if (docId === null) continue;
+    const previous = best.get(docId);
+    if (previous === undefined || chunk.score > previous) {
+      best.set(docId, chunk.score);
+    }
+  }
+  return [...best.entries()]
+    .map(([docId, score]) => ({ docId, score }))
+    .sort((left, right) => right.score - left.score || left.docId.localeCompare(right.docId))
+    .slice(0, k);
+}
+
+function docIdFromMetadata(metadata: Record<string, unknown>, docIdByRelativePath: Map<string, string>): string | null {
+  const relativePath = typeof metadata.relativePath === 'string' ? metadata.relativePath : null;
+  if (relativePath !== null) {
+    const docId = docIdByRelativePath.get(relativePath);
+    if (docId !== undefined) return docId;
+  }
+  const source = typeof metadata.source === 'string' ? metadata.source : null;
+  if (source !== null) {
+    const normalized = source.split(path.sep).join('/');
+    for (const [relPath, docId] of docIdByRelativePath) {
+      if (normalized.endsWith(relPath)) return docId;
+    }
+  }
+  return null;
+}
+
+async function loadLexicalIndex(buildRoot: string, kbName: string, kbPath: string): Promise<LexicalIndexLike> {
+  const moduleUrl = pathToFileURL(path.join(buildRoot, 'lexical-index.js')).href;
+  const module = await import(moduleUrl) as LexicalIndexModule;
+  return module.LexicalIndex.load(kbName, kbPath);
+}
+
+async function silenceServerLogger(buildRoot: string): Promise<void> {
+  const moduleUrl = pathToFileURL(path.join(buildRoot, 'logger.js')).href;
+  const loggerModule = await import(moduleUrl) as {
+    logger: Record<'debug' | 'error' | 'info' | 'warn', (...args: unknown[]) => void>;
+  };
+  loggerModule.logger.debug = () => undefined;
+  loggerModule.logger.info = () => undefined;
+  loggerModule.logger.warn = () => undefined;
+}
+
+function configureBenchmarkEnvironment(knowledgeBasesRootDir: string, faissIndexPath: string): void {
+  process.env.KNOWLEDGE_BASES_ROOT_DIR = knowledgeBasesRootDir;
+  process.env.FAISS_INDEX_PATH = faissIndexPath;
+  process.env.LOG_FILE = path.join(faissIndexPath, 'beir-bench.log');
+}
+
+async function readJsonlFile<T extends { _id: string }>(filePath: string): Promise<T[]> {
+  const raw = await fsp.readFile(filePath, 'utf-8');
+  const rows: T[] = [];
+  raw.split(/\r?\n/).forEach((line, index) => {
+    const trimmed = line.trim();
+    if (!trimmed) return;
+    const parsed = JSON.parse(trimmed) as unknown;
+    if (!isRecord(parsed) || typeof parsed._id !== 'string') {
+      throw new Error(`${filePath}:${index + 1}: expected JSON object with string _id`);
+    }
+    rows.push(parsed as T);
+  });
+  return rows;
+}
+
+async function assertDatasetShape(datasetDir: string, split: string): Promise<void> {
+  const required = [
+    path.join(datasetDir, 'corpus.jsonl'),
+    path.join(datasetDir, 'queries.jsonl'),
+    path.join(datasetDir, 'qrels', `${split}.tsv`),
+  ];
+  for (const filePath of required) {
+    await fsp.access(filePath);
+  }
+}
+
+async function datasetExists(datasetDir: string, split: string): Promise<boolean> {
+  try {
+    await assertDatasetShape(datasetDir, split);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function downloadBytes(url: string): Promise<Buffer> {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`download failed for ${url}: HTTP ${response.status}`);
+  }
+  return Buffer.from(await response.arrayBuffer());
+}
+
+async function unzip(zipPath: string, destination: string): Promise<void> {
+  await execFileAsync('python3', ['-c', [
+    'import sys, zipfile',
+    'with zipfile.ZipFile(sys.argv[1]) as z:',
+    '    z.extractall(sys.argv[2])',
+  ].join('\n'), zipPath, destination], { maxBuffer: 1024 * 1024 });
+}
+
+async function pythonVersion(): Promise<string | null> {
+  try {
+    const { stdout, stderr } = await execFileAsync('python3', ['--version']);
+    return (stdout || stderr).trim();
+  } catch {
+    return null;
+  }
+}
+
+async function hashDatasetFiles(datasetDir: string, split: string): Promise<string> {
+  const hash = crypto.createHash('sha256');
+  for (const relPath of ['corpus.jsonl', 'queries.jsonl', path.join('qrels', `${split}.tsv`)]) {
+    hash.update(relPath);
+    hash.update(await fsp.readFile(path.join(datasetDir, relPath)));
+  }
+  return hash.digest('hex');
+}
+
+function safeDocFileName(docId: string, index: number): string {
+  const readable = docId.replace(/[^A-Za-z0-9._-]+/g, '_').replace(/^_+|_+$/g, '').slice(0, 80) || `doc-${index}`;
+  const suffix = crypto.createHash('sha1').update(docId).digest('hex').slice(0, 12);
+  return `${readable}-${suffix}.md`;
+}
+
+function yamlScalar(value: string): string {
+  return JSON.stringify(value);
+}
+
+function formatMarkdownReport(report: BeirBenchmarkReport, trecPath: string, jsonPath: string): string {
+  const { dataset, latency, metrics } = report;
+  return [
+    `# BEIR/${dataset.name} local benchmark`,
+    '',
+    'This is a local BEIR benchmark run, not an official leaderboard submission.',
+    '',
+    '## Results',
+    '',
+    `- Dataset: ${dataset.name} ${dataset.split}`,
+    `- Corpus documents: ${dataset.corpus_documents}`,
+    `- Queries evaluated: ${dataset.queries_evaluated}`,
+    `- nDCG@10: ${metrics.ndcgAt10}`,
+    `- MAP@100: ${metrics.mapAt100}`,
+    `- Recall@10: ${metrics.recallAt10}`,
+    `- Recall@100: ${metrics.recallAt100}`,
+    `- Query latency: p50 ${latency.p50Ms} ms, p95 ${latency.p95Ms} ms, p99 ${latency.p99Ms} ms`,
+    '',
+    '## Artifacts',
+    '',
+    `- Metrics JSON: ${jsonPath}`,
+    `- TREC run: ${trecPath}`,
+    '',
+    '## Reproduce',
+    '',
+    '```bash',
+    'npm run bench:beir -- --dataset=scifact --split=test --mode=lexical --output-dir=/tmp/kb-beir-scifact',
+    '```',
+    '',
+    'Lexical mode requires no provider credentials. The runner builds a temporary KB corpus and collapses chunk hits to BEIR document IDs for scoring.',
+    '',
+  ].join('\n');
+}
+
+function parsePositiveInteger(raw: string, flag: string): number {
+  const parsed = Number(raw);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error(`${flag} must be a positive integer`);
+  }
+  return parsed;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function helpText(): string {
+  return `kb BEIR benchmark runner
+
+Usage:
+  npm run bench:beir -- --dataset=scifact --split=test --mode=lexical --output-dir=/tmp/kb-beir-scifact
+
+Options:
+  --dataset=<name>       BEIR dataset name. Built-in: scifact.
+  --split=<name>         Qrels split under qrels/<split>.tsv. Default: test.
+  --mode=lexical         Retrieval mode. Lexical is credential-free.
+  --dataset-dir=<path>   Existing BEIR directory with corpus.jsonl, queries.jsonl, qrels/.
+  --dataset-url=<url>    Zip URL for a custom BEIR-shaped dataset.
+  --output-dir=<path>    Directory for metrics JSON, TREC, and Markdown report.
+  --cache-dir=<path>     Download/unzip cache. Default: $BEIR_CACHE_DIR or /tmp/kb-beir-cache.
+  --workspace-root=<p>   Temporary KB/index workspace. Removed unless --keep-workspace.
+  --k=<n>                Document run depth. Default: 100.
+  --chunk-k=<n>          Lexical chunk candidates before doc collapse. Default: 1000.
+  --max-queries=<n>      Deterministic smoke-test subset.
+  --keep-workspace       Keep the temporary KB/index workspace for inspection.
+`;
+}
+
+const cliEntry = process.argv[1] !== undefined ? path.normalize(process.argv[1]) : '';
+if (
+  cliEntry.endsWith(path.join('benchmarks', 'beir', 'run.js')) ||
+  cliEntry.endsWith(path.join('benchmarks', 'beir', 'run.ts'))
+) {
+  main().catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.stack ?? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json && chmod +x build/index.js build/cli.js",
     "bench": "npm run build && tsc -p tsconfig.bench.json && node build/benchmarks/run.js",
+    "bench:beir": "npm run build && tsc -p tsconfig.bench.json && node build/benchmarks/beir/run.js",
     "bench:compare": "npm run build && tsc -p tsconfig.bench.json && node build/benchmarks/compare/run.js",
     "docs:check-anchors": "node scripts/check-doc-anchors.mjs",
     "test": "jest --runInBand",


### PR DESCRIPTION
## Summary
- add `npm run bench:beir` for local BEIR/SciFact benchmarking with lexical retrieval requiring no provider credentials
- emit reproducible metrics JSON, TREC run artifacts, and a Markdown report with dataset checksum, command, git SHA, runtime, and caveats
- document local-vs-official benchmark scope and reproduction commands

Closes #507

## Local BEIR/SciFact Result
Full local run:

```bash
npm run bench:beir -- --dataset=scifact --split=test --mode=lexical --output-dir=/tmp/kb-beir-scifact-full
```

Artifacts:
- `/tmp/kb-beir-scifact-full/kb-scifact-lexical-docrank-results.json`
- `/tmp/kb-beir-scifact-full/kb-scifact-lexical-docrank-run.trec`
- `/tmp/kb-beir-scifact-full/kb-scifact-lexical-docrank-report.md`

Metrics from the full local run:
- judged queries: 300
- nDCG@10: 0.581245
- MAP@100: 0.548299
- Recall@10: 0.691500
- Recall@100: 0.845444
- TREC rows: 30,000
- corpus: 5,183 docs / 14,954 indexed chunks

This is a local BEIR/SciFact benchmark result, not an official leaderboard submission.

## Verification
- `npx tsc -p tsconfig.bench.json --noEmit`
- `npx jest benchmarks/beir/metrics.test.ts benchmarks/beir/run.test.ts --runInBand`
- `npm run build`
- `npm run bench:beir -- --dataset=scifact --split=test --mode=lexical --max-queries=3 --output-dir=/tmp/kb-beir-scifact-smoke-final`
- `npm run bench:beir -- --dataset=scifact --split=test --mode=lexical --output-dir=/tmp/kb-beir-scifact-full`
- `git diff --check`
- `npm run docs:check-anchors` exits 0 in warning mode; it reports 54 pre-existing stale anchors outside this change. Strict mode remains blocked by those existing anchors.

Full `npm test` was attempted but not used as a merge signal: existing tests touched live `/home/jean/knowledge_bases` / `.faiss` state even when temporary env paths were provided, then timed out/failed. I stopped rerunning it to avoid live knowledge-base mutation risk.
