### PR TITLE
feat(cli): add kb cite citation export

### DIFF
--- a/src/cli-cite.test.ts
+++ b/src/cli-cite.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from '@jest/globals';
+import * as fsp from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  citationEntryFromFrontmatter,
+  formatCitation,
+  normalizeAuthors,
+  parseCiteArgs,
+  runCite,
+  type RunCiteDeps,
+} from './cli-cite.js';
+
+describe('kb cite', () => {
+  it('parses the required path selector and format option', () => {
+    expect(parseCiteArgs(['research/paper.md'])).toEqual({
+      target: 'research/paper.md',
+      format: 'bibtex',
+    });
+    expect(parseCiteArgs(['research/paper.md', '--format=csl-json'])).toEqual({
+      target: 'research/paper.md',
+      format: 'csl-json',
+    });
+    expect(() => parseCiteArgs([])).toThrow('missing <chunk-id|kb://uri|kb-relative-path>');
+    expect(() => parseCiteArgs(['research/paper.md', '--format=json'])).toThrow('invalid --format');
+  });
+
+  it('normalizes author string and array forms conservatively', () => {
+    expect(normalizeAuthors(['Ada Lovelace', 'Grace Hopper', 42])).toEqual([
+      'Ada Lovelace',
+      'Grace Hopper',
+    ]);
+    expect(normalizeAuthors('Ada Lovelace and Grace Hopper')).toEqual([
+      'Ada Lovelace',
+      'Grace Hopper',
+    ]);
+    expect(normalizeAuthors('Ada Lovelace, Grace Hopper, Katherine Johnson')).toEqual([
+      'Ada Lovelace',
+      'Grace Hopper',
+      'Katherine Johnson',
+    ]);
+    expect(normalizeAuthors('Lovelace, Ada')).toEqual(['Lovelace, Ada']);
+  });
+
+  it('builds a deterministic BibTeX entry from scholarly frontmatter', () => {
+    const entry = citationEntryFromFrontmatter({
+      arxiv_id: '2604.21215',
+      authors: 'Costin-Andrei Oncescu, Jane Smith, Alex Kim',
+      published: '2026-04-23',
+      title: 'The Recurrent Transformer: Efficient Long Context',
+      doi: 'https://doi.org/10.5555/example.42',
+    }, 'arxiv-llm-inference/papers/recurrent-transformer.md');
+
+    expect(entry.key).toBe('oncescu-2026-260421215');
+    expect(formatCitation(entry, 'bibtex')).toBe(`@article{oncescu-2026-260421215,
+  author = {Costin-Andrei Oncescu and Jane Smith and Alex Kim},
+  title = {The Recurrent Transformer: Efficient Long Context},
+  year = {2026},
+  doi = {10.5555/example.42},
+  url = {https://arxiv.org/abs/2604.21215},
+  eprint = {2604.21215},
+  archivePrefix = {arXiv},
+  note = {KB note: arxiv-llm-inference/papers/recurrent-transformer.md},
+}`);
+  });
+
+  it('emits CSL-JSON with literal authors and issued date parts', () => {
+    const entry = citationEntryFromFrontmatter({
+      authors: ['Ada Lovelace', 'Grace Hopper'],
+      published: '1843-09',
+      title: 'Notes on Analytical Engines',
+      url: 'https://example.test/notes',
+    }, 'history/notes/analytical-engine.md');
+
+    expect(JSON.parse(formatCitation(entry, 'csl-json'))).toEqual([
+      {
+        id: 'lovelace-1843-notesonanalyticalengines',
+        type: 'article',
+        title: 'Notes on Analytical Engines',
+        author: [{ literal: 'Ada Lovelace' }, { literal: 'Grace Hopper' }],
+        issued: { 'date-parts': [[1843, 9]] },
+        URL: 'https://example.test/notes',
+        note: 'KB note: history/notes/analytical-engine.md',
+      },
+    ]);
+  });
+
+  it('degrades gracefully when citation frontmatter is missing', () => {
+    const entry = citationEntryFromFrontmatter({}, 'notes/plain-note.md');
+
+    expect(entry.key).toBe('plainnote-nd-plainnote');
+    expect(formatCitation(entry, 'bibtex')).toBe(`@misc{plainnote-nd-plainnote,
+  note = {KB note: notes/plain-note.md},
+}`);
+    expect(formatCitation(entry, 'text')).toBe(
+      '[plainnote-nd-plainnote] KB note: notes/plain-note.md',
+    );
+  });
+
+  it('resolves a note path, reads frontmatter, and writes the requested format', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-cite-'));
+    await fsp.mkdir(path.join(tempDir, 'research', 'papers'), { recursive: true });
+    await fsp.writeFile(path.join(tempDir, 'research', 'papers', 'paper.md'), [
+      '---',
+      'title: Example Paper',
+      'authors:',
+      '  - Ada Lovelace',
+      'published: 1843-01-01',
+      'doi: doi:10.1000/example',
+      '---',
+      '',
+      '# Example Paper',
+      '',
+    ].join('\n'));
+
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const deps: RunCiteDeps = {
+      rootDir: tempDir,
+      readFile: (filePath) => fsp.readFile(filePath, 'utf-8'),
+      stdout: (text) => { stdout.push(text); },
+      stderr: (text) => { stderr.push(text); },
+    };
+
+    await expect(runCite(['research/papers/paper.md', '--format=text'], deps)).resolves.toBe(0);
+    expect(stderr.join('')).toBe('');
+    expect(stdout.join('')).toBe(
+      '[lovelace-1843-example] Ada Lovelace. (1843). Example Paper. DOI: 10.1000/example. KB note: research/papers/paper.md\n',
+    );
+  });
+
+  it('returns input and runtime exit codes for bad selectors and missing files', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-cite-errors-'));
+    await fsp.mkdir(path.join(tempDir, 'research'), { recursive: true });
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const deps: RunCiteDeps = {
+      rootDir: tempDir,
+      readFile: (filePath) => fsp.readFile(filePath, 'utf-8'),
+      stdout: (text) => { stdout.push(text); },
+      stderr: (text) => { stderr.push(text); },
+    };
+
+    await expect(runCite(['not-a-reference'], deps)).resolves.toBe(2);
+    await expect(runCite(['research/missing.md'], deps)).resolves.toBe(1);
+    expect(stdout.join('')).toBe('');
+    expect(stderr.join('')).toContain("cannot parse reference 'not-a-reference'");
+    expect(stderr.join('')).toContain('path not found: "missing.md"');
+  });
+});

