### PR TITLE
feat(config): show resolved configuration

### DIFF
--- a/src/cli-config.test.ts
+++ b/src/cli-config.test.ts
@@ -4,7 +4,12 @@ import * as fsp from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
-import { formatConfigValidateMarkdown, parseConfigArgs, runConfig } from './cli-config.js';
+import {
+  formatConfigShowMarkdown,
+  formatConfigValidateMarkdown,
+  parseConfigArgs,
+  runConfig,
+} from './cli-config.js';
 
 const ORIGINAL_ENV = { ...process.env };
 const cliPath = path.join(process.cwd(), 'build', 'cli.js');
@@ -40,10 +45,12 @@ describe('kb config validate (FR-OBS-470)', () => {
       action: 'validate',
       file: '.env',
       format: 'json',
+      nonDefaultOnly: false,
     });
-    expect(parseConfigArgs(['validate'])).toEqual({ action: 'validate', format: 'md' });
+    expect(parseConfigArgs(['validate'])).toEqual({ action: 'validate', format: 'md', nonDefaultOnly: false });
     expect(() => parseConfigArgs(['unknown'])).toThrow(/unknown action/);
     expect(() => parseConfigArgs(['validate', '--format=yaml'])).toThrow(/invalid --format/);
+    expect(() => parseConfigArgs(['validate', '--non-default-only'])).toThrow(/only supported by show/);
   });
 
   it('writes JSON and exits 0 when the supplied dotenv file is valid', async () => {
@@ -86,6 +93,7 @@ describe('kb config validate (FR-OBS-470)', () => {
     });
     expect(help.status).toBe(0);
     expect(help.stdout).toContain('kb config validate');
+    expect(help.stdout).toContain('kb config show');
 
     const result = spawnSync('node', [cliPath, 'config', 'validate', '--format=json'], {
       env: { PATH: ORIGINAL_ENV.PATH ?? '', KB_LOG_FORMAT: 'text', KB_RERANK: 'maybe' },
@@ -123,5 +131,139 @@ describe('kb config validate (FR-OBS-470)', () => {
 
     expect(markdown).toContain('status: warn');
     expect(markdown).toContain('| KB_RELEVANCE_GATE | warn | dependency | on |');
+  });
+});
+
+describe('kb config show (#545)', () => {
+  it('parses the show action and supported flags', () => {
+    expect(parseConfigArgs(['show'])).toEqual({
+      action: 'show',
+      format: 'md',
+      nonDefaultOnly: false,
+    });
+    expect(parseConfigArgs(['show', '--format=json', '--non-default-only'])).toEqual({
+      action: 'show',
+      format: 'json',
+      nonDefaultOnly: true,
+    });
+    expect(() => parseConfigArgs(['show', '--format=text'])).toThrow(/invalid --format/);
+    expect(() => parseConfigArgs(['show', '--file=.env'])).toThrow(/only supported by validate/);
+  });
+
+  it('writes JSON with resolved values, sources, and redacted secrets', async () => {
+    process.env = {
+      PATH: ORIGINAL_ENV.PATH ?? '',
+      KNOWLEDGE_BASES_ROOT_DIR: '/tmp/kbs',
+      KB_RELEVANCE_GATE: 'on',
+      OPENAI_API_KEY: 'sk-proj-test-secret',
+      MCP_AUTH_TOKEN: 'a'.repeat(32),
+    };
+
+    await expect(runConfig(['show', '--format=json'])).resolves.toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.schema_version).toBe('kb.config-show.v1');
+    expect(parsed.entries).toEqual(expect.arrayContaining([
+      {
+        name: 'KNOWLEDGE_BASES_ROOT_DIR',
+        kind: 'path',
+        value: '/tmp/kbs',
+        source: 'env',
+        redacted: false,
+      },
+      {
+        name: 'FAISS_INDEX_PATH',
+        kind: 'path',
+        value: '/tmp/kbs/.faiss',
+        source: 'default',
+        redacted: false,
+      },
+      {
+        name: 'KB_RELEVANCE_GATE',
+        kind: 'boolean',
+        value: 'on',
+        source: 'env',
+        redacted: false,
+      },
+      {
+        name: 'OPENAI_API_KEY',
+        kind: 'secret',
+        value: '<redacted>',
+        source: 'env',
+        redacted: true,
+      },
+      {
+        name: 'MCP_AUTH_TOKEN',
+        kind: 'secret',
+        value: '<redacted>',
+        source: 'env',
+        redacted: true,
+      },
+    ]));
+    expect(stderr).toBe('');
+  });
+
+  it('is reachable through the top-level kb dispatcher', () => {
+    const result = spawnSync('node', [cliPath, 'config', 'show', '--format=json', '--non-default-only'], {
+      env: { PATH: ORIGINAL_ENV.PATH ?? '', KB_LOG_FORMAT: 'text', KB_RELEVANCE_GATE: 'on' },
+      encoding: 'utf-8',
+    });
+
+    expect(result.status).toBe(0);
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed).toMatchObject({
+      schema_version: 'kb.config-show.v1',
+    });
+    expect(parsed.entries).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        name: 'KB_RELEVANCE_GATE',
+        kind: 'boolean',
+        value: 'on',
+        source: 'env',
+        redacted: false,
+      }),
+    ]));
+  });
+
+  it('filters JSON output to env-sourced values with --non-default-only', async () => {
+    process.env = {
+      PATH: ORIGINAL_ENV.PATH ?? '',
+      KB_RELEVANCE_GATE: 'on',
+    };
+
+    await expect(runConfig(['show', '--format=json', '--non-default-only'])).resolves.toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.entries).toEqual([
+      {
+        name: 'KB_RELEVANCE_GATE',
+        kind: 'boolean',
+        value: 'on',
+        source: 'env',
+        redacted: false,
+      },
+    ]);
+  });
+
+  it('renders deterministic markdown entries', () => {
+    const markdown = formatConfigShowMarkdown({
+      schema_version: 'kb.config-show.v1',
+      entries: [
+        {
+          name: 'KB_RELEVANCE_GATE',
+          kind: 'boolean',
+          value: 'on',
+          source: 'env',
+          redacted: false,
+        },
+      ],
+    });
+
+    expect(markdown).toBe([
+      '# kb config show',
+      '',
+      '| Variable | Source | Kind | Value |',
+      '| --- | --- | --- | --- |',
+      '| KB_RELEVANCE_GATE | env | boolean | on |',
+      '',
+    ].join('\n'));
   });
 });

