### PR TITLE
feat(doctor): inventory KB symlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ kb config validate            # static env-var schema validation before startup
 kb doctor                     # availability snapshot (index, embedding backend, LLM)
 kb doctor --endpoints         # focused MCP/daemon/Ollama/LLM endpoint preflight
 kb doctor --locks             # write-lock owner and stale-lock diagnosis
+kb doctor --kb-symlinks       # inventory KB-root symlinks and escaping targets
 kb doctor --bug-report=/tmp   # write a redacted support bundle for issue reports
 kb --help                     # top-level command list
 kb help search                # per-command help (also: kb search --help)
@@ -579,6 +580,7 @@ kb doctor                # human-readable report
 kb doctor --format=json  # machine-readable for agent shells
 kb doctor --endpoints    # focused bind/connect endpoint preflight
 kb doctor --locks        # model write-lock owner/stale diagnosis
+kb doctor --kb-symlinks  # KB-root symlink inventory and target classification
 kb doctor --bug-report=/tmp  # redacted support bundle directory
 ```
 
@@ -587,6 +589,8 @@ The report covers active-model resolution, FAISS index version + mtime, the late
 Use `kb doctor --endpoints` when you only need configured local endpoint readiness before starting or wiring clients. It checks MCP bind address/port availability, configured `KB_DAEMON_URL` health, configured Ollama embedding reachability, and configured `KB_LLM_ENDPOINT` or active LLM profile readiness without loading the full index health report.
 
 Use `kb doctor --locks` when refresh or model writes report lock contention. It scans per-model `.kb-write.lock` paths, reports lock age, recorded owner PID/command for new locks, stale suspicion, and conservative next actions without deleting any lock file.
+
+Use `kb doctor --kb-symlinks` when auditing KB content roots. It scans with `lstat`, does not follow symlink directories, and classifies symlink targets as inside-root, escaping, broken, or loop/error with capped examples.
 
 Use `kb doctor --bug-report[=<dir>]` when opening an issue or handing diagnostics to another operator. It writes a timestamped directory containing redacted `doctor.json`, `stats.json`, recent canonical log summaries, runtime/env metadata, and a README. The bundle does not include note contents or raw API keys; KB names, paths, model names, and log metadata can still be sensitive.
 

--- a/docs/cli-json-contracts.md
+++ b/docs/cli-json-contracts.md
@@ -732,6 +732,7 @@ Invocation:
 kb doctor --format=json
 kb doctor --endpoints --format=json
 kb doctor --locks --format=json
+kb doctor --kb-symlinks --format=json
 kb doctor --bug-report=/tmp --format=json
 kb doctor --bug-report=/tmp --include-command -- node -e 'process.exit(1)'
 ```
@@ -925,6 +926,56 @@ Stable lock-report fields:
   cwd, hostname, and start time beside the lock; older locks may report
   `source: "none"`.
 - `next_action`: conservative guidance. The command never deletes locks.
