### PR TITLE
Highlight kb search query terms in text output

### DIFF
--- a/src/cli-search.test.ts
+++ b/src/cli-search.test.ts
@@ -346,7 +346,7 @@ describe('runSearch timing guard (#331)', () => {
     Object.defineProperty(process.stdout, 'isTTY', { configurable: true, value: true });
 
     try {
-      const out = await captureSearchOutput(['pager query', '--pager', '--no-freshness'], deps);
+      const out = await captureSearchOutput(['pager query', '--pager', '--no-highlight', '--no-freshness'], deps);
 
       expect(out.code).toBe(0);
       expect(out.stdout).toBe('');

--- a/src/cli-search.test.ts
+++ b/src/cli-search.test.ts
@@ -131,6 +131,14 @@ describe('parseSearchArgs output format', () => {
       format: 'json',
     });
   });
+
+  it('accepts search highlight controls', () => {
+    expect(parseSearchArgs(['query'])).toMatchObject({ highlight: 'auto' });
+    expect(parseSearchArgs(['query', '--highlight=always'])).toMatchObject({ highlight: 'always' });
+    expect(parseSearchArgs(['query', '--highlight'])).toMatchObject({ highlight: 'always' });
+    expect(parseSearchArgs(['query', '--no-highlight'])).toMatchObject({ highlight: 'never' });
+    expect(() => parseSearchArgs(['query', '--highlight=sometimes'])).toThrow(/invalid --highlight/);
+  });
 });
 
 describe('parseSearchArgs freshness', () => {
@@ -285,6 +293,41 @@ describe('runSearch timing guard (#331)', () => {
     } finally {
       stdoutSpy.mockRestore();
       stderrSpy.mockRestore();
+    }
+  }
+
+  async function withStdoutTTY<T>(
+    stdoutIsTTY: boolean | undefined,
+    run: () => Promise<T>,
+  ): Promise<T> {
+    const descriptor = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY');
+    Object.defineProperty(process.stdout, 'isTTY', {
+      configurable: true,
+      value: stdoutIsTTY,
+    });
+    try {
+      return await run();
+    } finally {
+      if (descriptor) {
+        Object.defineProperty(process.stdout, 'isTTY', descriptor);
+      } else {
+        delete (process.stdout as unknown as { isTTY?: boolean }).isTTY;
+      }
+    }
+  }
+
+  async function withNoColor<T>(
+    value: string | undefined,
+    run: () => Promise<T>,
+  ): Promise<T> {
+    const previous = process.env.NO_COLOR;
+    if (value === undefined) delete process.env.NO_COLOR;
+    else process.env.NO_COLOR = value;
+    try {
+      return await run();
+    } finally {
+      if (previous === undefined) delete process.env.NO_COLOR;
+      else process.env.NO_COLOR = previous;
     }
   }
 
@@ -570,6 +613,93 @@ describe('runSearch timing guard (#331)', () => {
       freshness_omitted: true,
     });
     expect(payload).not.toHaveProperty('timing');
+  });
+
+  it('highlights query terms in markdown output when stdout is a TTY', async () => {
+    const { deps, manager } = makeDeps();
+    manager.similaritySearch.mockResolvedValueOnce([{
+      pageContent: 'Rollback plan for deployment',
+      metadata: { source: '/kb/ops/rollback.md', chunkIndex: 0 },
+      score: 0.12,
+    }] as never);
+
+    const out = await withNoColor(undefined, () =>
+      withStdoutTTY(true, () => captureSearchOutput(['rollback', '--no-freshness'], deps)),
+    );
+
+    expect(out.code).toBe(0);
+    expect(out.stdout).toContain('\x1b[1mRollback\x1b[22m plan');
+  });
+
+  it('suppresses markdown highlighting when NO_COLOR is set', async () => {
+    const { deps, manager } = makeDeps();
+    manager.similaritySearch.mockResolvedValueOnce([{
+      pageContent: 'Rollback plan',
+      metadata: { source: '/kb/ops/rollback.md', chunkIndex: 0 },
+      score: 0.12,
+    }] as never);
+
+    const out = await withNoColor('1', () =>
+      withStdoutTTY(true, () => captureSearchOutput(['rollback', '--no-freshness'], deps)),
+    );
+
+    expect(out.code).toBe(0);
+    expect(out.stdout).toContain('Rollback plan');
+    expect(out.stdout).not.toContain('\x1b[');
+  });
+
+  it('suppresses markdown highlighting with --no-highlight', async () => {
+    const { deps, manager } = makeDeps();
+    manager.similaritySearch.mockResolvedValueOnce([{
+      pageContent: 'Rollback plan',
+      metadata: { source: '/kb/ops/rollback.md', chunkIndex: 0 },
+      score: 0.12,
+    }] as never);
+
+    const out = await withNoColor(undefined, () =>
+      withStdoutTTY(true, () => captureSearchOutput(['rollback', '--no-highlight', '--no-freshness'], deps)),
+    );
+
+    expect(out.code).toBe(0);
+    expect(out.stdout).toContain('Rollback plan');
+    expect(out.stdout).not.toContain('\x1b[');
+  });
+
+  it('forces markdown highlighting with --highlight=always when stdout is not a TTY', async () => {
+    const { deps, manager } = makeDeps();
+    manager.similaritySearch.mockResolvedValueOnce([{
+      pageContent: 'Use C++ and foo.bar in the runbook',
+      metadata: { source: '/kb/ops/code.md', chunkIndex: 0 },
+      score: 0.12,
+    }] as never);
+
+    const out = await withNoColor(undefined, () =>
+      withStdoutTTY(false, () =>
+        captureSearchOutput(['C++ foo.bar', '--highlight=always', '--no-freshness'], deps),
+      ),
+    );
+
+    expect(out.code).toBe(0);
+    expect(out.stdout).toContain('Use \x1b[1mC++\x1b[22m and \x1b[1mfoo.bar\x1b[22m');
+  });
+
+  it('keeps JSON output unhighlighted even with --highlight=always', async () => {
+    const { deps, manager } = makeDeps();
+    manager.similaritySearch.mockResolvedValueOnce([{
+      pageContent: 'Rollback plan',
+      metadata: { source: '/kb/ops/rollback.md', chunkIndex: 0 },
+      score: 0.12,
+    }] as never);
+
+    const out = await withNoColor(undefined, () =>
+      withStdoutTTY(true, () =>
+        captureSearchOutput(['rollback', '--format=json', '--highlight=always', '--no-freshness'], deps),
+      ),
+    );
+
+    expect(out.code).toBe(0);
+    expect(out.stdout).not.toContain('\x1b[');
+    expect(JSON.parse(out.stdout).results[0].content).toBe('Rollback plan');
   });
 
   it('exposes query-cache telemetry in dense JSON, timing, and canonical metadata', async () => {

--- a/src/cli-search.ts
+++ b/src/cli-search.ts
@@ -33,6 +33,7 @@ import {
   formatRetrievalEmptyAsMarkdown,
   formatRetrievalGroupedBySourceAsMarkdown,
   groupRetrievalBySource,
+  type RetrievalHighlightOptions,
   type ScoredDocument,
 } from './formatter.js';
 import { runPicker } from './cli-search-picker.js';
@@ -202,6 +203,11 @@ Output:
   --pager               Page markdown/compact output through KB_PAGER, PAGER,
                         or less -R when stdout is a TTY.
   --no-pager            Disable KB_PAGER for this search.
+  --highlight=auto|always|never
+                        Highlight query terms in markdown snippets with ANSI
+                        emphasis. auto uses ANSI only on a TTY (default);
+                        always also works through pipes; never disables it.
+  --no-highlight        Alias for --highlight=never.
   --daemon              Use the local read-only daemon when available; falls
                         back to direct search when unreachable.
   --no-freshness        Skip the staleness scan and omit freshness output.
@@ -240,6 +246,7 @@ Examples:
 `;
 
 export type SearchFormat = 'md' | 'json' | 'vimgrep' | 'compact';
+export type SearchHighlightMode = 'auto' | 'always' | 'never';
 
 let lastSearchCanonicalTelemetry: Partial<CanonicalLogInput> | null = null;
 
@@ -270,6 +277,7 @@ interface SearchArgs {
   batchJsonl: boolean;
   noCache: boolean;
   freshness: boolean;
+  highlight: SearchHighlightMode;
   explainEmpty: boolean;
   explain: boolean;
   neighborContext?: NeighborContextOptions;
@@ -647,6 +655,7 @@ export async function runSearch(
       gateVerdict,
       explain: parsed.explain,
       advancedRetrieval,
+      highlight: buildSearchHighlightOptions(parsed, query),
     }));
   }
 
@@ -789,6 +798,7 @@ export function parseSearchArgs(rest: string[]): SearchArgs {
     batchJsonl: false,
     noCache: false,
     freshness: true,
+    highlight: 'auto',
     explainEmpty: false,
     explain: false,
     diverse: false,
@@ -805,6 +815,8 @@ export function parseSearchArgs(rest: string[]): SearchArgs {
     if (raw === '--pager') { out.pager = true; continue; }
     if (raw === '--no-pager') { out.pager = false; continue; }
     if (raw === '--no-cache') { out.noCache = true; continue; }
+    if (raw === '--highlight') { out.highlight = 'always'; continue; }
+    if (raw === '--no-highlight') { out.highlight = 'never'; continue; }
     if (raw === '--gate') { out.gateOverride = 'on'; continue; }
     if (raw === '--no-gate') { out.gateOverride = 'off'; continue; }
     if (raw === '--rerank') { out.rerankOverride = 'on'; continue; }
@@ -883,6 +895,13 @@ export function parseSearchArgs(rest: string[]): SearchArgs {
       }
       out.format = v === 'table' ? 'compact' : v; continue;
     }
+    if (raw.startsWith('--highlight=')) {
+      const v = raw.slice('--highlight='.length);
+      if (v !== 'auto' && v !== 'always' && v !== 'never') {
+        throw new Error(`invalid --highlight: ${raw} (expected 'auto', 'always', or 'never')`);
+      }
+      out.highlight = v; continue;
+    }
     if (raw.startsWith('--view=')) {
       const v = raw.slice('--view='.length);
       if (v !== 'compact') throw new Error(`invalid --view: ${raw} (expected 'compact')`);
@@ -901,6 +920,47 @@ function parseNonEmptyComponent(raw: string, prefix: string): string {
     throw new Error(`invalid ${prefix.slice(0, -1)}: value must not be empty`);
   }
   return value;
+}
+
+function buildSearchHighlightOptions(
+  parsed: SearchArgs,
+  query: string,
+): RetrievalHighlightOptions | undefined {
+  if (!shouldHighlightSearchOutput(parsed, process.env, process.stdout.isTTY === true)) {
+    return undefined;
+  }
+  const terms = extractSearchHighlightTerms(query);
+  return terms.length === 0 ? undefined : { terms };
+}
+
+export function shouldHighlightSearchOutput(
+  parsed: { format: SearchFormat; highlight: SearchHighlightMode },
+  env: NodeJS.ProcessEnv = process.env,
+  stdoutIsTTY: boolean = process.stdout.isTTY === true,
+): boolean {
+  if (parsed.format !== 'md') return false;
+  if (parsed.highlight === 'never') return false;
+  if (env.NO_COLOR !== undefined) return false;
+  if (parsed.highlight === 'always') return true;
+  return stdoutIsTTY;
+}
+
+export function extractSearchHighlightTerms(query: string): string[] {
+  const terms = query
+    .normalize('NFKC')
+    .match(/[\p{L}\p{N}_./:@+-]+/gu) ?? [];
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const term of terms) {
+    const trimmed = term.trim();
+    if (trimmed === '') continue;
+    if (!/[\p{L}\p{N}]/u.test(trimmed)) continue;
+    const key = trimmed.toLocaleLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(trimmed);
+  }
+  return out.sort((left, right) => right.length - left.length);
 }
 
 function warnIfRerankIgnored(parsed: SearchArgs, effectiveMode: EffectiveSearchMode): void {
@@ -1300,6 +1360,7 @@ export interface DenseSearchMarkdownOutputInput {
   gateVerdict?: RelevanceGateVerdict;
   explain?: boolean;
   advancedRetrieval?: AdvancedRetrievalMetadata | null;
+  highlight?: RetrievalHighlightOptions;
 }
 
 export function formatDenseSearchMarkdownOutput(input: DenseSearchMarkdownOutputInput): string {
@@ -1322,9 +1383,19 @@ export function formatDenseSearchMarkdownOutput(input: DenseSearchMarkdownOutput
   if (input.results.length === 0 && inlineEmptyGuidance !== null) {
     md = formatRetrievalEmptyAsMarkdown(inlineEmptyGuidance);
   } else if (input.groupBySource) {
-    md = formatRetrievalGroupedBySourceAsMarkdown(input.results, FRONTMATTER_EXTRAS_WIRE_VISIBLE, KB_EDITOR_URI);
+    md = formatRetrievalGroupedBySourceAsMarkdown(
+      input.results,
+      FRONTMATTER_EXTRAS_WIRE_VISIBLE,
+      KB_EDITOR_URI,
+      input.highlight,
+    );
   } else {
-    md = formatRetrievalAsMarkdown(input.results, FRONTMATTER_EXTRAS_WIRE_VISIBLE, KB_EDITOR_URI);
+    md = formatRetrievalAsMarkdown(
+      input.results,
+      FRONTMATTER_EXTRAS_WIRE_VISIBLE,
+      KB_EDITOR_URI,
+      input.highlight,
+    );
   }
   output += `${md}\n\n`;
   if (input.results.length === 0 && input.explainEmptyDiagnostics) {
@@ -2162,7 +2233,12 @@ async function runLexicalSearch(
     if (formatted.length === 0) {
       output += `_No matches._\n\n`;
     } else {
-      output += `${formatRetrievalAsMarkdown(formatted as never, FRONTMATTER_EXTRAS_WIRE_VISIBLE, KB_EDITOR_URI)}\n\n`;
+      output += `${formatRetrievalAsMarkdown(
+        formatted as never,
+        FRONTMATTER_EXTRAS_WIRE_VISIBLE,
+        KB_EDITOR_URI,
+        buildSearchHighlightOptions(parsed, query),
+      )}\n\n`;
     }
     const summaryLines = perKb.map((r) => {
       if (r.error) return `- ${r.kbName}: error — ${r.error.message}`;
@@ -2431,7 +2507,12 @@ async function runHybridSearch(
     if (ranked.length === 0) {
       output += `_No matches._\n\n`;
     } else {
-      output += `${formatRetrievalAsMarkdown(ranked as never, FRONTMATTER_EXTRAS_WIRE_VISIBLE, KB_EDITOR_URI)}\n\n`;
+      output += `${formatRetrievalAsMarkdown(
+        ranked as never,
+        FRONTMATTER_EXTRAS_WIRE_VISIBLE,
+        KB_EDITOR_URI,
+        buildSearchHighlightOptions(parsed, query),
+      )}\n\n`;
     }
     output += `> _Hybrid status: dense fetched ${denseResults.length}, lexical fetched ${lexicalResults.length} with unit=${parsed.lexicalUnit} (refreshed ${lexicalResultsRow.refreshed}, ${lexicalResultsRow.failed} failed); fused via RRF (c=${HYBRID_RRF_C}, fetch_k=${fetchK})._\n`;
     if (rerankResult.candidatesIn > 0) {

--- a/src/formatter.test.ts
+++ b/src/formatter.test.ts
@@ -7,6 +7,7 @@ import {
   formatRetrievalGroupedBySourceAsMarkdown,
   formatRetrievalAsMarkdown,
   groupRetrievalBySource,
+  highlightQueryTerms,
   sanitizeMetadataForWire,
   ScoredDocument,
 } from './formatter.js';
@@ -200,6 +201,34 @@ describe('formatRetrievalAsMarkdown', () => {
     expect(out).toContain('**Context chunks:**');
     expect(out).toContain('**Context (before, distance 1):**');
     expect(out).toContain('previous chunk');
+  });
+
+  it('highlights configured terms only in rendered markdown content', () => {
+    const doc: ScoredDocument = {
+      pageContent: 'Deploy rollback procedure',
+      metadata: { source: 'rollback.md' },
+      score: 0.42,
+    } as unknown as ScoredDocument;
+
+    const out = formatRetrievalAsMarkdown([doc], false, 'none', { terms: ['rollback'] });
+
+    expect(out).toContain(`Deploy \x1b[1mrollback\x1b[22m procedure`);
+    expect(out).toContain('"source": "rollback.md"');
+    expect(out).not.toContain('"source": "\\u001b');
+  });
+});
+
+describe('highlightQueryTerms', () => {
+  it('escapes regex-special terms and matches case-insensitively', () => {
+    expect(highlightQueryTerms('Use C++ with foo.bar and c++.', ['C++', 'foo.bar'])).toBe(
+      'Use \x1b[1mC++\x1b[22m with \x1b[1mfoo.bar\x1b[22m and \x1b[1mc++\x1b[22m.',
+    );
+  });
+
+  it('handles overlapping terms without nested ANSI escapes', () => {
+    expect(highlightQueryTerms('rollback roll', ['roll', 'rollback'])).toBe(
+      '\x1b[1mrollback\x1b[22m \x1b[1mroll\x1b[22m',
+    );
   });
 });
 

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -84,6 +84,13 @@ export interface CompactRetrievalOptions {
   width?: number;
 }
 
+export interface RetrievalHighlightOptions {
+  terms: readonly string[];
+}
+
+const ANSI_BOLD = '\x1b[1m';
+const ANSI_BOLD_OFF = '\x1b[22m';
+
 /**
  * Strips `frontmatter.extras` from a chunk's metadata before wire
  * serialization unless the operator has opted back in via
@@ -140,6 +147,7 @@ export function formatRetrievalAsMarkdown(
   results: ScoredDocument[] | null | undefined,
   extrasVisible: boolean,
   editorUriMode: KBEditorUriMode = KB_EDITOR_URI,
+  highlight?: RetrievalHighlightOptions,
 ): string {
   if (!results || results.length === 0) {
     return formatRetrievalEmptyAsMarkdown();
@@ -156,13 +164,13 @@ export function formatRetrievalAsMarkdown(
         extrasVisible,
       );
       const guarded = guardRetrievalChunk(doc.pageContent, sanitizedMetadata, guardOptions);
-      const content = guarded.content.trim();
+      const content = applyRetrievalHighlight(guarded.content.trim(), highlight);
       const citation = buildChunkCitation(guarded.metadata, editorUriMode);
       const metadata = JSON.stringify(guarded.metadata, null, 2);
       const scoreText = doc.score !== undefined ? `**Score:** ${doc.score.toFixed(2)}\n\n` : '';
       const signals = getShieldSignals(doc.pageContent, sanitizedMetadata, guardOptions);
       const shieldFooter = formatInjectionMarkdown(signals);
-      const contextText = formatContextChunksAsMarkdown(doc, extrasVisible, editorUriMode);
+      const contextText = formatContextChunksAsMarkdown(doc, extrasVisible, editorUriMode, highlight);
       return `${resultHeader}\n\n${scoreText}${content}\n\n${shieldFooter}${formatSourceBlock(metadata, citation)}${contextText}`;
     })
     .join('\n\n---\n\n');
@@ -173,6 +181,7 @@ export function formatRetrievalGroupedBySourceAsMarkdown(
   results: ScoredDocument[] | null | undefined,
   extrasVisible: boolean,
   editorUriMode: KBEditorUriMode = KB_EDITOR_URI,
+  highlight?: RetrievalHighlightOptions,
 ): string {
   const grouped = groupRetrievalBySource(results, extrasVisible, editorUriMode);
   if (grouped.length === 0) {
@@ -187,8 +196,9 @@ export function formatRetrievalGroupedBySourceAsMarkdown(
           const openText = chunk.editor_uri ? `\n   **Open:** ${chunk.editor_uri}` : '';
           const shieldText = formatInjectionGrouped(chunk.injection_signals);
           const typeText = chunk.match_type ? `\n   **Type:** ${chunk.match_type}` : '';
-          const contextText = formatJsonContextChunksForGroupedMarkdown(chunk.context_chunks);
-          return `${chunkIdx + 1}. **Score:** ${scoreText}${typeText}\n   **Location:** ${locationText}${openText}\n\n   ${indentChunkContent(chunk.content.trim())}${shieldText}${contextText}`;
+          const content = applyRetrievalHighlight(chunk.content.trim(), highlight);
+          const contextText = formatJsonContextChunksForGroupedMarkdown(chunk.context_chunks, highlight);
+          return `${chunkIdx + 1}. **Score:** ${scoreText}${typeText}\n   **Location:** ${locationText}${openText}\n\n   ${indentChunkContent(content)}${shieldText}${contextText}`;
         })
         .join('\n\n');
       return (
@@ -200,6 +210,36 @@ export function formatRetrievalGroupedBySourceAsMarkdown(
     })
     .join('\n\n---\n\n');
   return `${SEMANTIC_SEARCH_HEADER}\n\n${formattedResults}${SEMANTIC_SEARCH_DISCLAIMER}`;
+}
+
+export function highlightQueryTerms(text: string, terms: readonly string[]): string {
+  const normalizedTerms = normalizeHighlightTerms(terms);
+  if (normalizedTerms.length === 0 || text === '') return text;
+  const pattern = normalizedTerms.map(escapeRegex).join('|');
+  return text.replace(new RegExp(pattern, 'giu'), (match) => `${ANSI_BOLD}${match}${ANSI_BOLD_OFF}`);
+}
+
+function applyRetrievalHighlight(text: string, highlight: RetrievalHighlightOptions | undefined): string {
+  return highlight ? highlightQueryTerms(text, highlight.terms) : text;
+}
+
+function normalizeHighlightTerms(terms: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const normalized: string[] = [];
+  for (const rawTerm of terms) {
+    const term = rawTerm.trim();
+    if (term === '') continue;
+    if (!/[\p{L}\p{N}]/u.test(term)) continue;
+    const key = term.toLocaleLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    normalized.push(term);
+  }
+  return normalized.sort((left, right) => right.length - left.length);
+}
+
+function escapeRegex(term: string): string {
+  return term.replace(/[\\^$.*+?()[\]{}|]/g, '\\$&');
 }
 
 /**
@@ -581,6 +621,7 @@ function formatContextChunksAsMarkdown(
   doc: ScoredDocument,
   extrasVisible: boolean,
   editorUriMode: KBEditorUriMode,
+  highlight: RetrievalHighlightOptions | undefined,
 ): string {
   if (!doc.contextChunks || doc.contextChunks.length === 0) {
     return doc.contextTruncated ? '\n\n**Context chunks:** truncated by response cap.' : '';
@@ -598,9 +639,10 @@ function formatContextChunksAsMarkdown(
       const openText = citation?.editor_uri ? `\n   **Open:** ${citation.editor_uri}` : '';
       const sourceText = citation ? `\n   **Source:** ${citation.chunk_id}` : '';
       const shieldText = formatInjectionContext(signals);
+      const content = applyRetrievalHighlight(guarded.content.trim(), highlight);
       return (
         `- **Context (${chunk.contextDirection}, distance ${chunk.contextDistance}):**${sourceText}${openText}\n\n` +
-        `  ${indentListContent(guarded.content.trim())}${shieldText}`
+        `  ${indentListContent(content)}${shieldText}`
       );
     })
     .join('\n\n');
@@ -638,13 +680,17 @@ function formatContextChunksAsJson(
 
 function formatJsonContextChunksForGroupedMarkdown(
   chunks: RetrievalJsonContextChunk[] | undefined,
+  highlight: RetrievalHighlightOptions | undefined,
 ): string {
   if (!chunks || chunks.length === 0) return '';
   const lines = chunks
-    .map((chunk) => (
-      `   - **Context (${chunk.direction}, distance ${chunk.distance}):**\n\n` +
-      `     ${indentListContent(chunk.content.trim())}${formatInjectionGrouped(chunk.injection_signals)}`
-    ))
+    .map((chunk) => {
+      const content = applyRetrievalHighlight(chunk.content.trim(), highlight);
+      return (
+        `   - **Context (${chunk.direction}, distance ${chunk.distance}):**\n\n` +
+        `     ${indentListContent(content)}${formatInjectionGrouped(chunk.injection_signals)}`
+      );
+    })
     .join('\n\n');
   return `\n\n   **Context chunks:**\n\n${lines}`;
 }


### PR DESCRIPTION
Closes #546.

## Summary
- add TTY-aware ANSI bold highlighting for query terms in markdown `kb search` snippets
- add `--highlight=auto|always|never`, `--highlight`, and `--no-highlight` controls while respecting `NO_COLOR`
- keep JSON, vimgrep, batch JSONL, and compact output unhighlighted
- escape regex-special query terms and prefer longest terms to avoid nested overlap highlighting

## Validation
- `npm test -- /home/jean/git/knowledge-base-mcp-server/src/cli-search.test.ts /home/jean/git/knowledge-base-mcp-server/src/formatter.test.ts` (expected path mismatch in isolated worktree: Jest found no tests)
- `npm test -- /home/jean/git/knowledge-base-mcp-server-search-highlight-546/src/cli-search.test.ts /home/jean/git/knowledge-base-mcp-server-search-highlight-546/src/formatter.test.ts`
- `npm run build`