### PR TITLE
feat(bench): add replayable Optuna tuning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 node_modules/
 build/
+__pycache__/
+*.py[cod]
 .DS_Store
 .env

--- a/README.md
+++ b/README.md
@@ -166,6 +166,27 @@ normal `kb search --mode=lexical` remains chunk-level. See
 [benchmarks/README.md](benchmarks/README.md#beirscifact-local-retrieval-benchmark)
 for smoke-test commands and caveats.
 
+Optuna tuning is optional and only runs when explicitly invoked. A SciFact
+example that sweeps lexical chunking and writes a replayable best-config file:
+
+```bash
+npm run bench:tune -- \
+  --trials=12 \
+  --direction=maximize \
+  --metric=metrics.ndcgAt10 \
+  --study-name=scifact-lexical \
+  --best-config-out=/tmp/kb-scifact-lexical-best.json \
+  --param-int=KB_CHUNK_SIZE=256:1024:128 \
+  --param-int=KB_CHUNK_OVERLAP=0:128:32 \
+  -- npm run bench:beir -- --dataset=scifact --split=test --mode=lexical --max-queries=25 --output-dir=/tmp/kb-scifact-tune
+```
+
+Replay the best trial without importing Optuna:
+
+```bash
+npm run bench:tune -- --replay-config=/tmp/kb-scifact-lexical-best.json
+```
+
 ### Local LLM answers (RFC 015)
 
 `kb ask` keeps retrieval deterministic and adds a local OpenAI-compatible chat step on top. It resolves the LLM endpoint from `--endpoint`, `KB_LLM_ENDPOINT`, `--llm-profile`, the active `kb llm` profile, then finally the local-research-agent default on `127.0.0.1:8080`.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -351,6 +351,50 @@ npm run bench:tune -- \
 You can combine Optuna with MLflow by exporting `BENCH_MLFLOW_*` before running
 `bench:tune`; each trial benchmark logs normally.
 
+Tune BEIR/SciFact lexical chunking against `nDCG@10`:
+
+```bash
+npm run bench:tune -- \
+  --trials=12 \
+  --direction=maximize \
+  --metric=metrics.ndcgAt10 \
+  --study-name=scifact-lexical \
+  --best-config-out=/tmp/kb-scifact-lexical-best.json \
+  --param-int=KB_CHUNK_SIZE=256:1024:128 \
+  --param-int=KB_CHUNK_OVERLAP=0:128:32 \
+  -- npm run bench:beir -- --dataset=scifact --split=test --mode=lexical --max-queries=25 --output-dir=/tmp/kb-scifact-tune
+```
+
+The tuner writes a replay config containing the benchmark command and best-trial
+environment values. Replaying does not require Optuna:
+
+```bash
+npm run bench:tune -- --replay-config=/tmp/kb-scifact-lexical-best.json
+```
+
+`bench:beir` also accepts JSON config directly:
+
+```json
+{
+  "schema_version": "kb.beir-config.v1",
+  "env": {
+    "KB_CHUNK_SIZE": 512,
+    "KB_CHUNK_OVERLAP": 64
+  },
+  "beir": {
+    "dataset": "scifact",
+    "split": "test",
+    "mode": "lexical",
+    "k": 100,
+    "chunk_k": 1000
+  }
+}
+```
+
+```bash
+npm run bench:beir -- --config=/tmp/kb-beir-config.json --output-dir=/tmp/kb-beir-replay
+```
+
 ### Auto-clamping fixture chunk size to fit short-context models (#107)
 
 Before driving the bench legs, the orchestrator probes each model's `num_ctx`

--- a/benchmarks/beir/run.test.ts
+++ b/benchmarks/beir/run.test.ts
@@ -116,4 +116,57 @@ describe('BEIR benchmark runner', () => {
       silenceServerLogger: async () => undefined,
     })).rejects.toThrow('--workspace-root must not be the repository root or one of its parents');
   });
