### PR TITLE
docs: align system design with implementation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # knowledge-base-mcp-server — Agent Instructions
 
-MCP server that exposes two tools — `list_knowledge_bases` and `retrieve_knowledge` — backed by a local FAISS index and a pluggable embedding provider (HuggingFace, Ollama, or OpenAI).
+Local-first knowledge-base MCP server and `kb` CLI backed by embedded FAISS indexes and pluggable embedding providers (HuggingFace, Ollama, or OpenAI).
 
 ## Working on this repo
 
@@ -16,11 +16,12 @@ node build/index.js    # runs the server over stdio (clients launch it this way)
 
 ### Key architecture
 
-- **Transport:** `StdioServerTransport` in `src/KnowledgeBaseServer.ts`. Server speaks plain JSON-RPC over stdio — any MCP client (Claude Desktop, Codex CLI, Cursor, Continue, Cline) can launch it.
-- **Tool surface:** registered in `KnowledgeBaseServer.setupTools()` via the high-level `McpServer.tool(...)` API (see `@modelcontextprotocol/sdk@1.x`).
-- **Embeddings:** `FaissIndexManager` picks a provider at construction time based on `EMBEDDING_PROVIDER` (`huggingface` | `ollama` | `openai`). Each provider maps to a `@langchain/*` embeddings class.
-- **Index:** one FAISS store (`FaissStore` from `@langchain/community`) persisted at `FAISS_INDEX_PATH`. A sibling `model_name.txt` tracks which model built the index; a provider/model switch triggers auto-rebuild.
-- **Indexing strategy:** per-file SHA256 hashes in `<kb>/.index/` decide what to re-embed on each `retrieve_knowledge` call. Hidden files/dirs (dot-prefixed) are skipped.
+- **Transport:** `src/KnowledgeBaseServer.ts` starts stdio by default and can opt into SSE or streamable HTTP via `MCP_TRANSPORT`. HTTP/SSE mode requires `MCP_AUTH_TOKEN` and defaults to loopback.
+- **MCP tool surface:** tools are registered in `KnowledgeBaseServer.registerTools()`. Current tools include `list_knowledge_bases`, `retrieve_knowledge`, `ask_knowledge`, `list_models`, `kb_stats`, `diff_index`, `add_document`, `delete_document`, and `reindex_knowledge_base`.
+- **CLI surface:** `src/cli.ts` is the `kb` dispatcher. Command-specific behavior lives in `src/cli-*.ts`; shared command-independent logic belongs in `*-core.ts` helpers.
+- **Embeddings:** `FaissIndexManager` is constructed for a concrete `(provider, modelName)` pair. Provider defaults come from `EMBEDDING_PROVIDER` plus provider-specific model env vars.
+- **Index layout:** `$FAISS_INDEX_PATH/active.txt` selects a model id. Each model stores metadata and versioned FAISS data under `$FAISS_INDEX_PATH/models/<model_id>/`; `active-model.ts` is the layout authority.
+- **Indexing strategy:** per-file SHA256 and chunk manifests in `<kb>/.index/` decide what to re-embed. Mutating refreshes use per-model write locks plus versioned atomic saves.
 - **Logging:** `logger.ts` writes **only to stderr** (and optionally `LOG_FILE`). Writing to stdout corrupts the JSON-RPC stream — this is a landed bug, never reintroduce `console.log` inside the server process.
 
 ### Conventions
@@ -31,11 +32,12 @@ node build/index.js    # runs the server over stdio (clients launch it this way)
 
 ### Verification beyond `npm test`
 
-The Jest suite covers logger + FAISS permission handling + utils. It does **not** exercise the live MCP wire protocol or real embedding providers. For changes that touch the tool handlers, the embedding configuration, or the stdio transport, verify end-to-end by:
+The Jest suite is broad but still does **not** exercise every live MCP wire path or real embedding provider. For changes that touch tool handlers, embedding configuration, or transports, verify end-to-end by:
 
 1. Seeding a temp `KNOWLEDGE_BASES_ROOT_DIR` with a couple of markdown files.
-2. Spawning `build/index.js` over stdio from a tiny MCP client (the SDK exposes `Client` + `StdioClientTransport`) with `EMBEDDING_PROVIDER` + the matching API key set.
-3. Sending `tools/list` and `tools/call` for both tools and confirming responses.
+2. Spawning `build/index.js` over stdio from a tiny MCP client (the SDK exposes `Client` + `StdioClientTransport`) with `EMBEDDING_PROVIDER` plus the matching API key or local daemon set.
+3. Sending `tools/list` and representative `tools/call` requests for the changed tools.
+4. For HTTP/SSE changes, run `npm run dev:remote -- --transport=http` or `--transport=sse`.
 
 If a bug or improvement surfaces during that E2E pass, record it as an issue (see below) — it will not be caught by `npm test` alone.
 
@@ -64,7 +66,7 @@ Rationale: follow-up work evaporates the moment context is lost. An issue preser
 ## Gotchas
 
 - **HuggingFace endpoint:** the default now routes through `router.huggingface.co/hf-inference/models/<model>/pipeline/feature-extraction` because HuggingFace retired the legacy `api-inference.huggingface.co/models/...` endpoint. `HUGGINGFACE_ENDPOINT_URL` overrides.
-- **Model-switch invalidates the index:** changing `EMBEDDING_PROVIDER` or the model env var (`OLLAMA_MODEL`, `HUGGINGFACE_MODEL_NAME`, `OPENAI_MODEL_NAME`) for an existing `FAISS_INDEX_PATH` triggers an auto-rebuild via `FaissIndexManager.initialize()`. Expect a one-time delay on the next `retrieve_knowledge` call while every file is re-embedded.
+- **Model-switch no longer wipes the active index:** multi-model support stores each `(provider, model)` under its own `models/<id>/` directory. `kb models add` builds additional models side by side; `kb models set-active` changes the default.
 - **OpenAI not exposed in `smithery.yaml`:** the code supports OpenAI, the Smithery schema does not (`enum: ["huggingface", "ollama"]`). Users deploying via Smithery cannot currently pick OpenAI — tracked for a separate fix.
-- **Docs / agent skills** are being designed in `docs/rfcs/002-ai-skills-setup.md`. Until that lands, per-skill runbooks do not exist yet; this CLAUDE.md is the single agent-facing entry point.
+- **Docs / agent skills** have historical design notes in `docs/rfcs/002-ai-skills-setup.md`, but this `CLAUDE.md`, `README.md`, and `docs/architecture/` are the current repo-facing entry points.
 - **KB-author guidance** — when writing notes the server is meant to retrieve, see `docs/authoring-knowledge.md`. It documents chunker constants, the frontmatter whitelist, content-boundary risk, and the dense vs. lexical vs. hybrid retrieval trade-offs an author can lean into.

--- a/README.md
+++ b/README.md
@@ -479,12 +479,19 @@ npm install -g @jeanibarz/knowledge-base-mcp-server@latest
 
 > **Writing notes that retrieve well?** See [`docs/authoring-knowledge.md`](docs/authoring-knowledge.md) — six-section guide on chunk-friendly markdown, frontmatter taxonomy that lifts into filters, content-boundary safety, and when to split a KB.
 
-The core retrieval tools are:
+The MCP server exposes the current tool set registered by `src/KnowledgeBaseServer.ts`:
 
 *   `list_knowledge_bases`: Lists the available knowledge bases.
 *   `retrieve_knowledge`: Retrieves similar chunks from the knowledge base based on a query. Optionally, if a knowledge base is specified, only that one is searched; otherwise, all available knowledge bases are considered. By default, at most 10 document chunks are returned with a score below a threshold of 2. A different threshold can optionally be provided using the `threshold` parameter.
+*   `ask_knowledge`: Retrieves KB snippets and asks a configured local/OpenAI-compatible LLM to answer with citations.
+*   `list_models`: Lists registered embedding models and the active model.
+*   `kb_stats`: Returns read-only corpus, index, model, cache, and transport statistics.
+*   `diff_index`: Compares retrieval results across two persisted FAISS index versions.
+*   `add_document`: Writes a text document into a KB through the guarded MCP mutation path.
+*   `delete_document`: Deletes a KB-relative document through the guarded MCP mutation path.
+*   `reindex_knowledge_base`: Forces a global FAISS rebuild, optionally validating a named KB before the rebuild.
 
-You can use these tools through the MCP interface.
+You can use these tools through the MCP interface. The `kb` CLI covers the shell-oriented surfaces shown above.
 
 The server also exposes MCP resources for clients that want to enumerate and read source documents directly. `resources/list` returns `kb://<knowledge-base>/<encoded-relative-path>` URIs for ingestable, non-quarantined files under `KNOWLEDGE_BASES_ROOT_DIR`, and `resources/read` returns the raw document content as text or, when `.pdf` is opted into ingest, a base64 PDF blob. See [`docs/mcp-resources.md`](docs/mcp-resources.md) for client-facing URI, MIME type, and percent-encoding details.
 
@@ -555,7 +562,7 @@ not `X-Forwarded-For`, so configure proxy-side throttling for internet exposure.
 For a disposable remote playground during development, use `npm run dev:remote`
 from the local development section above.
 
-**Security defaults:** the server refuses to start in SSE or streamable HTTP mode without `MCP_AUTH_TOKEN`, binds only to loopback, and uses a constant-time bearer comparison. Operators exposing the endpoint off-host should set `MCP_BIND_ADDR=0.0.0.0` *and* terminate TLS in a reverse proxy — TLS is out of scope for this server. Only one process per `FAISS_INDEX_PATH` is supported (see [`docs/architecture/threat-model.md`](./docs/architecture/threat-model.md)).
+**Security defaults:** the server refuses to start in SSE or streamable HTTP mode without `MCP_AUTH_TOKEN`, binds only to loopback, and uses a constant-time bearer comparison. Operators exposing the endpoint off-host should set `MCP_BIND_ADDR=0.0.0.0` *and* terminate TLS in a reverse proxy — TLS is out of scope for this server. Multiple MCP/CLI processes may share a `FAISS_INDEX_PATH`; mutating paths serialize through per-model locks and versioned atomic saves (see [`docs/architecture/threat-model.md`](./docs/architecture/threat-model.md)).
 
 ## Troubleshooting & Logging
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -20,15 +20,15 @@ If you've never seen this repo before, read top-to-bottom:
 1. [`c4-context.md`](./c4-context.md) — one page. Who talks to the server, what it touches on disk, where the trust boundaries are.
 2. [`c4-container.md`](./c4-container.md) — the process and its two on-disk stores (`FAISS_INDEX_PATH`, `KNOWLEDGE_BASES_ROOT_DIR`) as independent containers with different lifecycles.
 3. [`c4-component.md`](./c4-component.md) — the TypeScript modules inside the server process and CLI, plus how they depend on each other.
-4. [`sequence-retrieve.md`](./sequence-retrieve.md) — `retrieve_knowledge` end-to-end, cold and warm.
-5. [`sequence-reindex.md`](./sequence-reindex.md) — what happens when `EMBEDDING_PROVIDER` or the model env var changes under an existing index.
+4. [`sequence-retrieve.md`](./sequence-retrieve.md) — `retrieve_knowledge` end-to-end, including dense/hybrid retrieval, refresh, cache, gate, and reranker behavior.
+5. [`sequence-reindex.md`](./sequence-reindex.md) — forced rebuild and model-selection behavior under the current multi-model layout.
 6. [`sequence-research-collect.md`](./sequence-research-collect.md) — `kb research collect` end-to-end: planner, per-shelf hybrid search loop, and atomic artifact writes.
 7. [`sequence-feedback-promote.md`](./sequence-feedback-promote.md) — `kb feedback add` (append to ledger) and `kb feedback promote` (materialise into a `kb eval` fixture).
-8. [`state-index.md`](./state-index.md) — the FAISS-index lifecycle (None → Loading → Loaded → Rebuilding → Recovering).
+8. [`state-index.md`](./state-index.md) — the per-model FAISS-index lifecycle from construction through load, build, update, rebuild, recovery, and failure.
 9. [`data-model.md`](./data-model.md) — on-disk artifacts and the chunk metadata schema.
 10. [`qa-budgets.md`](./qa-budgets.md) — latency / memory / cost budgets and the current scale ceiling.
-11. [`threat-model.md`](./threat-model.md) — trust boundaries, provider keys, concurrency constraint, path-traversal plan.
-12. [`adr/`](./adr/) — five decisions in MADR 3.0 format (`0001` faiss-over-qdrant, `0002` per-file-hash-sidecars, `0003` stdio-only-transport, `0004` markdown-splitter-default, `0005` auto-rebuild-on-model-change).
+11. [`threat-model.md`](./threat-model.md) — trust boundaries, provider keys, remote transport posture, path validation, and concurrency behavior.
+12. [`adr/`](./adr/) — accepted decisions plus superseded historical decisions. Older ADRs remain useful context, but each file should say when a later RFC or implementation changed the active behavior.
 
 ## Conventions
 
@@ -41,5 +41,5 @@ If you've never seen this repo before, read top-to-bottom:
 ## What this folder does NOT contain
 
 - **Proposals** — they go in `docs/rfcs/`.
-- **API reference** — the MCP tool surface is registered in `src/KnowledgeBaseServer.ts:260-307` and described one level up, in the repo root `README.md`.
-- **Runbooks or agent skills** — designed in `docs/rfcs/002-ai-skills-setup.md`; until that lands, agent-facing guidance lives in the repo root `CLAUDE.md`.
+- **API reference** — the MCP tool surface is registered in `src/KnowledgeBaseServer.ts` and described one level up, in the repo root `README.md`.
+- **Runbooks or agent skills** — operational runbooks live under `docs/operations/`; agent-facing repo guidance lives in the repo root `CLAUDE.md`.

--- a/docs/architecture/adr/0001-faiss-over-qdrant.md
+++ b/docs/architecture/adr/0001-faiss-over-qdrant.md
@@ -1,6 +1,6 @@
 # 0001 — FAISS (embedded) over a standalone vector DB
 
-- **Status:** Accepted
+- **Status:** Accepted; concurrency and layout notes superseded by RFC 013/014
 - **Date:** 2026-04-24 (back-documented)
 - **Deciders:** Repo owner
 
@@ -25,22 +25,33 @@ The server needs a vector store. It must persist across restarts, survive the us
 
 ## Decision Outcome
 
