### PR TITLE
feat(cli): add picker multi-select

### DIFF
--- a/src/cli-search-picker.test.ts
+++ b/src/cli-search-picker.test.ts
@@ -39,6 +39,7 @@ describe('createPickerState', () => {
     const s = makeState();
     expect(s.view).toBe('flat');
     expect(s.focusIndex).toBe(0);
+    expect(s.selectedFlatIndexes.size).toBe(0);
     expect(s.showHelp).toBe(false);
     expect(pickerItemCount(s)).toBe(3);
   });
@@ -131,6 +132,26 @@ describe('applyKey navigation', () => {
     expect(r.action).toEqual({ type: 'select', view: 'flat', index: 1 });
   });
 
+  it('Space marks and unmarks the focused flat row', () => {
+    let s = makeState();
+    s = applyKey(s, { sequence: 'j' }).state;
+
+    s = applyKey(s, { name: 'space' }).state;
+    expect(Array.from(s.selectedFlatIndexes)).toEqual([1]);
+
+    s = applyKey(s, { sequence: ' ' }).state;
+    expect(Array.from(s.selectedFlatIndexes)).toEqual([]);
+  });
+
+  it('Space is a no-op in grouped view', () => {
+    let s = makeState();
+    s = applyKey(s, { name: 'space' }).state;
+    s = applyKey(s, { name: 'tab' }).state;
+    const r = applyKey(s, { name: 'space' });
+    expect(r.action).toEqual({ type: 'continue' });
+    expect(Array.from(r.state.selectedFlatIndexes)).toEqual([0]);
+  });
+
   it('Enter on an empty result list exits with no selection', () => {
     const s = createPickerState([]);
     const r = applyKey(s, { name: 'return' });
@@ -151,6 +172,25 @@ describe('renderPickerFrame', () => {
     expect(out).toMatch(/3 chunks/);
     expect(out).toMatch(/view=flat/);
     expect(out).toMatch(/1\/3/);
+  });
+
+  it('shows selected count when flat rows are marked', () => {
+    let s = makeState();
+    s = applyKey(s, { name: 'space' }).state;
+    s = applyKey(s, { sequence: 'j' }).state;
+    s = applyKey(s, { name: 'space' }).state;
+
+    const out = renderPickerFrame(s, RENDER_OPTS);
+    expect(out).toMatch(/selected=2/);
+  });
+
+  it('renders marked and unmarked flat row markers', () => {
+    let s = makeState();
+    s = applyKey(s, { name: 'space' }).state;
+
+    const out = renderPickerFrame(s, RENDER_OPTS);
+    expect(out).toMatch(/\[x\] \[0\.21\] .*alpha content about rollback/);
+    expect(out).toMatch(/\[ \] \[0\.28\] .*bravo content about deploy/);
   });
 
   it('renders one row per result and marks the focused row', () => {
@@ -181,14 +221,25 @@ describe('renderPickerFrame', () => {
     const out = renderPickerFrame(s, RENDER_OPTS);
     expect(out).toMatch(/Keys:/);
     expect(out).toMatch(/j \/ Down/);
-    expect(out).toMatch(/print focused chunk to stdout/);
+    expect(out).toMatch(/Space\s+mark \/ unmark focused chunk/);
+    expect(out).toMatch(/print marked chunks/);
   });
 
   it('shows a short footer hint when help is collapsed', () => {
     const out = renderPickerFrame(makeState(), RENDER_OPTS);
-    expect(out).toMatch(/\[Enter\] open/);
+    expect(out).toMatch(/\[Space\] mark/);
+    expect(out).toMatch(/\[Enter\] print/);
     expect(out).toMatch(/\[Tab\] toggle view/);
     expect(out).not.toMatch(/Keys:/);
+  });
+
+  it('uses grouped footer copy that does not advertise Space marking', () => {
+    let s = makeState();
+    s = applyKey(s, { name: 'tab' }).state;
+
+    const out = renderPickerFrame(s, RENDER_OPTS);
+    expect(out).toMatch(/\[Enter\] print source/);
+    expect(out).not.toMatch(/\[Space\] mark/);
   });
 
   it('reports "(no results)" when the picker received an empty list', () => {
@@ -227,6 +278,33 @@ describe('formatSelection', () => {
     expect(out).toMatch(/Semantic Search Results/);
     expect(out).toMatch(/bravo content about deploy/);
     expect(out).not.toMatch(/alpha content/);
+  });
+
+  it('emits marked flat chunks in stable result order', () => {
+    let s = makeState();
+    s.focusIndex = 2;
+    s = applyKey(s, { name: 'space' }).state;
+    s.focusIndex = 0;
+    s = applyKey(s, { name: 'space' }).state;
+
+    const out = formatSelection(s, { view: 'flat', index: 1 });
+    expect(out).toMatch(/alpha content about rollback/);
+    expect(out).toMatch(/alpha content take two/);
+    expect(out).not.toMatch(/bravo content about deploy/);
+    expect(out.indexOf('alpha content about rollback')).toBeLessThan(out.indexOf('alpha content take two'));
+  });
+
+  it('emits marked flat chunks after switching to grouped view', () => {
+    let s = makeState();
+    s = applyKey(s, { name: 'space' }).state;
+    s = applyKey(s, { sequence: 'j' }).state;
+    s = applyKey(s, { name: 'space' }).state;
+    s = applyKey(s, { name: 'tab' }).state;
+
+    const out = formatSelection(s, { view: 'grouped', index: 0 });
+    expect(out).toMatch(/alpha content about rollback/);
+    expect(out).toMatch(/bravo content about deploy/);
+    expect(out).not.toMatch(/alpha content take two/);
   });
 
   it('emits all chunks of the focused source in grouped view', () => {

--- a/src/cli-search-picker.ts
+++ b/src/cli-search-picker.ts
@@ -20,6 +20,7 @@ export interface PickerState {
   grouped: GroupedRetrievalSource[];
   view: PickerView;
   focusIndex: number;
+  selectedFlatIndexes: Set<number>;
   showHelp: boolean;
 }
 
@@ -47,6 +48,7 @@ export function createPickerState(results: ScoredDocument[]): PickerState {
     grouped: groupRetrievalBySource(results, FRONTMATTER_EXTRAS_WIRE_VISIBLE, KB_EDITOR_URI),
     view: 'flat',
     focusIndex: 0,
+    selectedFlatIndexes: new Set<number>(),
     showHelp: false,
   };
 }
@@ -73,7 +75,7 @@ export function renderPickerFrame(state: PickerState, opts: PickerRenderOptions)
     for (let i = start; i < end; i += 1) {
       const focused = i === state.focusIndex;
       const row = state.view === 'flat'
-        ? renderFlatRow(state.results[i], i)
+        ? renderFlatRow(state.results[i], i, state.selectedFlatIndexes.has(i))
         : renderGroupedRow(state.grouped[i], i);
       lines.push(renderRow(row, focused, opts));
     }
@@ -84,7 +86,7 @@ export function renderPickerFrame(state: PickerState, opts: PickerRenderOptions)
     for (const helpLine of helpLines) lines.push(helpLine);
   } else {
     lines.push('');
-    lines.push(renderFooterHint(opts));
+    lines.push(renderFooterHint(state, opts));
   }
 
   return lines.join('\n');
@@ -99,6 +101,18 @@ export function applyKey(state: PickerState, key: PickerKey): { state: PickerSta
   if (name === 'return') {
     if (count === 0) return { state, action: { type: 'exit' } };
     return { state, action: { type: 'select', view: state.view, index: state.focusIndex } };
+  }
+  if (name === 'space' || seq === ' ') {
+    if (state.view !== 'flat' || count === 0) {
+      return { state, action: { type: 'continue' } };
+    }
+    const selectedFlatIndexes = new Set(state.selectedFlatIndexes);
+    if (selectedFlatIndexes.has(state.focusIndex)) {
+      selectedFlatIndexes.delete(state.focusIndex);
+    } else {
+      selectedFlatIndexes.add(state.focusIndex);
+    }
+    return { state: { ...state, selectedFlatIndexes }, action: { type: 'continue' } };
   }
   if (name === 'escape' || seq === 'q' || seq === 'Q') {
     return { state, action: { type: 'exit' } };
@@ -131,10 +145,14 @@ export function applyKey(state: PickerState, key: PickerKey): { state: PickerSta
 }
 
 export function formatSelection(state: PickerState, action: { view: PickerView; index: number }): string {
+  const selectedDocs = selectedDocumentsInResultOrder(state);
+  if (selectedDocs.length > 0) {
+    return `${formatRetrievalAsMarkdown(selectedDocs, FRONTMATTER_EXTRAS_WIRE_VISIBLE, KB_EDITOR_URI)}\n`;
+  }
   if (action.view === 'flat') {
-    const doc = state.results[action.index];
-    if (!doc) return '';
-    return `${formatRetrievalAsMarkdown([doc], FRONTMATTER_EXTRAS_WIRE_VISIBLE, KB_EDITOR_URI)}\n`;
+    const docs = [state.results[action.index]].filter((doc): doc is ScoredDocument => doc !== undefined);
+    if (docs.length === 0) return '';
+    return `${formatRetrievalAsMarkdown(docs, FRONTMATTER_EXTRAS_WIRE_VISIBLE, KB_EDITOR_URI)}\n`;
   }
   const group = state.grouped[action.index];
   if (!group) return '';
@@ -233,11 +251,17 @@ function renderHeader(state: PickerState, count: number, _opts: PickerRenderOpti
   const plural = count === 1 ? noun : `${noun}s`;
   const viewTag = state.view === 'flat' ? 'flat' : 'grouped';
   const position = count === 0 ? '0/0' : `${state.focusIndex + 1}/${count}`;
-  return `kb search · ${count} ${plural} · view=${viewTag} · ${position}`;
+  const selected = state.selectedFlatIndexes.size;
+  const selectedText = selected > 0 ? ` · selected=${selected}` : '';
+  return `kb search · ${count} ${plural} · view=${viewTag} · ${position}${selectedText}`;
 }
 
-function renderFooterHint(_opts: PickerRenderOptions): string {
-  return '[j/k] move  [Enter] open  [Tab] toggle view  [?] help  [q] quit';
+function renderFooterHint(state: PickerState, _opts: PickerRenderOptions): string {
+  if (state.view === 'grouped') {
+    const enter = state.selectedFlatIndexes.size > 0 ? '[Enter] print marks' : '[Enter] print source';
+    return `[j/k] move  ${enter}  [Tab] toggle view  [?] help  [q] quit`;
+  }
+  return '[j/k] move  [Space] mark  [Enter] print  [Tab] toggle view  [?] help  [q] quit';
 }
 
 function helpBodyLines(): string[] {
@@ -247,20 +271,22 @@ function helpBodyLines(): string[] {
     '  k / Up       previous result',
     '  g            jump to top',
     '  G            jump to bottom',
+    '  Space        mark / unmark focused chunk in flat view',
     '  Tab          toggle flat / grouped-by-source view',
-    '  Enter        print focused chunk to stdout and exit',
+    '  Enter        print marked chunks, or focused row/source if none are marked',
     '  ?            toggle this help',
     '  q / Esc      quit (no output)',
   ];
 }
 
-function renderFlatRow(doc: ScoredDocument | undefined, _idx: number): string {
+function renderFlatRow(doc: ScoredDocument | undefined, _idx: number, selected: boolean): string {
   if (!doc) return '(missing result)';
   const metadata = (doc.metadata ?? {}) as Record<string, unknown>;
   const score = doc.score === undefined ? 'n/a' : doc.score.toFixed(2);
   const source = pickSourceLabel(metadata);
   const preview = previewText(doc.pageContent);
-  return `[${score}] ${source} — ${preview}`;
+  const selectedMark = selected ? '[x]' : '[ ]';
+  return `${selectedMark} [${score}] ${source} — ${preview}`;
 }
 
 function renderGroupedRow(group: GroupedRetrievalSource | undefined, _idx: number): string {
@@ -288,4 +314,12 @@ function pickSourceLabel(metadata: Record<string, unknown>): string {
 
 function previewText(content: string): string {
   return content.replace(/\s+/g, ' ').trim().slice(0, 80);
+}
+
+function selectedDocumentsInResultOrder(state: PickerState): ScoredDocument[] {
+  return Array.from(state.selectedFlatIndexes)
+    .filter((idx) => idx >= 0 && idx < state.results.length)
+    .sort((a, b) => a - b)
+    .map((idx) => state.results[idx])
+    .filter((doc): doc is ScoredDocument => doc !== undefined);
 }


### PR DESCRIPTION
## Summary
- add flat-view multi-select state for `kb search -i` with Space mark/unmark
- print marked chunks in original result order on Enter, including after toggling to grouped view
- update picker help/footer copy, selected row markers, and focused tests

Closes #524

## Review notes
- pre-PR reviewer findings addressed: grouped-view marked selections now print marked chunks, grouped footer no longer advertises Space marking, tests cover row markers and grouped no-op preservation
- dead-code reviewer found no PR-introduced dead code

## Test plan
- npm test -- --runInBand src/cli-search-picker.test.ts
- npm run build
- npm test -- --runInBand
- git diff --check