### PR TITLE
feat(bench): improve BEIR lexical document ranking

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,20 +150,21 @@ The MCP server (`knowledge-base-mcp-server` bin) is unchanged and still works wi
 
 ### Local retrieval benchmarks
 
-Use `npm run bench:beir` to run a local BEIR/SciFact benchmark with
+Use `npm run bench:beir` to run a local BEIR document-ranking benchmark with
 credential-free lexical retrieval:
 
 ```bash
-npm run bench:beir -- --dataset=scifact --split=test --mode=lexical --output-dir=/tmp/kb-beir-scifact
+npm run bench:beir -- --dataset=scifact --split=test --mode=lexical --lexical-unit=document --output-dir=/tmp/kb-beir-scifact
 ```
 
-The runner builds a temporary KB root, emits metrics JSON plus a TREC run file,
-and records reproduction metadata such as git SHA, command, dataset checksum,
-runtime versions, chunking config, and latency percentiles. These are local
-benchmark artifacts, not official BEIR leaderboard submissions; the current
-lexical path is scored at document level by benchmark-only chunk collapse while
+The default document lexical unit uses benchmark-only BM25 over BEIR title+text
+fields. Use `--lexical-unit=chunk` to reproduce the normal temporary-KB
+LexicalIndex path with document-id collapse. The runner emits metrics JSON plus
+a TREC run file and records reproduction metadata such as git SHA, command,
+dataset checksum, runtime versions, chunking config, and latency percentiles.
+These are local benchmark artifacts, not official BEIR leaderboard submissions;
 normal `kb search --mode=lexical` remains chunk-level. See