+
+`kb doctor --kb-symlinks --format=json` emits a focused KB-root symlink
+inventory without running the aggregate backend/index checks:
+
+```json
+{
+  "schema_version": "kb.doctor.kb_symlinks.v1",
+  "status": "warn",
+  "inventory": {
+    "root_dir": "/path/to/kbs",
+    "root_realpath": "/path/to/kbs",
+    "summary": {
+      "total": 3,
+      "inside_root": 1,
+      "escaping": 1,
+      "broken": 1,
+      "loop_or_error": 0,
+      "scan_error_count": 0,
+      "sample_limit": 5
+    },
+    "symlinks": [
+      {
+        "kbName": "project",
+        "path": "/path/to/kbs/project/outside.md",
+        "relative_path": "project/outside.md",
+        "link_target": "/tmp/outside.md",
+        "resolved_target": "/tmp/outside.md",
+        "classification": "escaping",
+        "error_code": null,
+        "error_message": null
+      }
+    ],
+    "scan_errors": []
+  }
+}
+```
+
+Stable KB symlink report fields:
+
+- `schema_version`: currently `kb.doctor.kb_symlinks.v1`.
+- `status`: `ok` when no symlinks or only inside-root symlinks are found,
+  `warn` when escaping, broken, or loop/error symlinks are found, and `error`
+  when directory scanning itself fails.
+- `inventory.summary`: total symlink count, per-classification counts,
+  scan-error count, and the capped example `sample_limit`.
+- `inventory.symlinks[]`: capped examples discovered with `lstat`. Symlink
+  directories are reported as symlinks and are not followed. `classification`
+  is `inside_root`, `escaping`, `broken`, or `loop_or_error`.
+- `inventory.scan_errors[]`: capped directory or `lstat` failures with `path`,
+  `code`, and `message`.
 
 `kb doctor --bug-report[=<dir>]` writes a timestamped support bundle directory
 under `<dir>` (default: current directory). The bundle contains:

--- a/docs/troubleshooting-local-kb.md
+++ b/docs/troubleshooting-local-kb.md
@@ -13,6 +13,7 @@ kb doctor
 kb doctor --format=json
 kb doctor --endpoints
 kb doctor --locks