-**Option 1 — embedded FAISS.** Used via `FaissStore` (`src/FaissIndexManager.ts:7`) and persisted to `$FAISS_INDEX_PATH/faiss.index` (`:351`).
+**Option 1 — embedded FAISS.** The implementation still uses FAISS through the
+LangChain community store and `faiss-node`, wrapped by local layout and adapter
+helpers.
+
+Current layout note: the original root-level `$FAISS_INDEX_PATH/faiss.index`
+description is historical. Current saves are per model under
+`$FAISS_INDEX_PATH/models/<model_id>/index -> index.vN/`, with a legacy
+`faiss.index/` read fallback.
 
 ## Pros and Cons
 
 **Pros:**
 - No daemon, no port, no Docker. `npm install && npm start` works.
-- Index is just a file — `rm -rf` is safe reset; `tar` is safe backup.
+- Index state is still local files on disk. Operators can remove derived model
+  indexes to force rebuilds from source content.
 - First-class LangChain integration (`FaissStore.fromTexts`, `addDocuments`, `similaritySearchWithScore`).
 
 **Cons:**
 - Docstore is pickle-serialized (`pickleparser@0.2.1`, `package.json:27`). Loading an attacker-controlled index directory is code-execution-shaped — see [`../threat-model.md`](../threat-model.md).