-[benchmarks/README.md](benchmarks/README.md#beirscifact-local-retrieval-benchmark)
+[benchmarks/README.md](benchmarks/README.md#beir-local-retrieval-benchmark)
 for smoke-test commands and caveats.
 
 ### Local LLM answers (RFC 015)

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -26,13 +26,13 @@ Optional environment variables:
 - `BENCH_CLI_SEARCH_REPETITIONS` sets the per-variant repetition count for `cli_search`. Defaults to 5.
 - `BENCH_CLI_SEARCH_PROFILE=matrix` expands `cli_search` from the compact default profile to a broader local matrix across retrieval modes, scopes, formats, grouping, query shapes, and `k` values.
 
-## BEIR/SciFact local retrieval benchmark
+## BEIR local retrieval benchmark
 
 `bench:beir` runs a reproducible local BEIR benchmark, starting with SciFact
-test. It downloads the BEIR zip to a cache, expands `corpus.jsonl`,
-`queries.jsonl`, and `qrels/test.tsv`, converts the corpus into a temporary
-KB root, runs the selected `kb` retrieval primitive, and writes three
-artifacts:
+test and accepting several standard BEIR dataset names such as `nfcorpus`,
+`fiqa`, `trec-covid`, `nq`, and `hotpotqa`. It downloads the BEIR zip to a
+cache, expands `corpus.jsonl`, `queries.jsonl`, and `qrels/test.tsv`, runs the
+selected lexical ranking path, and writes three artifacts:
 
 - metrics JSON with `nDCG@10`, `MAP@100`, `Recall@10`, `Recall@100`, latency
   percentiles, git SHA, dataset checksum/source URL, command, runtime, and
@@ -40,14 +40,31 @@ artifacts:
 - a TREC-format run file for external scoring tools
 - a short Markdown report
 
-Lexical mode requires no provider credentials:
+Lexical mode requires no provider credentials. By default the runner uses a
+benchmark-only document-level BM25 ranker over BEIR title+text fields, because
+BEIR evaluates document rankings while normal `kb search --mode=lexical`
+returns chunks:
 
 ```bash
 npm run bench:beir -- \
   --dataset=scifact \
   --split=test \
   --mode=lexical \
+  --lexical-unit=document \
   --output-dir=/tmp/kb-beir-scifact
+```
+
+To reproduce the original `kb` chunk lexical path, use `--lexical-unit=chunk`.
+That path builds a temporary KB, runs `LexicalIndex` chunk BM25, and collapses
+chunk hits to BEIR document IDs by max chunk score before writing TREC rows:
+
+```bash
+npm run bench:beir -- \
+  --dataset=scifact \
+  --split=test \
+  --mode=lexical \
+  --lexical-unit=chunk \
+  --output-dir=/tmp/kb-beir-scifact-chunk
 ```
 
 For a fast deterministic smoke test, limit the query set:
@@ -57,17 +74,18 @@ npm run bench:beir -- \
   --dataset=scifact \
   --split=test \
   --mode=lexical \
+  --lexical-unit=document \
   --max-queries=3 \
   --output-dir=/tmp/kb-beir-scifact-smoke
 ```
 
-The runner uses `LexicalIndex` chunk BM25 and collapses chunk hits to BEIR
-document IDs by max chunk score before writing TREC rows. That collapse is
-benchmark-only; normal `kb search --mode=lexical` behavior remains chunk-level.
-Reports should be described as a **local BEIR/SciFact benchmark**, not an
-official BEIR leaderboard result. Optional MLflow logging is not required for
-the JSON/TREC artifacts and can be layered in by the separate bench
-observability hook.
+Document lexical mode records its BM25 parameters (`k1=0.6`, `b=0.9`, title
+weight `1`) and tokenizer in the JSON report. Both lexical units are
+benchmark-only interpretations; normal `kb search --mode=lexical` behavior
+remains chunk-level. Reports should be described as a **local BEIR benchmark**,
+not an official BEIR leaderboard result. Optional MLflow logging is not
+required for the JSON/TREC artifacts and can be layered in by the separate
+bench observability hook.
 
 ## Result file naming
 

--- a/benchmarks/beir/document-bm25.ts
+++ b/benchmarks/beir/document-bm25.ts
@@ -1,0 +1,107 @@
+import type { RankedDocument } from './metrics.js';
+
+export interface BeirDocument {
+  _id: string;
+  title?: string;
+  text?: string;
+}
+
+export interface DocumentBm25Options {
+  k1: number;
+  b: number;
+  titleWeight: number;
+}
+
+interface IndexedDocument {
+  docId: string;
+  length: number;
+}
+
+interface Posting {
+  docIndex: number;
+  tf: number;
+}
+
+export class DocumentBm25Ranker {
+  private constructor(
+    private readonly documents: IndexedDocument[],
+    private readonly postingsByTerm: Map<string, Posting[]>,
+    private readonly averageDocumentLength: number,
+    private readonly options: DocumentBm25Options,
+  ) {}
+
+  static fromCorpus(corpus: readonly BeirDocument[], options: DocumentBm25Options): DocumentBm25Ranker {
+    const documents: IndexedDocument[] = [];
+    const postingsByTerm = new Map<string, Posting[]>();
+    let totalLength = 0;
+
+    corpus.forEach((row, docIndex) => {
+      const termFrequency = new Map<string, number>();
+      const titleTokens = tokenize(row.title ?? '');
+      const bodyTokens = tokenize(row.text ?? '');
+      const tokens: string[] = [];
+      for (let i = 0; i < options.titleWeight; i += 1) {
+        tokens.push(...titleTokens);
+      }
+      tokens.push(...bodyTokens);
+
+      for (const token of tokens) {
+        termFrequency.set(token, (termFrequency.get(token) ?? 0) + 1);
+      }
+      for (const [term, tf] of termFrequency) {
+        const postings = postingsByTerm.get(term);
+        if (postings === undefined) {
+          postingsByTerm.set(term, [{ docIndex, tf }]);
+        } else {
+          postings.push({ docIndex, tf });
+        }
+      }
+
+      documents.push({ docId: row._id, length: tokens.length });
+      totalLength += tokens.length;
+    });
+
+    return new DocumentBm25Ranker(
+      documents,
+      postingsByTerm,
+      documents.length === 0 ? 0 : totalLength / documents.length,
+      options,
+    );
+  }
+
+  query(query: string, k: number): RankedDocument[] {
+    if (k <= 0 || this.documents.length === 0) return [];
+    const scores = new Map<number, number>();
+    for (const term of tokenize(query)) {
+      const postings = this.postingsByTerm.get(term);
+      if (postings === undefined) continue;
+      const idf = this.inverseDocumentFrequency(postings.length);
+      for (const posting of postings) {
+        const doc = this.documents[posting.docIndex];
+        const score = idf * this.termScore(posting.tf, doc.length);
+        scores.set(posting.docIndex, (scores.get(posting.docIndex) ?? 0) + score);
+      }
+    }
+
+    return [...scores.entries()]
+      .map(([docIndex, score]) => ({ docId: this.documents[docIndex].docId, score }))
+      .sort((left, right) => right.score - left.score || left.docId.localeCompare(right.docId))
+      .slice(0, k);
+  }
+
+  private inverseDocumentFrequency(documentFrequency: number): number {
+    return Math.log(1 + ((this.documents.length - documentFrequency + 0.5) / (documentFrequency + 0.5)));
+  }
+
+  private termScore(termFrequency: number, documentLength: number): number {
+    const { b, k1 } = this.options;
+    const denominator = termFrequency + k1 * (
+      1 - b + b * (documentLength / Math.max(1, this.averageDocumentLength))
+    );
+    return (termFrequency * (k1 + 1)) / denominator;
+  }
+}
+
+export function tokenize(text: string): string[] {
+  return text.toLowerCase().match(/[a-z0-9]+/g) ?? [];
+}

--- a/benchmarks/beir/run.test.ts
+++ b/benchmarks/beir/run.test.ts
@@ -7,6 +7,7 @@ import {
   runBeirBenchmark,
   type LexicalIndexLike,
 } from './run.js';
+import { DocumentBm25Ranker, tokenize } from './document-bm25.js';
 
 async function writeTinyBeirDataset(root: string): Promise<string> {
   const datasetDir = path.join(root, 'tiny');
@@ -29,6 +30,55 @@ async function writeTinyBeirDataset(root: string): Promise<string> {
 }
 
 describe('BEIR benchmark runner', () => {
+  it('uses document-level BM25 by default without loading the chunk lexical index', async () => {
+    const root = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-beir-run-test-'));
+    const datasetDir = await writeTinyBeirDataset(root);
+    const outputDir = path.join(root, 'out');
+    const workspaceRoot = path.join(root, 'kb-beir-workspace');
+
+    const args = parseArgs([
+      '--dataset=tiny',
+      `--dataset-dir=${datasetDir}`,
+      '--split=test',
+      '--mode=lexical',
+      `--output-dir=${outputDir}`,
+      `--workspace-root=${workspaceRoot}`,
+      '--k=10',
+    ]);
+
+    const result = await runBeirBenchmark(args, {
+      gitSha: async () => 'test-sha',
+      now: () => new Date('2026-05-27T12:00:00.000Z'),
+      pythonVersion: async () => 'Python 3.test',
+      silenceServerLogger: async () => {
+        throw new Error('document-level benchmark should not load server logger');
+      },
+      loadLexicalIndex: async () => {
+        throw new Error('document-level benchmark should not load LexicalIndex');
+      },
+    });
+
+    const json = JSON.parse(await fsp.readFile(result.jsonPath, 'utf-8')) as {
+      ranking: { lexical_unit: string; bm25: { k1: number; b: number } };
+      metrics: { ndcgAt10: number; mapAt100: number; recallAt10: number; recallAt100: number };
+      indexing: { files: number; chunks: number };
+    };
+    expect(json.ranking).toMatchObject({
+      lexical_unit: 'document',
+      bm25: { k1: 0.6, b: 0.9 },
+    });
+    expect(json.indexing).toMatchObject({ files: 2, chunks: 2 });
+    expect(json.metrics).toMatchObject({
+      ndcgAt10: 1,
+      mapAt100: 1,
+      recallAt10: 1,
+      recallAt100: 1,
+    });
+    await expect(fsp.readFile(result.trecPath, 'utf-8')).resolves.toContain(
+      'q1 Q0 doc-alpha 1 ',
+    );
+  });
+
   it('writes metrics JSON, TREC, and Markdown artifacts for a tiny local dataset', async () => {
     const root = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-beir-run-test-'));
     const datasetDir = await writeTinyBeirDataset(root);
@@ -40,6 +90,7 @@ describe('BEIR benchmark runner', () => {
       `--dataset-dir=${datasetDir}`,
       '--split=test',
       '--mode=lexical',
+      '--lexical-unit=chunk',
       `--output-dir=${outputDir}`,
       `--workspace-root=${workspaceRoot}`,
       '--k=10',
@@ -91,7 +142,7 @@ describe('BEIR benchmark runner', () => {
       recallAt100: 1,
     });
     await expect(fsp.readFile(result.trecPath, 'utf-8')).resolves.toBe(
-      'q1 Q0 doc-alpha 1 42.000000 kb-tiny-lexical-docrank\n',
+      'q1 Q0 doc-alpha 1 42.000000 kb-tiny-lexical-chunk-docrank\n',
     );
     await expect(fsp.readFile(result.reportPath, 'utf-8')).resolves.toContain(
       'This is a local BEIR benchmark run, not an official leaderboard submission.',
@@ -115,5 +166,33 @@ describe('BEIR benchmark runner', () => {
       pythonVersion: async () => null,
       silenceServerLogger: async () => undefined,
     })).rejects.toThrow('--workspace-root must not be the repository root or one of its parents');
+  });
+
+  it('accepts additional built-in BEIR dataset names without a custom directory', () => {
+    const args = parseArgs(['--dataset=nfcorpus']);
+
+    expect(args.dataset).toBe('nfcorpus');
+    expect(args.lexicalUnit).toBe('document');
+  });
+
+  it('reports the supported built-in datasets for unknown BEIR names', () => {
+    expect(() => parseArgs(['--dataset=unknown-beir'])).toThrow(
+      /built-in datasets: .*nfcorpus.*scifact/,
+    );
+  });
+});
+
+describe('document BM25 ranker', () => {
+  it('tokenizes case-insensitively with punctuation splitting', () => {
+    expect(tokenize('NF-kappaB/IL-6 response')).toEqual(['nf', 'kappab', 'il', '6', 'response']);
+  });
+
+  it('ranks matching BEIR documents by BM25 score', () => {
+    const ranker = DocumentBm25Ranker.fromCorpus([
+      { _id: 'doc-alpha', title: 'Alpha evidence', text: 'Alpha alpha benchmark.' },
+      { _id: 'doc-beta', title: 'Beta evidence', text: 'Beta benchmark.' },
+    ], { k1: 0.6, b: 0.9, titleWeight: 1 });
+
+    expect(ranker.query('alpha evidence', 10)[0]?.docId).toBe('doc-alpha');
   });
 });

--- a/benchmarks/beir/run.ts
+++ b/benchmarks/beir/run.ts
@@ -15,20 +15,37 @@ import {
   type RankedDocument,
   type QueryMetric,
 } from './metrics.js';
+import { DocumentBm25Ranker, type BeirDocument } from './document-bm25.js';
 import { durationMs, ensureDirectory, gitSha, resetDirectory, writeJsonFile } from '../utils.js';
 
 const execFileAsync = promisify(execFile);
 
 const DATASET_URLS: Record<string, string> = {
+  arguana: 'https://public.ukp.informatik.tu-darmstadt.de/thakur/BEIR/datasets/arguana.zip',
+  'climate-fever': 'https://public.ukp.informatik.tu-darmstadt.de/thakur/BEIR/datasets/climate-fever.zip',
+  'dbpedia-entity': 'https://public.ukp.informatik.tu-darmstadt.de/thakur/BEIR/datasets/dbpedia-entity.zip',
+  fever: 'https://public.ukp.informatik.tu-darmstadt.de/thakur/BEIR/datasets/fever.zip',
+  fiqa: 'https://public.ukp.informatik.tu-darmstadt.de/thakur/BEIR/datasets/fiqa.zip',
+  hotpotqa: 'https://public.ukp.informatik.tu-darmstadt.de/thakur/BEIR/datasets/hotpotqa.zip',
+  nfcorpus: 'https://public.ukp.informatik.tu-darmstadt.de/thakur/BEIR/datasets/nfcorpus.zip',
+  nq: 'https://public.ukp.informatik.tu-darmstadt.de/thakur/BEIR/datasets/nq.zip',
+  quora: 'https://public.ukp.informatik.tu-darmstadt.de/thakur/BEIR/datasets/quora.zip',
   scifact: 'https://public.ukp.informatik.tu-darmstadt.de/thakur/BEIR/datasets/scifact.zip',
+  scidocs: 'https://public.ukp.informatik.tu-darmstadt.de/thakur/BEIR/datasets/scidocs.zip',
+  'trec-covid': 'https://public.ukp.informatik.tu-darmstadt.de/thakur/BEIR/datasets/trec-covid.zip',
+  'webis-touche2020': 'https://public.ukp.informatik.tu-darmstadt.de/thakur/BEIR/datasets/webis-touche2020.zip',
 };
 
 const BENCHMARK_SCHEMA_VERSION = 'kb.beir-benchmark.v1';
+const DEFAULT_BM25_K1 = 0.6;
+const DEFAULT_BM25_B = 0.9;
+const DEFAULT_TITLE_WEIGHT = 1;
 
 interface Args {
   dataset: string;
   split: string;
   mode: 'lexical';
+  lexicalUnit: 'document' | 'chunk';
   outputDir: string;
   cacheDir: string;
   workspaceRoot: string;
@@ -36,11 +53,14 @@ interface Args {
   datasetUrl?: string;
   k: number;
   chunkK: number;
+  bm25K1: number;
+  bm25B: number;
+  titleWeight: number;
   maxQueries?: number;
   keepWorkspace: boolean;
 }
 
-interface BeirCorpusRow {
+interface BeirCorpusRow extends BeirDocument {
   _id: string;
   title?: string;
   text?: string;
@@ -55,7 +75,6 @@ interface CorpusPreparation {
   kbName: string;
   kbPath: string;
   docIdByRelativePath: Map<string, string>;
-  documents: number;
 }
 
 export interface LexicalIndexLike {
@@ -91,9 +110,16 @@ interface BeirBenchmarkReport {
   ranking: {
     unit: 'document';
     implementation: string;
+    lexical_unit: Args['lexicalUnit'];
     trec_run: string;
     k: number;
     chunk_candidate_k: number;
+    bm25?: {
+      k1: number;
+      b: number;
+      title_weight: number;
+      tokenizer: string;
+    };
   };
   chunking: {
     KB_CHUNK_SIZE: string | null;
@@ -154,26 +180,58 @@ export async function runBeirBenchmark(
   await resetDirectory(args.workspaceRoot);
 
   const dataset = await ensureDataset(args);
+  const corpus = await readJsonlFile<BeirCorpusRow>(path.join(dataset.datasetDir, 'corpus.jsonl'));
   const queries = await readJsonlFile<BeirQueryRow>(path.join(dataset.datasetDir, 'queries.jsonl'));
   const qrelsPath = path.join(dataset.datasetDir, 'qrels', `${args.split}.tsv`);
   const qrels = parseQrelsTsv(await fsp.readFile(qrelsPath, 'utf-8'));
   const selectedQueries = selectQueries(queries, qrels, args.maxQueries);
 
-  const knowledgeBasesRootDir = path.join(args.workspaceRoot, 'knowledge-bases');
-  const faissIndexPath = path.join(args.workspaceRoot, '.faiss');
-  const prepared = await prepareCorpus({
-    datasetName: args.dataset,
-    datasetDir: dataset.datasetDir,
-    knowledgeBasesRootDir,
-  });
+  let refresh: Awaited<ReturnType<LexicalIndexLike['refresh']>>;
+  let indexMs = 0;
+  let files = corpus.length;
+  let chunks = corpus.length;
+  let queryDocuments: (query: BeirQueryRow) => Promise<RankedDocument[]>;
 
-  configureBenchmarkEnvironment(knowledgeBasesRootDir, faissIndexPath);
-  await dependencies.silenceServerLogger(path.join(process.cwd(), 'build'));
-  const lexicalIndex = await dependencies.loadLexicalIndex(path.join(process.cwd(), 'build'), prepared.kbName, prepared.kbPath);
-  const indexStarted = process.hrtime.bigint();
-  const refresh = await lexicalIndex.refresh();
-  await lexicalIndex.save();
-  const indexMs = durationMs(indexStarted, process.hrtime.bigint());
+  if (args.lexicalUnit === 'document') {
+    const indexStarted = process.hrtime.bigint();
+    const ranker = DocumentBm25Ranker.fromCorpus(corpus, {
+      k1: args.bm25K1,
+      b: args.bm25B,
+      titleWeight: args.titleWeight,
+    });
+    indexMs = durationMs(indexStarted, process.hrtime.bigint());
+    refresh = {
+      added: corpus.length,
+      updated: 0,
+      removed: 0,
+      failed: 0,
+      totalFiles: corpus.length,
+      totalChunks: corpus.length,
+    };
+    queryDocuments = async (query) => ranker.query(query.text, args.k);
+  } else {
+    const knowledgeBasesRootDir = path.join(args.workspaceRoot, 'knowledge-bases');
+    const faissIndexPath = path.join(args.workspaceRoot, '.faiss');
+    const prepared = await prepareCorpus({
+      datasetName: args.dataset,
+      corpus,
+      knowledgeBasesRootDir,
+    });
+
+    configureBenchmarkEnvironment(knowledgeBasesRootDir, faissIndexPath);
+    await dependencies.silenceServerLogger(path.join(process.cwd(), 'build'));
+    const lexicalIndex = await dependencies.loadLexicalIndex(path.join(process.cwd(), 'build'), prepared.kbName, prepared.kbPath);
+    const indexStarted = process.hrtime.bigint();
+    refresh = await lexicalIndex.refresh();
+    await lexicalIndex.save();
+    indexMs = durationMs(indexStarted, process.hrtime.bigint());
+    files = lexicalIndex.numFiles();
+    chunks = lexicalIndex.numChunks();
+    queryDocuments = async (query) => {
+      const chunkResults = await lexicalIndex.query(query.text, args.chunkK);
+      return collapseChunksToDocuments(chunkResults, prepared.docIdByRelativePath, args.k);
+    };
+  }
 
   const queryRows: Array<{ queryId: string; ranking: RankedDocument[] }> = [];
   const perQuery: QueryMetric[] = [];
@@ -181,10 +239,9 @@ export async function runBeirBenchmark(
 
   for (const query of selectedQueries) {
     const started = process.hrtime.bigint();
-    const chunks = await lexicalIndex.query(query.text, args.chunkK);
+    const ranking = await queryDocuments(query);
     const latency = durationMs(started, process.hrtime.bigint());
     latenciesMs.push(latency);
-    const ranking = collapseChunksToDocuments(chunks, prepared.docIdByRelativePath, args.k);
     queryRows.push({ queryId: query._id, ranking });
     const scored = scoreQuery(query._id, ranking, qrels);
     if (scored !== null) {
@@ -192,7 +249,7 @@ export async function runBeirBenchmark(
     }
   }
 
-  const runTag = `kb-${args.dataset}-${args.mode}-docrank`;
+  const runTag = `kb-${args.dataset}-${args.mode}-${args.lexicalUnit}-docrank`;
   const trecPath = path.join(args.outputDir, `${runTag}-run.trec`);
   const jsonPath = path.join(args.outputDir, `${runTag}-results.json`);
   const reportPath = path.join(args.outputDir, `${runTag}-report.md`);
@@ -208,7 +265,7 @@ export async function runBeirBenchmark(
       split: args.split,
       source_url: dataset.sourceUrl,
       checksum_sha256: dataset.checksumSha256,
-      corpus_documents: prepared.documents,
+      corpus_documents: corpus.length,
       queries_total: queries.length,
       qrels_queries: qrels.byQuery.size,
       queries_evaluated: selectedQueries.length,
@@ -216,10 +273,19 @@ export async function runBeirBenchmark(
     mode: args.mode,
     ranking: {
       unit: 'document',
-      implementation: 'LexicalIndex chunk BM25 collapsed by BEIR document id using max chunk score',
+      implementation: args.lexicalUnit === 'document'
+        ? 'Benchmark-only document-level BM25 over BEIR title+text fields'
+        : 'LexicalIndex chunk BM25 collapsed by BEIR document id using max chunk score',
+      lexical_unit: args.lexicalUnit,
       trec_run: trecPath,
       k: args.k,
       chunk_candidate_k: args.chunkK,
+      bm25: args.lexicalUnit === 'document' ? {
+        k1: args.bm25K1,
+        b: args.bm25B,
+        title_weight: args.titleWeight,
+        tokenizer: 'lowercase regex /[a-z0-9]+/',
+      } : undefined,
     },
     chunking: {
       KB_CHUNK_SIZE: process.env.KB_CHUNK_SIZE ?? null,
@@ -234,16 +300,18 @@ export async function runBeirBenchmark(
     indexing: {
       ms: Number(indexMs.toFixed(3)),
       refresh,
-      files: lexicalIndex.numFiles(),
-      chunks: lexicalIndex.numChunks(),
+      files,
+      chunks,
     },
     metrics: aggregateQueryMetrics(perQuery),
     latency: summarizeLatencies(latenciesMs),
     per_query: perQuery,
     caveats: [
-      'This is a local BEIR/SciFact benchmark, not an official leaderboard submission.',
+      `This is a local BEIR/${args.dataset} benchmark, not an official leaderboard submission.`,
       'Lexical mode requires no provider credentials.',
-      'Scores are document-level after benchmark-only chunk collapse; normal kb search lexical output remains chunk-level.',
+      args.lexicalUnit === 'document'
+        ? 'Document lexical unit is benchmark-only and does not change normal kb search --mode=lexical behavior.'
+        : 'Scores are document-level after benchmark-only chunk collapse; normal kb search lexical output remains chunk-level.',
       'MLflow logging is not required for JSON/TREC artifacts; optional logging is expected to come from the bench observability hook.',
     ],
   };
@@ -264,11 +332,15 @@ export function parseArgs(argv: string[]): Args {
     dataset: 'scifact',
     split: 'test',
     mode: 'lexical',
+    lexicalUnit: 'document',
     outputDir: path.join(repoRoot, 'benchmarks', 'results'),
     cacheDir: process.env.BEIR_CACHE_DIR ?? path.join(os.tmpdir(), 'kb-beir-cache'),
     workspaceRoot: path.join(os.tmpdir(), `kb-beir-${process.pid}-${Date.now()}`),
     k: 100,
     chunkK: 1000,
+    bm25K1: DEFAULT_BM25_K1,
+    bm25B: DEFAULT_BM25_B,
+    titleWeight: DEFAULT_TITLE_WEIGHT,
     keepWorkspace: false,
   };
 
@@ -293,6 +365,12 @@ export function parseArgs(argv: string[]): Args {
       const mode = readValue();
       if (mode !== 'lexical') throw new Error('BEIR benchmark currently supports --mode=lexical only');
       args.mode = mode;
+    } else if (flag === '--lexical-unit') {
+      const unit = readValue();
+      if (unit !== 'document' && unit !== 'chunk') {
+        throw new Error('--lexical-unit must be document or chunk');
+      }
+      args.lexicalUnit = unit;
     } else if (flag === '--dataset-dir') {
       args.datasetDir = path.resolve(readValue());
     } else if (flag === '--dataset-url') {
@@ -307,6 +385,12 @@ export function parseArgs(argv: string[]): Args {
       args.k = parsePositiveInteger(readValue(), '--k');
     } else if (flag === '--chunk-k') {
       args.chunkK = parsePositiveInteger(readValue(), '--chunk-k');
+    } else if (flag === '--bm25-k1') {
+      args.bm25K1 = parsePositiveNumber(readValue(), '--bm25-k1');
+    } else if (flag === '--bm25-b') {
+      args.bm25B = parseUnitInterval(readValue(), '--bm25-b');
+    } else if (flag === '--title-weight') {
+      args.titleWeight = parsePositiveInteger(readValue(), '--title-weight');
     } else if (flag === '--max-queries') {
       args.maxQueries = parsePositiveInteger(readValue(), '--max-queries');
     } else if (flag === '--keep-workspace') {
@@ -320,7 +404,7 @@ export function parseArgs(argv: string[]): Args {
   }
 
   if (!Object.hasOwn(DATASET_URLS, args.dataset) && args.datasetDir === undefined && args.datasetUrl === undefined) {
-    throw new Error(`unsupported dataset "${args.dataset}"; pass --dataset-dir or --dataset-url for custom BEIR data`);
+    throw new Error(`unsupported dataset "${args.dataset}"; built-in datasets: ${builtInDatasets()}; pass --dataset-dir or --dataset-url for custom BEIR data`);
   }
   args.chunkK = Math.max(args.chunkK, args.k);
   return args;
@@ -404,16 +488,15 @@ function isAncestorPath(parent: string, child: string): boolean {
 
 async function prepareCorpus(options: {
   datasetName: string;
-  datasetDir: string;
+  corpus: readonly BeirCorpusRow[];
   knowledgeBasesRootDir: string;
 }): Promise<CorpusPreparation> {
   const kbName = options.datasetName;
   const kbPath = path.join(options.knowledgeBasesRootDir, kbName);
   await resetDirectory(kbPath);
-  const corpus = await readJsonlFile<BeirCorpusRow>(path.join(options.datasetDir, 'corpus.jsonl'));
   const docIdByRelativePath = new Map<string, string>();
   let index = 0;
-  for (const row of corpus) {
+  for (const row of options.corpus) {
     const fileName = safeDocFileName(row._id, index);
     const relativePath = `${kbName}/${fileName}`;
     docIdByRelativePath.set(relativePath, row._id);
@@ -430,7 +513,7 @@ async function prepareCorpus(options: {
     await fsp.writeFile(path.join(kbPath, fileName), body, 'utf-8');
     index += 1;
   }
-  return { kbName, kbPath, docIdByRelativePath, documents: corpus.length };
+  return { kbName, kbPath, docIdByRelativePath };
 }
 
 function selectQueries(queries: readonly BeirQueryRow[], qrels: Qrels, maxQueries?: number): BeirQueryRow[] {
@@ -601,10 +684,12 @@ function formatMarkdownReport(report: BeirBenchmarkReport, trecPath: string, jso
     '## Reproduce',
     '',
     '```bash',
-    'npm run bench:beir -- --dataset=scifact --split=test --mode=lexical --output-dir=/tmp/kb-beir-scifact',
+    `npm run bench:beir -- --dataset=${dataset.name} --split=${dataset.split} --mode=${report.mode} --lexical-unit=${report.ranking.lexical_unit} --output-dir=/tmp/kb-beir-${dataset.name}`,
     '```',
     '',
-    'Lexical mode requires no provider credentials. The runner builds a temporary KB corpus and collapses chunk hits to BEIR document IDs for scoring.',
+    report.ranking.lexical_unit === 'document'
+      ? 'Lexical document mode requires no provider credentials and scores BEIR title+text as documents.'
+      : 'Lexical chunk mode requires no provider credentials. The runner builds a temporary KB corpus and collapses chunk hits to BEIR document IDs for scoring.',
     '',
   ].join('\n');
 }