+
+  it('applies BEIR runner arguments and retrieval environment from a JSON config file', async () => {
+    const root = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-beir-config-test-'));
+    const configPath = path.join(root, 'beir-config.json');
+    const previousChunkSize = process.env.KB_CHUNK_SIZE;
+    const previousChunkOverlap = process.env.KB_CHUNK_OVERLAP;
+    await fsp.writeFile(configPath, JSON.stringify({
+      schema_version: 'kb.beir-config.v1',
+      env: {
+        KB_CHUNK_SIZE: 384,
+        KB_CHUNK_OVERLAP: '48',
+      },
+      beir: {
+        dataset: 'tiny',
+        dataset_dir: path.join(root, 'tiny-dataset'),
+        split: 'dev',
+        mode: 'lexical',
+        output_dir: path.join(root, 'out-from-config'),
+        workspace_root: path.join(root, 'kb-beir-workspace-from-config'),
+        k: 7,
+        chunk_k: 11,
+        max_queries: 2,
+        keep_workspace: true,
+      },
+    }), 'utf-8');
+
+    try {
+      const args = parseArgs([
+        `--config=${configPath}`,
+        '--k=5',
+      ]);
+
+      expect(args).toMatchObject({
+        dataset: 'tiny',
+        datasetDir: path.join(root, 'tiny-dataset'),
+        split: 'dev',
+        mode: 'lexical',
+        outputDir: path.join(root, 'out-from-config'),
+        workspaceRoot: path.join(root, 'kb-beir-workspace-from-config'),
+        k: 5,
+        chunkK: 11,
+        maxQueries: 2,
+        keepWorkspace: true,
+      });
+      expect(process.env.KB_CHUNK_SIZE).toBe('384');
+      expect(process.env.KB_CHUNK_OVERLAP).toBe('48');
+    } finally {
+      if (previousChunkSize === undefined) delete process.env.KB_CHUNK_SIZE;
+      else process.env.KB_CHUNK_SIZE = previousChunkSize;
+      if (previousChunkOverlap === undefined) delete process.env.KB_CHUNK_OVERLAP;
+      else process.env.KB_CHUNK_OVERLAP = previousChunkOverlap;
+    }
+  });
 });

--- a/benchmarks/beir/run.ts
+++ b/benchmarks/beir/run.ts
@@ -1,4 +1,5 @@
 import * as crypto from 'crypto';
+import * as fs from 'fs';
 import * as fsp from 'fs/promises';
 import * as os from 'os';
 import * as path from 'path';
@@ -39,6 +40,28 @@ interface Args {
   maxQueries?: number;
   keepWorkspace: boolean;
 }