+kb doctor --kb-symlinks
 kb doctor --bug-report=/tmp
 ```
 
@@ -21,6 +22,8 @@ kb doctor --bug-report=/tmp
 Use `kb doctor --endpoints` for the narrower port/URL preflight: MCP bind target availability, configured `KB_DAEMON_URL`, configured Ollama embedding endpoint, and configured `KB_LLM_ENDPOINT` or active LLM profile.
 
 Use `kb doctor --locks` for write-lock contention. It reports per-model lock path, age, recorded owner PID/command when available, whether that PID is still live, stale suspicion, and the next safe action. It never removes lock files.
+
+Use `kb doctor --kb-symlinks` for KB content-root symlink audits. It uses `lstat`, does not follow symlink directories, and reports inside-root, escaping, broken, and loop/error targets with capped examples.
 
 Use `kb doctor --bug-report[=<dir>]` when preparing an issue-ready diagnostic bundle. The command writes a timestamped directory with redacted doctor/stats/log/runtime JSON plus a README, without note contents or raw API keys.
 

--- a/src/cli-doctor.test.ts
+++ b/src/cli-doctor.test.ts
@@ -1295,13 +1295,144 @@ describe('kb doctor', () => {
     }
   });
 
-  it('parses --format=json, --endpoints, --locks, and rejects unsupported formats', async () => {
+  itOnPosix('routes --kb-symlinks through runDoctor with JSON output', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-doctor-run-kb-symlinks-'));
+    try {
+      const rootDir = path.join(tempDir, 'kbs');
+      const alphaDir = path.join(rootDir, 'alpha');
+      const betaDir = path.join(rootDir, 'beta');
+      const outsideDir = path.join(tempDir, 'outside');
+      await fsp.mkdir(alphaDir, { recursive: true });
+      await fsp.mkdir(betaDir, { recursive: true });
+      await fsp.mkdir(outsideDir, { recursive: true });
+      await fsp.writeFile(path.join(betaDir, 'inside.md'), 'inside');
+      await fsp.writeFile(path.join(outsideDir, 'outside.md'), 'outside');
+      await fsp.symlink(path.join(betaDir, 'inside.md'), path.join(alphaDir, 'inside-link.md'));
+      await fsp.symlink(path.join(outsideDir, 'outside.md'), path.join(alphaDir, 'outside-link.md'));
+      await fsp.symlink(path.join(alphaDir, 'missing.md'), path.join(alphaDir, 'broken-link.md'));
+      await fsp.symlink('loop-b', path.join(alphaDir, 'loop-a'));
+      await fsp.symlink('loop-a', path.join(alphaDir, 'loop-b'));
+
+      const { runDoctor } = await freshDoctor({
+        KNOWLEDGE_BASES_ROOT_DIR: rootDir,
+      });
+
+      const ok = await captureStdout(() => runDoctor(['--kb-symlinks', '--format=json']));
+      expect(ok.code).toBe(0);
+      const report = JSON.parse(ok.stdout);
+      expect(report.schema_version).toBe('kb.doctor.kb_symlinks.v1');
+      expect(report.status).toBe('warn');
+      expect(report.inventory.summary).toEqual({
+        total: 5,
+        inside_root: 1,
+        escaping: 1,
+        broken: 1,
+        loop_or_error: 2,
+        scan_error_count: 0,
+        sample_limit: 5,
+      });
+      expect(report.inventory.symlinks).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          kbName: 'alpha',
+          relative_path: path.join('alpha', 'inside-link.md'),
+          classification: 'inside_root',
+        }),
+        expect.objectContaining({
+          relative_path: path.join('alpha', 'outside-link.md'),
+          classification: 'escaping',
+        }),
+        expect.objectContaining({
+          relative_path: path.join('alpha', 'broken-link.md'),
+          classification: 'broken',
+          error_code: 'ENOENT',
+        }),
+        expect.objectContaining({
+          relative_path: path.join('alpha', 'loop-a'),
+          classification: 'loop_or_error',
+          error_code: 'ELOOP',
+        }),
+      ]));
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('routes --kb-symlinks scan errors through runDoctor with JSON output and exit codes', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-doctor-run-kb-symlinks-error-'));
+    try {
+      const missingRoot = path.join(tempDir, 'missing-kbs');
+      const { runDoctor } = await freshDoctor({
+        KNOWLEDGE_BASES_ROOT_DIR: missingRoot,
+      });
+
+      const error = await captureStdout(() => runDoctor(['--kb-symlinks', '--format=json']));
+      expect(error.code).toBe(1);
+      expect(JSON.parse(error.stdout)).toMatchObject({
+        schema_version: 'kb.doctor.kb_symlinks.v1',
+        status: 'error',
+        inventory: {
+          root_dir: missingRoot,
+          root_realpath: null,
+          summary: expect.objectContaining({
+            total: 0,
+            scan_error_count: 1,
+          }),
+          scan_errors: [
+            expect.objectContaining({
+              path: missingRoot,
+              code: 'ENOENT',
+            }),
+          ],
+        },
+      });
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  itOnPosix('formats --kb-symlinks markdown without following symlink directories', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-doctor-md-kb-symlinks-'));
+    try {
+      const rootDir = path.join(tempDir, 'kbs');
+      const alphaDir = path.join(rootDir, 'alpha');
+      const outsideDir = path.join(tempDir, 'outside');
+      await fsp.mkdir(alphaDir, { recursive: true });
+      await fsp.mkdir(path.join(outsideDir, 'nested'), { recursive: true });
+      await fsp.writeFile(path.join(outsideDir, 'nested', 'secret.md'), 'outside');
+      await fsp.symlink(outsideDir, path.join(alphaDir, 'outside-dir'));
+
+      const { buildDoctorKbSymlinksReport, formatDoctorKbSymlinksMarkdown, runDoctor } = await freshDoctor({
+        KNOWLEDGE_BASES_ROOT_DIR: rootDir,
+      });
+
+      const report = await buildDoctorKbSymlinksReport();
+      expect(report.inventory.summary).toMatchObject({
+        total: 1,
+        escaping: 1,
+      });
+      const markdown = formatDoctorKbSymlinksMarkdown(report);
+      expect(markdown).toContain('Symlinks: 1 total, 0 inside-root, 1 escaping');
+      expect(markdown).toContain(`${path.join('alpha', 'outside-dir')} ->`);
+      expect(markdown).not.toContain('secret.md');
+
+      const routed = await captureStdout(() => runDoctor(['--kb-symlinks']));
+      expect(routed.code).toBe(0);
+      expect(routed.stdout).toContain('Symlinks: 1 total, 0 inside-root, 1 escaping');
+      expect(routed.stdout).toContain(`${path.join('alpha', 'outside-dir')} ->`);
+      expect(routed.stdout).not.toContain('secret.md');
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('parses --format=json, --endpoints, --locks, --kb-symlinks, and rejects unsupported formats', async () => {
     const { parseDoctorArgs } = await freshDoctor({});
     expect(parseDoctorArgs(['--format=json'])).toEqual({
       format: 'json',
       reindexTrigger: false,
       endpoints: false,
       locks: false,
+      kbSymlinks: false,
       integrity: false,
       bugReport: null,
     });
@@ -1310,6 +1441,7 @@ describe('kb doctor', () => {
       reindexTrigger: true,
       endpoints: false,
       locks: false,
+      kbSymlinks: false,
       integrity: false,
       bugReport: null,
     });
@@ -1318,6 +1450,7 @@ describe('kb doctor', () => {
       reindexTrigger: false,
       endpoints: true,
       locks: false,
+      kbSymlinks: false,
       integrity: false,
       bugReport: null,
     });
@@ -1326,6 +1459,16 @@ describe('kb doctor', () => {
       reindexTrigger: false,
       endpoints: false,
       locks: true,
+      kbSymlinks: false,
+      integrity: false,
+      bugReport: null,
+    });
+    expect(parseDoctorArgs(['--kb-symlinks', '--format=json'])).toEqual({
+      format: 'json',
+      reindexTrigger: false,
+      endpoints: false,
+      locks: false,
+      kbSymlinks: true,
       integrity: false,
       bugReport: null,
     });
@@ -1334,6 +1477,7 @@ describe('kb doctor', () => {
       reindexTrigger: true,
       endpoints: false,
       locks: false,
+      kbSymlinks: false,
       integrity: false,
       bugReport: null,
     });
@@ -1342,6 +1486,7 @@ describe('kb doctor', () => {
       reindexTrigger: false,
       endpoints: false,
       locks: false,
+      kbSymlinks: false,
       integrity: false,
       bugReport: null,
     });
@@ -1350,6 +1495,7 @@ describe('kb doctor', () => {
       reindexTrigger: false,
       endpoints: false,
       locks: false,
+      kbSymlinks: false,
       integrity: false,
       bugReport: {
         outputParentDir: '/tmp/out',
@@ -1369,6 +1515,7 @@ describe('kb doctor', () => {
       reindexTrigger: false,
       endpoints: false,
       locks: false,
+      kbSymlinks: false,
       integrity: false,
       bugReport: {
         outputParentDir: undefined,
@@ -1379,6 +1526,7 @@ describe('kb doctor', () => {
     expect(() => parseDoctorArgs(['--format=yaml'])).toThrow(/invalid --format/);
     expect(() => parseDoctorArgs(['--bug-report', '--include-command'])).toThrow(/requires/);
     expect(() => parseDoctorArgs(['--endpoints', '--locks'])).toThrow(/cannot be combined/);
+    expect(() => parseDoctorArgs(['--locks', '--kb-symlinks'])).toThrow(/cannot be combined/);
   });
 
   describe('age budgets (issue #218)', () => {

--- a/src/cli-doctor.ts
+++ b/src/cli-doctor.ts
@@ -41,8 +41,10 @@ import {
 import {
   aggregateEnumerationDiagnostics,
   enumerateIngestableKbFiles,
+  inventoryKbSymlinks,
   listKnowledgeBases,
   type KbFilesystemEnumerationDiagnostics,
+  type KbSymlinkInventory,
 } from './kb-fs.js';
 import {
   createNeverRunIndexUpdateSummary,
@@ -116,7 +118,7 @@ const execFileAsync = promisify(execFile);
 export const DOCTOR_HELP = `kb doctor — aggregate model / index / backend health report
 
 Usage:
