### PR TITLE
test(e2e): add CLI MCP retrieval parity coverage

### DIFF
--- a/src/e2e/mcp-binary.e2e.test.ts
+++ b/src/e2e/mcp-binary.e2e.test.ts
@@ -8,11 +8,10 @@
 // are the FIRST tests in the repo that exercise the binary itself; all
 // 30+ in-process Jest tests stop short of `process.spawn`.
 //
-// Scope cap for v0: only handlers that DO NOT need an embedder are
-// covered (`tools/list`, `list_knowledge_bases`, `list_models`). Adding a
-// deterministic stub embedder so `retrieve_knowledge` / `kb_stats` can
-// be driven through the binary is intentionally left to a follow-up —
-// see issue body §"Stage 2" / §"Stub embedder".
+// The original v0 suite covered only handlers that do not need an embedder
+// (`tools/list`, `list_knowledge_bases`, `list_models`). Retrieval parity now
+// uses the deterministic fake provider and a temp active model registration so
+// `retrieve_knowledge` can run through the real binary without network.
 //
 // The suite is gated behind `KB_RUN_E2E=1` (also enforced by
 // `jest.config.js` testPathIgnorePatterns) so the default `npm test`
@@ -20,6 +19,8 @@
 // must first `npm run build`; the harness asserts the binary exists and
 // fails loudly otherwise.
 
