### PR TITLE
feat(models): add dry-run gc planning

### DIFF
--- a/docs/cli-json-contracts.md
+++ b/docs/cli-json-contracts.md
@@ -1555,6 +1555,81 @@ Source and test anchors: `src/cli-models.ts:20-64`,
 `src/cli-models.ts:88-117`, `src/active-model.ts:129-166`,
 `src/cli.test.ts:1463-1505`.
 
+## `kb models gc --dry-run --format=json`
+
+Invocation:
+
+```bash
+kb models gc --dry-run --format=json
+```
+
+Output schema:
+
+```json
+{
+  "schema_version": "kb.models.gc.v1",
+  "dry_run": true,
+  "models_root": "/path/to/.faiss/models",
+  "active_file": {
+    "status": "valid",
+    "model_id": "ollama__nomic-embed-text"
+  },
+  "active_env_model_id": null,
+  "total_bytes": 4096,
+  "reclaimable_bytes": 1024,
+  "models": [
+    {
+      "model_id": "openai__text-embedding-3-small",
+      "provider": "openai",
+      "model_name": "text-embedding-3-small",
+      "registered": true,
+      "active_by_file": false,
+      "active_by_env": false,
+      "incomplete_status": null,
+      "incomplete_detail": null,
+      "bytes": 1024,
+      "hazards": ["downgrade-hazard"],
+      "proposed_action": "would-remove"
+    }
+  ]
+}
+```
+
+Stable fields:
+
+- `schema_version`: currently `kb.models.gc.v1`.
+- `dry_run`: always `true`; v1 never deletes model directories.
+- `active_file.status`: one of `absent`, `empty`, `malformed`, or `valid`.
+- `active_env_model_id`: `KB_ACTIVE_MODEL` when set; otherwise the
+  legacy provider/model env-derived candidate when `active.txt` is absent or
+  empty; otherwise `null`.
+- `total_bytes`: summed size of valid model-id directories under
+  `$FAISS_INDEX_PATH/models`.
+- `reclaimable_bytes`: summed size for entries whose `proposed_action` is
+  `would-remove`.
+- `models[].model_id`: valid model directory id under `$FAISS_INDEX_PATH/models`.
+- `models[].provider`: provider parsed from the model id or incomplete sentinel.
+- `models[].model_name`: stored or sentinel model name when available.
+- `models[].registered`: whether the directory satisfies the registered-model
+  predicate.
+- `models[].active_by_file`: whether `active.txt` names this model id.
+- `models[].active_by_env`: whether `KB_ACTIVE_MODEL` or legacy env fallback
+  selects this model id.
+- `models[].incomplete_status`: `.adding`/incomplete-state classification when
+  present, otherwise `null`.
+- `models[].incomplete_detail`: human-readable incomplete-state detail when
+  present, otherwise `null`.
+- `models[].bytes`: recursive byte size of the model directory.
+- `models[].proposed_action`: one of `keep-active`, `keep-in-progress`,
+  `review-incomplete`, `inspect-incomplete`, or `would-remove`.
+- `models[].hazards`: zero or more of `active-by-file`, `active-by-env`,
+  `downgrade-hazard`, or `incomplete-<status>`. `active-by-env` covers both
+  explicit `KB_ACTIVE_MODEL` selection and legacy env fallback when active-file
+  resolution falls through.
+
+`kb models gc` exits `2` unless `--dry-run` is present. Human-readable dry-run
+output is text; use `--format=json` for machine consumption.
+
 ## `kb reindex status`
 
 Invocation:

--- a/src/active-model.ts
+++ b/src/active-model.ts
@@ -41,6 +41,10 @@ export function modelsRoot(): string {
   return MODELS_DIR;
 }
 
