### PR TITLE
feat(search): expose filter selectivity diagnostics

### DIFF
--- a/docs/cli-json-contracts.md
+++ b/docs/cli-json-contracts.md
@@ -212,7 +212,12 @@ Optional stable fields:
   mode labels. Dense query-cache diagnostics use the flat keys
   `query_cache`, `query_cache_enabled`, `query_cache_model_id`, and
   `query_cache_elapsed_ms`. Treat the object as diagnostic, not a compatibility
-  contract.
+  contract. For non-empty filtered dense searches, aggregate selectivity
+  counters such as `fetch_k`, `sidecar_candidates`, `sidecar_fast_path`,
+  `post_filter_kept`, and `post_filter_ms` may appear.
+- `filter_diagnostics`: present with `--timing` for non-empty filtered dense
+  searches when aggregate selectivity counters are available. Shape:
+  `{"schema_version":"kb.search.filter-diagnostics.v1","fetch_k":number|null,"sidecar_candidates":number|null,"sidecar_fast_path":string|null,"post_filter_kept":number|null,"post_filter_ms":number|null}`.
   For dense and hybrid `--refresh` runs, the same diagnostic object may include
   refresh counters such as `refresh_embed_batches`,
   `refresh_embed_batches_total`, `refresh_embed_chunks`,

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -116,7 +116,7 @@ wrap-close vars below.
 |---|---|---:|---|---|---|---|
 | Editor URI links | `KB_EDITOR_URI` | `none` | CLI and MCP retrieval output | Implemented | none | `KB_EDITOR_URI=cursor kb search "query" --format=json` |
 | Frontmatter extras on wire | `FRONTMATTER_EXTRAS_WIRE_VISIBLE` | `false` | MCP and CLI JSON retrieval output | Implemented | none | `FRONTMATTER_EXTRAS_WIRE_VISIBLE=true kb search "query" --format=json` |
-| CLI timing | `--timing` | off | CLI search and ask | Implemented | `--timing` | `kb search "query" --timing` |
+| CLI timing | `--timing` | off | CLI search and ask; aggregate filter selectivity diagnostics for non-empty filtered dense search | Implemented | `--timing` | `kb search "query" --timing` |
 | Compact search output | `kb search --format=compact` | `md` | CLI search | Implemented | `--format=compact` | `kb search "query" --format=compact` |
 | Search pager | `KB_PAGER`, `kb search --pager` | off; `less -R` when enabled without a pager env | CLI search markdown/compact output on TTY stdout | Implemented, opt-in | `--pager`, `--no-pager` | `KB_PAGER='less -R' kb search "query" --pager --k=30` |
 | Batch JSONL search input | `kb search --batch-jsonl` | off | CLI search | Implemented | `--batch-jsonl < queries.jsonl` | `printf '{"query":"q1"}\n{"query":"q2"}\n' \| kb search --batch-jsonl` |