+import { spawnSync } from 'child_process';
+import * as path from 'path';
 import {
   startMcpBinaryHarness,
   parseToolJsonText,
@@ -27,6 +28,117 @@ import {
 } from './test-fixtures.js';
 
 const RUN_E2E = process.env.KB_RUN_E2E === '1';
+const REPO_ROOT = path.resolve(process.cwd());
+const CLI_BINARY = path.join(REPO_ROOT, 'build', 'cli.js');
+const FAKE_PARITY_MODEL_ID = 'fake__parity-32d';
+const FAKE_PARITY_MODEL_NAME = 'parity-32d';
+
+interface RetrievalIdentity {
+  chunkId: string;
+  source: string;
+  relativePath: string;
+  knowledgeBase: string;
+  chunkIndex: number;
+}
+
+interface CliSearchPayload {
+  results: Array<{
+    chunk_id?: unknown;
+    metadata?: {
+      source?: unknown;
+      relativePath?: unknown;
+      knowledgeBase?: unknown;
+      chunkIndex?: unknown;
+    };
+  }>;
+}
+
+function parseCliSearchPayload(stdout: string): CliSearchPayload {
+  const payload = JSON.parse(stdout) as { results?: unknown };
+  if (!Array.isArray(payload.results)) {
+    throw new Error(`Expected CLI search JSON with results[], got: ${stdout}`);
+  }
+  return payload as CliSearchPayload;
+}
+
+function identityFromCliResult(result: CliSearchPayload['results'][number]): RetrievalIdentity {
+  const chunkId = result.chunk_id;
+  const metadata = result.metadata;
+  if (
+    typeof chunkId !== 'string' ||
+    !metadata ||
+    typeof metadata.source !== 'string' ||
+    typeof metadata.relativePath !== 'string' ||
+    typeof metadata.knowledgeBase !== 'string' ||
+    typeof metadata.chunkIndex !== 'number'
+  ) {
+    throw new Error(`CLI result is missing stable identity fields: ${JSON.stringify(result)}`);
+  }
+  return {
+    chunkId,
+    source: metadata.source,
+    relativePath: metadata.relativePath,
+    knowledgeBase: metadata.knowledgeBase,
+    chunkIndex: metadata.chunkIndex,
+  };
+}
+
+function extractMcpMarkdownText(result: unknown): string {
+  const content = (result as { content?: Array<{ type: string; text?: string }> }).content;
+  const first = content?.[0];
+  if (!first || first.type !== 'text' || typeof first.text !== 'string') {
+    throw new Error(`Expected first content block to be text, got: ${JSON.stringify(result)}`);
+  }
+  return first.text;
+}
+
+function parseMcpRetrievalIdentities(markdown: string): RetrievalIdentity[] {
+  const sourceBlocks = [...markdown.matchAll(/\*\*Source:\*\* \[([^\]]+)\]\([^)]+\)[\s\S]*?```json\n([\s\S]*?)\n```/g)];
+  return sourceBlocks.map((match) => {
+    const chunkId = match[1];
+    const metadata = JSON.parse(match[2]) as {
+      source?: unknown;
+      relativePath?: unknown;
+      knowledgeBase?: unknown;
+      chunkIndex?: unknown;
+    };
+    if (
+      typeof metadata.source !== 'string' ||
+      typeof metadata.relativePath !== 'string' ||
+      typeof metadata.knowledgeBase !== 'string' ||
+      typeof metadata.chunkIndex !== 'number'
+    ) {
+      throw new Error(`MCP metadata block is missing stable identity fields: ${match[2]}`);
+    }
+    return {
+      chunkId,
+      source: metadata.source,
+      relativePath: metadata.relativePath,
+      knowledgeBase: metadata.knowledgeBase,
+      chunkIndex: metadata.chunkIndex,
+    };
+  });
+}
+
+function runKbCliSearch(
+  harness: E2eHarness,
+  args: string[],
+): ReturnType<typeof spawnSync> {
+  return spawnSync(process.execPath, [CLI_BINARY, 'search', ...args], {
+    cwd: REPO_ROOT,
+    encoding: 'utf-8',
+    env: {
+      PATH: process.env.PATH ?? '',
+      HOME: process.env.HOME ?? '',
+      NODE_OPTIONS: process.env.NODE_OPTIONS ?? '',
+      KNOWLEDGE_BASES_ROOT_DIR: harness.knowledgeBasesRootDir,
+      FAISS_INDEX_PATH: harness.faissIndexPath,
+      REINDEX_TRIGGER_POLL_MS: '0',
+      EMBEDDING_PROVIDER: 'fake',
+      KB_FAKE_DIM: '32',
+    },
+  });
+}
 
 (RUN_E2E ? describe : describe.skip)('mcp-binary E2E (spawn build/index.js over stdio)', () => {
   jest.setTimeout(30_000);
@@ -56,6 +168,7 @@ const RUN_E2E = process.env.KB_RUN_E2E === '1';
       'add_document',
       'ask_knowledge',
       'delete_document',
+      'diff_index',
       'kb_stats',
       'list_knowledge_bases',
       'list_models',
@@ -114,5 +227,53 @@ const RUN_E2E = process.env.KB_RUN_E2E === '1';
     expect(result.isError).toBeFalsy();
     const payload = parseToolJsonText(result as Parameters<typeof parseToolJsonText>[0]);
     expect(payload).toEqual([]);
+  });
+
+  it('keeps binary CLI search and MCP retrieve_knowledge dense results aligned on stable chunk identities', async () => {
+    harness = await startMcpBinaryHarness({
+      activeModel: {
+        modelId: FAKE_PARITY_MODEL_ID,
+        modelName: FAKE_PARITY_MODEL_NAME,
+      },
+      extraEnv: {
+        EMBEDDING_PROVIDER: 'fake',
+        KB_FAKE_DIM: '32',
+      },
+      knowledgeBases: {
+        parity: {
+          files: {
+            'alpha.md': '# Alpha\n\nalpha retrieval parity apple banana anchor\n',
+            'beta.md': '# Beta\n\nbeta retrieval parity orange grape anchor\n',
+          },
+        },
+      },
+    });
+
+    const cli = runKbCliSearch(harness, [
+      'alpha retrieval parity apple',
+      '--refresh',
+      '--kb=parity',
+      '--format=json',
+      '--no-freshness',
+      '--no-gate',
+    ]);
+    expect(cli.status).toBe(0);
+    const cliPayload = parseCliSearchPayload(String(cli.stdout));
+    const cliIdentities = cliPayload.results.map(identityFromCliResult);
+    expect(cliIdentities.length).toBeGreaterThan(0);
+
+    const mcpResult = await harness.client.callTool({
+      name: 'retrieve_knowledge',
+      arguments: {
+        query: 'alpha retrieval parity apple',
+        knowledge_base_name: 'parity',
+        search_mode: 'dense',
+        gate: 'off',
+      },
+    });
+    expect(mcpResult.isError).toBeFalsy();
+    const mcpIdentities = parseMcpRetrievalIdentities(extractMcpMarkdownText(mcpResult));
+
+    expect(mcpIdentities).toEqual(cliIdentities);
   });
 });