+export function activeModelFilePath(): string {
+  return ACTIVE_FILE;
+}
+
 export function modelDir(modelId: string): string {
   if (!isValidModelId(modelId)) {
     // Hard fail BEFORE path.join — round-1 failure F12 (path-traversal).

--- a/src/cli-models.ts
+++ b/src/cli-models.ts
@@ -1,19 +1,26 @@
 import * as fsp from 'fs/promises';
+import * as path from 'path';
 import { FaissIndexManager } from './FaissIndexManager.js';
 import {
   ActiveModelResolutionError,
+  activeModelFilePath,
   addingSentinelPath,
   buildAddingSentinelMetadata,
   classifyIncompleteModelState,
+  computeLegacyEnvDerivedId,
   isRegisteredModel,
+  isValidModelId,
   listRegisteredModels,
   modelDir,
+  modelsRoot,
   parseModelId,
+  readStoredModelName,
   resolveActiveModel,
   writeAddingSentinel,
   writeActiveModelAtomic,
 } from './active-model.js';
 import { resolveFaissIndexType, type FaissIndexType } from './config/indexing.js';
+import { KB_ACTIVE_MODEL } from './config/provider.js';
 import { deriveModelId, type EmbeddingProvider } from './model-id.js';
 import { KNOWLEDGE_BASES_ROOT_DIR } from './config/paths.js';
 import { enumerateIngestableKbFiles, listKnowledgeBases } from './kb-fs.js';
@@ -28,6 +35,7 @@ Usage:
   kb models add <provider> <model> [--index-type=flat|sq8] [--yes] [--dry-run] [--recover]
   kb models set-active <id>
   kb models remove <id>
+  kb models gc --dry-run [--format=json]
 
 Each model gets its own per-model FAISS index under
 \`\${FAISS_INDEX_PATH}/models/<id>/\`. The active model is the default for
@@ -51,6 +59,10 @@ Verbs:
                         without an explicit \`--model=\` use the new active id.
   remove <id>           Delete the per-model index directory. Forces a
                         rebuild on the next \`kb models add <same id>\`.
+  gc --dry-run          Plan inactive model directory cleanup without
+                        deleting anything. Reports active-by-file/env
+                        protection, incomplete state, byte size, downgrade
+                        hazards, and the proposed action.
 
 Options for \`add\`:
   --yes                 Skip the cost-estimate confirmation prompt.
@@ -61,6 +73,10 @@ Options for \`add\`:
   --index-type=flat|sq8 Select the FAISS index type for this model. Default
                         is KB_INDEX_TYPE when set, otherwise flat.
 
+Options for \`gc\`:
+  --dry-run             Required. Print the cleanup plan; never delete.
+  --format=json         Emit a stable JSON payload instead of text.
+
 Global:
   --help, -h            Show this help.
 
@@ -69,13 +85,15 @@ Examples:
   kb models add ollama nomic-embed-text
   kb models add openai text-embedding-3-small --dry-run
   kb models set-active openai__text-embedding-3-small
+  kb models gc --dry-run
+  kb models gc --dry-run --format=json
   kb models remove ollama__nomic-embed-text
 `;
 
 export async function runModels(rest: string[]): Promise<number> {
   const verb = rest[0];
   if (!verb) {
-    process.stderr.write('kb models: missing subcommand (list, add, set-active, remove)\n');
+    process.stderr.write('kb models: missing subcommand (list, add, set-active, remove, gc)\n');
     return 2;
   }
   try {
@@ -89,6 +107,7 @@ export async function runModels(rest: string[]): Promise<number> {
   if (verb === 'add') return runModelsAdd(rest.slice(1));
   if (verb === 'set-active') return runModelsSetActive(rest.slice(1));
   if (verb === 'remove') return runModelsRemove(rest.slice(1));
+  if (verb === 'gc') return runModelsGc(rest.slice(1));
 
   process.stderr.write(`kb models: unknown verb '${verb}'\n`);
   return 2;
@@ -406,6 +425,245 @@ async function runModelsRemove(rest: string[]): Promise<number> {
   await fsp.rm(dir, { recursive: true, force: true });
   process.stderr.write(`Removed ${id}.\n`);
   return 0;
+}
+
+type ModelsGcFormat = 'text' | 'json';
+
+const MODELS_GC_SCHEMA_VERSION = 'kb.models.gc.v1';
+
+interface ActiveFileSnapshot {
+  model_id: string | null;
+  status: 'absent' | 'empty' | 'malformed' | 'valid';
+}
+
+interface ModelsGcPlanEntry {
+  model_id: string;
+  provider: string | null;
+  model_name: string | null;
+  registered: boolean;
+  active_by_file: boolean;
+  active_by_env: boolean;
+  incomplete_status: string | null;
+  incomplete_detail: string | null;
+  bytes: number;
+  hazards: string[];
+  proposed_action: 'keep-active' | 'keep-in-progress' | 'review-incomplete' | 'inspect-incomplete' | 'would-remove';
+}
+
+interface ModelsGcPlan {
+  schema_version: typeof MODELS_GC_SCHEMA_VERSION;
+  dry_run: true;
+  models_root: string;
+  active_file: ActiveFileSnapshot;
+  active_env_model_id: string | null;
+  total_bytes: number;
+  reclaimable_bytes: number;
+  models: ModelsGcPlanEntry[];
+}
+
+async function runModelsGc(rest: string[]): Promise<number> {
+  let dryRun = false;
+  let format: ModelsGcFormat = 'text';
+  for (const raw of rest) {
+    if (raw === '--dry-run') {
+      dryRun = true;
+      continue;
+    }
+    if (raw === '--format=json') {
+      format = 'json';
+      continue;
+    }
+    if (raw === '--format=text') {
+      format = 'text';
+      continue;
+    }
+    if (raw.startsWith('--format=')) {
+      process.stderr.write(`kb models gc: invalid --format: ${raw}\n`);
+      return 2;
+    }
+    if (raw.startsWith('--')) {
+      process.stderr.write(`kb models gc: unknown flag: ${raw}\n`);
+      return 2;
+    }
+    process.stderr.write('kb models gc: does not accept positional arguments\n');
+    return 2;
+  }
+
+  if (!dryRun) {
+    process.stderr.write('kb models gc: v1 is dry-run only; pass --dry-run to print the cleanup plan.\n');
+    return 2;
+  }
+
+  const plan = await buildModelsGcPlan();
+  if (format === 'json') {
+    process.stdout.write(`${JSON.stringify(plan, null, 2)}\n`);
+  } else {
+    process.stdout.write(formatModelsGcPlan(plan));
+  }
+  return 0;
+}
+
+async function buildModelsGcPlan(): Promise<ModelsGcPlan> {
+  const activeFile = await readActiveFileSnapshot();
+  const activeEnvModelId = resolveActiveEnvCandidate(activeFile);
+  const registeredModels = new Map((await listRegisteredModels()).map((m) => [m.model_id, m]));
+  const entries = await listValidModelDirectoryNames();
+  const models: ModelsGcPlanEntry[] = [];
+
+  for (const modelId of entries) {
+    const registered = registeredModels.get(modelId) ?? null;
+    const incomplete = await classifyIncompleteModelState(modelId);
+    const storedName = registered?.model_name ?? incomplete?.model_name ?? await readStoredModelName(modelId);
+    const provider = registered?.provider ?? incomplete?.provider ?? parseModelId(modelId).provider;
+    const bytes = await directorySizeBytes(modelDir(modelId));
+    const activeByFile = activeFile.model_id === modelId;
+    const activeByEnv = activeEnvModelId === modelId;
+    const hazards: string[] = [];
+    if (registered?.downgrade_hazard) hazards.push('downgrade-hazard');
+    if (incomplete !== null) hazards.push(`incomplete-${incomplete.status}`);
+    if (activeByFile) hazards.push('active-by-file');
+    if (activeByEnv) hazards.push('active-by-env');
+
+    models.push({
+      model_id: modelId,
+      provider,
+      model_name: storedName,
+      registered: registered !== null,
+      active_by_file: activeByFile,
+      active_by_env: activeByEnv,
+      incomplete_status: incomplete?.status ?? null,
+      incomplete_detail: incomplete?.detail ?? null,
+      bytes,
+      hazards,
+      proposed_action: proposeModelsGcAction({ activeByFile, activeByEnv, incompleteStatus: incomplete?.status ?? null }),
+    });
+  }
+
+  models.sort((a, b) => a.model_id.localeCompare(b.model_id));
+  return {
+    schema_version: MODELS_GC_SCHEMA_VERSION,
+    dry_run: true,
+    models_root: modelsRoot(),
+    active_file: activeFile,
+    active_env_model_id: activeEnvModelId,
+    total_bytes: models.reduce((sum, m) => sum + m.bytes, 0),
+    reclaimable_bytes: models
+      .filter((m) => m.proposed_action === 'would-remove')
+      .reduce((sum, m) => sum + m.bytes, 0),
+    models,
+  };
+}
+
+function resolveActiveEnvCandidate(activeFile: ActiveFileSnapshot): string | null {
+  if (KB_ACTIVE_MODEL !== '') return KB_ACTIVE_MODEL;
+  if (activeFile.status === 'absent' || activeFile.status === 'empty') {
+    return computeLegacyEnvDerivedId();
+  }
+  return null;
+}
+
+async function listValidModelDirectoryNames(): Promise<string[]> {
+  let entries: Array<import('fs').Dirent>;
+  try {
+    entries = await fsp.readdir(modelsRoot(), { withFileTypes: true });
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return [];
+    throw err;
+  }
+  return entries
+    .filter((entry) => entry.isDirectory() && isValidModelId(entry.name))
+    .map((entry) => entry.name)
+    .sort((a, b) => a.localeCompare(b));
+}
+
+async function readActiveFileSnapshot(): Promise<ActiveFileSnapshot> {
+  let raw: string;
+  try {
+    raw = await fsp.readFile(activeModelFilePath(), 'utf-8');
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return { status: 'absent', model_id: null };
+    throw err;
+  }
+  const normalized = raw.charCodeAt(0) === 0xfeff ? raw.slice(1) : raw;
+  const trimmed = normalized.replace(/\r/g, '').trim();
+  if (trimmed === '') return { status: 'empty', model_id: null };
+  if (!isValidModelId(trimmed)) return { status: 'malformed', model_id: null };
+  return { status: 'valid', model_id: trimmed };
+}
+
+function proposeModelsGcAction(args: {
+  activeByFile: boolean;
+  activeByEnv: boolean;
+  incompleteStatus: string | null;
+}): ModelsGcPlanEntry['proposed_action'] {
+  if (args.activeByFile || args.activeByEnv) return 'keep-active';
+  if (args.incompleteStatus === 'in_progress') return 'keep-in-progress';
+  if (args.incompleteStatus === 'stale_interrupted') return 'review-incomplete';
+  if (args.incompleteStatus !== null) return 'inspect-incomplete';
+  return 'would-remove';
+}
+
+function formatModelsGcPlan(plan: ModelsGcPlan): string {
+  const lines: string[] = [];
+  lines.push(`Model cleanup dry-run (${plan.models.length} model director${plan.models.length === 1 ? 'y' : 'ies'})`);
+  lines.push(`Models root: ${plan.models_root}`);
+  lines.push(`Active by file: ${plan.active_file.model_id ?? `<${plan.active_file.status}>`}`);
+  lines.push(`Active by env: ${plan.active_env_model_id ?? '<unset>'}`);
+  lines.push(`Total size: ${formatBytes(plan.total_bytes)}; would reclaim: ${formatBytes(plan.reclaimable_bytes)}`);
+  if (plan.models.length === 0) {
+    lines.push('(no model directories found)');
+    return `${lines.join('\n')}\n`;
+  }
+  const idWidth = Math.max(8, ...plan.models.map((m) => m.model_id.length));
+  const actionWidth = Math.max(14, ...plan.models.map((m) => m.proposed_action.length));
+  for (const model of plan.models) {
+    const flags = model.hazards.length > 0 ? ` [${model.hazards.join(',')}]` : '';
+    lines.push(
+      `${model.model_id.padEnd(idWidth)}  ${model.proposed_action.padEnd(actionWidth)}  ${formatBytes(model.bytes).padStart(9)}${flags}`,
+    );
+    if (model.incomplete_detail !== null) {
+      lines.push(`  incomplete: ${model.incomplete_detail}`);
+    }
+  }
+  lines.push('Dry run only: no files were deleted.');
+  return `${lines.join('\n')}\n`;
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  const units = ['KiB', 'MiB', 'GiB', 'TiB'];
+  let value = bytes / 1024;
+  let unit = units[0];
+  for (let i = 1; i < units.length && value >= 1024; i += 1) {
+    value /= 1024;
+    unit = units[i];
+  }
+  return `${value.toFixed(value >= 10 ? 1 : 2)} ${unit}`;
+}
+
+async function directorySizeBytes(dir: string): Promise<number> {
+  let total = 0;
+  let entries: Array<import('fs').Dirent>;
+  try {
+    entries = await fsp.readdir(dir, { withFileTypes: true });
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT' || code === 'ENOTDIR') return 0;
+    throw err;
+  }
+  for (const entry of entries) {
+    const child = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      total += await directorySizeBytes(child);
+    } else if (entry.isFile()) {
+      try {
+        total += (await fsp.stat(child)).size;
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+      }
+    }
+  }
+  return total;
 }
 
 async function readConfirmation(): Promise<string> {

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -2286,6 +2286,268 @@ describe('kb search — active-model resolution (RFC 013 §4.7)', () => {
     }
   });
 
+  it('kb models list --format=json still emits text, not a JSON contract', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-cli-models-list-json-'));
+    try {
+      const faissDir = path.join(tempDir, '.faiss');
+      await fsp.mkdir(faissDir, { recursive: true });
+
+      const r = runCli(['models', 'list', '--format=json'], {
+        KNOWLEDGE_BASES_ROOT_DIR: path.join(tempDir, 'kb'),
+        FAISS_INDEX_PATH: faissDir,
+        EMBEDDING_PROVIDER: 'huggingface',
+        HUGGINGFACE_API_KEY: 'test-key',
+      });
+
+      expect(r.code).toBe(0);
+      expect(r.stdout).toContain('(no models registered');
+      expect(() => JSON.parse(r.stdout)).toThrow();
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('kb models gc requires --dry-run because v1 does not delete', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-cli-models-gc-required-'));
+    try {
+      const faissDir = path.join(tempDir, '.faiss');
+      await fsp.mkdir(faissDir, { recursive: true });
+
+      const r = runCli(['models', 'gc'], {
+        KNOWLEDGE_BASES_ROOT_DIR: path.join(tempDir, 'kb'),
+        FAISS_INDEX_PATH: faissDir,
+        EMBEDDING_PROVIDER: 'huggingface',
+        HUGGINGFACE_API_KEY: 'test-key',
+      });
+
+      expect(r.code).toBe(2);
+      expect(r.stderr).toContain('dry-run only');
+      expect(r.stderr).toContain('--dry-run');
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('kb models gc --dry-run plans active, inactive, incomplete, and hazard states as JSON', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-cli-models-gc-json-'));
+    try {
+      const faissDir = path.join(tempDir, '.faiss');
+      const activeByFile = 'huggingface__BAAI-bge-small-en-v1.5';
+      const activeByEnv = 'ollama__nomic-embed-text-latest';
+      const inactiveHazard = 'openai__text-embedding-3-small';
+      const incomplete = 'ollama__stale-partial';
+      for (const [id, name] of [
+        [activeByFile, 'BAAI/bge-small-en-v1.5'],
+        [activeByEnv, 'nomic-embed-text:latest'],
+        [inactiveHazard, 'text-embedding-3-small'],
+      ] as const) {
+        await fsp.mkdir(path.join(faissDir, 'models', id), { recursive: true });
+        await fsp.writeFile(path.join(faissDir, 'models', id, 'model_name.txt'), name);
+        await fsp.writeFile(path.join(faissDir, 'models', id, 'payload.bin'), 'payload');
+      }
+      await fsp.mkdir(path.join(faissDir, 'models', inactiveHazard, 'index.v1'), { recursive: true });
+      await fsp.writeFile(path.join(faissDir, 'models', inactiveHazard, 'index.v1', 'faiss.index'), 'index');
+      await fsp.symlink('index.v1', path.join(faissDir, 'models', inactiveHazard, 'index'));
+      await fsp.mkdir(path.join(faissDir, 'models', inactiveHazard, 'faiss.index'), { recursive: true });
+
+      await fsp.mkdir(path.join(faissDir, 'models', incomplete), { recursive: true });
+      await fsp.writeFile(path.join(faissDir, 'models', incomplete, '.adding'), '999999999\n');
+      await fsp.writeFile(path.join(faissDir, 'models', incomplete, 'partial.bin'), 'partial');
+      await fsp.writeFile(path.join(faissDir, 'active.txt'), `${activeByFile}\n`);
+
+      const r = runCli(['models', 'gc', '--dry-run', '--format=json'], {
+        KNOWLEDGE_BASES_ROOT_DIR: path.join(tempDir, 'kb'),
+        FAISS_INDEX_PATH: faissDir,
+        KB_ACTIVE_MODEL: activeByEnv,
+        EMBEDDING_PROVIDER: 'huggingface',
+        HUGGINGFACE_API_KEY: 'test-key',
+      });
+
+      expect(r.code).toBe(0);
+      expect(r.stderr).toBe('');
+      const payload = JSON.parse(r.stdout) as {
+        schema_version: string;
+        dry_run: boolean;
+        models_root: string;
+        active_file: { model_id: string | null; status: string };
+        active_env_model_id: string | null;
+        total_bytes: number;
+        reclaimable_bytes: number;
+        models: Array<{
+          model_id: string;
+          provider: string | null;
+          model_name: string | null;
+          registered: boolean;
+          active_by_file: boolean;
+          active_by_env: boolean;
+          incomplete_status: string | null;
+          incomplete_detail: string | null;
+          hazards: string[];
+          proposed_action: string;
+          bytes: number;
+        }>;
+      };
+
+      expect(payload.schema_version).toBe('kb.models.gc.v1');
+      expect(payload.dry_run).toBe(true);
+      expect(payload.models_root).toBe(path.join(faissDir, 'models'));
+      expect(payload.active_file).toEqual({ status: 'valid', model_id: activeByFile });
+      expect(payload.active_env_model_id).toBe(activeByEnv);
+
+      const byId = new Map(payload.models.map((model) => [model.model_id, model]));
+      expect(byId.get(activeByFile)).toMatchObject({
+        provider: 'huggingface',
+        model_name: 'BAAI/bge-small-en-v1.5',
+        registered: true,
+        active_by_file: true,
+        active_by_env: false,
+        proposed_action: 'keep-active',
+      });
+      expect(byId.get(activeByEnv)).toMatchObject({
+        provider: 'ollama',
+        model_name: 'nomic-embed-text:latest',
+        registered: true,
+        active_by_file: false,
+        active_by_env: true,
+        proposed_action: 'keep-active',
+      });
+      expect(byId.get(inactiveHazard)?.proposed_action).toBe('would-remove');
+      expect(byId.get(inactiveHazard)?.hazards).toContain('downgrade-hazard');
+      expect(byId.get(incomplete)).toMatchObject({
+        provider: 'ollama',
+        model_name: null,
+        registered: false,
+        incomplete_status: 'stale_interrupted',
+        incomplete_detail: 'previous kb models add writer pid 999999999 is no longer running',
+        proposed_action: 'review-incomplete',
+      });
+      expect(byId.get(incomplete)?.hazards).toContain('incomplete-stale_interrupted');
+      expect(payload.total_bytes).toBe(payload.models.reduce((sum, model) => sum + model.bytes, 0));
+      expect(payload.reclaimable_bytes).toBe(byId.get(inactiveHazard)?.bytes);
+
+      for (const id of [activeByFile, activeByEnv, inactiveHazard, incomplete]) {
+        await expect(fsp.access(path.join(faissDir, 'models', id))).resolves.toBeUndefined();
+      }
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('kb models gc --dry-run maps active-file fallbacks and incomplete states', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-cli-models-gc-edges-'));
+    try {
+      const faissDir = path.join(tempDir, '.faiss');
+      const legacyActive = 'ollama__nomic-embed-text';
+      const liveIncomplete = 'ollama__live-partial';
+      const unknownIncomplete = 'ollama__unknown-partial';
+      await fsp.mkdir(path.join(faissDir, 'models', legacyActive), { recursive: true });
+      await fsp.writeFile(path.join(faissDir, 'models', legacyActive, 'model_name.txt'), 'nomic-embed-text');
+      await fsp.mkdir(path.join(faissDir, 'models', liveIncomplete), { recursive: true });
+      await fsp.writeFile(path.join(faissDir, 'models', liveIncomplete, '.adding'), `${process.pid}\n`);
+      await fsp.mkdir(path.join(faissDir, 'models', unknownIncomplete), { recursive: true });
+      await fsp.writeFile(path.join(faissDir, 'models', unknownIncomplete, 'partial.bin'), 'partial');
+
+      const env = {
+        KNOWLEDGE_BASES_ROOT_DIR: path.join(tempDir, 'kb'),
+        FAISS_INDEX_PATH: faissDir,
+        EMBEDDING_PROVIDER: 'ollama',
+        OLLAMA_MODEL: 'nomic-embed-text',
+      };
+      const absent = runCli(['models', 'gc', '--dry-run', '--format=json'], env);
+      expect(absent.code).toBe(0);
+      const absentPayload = JSON.parse(absent.stdout) as {
+        active_file: { status: string; model_id: string | null };
+        active_env_model_id: string | null;
+        models: Array<{
+          model_id: string;
+          active_by_env: boolean;
+          incomplete_status: string | null;
+          proposed_action: string;
+        }>;
+      };
+      const absentById = new Map(absentPayload.models.map((model) => [model.model_id, model]));
+      expect(absentPayload.active_file).toEqual({ status: 'absent', model_id: null });
+      expect(absentPayload.active_env_model_id).toBe(legacyActive);
+      expect(absentById.get(legacyActive)).toMatchObject({
+        active_by_env: true,
+        proposed_action: 'keep-active',
+      });
+      expect(absentById.get(liveIncomplete)).toMatchObject({
+        incomplete_status: 'in_progress',
+        proposed_action: 'keep-in-progress',
+      });
+      expect(absentById.get(unknownIncomplete)).toMatchObject({
+        incomplete_status: 'unknown',
+        proposed_action: 'inspect-incomplete',
+      });
+
+      await fsp.writeFile(path.join(faissDir, 'active.txt'), '\n');
+      const empty = runCli(['models', 'gc', '--dry-run', '--format=json'], env);
+      expect(empty.code).toBe(0);
+      const emptyPayload = JSON.parse(empty.stdout) as {
+        active_file: { status: string; model_id: string | null };
+        active_env_model_id: string | null;
+      };
+      expect(emptyPayload.active_file).toEqual({ status: 'empty', model_id: null });
+      expect(emptyPayload.active_env_model_id).toBe(legacyActive);
+
+      await fsp.writeFile(path.join(faissDir, 'active.txt'), '../bad\n');
+      const malformed = runCli(['models', 'gc', '--dry-run', '--format=json'], env);
+      expect(malformed.code).toBe(0);
+      const malformedPayload = JSON.parse(malformed.stdout) as {
+        active_file: { status: string; model_id: string | null };
+        active_env_model_id: string | null;
+      };
+      expect(malformedPayload.active_file).toEqual({ status: 'malformed', model_id: null });
+      expect(malformedPayload.active_env_model_id).toBeNull();
+
+      const whitespaceEnv = runCli(['models', 'gc', '--dry-run', '--format=json'], {
+        ...env,
+        KB_ACTIVE_MODEL: '   ',
+      });
+      expect(whitespaceEnv.code).toBe(0);
+      const whitespacePayload = JSON.parse(whitespaceEnv.stdout) as {
+        active_env_model_id: string | null;
+        models: Array<{ model_id: string; active_by_env: boolean; proposed_action: string }>;
+      };
+      const whitespaceById = new Map(whitespacePayload.models.map((model) => [model.model_id, model]));
+      expect(whitespacePayload.active_env_model_id).toBe('   ');
+      expect(whitespaceById.get(legacyActive)).toMatchObject({
+        active_by_env: false,
+        proposed_action: 'would-remove',
+      });
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('kb models gc --dry-run prints a text plan without deleting', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-cli-models-gc-text-'));
+    try {
+      const faissDir = path.join(tempDir, '.faiss');
+      const id = 'ollama__nomic-embed-text';
+      await fsp.mkdir(path.join(faissDir, 'models', id), { recursive: true });
+      await fsp.writeFile(path.join(faissDir, 'models', id, 'model_name.txt'), 'nomic-embed-text');
+
+      const r = runCli(['models', 'gc', '--dry-run'], {
+        KNOWLEDGE_BASES_ROOT_DIR: path.join(tempDir, 'kb'),
+        FAISS_INDEX_PATH: faissDir,
+        EMBEDDING_PROVIDER: 'ollama',
+        OLLAMA_MODEL: 'nomic-embed-text',
+      });
+
+      expect(r.code).toBe(0);
+      expect(r.stdout).toContain('Model cleanup dry-run');
+      expect(r.stdout).toContain(id);
+      expect(r.stdout).toContain('keep-active');
+      expect(r.stdout).toContain('active-by-env');
+      expect(r.stdout).toContain('Dry run only: no files were deleted.');
+      await expect(fsp.access(path.join(faissDir, 'models', id))).resolves.toBeUndefined();
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it('kb models add exits 2 in non-TTY context without --yes (round-1 failure F9)', async () => {
     const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-cli-add-noyes-'));
     try {


### PR DESCRIPTION
## Summary
- add `kb models gc --dry-run` with text and `--format=json` output
- report active-by-file/env protection, incomplete model states, byte counts, downgrade hazards, and proposed dry-run actions
- document the JSON contract for agent-facing consumers

Closes #523

## Test plan
- `npm run build`
- `npm test -- --runInBand src/cli.test.ts`
- `npm test -- --runInBand src/active-model.test.ts`
- `npm run docs:check-anchors`
- `git diff --check`
- `npm test -- --runInBand` (126 suites, 2033 passed, 4 skipped, 1 todo)

## Pre-PR review
- conventions: fixed missing `gc` copy and expanded stable JSON field docs
- correctness: fixed whitespace-only `KB_ACTIVE_MODEL` handling to match runtime active-model resolution
- tests: added coverage for stable JSON fields, active-file fallback states, incomplete-state action mapping, and the `models list` negative JSON contract
- dead-code: no dead code introduced