+
+type BeirConfigKey =
+  | 'dataset'
+  | 'split'
+  | 'mode'
+  | 'output_dir'
+  | 'outputDir'
+  | 'cache_dir'
+  | 'cacheDir'
+  | 'workspace_root'
+  | 'workspaceRoot'
+  | 'dataset_dir'
+  | 'datasetDir'
+  | 'dataset_url'
+  | 'datasetUrl'
+  | 'k'
+  | 'chunk_k'
+  | 'chunkK'
+  | 'max_queries'
+  | 'maxQueries'
+  | 'keep_workspace'
+  | 'keepWorkspace';
 
 interface BeirCorpusRow {
   _id: string;
@@ -275,6 +298,18 @@ export function parseArgs(argv: string[]): Args {
   for (let i = 0; i < argv.length; i += 1) {
     const token = argv[i];
     const [flag, inlineValue] = token.includes('=') ? token.split(/=(.*)/s, 2) : [token, undefined];
+    if (flag !== '--config') continue;
+    const configPath = inlineValue ?? argv[i + 1];
+    if (configPath === undefined || configPath.startsWith('--')) {
+      throw new Error('--config requires a value');
+    }
+    applyBenchmarkConfig(args, path.resolve(configPath));
+    if (inlineValue === undefined) i += 1;
+  }
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    const [flag, inlineValue] = token.includes('=') ? token.split(/=(.*)/s, 2) : [token, undefined];
     const readValue = (): string => {
       if (inlineValue !== undefined) return inlineValue;
       i += 1;
@@ -311,6 +346,8 @@ export function parseArgs(argv: string[]): Args {
       args.maxQueries = parsePositiveInteger(readValue(), '--max-queries');
     } else if (flag === '--keep-workspace') {
       args.keepWorkspace = true;
+    } else if (flag === '--config') {
+      if (inlineValue === undefined) i += 1;
     } else if (flag === '--help' || flag === '-h') {
       process.stdout.write(helpText());
       process.exit(0);
@@ -324,6 +361,101 @@ export function parseArgs(argv: string[]): Args {
   }
   args.chunkK = Math.max(args.chunkK, args.k);
   return args;
+}
+
+function applyBenchmarkConfig(args: Args, configPath: string): void {
+  const parsed = JSON.parse(fs.readFileSync(configPath, 'utf-8')) as unknown;
+  if (!isRecord(parsed)) {
+    throw new Error(`benchmark config ${configPath} must contain a JSON object`);
+  }
+  if (
+    parsed.schema_version !== undefined &&
+    parsed.schema_version !== 'kb.beir-config.v1' &&
+    parsed.schema_version !== 'kb.benchmark-replay-config.v1'
+  ) {
+    throw new Error(`unsupported benchmark config schema_version: ${String(parsed.schema_version)}`);
+  }
+
+  if (parsed.env !== undefined) {
+    if (!isRecord(parsed.env)) {
+      throw new Error(`benchmark config ${configPath} env must be a JSON object`);
+    }
+    applyEnvironmentConfig(parsed.env);
+  }
+
+  if (parsed.beir !== undefined) {
+    if (!isRecord(parsed.beir)) {
+      throw new Error(`benchmark config ${configPath} beir must be a JSON object`);
+    }
+    applyBeirConfig(args, parsed.beir as Partial<Record<BeirConfigKey, unknown>>);
+  }
+}
+
+function applyEnvironmentConfig(envConfig: Record<string, unknown>): void {
+  for (const [name, value] of Object.entries(envConfig)) {
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) {
+      throw new Error(`invalid environment variable name in benchmark config: ${name}`);
+    }
+    if (value === null) {
+      delete process.env[name];
+    } else if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+      process.env[name] = String(value);
+    } else {
+      throw new Error(`benchmark config env.${name} must be string, number, boolean, or null`);
+    }
+  }
+}
+
+function applyBeirConfig(args: Args, beir: Partial<Record<BeirConfigKey, unknown>>): void {
+  for (const key of Object.keys(beir) as BeirConfigKey[]) {
+    const value = beir[key];
+    if (value === undefined) continue;
+    if (key === 'dataset') {
+      args.dataset = parseStringConfig(value, 'beir.dataset');
+    } else if (key === 'split') {
+      args.split = parseStringConfig(value, 'beir.split');
+    } else if (key === 'mode') {
+      const mode = parseStringConfig(value, 'beir.mode');
+      if (mode !== 'lexical') throw new Error('BEIR benchmark currently supports mode=lexical only');
+      args.mode = mode;
+    } else if (key === 'output_dir' || key === 'outputDir') {
+      args.outputDir = path.resolve(parseStringConfig(value, `beir.${key}`));
+    } else if (key === 'cache_dir' || key === 'cacheDir') {
+      args.cacheDir = path.resolve(parseStringConfig(value, `beir.${key}`));
+    } else if (key === 'workspace_root' || key === 'workspaceRoot') {
+      args.workspaceRoot = path.resolve(parseStringConfig(value, `beir.${key}`));
+    } else if (key === 'dataset_dir' || key === 'datasetDir') {
+      args.datasetDir = path.resolve(parseStringConfig(value, `beir.${key}`));
+    } else if (key === 'dataset_url' || key === 'datasetUrl') {
+      args.datasetUrl = parseStringConfig(value, `beir.${key}`);
+    } else if (key === 'k') {
+      args.k = parsePositiveIntegerConfig(value, 'beir.k');
+    } else if (key === 'chunk_k' || key === 'chunkK') {
+      args.chunkK = parsePositiveIntegerConfig(value, `beir.${key}`);
+    } else if (key === 'max_queries' || key === 'maxQueries') {
+      args.maxQueries = parsePositiveIntegerConfig(value, `beir.${key}`);
+    } else if (key === 'keep_workspace' || key === 'keepWorkspace') {
+      if (typeof value !== 'boolean') throw new Error(`beir.${key} must be a boolean`);
+      args.keepWorkspace = value;
+    } else {
+      throw new Error(`unknown BEIR benchmark config key: ${key}`);
+    }
+  }
+}
+
+function parseStringConfig(value: unknown, label: string): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`${label} must be a non-empty string`);
+  }
+  return value;
+}
+
+function parsePositiveIntegerConfig(value: unknown, label: string): number {
+  if (typeof value === 'number') {
+    if (!Number.isSafeInteger(value) || value <= 0) throw new Error(`${label} must be a positive integer`);
+    return value;
+  }
+  return parsePositiveInteger(parseStringConfig(value, label), label);
 }
 
 async function ensureDataset(args: Args): Promise<{ datasetDir: string; sourceUrl: string | null; checksumSha256: string }> {
@@ -629,6 +761,7 @@ Usage:
 
 Options:
   --dataset=<name>       BEIR dataset name. Built-in: scifact.
+  --config=<path>        JSON config with env overrides and BEIR runner args.
   --split=<name>         Qrels split under qrels/<split>.tsv. Default: test.
   --mode=lexical         Retrieval mode. Lexical is credential-free.
   --dataset-dir=<path>   Existing BEIR directory with corpus.jsonl, queries.jsonl, qrels/.

--- a/benchmarks/optuna_tune.py
+++ b/benchmarks/optuna_tune.py
@@ -22,12 +22,16 @@ import os
 import re
 import subprocess
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 
 def main() -> int:
     args = parse_args()
+
+    if args.replay_config is not None:
+        return run_replay_config(Path(args.replay_config)).returncode
 
     try:
         import optuna  # type: ignore
@@ -41,6 +45,9 @@ def main() -> int:
 
     if not args.command:
         print("bench:optuna: missing benchmark command after `--`", file=sys.stderr)
+        return 2
+    if args.metric is None:
+        print("bench:optuna: --metric is required unless --replay-config is used", file=sys.stderr)
         return 2
 
     study = optuna.create_study(
@@ -89,10 +96,12 @@ def main() -> int:
         return value
 
     study.optimize(objective, n_trials=args.trials)
+    best_config_path = write_replay_config(study, args)
     print(f"study: {study.study_name}")
     print(f"best_trial: {study.best_trial.number}")
     print(f"best_value: {study.best_value}")
     print(f"best_params: {json.dumps(study.best_params, sort_keys=True)}")
+    print(f"best_config: {best_config_path}")
     return 0
 
 
@@ -102,9 +111,11 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--trials", type=int, default=20)
     parser.add_argument("--direction", choices=["minimize", "maximize"], default="maximize")
-    parser.add_argument("--metric", required=True, help="Dot path in benchmark JSON, e.g. scenarios.warm_query.p95_ms")
+    parser.add_argument("--metric", help="Dot path in benchmark JSON, e.g. scenarios.warm_query.p95_ms")
     parser.add_argument("--study-name", default="kb-bench")
     parser.add_argument("--storage", help="Optuna storage URL, e.g. sqlite:///benchmarks/results/optuna.db")
+    parser.add_argument("--best-config-out", help="Replay config path. Defaults to benchmarks/results/<study-name>-best-config.json")
+    parser.add_argument("--replay-config", help="Run a generated replay config without importing Optuna")
     parser.add_argument("--param-int", action="append", default=[], metavar="NAME=LOW:HIGH[:STEP]")
     parser.add_argument("--param-float", action="append", default=[], metavar="NAME=LOW:HIGH")
     parser.add_argument("--param-categorical", action="append", default=[], metavar="NAME=A,B,C")
@@ -113,6 +124,53 @@ def parse_args() -> argparse.Namespace:
     if parsed.command and parsed.command[0] == "--":
         parsed.command = parsed.command[1:]
     return parsed
+
+
+def build_replay_config(study: Any, args: argparse.Namespace) -> dict[str, Any]:
+    best_trial = study.best_trial
+    env = {str(name): str(value) for name, value in best_trial.params.items()}
+    return {
+        "schema_version": "kb.benchmark-replay-config.v1",
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "study_name": args.study_name,
+        "direction": args.direction,
+        "metric": args.metric,
+        "best_trial": best_trial.number,
+        "best_value": study.best_value,
+        "command": list(args.command),
+        "env": env,
+        "params": dict(best_trial.params),
+    }
+
+
+def write_replay_config(study: Any, args: argparse.Namespace) -> Path:
+    output_path = Path(args.best_config_out) if args.best_config_out else default_best_config_path(args.study_name)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(build_replay_config(study, args), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return output_path
+
+
+def default_best_config_path(study_name: str) -> Path:
+    safe_name = re.sub(r"[^A-Za-z0-9._-]+", "-", study_name).strip("-") or "kb-bench"
+    return Path("benchmarks") / "results" / f"{safe_name}-best-config.json"
+
+
+def run_replay_config(config_path: Path) -> subprocess.CompletedProcess[str]:
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    if not isinstance(config, dict):
+        raise ValueError("replay config must contain a JSON object")
+    if config.get("schema_version") != "kb.benchmark-replay-config.v1":
+        raise ValueError("replay config schema_version must be kb.benchmark-replay-config.v1")
+    command = config.get("command")
+    if not isinstance(command, list) or not command or not all(isinstance(part, str) for part in command):
+        raise ValueError("replay config command must be a non-empty string array")
+    env_config = config.get("env", {})
+    if not isinstance(env_config, dict) or not all(isinstance(name, str) and isinstance(value, str) for name, value in env_config.items()):
+        raise ValueError("replay config env must be an object of string values")
+
+    env = os.environ.copy()
+    env.update(env_config)
+    return subprocess.run(command, env=env, text=True, check=False)
 
 
 def parse_int_spec(spec: str) -> tuple[str, int, int, int]:

--- a/benchmarks/optuna_tune_test.py
+++ b/benchmarks/optuna_tune_test.py
@@ -1,0 +1,88 @@
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+from types import SimpleNamespace
+
+import optuna_tune
+
+
+class ReplayConfigTests(unittest.TestCase):
+    def test_build_replay_config_records_command_and_best_trial_environment(self) -> None:
+        args = SimpleNamespace(
+            command=["npm", "run", "bench:beir", "--", "--dataset=scifact"],
+            direction="maximize",
+            metric="metrics.ndcgAt10",
+            study_name="scifact-lexical",
+        )
+        study = SimpleNamespace(
+            best_trial=SimpleNamespace(number=3, params={"KB_CHUNK_SIZE": 384, "KB_CHUNK_OVERLAP": 48}),
+            best_value=0.667,
+        )
+
+        config = optuna_tune.build_replay_config(study, args)
+
+        self.assertEqual(config["schema_version"], "kb.benchmark-replay-config.v1")
+        self.assertEqual(config["command"], ["npm", "run", "bench:beir", "--", "--dataset=scifact"])
+        self.assertEqual(config["env"], {"KB_CHUNK_SIZE": "384", "KB_CHUNK_OVERLAP": "48"})
+        self.assertEqual(config["best_trial"], 3)
+        self.assertEqual(config["best_value"], 0.667)
+
+    def test_replay_config_runs_recorded_command_with_recorded_environment(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="kb-optuna-replay-test-") as tmp:
+            tmp_path = Path(tmp)
+            output_path = tmp_path / "env.json"
+            config_path = tmp_path / "replay.json"
+            config_path.write_text(json.dumps({
+                "schema_version": "kb.benchmark-replay-config.v1",
+                "command": [
+                    sys.executable,
+                    "-c",
+                    (
+                        "import json, os, sys; "
+                        "json.dump({'chunk': os.environ.get('KB_CHUNK_SIZE')}, open(sys.argv[1], 'w'))"
+                    ),
+                    str(output_path),
+                ],
+                "env": {
+                    "KB_CHUNK_SIZE": "512",
+                },
+            }), encoding="utf-8")
+
+            completed = optuna_tune.run_replay_config(config_path)
+
+            self.assertEqual(completed.returncode, 0)
+            self.assertEqual(json.loads(output_path.read_text(encoding="utf-8")), {"chunk": "512"})
+
+    def test_main_replays_config_without_importing_optuna(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="kb-optuna-main-replay-test-") as tmp:
+            tmp_path = Path(tmp)
+            output_path = tmp_path / "env.json"
+            config_path = tmp_path / "replay.json"
+            config_path.write_text(json.dumps({
+                "schema_version": "kb.benchmark-replay-config.v1",
+                "command": [
+                    sys.executable,
+                    "-c",
+                    (
+                        "import json, os, sys; "
+                        "json.dump({'chunk': os.environ.get('KB_CHUNK_SIZE')}, open(sys.argv[1], 'w'))"
+                    ),
+                    str(output_path),
+                ],
+                "env": {
+                    "KB_CHUNK_SIZE": "768",
+                },
+            }), encoding="utf-8")
+
+            with patch.object(sys, "argv", ["optuna_tune.py", f"--replay-config={config_path}"]):
+                exit_code = optuna_tune.main()
+
+            self.assertEqual(exit_code, 0)
+            self.assertEqual(json.loads(output_path.read_text(encoding="utf-8")), {"chunk": "768"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/benchmarks/results/.gitignore
+++ b/benchmarks/results/.gitignore
@@ -1,3 +1,4 @@
 run-*.json
 ci-*.json
 local-*.json
+*-best-config.json

--- a/docs/requirements/retrieval-eval.md
+++ b/docs/requirements/retrieval-eval.md
@@ -18,3 +18,21 @@
 **Linked Tests:** TS-RETRIEVAL-EVAL-001
 
 **Authoring Guidance:** See [Retrieval eval fixture methodology](../testing/retrieval-eval-methodology.md) for fixture archetypes, gating policy, contamination guardrails, and the worked starter fixture.
+
+### FR-RETRIEVAL-EVAL-509: Replayable Benchmark Tuning
+
+**Status:** Implemented
+**Priority:** High
+
+**Requirement:** The system shall support optional Optuna-driven benchmark tuning without adding Optuna to the default benchmark path.
+**Rationale:** Retrieval benchmark experiments need reproducible tuning runs whose best trial can be replayed without relying on transient terminal output or mandatory optional dependencies.
+
+**Acceptance Criteria:**
+
+- [x] Given `npm run bench:tune` is invoked with a benchmark command and tunable environment variables, when Optuna is installed, then the tuner shall optimize the selected numeric metric.
+- [x] Given Optuna is not installed, when tuning is requested, then the tuner shall fail with actionable setup guidance.
+- [x] Given a tuning run completes, then the tuner shall write a replay config containing the benchmark command and best-trial environment values.
+- [x] Given a replay config, when replay is requested, then the tuner shall run the recorded command with the recorded environment without requiring Optuna.
+- [x] Given a BEIR benchmark config file, when `bench:beir` runs with `--config`, then the runner shall apply retrieval parameters and environment overrides from that JSON file.
+
+**Linked Tests:** TS-RETRIEVAL-EVAL-509

--- a/docs/testing/retrieval-eval.md
+++ b/docs/testing/retrieval-eval.md
@@ -53,3 +53,10 @@ alpha-nDCG@k. Cases without judgments preserve the original binary pass/fail
 output shape, plus the source diversity diagnostics.
 
 For authoring guidance, see [Retrieval eval fixture methodology](retrieval-eval-methodology.md).
+
+### TS-RETRIEVAL-EVAL-509: Replayable Benchmark Tuning
+
+The benchmark tuning tests cover:
+
+- `benchmarks/beir/run.test.ts` verifies that `--config` applies BEIR runner arguments and retrieval environment overrides from JSON.
+- `benchmarks/optuna_tune_test.py` verifies replay-config generation and replay execution without importing Optuna.


### PR DESCRIPTION
## Summary
- add BEIR benchmark JSON config support for retrieval env and runner arguments
- make `bench:tune` write replayable best-config JSON and replay it without importing Optuna
- document a SciFact lexical tuning workflow and add requirement/test traceability

Closes #509

## Pre-PR review
- conventions specialist: added ignore rule for generated `*-best-config.json` benchmark artifacts
- correctness specialist: no findings
- dead-code specialist: no findings
- test specialist: added direct `main()` replay-path coverage so replay stays independent of Optuna import

## Verification
- `python3 -m unittest optuna_tune_test`
- `npx jest benchmarks/beir/metrics.test.ts benchmarks/beir/run.test.ts --runInBand`
- `npx tsc -p tsconfig.bench.json --noEmit`
- `npm run build`
- `npm run docs:check-anchors` exits 0 in warning mode; reports 54 pre-existing stale anchors
- `git diff --check`
- `npm run bench:tune -- --replay-config=<temp>` replay smoke passed
- `python3 benchmarks/optuna_tune.py --metric=metrics.ndcgAt10 --trials=1 --param-int=KB_CHUNK_SIZE=256:256 -- python3 -c ...` exits 2 with Optuna install guidance because Optuna is not installed locally

## Notes
Full `npm test` was not run because prior benchmark-chain verification found existing tests can touch live `/home/jean/knowledge_bases` / `.faiss` state even with temporary env paths. Focused benchmark tests were used instead.