@@ -615,6 +700,26 @@ function parsePositiveInteger(raw: string, flag: string): number {
     throw new Error(`${flag} must be a positive integer`);
   }
   return parsed;
+}
+
+function parsePositiveNumber(raw: string, flag: string): number {
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`${flag} must be a positive number`);
+  }
+  return parsed;
+}
+
+function parseUnitInterval(raw: string, flag: string): number {
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) {
+    throw new Error(`${flag} must be a number between 0 and 1`);
+  }
+  return parsed;
+}
+
+function builtInDatasets(): string {
+  return Object.keys(DATASET_URLS).sort().join(', ');
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -628,9 +733,10 @@ Usage:
   npm run bench:beir -- --dataset=scifact --split=test --mode=lexical --output-dir=/tmp/kb-beir-scifact
 
 Options:
-  --dataset=<name>       BEIR dataset name. Built-in: scifact.
+  --dataset=<name>       BEIR dataset name. See built-in list below.
   --split=<name>         Qrels split under qrels/<split>.tsv. Default: test.
   --mode=lexical         Retrieval mode. Lexical is credential-free.
+  --lexical-unit=<unit>  document (default) or chunk. Document is benchmark-only BM25.
   --dataset-dir=<path>   Existing BEIR directory with corpus.jsonl, queries.jsonl, qrels/.
   --dataset-url=<url>    Zip URL for a custom BEIR-shaped dataset.
   --output-dir=<path>    Directory for metrics JSON, TREC, and Markdown report.
@@ -638,8 +744,14 @@ Options:
   --workspace-root=<p>   Temporary KB/index workspace. Removed unless --keep-workspace.
   --k=<n>                Document run depth. Default: 100.
   --chunk-k=<n>          Lexical chunk candidates before doc collapse. Default: 1000.
+  --bm25-k1=<n>          Document BM25 k1. Default: ${DEFAULT_BM25_K1}.
+  --bm25-b=<n>           Document BM25 b in [0,1]. Default: ${DEFAULT_BM25_B}.
+  --title-weight=<n>     Document BM25 title repetition weight. Default: ${DEFAULT_TITLE_WEIGHT}.
   --max-queries=<n>      Deterministic smoke-test subset.
   --keep-workspace       Keep the temporary KB/index workspace for inspection.
+
+Built-in datasets:
+  ${builtInDatasets()}
 `;
 }
 

--- a/docs/requirements/INDEX.md
+++ b/docs/requirements/INDEX.md
@@ -308,6 +308,25 @@
 **Linked Tests:** TS-FEEDBACK-436
 **Dependencies:** FR-RETRIEVAL-EVAL
 
+## Benchmarks
+
+### FR-BENCH-508: BEIR Document-Level Lexical Benchmark
+**Status:** Implemented
+**Priority:** High
+
+**Requirement:** The BEIR benchmark runner shall provide a credential-free document-level lexical BM25 ranking path for BEIR-shaped corpora while preserving the existing chunk-collapsed LexicalIndex benchmark path as an explicit option.
+**Rationale:** BEIR scores document rankings, while normal `kb search --mode=lexical` returns chunks. A benchmark-only document ranker lets maintainers compare `kb` lexical behavior against standard BEIR BM25 references without changing operator-facing search behavior.
+
+**Acceptance Criteria:**
+- [x] Given `npm run bench:beir -- --dataset=scifact --mode=lexical`, when the runner executes, then it shall default to document-level BM25 scoring over BEIR title and text fields and emit document-level TREC rows.
+- [x] Given `--lexical-unit=chunk`, when the runner executes, then it shall use the existing temporary-KB LexicalIndex path and collapse chunk hits to BEIR document ids.
+- [x] Given the report JSON, then it shall record the lexical unit, BM25 parameters for document mode, document-level scoring caveats, and the dataset/run metadata needed for reproduction.
+- [x] Given SciFact test with document lexical defaults, then nDCG@10 shall meet or exceed 0.64 and Recall@100 shall not regress below 0.835.
+- [x] Given an additional built-in BEIR dataset such as `nfcorpus`, when no custom dataset path is supplied, then argument validation shall accept the dataset name and resolve its standard BEIR download URL.
+
+**Linked Tests:** TS-BENCH-508
+**Dependencies:** FR-RETRIEVAL-EVAL
+
 ## Logging and Observability
 
 ### FR-LOGS-397: Canonical Log Reader

--- a/docs/testing/INDEX.md
+++ b/docs/testing/INDEX.md
@@ -220,6 +220,17 @@
 - `kb feedback promote` shall produce a YAML preview without `--fixture --yes` and shall append a `kb eval` case to the target fixture when both are supplied.
 - The ledger shall store `task_context_sha256` (never the raw text) when `--task-context` is supplied.
 
+## Benchmarks
+
+### TS-BENCH-508: BEIR Document-Level Lexical Benchmark
+**Requirement:** FR-BENCH-508
+
+**Test Cases:**
+- `bench:beir` shall default to document-level BM25 and shall not load the chunk LexicalIndex path for document mode.
+- `bench:beir --lexical-unit=chunk` shall preserve the existing temporary-KB LexicalIndex path and chunk-to-document collapse behavior.
+- The document BM25 ranker shall tokenize case-insensitively with punctuation splitting and rank matching BEIR documents by BM25 score.
+- `parseArgs` shall accept additional built-in BEIR datasets such as `nfcorpus` and shall list supported names for unknown datasets.
+
 ## Logging and Observability
 
 ### TS-LOGS-397: Canonical Log Reader


### PR DESCRIPTION
## Summary

Closes #508.

Builds on #511 and improves the BEIR/SciFact lexical benchmark by adding a benchmark-only document-level BM25 ranker for BEIR-shaped corpora.

## What changed

- Added `--lexical-unit=document` as the `bench:beir` default.
- Preserved the original temporary-KB `LexicalIndex` path behind `--lexical-unit=chunk`.
- Added reproducible BM25 metadata to report JSON (`k1`, `b`, title weight, tokenizer).
- Added built-in BEIR dataset names beyond SciFact (`nfcorpus`, `fiqa`, `trec-covid`, `nq`, `hotpotqa`, etc.).
- Updated README, benchmark docs, requirements, and test index.

## SciFact result

Full local run:

```bash
npm run bench:beir -- --dataset=scifact --split=test --mode=lexical --output-dir=/tmp/kb-beir-scifact-document-final
```

Metrics:

- judged queries: 300
- nDCG@10: 0.667810
- MAP@100: 0.628277
- Recall@10: 0.790111
- Recall@100: 0.881889
- corpus: 5,183 docs
- indexing: 464.759 ms
- query latency p50/p95/p99: 6.413 / 12.291 / 17.444 ms

This clears the issue floor (`nDCG@10 >= 0.64`) and the stretch target band called out in #508 while keeping Recall@100 above the exploratory 0.845 baseline.

## Pre-PR review

- conventions specialist: fixed stale help text that implied SciFact was the only built-in dataset
- correctness specialist: removed `robust04` and `trec-news` built-ins because their configured BEIR URLs returned 404
- dead-code specialist: removed unused `CorpusPreparation.documents`
- test specialist: no findings; verified runtime path is directly tested

## Verification

- `npm run build` — passed
- `npm test -- --runTestsByPath benchmarks/beir/metrics.test.ts benchmarks/beir/run.test.ts` — passed
- `npx tsc -p tsconfig.bench.json --noEmit` — passed
- `npx jest benchmarks/beir/metrics.test.ts benchmarks/beir/run.test.ts --runInBand` — passed
- `npm run bench:beir -- --dataset=scifact --split=test --mode=lexical --output-dir=/tmp/kb-beir-scifact-document-final` — passed
- `npm run bench:beir -- --dataset=scifact --split=test --mode=lexical --lexical-unit=chunk --max-queries=3 --output-dir=/tmp/kb-beir-scifact-chunk-smoke-final` — passed
- `git diff --check` — passed
- `npm run docs:check-anchors` — warning mode exits 0 and reports 54 pre-existing stale anchors outside this change
- portability scan: repo helper absent; manual changed-line scan found no user-specific absolute paths

## Notes

This is a stacked PR against `issue-507-beir-benchmark` / #511 because `main` does not yet contain `bench:beir`.