-  kb doctor [--format=md|json] [--reindex-trigger] [--endpoints] [--locks] [--integrity|--slow]
+  kb doctor [--format=md|json] [--reindex-trigger] [--endpoints] [--locks] [--kb-symlinks] [--integrity|--slow]
   kb doctor --bug-report[=<dir>] [--include-command -- <cmd> [args...]]
 
 Composes existing read-only checks (env vars, registered models, active
@@ -139,6 +141,9 @@ Options:
                         Ollama embedding endpoint, and KB_LLM_ENDPOINT/profile).
   --locks               Check only FAISS/model write-lock paths, including
                         owner metadata when available and stale-lock guidance.
+  --kb-symlinks         Inventory symlinks under KB roots without following
+                        symlink directories; classifies inside-root, escaping,
+                        broken, and loop/error targets.
   --bug-report[=<dir>]  Write a timestamped redacted support bundle under
                         <dir> (default: current directory). Includes doctor,
                         stats, recent canonical logs, runtime metadata, and
@@ -154,6 +159,7 @@ Examples:
   kb doctor
   kb doctor --format=json
   kb doctor && kb search "rollback"
+  kb doctor --kb-symlinks
 `;
 
 export interface DoctorArgs {
@@ -161,6 +167,7 @@ export interface DoctorArgs {
   reindexTrigger: boolean;
   endpoints: boolean;
   locks: boolean;
+  kbSymlinks: boolean;
   integrity: boolean;
   bugReport: {
     outputParentDir?: string;
@@ -232,6 +239,12 @@ export interface DoctorLocksReport {
     stale_suspected: number;
     unknown: number;
   };
+}
+
+export interface DoctorKbSymlinksReport {
+  schema_version: 'kb.doctor.kb_symlinks.v1';
+  status: HealthStatus;
+  inventory: KbSymlinkInventory;
 }
 
 export interface DoctorIndexSecurityEntry {
@@ -480,6 +493,16 @@ export async function runDoctor(rest: string[]): Promise<number> {
     return report.status === 'error' ? 1 : 0;
   }
 
+  if (parsed.kbSymlinks) {
+    const report = await buildDoctorKbSymlinksReport();
+    if (parsed.format === 'json') {
+      process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    } else {
+      process.stdout.write(formatDoctorKbSymlinksMarkdown(report));
+    }
+    return report.status === 'error' ? 1 : 0;
+  }
+
   if (parsed.bugReport !== null) {
     const result = await createDoctorBugReportBundle({
       outputParentDir: parsed.bugReport.outputParentDir,
@@ -509,6 +532,7 @@ export function parseDoctorArgs(rest: string[]): DoctorArgs {
     reindexTrigger: false,
     endpoints: false,
     locks: false,
+    kbSymlinks: false,
     integrity: false,
     bugReport: null,
   };
@@ -542,6 +566,10 @@ export function parseDoctorArgs(rest: string[]): DoctorArgs {
     }
     if (raw === '--locks') {
       out.locks = true;
+      continue;
+    }
+    if (raw === '--kb-symlinks') {
+      out.kbSymlinks = true;
       continue;
     }
     if (raw === '--bug-report' || raw.startsWith('--bug-report=')) {
@@ -584,8 +612,16 @@ export function parseDoctorArgs(rest: string[]): DoctorArgs {
   if (out.bugReport !== null && out.locks) {
     throw new Error('--bug-report cannot be combined with --locks');
   }
-  if (out.endpoints && out.locks) {
-    throw new Error('--endpoints cannot be combined with --locks');
+  if (out.bugReport !== null && out.kbSymlinks) {
+    throw new Error('--bug-report cannot be combined with --kb-symlinks');
+  }
+  const focused = [
+    out.endpoints ? '--endpoints' : null,
+    out.locks ? '--locks' : null,
+    out.kbSymlinks ? '--kb-symlinks' : null,
+  ].filter((flag): flag is string => flag !== null);
+  if (focused.length > 1) {
+    throw new Error(`${focused.join(' and ')} cannot be combined`);
   }
   return out;
 }
@@ -1200,6 +1236,59 @@ export function formatDoctorLocksMarkdown(report: DoctorLocksReport): string {
         for (const warning of entry.warnings) lines.push(`    WARN ${warning}`);
       }
       lines.push(`    next: ${entry.next_action}`);
+    }
+  }
+  return lines.join('\n') + '\n';
+}
+
+export async function buildDoctorKbSymlinksReport(): Promise<DoctorKbSymlinksReport> {
+  const inventory = await inventoryKbSymlinks(KNOWLEDGE_BASES_ROOT_DIR);
+  const status: HealthStatus = inventory.summary.scan_error_count > 0
+    ? 'error'
+    : inventory.summary.escaping > 0 ||
+      inventory.summary.broken > 0 ||
+      inventory.summary.loop_or_error > 0
+      ? 'warn'
+      : 'ok';
+  return {
+    schema_version: 'kb.doctor.kb_symlinks.v1',
+    status,
+    inventory,
+  };
+}
+
+export function formatDoctorKbSymlinksMarkdown(report: DoctorKbSymlinksReport): string {
+  const lines: string[] = [];
+  const summary = report.inventory.summary;
+  lines.push(`Status: ${report.status.toUpperCase()}`);
+  lines.push(`KB root: ${report.inventory.root_dir}`);
+  lines.push(`KB root realpath: ${report.inventory.root_realpath ?? '<unresolved>'}`);
+  lines.push(
+    `Symlinks: ${summary.total} total, ${summary.inside_root} inside-root, ` +
+      `${summary.escaping} escaping, ${summary.broken} broken, ` +
+      `${summary.loop_or_error} loop/error`,
+  );
+  if (summary.scan_error_count > 0) {
+    lines.push(`Scan errors: ${summary.scan_error_count}`);
+    for (const error of report.inventory.scan_errors) {
+      const code = error.code ?? 'unknown';
+      lines.push(`  ERROR ${error.path} (${code}) ${error.message}`);
+    }
+  }
+  if (report.inventory.symlinks.length === 0) {
+    lines.push('Examples: (none)');
+  } else {
+    lines.push(`Examples (capped at ${summary.sample_limit}):`);
+    for (const link of report.inventory.symlinks) {
+      const resolved = link.resolved_target ?? '<unresolved>';
+      const target = link.link_target ?? '<unreadable>';
+      const error = link.error_message === null
+        ? ''
+        : `; ${link.error_code ?? 'unknown'} ${link.error_message}`;
+      lines.push(
+        `  ${link.classification} ${link.relative_path} -> ${target} ` +
+          `(resolved=${resolved}${error})`,
+      );
     }
   }
   return lines.join('\n') + '\n';

--- a/src/cli-json-contracts.test.ts
+++ b/src/cli-json-contracts.test.ts
@@ -213,7 +213,7 @@ const docAssertions: Record<DocumentedCommand, (examples: unknown[]) => void> = 
     expect(record(examples[1])).toEqual({ recommended_kb: null, results: [] });
   },
   'kb doctor': (examples) => {
-    expect(examples).toHaveLength(4);
+    expect(examples).toHaveLength(5);
     expect(record(examples[0])).toMatchObject({
       status: expect.any(String),
       checks: expect.any(Array),
@@ -238,13 +238,30 @@ const docAssertions: Record<DocumentedCommand, (examples: unknown[]) => void> = 
       locks: expect.any(Array),
     });
     expect(record(examples[2])).toMatchObject({
+      schema_version: 'kb.doctor.kb_symlinks.v1',
+      status: expect.any(String),
+      inventory: expect.objectContaining({
+        root_dir: expect.any(String),
+        summary: expect.objectContaining({
+          total: expect.any(Number),
+          inside_root: expect.any(Number),
+          escaping: expect.any(Number),
+          broken: expect.any(Number),
+          loop_or_error: expect.any(Number),
+          scan_error_count: expect.any(Number),
+        }),
+        symlinks: expect.any(Array),
+        scan_errors: expect.any(Array),
+      }),
+    });
+    expect(record(examples[3])).toMatchObject({
       schema_version: 'kb.doctor.bug_report.v1',
       bundle_dir: expect.any(String),
       created_at: expect.any(String),
       files: expect.any(Array),
       redaction_summary: expect.any(Object),
     });
-    expect(record(examples[3])).toMatchObject({
+    expect(record(examples[4])).toMatchObject({
       schema_version: 'kb.doctor.endpoints.v1',
       status: expect.any(String),
       endpoints: expect.arrayContaining([

--- a/src/kb-fs.ts
+++ b/src/kb-fs.ts
@@ -77,6 +77,41 @@ export interface KbFilesystemEnumerationDiagnostics {
   failures: KbFilesystemEnumerationFailure[];
 }
 
+export type KbSymlinkClassification = 'inside_root' | 'escaping' | 'broken' | 'loop_or_error';
+
+export interface KbSymlinkInventoryEntry {
+  kbName: string;
+  path: string;
+  relative_path: string;
+  link_target: string | null;
+  resolved_target: string | null;
+  classification: KbSymlinkClassification;
+  error_code: string | null;
+  error_message: string | null;
+}
+
+export interface KbSymlinkScanError {
+  path: string;
+  code: string | null;
+  message: string;
+}
+
+export interface KbSymlinkInventory {
+  root_dir: string;
+  root_realpath: string | null;
+  summary: {
+    total: number;
+    inside_root: number;
+    escaping: number;
+    broken: number;
+    loop_or_error: number;
+    scan_error_count: number;
+    sample_limit: number;
+  };
+  symlinks: KbSymlinkInventoryEntry[];
+  scan_errors: KbSymlinkScanError[];
+}
+
 export interface EnumerateIngestableKbFilesOptions {
   extraExtensions?: readonly string[];
   excludePaths?: readonly string[];
@@ -138,6 +173,150 @@ export function aggregateEnumerationDiagnostics(
     }
   }
   return { failure_count: failureCount, failures };
+}
+
+export async function inventoryKbSymlinks(
+  rootDir: string,
+  options: { sampleLimit?: number } = {},
+): Promise<KbSymlinkInventory> {
+  const sampleLimit = options.sampleLimit ?? DEFAULT_ENUMERATION_FAILURE_SAMPLE_LIMIT;
+  const summary: KbSymlinkInventory['summary'] = {
+    total: 0,
+    inside_root: 0,
+    escaping: 0,
+    broken: 0,
+    loop_or_error: 0,
+    scan_error_count: 0,
+    sample_limit: sampleLimit,
+  };
+  const symlinks: KbSymlinkInventoryEntry[] = [];
+  const scanErrors: KbSymlinkScanError[] = [];
+  let rootRealpath: string | null = null;
+
+  try {
+    rootRealpath = await fsp.realpath(rootDir);
+  } catch (error: unknown) {
+    recordScanError(rootDir, error);
+    return {
+      root_dir: rootDir,
+      root_realpath: null,
+      summary,
+      symlinks,
+      scan_errors: scanErrors,
+    };
+  }
+
+  async function scanDirectory(currentPath: string, kbName: string): Promise<void> {
+    let names: string[];
+    try {
+      names = await fsp.readdir(currentPath);
+    } catch (error: unknown) {
+      recordScanError(currentPath, error);
+      return;
+    }
+
+    for (const name of names) {
+      const childPath = path.join(currentPath, name);
+      let st: import('fs').Stats;
+      try {
+        st = await fsp.lstat(childPath);
+      } catch (error: unknown) {
+        recordScanError(childPath, error);
+        continue;
+      }
+      if (st.isSymbolicLink()) {
+        await recordSymlink(childPath, kbName);
+        continue;
+      }
+      if (st.isDirectory()) {
+        await scanDirectory(childPath, kbName);
+      }
+    }
+  }
+
+  async function recordSymlink(linkPath: string, kbName: string): Promise<void> {
+    summary.total += 1;
+    const relativePath = path.relative(rootDir, linkPath);
+    const linkTarget = await readLinkTarget(linkPath);
+    let resolvedTarget: string | null = null;
+    let classification: KbSymlinkClassification = 'loop_or_error';
+    let errorCode: string | null = null;
+    let errorMessage: string | null = null;
+
+    try {
+      resolvedTarget = await fsp.realpath(linkPath);
+      classification = isInsideOrEqual(rootRealpath!, resolvedTarget) ? 'inside_root' : 'escaping';
+    } catch (error: unknown) {
+      const err = error as NodeJS.ErrnoException;
+      errorCode = typeof err.code === 'string' ? err.code : null;
+      errorMessage = err.message;
+      classification = errorCode === 'ENOENT' || errorCode === 'ENOTDIR'
+        ? 'broken'
+        : 'loop_or_error';
+    }
+
+    summary[classification] += 1;
+    if (symlinks.length < sampleLimit) {
+      symlinks.push({
+        kbName,
+        path: linkPath,
+        relative_path: relativePath,
+        link_target: linkTarget,
+        resolved_target: resolvedTarget,
+        classification,
+        error_code: errorCode,
+        error_message: errorMessage,
+      });
+    }
+  }
+
+  function recordScanError(targetPath: string, error: unknown): void {
+    summary.scan_error_count += 1;
+    if (scanErrors.length >= sampleLimit) return;
+    const err = error as NodeJS.ErrnoException;
+    scanErrors.push({
+      path: targetPath,
+      code: typeof err.code === 'string' ? err.code : null,
+      message: err.message,
+    });
+  }
+
+  const rootEntries = await fsp.readdir(rootDir).catch((error: unknown) => {
+    recordScanError(rootDir, error);
+    return [];
+  });
+  for (const name of rootEntries) {
+    if (name.startsWith('.')) continue;
+    const entryPath = path.join(rootDir, name);
+    let st: import('fs').Stats;
+    try {
+      st = await fsp.lstat(entryPath);
+    } catch (error: unknown) {
+      recordScanError(entryPath, error);
+      continue;
+    }
+    if (st.isSymbolicLink()) {
+      await recordSymlink(entryPath, name);
+    } else if (st.isDirectory()) {
+      await scanDirectory(entryPath, name);
+    }
+  }
+
+  return {
+    root_dir: rootDir,
+    root_realpath: rootRealpath,
+    summary,
+    symlinks,
+    scan_errors: scanErrors,
+  };
+}
+
+async function readLinkTarget(linkPath: string): Promise<string | null> {
+  try {
+    return await fsp.readlink(linkPath);
+  } catch {
+    return null;
+  }
 }
 
 const KB_DESCRIPTION_MAX_LEN = 80;


### PR DESCRIPTION
## Summary
- add `kb doctor --kb-symlinks` focused report for KB-root symlink inventory
- classify symlinks as inside-root, escaping, broken, or loop/error without following symlink directories
- document the new markdown/JSON surface and pin the JSON example contract

Closes #525

## Test plan
- npm test -- --runInBand src/cli-doctor.test.ts src/cli-json-contracts.test.ts
- npm run docs:check-anchors
- git diff --check
- npm run build
- npm test -- --runInBand

## Pre-PR review
- conventions: addressed JSON-contract test coverage finding
- correctness: no findings
- dead-code: removed unreachable dot-entry guard
- tests: added runtime markdown route and scan-error exit coverage