-- No native support for concurrent writers; one process per `$FAISS_INDEX_PATH` (issue #44, [`../threat-model.md`](../threat-model.md)).
+- FAISS itself still has no native concurrent writer support, but this project
+  now serializes writes with per-model locks and uses versioned atomic saves.
 - Index files are platform-endian; fixtures cannot be shared across architectures (flagged in RFC 007 §8).
 - Deletions are not supported natively (faiss-node) — orphan vectors accumulate until a full rebuild.
 
 ## More Information
 
-- RFC 006 (multi-provider tiered retrieval) and RFC 007 (architecture/perf) both assume FAISS; neither proposes replacing it.
+- RFC 006 (multi-provider tiered retrieval), RFC 007 (architecture/perf), RFC
+  013 (multi-model layout), and RFC 014 (atomic save) all keep the embedded
+  FAISS decision.
 - A future RFC may swap the docstore format away from pickle to close the trust-boundary risk without abandoning the embedded-index model.

--- a/docs/architecture/adr/0002-per-file-hash-sidecars.md
+++ b/docs/architecture/adr/0002-per-file-hash-sidecars.md
@@ -1,12 +1,15 @@
 # 0002 — Per-file hash sidecars
 
-- **Status:** Accepted
+- **Status:** Accepted; crash-safety notes updated by pending sidecar manifests
 - **Date:** 2026-04-24 (back-documented)
 - **Deciders:** Repo owner
 
 ## Context and Problem Statement
 
-On every `retrieve_knowledge` call the server must decide which files (if any) have changed since they were last indexed. The check needs to be correct (no false negatives — changed files must re-embed) and cheap (happens on the hot path, `src/KnowledgeBaseServer.ts:84`).
+On every refresh-before-query `retrieve_knowledge` call the server must decide
+which files, if any, have changed since they were last indexed. The check needs
+to be correct (no false negatives — changed files must re-embed) and cheap
+because it runs on the hot path.
 
 ## Decision Drivers
 
@@ -25,23 +28,31 @@ On every `retrieve_knowledge` call the server must decide which files (if any) h
 
 ## Decision Outcome
 
-**Option 1 — per-file sha256 sidecar.** Implemented at `src/FaissIndexManager.ts:228-247` (read) and `:362-377` (atomic tmp+rename write). One text file per source, content is a 64-char hex digest of the source bytes.
+**Option 1 — per-file sha256 sidecar.** One text file per source stores a
+64-character hex digest of the source bytes under `<kb>/.index/<relpath>`.
+Chunk manifests sit next to those hash sidecars to detect chunk-boundary drift.
 
 ## Pros and Cons
 
 **Pros:**
 - O(1) lookup per file — no parsing / no contention on a shared manifest.
-- Each sidecar survives a partial write via tmp+rename; a crash mid-batch only leaves the unrenamed tail untouched (recovery at `src/FaissIndexManager.ts:369-373`).
+- Each sidecar survives a partial write via tmp+rename; pending sidecar commit
+  recovery in `src/pending-sidecar-commit.ts` handles crashes between FAISS save
+  and sidecar persistence.
 - Stays colocated with the source: moving `<kb>/` between roots keeps its sidecar tree intact.
 - Inspectable — `cat <kb>/.index/foo/bar.md` shows a hex digest; no JSON parser needed.
 
 **Cons:**
 - One inode per source file. On KBs with very large file counts this starts to matter (RFC 007 §7.4 flags for future attention).
 - Reads twice per unchanged file (sha + sidecar read), instead of once (`stat`). RFC 007 §7.5 proposes an mtime+size short-circuit that adds a cheap pre-check without abandoning the hash.
-- No atomic swap across the whole batch — only per-file. RFC 007 §6.2.1 tracks the `pending-manifest.json` protocol that makes the save-then-rename ordering crash-safe across files.
+- No single atomic swap across the whole KB sidecar tree. Current code mitigates
+  the FAISS-save/sidecar-write gap with a per-model `pending-manifest.json` that
+  rolls forward `save-complete` sidecar commits or purges ambiguous
+  `save-started` state.
 
 ## More Information
 
-- `calculateSHA256` at `src/file-utils.ts:6-11` (read once, hash once — no streaming chunk reader).
+- `calculateSHA256` lives in `src/file-utils.ts` (read once, hash once — no
+  streaming chunk reader).
 - Option 2 (single manifest) was rejected because contention on the manifest file makes batched writers trickier than per-file writers, and a corrupt manifest invalidates the whole KB where one corrupt sidecar invalidates one file.
 - Option 4 (mtime+size) trades correctness for speed; the RFC 007 §7.5 proposal keeps it as a **short-circuit** on top of sha, not a replacement.

--- a/docs/architecture/adr/0003-stdio-only-transport.md
+++ b/docs/architecture/adr/0003-stdio-only-transport.md
@@ -1,6 +1,6 @@
 # 0003 — stdio-only MCP transport (for now)
 
-- **Status:** Accepted (provisional — see RFC 008 for the remote-transport design)
+- **Status:** Superseded by RFC 008 implementation; stdio remains the default
 - **Date:** 2026-04-24 (back-documented)
 - **Deciders:** Repo owner
 
@@ -24,7 +24,13 @@ MCP supports multiple transports: stdio (pipe-based, one client per process), SS
 
 ## Decision Outcome
 
-**Option 1 — stdio only.** Implemented at `src/KnowledgeBaseServer.ts:126-127` via `StdioServerTransport`. Remote transport is explicitly a follow-up; RFC 008 captures that design.
+**Original outcome: option 1 — stdio only.** That was the correct initial
+shipping posture.
+
+**Current outcome:** stdio remains the default, and RFC 008 has since added
+opt-in SSE and streamable HTTP transports. Remote modes require
+`MCP_AUTH_TOKEN`, reject wildcard browser origins, bind to loopback by default,
+and share the same MCP tool registration path.
 
 ## Pros and Cons
 
@@ -34,11 +40,14 @@ MCP supports multiple transports: stdio (pipe-based, one client per process), SS
 - Small attack surface — no open ports, no listener thread.
 
 **Cons:**
-- No multi-client support. One server = one client.
-- No way to run the server on one host and query from another (the natural "shared team knowledge base" shape).
-- Any future remote transport must be retrofitted through `McpServer.connect(...)` (`src/KnowledgeBaseServer.ts:127`) in a way that doesn't regress the stdio path.
+- Stdio still has one-client-per-process semantics.
+- HTTP/SSE modes add a network listener and therefore require the auth/origin
+  posture described in the threat model.
+- TLS termination and general internet-facing rate limiting remain out of scope
+  for this server.
 
 ## More Information
 
-- RFC 008 is the design for remote transport; this ADR is **not** a rejection of remote, only a decision to defer.
-- The SIGINT handler at `src/KnowledgeBaseServer.ts:27-30` assumes stdio lifecycle — it tears down the MCP server on receipt. Remote transport will likely keep the same handler with different implications for client reconnection; the future RFC covers that.
+- RFC 008 is now implemented in `src/transport-config.ts`,
+  `src/transport/sse.ts`, `src/transport/http.ts`, and
+  `src/transport/base-http-host.ts`.

--- a/docs/architecture/adr/0004-markdown-splitter-default.md
+++ b/docs/architecture/adr/0004-markdown-splitter-default.md
@@ -1,6 +1,6 @@
 # 0004 — `MarkdownTextSplitter` as the only splitter
 
-- **Status:** Accepted (interim — recursive-character fallback is a follow-up)
+- **Status:** Superseded by recursive-character fallback and chunk-size flags
 - **Date:** 2026-04-24 (back-documented)
 - **Deciders:** Repo owner
 
@@ -24,24 +24,28 @@ Source files must be chunked before embedding. The splitter choice controls chun
 
 ## Decision Outcome
 
-**Option 1.** `src/FaissIndexManager.ts:261-275` (and the fallback rebuild's mirror at `:317-332`) branches on `.md` extension:
+**Original outcome: option 1.** Markdown used `MarkdownTextSplitter`; other
+files were single documents.
 
-- `.md` → `MarkdownTextSplitter({ chunkSize: 1000, chunkOverlap: 200, keepSeparator: false })` creates multiple documents preserving markdown structure.
-- Anything else → one `Document` wrapping the whole file.
+**Current outcome:** `src/file-ingest.ts` builds chunks for every ingestable file.
+Markdown still uses `MarkdownTextSplitter`, while non-markdown text extracted
+from `.txt`, `.rst`, `.html`, `.pdf` when explicitly enabled, and operator-added
+extensions uses `RecursiveCharacterTextSplitter`. `KB_CHUNK_SIZE` and
+`KB_CHUNK_OVERLAP` control the shared chunking constants.
 
 ## Pros and Cons
 
 **Pros:**
-- Correct markdown structure preservation for the dominant case (headings, lists, code fences split cleanly).
-- No config surface; no foot-guns for new users.
-- Non-`.md` files still work — just as a single chunk. Small text files will be fine; large non-markdown files will produce one huge vector that reduces retrieval quality.
+- Correct markdown structure preservation for the dominant case.
+- Large non-markdown files are split instead of becoming one huge vector.
+- Operators can tune chunk size/overlap without forking.
 
 **Cons:**
-- Large non-markdown files (e.g. `.txt` transcripts, `.org` notes, code files) get a single document, which is wrong for retrieval. A `RecursiveCharacterTextSplitter` fallback would be the obvious fix.
-- No way to override the chunk size / overlap without forking.
-- Duplicated splitter construction between the changed-file branch and the fallback branch (`:261-267` vs `:319-323`). A refactor could hoist it to a helper.
+- Chunking is now a broader ingest concern rather than a markdown-only decision;
+  future splitter changes should update `src/file-ingest.ts` and
+  `docs/feature-flags.md` together.
 
 ## More Information
 
-- The recursive-character fallback for non-markdown files is a known follow-up; capturing it here so future maintainers see it is an intentional deferral, not an oversight.
+- The recursive-character fallback for non-markdown files has landed.
 - RFC 006 discusses retrieval quality more broadly; the splitter question can move inside that umbrella if the tiered retrieval work lands first.

--- a/docs/architecture/adr/0005-auto-rebuild-on-model-change.md
+++ b/docs/architecture/adr/0005-auto-rebuild-on-model-change.md
@@ -1,6 +1,6 @@
 # 0005 — Auto-rebuild on model change (probably wrong)
 
-- **Status:** Accepted with reservations — see "More Information" and RFC 007 follow-ups
+- **Status:** Superseded by RFC 013 multi-model layout
 - **Date:** 2026-04-24 (back-documented)
 - **Deciders:** Repo owner
 
@@ -12,7 +12,8 @@ Vectors from one embedding model are not comparable to vectors from another. If 
 - Error out until the user manually resolves it.
 - Rebuild automatically, incurring one full re-embedding pass.
 
-The current code picks option 3, guarded by a `model_name.txt` tag. Whether this is the right call is debatable.
+The original code picked option 3, guarded by a root-level `model_name.txt` tag.
+That behavior is now historical.
 
 ## Decision Drivers
 
@@ -23,29 +24,34 @@ The current code picks option 3, guarded by a `model_name.txt` tag. Whether this
 
 ## Considered Options
 
-1. **Auto-rebuild on mismatch** — current. `src/FaissIndexManager.ts:153-164` deletes `faiss.index`, sets `faissIndex = null`, writes the new model name.
+1. **Auto-rebuild on mismatch** — historical. The old implementation deleted
+   the single FAISS store when `model_name.txt` did not match the current env.
 2. **Refuse to start** with an error message telling the user to `rm -rf $FAISS_INDEX_PATH` (or similar) and restart.
 3. **Rebuild only on `FORCE_REINDEX=1`**, otherwise refuse.
 4. **Two indexes side-by-side**, keyed by model name; never delete the old.
 
 ## Decision Outcome
 
-**Option 1** is in production. The fallback branch at `src/FaissIndexManager.ts:302-346` handles the rebuild on the next `retrieve_knowledge` call.
+**Current outcome: option 4.** RFC 013 made model state side-by-side under
+`$FAISS_INDEX_PATH/models/<model_id>/`. `active.txt` selects the default model,
+and `KB_ACTIVE_MODEL` or per-call overrides can select another registered model.
+Changing provider/model env vars no longer destroys an existing model directory.
 
 ## Pros and Cons
 
 **Pros:**
-- Zero configuration recovery — flipping the env var eventually "just works".
-- No orphan on-disk state to clean up later.
-- Cost is local and bounded (one full rebuild, then back to normal warm-query cost).
+- Existing model indexes remain available after registering or activating another
+  model.
+- Operators can compare models and switch back without re-embedding.
+- Paid-provider rebuilds are explicit through `kb models add` or refresh/reindex
+  commands rather than a silent destructive startup side effect.
 
 **Cons (the "probably wrong" part):**
-- **Silently expensive.** The rebuild can cost real dollars (OpenAI) or real minutes (HuggingFace) the user didn't explicitly authorize. The log line at `src/FaissIndexManager.ts:154` is the only signal.
-- **Silently destructive.** `unlink(faiss.index)` (`:157`) throws away work the user paid to produce. If the env change was an accident (shell oops, wrong `OLLAMA_MODEL` pulled), there is no undo.
-- **Sidecar mismatch.** The hash sidecars survive the rebuild because they hash source content, not embeddings — which is correct, but confusing: a user inspecting `.index/` sidecars after a model switch sees identical hashes and might assume nothing happened.
+- Side-by-side model directories use more disk than a single overwritten store.
+- Operators must manage inactive models with `kb models remove` when they no
+  longer want to keep them.
 
 ## More Information
 
-- RFC 007 follow-ups discuss making this loud: log a `warn` with the estimated rebuild cost, or gate it behind an explicit flag. That conversation is still open.
-- The error-out-and-require-manual-reset path (option 2) is not obviously worse — it's just more friction. A reasonable future change is to flip the default to option 2 and require `AUTO_REBUILD_ON_MODEL_CHANGE=1` to opt into current behaviour.
-- See [`../sequence-reindex.md`](../sequence-reindex.md) for the full flow this ADR describes.
+- See [`../sequence-reindex.md`](../sequence-reindex.md) for the current
+  model-add, activation, and forced-rebuild flows.

--- a/docs/architecture/c4-component.md
+++ b/docs/architecture/c4-component.md
@@ -19,7 +19,7 @@ flowchart TB
 
   subgraph server["MCP runtime"]
     KBS["KnowledgeBaseServer.ts:191-790<br/>tools, resources, transports, warmup"]
-    SSE["transport/sse.ts:52-418<br/>SSE host and session dispatch"]
+    SSE["transport/sse.ts<br/>SSE host and session dispatch"]
     Watcher["triggerWatcher.ts:41-209<br/>polling reindex trigger"]
   end
 
@@ -36,13 +36,13 @@ flowchart TB
     ModelId["model-id.ts:8-66<br/>model id parsing and validation"]
     KbFs["kb-fs.ts:11-90<br/>KB listing and document path resolution"]
     FileUtils["file-utils.ts:6-46<br/>SHA256 and recursive walk"]
-    IngestFilter["ingest-filter.ts:31-237<br/>ingestable path rules"]
-    KbPaths["kb-paths.ts:13-104<br/>KB name and safe path validation"]
+    IngestFilter["ingest-filter.ts<br/>ingestable path rules"]
+    KbPaths["kb-paths.ts<br/>KB name validation"]
     Frontmatter["frontmatter.ts:16-83<br/>YAML frontmatter parsing"]
     ErrorUtils["error-utils.ts:1-23<br/>unknown-to-Error coercion"]
   end
 
-  Config["config.ts:5-280<br/>env-derived runtime config"]
+  Config["config/*.ts<br/>env-derived runtime config"]
   Logger["logger.ts:14-74<br/>stderr logger + optional file mirror"]
   Errors["errors.ts:1-23<br/>typed KB errors"]
   OllamaErr["ollama-error.ts:34-108<br/>Ollama retry/error translation"]
@@ -133,15 +133,15 @@ flowchart TB
 | Model id helpers | `src/model-id.ts:8-66` | Validates and derives provider-qualified model ids. | Used by active-model, CLI, FAISS manager, and cost estimates. |
 | KB filesystem helpers | `src/kb-fs.ts:11-90` | Lists KB directories and resolves exposed MCP resource document paths. | Used by CLI, MCP server, and FAISS manager. |
 | File utilities | `src/file-utils.ts:6-46` | SHA256 hashing and recursive, dotfile-skipping file walks. | Used by CLI handlers and FAISS manager. |
-| Ingest filter | `src/ingest-filter.ts:31-237` | Applies corpus inclusion/exclusion rules and public skipped-filename patterns. | Used by CLI handlers, MCP server, and FAISS manager. |
-| KB path validation | `src/kb-paths.ts:13-104` | Validates KB names and resolves user document paths without traversal or symlink escape. | Used by MCP server and KB FS. |
+| Ingest filter | `src/ingest-filter.ts` | Applies corpus inclusion/exclusion rules and public skipped-filename patterns. | Used by CLI handlers, MCP server, and FAISS manager. |
+| KB path validation | `src/kb-paths.ts` | Validates KB names. Document path resolution without traversal or symlink escape lives in `src/kb-fs.ts` and `src/mcp-resources.ts`. | Used by MCP server, resources, and KB FS. |
 | Frontmatter parser | `src/frontmatter.ts:16-83` | Parses bounded FAILSAFE YAML frontmatter into tags/body/raw object. | Used by FAISS manager chunk metadata shaping. |
 | Error utilities | `src/error-utils.ts:1-23` | Converts unknown thrown values into stable `Error` instances at catch boundaries. | Used by MCP server and FAISS manager. |
-| Config | `src/config.ts:5-280` | Reads env-derived runtime config at module load and validates SSE transport settings on startup. | Used by most runtime modules. |
+| Config | `src/config/*.ts`, `src/transport-config.ts` | Reads env-derived runtime config at module load; validates MCP transport settings at startup. | Used by most runtime modules. |
 | Formatter | `src/formatter.ts:25-88` | Sanitizes metadata and formats retrieval results as markdown/JSON. | Used by CLI and MCP server. |
 | Loaders | `src/loaders.ts:28-101` | Routes file loading by extension for plain text, PDF, and HTML. | Used by FAISS manager. |
 | Write lock | `src/write-lock.ts:17-72` | Serializes write paths with `proper-lockfile`. | Used by CLI and MCP server. |
-| SSE host | `src/transport/sse.ts:52-418` | Hosts MCP-over-SSE sessions with auth/origin checks and per-session `McpServer` instances. | Used by `KnowledgeBaseServer.runSse()`. |
+| SSE host | `src/transport/sse.ts` | Hosts MCP-over-SSE sessions with auth/origin checks and per-session `McpServer` instances. | Used by `KnowledgeBaseServer.runSse()`. |
 | Trigger watcher | `src/triggerWatcher.ts:41-209` | Polls a trigger file and requests reindexing when mtime changes. | Used by `KnowledgeBaseServer.startTriggerWatcher()`. |
 | Logger | `src/logger.ts:14-74` | Writes logs to stderr and optional `LOG_FILE`, preserving stdout for JSON-RPC/CLI output. | Imported by runtime modules. |
 | Error taxonomy | `src/errors.ts:1-23` | Defines `KBError` codes for operator-facing failure paths. | Used by FAISS manager, MCP server, and Ollama error translation. |
@@ -151,11 +151,15 @@ flowchart TB
 
 ### Request path
 
-`retrieve_knowledge` is registered in `src/KnowledgeBaseServer.ts:267-285`. At request time, `handleRetrieveKnowledge` resolves the active or explicit model at `src/KnowledgeBaseServer.ts:557-572`, runs `manager.updateIndex()` under the per-model write lock at `src/KnowledgeBaseServer.ts:574-577`, queries `manager.similaritySearch()` at `src/KnowledgeBaseServer.ts:579-586`, then formats results through `formatRetrievalAsMarkdown()` at `src/KnowledgeBaseServer.ts:589-602`.
+`retrieve_knowledge` is registered in `src/KnowledgeBaseServer.ts`. At request
+time, `handleRetrieveKnowledge` resolves the active or explicit model, runs
+`manager.updateIndex()` under the per-model write lock, queries
+`manager.similaritySearch()` or the hybrid search path, then formats results
+through `formatRetrievalAsMarkdown()`.
 
 ### Startup path
 
-`src/index.ts:8` calls `server.run()`. `KnowledgeBaseServer.run()` loads transport config at `src/KnowledgeBaseServer.ts:619-631`, bootstraps the FAISS layout at `src/KnowledgeBaseServer.ts:633-646`, then starts either stdio at `src/KnowledgeBaseServer.ts:664-671` or SSE at `src/KnowledgeBaseServer.ts:673-686`. Active-manager warmup is best-effort and starts after transport connect at `src/KnowledgeBaseServer.ts:694-731`.
+`src/index.ts:8` calls `server.run()`. `KnowledgeBaseServer.run()` loads transport config, bootstraps the FAISS layout, then starts stdio, SSE, or streamable HTTP. Active-manager warmup is best-effort and starts after transport connect.
 
 ### Model layout path
 
@@ -163,7 +167,12 @@ flowchart TB
 
 ### Index persistence path
 
-`FaissIndexManager.initialize()` creates embeddings lazily and loads the current store at `src/FaissIndexManager.ts:656-700`. The manager delegates versioned persistence to `loadFaissStoreAtomic()` at `src/faiss-store-layout.ts:72-162` and `saveFaissStoreAtomic()` at `src/faiss-store-layout.ts:164-193`; those helpers prefer the RFC 014 symlink layout, fall back to legacy `faiss.index/`, write a new `index.vN/`, atomically swap the `index` symlink, and garbage-collect old versions.
+`FaissIndexManager.initialize()` creates embeddings lazily and loads the current
+store. The manager delegates versioned persistence to
+`loadFaissStoreAtomic()` and `saveFaissStoreAtomic()` in
+`src/faiss-store-layout.ts`; those helpers prefer the RFC 014 symlink layout,
+fall back to legacy `faiss.index/`, write a new `index.vN/`, atomically swap the
+`index` symlink, and garbage-collect old versions.
 
 ### CLI path
 
@@ -178,4 +187,4 @@ flowchart TB
 - **`active-model.ts` is the model layout authority.** New code should not reconstruct `models/<id>/` paths independently.
 - **FAISS store layout is not embedded in the manager.** Versioned index load/save behavior belongs in `faiss-store-layout.ts`; `FaissIndexManager` remains the ingest/search orchestrator.
 - **Shared helpers are domain-scoped.** Prefer `file-utils.ts`, `ingest-filter.ts`, `kb-paths.ts`, `frontmatter.ts`, and `error-utils.ts` over reintroducing broad utility barrels.
-- **Config is read at module load except transport validation.** `loadTransportConfig()` is the explicit startup validation boundary at `src/config.ts:255-280`.
+- **Config is read at module load except transport validation.** `loadTransportConfig()` in `src/transport-config.ts` is the explicit startup validation boundary for MCP transport settings.

--- a/docs/architecture/c4-container.md
+++ b/docs/architecture/c4-container.md
@@ -1,78 +1,98 @@
-# C4 — Container
+# C4 - Container
 
-Zooming one level in from [`c4-context.md`](./c4-context.md). The system is the server process plus two on-disk stores with **different lifecycles**. They are independent containers: the server can be restarted without touching either; either can be deleted or relocated independently of the other; `model_name.txt` links the two across restarts.
+Zooming one level in from [`c4-context.md`](./c4-context.md). The current system
+has two executable containers in this package (`build/index.js` and
+`build/cli.js`) plus persistent stores under the KB root and FAISS root. The MCP
+server and CLI share the same model registry and index layout.
 
 ## Diagram
 
 ```mermaid
 flowchart LR
-  subgraph client_side["MCP client process"]
-    Client["Client SDK<br/>StdioClientTransport"]
+  subgraph clients["Clients"]
+    McpClient["MCP client<br/>stdio or HTTP/SSE"]
+    Shell["Shell / editor / automation"]
   end
 
-  subgraph server_container["Server container — Node.js ≥16, single process"]
-    direction TB
-    Transport["StdioServerTransport<br/>src/KnowledgeBaseServer.ts:126-127"]
-    McpServer["McpServer (SDK)<br/>src/KnowledgeBaseServer.ts:19-22<br/>exposes list_knowledge_bases, retrieve_knowledge"]
-    Indexer["FaissIndexManager (in-memory)<br/>holds faissIndex + embeddings client<br/>src/FaissIndexManager.ts:80-131"]
-    Logger["logger<br/>stderr + optional LOG_FILE<br/>src/logger.ts:16,18-49"]
+  subgraph package["This package"]
+    Server["MCP server<br/>src/KnowledgeBaseServer.ts"]
+    Cli["kb CLI<br/>src/cli.ts + cli-*.ts"]
+    Daemon["kb serve daemon<br/>src/cli-serve.ts"]
   end
 
-  subgraph kbs_store["Container: Knowledge-base source tree<br/>$KNOWLEDGE_BASES_ROOT_DIR"]
-    Docs[("&lt;kb&gt;/**.md, .txt (user-authored)")]
-    Hashes[("&lt;kb&gt;/.index/**/&lt;basename&gt;<br/>one sha256 per source file")]
+  subgraph kbs_store["Knowledge-base source tree<br/>$KNOWLEDGE_BASES_ROOT_DIR"]
+    Source[("User-authored files")]
+    KbIndex[(".index/<br/>hash sidecars, chunk manifests,<br/>quarantine, feedback")]
   end
 
-  subgraph faiss_store["Container: FAISS index store<br/>$FAISS_INDEX_PATH"]
-    FaissFiles[("faiss.index + docstore.json<br/>written by FaissStore.save")]
-    ModelFile[("model_name.txt<br/>src/FaissIndexManager.ts:25")]
+  subgraph faiss_store["FAISS/model store<br/>$FAISS_INDEX_PATH"]
+    Active[("active.txt")]
+    Models[("models/<model_id>/")]
+    Versioned[("index -> index.vN/<br/>faiss.index + docstore.json")]
+    Cache[("cache/queries/<model_id>/")]
   end
 
-  subgraph provider_box["Container: Embedding provider (external)"]
-    HF["HuggingFace router<br/>router.huggingface.co/...<br/>src/config.ts:29-34"]
-    OAI["OpenAI API"]
-    Ollama["Ollama (local HTTP)<br/>OLLAMA_BASE_URL"]
+  subgraph services["External/local services"]
+    Embeddings["Embedding provider"]
+    Llm["Optional LLM endpoint"]
   end
 
-  Client == "JSON-RPC / stdio" ==> Transport
-  Transport --> McpServer
-  McpServer -- "updateIndex / similaritySearch" --> Indexer
-  Indexer -- "readdir, sha256, readFile" --> Docs
-  Indexer -- "read/write sidecar" --> Hashes
-  Indexer -- "FaissStore.load/save" --> FaissFiles
-  Indexer -- "read/write model name" --> ModelFile
-  Indexer -- "embedDocuments / embedQuery" --> HF & OAI & Ollama
-  McpServer -.-> Logger
-  Indexer -.-> Logger
+  McpClient --> Server
+  Shell --> Cli
+  Cli --> Daemon
+  Server --> Source
+  Server --> KbIndex
+  Cli --> Source
+  Cli --> KbIndex
+  Server --> Active
+  Server --> Models
+  Server --> Versioned
+  Server --> Cache
+  Cli --> Active
+  Cli --> Models
+  Cli --> Versioned
+  Cli --> Cache
+  Server --> Embeddings
+  Cli --> Embeddings
+  Server --> Llm
+  Cli --> Llm
 ```
 
 ## Containers
 
-| Container                           | Tech                              | Lifecycle                                                                 | Persistence        |
-| ----------------------------------- | --------------------------------- | ------------------------------------------------------------------------- | ------------------ |
-| Server process                      | Node.js ≥16, TypeScript strict    | Launched per MCP client session; SIGINT triggers graceful shutdown (`src/KnowledgeBaseServer.ts:27-30`). | None (pure in-memory aside from two stores below). |
-| Knowledge-base source tree          | Plain files on local FS           | User-authored, long-lived. Server only reads content; writes `.index/` sidecars next to sources. | User's responsibility. |
-| FAISS index store                   | `faiss.index` + pickled docstore + `model_name.txt` | Written incrementally by this server. Wiped + rebuilt when the model changes (`src/FaissIndexManager.ts:153-164`). | Survives restarts; safe to delete (will rebuild from source tree on next call). |
-| Embedding provider                  | Remote HTTP or local HTTP daemon  | External; one per configured `EMBEDDING_PROVIDER` (`src/config.ts:12`).   | N/A.               |
+| Container | Tech | Lifecycle | Persistence |
+| --- | --- | --- | --- |
+| MCP server | Node.js >=20, TypeScript output | Launched by an MCP client over stdio, or by an operator/supervisor for HTTP/SSE mode. | In-memory managers only; durable state is in the stores below. |
+| `kb` CLI | Node.js command binary | Fresh process per command, except when a command opts into `kb serve` for warm reads. | Writes only through explicit write commands or refresh/reindex flows. |
+| `kb serve` daemon | Loopback HTTP helper | Foreground process or user service; optional. | Keeps warm in-memory state; durable state remains in the stores. |
+| Knowledge-base source tree | Plain files | User-owned, long-lived content. | Source files plus `.index/` sidecars. |
+| FAISS/model store | `active.txt`, `models/<id>/`, versioned FAISS dirs, cache | Server-owned local state; safe to delete when the operator wants a rebuild. | Active model, model metadata, FAISS index versions, query cache, update summaries. |
+| Embedding provider | Local or remote HTTP/client library | External service selected by provider/model config. | N/A. |
+| Optional LLM endpoint | OpenAI-compatible chat endpoint | External or `kb llm` managed profile. | Profile config/state is outside the FAISS store; see the data model. |
 
-## Why the two stores are separate containers
+## Why The Stores Are Separate
 
-They **look** like one thing — both are directories on the user's disk — but they have different owners, different lifecycles, and different risk profiles:
+- `$KNOWLEDGE_BASES_ROOT_DIR` is owned by the user. It contains durable notes and
+  per-KB operational sidecars.
+- `$FAISS_INDEX_PATH` is owned by the server. It contains derived indexes,
+  model-selection state, query cache entries, and persisted diagnostics.
+- Deleting `$FAISS_INDEX_PATH` removes derived retrieval state only; the next
+  refresh/rebuild can reconstruct vectors from the source tree.
+- Deleting a KB source directory removes user content and cannot be reconstructed
+  from FAISS.
 
-- `$KNOWLEDGE_BASES_ROOT_DIR` is **owned by the user** (the user writes the markdown). The server only writes sidecars into `.index/` subdirs.
-- `$FAISS_INDEX_PATH` is **owned by the server** (every file here is either written by `FaissStore.save()` or by `initialize()` itself, `src/FaissIndexManager.ts:181`). Users must not drop files into it from other sources — see [`threat-model.md`](./threat-model.md) on `pickleparser` deserialization.
-- Deleting `$FAISS_INDEX_PATH` is a safe no-op: next `retrieve_knowledge` call rebuilds it from the source tree via the fallback path at `src/FaissIndexManager.ts:302-346`.
-- Deleting `$KNOWLEDGE_BASES_ROOT_DIR` makes queries return `_No similar results found._` on the next call (and the scan at `src/FaissIndexManager.ts:209` will find no KBs).
+## Cross-Container Links
 
-## Cross-container links
+| Link | Direction | Source of truth |
+| --- | --- | --- |
+| Active model selection | CLI/MCP read `active.txt`; model commands write it. | `src/active-model.ts` |
+| Per-model FAISS persistence | Managers load/save versioned `models/<id>/index.vN/` directories. | `src/faiss-store-layout.ts`, `src/FaissIndexManager.ts` |
+| Source freshness | Refresh compares source hashes with `<kb>/.index/` sidecars and chunk manifests. | `src/file-ingest.ts`, `src/FaissIndexManager.ts` |
+| Query cache | Retrieval can reuse query embeddings from memory or `$FAISS_INDEX_PATH/cache/queries/`. | `src/query-cache.ts` |
+| Remote MCP runtime stats | HTTP/SSE hosts expose counters to `kb_stats` while active. | `src/transport-runtime-stats.ts`, `src/KnowledgeBaseServer.ts` |
 
-| Link                                             | Direction | Anchored at                                                          |
-| ------------------------------------------------ | --------- | -------------------------------------------------------------------- |
-| `KNOWLEDGE_BASES_ROOT_DIR` → per-file sha256 sidecar inside `.index/` | write     | `src/FaissIndexManager.ts:230-231, :362-377`                         |
-| `FAISS_INDEX_PATH/model_name.txt` → model guard  | read/write | `src/FaissIndexManager.ts:143-164, :181`                             |
-| `FAISS_INDEX_PATH/faiss.index` → in-memory `faissIndex` | load/save | `src/FaissIndexManager.ts:166-177, :348-355`                         |
+## Out Of Scope
 
-## Out of scope
-
-- How requests are routed *inside* the server process — see [`c4-component.md`](./c4-component.md).
-- Retrieval vs indexing sequences — see [`sequence-retrieve.md`](./sequence-retrieve.md) and [`sequence-reindex.md`](./sequence-reindex.md).
+- Request-level sequences; see [`sequence-retrieve.md`](./sequence-retrieve.md).
+- Forced rebuild and model selection flows; see [`sequence-reindex.md`](./sequence-reindex.md).
+- Security posture; see [`threat-model.md`](./threat-model.md).

--- a/docs/architecture/c4-context.md
+++ b/docs/architecture/c4-context.md
@@ -1,34 +1,53 @@
-# C4 — Context
+# C4 - Context
 
-The server is a single-process, stdio-attached MCP server. One human talks to one MCP client; the client launches one server process per configured knowledge-base root; that process reaches out to one embedding provider and persists to one on-disk FAISS index.
+The server is a local-first knowledge retrieval process plus a companion `kb`
+CLI. A human or agent can reach it through an MCP client, through optional
+HTTP/SSE MCP transport, or directly through the CLI. All modes share the same
+knowledge-base source tree, embedding-provider configuration, and per-model
+FAISS index layout.
 
 ## Diagram
 
 ```mermaid
 flowchart TB
-  subgraph user_box["User's machine (trusted)"]
+  subgraph user_box["User's machine"]
     direction TB
-    User["👤 Human"]
+    User["Human or local agent"]
+    Shell["Shell / editor / automation"]
     Client["MCP client<br/>(Claude Desktop, Codex, Cursor, Cline, Continue)"]
-    subgraph server_proc["knowledge-base-mcp-server (this repo)"]
-      Server["Node.js process<br/>build/index.js"]
+    Cli["kb CLI<br/>build/cli.js"]
+    Server["knowledge-base-mcp-server<br/>build/index.js"]
+    Daemon["optional kb serve daemon<br/>loopback HTTP"]
+
+    subgraph kbs_trust["$KNOWLEDGE_BASES_ROOT_DIR<br/>content trust boundary"]
+      KBs[("KB folders<br/>source files + .index sidecars")]
     end
-    subgraph kbs_trust["$KNOWLEDGE_BASES_ROOT_DIR (content trust boundary)"]
-      KBs[("Markdown / text files<br/>in &lt;kb&gt;/ subdirs<br/>+ .index/ sidecars")]
+
+    subgraph faiss_trust["$FAISS_INDEX_PATH<br/>index/code-exec trust boundary"]
+      FAISS[("active.txt<br/>models/<model_id>/<br/>index -> index.vN<br/>query cache")]
     end
-    subgraph faiss_trust["$FAISS_INDEX_PATH (code-exec trust boundary — see threat-model)"]
-      FAISS[("faiss.index<br/>docstore.json<br/>model_name.txt")]
-    end
-  end
-  subgraph remote["Remote (network boundary)"]
-    Provider["Embedding provider<br/>HuggingFace router · OpenAI · Ollama"]
   end
 
-  User -- "chat" --> Client
-  Client == "JSON-RPC over stdio<br/>tools/list · tools/call" ==> Server
-  Server -- "readdir / readFile / writeFile<br/>sha256" --> KBs
-  Server -- "FaissStore.load / save<br/>pickle docstore" --> FAISS
-  Server -- "embedDocuments / embedQuery" --> Provider
+  subgraph remote["External or local services"]
+    Provider["Embedding provider<br/>HuggingFace router / OpenAI / Ollama"]
+    Llm["optional OpenAI-compatible LLM<br/>kb ask / gate / contextual ingest"]
+    BrowserClient["optional remote MCP client<br/>HTTP or SSE"]
+  end
+
+  User --> Client
+  User --> Shell
+  Shell --> Cli
+  Cli --> Daemon
+  Cli --> KBs
+  Cli --> FAISS
+  Client == "JSON-RPC over stdio" ==> Server
+  BrowserClient == "MCP over HTTP/SSE<br/>bearer auth" ==> Server
+  Server --> KBs
+  Server --> FAISS
+  Server --> Provider
+  Cli --> Provider
+  Server --> Llm
+  Cli --> Llm
 
   classDef boundary stroke-dasharray:5 5,fill:#fafafa,color:#333;
   class kbs_trust,faiss_trust,remote boundary;
@@ -36,25 +55,34 @@ flowchart TB
 
 ## Participants
 
-| Actor                         | Role                                                                    | Where it's anchored                                                 |
-| ----------------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------- |
-| Human                         | Types natural-language queries into an MCP client.                      | Out of process.                                                     |
-| MCP client                    | Spawns `build/index.js`, connects to its stdio, calls `tools/list` + `tools/call`. | Any SDK-compliant client; our server registers in `src/KnowledgeBaseServer.ts:19-22`. |
-| Server process                | The Node.js process built from `src/`.                                  | Entry point `src/index.ts:5-11`; transport hook-up `src/KnowledgeBaseServer.ts:126-127`. |
-| Embedding provider            | External HTTP service that turns text into vectors.                     | Provider picked in `src/FaissIndexManager.ts:86-131`; routed URL for HF is `src/config.ts:29-34`. |
-| `$KNOWLEDGE_BASES_ROOT_DIR`   | Local directory the user populates with markdown/text.                  | Default at `src/config.ts:5-6`.                                     |
-| `$FAISS_INDEX_PATH`           | Local directory holding the FAISS index + docstore + `model_name.txt`. | Default at `src/config.ts:8-9`; files listed in [`data-model.md`](./data-model.md). |
+| Actor | Role | Where it is anchored |
+| --- | --- | --- |
+| Human or local agent | Issues queries, asks questions, writes notes, and runs diagnostics. | Out of process. |
+| MCP client | Launches stdio server or connects to opt-in HTTP/SSE transport. | `src/KnowledgeBaseServer.ts` transport startup and tool registration. |
+| `kb` CLI | Shell-friendly search, ask, model, diagnostics, eval, research, feedback, and write workflows. | `src/cli.ts` dispatcher and `src/cli-*.ts` command modules. |
+| Optional `kb serve` daemon | Keeps warm CLI read paths available over loopback HTTP. | `src/cli-serve.ts` and `src/daemon-client.ts`. |
+| Server process | Registers MCP tools/resources and coordinates model managers, retrieval, writes, and transport hosts. | `src/KnowledgeBaseServer.ts`. |
+| Embedding provider | Converts source chunks and queries into vectors. | `src/embedding-provider.ts`. |
+| Optional LLM endpoint | Answers `kb ask`, relevance-gate judge calls, and contextual ingest prefaces when enabled. | `src/llm-client.ts`, `src/ask-core.ts`, `src/contextual-preface.ts`. |
+| `$KNOWLEDGE_BASES_ROOT_DIR` | User-owned source tree plus per-KB `.index/` sidecars. | `src/config/paths.ts`, `src/kb-fs.ts`, `src/file-ingest.ts`. |
+| `$FAISS_INDEX_PATH` | Server-owned model registry, versioned FAISS stores, cache, and index metadata. | `src/active-model.ts`, `src/faiss-store-layout.ts`, `src/query-cache.ts`. |
 
-## Trust boundaries
+## Trust Boundaries
 
-Three dashed boxes in the diagram, three distinct trust stories:
+1. **`$KNOWLEDGE_BASES_ROOT_DIR` is a content boundary.** Retrieved text is
+   untrusted input for downstream agents. Injection guards can tag or wrap
+   suspicious content, but they do not make retrieved text trustworthy.
+2. **`$FAISS_INDEX_PATH` is an index/code-execution boundary.** FAISS docstore
+   loading goes through LangChain/FAISS serialization, so only this server should
+   write those files.
+3. **Embedding and LLM providers are network/data boundaries.** Query text and
+   source chunks can leave the machine unless the operator uses local providers.
+4. **HTTP/SSE MCP transport is optional and authenticated.** Non-stdio transport
+   requires a bearer token, denies browser origins unless explicitly allowed,
+   and binds to loopback by default.
 
-1. **`$KNOWLEDGE_BASES_ROOT_DIR` (content boundary).** File contents are embedded and returned verbatim to the MCP client. If this directory contains attacker-written prose, the result is prompt-injection against downstream agents — not code execution against the server. See [`threat-model.md`](./threat-model.md).
-2. **`$FAISS_INDEX_PATH` (code-exec boundary).** `FaissStore.load()` deserializes the docstore via `pickleparser` (`package.json:27`, load site `src/FaissIndexManager.ts:169`). Loading an attacker-controlled index directory is arbitrary-code-execution-shaped. **Only files written by this server belong here.**
-3. **Network boundary to the embedding provider.** Query text and knowledge-base content leave the machine in cleartext over TLS to whichever provider is configured. Provider keys (`HUGGINGFACE_API_KEY`, `OPENAI_API_KEY`, `OLLAMA_BASE_URL`) are read from env and never logged as payload.
+## What Is Not In This View
 
-## What is *not* in this view
-
-- Process-to-process concurrency (there is none — see [`threat-model.md`](./threat-model.md) concurrency section; constraint is one process per `$FAISS_INDEX_PATH`).
-- Remote MCP transport (not implemented today; see RFC 008 for the proposal).
-- Access control (none; stdio clients inherit the user's permissions).
+- Internal module relationships; see [`c4-component.md`](./c4-component.md).
+- Detailed index state transitions; see [`state-index.md`](./state-index.md).
+- Full security analysis; see [`threat-model.md`](./threat-model.md).

--- a/docs/architecture/data-model.md
+++ b/docs/architecture/data-model.md
@@ -6,7 +6,7 @@ Every artifact that survives a process restart lives under either `$KNOWLEDGE_BA
 
 ```mermaid
 flowchart LR
-  subgraph kbs["$KNOWLEDGE_BASES_ROOT_DIR<br/>src/config.ts"]
+  subgraph kbs["$KNOWLEDGE_BASES_ROOT_DIR<br/>src/config/paths.ts"]
     direction TB
     subgraph kb1["&lt;kb_name&gt;/  (user-authored)"]
       Source["*.md, *.txt, *.pdf, *.html<br/>plus configured extra extensions"]
@@ -17,25 +17,33 @@ flowchart LR
     kb2["&lt;other_kb&gt;/"]
   end
 
-  subgraph faiss["$FAISS_INDEX_PATH<br/>src/config.ts"]
+  subgraph faiss["$FAISS_INDEX_PATH<br/>src/config/paths.ts"]
     direction TB
     Active["active.txt<br/>active model_id"]
     Models["models/"]
     ModelDir["&lt;model_id&gt;/<br/>provider__filesystem-safe-slug"]
-    ModelName["model_name.txt<br/>configured embedding model name"]
-    IndexLink["index<br/>symlink to index.vN"]
-    Version["index.vN/"]
-    Faiss["faiss.index<br/>faiss-node binary vector index"]
-    Docs["docstore.json<br/>LangChain docstore sibling"]
-    Legacy["faiss.index/<br/>legacy layout, read fallback"]
+      ModelName["model_name.txt<br/>configured embedding model name"]
+      IndexType["index-type.txt<br/>flat or sq8"]
+      LastUpdate["last-index-update.json<br/>latest update summary"]
+      MetadataSidecar["metadata-sidecar.jsonl<br/>filter fast-path rows"]
+      IndexLink["index<br/>symlink to index.vN"]
+      Version["index.vN/"]
+      Faiss["faiss.index<br/>faiss-node binary vector index"]
+      Docs["docstore.json<br/>LangChain docstore sibling"]
+      QueryCache["cache/queries/&lt;model_id&gt;/<br/>query embedding cache"]
+      Legacy["faiss.index/<br/>legacy layout, read fallback"]
 
     Active --> ModelDir
     Models --> ModelDir
     ModelDir --> ModelName
+    ModelDir --> IndexType
+    ModelDir --> LastUpdate
+    ModelDir --> MetadataSidecar
     ModelDir --> IndexLink
     IndexLink --> Version
     Version --> Faiss
     Version --> Docs
+    ModelDir --> QueryCache
     ModelDir -.pre-RFC-014.-> Legacy
   end
 ```
@@ -101,6 +109,41 @@ models/<model_id>/
 
 The pre-RFC-014 layout is `models/<model_id>/faiss.index/{faiss.index,docstore.json}`. The loader still falls back to it when the `index` symlink is absent (`src/faiss-store-layout.ts:122-142`). The first successful save under the new layout writes `index.vN/` and leaves the legacy directory untouched as downgrade/rollback slack (`src/FaissIndexManager.ts:765-770`). When both layouts are present, `kb models list` can surface a downgrade hazard derived directly from filesystem state (`src/active-model.ts:129-185`).
 
+### Query embedding cache
+
+`$FAISS_INDEX_PATH/cache/queries/<model_id>/` stores optional query-vector cache
+entries. Each query key is a SHA-256 over schema version, `model_id`, and the
+normalized query. The vector is stored as `<sha>.f32`; metadata is stored as
+`<sha>.meta.json`. The cache is a latency/cost optimization only: corrupt or
+incomplete entries are removed and treated as misses. Operators can disable it
+with `KB_QUERY_CACHE=off` or per-call CLI flags where supported.
+
+### Model sidecar files
+
+Each model directory can also contain:
+
+- `index-type.txt` — index creation type such as `flat` or `sq8`.
+- `last-index-update.json` — latest sanitized `updateIndex` summary for fresh
+  process stats and doctor reports.
+- `metadata-sidecar.jsonl` — per-doc metadata rows used to speed filtered search
+  before falling back to post-filter overfetch.
+- `pending-manifest.json` — crash-recovery manifest between FAISS save and
+  sidecar commit.
+- `.adding` — temporary sentinel while `kb models add` is in progress.
+
+### Other durable operator artifacts
+
+Not every durable artifact belongs under the two retrieval stores:
+
+- `kb research collect --run-dir=<path>` writes `run.json`, `plan.json`,
+  `ledger.json`, `events.jsonl`, and `evidence_packet.md` to the operator-chosen
+  run directory.
+- `KB_MUTATION_AUDIT_LOG=<path>` writes an append-only mutation audit JSONL file
+  outside the KB and FAISS roots when configured.
+- `kb llm` profile and managed-service state live under configurable user config,
+  state, and systemd directories (`KB_LLM_CONFIG_DIR`, `KB_LLM_STATE_DIR`,
+  `KB_LLM_SYSTEMD_USER_DIR`).
+
 ## In-memory: chunk metadata schema
 
 `FaissIndexManager.updateIndex` uses one chunk builder for changed-file indexing and full-rebuild fallback (`src/FaissIndexManager.ts:705-709`, `:748-752`). `buildChunkDocuments` splits markdown with `MarkdownTextSplitter`, other ingested extensions with `RecursiveCharacterTextSplitter`, strips YAML frontmatter from page content, and attaches the metadata below to every emitted `Document` (`src/file-ingest.ts:37-104`).
@@ -143,9 +186,13 @@ For markdown chunks only, `detectSiblingPdfPath` looks for a same-stem PDF in th
 
 ## Not persisted
 
-- Query text is not written to disk by the retrieval path; it flows to the embedding provider for the request and then is discarded.
+- Raw query text is not written to disk by the retrieval path. Query-cache keys
+  are hashes of normalized query text, model id, and schema version; cache values
+  are vectors, not raw queries.
 - Embedding provider keys (`HUGGINGFACE_API_KEY`, `OPENAI_API_KEY`) are held in `process.env` for the life of the process. They are not written to sidecars, model registry files, or FAISS docstore metadata.
-- There is no cache, queue, or scratch directory outside `$KNOWLEDGE_BASES_ROOT_DIR` and `$FAISS_INDEX_PATH`.
+- Retrieval itself has no queue. Operator workflows such as `kb research`,
+  mutation audit logging, and `kb llm` profiles write outside the retrieval
+  stores only when the operator selects or enables those surfaces.
 
 ## Checked against
 
@@ -154,6 +201,8 @@ This page is verified against the following source files. If one of these files 
 - Chunk metadata wire shape: `src/file-ingest.ts:37-104`.
 - Frontmatter whitelist + sanitisation: `src/frontmatter-lift.ts:19-218`, `src/formatter.ts:34-90`.
 - Atomic FAISS save / pinned load / version retention: `src/faiss-store-layout.ts`.
+- Query embedding cache: `src/query-cache.ts`.
+- Model registry, model sidecars, incomplete-add sentinel: `src/active-model.ts`.
 - Sidecar write path: `src/file-ingest.ts:118-144`, `src/FaissIndexManager.ts:782-793`.
 - Active-model resolution: `src/active-model.ts:5-26`, `:259-330`.
 - Per-model directory and `model_name.txt`: `src/active-model.ts:107-127`, `src/FaissIndexManager.ts:327-334`.

--- a/docs/architecture/qa-budgets.md
+++ b/docs/architecture/qa-budgets.md
@@ -9,7 +9,7 @@ If you are changing indexing, embeddings, or the request path, re-run `npm run b
 | Phase                                                 | Today        | Source                       | Notes |
 | ----------------------------------------------------- | ------------ | ---------------------------- | ----- |
 | Constructor + module import (stub env)                | **170 ms**   | RFC 007 §5.1                 | Dominated by `@langchain/*` module load. No lazy imports today. |
-| `initialize()` when `faiss.index` is absent           | **~2 ms**    | RFC 007 §5.1                 | Just creates the dir and writes `model_name.txt`. |
+| `initialize()` when a model index is absent           | **~2 ms**    | RFC 007 §5.1                 | Just creates the per-model dir and writes model metadata. |
 | `initialize()` when loading existing index            | **not measured in-repo** | —                | RFC 007 §5.5 flags this as a deferred measurement; depends on index size + disk. |
 | **Cold build**, 100 files × ~500 chunks, stubbed 20 ms/embedding | **10 761 ms**| RFC 007 §5.2                 | ~10 000 ms is the serial-embedding floor (500 × 20 ms); rest is 100 `save()` calls (now collapsed to 1 by PR #27). |
 | **Warm no-op** (all hashes match), 100 files          | **84 ms p50** | RFC 007 §5.3                | Fixed floor from async-loop + per-file sha + sidecar read. |
@@ -17,7 +17,11 @@ If you are changing indexing, embeddings, or the request path, re-run `npm run b
 | **Warm no-op**, 2 000 files                           | **87 ms p50** | RFC 007 §5.3                | Per-file cost drops to 44 µs; fixed floor still dominates. |
 | `similaritySearch` (stubbed FAISS, k=10)              | **0.26 ms**  | RFC 007 §5.4                 | FAISS itself is not the bottleneck; the query-vector embedding round-trip is (not stubbed out). |
 
-**Interpretation.** The request-path cost on a warm index is dominated by the mandatory `updateIndex()` scan at `src/KnowledgeBaseServer.ts:84`, not by FAISS search. That is the lever RFC 007 §6.3 / §7.5 is pulling. For now, budget every `retrieve_knowledge` call at **80–100 ms warm + query-embedding RTT**; cold builds are proportional to `total_chunks × per_chunk_embedding_latency`.
+**Interpretation.** The request-path cost on a warm index is dominated by the
+mandatory `updateIndex()` scan in the MCP `retrieve_knowledge` path, not by
+FAISS search. That is the lever RFC 007 §6.3 / §7.5 is pulling. For now, budget
+every `retrieve_knowledge` call at **80–100 ms warm + query-embedding RTT**;
+cold builds are proportional to `total_chunks × per_chunk_embedding_latency`.
 
 ## Memory budgets
 
@@ -25,7 +29,7 @@ If you are changing indexing, embeddings, or the request path, re-run `npm run b
 | --------------------------------- | ---------- | -------------- |
 | After `new KnowledgeBaseServer()` | ~81 MB     | RFC 007 §5.1   |
 | After cold build of 100 files     | ~112 MB    | RFC 007 §5.2 (Δ ≈ 31 MB) |
-| After much larger KBs             | grows linearly with total chunks — **single global FAISS store** holds every KB's vectors today (`src/FaissIndexManager.ts:81`). RFC 007 §6.4 plans per-KB isolation + bounded LRU. |
+| After much larger KBs             | grows linearly with total chunks in the loaded model. Each model has its own FAISS store, and each store still contains every KB's vectors for that model. |
 
 ## Cost budgets (embedding-provider calls)
 
@@ -47,16 +51,22 @@ Current ceiling (informal, from code + §5 measurements, **not** a tested guaran
 | Dimension                    | Ceiling                                           |
 | ---------------------------- | ------------------------------------------------- |
 | Number of files              | **Thousands.** Warm scan stays sub-100 ms up to ~2 000 (§5.3); beyond that, per-file sha256 cost starts to dominate. |
-| Number of knowledge bases    | **Tens**, informally. No hard cap in code; a global FAISS store means memory is the practical limit. |
+| Number of knowledge bases    | **Tens**, informally. No hard cap in code; per-model FAISS store memory is the practical limit. |
 | Index size on disk           | **Tens of MB.** Larger is fine on modern disks; the not-yet-measured risk is `FaissStore.load` time at startup (RFC 007 §5.5). |
-| Concurrent server processes  | **1 per `$FAISS_INDEX_PATH`.** See [`threat-model.md`](./threat-model.md#concurrency) — multiple processes race on `save()` and sidecar tmp+rename, and will corrupt state. |
+| Concurrent server processes  | Multiple MCP/CLI processes may share a `$FAISS_INDEX_PATH`; writes serialize through per-model locks and versioned atomic saves. |
 
 ## Known cliffs
 
-- **Per-query scan** (`src/KnowledgeBaseServer.ts:84` → `src/FaissIndexManager.ts:202-389`). Every `retrieve_knowledge` pays the ~85 ms scan floor even when nothing changed. RFC 007 §6.3 (scan-on-signal) and §7.5 (mtime+size short-circuit) are the two candidate fixes.
+- **Per-query scan.** Every MCP `retrieve_knowledge` call pays the warm scan
+  floor even when nothing changed. RFC 007 §6.3 (scan-on-signal) and §7.5
+  (mtime+size short-circuit) are the two candidate fixes.
 - **Embedding provider payload limits.** `INDEXING_BATCH_SIZE` bounds changed-file and fallback rebuild batches. Raise it cautiously for high-throughput remote providers; lower it when a provider rejects large payloads.
-- **Global FAISS store memory** (`src/FaissIndexManager.ts:81`). Querying one KB still loads vectors from every KB into RAM. RFC 007 §6.4 tracks the per-KB split.
-- **No concurrency guard** across processes. One process per `$FAISS_INDEX_PATH` is a documented constraint, not an enforced one — see [`threat-model.md`](./threat-model.md) and issue #44.
+- **Per-model global FAISS store memory.** Querying one KB still loads vectors
+  from every KB for the selected model into RAM. The multi-model layout isolates
+  models, not KBs.
+- **Concurrent writers wait on locks.** Per-model write locks and versioned
+  atomic saves protect index data. Very long writes can still delay refreshes for
+  the same model.
 
 ## How to re-measure
 

--- a/docs/architecture/sequence-reindex.md
+++ b/docs/architecture/sequence-reindex.md
@@ -1,87 +1,94 @@
-# Sequence — model-change reindex
+# Sequence - reindex and model selection
 
-What happens when the user changes `EMBEDDING_PROVIDER`, `HUGGINGFACE_MODEL_NAME`, `OLLAMA_MODEL`, or `OPENAI_MODEL_NAME` with an existing index on disk. The triggering comparison is at `src/FaissIndexManager.ts:153`; the teardown at `:154-164`; the reconstruction at `src/FaissIndexManager.ts:302-346` on the next `updateIndex` call.
+This page replaces the earlier "model-change wipes the index" description. The
+current system uses RFC 013 multi-model layout: a provider/model pair maps to a
+stable `model_id`, each model has its own directory, and changing the active
+model selects a different directory instead of deleting the previous one.
 
-This is a **destructive** path — the old `faiss.index` is deleted, then rebuilt from source markdown using the new model. ADR [`0005-auto-rebuild-on-model-change.md`](./adr/0005-auto-rebuild-on-model-change.md) explains why the current code wipes rather than refuses, and why that choice is debatable.
-
-## Diagram
+## Model Add And Activation
 
 ```mermaid
 sequenceDiagram
   autonumber
-  participant Entry as index.ts:5
-  participant Server as KnowledgeBaseServer
+  participant Op as Operator
+  participant Cli as kb models
+  participant Active as active-model.ts
   participant FIM as FaissIndexManager
-  participant Store as $FAISS_INDEX_PATH
-  participant FS as $KNOWLEDGE_BASES_ROOT_DIR
-  participant Provider as Embedding provider<br/>(NEW model)
+  participant Lock as withWriteLock(modelDir)
+  participant Store as $FAISS_INDEX_PATH/models/<id>
+  participant Provider as Embedding provider
+  participant FS as KB source tree
 
-  Note over Entry,Provider: User changed OLLAMA_MODEL<br/>and restarted the server
-  Entry->>Server: new KnowledgeBaseServer().run()
-  Server->>FIM: new FaissIndexManager()<br/>:86-131
-  Note over FIM: constructor picks new model<br/>from config.ts env vars
-
-  Server->>Server: McpServer.connect(stdio)<br/>:126-127
-  Note over Server: MCP handshake completes<br/>BEFORE initialize() runs
-
-  Server->>FIM: initialize()<br/>:133-194
-  FIM->>Store: pathExists(FAISS_INDEX_PATH)<br/>:135
-  FIM->>Store: readFile(model_name.txt)<br/>:146-148
-  Store-->>FIM: "old-model-name"
-
-  alt stored != current (MISMATCH)
-    Note over FIM: warn: "Model name has changed..."<br/>:154
-    FIM->>Store: unlink(faiss.index)<br/>:157
-    Note over FIM: this.faissIndex = null<br/>:163
-  end
-
-  FIM->>Store: pathExists(faiss.index)
-  Note over FIM,Store: file just deleted → branch at :174-177
-  Note over FIM: faissIndex stays null
-
-  FIM->>Store: writeFile(model_name.txt, NEW-model)<br/>:181
-  Note over FIM: initialize() returns
-
-  Note over Server,Provider: Time passes — first retrieve_knowledge request arrives
-
-  Server->>FIM: updateIndex(kb?)<br/>:202-389
-  loop for each file in each KB
-    FIM->>FS: sha256 + read sidecar
-    Note over FIM: sidecars still reflect OLD-model<br/>content (hash of source file, not embedding)
-    Note over FIM: hashes match → NOT re-embedded<br/>via the changed-file branch
-  end
-
-  Note over FIM: indexMutated==false, faissIndex==null,<br/>anyFileProcessed==true → fallback branch
-  rect rgba(255, 235, 200, 0.6)
-    Note over FIM,Provider: Fallback rebuild from all files<br/>:302-346
-    FIM->>FS: re-walk every KB (second pass)
-    loop for each file
-      FIM->>FS: readFile + split
-    end
-    FIM->>Provider: embedDocuments([...all chunks, new model])
-    Provider-->>FIM: new vectors
-    FIM->>Store: FaissStore.fromTexts(all)<br/>:338-343
-  end
-  FIM->>Store: faissIndex.save(faiss.index)<br/>:348-355
-  par tmp+rename sidecars (unchanged hashes)
-    FIM->>FS: overwrite sidecar (.tmp → rename)
-  end
+  Op->>Cli: kb models add <provider> <model>
+  Cli->>Active: derive model_id and create .adding sentinel
+  Cli->>FIM: new FaissIndexManager({provider, modelName})
+  Cli->>Lock: acquire lock for models/<id>
+  Lock->>FIM: initialize()
+  FIM->>Store: create model dir + model_name.txt + index-type.txt
+  Lock->>FIM: updateIndex(undefined, force/build)
+  FIM->>FS: enumerate, load, split files
+  FIM->>Provider: embed chunks in bounded batches
+  FIM->>Store: save index.vN and atomically swap index
+  FIM->>FS: write hash/chunk sidecars
+  Cli->>Active: remove .adding; optionally write active.txt
+  Cli-->>Op: model registered
 ```
 
-## Why the fallback runs
+Activation is a small metadata write:
 
-The sha256 sidecars are hashes of the **source file content**, not of the embedding — so changing the embedding model does **not** invalidate them (`src/file-utils.ts:6-11`). On the first call after a model change:
+```mermaid
+sequenceDiagram
+  autonumber
+  participant Op as Operator
+  participant Cli as kb models set-active
+  participant Active as active-model.ts
+  participant Store as $FAISS_INDEX_PATH
 
-- Every file's hash matches its sidecar, so the changed-file branch at `src/FaissIndexManager.ts:250-293` is skipped.
-- But `this.faissIndex` is still `null` (cleared by the model-change block at `:163`, not replaced by the `FaissStore.load` branch at `:166-177` because `faiss.index` no longer exists).
-- The combination — "some files scanned AND `faissIndex === null`" — triggers the fallback at `src/FaissIndexManager.ts:302-346`, which unconditionally re-embeds every file.
+  Op->>Cli: kb models set-active <model_id>
+  Cli->>Active: validate registered model
+  Active->>Store: atomic write active.txt
+  Cli-->>Op: active model changed
+```
 
-That fallback is also what recovers from a user manually deleting `$FAISS_INDEX_PATH/faiss.index`.
+The previously active model directory remains on disk. Operators can switch back
+without re-embedding unless they removed that model or its index.
 
-## Cost
+## Forced Reindex
 
-Proportional to `total_chunks × per_chunk_embedding_latency` plus one `save()`. RFC 007 §5.2 measured 10 761 ms for 100 files / 500 chunks against a 20 ms/chunk stub; real providers range from 50 to 200 ms/chunk — see [`qa-budgets.md`](./qa-budgets.md).
+`kb reindex --with-context`, `kb search --refresh`, and MCP
+`reindex_knowledge_base` all eventually call `FaissIndexManager.updateIndex`.
+When `force` is true, the rebuild is global for the active model even if the
+caller supplied a KB name. FAISS deletion is not supported in this server, so a
+"scoped force rebuild" would either duplicate old vectors or drop other KBs.
 
-## Partial-model switch (e.g. wrong provider env)
+```mermaid
+sequenceDiagram
+  autonumber
+  participant Caller as CLI or MCP caller
+  participant Active as active-model.ts
+  participant Lock as withWriteLock(modelDir)
+  participant FIM as FaissIndexManager
+  participant Store as models/<active_id>
+  participant FS as KB source tree
 
-If the user sets `EMBEDDING_PROVIDER=openai` but forgets `OPENAI_API_KEY`, construction throws at `src/FaissIndexManager.ts:100` before `initialize()` runs — so the on-disk index is **not** touched. Same for HuggingFace at `:112`. The `.faiss/` directory survives, and reverting the env on the next start restores the prior behaviour with no rebuild cost.
+  Caller->>Active: resolveActiveModel()
+  Active-->>Caller: active model_id
+  Caller->>Lock: acquire active model write lock
+  Lock->>FIM: updateIndex(kb?, {force:true})
+  FIM->>FIM: upgrade scoped force to global rebuild
+  FIM->>FS: enumerate all ingestable files
+  FIM->>Store: build new versioned FAISS store
+  FIM->>FS: rewrite sidecars and manifests
+  Lock-->>Caller: release
+```
+
+## Recovery And Safety
+
+- `.adding` sentinels hide incomplete model directories from `list_models` and
+  let `kb models` report interrupted additions.
+- Pending sidecar commit manifests recover crashes between FAISS persistence and
+  sidecar persistence.
+- Versioned saves write a new `index.vN/` directory and atomically swap the
+  `index` symlink, so readers pin one coherent version.
+- The old destructive model-switch path described by ADR 0005 is superseded by
+  side-by-side model directories.

--- a/docs/architecture/sequence-retrieve.md
+++ b/docs/architecture/sequence-retrieve.md
@@ -1,104 +1,84 @@
-# Sequence — `retrieve_knowledge`
+# Sequence - `retrieve_knowledge`
 
-End-to-end flow for the `retrieve_knowledge` tool. The handler lives at `src/KnowledgeBaseServer.ts:74-122` and always runs two steps in order: refresh the index (`updateIndex` at `src/FaissIndexManager.ts:202-389`), then query it (`similaritySearch` at `src/FaissIndexManager.ts:394-408`).
+End-to-end flow for the MCP `retrieve_knowledge` tool. The handler resolves the
+active or requested model, refreshes the selected model's index under a
+per-model write lock, runs dense or hybrid retrieval, optionally applies the
+relevance gate and reranker, and returns formatted markdown.
 
-There are two paths through the same handler, distinguished by **whether the in-memory `faissIndex` is already populated when the request arrives**. Both land at the same `similaritySearch` call.
-
-## Warm path — index loaded, all hashes match
-
-This is the cheap case: every file's on-disk sha matches the sidecar, so no embedding calls happen.
-
-```mermaid
-sequenceDiagram
-  autonumber
-  participant Client as MCP client
-  participant Server as KnowledgeBaseServer<br/>:74-122
-  participant FIM as FaissIndexManager
-  participant FS as $KNOWLEDGE_BASES_ROOT_DIR
-  participant Faiss as faissIndex (in-memory)
-  participant Provider as Embedding provider
-
-  Client->>Server: tools/call retrieve_knowledge<br/>{query, knowledge_base_name?, threshold?}
-  Server->>FIM: updateIndex(knowledge_base_name?)<br/>:202-389
-  FIM->>FS: readdir + getFilesRecursively<br/>:209, :223
-  loop for each file
-    FIM->>FS: readFile + sha256<br/>file-utils.ts:6-11
-    FIM->>FS: read sidecar hash<br/>:242-247
-    Note over FIM: hashes match → skip branch<br/>:294-296
-  end
-  Note over FIM,Faiss: indexMutated == false → no save
-  Server->>FIM: similaritySearch(query, 10, threshold)<br/>:394-408
-  FIM->>Provider: embedQuery(query)
-  Provider-->>FIM: query vector
-  FIM->>Faiss: similaritySearchWithScore(vec, 10, filter)
-  Faiss-->>FIM: [(doc, score), ...]
-  FIM-->>Server: ScoredDocument[]
-  Server-->>Client: markdown-formatted results
-```
-
-**Cost profile.** No embedding batches for documents, no FAISS save, no sidecar writes. The scan is O(files-across-selected-KBs) with one `stat` + `readFile` + sha256 + sidecar-read per file. See [`qa-budgets.md`](./qa-budgets.md) for the ~85 ms warm floor measured in RFC 007 §5.3.
-
-## Cold path — no persisted index (or first-touch files)
-
-Either `initialize()` found no `faiss.index` on disk (`src/FaissIndexManager.ts:174-177`), so `this.faissIndex` is `null` at request time, **or** some file hashes don't match. Both land in the same branch: changed chunks are embedded, `faissIndex` is built or extended, then persisted once.
+## Dense Path
 
 ```mermaid
 sequenceDiagram
   autonumber
   participant Client as MCP client
-  participant Server as KnowledgeBaseServer<br/>:74-122
+  participant Server as KnowledgeBaseServer
+  participant Active as active-model.ts
+  participant Lock as withWriteLock(modelDir)
   participant FIM as FaissIndexManager
-  participant FS as $KNOWLEDGE_BASES_ROOT_DIR
-  participant Faiss as faissIndex (in-memory)
-  participant Store as $FAISS_INDEX_PATH
+  participant FS as KB source tree
+  participant Store as models/<model_id>/index
   participant Provider as Embedding provider
+  participant Formatter as formatter.ts
 
-  Client->>Server: tools/call retrieve_knowledge
-  Server->>FIM: updateIndex(knowledge_base_name?)<br/>:202-389
-  FIM->>FS: readdir KBs + recursive file walk<br/>:209, :223
-  loop for each file with mismatched/absent hash
-    FIM->>FS: readFile<br/>:253-258
-    alt *.md
-      FIM->>FIM: MarkdownTextSplitter.createDocuments<br/>:261-267
-    else other ext
-      FIM->>FIM: new Document({pageContent, metadata: {source}})<br/>:268-275
-    end
-    alt faissIndex == null (first chunk)
-      FIM->>Provider: embedDocuments(chunks)
-      FIM->>Faiss: FaissStore.fromTexts(...)<br/>:278-284
-    else index exists
-      FIM->>Provider: embedDocuments(chunks)
-      FIM->>Faiss: addDocuments(chunks)<br/>:285-287
-    end
-    Note over FIM: pendingHashWrites.push({path, hash})<br/>:289
+  Client->>Server: tools/call retrieve_knowledge {query, model_name?, filters?}
+  Server->>Active: resolveActiveModel(explicitOverride?)
+  Active-->>Server: model_id
+  Server->>FIM: managers.getOrCreate(model_id)
+  Server->>Lock: acquire per-model write lock
+  Lock->>FIM: updateIndex(kb?)
+  FIM->>FS: enumerate ingestable files + read hashes/manifests
+  alt changed files or missing index
+    FIM->>FS: load and split files
+    FIM->>Provider: embed changed/rebuild chunks in bounded batches
+    FIM->>Store: save index.vN and atomically swap index symlink
+    FIM->>FS: write hash + chunk sidecars after save
+  else all current
+    FIM-->>Lock: no save
   end
-  opt faissIndex still null && any file scanned
-    FIM->>FS: re-walk all KBs<br/>:302-337<br/>(fallback rebuild from every file)
-    FIM->>Provider: embedDocuments(all chunks)
-    FIM->>Faiss: FaissStore.fromTexts(all)<br/>:338-345
-  end
-  FIM->>Store: faissIndex.save(FAISS_INDEX_PATH/faiss.index)<br/>:348-355
-  par write hash sidecars (tmp + rename)
-    FIM->>FS: writeFile <sidecar>.tmp + rename<br/>:362-377
-  end
-  Server->>FIM: similaritySearch(query, 10, threshold)<br/>:394-408
-  FIM->>Provider: embedQuery(query)
-  FIM->>Faiss: similaritySearchWithScore(vec, 10, filter)
-  Faiss-->>FIM: [(doc, score), ...]
-  FIM-->>Server: ScoredDocument[]
-  Server-->>Client: markdown-formatted results
+  Lock-->>Server: release
+  Server->>FIM: similaritySearch(query, k=10, threshold, filters)
+  FIM->>Provider: embedQuery(query) or query-cache hit
+  FIM->>Store: FAISS search
+  FIM-->>Server: scored documents
+  Server->>Server: apply relevance gate when enabled
+  Server->>Formatter: formatRetrievalAsMarkdown(results)
+  Server-->>Client: markdown + structured gate verdict
 ```
 
-### Ordering invariant
+## Hybrid Path
 
-One `save()` per index-mutating `updateIndex` call; hash and chunk sidecars are written **after** `save()` completes and use tmp+rename so each sidecar is atomic. Before the save, `updateIndex` writes `$FAISS_INDEX_PATH/models/<model_id>/pending-manifest.json` with the pending sidecar set and phase `save-started`; after the FAISS save succeeds it advances the phase to `save-complete`; after every sidecar is durable it removes the manifest. On the next normal `initialize()`, `save-complete` manifests are rolled forward by finishing the sidecar writes. Ambiguous `save-started` manifests cause the persisted store and stale sidecars to be purged so the next scan rebuilds instead of duplicating vectors.
+When `search_mode: "hybrid"` is passed, the server still refreshes the dense
+index first. It then runs:
 
-### Fallback rebuild edge case
+- a dense FAISS leg against the selected model;
+- a lexical BM25 leg over the same KB scope;
+- Reciprocal Rank Fusion with `c=60`;
+- optional cross-encoder reranking when enabled;
+- the relevance gate when enabled.
 
-If the hash-scan phase embedded nothing (e.g. first call after a fresh restart with a `faiss.index` that failed to load, or an index-less directory that also has stale sidecar state) but files exist, the branch at `src/FaissIndexManager.ts:302-346` re-walks every KB and embeds **all** chunks unconditionally. This is the path that makes cold starts slow on large KBs — see [`qa-budgets.md`](./qa-budgets.md) for the 10 761 ms measurement at 100 files / 500 chunks.
+Hybrid currently rejects neighbor-context expansion because context expansion is
+implemented against dense semantic matches only.
 
-## Error paths (not drawn)
+## Key Invariants
 
-- Permission error during save/sidecar → `handleFsOperationError` at `src/FaissIndexManager.ts:50-78` marks the error `__alreadyLogged` and rethrows. The tool handler catches it at `src/KnowledgeBaseServer.ts:114-121` and returns `{ isError: true }`.
-- `similaritySearch` called when `faissIndex` is still `null` (e.g. empty `$KNOWLEDGE_BASES_ROOT_DIR`) → throws `"FAISS index is not initialized"` from `src/FaissIndexManager.ts:395-397`; the same handler converts it to `isError: true`.
-- Provider call failure → unwound through the `throw error` at `src/FaissIndexManager.ts:380-388`; same handler path.
+- **Model resolution is per call.** `model_name` overrides the active model only
+  for that request; otherwise `KB_ACTIVE_MODEL`, `active.txt`, then legacy env
+  fallback are used.
+- **Writes are per-model locked.** Refreshes for one model do not block reads or
+  additions for another model unless they share the same model directory.
+- **FAISS saves are versioned.** The active store is `models/<model_id>/index`,
+  a symlink to an `index.vN/` directory containing `faiss.index` and
+  `docstore.json`.
+- **Sidecars are committed after FAISS.** Pending sidecar manifests make crashes
+  between index save and sidecar write recoverable on the next initialize.
+- **Default CLI search differs from MCP retrieval.** `kb search` is read-only
+  unless `--refresh` is passed; MCP `retrieve_knowledge` preserves the historical
+  refresh-before-query behavior.
+
+## Error Paths
+
+- Missing or corrupt active model resolution returns an MCP `isError` result.
+- Provider, index, and validation failures are mapped to structured KB error
+  payloads where possible.
+- Relevance-gate or reranker provider failures degrade to the retrieval baseline
+  unless the specific feature documents a stricter mode.

--- a/docs/architecture/state-index.md
+++ b/docs/architecture/state-index.md
@@ -1,92 +1,75 @@
-# State — FAISS index lifecycle
+# State - FAISS index lifecycle
 
-Lifecycle of the in-memory `this.faissIndex: FaissStore | null` field and its on-disk counterpart under `$FAISS_INDEX_PATH/models/<model_id>/`. The diagram describes observable states from the caller's perspective: the field is either `null` or a loaded FAISS store; the lifecycle enriches that single bit with the reason for its current value.
+Lifecycle of a single `FaissIndexManager` instance for one `model_id`. The
+manager owns one in-memory FAISS adapter and one model directory under
+`$FAISS_INDEX_PATH/models/<model_id>/`.
 
 ## Diagram
 
 ```mermaid
 stateDiagram-v2
-  [*] --> None: process start<br/>before initialize()
+  [*] --> Constructed: new FaissIndexManager({provider, modelName})
 
-  state "None" as None
-  note left of None
-    faissIndex = null
-    model directory may or may not exist
-    FaissIndexManager.initialize()
+  state "Constructed" as Constructed
+  note right of Constructed
+    model_id, modelDir, modelNameFile
+    are derived; embeddings are not
+    loaded until initialize().
   end note
 
-  None --> Loading: initialize() sees a versioned<br/>or legacy FAISS store on disk
+  Constructed --> Initializing: initialize()
+  Initializing --> Loaded: active versioned or legacy store loads
+  Initializing --> Empty: no store exists
+  Initializing --> Recovering: pending-manifest.json exists
+  Initializing --> Failed: provider/config/load failure
 
-  state "Loading" as Loading
-  note right of Loading
-    FaissStore.load(path, embeddings)
-    loadFaissStoreAtomic()
-    (may throw → handleFsOperationError)
-  end note
+  Recovering --> Loaded: save-complete manifest rolls sidecars forward
+  Recovering --> Empty: save-started manifest purges ambiguous store
 
-  Loading --> Loaded: load() resolves
-  Loading --> None: load() fails → re-thrown; next init retries
+  Empty --> Building: updateIndex() finds ingestable chunks
+  Loaded --> Updating: updateIndex() finds append-safe changed chunks
+  Loaded --> Rebuilding: force reindex, missing freshness manifest, or non-append-safe chunk drift
 
-  None --> Rebuilding: force reindex or freshness manifest mismatch
-  Loaded --> Rebuilding: force reindex or freshness manifest mismatch
+  Building --> Loaded: first index version saved
+  Updating --> Loaded: new docs added + index.vN saved
+  Updating --> Loaded: metadata-only sidecars advanced
+  Updating --> Failed: save/sidecar/provider failure
+  Rebuilding --> Loaded: global rebuild saved
+  Rebuilding --> Loaded: rebuild deferred; prior persisted store reloaded
+  Rebuilding --> Empty: persisted store purged and no replacement was saved
 
-  state "Rebuilding" as Rebuilding
-  note right of Rebuilding
-    faissIndex = null
-    persisted index store removed
-    updateIndex() embeds from current files
-  end note
-
-  Rebuilding --> None: persisted store purged
-
-  None --> Loaded: updateIndex fallback rebuild
-  None --> Loaded: first updateIndex call with changed files
-
-  state "Loaded" as Loaded
-  note left of Loaded
-    faissIndex wraps a FaissStore
-    models/<model_id>/index -> index.vN
-    ready to answer similaritySearch
-  end note
-
-  Loaded --> Loaded: updateIndex with new / changed files<br/>add documents + atomicSave()
-  Loaded --> Loaded: updateIndex with all-matching hashes<br/>(no-op save path)
-
-  Loaded --> Recovering: initialize() sees pending-manifest.json<br/>phase=save-complete
-  Recovering --> Loaded: finish pending sidecar writes
-  Recovering --> None: phase=save-started<br/>purge persisted store + sidecars
-
-  state "Recovering" as Recovering
-  note right of Recovering
-    pending-manifest.json records
-    hash + chunk sidecars that
-    must match the saved vectors
-  end note
-
-  Loaded --> [*]: SIGINT → McpServer.close()<br/>src/KnowledgeBaseServer.ts:27-30
+  Loaded --> Loaded: updateIndex() all hashes current; no save
+  Failed --> [*]
+  Loaded --> [*]: process exit
+  Empty --> [*]: process exit
 ```
 
-## Transition triggers
+## Transition Triggers
 
-| From → To                     | Trigger                                                                                   | Anchor                                             |
-| ----------------------------- | ----------------------------------------------------------------------------------------- | -------------------------------------------------- |
-| `[*]` → `None`                | Process start; constructor runs but does not load a FAISS store.                          | `FaissIndexManager.constructor`                    |
-| `None` → `Loading`            | `initialize()` asks the atomic loader for the active versioned or legacy FAISS store.     | `FaissIndexManager.initialize`, `loadFaissStoreAtomic` |
-| `Loading` → `Loaded`          | `FaissStore.load` resolves.                                                               | `loadFaissStoreAtomic`                             |
-| `Loading` → `None`            | `FaissStore.load` rejects (permission / corrupt / incompatible). Error propagated or repaired to null depending on read-only mode. | `loadFaissStoreAtomic` |
-| `None` → `Rebuilding`         | Forced reindex, freshness-manifest mismatch, or ambiguous pending sidecar commit requires a full rebuild. | `FaissIndexManager.updateIndex`, `recoverPendingSidecarCommit` |
-| `Rebuilding` → `None`         | Persisted store and stale sidecars are purged; next `updateIndex` embeds from source files. | `purgePersistedIndexStore`, `purgeStaleSidecars` |
-| `None` → `Loaded` (build)     | Changed-file branch creates the in-memory store from pending documents.                  | `addDocumentsToIndex`                              |
-| `None` → `Loaded` (fallback)  | All hashes match but `faissIndex` was null → full rebuild from every file.                | `FaissIndexManager.updateIndex`                    |
-| `Loaded` → `Loaded` (delta)   | Subsequent `updateIndex` with new/changed files; add documents and one atomic save.       | `addDocumentsToIndex`, `atomicSave`                |
-| `Loaded` → `Recovering`       | `initialize()` detects a `save-complete` `pending-manifest.json` on disk.                | `src/FaissIndexManager.ts`, `src/pending-sidecar-commit.ts` |
-| `Recovering` → `None`         | `initialize()` detects an ambiguous `save-started` manifest and purges persisted store + sidecars for a rebuild. | `src/FaissIndexManager.ts`, `src/pending-sidecar-commit.ts` |
-| `Loaded` → `[*]`              | SIGINT handler closes the MCP server.                                                     | `src/KnowledgeBaseServer.ts:27-30`                 |
+| From -> To | Trigger | Source of truth |
+| --- | --- | --- |
+| `Constructed -> Initializing` | `initialize()` creates the embedding client and model directory as needed. | `src/FaissIndexManager.ts` |
+| `Initializing -> Loaded` | `loadFaissStoreAtomic` loads `index -> index.vN/` or legacy `faiss.index/`. | `src/faiss-store-layout.ts` |
+| `Initializing -> Empty` | No persisted store exists for the model. | `src/FaissIndexManager.ts` |
+| `Initializing -> Recovering` | Pending sidecar commit manifest exists. | `src/pending-sidecar-commit.ts` |
+| `Empty -> Building` | First refresh finds chunks for a model with no loaded index. | `src/FaissIndexManager.ts` |
+| `Loaded -> Updating` | Changed files can be appended without deleting stale vectors. | `src/file-ingest.ts`, `src/FaissIndexManager.ts` |
+| `Loaded -> Rebuilding` | Force reindex, stale freshness manifest, missing chunk manifest, or chunk drift that cannot be append-only. | `src/FaissIndexManager.ts`, `src/freshness-manifest.ts` |
+| `Building/Updating/Rebuilding -> Loaded` | Versioned atomic save commits, sidecars/manifests are written, and freshness manifest is updated. | `src/faiss-store-layout.ts`, `src/file-ingest.ts` |
+| `Rebuilding -> Loaded` | Rebuild is deferred because quiescence checks saw a changing file; previous persisted index is reloaded. | `src/FaissIndexManager.ts` |
 
 ## Invariants
 
-- **`model_name.txt` is written only in `initialize()`**. Consequence: between a successful rebuild and the subsequent save in `updateIndex`, a crash can leave a model metadata file without an active `index` symlink, which is the scenario the `None → Loaded (fallback)` transition handles.
-- **`faissIndex === null` and a persisted store exists** is possible after an interrupted or failed rebuild until recovery purges the store or a later `updateIndex` rebuilds from source files.
-- **`Loaded → Loaded` with all hashes matching does NOT write** (`indexMutated` stays `false`, so the save/sidecar block is skipped).
-- **A `save-complete` pending manifest is a roll-forward record.** The saved FAISS store is assumed durable enough to claim the sidecars, so recovery finishes hash and chunk manifest writes before loading the store.
-- **A `save-started` pending manifest is ambiguous.** The process may have crashed before or after the symlink swap. Recovery chooses a rebuild by deleting the persisted store and stale sidecars instead of writing sidecars for vectors that may not be present.
+- **The lifecycle is per model.** A different provider/model pair gets a
+  different `model_id` and therefore a different manager/store.
+- **`active.txt` is outside this state machine.** It selects which model is the
+  default, but it does not mutate an existing model directory.
+- **Versioned save is the persistence boundary.** Readers resolve the active
+  `index` symlink once and load a coherent `faiss.index` plus `docstore.json`.
+- **Sidecars lag FAISS only with a recovery record.** If FAISS save completes
+  before sidecars are written, `pending-manifest.json` lets the next initialize
+  roll forward.
+- **Force is global for the active model.** A scoped force rebuild is upgraded to
+  a global rebuild because FAISS vector deletion is unsupported here.
+- **Read-only commands can load without repair.** Strict read-only audit paths do
+  not create or mutate model directories.

--- a/docs/architecture/threat-model.md
+++ b/docs/architecture/threat-model.md
@@ -52,7 +52,8 @@ This guard is a boundary cue, not a guarantee. Pattern matching cannot eliminate
 
 ## 3. Embedding-provider keys
 
-Three env vars are read at construction time (`src/FaissIndexManager.ts:98-121`, `src/config.ts:37-41`):
+Provider env vars are resolved through the provider/config modules when a
+manager initializes its embedding client:
 
 | Variable                  | Provider    | Leak surface                                           |
 | ------------------------- | ----------- | ------------------------------------------------------ |
@@ -76,21 +77,23 @@ Query text and knowledge-base chunks leave the machine over TLS to the configure
 
 ## 5. Path-traversal (path-taking tools and `kb://` resources)
 
-Three exposed surfaces now accept client-supplied paths into `$KNOWLEDGE_BASES_ROOT_DIR`. All of them route the candidate through the same `resolveKbPath` validator (`src/kb-fs.ts:216-274`) so the guard chain is implemented once:
+Exposed mutation/resource surfaces that accept client-supplied paths into
+`$KNOWLEDGE_BASES_ROOT_DIR` route candidates through shared KB path helpers, so
+the guard chain is implemented once:
 
-1. **Lexical guards** — empty path, embedded null byte, and `..` traversal are rejected before any I/O (`src/kb-fs.ts:223-235`).
-2. **KB-name validation** — `knowledge_base_name` must match `isValidKbName` (`src/kb-paths.ts:12-20`); the resolved KB directory must exist as a real directory under `KNOWLEDGE_BASES_ROOT_DIR`.
-3. **Lexical inside-or-equal check** — the resolved candidate is required to live under the KB root before any `realpath` call (`src/kb-fs.ts:243-249`).
-4. **`realpath` check** — when the target (or its nearest existing ancestor in `mustExist:false` mode) resolves through symlinks, the realpath must still be inside the KB realpath (`src/kb-fs.ts:251-260`). Symlink jailbreaks fail closed.
+1. **Lexical guards** — empty path, embedded null byte, and `..` traversal are rejected before any I/O.
+2. **KB-name validation** — `knowledge_base_name` must match `isValidKbName`; the resolved KB directory must exist as a real directory under `KNOWLEDGE_BASES_ROOT_DIR`.
+3. **Lexical inside-or-equal check** — the resolved candidate is required to live under the KB root before any `realpath` call.
+4. **`realpath` check** — when the target or nearest existing ancestor resolves through symlinks, the realpath must still be inside the KB realpath. Symlink jailbreaks fail closed.
 
 The current path-taking surfaces are:
 
 | Surface | Where the path comes in | mustExist | Notes |
 | --- | --- | --- | --- |
-| `add_document` | `path` arg, joined with `knowledge_base_name` | `false` | Snapshots existing content first; index update failure rolls the file write back (`src/KnowledgeBaseServer.ts:501-568`). |
-| `delete_document` | `path` arg, joined with `knowledge_base_name` | `false` | Removes the source file and its hash sidecar; FAISS orphan vectors persist until `reindex_knowledge_base` (`src/KnowledgeBaseServer.ts:570-624`). |
+| `add_document` | `path` arg, joined with `knowledge_base_name` | `false` | Snapshots existing content first; index update failure rolls the file write back. |
+| `delete_document` | `path` arg, joined with `knowledge_base_name` | `false` | Removes the source file and its hash sidecar; FAISS orphan vectors persist until a forced rebuild. |
 | `reindex_knowledge_base` | optional `knowledge_base_name` only — no per-file path | n/a | Resolves the KB directory to validate the name; the rebuild is global (no per-vector deletion in this server). |
-| `resources/read` for `kb://<kb>/<rel-path>` | URI authority + path | `true` | URI parser additionally rejects `%2F` / `%5C` and `..` segments before per-segment `decodeURIComponent` (`src/mcp-resources.ts:59-120`). PDFs are returned as base64 blobs; everything else as UTF-8 text. |
+| `resources/read` for `kb://<kb>/<rel-path>` | URI authority + path | `true` | URI parser additionally rejects encoded slash/backslash and `..` segments before per-segment decoding. PDFs are returned as base64 blobs; everything else as UTF-8 text. |
 
 `list_knowledge_bases` continues to read `KNOWLEDGE_BASES_ROOT_DIR` directly without taking any client path. `retrieve_knowledge` takes only `query`, optional `knowledge_base_name`, optional numeric filters, and never writes based on the name.
 
@@ -130,9 +133,9 @@ Setting `KB_MUTATION_AUDIT_LOG` (`src/audit-log.ts`) opts into an append-only JS
 
 This page is verified against the following source files and README sections. If one of these moves or its cited lines drift, refresh this doc rather than letting the claim go stale.
 
-- Path validation (write tools + resources): `src/kb-fs.ts:216-274`, `src/kb-paths.ts:12-20`, `src/mcp-resources.ts:59-120`.
-- Write-tool surfaces: `src/KnowledgeBaseServer.ts:501-661`.
-- `resources/read` body: `src/mcp-resources.ts:153-180`.
+- Path validation (write tools + resources): `src/kb-fs.ts`, `src/kb-paths.ts`, `src/mcp-resources.ts`.
+- Write-tool surfaces: `src/KnowledgeBaseServer.ts`, `src/mcp-document-mutations.ts`.
+- `resources/read` body: `src/mcp-resources.ts`.
 - Per-model write lock + atomic save: `src/write-lock.ts`, `src/faiss-store-layout.ts:58-179`.
 - Transport config + bearer / origin gates: `src/transport-config.ts:14-122`, `src/transport/base-http-host.ts`.
 - Remote transport hosts: `src/transport/sse.ts:1-139`, `src/transport/http.ts:1-220`.

--- a/docs/cli-json-contracts.md
+++ b/docs/cli-json-contracts.md
@@ -1,7 +1,13 @@
-# CLI JSON Output Contracts
+# Selected CLI JSON Output Contracts
 
-This page records the stable JSON shapes for agent-facing `kb` commands. It is
-for shell agents that branch on fields, not for humans reading examples.
+This page records stable JSON shapes for the agent-facing `kb` commands whose
+machine-readable contracts have been explicitly documented. It is for shell
+agents that branch on fields, not for humans reading examples.
+
+The `kb` CLI has more implemented commands than this page currently enumerates.
+For commands not listed below, treat JSON output as command-local until a
+section is added here. Use `kb help --format=json` to discover the current
+command registry.
 
 Contract policy:
 

--- a/docs/operations/incident-response.md
+++ b/docs/operations/incident-response.md
@@ -402,7 +402,8 @@ and there is remaining work.
    ```
 
 4. Remember that `--kb=<name>` is a guard and estimator hint for contextual
-   reindex; the rebuild still covers the single global FAISS index.
+   reindex; the forced rebuild still covers the active model's full FAISS index,
+   not just one KB.
 
 **Escalate**
 

--- a/docs/requirements/retrieval-eval.md
+++ b/docs/requirements/retrieval-eval.md
@@ -9,11 +9,11 @@
 
 **Acceptance Criteria:**
 
-- [ ] Given a fixture case with required sources, when `kb eval` runs the query, then the case fails if any required source is missing.
-- [ ] Given a fixture case with forbidden sources, when a forbidden source appears in the results, then the case fails.
-- [ ] Given a fixture case with a duplicate-source budget, when the number of repeated-source groups exceeds the budget, then the case fails.
-- [ ] Given a fixture case without gate behavior, when the case fails, then the command reports the failure as a warning and exits 0.
-- [ ] Given a fixture case with gate behavior, when the case fails, then the command exits nonzero.
+- [x] Given a fixture case with required sources, when `kb eval` runs the query, then the case fails if any required source is missing.
+- [x] Given a fixture case with forbidden sources, when a forbidden source appears in the results, then the case fails.
+- [x] Given a fixture case with a duplicate-source budget, when the number of repeated-source groups exceeds the budget, then the case fails.
+- [x] Given a fixture case without gate behavior, when the case fails, then the command reports the failure as a warning and exits 0.
+- [x] Given a fixture case with gate behavior, when the case fails, then the command exits nonzero.
 
 **Linked Tests:** TS-RETRIEVAL-EVAL-001
 

--- a/docs/rfcs/002-ai-skills-setup.md
+++ b/docs/rfcs/002-ai-skills-setup.md
@@ -1,5 +1,9 @@
 # RFC 002 — AI assistant skills bundled with the repo for setup & troubleshooting
 
+<!-- anchor-check: off -->
+
+> Historical RFC: source anchors in this proposal refer to code at drafting time and are not maintained as current-main anchors.
+
 - **Status:** Draft — awaiting approval
 - **Author:** Jean Ibarz (drafted by automation)
 - **Target:** `jeanibarz/knowledge-base-mcp-server` `main`

--- a/docs/rfcs/006-multi-provider-tiered-retrieval.md
+++ b/docs/rfcs/006-multi-provider-tiered-retrieval.md
@@ -1,5 +1,9 @@
 # RFC 006 — Multi-provider embedding fusion and fast-vs-quality retrieval tiers
 
+<!-- anchor-check: off -->
+
+> Historical RFC: source anchors in this proposal refer to code at drafting time and are not maintained as current-main anchors.
+
 - **Status:** Draft — awaiting approval
 - **Author:** Jean Ibarz (drafted by automation)
 - **Target:** `jeanibarz/knowledge-base-mcp-server` `main`

--- a/docs/rfcs/007-architecture-performance.md
+++ b/docs/rfcs/007-architecture-performance.md
@@ -1,5 +1,9 @@
 # RFC 007 — Architecture clean-up and performance benchmarks
 
+<!-- anchor-check: off -->
+
+> Historical RFC: source anchors in this proposal refer to code at drafting time and are not maintained as current-main anchors.
+
 - **Status:** Draft — awaiting approval
 - **Author:** Jean Ibarz (drafted by automation)
 - **Target:** `jeanibarz/knowledge-base-mcp-server` `main`

--- a/docs/rfcs/008-remote-transport.md
+++ b/docs/rfcs/008-remote-transport.md
@@ -1,5 +1,9 @@
 # RFC 008 — Remote transport (SSE + streamable-http)
 
+<!-- anchor-check: off -->
+
+> Historical RFC: source anchors in this proposal refer to code at drafting time and are not maintained as current-main anchors.
+
 - **Status:** Draft — awaiting approval
 - **Author:** Jean Ibarz (drafted by automation)
 - **Target:** `jeanibarz/knowledge-base-mcp-server` `main`

--- a/docs/rfcs/010-mcp-surface-v2.md
+++ b/docs/rfcs/010-mcp-surface-v2.md
@@ -1,5 +1,9 @@
 # RFC 010 — MCP surface v2: Resources, ingest, filters, stats, description overrides
 
+<!-- anchor-check: off -->
+
+> Historical RFC: source anchors in this proposal refer to code at drafting time and are not maintained as current-main anchors.
+
 - **Status:** Draft — awaiting approval
 - **Author:** Jean Ibarz (drafted by automation)
 - **Target:** `jeanibarz/knowledge-base-mcp-server` `main`

--- a/docs/rfcs/011-arxiv-backend.md
+++ b/docs/rfcs/011-arxiv-backend.md
@@ -1,5 +1,9 @@
 # RFC 011 — arxiv-backend: operational KB for the local-research-agent ingestion pipeline
 
+<!-- anchor-check: off -->
+
+> Historical RFC: source anchors in this proposal refer to code at drafting time and are not maintained as current-main anchors.
+
 - **Status:** Draft — awaiting approval
 - **Author:** Jean Ibarz (drafted by automation)
 - **Target:** `jeanibarz/knowledge-base-mcp-server` `main`

--- a/docs/rfcs/014-atomic-faiss-save.md
+++ b/docs/rfcs/014-atomic-faiss-save.md
@@ -1,5 +1,9 @@
 # RFC 014 — Atomic FAISS Save
 
+<!-- anchor-check: off -->
+
+> Historical RFC: source anchors in this proposal refer to code at drafting time and are not maintained as current-main anchors.
+
 **Status:** Draft (lifts RFC 013 §11 N4)
 **Depends on:** RFC 013 (per-model layout, write locks, instance advisory)
 **Unblocks:** removal of single-instance enforcement (`src/instance-lock.ts`) — separate follow-up PR


### PR DESCRIPTION
## Summary

Fixes misalignments between the system design docs and the current implementation.

### Changes
- Updated README and CLAUDE guidance from the old two-tool, stdio-only, single-index description to the current MCP tool surface, CLI, remote transports, and multi-model FAISS layout.
- Rewrote current architecture snapshots for C4 context/container, retrieval, reindex/model activation, index lifecycle, data model, QA budgets, and threat-model/concurrency behavior.
- Marked superseded ADR decisions for remote transport, splitter behavior, and destructive model-switch rebuilds while preserving historical rationale.
- Clarified that CLI JSON contracts are selected documented contracts, marked retrieval-eval requirements implemented, and fixed the contextual reindex incident note.
- Marked historical RFC drafts with archival anchor-check notes so stale proposal anchors do not count as maintained current-code references.

### Verification
- npm run docs:check-anchors
- npm run build

### Gaps deferred
- None; all gaps selected for this run were addressed as documentation updates.