--- a/src/FaissIndexManager.test.ts
+++ b/src/FaissIndexManager.test.ts
@@ -4906,6 +4906,7 @@ describe('FaissIndexManager predicate-pushdown sidecar (#283)', () => {
     expect(similaritySearchMock).not.toHaveBeenCalled();
     expect(timing.sidecar_fast_path).toBe('short_circuit');
     expect(timing.sidecar_candidates).toBe(0);
+    expect(timing.post_filter_kept).toBe(0);
   });
 
   it('runs a single FAISS search at the targeted fetchK when the filter is highly selective', async () => {
@@ -4964,6 +4965,7 @@ describe('FaissIndexManager predicate-pushdown sidecar (#283)', () => {
     // The fast-path requested far less than ntotal (which the post-filter
     // ladder would walk up to in the worst case).
     const callArgs = similaritySearchMock.mock.calls[0];
+    expect(timing.post_filter_kept).toBe((callArgs[1] as number) / 2);
     expect(callArgs[1]).toBeLessThan(10_000);
   });
 
@@ -5015,6 +5017,7 @@ describe('FaissIndexManager predicate-pushdown sidecar (#283)', () => {
     expect(similaritySearchMock).toHaveBeenCalledWith('q', 20);
     expect(results).toHaveLength(5);
     expect(timing.sidecar_fast_path).toBe('unused');
+    expect(timing.post_filter_kept).toBe(6);
   });
 
   it('falls back to the post-filter ladder when the sidecar is missing entirely', async () => {

--- a/src/FaissIndexManager.ts
+++ b/src/FaissIndexManager.ts
@@ -316,6 +316,7 @@ export interface SimilaritySearchTiming {
   faiss_search_ms?: number;
   query_search_ms?: number;
   post_filter_ms?: number;
+  post_filter_kept?: number;
   total_ms?: number;
   fetch_k?: number;
   query_cache?: QueryCacheLookupStatus | 'unavailable';
@@ -2543,6 +2544,7 @@ export class FaissIndexManager {
           timing.sidecar_fast_path = 'short_circuit';
           timing.fetch_k = 0;
           timing.post_filter_ms = 0;
+          timing.post_filter_kept = 0;
           timing.total_ms = Date.now() - totalStartedAt;
         }
         return [];
@@ -2563,6 +2565,7 @@ export class FaissIndexManager {
           if (timing) {
             timing.fetch_k = fastFetchK;
             timing.post_filter_ms = cumulativePostFilterMs;
+            timing.post_filter_kept = filtered.length;
             timing.sidecar_fast_path = 'hit';
             timing.total_ms = Date.now() - totalStartedAt;
           }
@@ -2595,6 +2598,7 @@ export class FaissIndexManager {
     if (timing) {
       timing.fetch_k = lastFetchK;
       timing.post_filter_ms = cumulativePostFilterMs;
+      timing.post_filter_kept = filtered.length;
       timing.total_ms = Date.now() - totalStartedAt;
     }
 

--- a/src/cli-search.test.ts
+++ b/src/cli-search.test.ts
@@ -615,6 +615,175 @@ describe('runSearch timing guard (#331)', () => {
     });
   });
 
+  it('exposes aggregate filter diagnostics for non-empty scoped JSON searches with --timing', async () => {
+    const { deps, manager } = makeDeps();
+    manager.similaritySearch.mockImplementationOnce(async (...args: unknown[]) => {
+      const denseTiming = args[5] as SimilaritySearchTiming;
+      denseTiming.faiss_search_ms = 6;
+      denseTiming.fetch_k = 20;
+      denseTiming.post_filter_ms = 3;
+      denseTiming.post_filter_kept = 6;
+      denseTiming.sidecar_candidates = 42;
+      denseTiming.sidecar_fast_path = 'hit';
+      return [{
+        pageContent: 'scoped runbook',
+        metadata: { source: '/kb/ops/runbook.md', relativePath: 'ops/runbook.md', chunkIndex: 0 },
+        score: 0.12,
+      }] as never;
+    });
+
+    const out = await captureSearchOutput([
+      'runbook',
+      '--kb=ops',
+      '--format=json',
+      '--timing',
+      '--no-freshness',
+    ], deps);
+
+    expect(out.code).toBe(0);
+    expect(manager.similaritySearch.mock.calls[0][3]).toBe('ops');
+    const payload = JSON.parse(out.stdout);
+    expect(payload.filter_diagnostics).toEqual({
+      schema_version: 'kb.search.filter-diagnostics.v1',
+      fetch_k: 20,
+      sidecar_candidates: 42,
+      sidecar_fast_path: 'hit',
+      post_filter_kept: 6,
+      post_filter_ms: 3,
+    });
+    expect(payload.timing).toMatchObject({
+      fetch_k: 20,
+      sidecar_candidates: 42,
+      sidecar_fast_path: 'hit',
+      post_filter_kept: 6,
+      post_filter_ms: 3,
+    });
+  });
+
+  it('omits filter diagnostics when an unscoped successful search has no filter counters', async () => {
+    const { deps, manager } = makeDeps();
+    manager.similaritySearch.mockResolvedValueOnce([{
+      pageContent: 'ordinary result',
+      metadata: { source: '/kb/ops/plain.md', relativePath: 'ops/plain.md', chunkIndex: 0 },
+      score: 0.12,
+    }] as never);
+
+    const out = await captureSearchOutput([
+      'plain',
+      '--format=json',
+      '--timing',
+      '--no-freshness',
+    ], deps);
+
+    expect(out.code).toBe(0);
+    expect(JSON.parse(out.stdout)).not.toHaveProperty('filter_diagnostics');
+  });
+
+  it('renders filter diagnostics in markdown when provided', () => {
+    const output = formatDenseSearchMarkdownOutput({
+      results: [{
+        pageContent: 'hit',
+        metadata: { source: '/kb/ops/runbook.md', relativePath: 'ops/runbook.md', chunkIndex: 0 },
+        score: 0.1,
+      } as ScoredDocument],
+      groupBySource: false,
+      staleness: null,
+      refreshed: false,
+      scopedKb: 'ops',
+      autoModeDecision: null,
+      autoThresholdDecision: null,
+      timing: { fetch_k: 20, post_filter_kept: 6 },
+      filterDiagnostics: {
+        schemaVersion: 'kb.search.filter-diagnostics.v1',
+        fetchK: 20,
+        sidecarCandidates: 42,
+        sidecarFastPath: 'hit',
+        postFilterKept: 6,
+        postFilterMs: 3,
+      },
+    });
+
+    expect(output).toContain('> _Filter diagnostics:');
+    expect(output).toContain('fetch_k=20');
+    expect(output).toContain('sidecar_candidates=42');
+    expect(output).toContain('post_filter_kept=6');
+    expect(output).toContain('post_filter_ms=3ms');
+  });
+
+  it('renders filter diagnostics in compact output when provided', () => {
+    const output = formatDenseSearchCompactOutput({
+      results: [{
+        pageContent: 'hit',
+        metadata: { source: '/kb/ops/runbook.md', relativePath: 'ops/runbook.md', chunkIndex: 0 },
+        score: 0.1,
+      } as ScoredDocument],
+      mode: 'dense',
+      staleness: null,
+      refreshed: false,
+      timing: { fetch_k: 20, post_filter_kept: 6 },
+      filterDiagnostics: {
+        schemaVersion: 'kb.search.filter-diagnostics.v1',
+        fetchK: 20,
+        sidecarCandidates: 42,
+        sidecarFastPath: 'hit',
+        postFilterKept: 6,
+        postFilterMs: 3,
+      },
+      width: 120,
+    });
+
+    expect(output).toContain('> _Filter diagnostics:');
+    expect(output).toContain('fetch_k=20');
+    expect(output).toContain('post_filter_kept=6');
+  });
+
+  it('omits filter diagnostics for advanced retrieval because component counters are not aggregate', async () => {
+    const { deps, manager } = makeDeps();
+    manager.similaritySearch
+      .mockImplementationOnce(async (...args: unknown[]) => {
+        const denseTiming = args[5] as SimilaritySearchTiming;
+        denseTiming.fetch_k = 20;
+        denseTiming.post_filter_ms = 2;
+        denseTiming.post_filter_kept = 4;
+        denseTiming.sidecar_candidates = 10;
+        return [{
+          pageContent: 'primary result',
+          metadata: { source: '/kb/ops/primary.md', relativePath: 'ops/primary.md', chunkIndex: 0 },
+          score: 0.1,
+        }] as never;
+      })
+      .mockImplementationOnce(async (...args: unknown[]) => {
+        const denseTiming = args[5] as SimilaritySearchTiming;
+        denseTiming.fetch_k = 40;
+        denseTiming.post_filter_ms = 5;
+        denseTiming.post_filter_kept = 2;
+        denseTiming.sidecar_candidates = 3;
+        return [{
+          pageContent: 'plus result',
+          metadata: { source: '/kb/ops/plus.md', relativePath: 'ops/plus.md', chunkIndex: 0 },
+          score: 0.05,
+        }] as never;
+      });
+
+    const out = await captureSearchOutput([
+      'primary',
+      '--plus=plus',
+      '--kb=ops',
+      '--format=json',
+      '--timing',
+      '--no-freshness',
+    ], deps);
+
+    expect(out.code).toBe(0);
+    const payload = JSON.parse(out.stdout);
+    expect(payload).not.toHaveProperty('filter_diagnostics');
+    expect(payload.timing).toMatchObject({
+      fetch_k: 40,
+      sidecar_candidates: 3,
+      post_filter_kept: 2,
+    });
+  });
+
   it('records the computed threshold in canonical metadata for --threshold=auto', async () => {
     const { deps, manager } = makeDeps();
     manager.similaritySearch.mockResolvedValueOnce([

--- a/src/cli-search.ts
+++ b/src/cli-search.ts
@@ -197,6 +197,8 @@ Output:
                         in markdown output. With \`--format=json\`, adds a
                         \`grouped_results\` field alongside raw results.
   --timing              Include elapsed milliseconds for retrieval stages.
+                        For non-empty filtered dense searches, also surfaces
+                        aggregate filter selectivity counters.
   --pager               Page markdown/compact output through KB_PAGER, PAGER,
                         or less -R when stdout is a TTY.
   --no-pager            Disable KB_PAGER for this search.
@@ -554,6 +556,14 @@ export async function runSearch(
     return reportFailure(classifyKbSearchError(err), parsed.format);
   }
 
+  const filterDiagnostics =
+    timing && results.length > 0
+      ? buildFilterSelectivityDiagnostics({
+          parsed,
+          denseTiming,
+        })
+      : null;
+
   const staleness = parsed.freshness
     ? await computeStalenessWithTiming(activeModelId, parsed.kb, timing)
     : null;
@@ -601,6 +611,7 @@ export async function runSearch(
       staleness,
       autoThresholdDecision,
       timing,
+      filterDiagnostics,
       explainEmptyDiagnostics,
       gateVerdict,
       advancedRetrieval,
@@ -618,6 +629,7 @@ export async function runSearch(
       refreshed: parsed.refresh,
       gateVerdict,
       timing,
+      filterDiagnostics,
     }));
   } else {
     await writeSearchOutput(parsed, deps, formatDenseSearchMarkdownOutput({
@@ -630,6 +642,7 @@ export async function runSearch(
       autoModeDecision,
       autoThresholdDecision,
       timing,
+      filterDiagnostics,
       explainEmptyDiagnostics,
       gateVerdict,
       explain: parsed.explain,
@@ -1015,8 +1028,11 @@ function mergeDenseTiming(target: TimingPayload, source: SimilaritySearchTiming)
   if (source.faiss_search_ms !== undefined) target.faiss_search_ms = source.faiss_search_ms;
   if (source.query_search_ms !== undefined) target.query_search_ms = source.query_search_ms;
   if (source.post_filter_ms !== undefined) target.post_filter_ms = source.post_filter_ms;
+  if (source.post_filter_kept !== undefined) target.post_filter_kept = source.post_filter_kept;
   if (source.total_ms !== undefined) target.dense_total_ms = source.total_ms;
   if (source.fetch_k !== undefined) target.fetch_k = source.fetch_k;
+  if (source.sidecar_candidates !== undefined) target.sidecar_candidates = source.sidecar_candidates;
+  if (source.sidecar_fast_path !== undefined) target.sidecar_fast_path = source.sidecar_fast_path;
   if (source.query_cache_telemetry !== undefined) {
     target.query_cache = source.query_cache_telemetry.outcome;
     target.query_cache_enabled = source.query_cache_telemetry.enabled;
@@ -1025,6 +1041,43 @@ function mergeDenseTiming(target: TimingPayload, source: SimilaritySearchTiming)
   } else if (source.query_cache !== undefined) {
     target.query_cache = source.query_cache;
   }
+}
+
+export interface FilterSelectivityDiagnostics {
+  schemaVersion: 'kb.search.filter-diagnostics.v1';
+  fetchK: number | null;
+  sidecarCandidates: number | null;
+  sidecarFastPath: SimilaritySearchTiming['sidecar_fast_path'] | null;
+  postFilterKept: number | null;
+  postFilterMs: number | null;
+}
+
+function buildFilterSelectivityDiagnostics(input: {
+  parsed: SearchArgs;
+  denseTiming: SimilaritySearchTiming;
+}): FilterSelectivityDiagnostics | null {
+  if (!input.parsed.timing) return null;
+  if (hasAdvancedRetrieval(input.parsed)) return null;
+  if (!hasFilterSelectivitySurface(input.parsed, input.denseTiming)) return null;
+  return {
+    schemaVersion: 'kb.search.filter-diagnostics.v1',
+    fetchK: input.denseTiming.fetch_k ?? null,
+    sidecarCandidates: input.denseTiming.sidecar_candidates ?? null,
+    sidecarFastPath: input.denseTiming.sidecar_fast_path ?? null,
+    postFilterKept: input.denseTiming.post_filter_kept ?? null,
+    postFilterMs: input.denseTiming.post_filter_ms ?? null,
+  };
+}
+
+function hasFilterSelectivitySurface(
+  parsed: SearchArgs,
+  denseTiming: SimilaritySearchTiming,
+): boolean {
+  return (
+    typeof parsed.kb === 'string' && parsed.kb.length > 0
+  ) || denseTiming.sidecar_candidates !== undefined
+    || denseTiming.sidecar_fast_path !== undefined
+    || denseTiming.post_filter_kept !== undefined;
 }
 
 function recordDenseSearchCanonicalTelemetry(input: {
@@ -1104,6 +1157,7 @@ export interface DenseSearchJsonPayloadInput {
   staleness: Staleness | null;
   autoThresholdDecision: AutoThresholdDecision | null;
   timing: TimingPayload | null;
+  filterDiagnostics?: FilterSelectivityDiagnostics | null;
   /** Issue #328 — opt-in deep diagnostics for an empty result set. Ignored when results is non-empty. */
   explainEmptyDiagnostics?: ExplainEmptyDiagnostics | null;
   gateVerdict?: RelevanceGateVerdict;
@@ -1134,6 +1188,9 @@ export function buildDenseSearchJsonPayload(input: DenseSearchJsonPayloadInput):
   }
   if (input.results.length === 0 && input.explainEmptyDiagnostics) {
     payload.empty_result_diagnostics = explainEmptyDiagnosticsToJson(input.explainEmptyDiagnostics);
+  }
+  if (input.results.length > 0 && input.filterDiagnostics) {
+    payload.filter_diagnostics = filterSelectivityDiagnosticsToJson(input.filterDiagnostics);
   }
   if (input.autoThresholdDecision !== null) {
     payload.auto_threshold = {
@@ -1237,6 +1294,7 @@ export interface DenseSearchMarkdownOutputInput {
   autoModeDecision: AutoSearchModeDecision | null;
   autoThresholdDecision: AutoThresholdDecision | null;
   timing: TimingPayload | null;
+  filterDiagnostics?: FilterSelectivityDiagnostics | null;
   /** Issue #328 — opt-in deep diagnostics block, rendered only when results is empty. */
   explainEmptyDiagnostics?: ExplainEmptyDiagnostics | null;
   gateVerdict?: RelevanceGateVerdict;
@@ -1281,6 +1339,9 @@ export function formatDenseSearchMarkdownOutput(input: DenseSearchMarkdownOutput
   if (input.advancedRetrieval !== undefined && input.advancedRetrieval !== null) {
     output += `${formatAdvancedRetrievalFooter(input.advancedRetrieval)}\n`;
   }
+  if (input.results.length > 0 && input.filterDiagnostics) {
+    output += `${formatFilterSelectivityDiagnosticsFooter(input.filterDiagnostics)}\n`;
+  }
   const gateVerdict = input.gateVerdict ?? defaultBypassedGateVerdict(input.results.length);
   if (gateVerdict.state !== 'bypassed') {
     output += `${formatGateVerdictFooter(gateVerdict)}\n`;
@@ -1312,6 +1373,7 @@ export function formatDenseSearchCompactOutput(input: {
   refreshed: boolean;
   gateVerdict?: RelevanceGateVerdict;
   timing: TimingPayload | null;
+  filterDiagnostics?: FilterSelectivityDiagnostics | null;
   width?: number;
 }): string {
   let output = `${formatRetrievalAsCompactTable(input.results, {
@@ -1326,6 +1388,9 @@ export function formatDenseSearchCompactOutput(input: {
   if (gateVerdict.state !== 'bypassed') {
     output += `${formatGateVerdictFooter(gateVerdict)}\n`;
   }
+  if (input.results.length > 0 && input.filterDiagnostics) {
+    output += `${formatFilterSelectivityDiagnosticsFooter(input.filterDiagnostics)}\n`;
+  }
   if (input.timing) {
     output += `${formatTimingFooter('Timing', input.timing)}\n`;
   }
@@ -1335,6 +1400,40 @@ export function formatDenseSearchCompactOutput(input: {
 function compactGateMarker(gateVerdict: RelevanceGateVerdict | undefined): 'bypassed' | 'kept' {
   if (gateVerdict === undefined || gateVerdict.state === 'bypassed') return 'bypassed';
   return 'kept';
+}
+
+function filterSelectivityDiagnosticsToJson(
+  diagnostics: FilterSelectivityDiagnostics,
+): Record<string, unknown> {
+  return {
+    schema_version: diagnostics.schemaVersion,
+    fetch_k: diagnostics.fetchK,
+    sidecar_candidates: diagnostics.sidecarCandidates,
+    sidecar_fast_path: diagnostics.sidecarFastPath,
+    post_filter_kept: diagnostics.postFilterKept,
+    post_filter_ms: diagnostics.postFilterMs,
+  };
+}
+
+function formatFilterSelectivityDiagnosticsFooter(
+  diagnostics: FilterSelectivityDiagnostics,
+): string {
+  const fields = [
+    ['fetch_k', diagnostics.fetchK],
+    ['sidecar_candidates', diagnostics.sidecarCandidates],
+    ['sidecar_fast_path', diagnostics.sidecarFastPath],
+    ['post_filter_kept', diagnostics.postFilterKept],
+    ['post_filter_ms', diagnostics.postFilterMs],
+  ]
+    .filter((entry): entry is [string, string | number] => entry[1] !== null)
+    .map(([key, value]) => `${key}=${formatFilterDiagnosticValue(key, value)}`);
+  const body = fields.length > 0 ? fields.join(', ') : 'no aggregate counters';
+  return `> _Filter diagnostics: ${body}._`;
+}
+
+function formatFilterDiagnosticValue(key: string, value: string | number): string {
+  if (typeof value === 'number' && key.endsWith('_ms')) return `${Math.round(value)}ms`;
+  return String(value);
 }
 
 function defaultBypassedGateVerdict(count: number): RelevanceGateVerdict {


### PR DESCRIPTION
## Summary
- expose aggregate filter selectivity diagnostics for non-empty filtered dense searches when `--timing` is enabled
- surface `fetch_k`, `sidecar_candidates`, `post_filter_kept`, and `post_filter_ms` in JSON plus concise markdown/compact output
- document the JSON timing contract and feature flag behavior

Closes #522

## Verification
- npm test -- --runInBand src/cli-search.test.ts
- npm test -- --runInBand src/FaissIndexManager.test.ts
- npm test -- --runInBand src/search-core.test.ts
- npm run docs:check-anchors
- npm run build
- git diff --check
- npm test -- --runInBand

## Pre-PR review
- project type: npm
- build and full tests passed locally
- diff and portability review clean; no helper script present, manual scan completed
- reviewer specialists ran; blocking correctness/test findings were addressed before PR creation
- OSS base-branch policy not applicable for this same-repo PR