--- a/src/cli-config.ts
+++ b/src/cli-config.ts
@@ -2,8 +2,10 @@ import * as fsp from 'node:fs/promises';
 
 import {
   parseDotEnvText,
+  showConfigEnv,
   validateConfigEnv,
   type ConfigFinding,
+  type ConfigShowReport,
   type ConfigValidateReport,
 } from './config/schema.js';
 
@@ -11,14 +13,19 @@ export const CONFIG_HELP = `kb config — inspect and validate KB configuration
 
 Usage:
   kb config validate [--file=.env] [--format=md|json]
+  kb config show [--format=md|json] [--non-default-only]
 
 Validates known environment variables against the static KB config schema:
 type, enum membership, numeric ranges, URL syntax, and cross-variable
 dependencies. The command is read-only and does not probe live endpoints.
 
+Shows the effective value and source for every known configuration variable.
+Secrets such as API keys and MCP_AUTH_TOKEN are redacted.
+
 Options:
   --file=<path>             Parse this dotenv file instead of process.env.
   --format=md|json          Output format (default: md).
+  --non-default-only        For show, print only values supplied by env.
   --help, -h                Show this help.
 
 Exit codes:
@@ -28,9 +35,10 @@ Exit codes:
 `;
 
 export interface ConfigArgs {
-  action: 'validate';
+  action: 'validate' | 'show';
   file?: string;
   format: 'md' | 'json';
+  nonDefaultOnly: boolean;
 }
 
 export async function runConfig(rest: string[]): Promise<number> {
@@ -40,6 +48,16 @@ export async function runConfig(rest: string[]): Promise<number> {
   } catch (err) {
     process.stderr.write(`kb config: ${(err as Error).message}\n`);
     return 2;
+  }
+
+  if (parsed.action === 'show') {
+    const report = showConfigEnv(process.env, { nonDefaultOnly: parsed.nonDefaultOnly });
+    if (parsed.format === 'json') {
+      process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    } else {
+      process.stdout.write(formatConfigShowMarkdown(report));
+    }
+    return 0;
   }
 
   let env: NodeJS.ProcessEnv | Record<string, string | undefined> = process.env;
@@ -76,13 +94,13 @@ export async function runConfig(rest: string[]): Promise<number> {
 
 export function parseConfigArgs(rest: readonly string[]): ConfigArgs {
   if (rest.length === 0) {
-    throw new Error('expected action: validate');
+    throw new Error('expected action: validate or show');
   }
   const [action, ...args] = rest;
-  if (action !== 'validate') {
+  if (action !== 'validate' && action !== 'show') {
     throw new Error(`unknown action: ${action}`);
   }
-  const out: ConfigArgs = { action: 'validate', format: 'md' };
+  const out: ConfigArgs = { action, format: 'md', nonDefaultOnly: false };
   for (const raw of args) {
     if (raw === '--format=json') {
       out.format = 'json';
@@ -98,7 +116,13 @@ export function parseConfigArgs(rest: readonly string[]): ConfigArgs {
     if (raw.startsWith('--file=')) {
       const value = raw.slice('--file='.length);
       if (value.trim() === '') throw new Error('--file requires a path');
+      if (action !== 'validate') throw new Error('--file is only supported by validate');
       out.file = value;
+      continue;
+    }
+    if (raw === '--non-default-only') {
+      if (action !== 'show') throw new Error('--non-default-only is only supported by show');
+      out.nonDefaultOnly = true;
       continue;
     }
     throw new Error(`unknown flag: ${raw}`);
@@ -128,6 +152,25 @@ export function formatConfigValidateMarkdown(report: ConfigValidateReport): stri
       finding.message,
       '',
     ].map(escapeMarkdownTableCell).join(' | '));
+  }
+  return `${lines.join('\n')}\n`;
+}
+
+export function formatConfigShowMarkdown(report: ConfigShowReport): string {
+  const lines = [
+    '# kb config show',
+    '',
+    '| Variable | Source | Kind | Value |',
+    '| --- | --- | --- | --- |',
+  ];
+  for (const entry of report.entries) {
+    const cells = [
+      entry.name,
+      entry.source,
+      entry.kind,
+      entry.value ?? '',
+    ].map(escapeMarkdownTableCell);
+    lines.push(`| ${cells.join(' | ')} |`);
   }
   return `${lines.join('\n')}\n`;
 }

--- a/src/config/indexing.ts
+++ b/src/config/indexing.ts
@@ -4,8 +4,8 @@ import { EMBEDDING_PROVIDER } from './provider.js';
 // Indexing batch configuration (RFC 007 section6.2 / issue #236).
 // ---------------------------------------------------------------------------
 
-const DEFAULT_INDEXING_BATCH_SIZE = 64;
-const DEFAULT_OLLAMA_INDEXING_BATCH_SIZE = 16;
+export const DEFAULT_INDEXING_BATCH_SIZE = 64;
+export const DEFAULT_OLLAMA_INDEXING_BATCH_SIZE = 16;
 const MAX_INDEXING_BATCH_SIZE = 512;
 export const KB_INDEX_TYPE_ENV = 'KB_INDEX_TYPE';
 export type FaissIndexType = 'flat' | 'sq8';
@@ -13,9 +13,7 @@ export type FaissIndexType = 'flat' | 'sq8';
 export function resolveIndexingBatchSize(
   provider: string = EMBEDDING_PROVIDER,
 ): number {
-  const defaultForProvider = provider === 'ollama'
-    ? DEFAULT_OLLAMA_INDEXING_BATCH_SIZE
-    : DEFAULT_INDEXING_BATCH_SIZE;
+  const defaultForProvider = defaultIndexingBatchSize(provider);
   const raw = process.env.INDEXING_BATCH_SIZE;
   if (raw === undefined || raw.trim() === '') {
     return defaultForProvider;
@@ -28,6 +26,12 @@ export function resolveIndexingBatchSize(
 }
 
 export const INDEXING_BATCH_SIZE: number = resolveIndexingBatchSize();
+
+export function defaultIndexingBatchSize(provider: string): number {
+  return provider === 'ollama'
+    ? DEFAULT_OLLAMA_INDEXING_BATCH_SIZE
+    : DEFAULT_INDEXING_BATCH_SIZE;
+}
 
 export function resolveFaissIndexType(
   raw: string | undefined = process.env[KB_INDEX_TYPE_ENV],

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -1,8 +1,15 @@
 import * as os from 'os';
 import * as path from 'path';
 
-export const KNOWLEDGE_BASES_ROOT_DIR = process.env.KNOWLEDGE_BASES_ROOT_DIR
-  || path.join(os.homedir(), 'knowledge_bases');
+export function resolveKnowledgeBasesRootDir(raw: string | undefined): string {
+  return raw || path.join(os.homedir(), 'knowledge_bases');
+}
 
-export const DEFAULT_FAISS_INDEX_PATH = path.join(KNOWLEDGE_BASES_ROOT_DIR, '.faiss');
+export function defaultFaissIndexPath(rootDir: string): string {
+  return path.join(rootDir, '.faiss');
+}
+
+export const KNOWLEDGE_BASES_ROOT_DIR = resolveKnowledgeBasesRootDir(process.env.KNOWLEDGE_BASES_ROOT_DIR);
+
+export const DEFAULT_FAISS_INDEX_PATH = defaultFaissIndexPath(KNOWLEDGE_BASES_ROOT_DIR);
 export const FAISS_INDEX_PATH = process.env.FAISS_INDEX_PATH || DEFAULT_FAISS_INDEX_PATH;

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from '@jest/globals';
 
-import { parseDotEnvText, validateConfigEnv } from './schema.js';
+import { CONFIG_SCHEMA, parseDotEnvText, showConfigEnv, validateConfigEnv } from './schema.js';
 
 describe('config schema validation (FR-OBS-470)', () => {
   it('emits ok findings and counts for valid known environment variables', () => {
@@ -67,6 +67,22 @@ describe('config schema validation (FR-OBS-470)', () => {
     ]));
   });
 
+  it('matches the runtime KB_INDEX_TYPE parser for case-insensitive values', () => {
+    const validation = validateConfigEnv({
+      KB_INDEX_TYPE: ' SQ8 ',
+    });
+    const show = showConfigEnv({
+      KB_INDEX_TYPE: ' SQ8 ',
+    });
+
+    expect(validation.findings).toEqual(expect.arrayContaining([
+      expect.objectContaining({ name: 'KB_INDEX_TYPE', status: 'ok', value: 'sq8' }),
+    ]));
+    expect(show.entries).toEqual(expect.arrayContaining([
+      expect.objectContaining({ name: 'KB_INDEX_TYPE', value: 'sq8', source: 'env' }),
+    ]));
+  });
+
   it('emits static dependency findings without probing live endpoints', () => {
     const report = validateConfigEnv({
       KB_RELEVANCE_GATE: 'on',
@@ -113,5 +129,90 @@ describe('config schema validation (FR-OBS-470)', () => {
       EMPTY: '',
     });
     expect(parsed.errors).toEqual([]);
+  });
+
+  it('emits effective config entries with env/default provenance', () => {
+    const report = showConfigEnv({
+      EMBEDDING_PROVIDER: 'ollama',
+      KNOWLEDGE_BASES_ROOT_DIR: '/tmp/kbs',
+      HUGGINGFACE_API_KEY: 'hf_secret',
+    });
+
+    expect(report.schema_version).toBe('kb.config-show.v1');
+    expect(report.entries.map((entry) => entry.name)).toEqual(CONFIG_SCHEMA.map((spec) => spec.name));
+    expect(report.entries).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        name: 'KNOWLEDGE_BASES_ROOT_DIR',
+        value: '/tmp/kbs',
+        source: 'env',
+        redacted: false,
+      }),
+      expect.objectContaining({
+        name: 'FAISS_INDEX_PATH',
+        value: '/tmp/kbs/.faiss',
+        source: 'default',
+        redacted: false,
+      }),
+      expect.objectContaining({
+        name: 'INDEXING_BATCH_SIZE',
+        value: '16',
+        source: 'default',
+        redacted: false,
+      }),
+      expect.objectContaining({
+        name: 'HUGGINGFACE_API_KEY',
+        value: '<redacted>',
+        source: 'env',
+        redacted: true,
+      }),
+      expect.objectContaining({
+        name: 'KB_CONTEXTUAL_MAX_TOKENS',
+        value: '150',
+        source: 'default',
+        redacted: false,
+      }),
+      expect.objectContaining({
+        name: 'KB_INGEST_SECRET_SCAN',
+        value: 'off',
+        source: 'default',
+        redacted: false,
+      }),
+    ]));
+  });
+
+  it('uses runtime defaults for empty string values that runtime treats as unset', () => {
+    const report = showConfigEnv({
+      HUGGINGFACE_MODEL_NAME: '',
+    });
+
+    expect(report.entries).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        name: 'HUGGINGFACE_MODEL_NAME',
+        value: 'BAAI/bge-small-en-v1.5',
+        source: 'default',
+      }),
+      expect.objectContaining({
+        name: 'HUGGINGFACE_ENDPOINT_URL',
+        value: 'https://router.huggingface.co/hf-inference/models/BAAI/bge-small-en-v1.5/pipeline/feature-extraction',
+        source: 'default',
+      }),
+    ]));
+  });
+
+  it('filters effective config entries to non-default values', () => {
+    const report = showConfigEnv({
+      KB_RELEVANCE_GATE: 'on',
+      KB_QUERY_CACHE: '',
+    }, { nonDefaultOnly: true });
+
+    expect(report.entries).toEqual([
+      {
+        name: 'KB_RELEVANCE_GATE',
+        kind: 'boolean',
+        value: 'on',
+        source: 'env',
+        redacted: false,
+      },
+    ]);
   });
 });

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1,3 +1,20 @@
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import {
+  DEFAULT_ASK_KNOWLEDGE_DESCRIPTION,
+  DEFAULT_KB_STATS_DESCRIPTION,
+  DEFAULT_LIST_KNOWLEDGE_BASES_DESCRIPTION,
+  DEFAULT_LIST_MODELS_DESCRIPTION,
+  DEFAULT_RETRIEVE_KNOWLEDGE_DESCRIPTION,
+} from './mcp-descriptions.js';
+import {
+  defaultFaissIndexPath,
+  resolveKnowledgeBasesRootDir,
+} from './paths.js';
+import {
+  defaultIndexingBatchSize,
+} from './indexing.js';
 import {
   DEFAULT_HUGGINGFACE_MODEL_NAME,
   DEFAULT_OPENAI_MODEL_NAME,
@@ -42,6 +59,21 @@ export interface ConfigValidateReport {
   findings: ConfigFinding[];
 }
 
+export type ConfigValueSource = 'env' | 'default';
+
+export interface ConfigShowEntry {
+  name: string;
+  kind: ConfigValueKind;
+  value: string | null;
+  source: ConfigValueSource;
+  redacted: boolean;
+}
+
+export interface ConfigShowReport {
+  schema_version: 'kb.config-show.v1';
+  entries: ConfigShowEntry[];
+}
+
 export interface DotEnvParseResult {
   env: Record<string, string>;
   errors: ConfigFinding[];
@@ -63,6 +95,9 @@ interface BaseSpec<K extends ConfigValueKind> {
   name: string;
   kind: K;
   default?: string;
+  defaultValue?: (env: NodeJS.ProcessEnv | Record<string, string | undefined>) => string | null;
+  emptyUsesDefault?: boolean;
+  normalize?: (value: string) => string;
   min?: number;
   max?: number;
   secret?: boolean;
@@ -103,30 +138,33 @@ const CONTROLLED_PREFIXES = [
 ];
 
 export const CONFIG_SCHEMA: readonly ConfigSpec[] = [
-  { name: 'KNOWLEDGE_BASES_ROOT_DIR', kind: 'path', default: '~/knowledge_bases' },
-  { name: 'FAISS_INDEX_PATH', kind: 'path', default: '$KNOWLEDGE_BASES_ROOT_DIR/.faiss' },
+  { name: 'KNOWLEDGE_BASES_ROOT_DIR', kind: 'path', defaultValue: (env) => resolveKnowledgeBasesRootDir(env.KNOWLEDGE_BASES_ROOT_DIR) },
+  { name: 'FAISS_INDEX_PATH', kind: 'path', defaultValue: (env) => defaultFaissIndexPath(effectiveStringValue(env, 'KNOWLEDGE_BASES_ROOT_DIR', resolveKnowledgeBasesRootDir(undefined))) },
+  { name: 'KB_INDEX_TYPE', kind: 'enum', values: ['flat', 'sq8'], default: 'flat', normalize: lowercase },
   { name: 'EMBEDDING_PROVIDER', kind: 'enum', values: [...KNOWN_EMBEDDING_PROVIDERS], default: 'huggingface' },
   { name: 'KB_ACTIVE_MODEL', kind: 'string' },
   { name: 'KB_FAKE_DIM', kind: 'integer', default: '256', min: 8, max: 4096 },
 
   { name: 'HUGGINGFACE_API_KEY', kind: 'secret', secret: true },
-  { name: 'HUGGINGFACE_MODEL_NAME', kind: 'string', default: DEFAULT_HUGGINGFACE_MODEL_NAME },
-  { name: 'HUGGINGFACE_PROVIDER', kind: 'string', default: 'hf-inference' },
-  { name: 'HUGGINGFACE_ENDPOINT_URL', kind: 'url', protocols: ['http:', 'https:'] },
+  { name: 'HUGGINGFACE_MODEL_NAME', kind: 'string', default: DEFAULT_HUGGINGFACE_MODEL_NAME, emptyUsesDefault: true },
+  { name: 'HUGGINGFACE_PROVIDER', kind: 'string', default: 'hf-inference', emptyUsesDefault: true },
+  { name: 'HUGGINGFACE_ENDPOINT_URL', kind: 'url', defaultValue: (env) => `https://router.huggingface.co/hf-inference/models/${effectiveValue(env, 'HUGGINGFACE_MODEL_NAME')}/pipeline/feature-extraction`, protocols: ['http:', 'https:'] },
   { name: 'OLLAMA_BASE_URL', kind: 'url', default: 'http://localhost:11434', protocols: ['http:', 'https:'] },
-  { name: 'OLLAMA_MODEL', kind: 'string', default: 'dengcao/Qwen3-Embedding-0.6B:Q8_0' },
+  { name: 'OLLAMA_MODEL', kind: 'string', default: 'dengcao/Qwen3-Embedding-0.6B:Q8_0', emptyUsesDefault: true },
   { name: 'OPENAI_API_KEY', kind: 'secret', secret: true },
-  { name: 'OPENAI_MODEL_NAME', kind: 'string', default: DEFAULT_OPENAI_MODEL_NAME },
+  { name: 'OPENAI_MODEL_NAME', kind: 'string', default: DEFAULT_OPENAI_MODEL_NAME, emptyUsesDefault: true },
 
-  { name: 'INDEXING_BATCH_SIZE', kind: 'integer', min: 1, max: 512 },
-  { name: 'KB_CHUNK_SIZE', kind: 'integer', min: 1 },
-  { name: 'KB_CHUNK_OVERLAP', kind: 'integer', min: 0 },
-  { name: 'INGEST_EXTRA_EXTENSIONS', kind: 'csv' },
-  { name: 'INGEST_EXCLUDE_PATHS', kind: 'csv' },
-  { name: 'KB_MAX_FILE_BYTES', kind: 'integer', min: 1 },
-  { name: 'KB_MAX_EXTRACTED_TEXT_BYTES', kind: 'integer', min: 1 },
+  { name: 'INDEXING_BATCH_SIZE', kind: 'integer', defaultValue: (env) => String(defaultIndexingBatchSize(effectiveStringValue(env, 'EMBEDDING_PROVIDER', 'huggingface'))), min: 1, max: 512 },
+  { name: 'KB_CHUNK_SIZE', kind: 'integer', default: '1000', min: 1 },
+  { name: 'KB_CHUNK_OVERLAP', kind: 'integer', defaultValue: (env) => defaultChunkOverlap(env), min: 0 },
+  { name: 'INGEST_EXTRA_EXTENSIONS', kind: 'csv', default: '' },
+  { name: 'INGEST_EXCLUDE_PATHS', kind: 'csv', default: '' },
+  { name: 'KB_MAX_FILE_BYTES', kind: 'integer', default: String(100 * 1024 * 1024), min: 1 },
+  { name: 'KB_MAX_EXTRACTED_TEXT_BYTES', kind: 'integer', default: String(16 * 1024 * 1024), min: 1 },
   { name: 'KB_LARGE_FILE_POLICY', kind: 'enum', values: ['skip', 'truncate', 'error'], default: 'skip' },
-  { name: 'KB_REFRESH_QUIESCE_MS', kind: 'duration', min: 0 },
+  { name: 'KB_REFRESH_QUIESCE_MS', kind: 'duration', default: '0', min: 0 },
+  { name: 'KB_INGEST_SECRET_SCAN', kind: 'boolean', default: 'off', booleanValues: YES_NO_BOOL_VALUES, truthyValues: YES_NO_TRUTHY_VALUES },
+  { name: 'KB_SECRET_SCAN_BYPASS_KBS', kind: 'csv', default: '' },
 
   { name: 'KB_QUERY_CACHE', kind: 'boolean', default: 'on', booleanValues: QUERY_CACHE_BOOL_VALUES, truthyValues: ['on', 'true', '1', 'yes', 'enabled'] },
   { name: 'KB_QUERY_CACHE_LRU_MAX', kind: 'integer', default: '256', min: 0 },
@@ -140,13 +178,13 @@ export const CONFIG_SCHEMA: readonly ConfigSpec[] = [
   { name: 'KB_LLM_PROVIDER', kind: 'enum', values: ['local', 'openrouter'], default: 'local' },
   { name: 'KB_OPENROUTER_API_KEY', kind: 'secret', secret: true },
   { name: 'OPENROUTER_API_KEY', kind: 'secret', secret: true },
-  { name: 'KB_LLM_APP_TITLE', kind: 'string', default: 'knowledge-base-mcp' },
+  { name: 'KB_LLM_APP_TITLE', kind: 'string', default: 'knowledge-base-mcp', emptyUsesDefault: true },
   { name: 'KB_LLM_HTTP_REFERER', kind: 'string' },
   { name: 'KB_LLM_FAKE', kind: 'boolean', default: 'off', booleanValues: YES_NO_BOOL_VALUES, truthyValues: YES_NO_TRUTHY_VALUES },
   { name: 'KB_LLM_FAKE_RULES', kind: 'path' },
-  { name: 'KB_LLM_CONFIG_DIR', kind: 'path' },
-  { name: 'KB_LLM_STATE_DIR', kind: 'path' },
-  { name: 'KB_LLM_SYSTEMD_USER_DIR', kind: 'path' },
+  { name: 'KB_LLM_CONFIG_DIR', kind: 'path', defaultValue: (env) => path.join(env.XDG_CONFIG_HOME || path.join(os.homedir(), '.config'), 'kb', 'llm') },
+  { name: 'KB_LLM_STATE_DIR', kind: 'path', defaultValue: (env) => path.join(env.XDG_STATE_HOME || path.join(os.homedir(), '.local', 'state'), 'kb', 'llm') },
+  { name: 'KB_LLM_SYSTEMD_USER_DIR', kind: 'path', defaultValue: (env) => path.join(env.XDG_CONFIG_HOME || path.join(os.homedir(), '.config'), 'systemd', 'user') },
 
   { name: 'KB_RELEVANCE_GATE', kind: 'boolean', default: 'off', booleanValues: YES_NO_BOOL_VALUES, truthyValues: YES_NO_TRUTHY_VALUES },
   { name: 'KB_GATE_EMPTY_VERDICT', kind: 'boolean', default: 'off', booleanValues: YES_NO_BOOL_VALUES, truthyValues: YES_NO_TRUTHY_VALUES },
@@ -174,11 +212,13 @@ export const CONFIG_SCHEMA: readonly ConfigSpec[] = [
   { name: 'LOG_LEVEL', kind: 'enum', values: ['debug', 'info', 'warn', 'error'], default: 'info' },
   { name: 'LOG_FILE', kind: 'path' },
   { name: 'KB_LOG_VERBOSE', kind: 'boolean', default: 'off' },
+  { name: 'KB_SLOW_QUERY_MS', kind: 'duration', min: 1 },
+  { name: 'KB_METRICS_EXPORT', kind: 'boolean', default: 'off', booleanValues: YES_NO_BOOL_VALUES, truthyValues: YES_NO_TRUTHY_VALUES },
   { name: 'KB_MUTATION_AUDIT_LOG', kind: 'path' },
   { name: 'KB_AGE_BUDGET_HOURS', kind: 'integer', min: 1 },
 
   { name: 'KB_DAEMON_URL', kind: 'url', protocols: ['http:', 'https:'] },
-  { name: 'KB_DAEMON_HOST', kind: 'string', default: '127.0.0.1' },
+  { name: 'KB_DAEMON_HOST', kind: 'string', default: '127.0.0.1', emptyUsesDefault: true },
   { name: 'KB_DAEMON_PORT', kind: 'integer', default: '17799', min: 1, max: 65535 },
   { name: 'MCP_TRANSPORT', kind: 'enum', values: ['stdio', 'sse', 'http'], default: 'stdio' },
   { name: 'MCP_PORT', kind: 'integer', default: '8765', min: 1, max: 65535 },
@@ -189,16 +229,17 @@ export const CONFIG_SCHEMA: readonly ConfigSpec[] = [
   { name: 'MCP_AUTH_BACKOFF_MS', kind: 'duration', default: '30000', min: 0 },
   { name: 'MCP_AUTH_BACKOFF_MAX_ENTRIES', kind: 'integer', default: '1024', min: 1 },
 
-  { name: 'REINDEX_TRIGGER_PATH', kind: 'path' },
+  { name: 'REINDEX_TRIGGER_PATH', kind: 'path', defaultValue: (env) => path.join(effectiveStringValue(env, 'KNOWLEDGE_BASES_ROOT_DIR', resolveKnowledgeBasesRootDir(undefined)), '.reindex-trigger') },
   { name: 'REINDEX_TRIGGER_POLL_MS', kind: 'duration', default: '5000', min: 0, max: 60000 },
   { name: 'KB_FS_WATCH', kind: 'boolean', default: 'off', booleanValues: YES_NO_BOOL_VALUES, truthyValues: YES_NO_TRUTHY_VALUES },
   { name: 'KB_FS_WATCH_DEBOUNCE_MS', kind: 'duration', default: '250', min: 25, max: 60000 },
   { name: 'KB_INDEX_VERSION_RETENTION', kind: 'integer', default: '2', min: 0, integerSyntax: 'digits' },
 
-  { name: 'RETRIEVE_KNOWLEDGE_DESCRIPTION', kind: 'string' },
-  { name: 'LIST_KNOWLEDGE_BASES_DESCRIPTION', kind: 'string' },
-  { name: 'LIST_MODELS_DESCRIPTION', kind: 'string' },
-  { name: 'KB_STATS_DESCRIPTION', kind: 'string' },
+  { name: 'RETRIEVE_KNOWLEDGE_DESCRIPTION', kind: 'string', default: DEFAULT_RETRIEVE_KNOWLEDGE_DESCRIPTION, emptyUsesDefault: true },
+  { name: 'ASK_KNOWLEDGE_DESCRIPTION', kind: 'string', default: DEFAULT_ASK_KNOWLEDGE_DESCRIPTION, emptyUsesDefault: true },
+  { name: 'LIST_KNOWLEDGE_BASES_DESCRIPTION', kind: 'string', default: DEFAULT_LIST_KNOWLEDGE_BASES_DESCRIPTION, emptyUsesDefault: true },
+  { name: 'LIST_MODELS_DESCRIPTION', kind: 'string', default: DEFAULT_LIST_MODELS_DESCRIPTION, emptyUsesDefault: true },
+  { name: 'KB_STATS_DESCRIPTION', kind: 'string', default: DEFAULT_KB_STATS_DESCRIPTION, emptyUsesDefault: true },
 ] as const;
 
 const SCHEMA_BY_NAME = new Map(CONFIG_SCHEMA.map((spec) => [spec.name, spec]));
@@ -210,12 +251,12 @@ export function validateConfigEnv(
   const source = options.source ?? 'process.env';
   const findings: ConfigFinding[] = [];
   for (const spec of CONFIG_SCHEMA) {
-    findings.push(validateSpec(spec, env[spec.name], source));
+    findings.push(validateSpec(spec, env[spec.name], source, env));
   }
   for (const [name, raw] of Object.entries(env).sort(([a], [b]) => a.localeCompare(b))) {
     if (SCHEMA_BY_NAME.has(name)) continue;
     const spec = dynamicSpecForName(name);
-    if (spec !== null) findings.push(validateSpec(spec, raw, source));
+    if (spec !== null) findings.push(validateSpec(spec, raw, source, env));
   }
   findings.push(...validateDependencies(env, source));
   findings.push(...validateUnknownControlledVars(env, source));
@@ -229,6 +270,20 @@ export function validateConfigEnv(
     checked_at: (options.now ?? (() => new Date()))().toISOString(),
     counts,
     findings,
+  };
+}
+
+export function showConfigEnv(
+  env: NodeJS.ProcessEnv | Record<string, string | undefined>,
+  options: { nonDefaultOnly?: boolean } = {},
+): ConfigShowReport {
+  const entries = CONFIG_SCHEMA
+    .map((spec) => showSpec(spec, env))
+    .filter((entry) => !options.nonDefaultOnly || entry.source !== 'default');
+
+  return {
+    schema_version: 'kb.config-show.v1',
+    entries,
   };
 }
 
@@ -271,15 +326,21 @@ export function parseDotEnvText(text: string, source = '.env'): DotEnvParseResul
   return { env, errors };
 }
 
-function validateSpec(spec: ConfigSpec, raw: string | undefined, source: string): ConfigFinding {
-  const value = normalizeRaw(raw);
+function validateSpec(
+  spec: ConfigSpec,
+  raw: string | undefined,
+  source: string,
+  env: NodeJS.ProcessEnv | Record<string, string | undefined>,
+): ConfigFinding {
+  const value = normalizeSpecValue(spec, normalizeRaw(raw));
   const displayValue = displayRawValue(spec, value);
+  const defaultValue = defaultForSpec(spec, env);
   if (value === undefined) {
-    return finding(spec.name, 'ok', spec.kind, source, null, spec.default === undefined
+    return finding(spec.name, 'ok', spec.kind, source, null, defaultValue === null
       ? 'unset'
-      : `unset; default ${spec.default} applies`);
+      : `unset; default ${defaultValue} applies`);
   }
-  if (value === '' && spec.kind !== 'string' && spec.kind !== 'secret') {
+  if (value === '' && usesDefaultForEmpty(spec)) {
     return finding(spec.name, 'ok', spec.kind, source, displayValue, 'empty; default applies');
   }
 
@@ -308,6 +369,21 @@ function validateSpec(spec: ConfigSpec, raw: string | undefined, source: string)
     case 'string':
       return finding(spec.name, 'ok', spec.kind, source, displayValue, value === '' ? 'empty string' : 'set');
   }
+}
+
+function showSpec(
+  spec: ConfigSpec,
+  env: NodeJS.ProcessEnv | Record<string, string | undefined>,
+): ConfigShowEntry {
+  const value = effectiveValue(env, spec.name);
+  const redacted = isSecretSpec(spec) && value !== null && value !== '';
+  return {
+    name: spec.name,
+    kind: spec.kind,
+    value: redacted ? '<redacted>' : value,
+    source: sourceForSpec(spec, env),
+    redacted,
+  };
 }
 
 function validateNumberLike(
@@ -466,6 +542,65 @@ function normalizeRaw(raw: string | undefined): string | undefined {
   return raw === undefined ? undefined : raw.trim();
 }
 
+function effectiveValue(
+  env: NodeJS.ProcessEnv | Record<string, string | undefined>,
+  name: string,
+): string | null {
+  const spec = SCHEMA_BY_NAME.get(name);
+  if (spec === undefined) return null;
+  const value = normalizeSpecValue(spec, normalizeRaw(env[name]));
+  if (value === undefined) return defaultForSpec(spec, env);
+  if (value === '' && usesDefaultForEmpty(spec)) {
+    return defaultForSpec(spec, env);
+  }
+  return value;
+}
+
+function effectiveStringValue(
+  env: NodeJS.ProcessEnv | Record<string, string | undefined>,
+  name: string,
+  fallback: string,
+): string {
+  return effectiveValue(env, name) ?? fallback;
+}
+
+function sourceForSpec(
+  spec: ConfigSpec,
+  env: NodeJS.ProcessEnv | Record<string, string | undefined>,
+): ConfigValueSource {
+  const value = normalizeSpecValue(spec, normalizeRaw(env[spec.name]));
+  if (value === undefined) return 'default';
+  if (value === '' && usesDefaultForEmpty(spec)) return 'default';
+  return 'env';
+}
+
+function defaultForSpec(
+  spec: ConfigSpec,
+  env: NodeJS.ProcessEnv | Record<string, string | undefined>,
+): string | null {
+  if (spec.defaultValue !== undefined) return spec.defaultValue(env);
+  return spec.default ?? null;
+}
+
+function defaultChunkOverlap(env: NodeJS.ProcessEnv | Record<string, string | undefined>): string {
+  const size = Number(effectiveValue(env, 'KB_CHUNK_SIZE'));
+  if (!Number.isFinite(size) || size <= 0 || Math.floor(size) === 1000) return '200';
+  return String(Math.floor(Math.floor(size) / 5));
+}
+
+function normalizeSpecValue(spec: ConfigSpec, value: string | undefined): string | undefined {
+  if (value === undefined) return undefined;
+  return spec.normalize?.(value) ?? value;
+}
+
+function usesDefaultForEmpty(spec: ConfigSpec): boolean {
+  return spec.emptyUsesDefault === true || (spec.kind !== 'string' && spec.kind !== 'secret');
+}
+
+function lowercase(value: string): string {
+  return value.toLowerCase();
+}
+
 function isOn(name: string, raw: string | undefined): boolean {
   const spec = SCHEMA_BY_NAME.get(name);
   const normalized = normalizeRaw(raw)?.toLowerCase();
@@ -480,10 +615,16 @@ function isNonEmpty(raw: string | undefined): boolean {
 
 function displayRawValue(spec: Pick<ConfigSpec, 'kind' | 'name' | 'secret'>, value: string | undefined): string | null {
   if (value === undefined) return null;
-  if (spec.secret || spec.kind === 'secret' || /TOKEN|KEY|SECRET/.test(spec.name)) {
+  if (isSecretSpec(spec)) {
     return value === '' ? '' : '<redacted>';
   }
   return value;
+}
+
+function isSecretSpec(spec: Pick<ConfigSpec, 'kind' | 'name' | 'secret'>): boolean {
+  return Boolean(spec.secret)
+    || spec.kind === 'secret'
+    || /(?:^|_)(?:API_KEY|ACCESS_TOKEN|AUTH_TOKEN|REFRESH_TOKEN|SESSION_TOKEN|PRIVATE_KEY|CLIENT_SECRET|SECRET|PASSWORD|PASSWD|COOKIE)$/.test(spec.name);
 }
 
 function booleanValuesFor(spec: Pick<BaseSpec<'boolean'>, 'booleanValues'>): Set<string> {


### PR DESCRIPTION
Closes #545.

## Summary
- adds `kb config show [--format=md|json] [--non-default-only]` under the existing config command
- reports schema-backed effective values with `env`/`default` provenance
- redacts credential-shaped config values while leaving non-secret token-count settings visible
- expands the schema defaults used by config introspection, including transport and path/indexing defaults

## Verification
- `npm test -- /home/jean/git/knowledge-base-mcp-server-config-show-545/src/cli-config.test.ts /home/jean/git/knowledge-base-mcp-server-config-show-545/src/config.test.ts /home/jean/git/knowledge-base-mcp-server-config-show-545/src/config/schema.test.ts`
- `npm run build`
- `node /home/jean/git/knowledge-base-mcp-server-config-show-545/build/cli.js config show --format=json`
- `KB_RELEVANCE_GATE=on node /home/jean/git/knowledge-base-mcp-server-config-show-545/build/cli.js config show --non-default-only`
- `git diff --check`

## Review
- pre-PR specialist review run: correctness, conventions, dead-code, tests
- addressed reviewer findings for `KB_INDEX_TYPE` normalization, empty string runtime defaults, dispatcher coverage, full-schema coverage, and `--format` help/parser alignment