### PR TITLE
fix: probe active Ollama embedding model

### DIFF
--- a/src/cli-doctor.test.ts
+++ b/src/cli-doctor.test.ts
@@ -38,6 +38,8 @@ const originalEnv = {
 
 const MODEL_ID = 'huggingface__BAAI-bge-small-en-v1.5';
 const MODEL_NAME = 'BAAI/bge-small-en-v1.5';
+const OLLAMA_MODEL_ID = 'ollama__nomic-embed-text-latest';
+const OLLAMA_MODEL_NAME = 'nomic-embed-text:latest';
 const RERANK_MODEL = 'Xenova/ms-marco-MiniLM-L-6-v2';
 
 afterEach(() => {
@@ -414,6 +416,68 @@ describe('kb doctor', () => {
       expect(json.quarantine_counts_by_kb.alpha).toBe(0);
       expect(json.last_index_update.saved).toBe(true);
     } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('marks Ollama backend unhealthy when the active embedding model is missing', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-doctor-ollama-missing-model-'));
+    const oldFetch = global.fetch;
+    try {
+      const rootDir = path.join(tempDir, 'kbs');
+      const faissDir = path.join(tempDir, '.faiss');
+      const modelDir = path.join(faissDir, 'models', OLLAMA_MODEL_ID);
+      await fsp.mkdir(rootDir, { recursive: true });
+      await fsp.mkdir(modelDir, { recursive: true });
+      await fsp.writeFile(path.join(modelDir, 'model_name.txt'), OLLAMA_MODEL_NAME);
+      await fsp.writeFile(path.join(faissDir, 'active.txt'), OLLAMA_MODEL_ID);
+      await seedVersionedIndex(modelDir);
+
+      const fetchMock = jest.fn(async (input: string | URL | Request, init?: RequestInit) => {
+        expect(String(input)).toBe('http://127.0.0.1:11434/api/embed');
+        expect(init?.method).toBe('POST');
+        expect(JSON.parse(String(init?.body))).toMatchObject({
+          model: OLLAMA_MODEL_NAME,
+          input: expect.stringContaining('kb doctor'),
+        });
+        return new Response(JSON.stringify({
+          error: `model "${OLLAMA_MODEL_NAME}" not found, try pulling it first`,
+        }), { status: 404 });
+      });
+      global.fetch = fetchMock as unknown as typeof fetch;
+
+      const { buildDoctorReport, formatDoctorMarkdown } = await freshDoctor({
+        KNOWLEDGE_BASES_ROOT_DIR: rootDir,
+        FAISS_INDEX_PATH: faissDir,
+        EMBEDDING_PROVIDER: 'ollama',
+        OLLAMA_MODEL: OLLAMA_MODEL_NAME,
+        OLLAMA_BASE_URL: 'http://127.0.0.1:11434',
+      });
+
+      const report = await buildDoctorReport({
+        packageRoot: tempDir,
+        invokedPath: null,
+        packageVersion: '9.9.9',
+        llmEndpointProbe: healthyLlmProbe,
+        lastIndexUpdateSummary: persistedSuccessSummary(),
+      });
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(report.status).toBe('error');
+      expect(report.backend).toMatchObject({
+        provider: 'ollama',
+        healthy: false,
+      });
+      expect(report.backend.detail).toContain('failed embedding probe');
+      expect(report.backend.detail).toContain('model "nomic-embed-text:latest" not found');
+      expect(report.checks).toContainEqual({
+        name: 'backend',
+        status: 'error',
+        detail: report.backend.detail,
+      });
+      expect(formatDoctorMarkdown(report)).toMatch(/ERROR\s+backend:/);
+    } finally {
+      global.fetch = oldFetch;
       await fsp.rm(tempDir, { recursive: true, force: true });
     }
   });

--- a/src/cli-doctor.ts
+++ b/src/cli-doctor.ts
@@ -123,9 +123,10 @@ Usage:
 
 Composes existing read-only checks (env vars, registered models, active
 model, FAISS index presence + mtime, knowledge-base count, embedding
-backend reachability, and local LLM endpoint readiness for kb ask) into
-a single status report. Does NOT load the FAISS store, embed documents,
-or start managed LLM services.
+backend readiness, and local LLM endpoint readiness for kb ask) into
+a single status report. Does NOT load the FAISS store, embed KB documents,
+or start managed LLM services; backend checks may perform a tiny
+model-specific smoke embedding.
 
 Report status is one of \`ok\`, \`warn\`, or \`error\`. The exit code is non-zero
 when any required check fails, so \`kb doctor && kb search ...\` is a safe
@@ -2161,16 +2162,28 @@ async function defaultBackendHealthCheck(
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), 2000);
     try {
-      const res = await fetch(new URL('/api/tags', OLLAMA_BASE_URL), {
+      const res = await fetch(new URL('/api/embed', OLLAMA_BASE_URL), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          model: modelName,
+          input: 'kb doctor backend smoke test',
+        }),
         signal: controller.signal,
       });
-      if (!res.ok) return { healthy: false, detail: `Ollama ${OLLAMA_BASE_URL} returned HTTP ${res.status}` };
-      return { healthy: true, detail: `Ollama ${OLLAMA_BASE_URL} is reachable for ${modelName}` };
+      if (!res.ok) {
+        return {
+          healthy: false,
+          detail: `Ollama ${OLLAMA_BASE_URL} failed embedding probe for ${modelName}: ` +
+            `HTTP ${res.status}${await formatOllamaResponseDetail(res)}`,
+        };
+      }
+      return { healthy: true, detail: `Ollama ${OLLAMA_BASE_URL} embedded smoke query with ${modelName}` };
     } catch (err) {
       const message = (err as Error).name === 'AbortError'
         ? 'timed out'
         : (err as Error).message;
-      return { healthy: false, detail: `Ollama ${OLLAMA_BASE_URL} is not reachable: ${message}` };
+      return { healthy: false, detail: `Ollama ${OLLAMA_BASE_URL} embedding probe failed: ${message}` };
     } finally {
       clearTimeout(timeout);
     }
@@ -2193,6 +2206,26 @@ async function defaultBackendHealthCheck(
   }
 
   return { healthy: false, detail: `unsupported provider: ${provider}` };
+}
+
+async function formatOllamaResponseDetail(res: Response): Promise<string> {
+  let text: string;
+  try {
+    text = await res.text();
+  } catch {
+    return '';
+  }
+  const trimmed = text.trim();
+  if (trimmed === '') return '';
+  try {
+    const parsed = JSON.parse(trimmed) as { error?: unknown };
+    if (typeof parsed.error === 'string' && parsed.error.trim() !== '') {
+      return `: ${parsed.error.trim().slice(0, 300)}`;
+    }
+  } catch {
+    // Fall through to plain text below.
+  }
+  return `: ${trimmed.slice(0, 300)}`;
 }
 
 function summarizeStatus(checks: DoctorReport['checks']): HealthStatus {


### PR DESCRIPTION
## Summary
- make kb doctor verify the active Ollama embedding model via /api/embed
- surface Ollama model-not-found responses in backend health details
- add regression coverage for missing nomic-embed-text

## Root cause
The backend health check only verified Ollama reachability through /api/tags, so it missed the case where the configured embedding model was absent and semantic search would fail.

## Validation
- npm test -- --runTestsByPath src/cli-doctor.test.ts
- npm run build
- live kb doctor reports backend ok after embedding smoke probe
- live kb search "semantic search smoke test" --k=1 works