--- a/src/cli-cite.ts
+++ b/src/cli-cite.ts
@@ -1,0 +1,351 @@
+// `kb cite` — export bibliography entries from note frontmatter.
+//
+// This first version is intentionally path-selector only: it resolves the
+// same note pointers that `kb open` accepts, parses YAML frontmatter, and
+// formats one citation without consulting indexes or live KB services.
+
+import * as fsp from 'fs/promises';
+import * as path from 'path';
+import { parseChunkReference } from './chunk-id.js';
+import { KNOWLEDGE_BASES_ROOT_DIR } from './config/paths.js';
+import { KBError } from './errors.js';
+import { parseFrontmatter } from './frontmatter.js';
+import { resolveKbPath } from './kb-fs.js';
+
+export const CITE_HELP = `kb cite — export a bibliography entry from note frontmatter
+
+Usage:
+  kb cite <chunk-id|kb://uri|kb-relative-path> [--format=bibtex|csl-json|text]
+
+Reads one markdown note, extracts citation-oriented frontmatter fields, and
+prints a ready-to-paste bibliography entry. Accepted selector forms match
+\`kb open\`: a chunk id, a kb:// URI, or a KB-relative path such as
+\`research/papers/example.md\`. Line or chunk fragments are accepted but only
+identify the containing note; citation fields come from note frontmatter.
+
+Recognized frontmatter fields:
+  authors, author       String or string array. String values split on
+                        " and "; comma splitting is used only for lists of
+                        three or more names to avoid breaking "Last, First".
+  title                 Citation title.
+  published, date       YYYY, YYYY-MM, or YYYY-MM-DD publication date.
+  doi                   DOI.
+  url                   Canonical URL. If absent and arxiv_id is present,
+                        an arXiv abstract URL is emitted.
+  arxiv_id              arXiv identifier, emitted as eprint/archive metadata.
+
+Options:
+  --format=bibtex|csl-json|text
+                        Output format (default: bibtex).
+  --help, -h            Show this help.
+
+Environment:
+  KNOWLEDGE_BASES_ROOT_DIR  Root directory containing one folder per KB.
+
+Exit codes:
+  0   citation exported
+  1   note path is well-formed but cannot be read
+  2   missing / invalid argument, format, selector, or KB name
+
+Examples:
+  kb cite arxiv-llm-inference/papers/recurrent-transformer.md
+  kb cite kb://research/papers/example.md --format=csl-json
+  kb cite research/papers/example.md#L12-L48 --format=text
+`;
+
+export type CiteFormat = 'bibtex' | 'csl-json' | 'text';
+
+export interface CiteArgs {
+  target: string;
+  format: CiteFormat;
+}
+
+export interface CitationEntry {
+  key: string;
+  notePath: string;
+  title?: string;
+  authors: string[];
+  published?: string;
+  year?: string;
+  dateParts?: number[];
+  doi?: string;
+  url?: string;
+  arxivId?: string;
+}
+
+export interface RunCiteDeps {
+  rootDir: string;
+  readFile: (filePath: string) => Promise<string>;
+  stdout: (text: string) => void;
+  stderr: (text: string) => void;
+}
+
+export function defaultCiteDeps(): RunCiteDeps {
+  return {
+    rootDir: KNOWLEDGE_BASES_ROOT_DIR,
+    readFile: (filePath) => fsp.readFile(filePath, 'utf-8'),
+    stdout: (text) => process.stdout.write(text),
+    stderr: (text) => process.stderr.write(text),
+  };
+}
+
+export async function runCite(
+  rest: string[] = [],
+  deps: RunCiteDeps = defaultCiteDeps(),
+): Promise<number> {
+  let args: CiteArgs;
+  try {
+    args = parseCiteArgs(rest);
+  } catch (err) {
+    deps.stderr(`kb cite: ${(err as Error).message}\n`);
+    return 2;
+  }
+
+  let reference: ReturnType<typeof parseChunkReference>;
+  try {
+    reference = parseChunkReference(args.target);
+  } catch (err) {
+    deps.stderr(`kb cite: ${(err as Error).message}\n`);
+    return 2;
+  }
+
+  let absolutePath: string;
+  try {
+    absolutePath = await resolveKbPath(
+      deps.rootDir,
+      reference.knowledgeBase,
+      reference.kbRelativePath,
+      { mustExist: true },
+    );
+  } catch (err) {
+    deps.stderr(`kb cite: ${(err as Error).message}\n`);
+    return exitCodeForResolveError(err);
+  }
+
+  let content: string;
+  try {
+    content = await deps.readFile(absolutePath);
+  } catch (err) {
+    deps.stderr(`kb cite: failed to read ${reference.displayPath}: ${(err as Error).message}\n`);
+    return 1;
+  }
+
+  const parsed = parseFrontmatter(content);
+  const entry = citationEntryFromFrontmatter(parsed.frontmatter, reference.displayPath);
+  deps.stdout(`${formatCitation(entry, args.format)}\n`);
+  return 0;
+}
+
+export function parseCiteArgs(rest: readonly string[]): CiteArgs {
+  const out: { target: string | null; format: CiteFormat } = {
+    target: null,
+    format: 'bibtex',
+  };
+  for (const raw of rest) {
+    if (raw.startsWith('--format=')) {
+      const value = raw.slice('--format='.length);
+      if (!isCiteFormat(value)) throw new Error(`invalid --format: ${raw}`);
+      out.format = value;
+      continue;
+    }
+    if (raw.startsWith('--')) throw new Error(`unknown flag: ${raw}`);
+    if (out.target !== null) throw new Error(`unexpected argument: ${raw}`);
+    out.target = raw;
+  }
+  if (out.target === null) {
+    throw new Error('missing <chunk-id|kb://uri|kb-relative-path>');
+  }
+  return out as CiteArgs;
+}
+
+export function citationEntryFromFrontmatter(
+  frontmatter: Record<string, unknown>,
+  notePath: string,
+): CitationEntry {
+  const title = optionalString(frontmatter.title);
+  const authors = normalizeAuthors(frontmatter.authors ?? frontmatter.author);
+  const published = optionalString(frontmatter.published ?? frontmatter.date);
+  const dateParts = published === undefined ? undefined : parseDateParts(published);
+  const year = dateParts?.[0]?.toString() ?? yearFromString(published);
+  const doi = normalizeDoi(optionalString(frontmatter.doi));
+  const arxivId = optionalString(frontmatter.arxiv_id ?? frontmatter.arxivId);
+  const explicitUrl = optionalString(frontmatter.url);
+  const url = explicitUrl ?? (arxivId === undefined ? undefined : `https://arxiv.org/abs/${arxivId}`);
+  const key = buildCitationKey({ authors, title, year, arxivId, doi, notePath });
+
+  return {
+    key,
+    notePath,
+    ...(title === undefined ? {} : { title }),
+    authors,
+    ...(published === undefined ? {} : { published }),
+    ...(year === undefined ? {} : { year }),
+    ...(dateParts === undefined ? {} : { dateParts }),
+    ...(doi === undefined ? {} : { doi }),
+    ...(url === undefined ? {} : { url }),
+    ...(arxivId === undefined ? {} : { arxivId }),
+  };
+}
+
+export function formatCitation(entry: CitationEntry, format: CiteFormat): string {
+  if (format === 'bibtex') return formatBibTeX(entry);
+  if (format === 'csl-json') return JSON.stringify([toCslJson(entry)], null, 2);
+  return formatTextCitation(entry);
+}
+
+export function normalizeAuthors(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value
+      .filter((entry): entry is string => typeof entry === 'string')
+      .map((entry) => collapseWhitespace(entry))
+      .filter((entry) => entry.length > 0);
+  }
+  if (typeof value !== 'string') return [];
+  const trimmed = collapseWhitespace(value);
+  if (trimmed.length === 0) return [];
+  if (/\s+and\s+/i.test(trimmed)) {
+    return trimmed.split(/\s+and\s+/i).map(collapseWhitespace).filter((entry) => entry.length > 0);
+  }
+  const commaParts = trimmed.split(',').map(collapseWhitespace).filter((entry) => entry.length > 0);
+  if (commaParts.length >= 3) return commaParts;
+  return [trimmed];
+}
+
+function formatBibTeX(entry: CitationEntry): string {
+  const fields: Array<[string, string]> = [];
+  if (entry.authors.length > 0) fields.push(['author', entry.authors.join(' and ')]);
+  if (entry.title !== undefined) fields.push(['title', entry.title]);
+  if (entry.year !== undefined) fields.push(['year', entry.year]);
+  if (entry.doi !== undefined) fields.push(['doi', entry.doi]);
+  if (entry.url !== undefined) fields.push(['url', entry.url]);
+  if (entry.arxivId !== undefined) {
+    fields.push(['eprint', entry.arxivId]);
+    fields.push(['archivePrefix', 'arXiv']);
+  }
+  fields.push(['note', `KB note: ${entry.notePath}`]);
+
+  const body = fields
+    .map(([name, value]) => `  ${name} = {${escapeBibTeX(value)}},`)
+    .join('\n');
+  return `@${entry.doi === undefined ? 'misc' : 'article'}{${entry.key},\n${body}\n}`;
+}
+
+function toCslJson(entry: CitationEntry): Record<string, unknown> {
+  const out: Record<string, unknown> = {
+    id: entry.key,
+    type: entry.doi === undefined ? 'article' : 'article-journal',
+    note: `KB note: ${entry.notePath}`,
+  };
+  if (entry.title !== undefined) out.title = entry.title;
+  if (entry.authors.length > 0) {
+    out.author = entry.authors.map((author) => ({ literal: author }));
+  }
+  if (entry.dateParts !== undefined) out.issued = { 'date-parts': [entry.dateParts] };
+  if (entry.doi !== undefined) out.DOI = entry.doi;
+  if (entry.url !== undefined) out.URL = entry.url;
+  if (entry.arxivId !== undefined) {
+    out.archive = 'arXiv';
+    out.archive_location = entry.arxivId;
+  }
+  return out;
+}
+
+function formatTextCitation(entry: CitationEntry): string {
+  const parts: string[] = [];
+  if (entry.authors.length > 0) parts.push(entry.authors.join('; '));
+  if (entry.year !== undefined) parts.push(`(${entry.year})`);
+  if (entry.title !== undefined) parts.push(entry.title);
+  if (entry.doi !== undefined) parts.push(`DOI: ${entry.doi}`);
+  if (entry.arxivId !== undefined) parts.push(`arXiv: ${entry.arxivId}`);
+  if (entry.url !== undefined) parts.push(entry.url);
+  parts.push(`KB note: ${entry.notePath}`);
+  return `[${entry.key}] ${parts.join('. ')}`;
+}
+
+function isCiteFormat(value: string): value is CiteFormat {
+  return value === 'bibtex' || value === 'csl-json' || value === 'text';
+}
+
+function optionalString(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = collapseWhitespace(value);
+  return trimmed.length === 0 ? undefined : trimmed;
+}
+
+function normalizeDoi(value: string | undefined): string | undefined {
+  if (value === undefined) return undefined;
+  return value
+    .replace(/^doi:\s*/i, '')
+    .replace(/^https?:\/\/(?:dx\.)?doi\.org\//i, '')
+    .trim();
+}
+
+function parseDateParts(value: string): number[] | undefined {
+  const match = /^(\d{4})(?:-(\d{1,2})(?:-(\d{1,2}))?)?/.exec(value.trim());
+  if (match === null) return undefined;
+  const parts = [Number(match[1])];
+  if (match[2] !== undefined) parts.push(Number(match[2]));
+  if (match[3] !== undefined) parts.push(Number(match[3]));
+  return parts;
+}
+
+function yearFromString(value: string | undefined): string | undefined {
+  const match = value?.match(/\b(1[5-9]\d{2}|20\d{2}|21\d{2})\b/);
+  return match?.[1];
+}
+
+function buildCitationKey(input: {
+  authors: readonly string[];
+  title?: string;
+  year?: string;
+  arxivId?: string;
+  doi?: string;
+  notePath: string;
+}): string {
+  const author = input.authors[0] === undefined ? undefined : authorKeyPart(input.authors[0]);
+  const baseName = path.basename(input.notePath, path.extname(input.notePath));
+  const fallback = slugPart(input.title) ?? slugPart(baseName) ?? 'note';
+  const subject = author ?? fallback;
+  const year = input.year ?? 'nd';
+  const id = slugPart(input.arxivId) ?? doiKeyPart(input.doi) ?? slugPart(input.title) ?? slugPart(baseName);
+  return [subject, year, id].filter((part): part is string => part !== undefined).join('-');
+}
+
+function authorKeyPart(author: string): string | undefined {
+  const beforeComma = author.split(',')[0]?.trim();
+  const source = beforeComma && beforeComma.length > 0 ? beforeComma : author;
+  const tokens = source.split(/\s+/).filter((token) => token.length > 0);
+  return slugPart(tokens[tokens.length - 1]);
+}
+
+function doiKeyPart(doi: string | undefined): string | undefined {
+  if (doi === undefined) return undefined;
+  const tail = doi.split('/').filter((part) => part.length > 0).pop();
+  return slugPart(tail ?? doi);
+}
+
+function slugPart(value: string | undefined): string | undefined {
+  if (value === undefined) return undefined;
+  const slug = value
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '')
+    .trim();
+  return slug.length === 0 ? undefined : slug;
+}
+
+function escapeBibTeX(value: string): string {
+  return collapseWhitespace(value).replace(/[\\{}]/g, (match) => `\\${match}`);
+}
+
+function collapseWhitespace(value: string): string {
+  return value.trim().replace(/\s+/g, ' ');
+}
+
+function exitCodeForResolveError(err: unknown): number {
+  if (err instanceof KBError) {
+    return err.code === 'VALIDATION' || err.code === 'KB_NOT_FOUND' ? 2 : 1;
+  }
+  return 1;
+}

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -57,6 +57,7 @@ describe('kb CLI — argv parsing and dispatch', () => {
       'list',
       'search',
       'open',
+      'cite',
       'related',
       'cache',
       'serve',
@@ -100,6 +101,7 @@ describe('kb CLI — argv parsing and dispatch', () => {
     ['list', 'kb list'],
     ['search', 'kb search'],
     ['open', 'kb open'],
+    ['cite', 'kb cite'],
     ['related', 'kb related'],
     ['cache', 'kb cache'],
     ['serve', 'kb serve'],
@@ -208,6 +210,7 @@ describe('kb CLI — argv parsing and dispatch', () => {
       'list',
       'search',
       'open',
+      'cite',
       'related',
       'cache',
       'serve',
@@ -290,6 +293,7 @@ describe('kb CLI — argv parsing and dispatch', () => {
     expect(r.stdout).toContain('help');
     expect(r.stdout).toContain('list');
     expect(r.stdout).toContain('search');
+    expect(r.stdout).toContain('cite');
     expect(r.stdout).toContain('reindex');
     expect(r.stdout).toContain('completion');
     expect(r.stdout).toContain('bash');

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,6 +13,7 @@ import { parseDotEnvText } from './config/schema.js';
 import { ASK_HELP, runAsk } from './cli-ask.js';
 import { CACHE_HELP, runCache } from './cli-cache.js';
 import { CAPTURE_HELP, runCapture } from './cli-capture.js';
+import { CITE_HELP, runCite } from './cli-cite.js';
 import { COMPLETION_HELP, runCompletion } from './cli-completion.js';
 import { CONFIG_HELP, runConfig } from './cli-config.js';
 import { COMPARE_HELP, runCompare } from './cli-compare.js';
@@ -100,6 +101,7 @@ const SUBCOMMANDS: readonly Subcommand[] = [
   { name: 'list',         summary: 'List available knowledge bases.',                                         help: LIST_HELP,         handler: runList },
   { name: 'search',       summary: 'Semantic search across one or all knowledge bases.',                     help: SEARCH_HELP,       handler: runSearch },
   { name: 'open',         summary: 'Resolve a chunk id / kb:// URI / result path to its source file.',        help: OPEN_HELP,         handler: runOpen },
+  { name: 'cite',         summary: 'Export BibTeX or CSL-JSON from note frontmatter.',                       help: CITE_HELP,         handler: runCite },
   { name: 'related',      summary: 'Find chunks related to an existing chunk id or kb:// URI.',               help: RELATED_HELP,      handler: runRelated },
   { name: 'cache',        summary: 'Inspect and prune local cache surfaces.',                                help: CACHE_HELP,        handler: runCache },
   { name: 'serve',        summary: 'Run a localhost daemon for warm read-only CLI requests.',                 help: SERVE_HELP,        handler: runServe },


### PR DESCRIPTION
## Summary
- add `kb cite <selector>` for path, chunk-id, and `kb://` note selectors
- export BibTeX, CSL-JSON, and text citations from note frontmatter
- normalize string/array authors and degrade to note-only citations when fields are missing

## Scope
- Implements the smallest path-selector version for #539 without search/query selector changes.
- Touched only expected CLI/frontmatter-adjacent files; no forbidden files were edited.

## Verification
- `npm test -- src/cli-cite.test.ts /home/jean/git/knowledge-base-mcp-server-cite-539/src/cli.test.ts`
- `npm run build`
- Smoke: `KB_LOG_FORMAT=text KNOWLEDGE_BASES_ROOT_DIR=<tmp> node build/cli.js cite research/papers/smoke.md --format=bibtex`
- Smoke: `KB_LOG_FORMAT=text KNOWLEDGE_BASES_ROOT_DIR=<tmp> node build/cli.js cite research/papers/smoke.md --format=csl-json`
- Accidental extra validation from PR-body quoting mistake: `npm test` full suite passed locally (128 suites, 2068 tests passed, 4 skipped, 1 todo).

Closes #539