--- a/src/e2e/test-fixtures.ts
+++ b/src/e2e/test-fixtures.ts
@@ -9,11 +9,9 @@
 // Cline) all launch this exact entrypoint over stdio — these helpers let
 // Jest exercise the same surface.
 //
-// The harness is intentionally embedder-free: it covers tools whose
-// handlers do not construct an embeddings client (`tools/list`,
-// `list_knowledge_bases`, `list_models`). Adding a deterministic stub
-// embedder so `retrieve_knowledge` / `kb_stats` can be wired end-to-end
-// is a follow-up (see issue body §"Stage 2") and is out of scope for v0.
+// By default the harness remains embedder-free for lightweight tool tests.
+// Retrieval tests can opt into a temp active model registration plus the fake
+// provider so embedder-dependent handlers run without network or user state.
 
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
@@ -29,6 +27,13 @@ export interface KnowledgeBaseSpec {
   files: Record<string, string>;
 }
 
+export interface ActiveModelSpec {
+  /** Registered model_id, e.g. "fake__parity-32d". */
+  modelId: string;
+  /** Contents of models/<modelId>/model_name.txt. */
+  modelName: string;
+}
+
 export interface StartHarnessOptions {
   /**
    * Knowledge bases to materialise under the temp `KNOWLEDGE_BASES_ROOT_DIR`.
@@ -36,6 +41,12 @@ export interface StartHarnessOptions {
    * the files to write inside that KB.
    */
   knowledgeBases?: Record<string, KnowledgeBaseSpec>;
+  /**
+   * Optional active model registration written before the binary starts.
+   * Retrieval E2E tests use this with the fake provider so both CLI and MCP
+   * resolve the same deterministic model from active.txt without network.
+   */
+  activeModel?: ActiveModelSpec;
   /**
    * Extra environment variables passed to the spawned binary. Override or
    * augment the harness defaults; if absent, the child runs with a
@@ -81,6 +92,17 @@ async function writeKnowledgeBases(
       await fsp.writeFile(absPath, content, 'utf-8');
     }
   }
+}
+
+async function writeActiveModel(
+  faissIndexPath: string,
+  activeModel: ActiveModelSpec | undefined,
+): Promise<void> {
+  if (!activeModel) return;
+  const modelDir = path.join(faissIndexPath, 'models', activeModel.modelId);
+  await fsp.mkdir(modelDir, { recursive: true });
+  await fsp.writeFile(path.join(modelDir, 'model_name.txt'), activeModel.modelName, 'utf-8');
+  await fsp.writeFile(path.join(faissIndexPath, 'active.txt'), activeModel.modelId, 'utf-8');
 }
 
 function buildChildEnv(
@@ -132,6 +154,7 @@ export async function startMcpBinaryHarness(
   await fsp.mkdir(knowledgeBasesRootDir, { recursive: true });
   await fsp.mkdir(faissIndexPath, { recursive: true });
   await writeKnowledgeBases(knowledgeBasesRootDir, opts.knowledgeBases);
+  await writeActiveModel(faissIndexPath, opts.activeModel);
 
   const env = buildChildEnv(knowledgeBasesRootDir, faissIndexPath, opts.extraEnv);
 


### PR DESCRIPTION
Closes #526

## Summary
- seed an active fake model in the binary MCP E2E harness
- add a gated binary parity test that runs `kb search --refresh --format=json` and MCP `retrieve_knowledge` over the same fixture
- compare stable ordered chunk/source identities instead of scores or formatted prose
- refresh the tool catalog assertion for the existing `diff_index` tool

## Test plan
- `npm ci`
- `npm run build`
- `KB_RUN_E2E=1 npm test -- --runInBand src/e2e/mcp-binary.e2e.test.ts`
- `git diff --check`
- `npm test -- --runInBand`

## Pre-PR review
- conventions-specialist: addressed stale comments/import order
- correctness-specialist: no findings
- deadcode-specialist: no dead code introduced
- test-specialist: no findings
- portability check: helper absent in repo; manually scanned added lines, no machine-local reusable paths