### PR TITLE
Cache lexical indexes in kb serve

### DIFF
--- a/src/cli-search.test.ts
+++ b/src/cli-search.test.ts
@@ -1271,6 +1271,7 @@ describe('runSearch timing guard (#331)', () => {
       loadManagerForModel: jest.fn(async () => manager),
       loadWithJsonRetry: jest.fn(async () => {}),
       listLexicalKbs: jest.fn(async () => [{ kbName: 'alpha', kbPath: '/kb/alpha' }]),
+      loadLexicalIndex: jest.fn(async () => ({ numFiles: () => 1 } as unknown as LexicalIndex)),
       runLexicalLeg: jest.fn(async () => ({
         refreshed: 0,
         failed: 0,
@@ -1289,7 +1290,52 @@ describe('runSearch timing guard (#331)', () => {
     expect(deps.runLexicalLeg).toHaveBeenCalledWith(expect.objectContaining({
       query: 'query',
       rankingUnit: 'source',
+      loadIndex: deps.loadLexicalIndex,
     }));
+  });
+
+  it('runs the hybrid lexical leg through an injected lexical index loader', async () => {
+    const { deps, manager } = makeDeps();
+    manager.similaritySearch = jest.fn(async (...args: unknown[]) => {
+      const timing = args[5] as SimilaritySearchTiming | undefined;
+      if (timing) timing.faiss_search_ms = 1;
+      return [];
+    });
+    const lexicalIndex = {
+      numFiles: jest.fn(() => 1),
+      refresh: jest.fn(async () => ({ added: 0, updated: 0, removed: 0, failed: 0, totalFiles: 1, totalChunks: 1 })),
+      save: jest.fn(async () => {}),
+      query: jest.fn(async () => [
+        {
+          pageContent: 'Warm lexical result',
+          metadata: {
+            source: '/kb/alpha/warm.md',
+            knowledgeBase: 'alpha',
+            relativePath: 'alpha/warm.md',
+            chunkIndex: 0,
+          },
+          score: 7,
+        },
+      ]),
+    } as unknown as LexicalIndex;
+    deps.listLexicalKbs = jest.fn(async () => [{ kbName: 'alpha', kbPath: '/kb/alpha' }]);
+    deps.loadLexicalIndex = jest.fn(async () => lexicalIndex);
+
+    const out = await captureSearchOutput(
+      ['query', '--mode=hybrid', '--format=json', '--k=1', '--no-freshness'],
+      deps,
+    );
+
+    expect(out.code).toBe(0);
+    const payload = JSON.parse(out.stdout) as {
+      results: Array<{ content: string; metadata: { relativePath: string } }>;
+      retrievers: { lexical: { fetched: number; refreshed: number; failed: number } };
+    };
+    expect(deps.loadLexicalIndex).toHaveBeenCalledWith('alpha', '/kb/alpha');
+    expect(lexicalIndex.query).toHaveBeenCalledWith('query', 4, { unit: 'chunk' });
+    expect(lexicalIndex.refresh).not.toHaveBeenCalled();
+    expect(payload.retrievers.lexical).toMatchObject({ fetched: 1, refreshed: 0, failed: 0 });
+    expect(payload.results[0]?.metadata.relativePath).toBe('alpha/warm.md');
   });
 
   it('includes gate_verdict in JSON output when --gate is used', async () => {

--- a/src/cli-search.ts
+++ b/src/cli-search.ts
@@ -306,6 +306,10 @@ const DEFAULT_RUN_SEARCH_DEPS: RunSearchDeps = {
   runLexicalLeg,
 };
 
+export function createRunSearchDeps(overrides: Partial<RunSearchDeps> = {}): RunSearchDeps {
+  return { ...DEFAULT_RUN_SEARCH_DEPS, ...overrides };
+}
+
 export async function runSearch(
   rest: string[],
   deps: RunSearchDeps = DEFAULT_RUN_SEARCH_DEPS,
@@ -2285,6 +2289,7 @@ async function runHybridSearch(
     fetchK,
     refresh: parsed.refresh ? 'always' : 'when-empty',
     rankingUnit: parsed.lexicalUnit,
+    loadIndex: deps.loadLexicalIndex,
     onError: (kbName, err) => {
       process.stderr.write(`kb search (hybrid lexical leg): ${kbName} — ${err.message}\n`);
     },

--- a/src/cli-serve.test.ts
+++ b/src/cli-serve.test.ts
@@ -1,6 +1,7 @@
-import { afterEach, describe, expect, it } from '@jest/globals';
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
 import * as http from 'node:http';
 import {
+  createDaemonCommandHandlers,
   formatStatsRunResultAsOpenMetrics,
   parseServeArgs,
   runServeStatus,
@@ -8,6 +9,8 @@ import {
 } from './cli-serve.js';
 import type { DaemonRunResult } from './daemon-client.js';
 import type { KbStatsPayload } from './kb-stats.js';
+import type { RunSearchDeps } from './cli-search.js';
+import type { LexicalIndex } from './lexical-index.js';
 
 interface RawResponse {
   statusCode: number;
@@ -111,6 +114,24 @@ describe('kb serve daemon', () => {
     } finally {
       await daemon.stop();
     }
+  });
+
+  it('injects a cached lexical loader into daemon-served search', async () => {
+    const lexicalIndex = { numFiles: () => 1 } as unknown as LexicalIndex;
+    const lexicalIndexLoader = jest.fn(async () => lexicalIndex);
+    const runSearchImpl = jest.fn(async (_args: string[], deps: RunSearchDeps = {} as RunSearchDeps) => {
+      await expect(deps.loadLexicalIndex?.('alpha', '/kb/alpha')).resolves.toBe(lexicalIndex);
+      return 0;
+    });
+    const handlers = createDaemonCommandHandlers({ lexicalIndexLoader, runSearchImpl });
+
+    const result = await handlers.search(['query', '--mode=hybrid']);
+
+    expect(result).toEqual({ exitCode: 0, stdout: '', stderr: '' });
+    expect(runSearchImpl).toHaveBeenCalledWith(['query', '--mode=hybrid'], expect.objectContaining({
+      loadLexicalIndex: lexicalIndexLoader,
+    }));
+    expect(lexicalIndexLoader).toHaveBeenCalledWith('alpha', '/kb/alpha');
   });
 
   it('exposes OpenMetrics text only when KB_METRICS_EXPORT is enabled', async () => {

--- a/src/cli-serve.ts
+++ b/src/cli-serve.ts
@@ -1,7 +1,7 @@
 import * as http from 'node:http';
 import type { AddressInfo } from 'node:net';
 import { runList } from './cli-list.js';
-import { runSearch } from './cli-search.js';
+import { createRunSearchDeps, runSearch, type RunSearchDeps } from './cli-search.js';
 import { captureProcessOutput } from './cli-shared.js';
 import { runStats } from './cli-stats.js';
 import {
@@ -17,6 +17,8 @@ import {
 } from './daemon-client.js';
 import { formatKbStatsOpenMetrics } from './prometheus-export.js';
 import type { KbStatsPayload } from './kb-stats.js';
+import { LexicalIndexCache } from './lexical-index-cache.js';
+import type { LexicalIndex } from './lexical-index.js';
 
 export const SERVE_HELP = `kb serve — resident local daemon for warm CLI reads
 
@@ -72,6 +74,13 @@ export interface DaemonCommandHandlers {
 export interface StartDaemonServerOptions extends Partial<ServeArgs> {
   handlers?: DaemonCommandHandlers;
   metricsHandler?: () => Promise<string>;
+}
+
+export interface DaemonCommandHandlerOptions {
+  lexicalIndexLoader?: (kbName: string, kbPath: string) => Promise<LexicalIndex>;
+  runSearchImpl?: typeof runSearch;
+  runListImpl?: typeof runList;
+  runStatsImpl?: typeof runStats;
 }
 
 export interface ResidentDaemon {
@@ -207,7 +216,7 @@ export async function startDaemonServer(
     idleTimeoutMs: options.idleTimeoutMs ?? DEFAULT_SERVE_ARGS.idleTimeoutMs,
   };
   assertLoopbackHost(parsed.host);
-  const handlers = options.handlers ?? defaultHandlers();
+  const handlers = options.handlers ?? createDaemonCommandHandlers();
   const metricsHandler = options.metricsHandler ?? defaultMetricsHandler;
   let idleTimer: NodeJS.Timeout | undefined;
   let queue: Promise<void> = Promise.resolve();
@@ -315,11 +324,17 @@ export function parseServeArgs(rest: string[]): ServeArgs {
   return out;
 }
 
-function defaultHandlers(): DaemonCommandHandlers {
+export function createDaemonCommandHandlers(options: DaemonCommandHandlerOptions = {}): DaemonCommandHandlers {
+  const cache = new LexicalIndexCache();
+  const loadLexicalIndex = options.lexicalIndexLoader ?? cache.load.bind(cache);
+  const searchDeps: RunSearchDeps = createRunSearchDeps({ loadLexicalIndex });
+  const runSearchImpl = options.runSearchImpl ?? runSearch;
+  const runListImpl = options.runListImpl ?? runList;
+  const runStatsImpl = options.runStatsImpl ?? runStats;
   return {
-    search: async (args) => captureProcessOutput(() => runSearch(args)),
-    list: async (args) => captureProcessOutput(() => runList(args)),
-    stats: async (args) => captureProcessOutput(() => runStats(args)),
+    search: async (args) => captureProcessOutput(() => runSearchImpl(args, searchDeps)),
+    list: async (args) => captureProcessOutput(() => runListImpl(args)),
+    stats: async (args) => captureProcessOutput(() => runStatsImpl(args)),
   };
 }
 
@@ -430,7 +445,7 @@ async function handleMetricsRequest(
 }
 
 async function defaultMetricsHandler(): Promise<string> {
-  const result = await defaultHandlers().stats(['--format=json']);
+  const result = await createDaemonCommandHandlers().stats(['--format=json']);
   return formatStatsRunResultAsOpenMetrics(result);
 }
 

--- a/src/lexical-index-cache.test.ts
+++ b/src/lexical-index-cache.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
+import * as fsp from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import type { LexicalIndex } from './lexical-index.js';
+
+const originalEnv = {
+  KNOWLEDGE_BASES_ROOT_DIR: process.env.KNOWLEDGE_BASES_ROOT_DIR,
+  FAISS_INDEX_PATH: process.env.FAISS_INDEX_PATH,
+};
+
+afterEach(() => {
+  for (const [key, value] of Object.entries(originalEnv)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+async function freshCache(faissDir: string): Promise<typeof import('./lexical-index-cache.js')> {
+  process.env.KNOWLEDGE_BASES_ROOT_DIR = path.join(path.dirname(faissDir), 'kbs');
+  process.env.FAISS_INDEX_PATH = faissDir;
+  jest.resetModules();
+  return import('./lexical-index-cache.js');
+}
+
+function fakeIndex(files = 1): LexicalIndex {
+  return { numFiles: jest.fn(() => files) } as unknown as LexicalIndex;
+}
+
+async function writePersistedIndex(
+  faissDir: string,
+  kbName: string,
+  body: string,
+  mtime: Date,
+): Promise<void> {
+  const filePath = path.join(faissDir, 'lexical', kbName, 'index.json');
+  await fsp.mkdir(path.dirname(filePath), { recursive: true });
+  await fsp.writeFile(filePath, body, 'utf-8');
+  await fsp.utimes(filePath, mtime, mtime);
+}
+
+describe('LexicalIndexCache', () => {
+  it('reuses a parsed non-empty index while persisted metadata is unchanged', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lexical-cache-hit-'));
+    const faissDir = path.join(tempDir, 'faiss');
+    await writePersistedIndex(faissDir, 'alpha', '{"files":{"a":1}}', new Date('2026-01-01T00:00:00Z'));
+    const { LexicalIndexCache } = await freshCache(faissDir);
+    const index = fakeIndex(1);
+    const loadIndex = jest.fn(async () => index);
+    const cache = new LexicalIndexCache({ loadIndex });
+
+    await expect(cache.load('alpha', '/kb/alpha')).resolves.toBe(index);
+    await expect(cache.load('alpha', '/kb/alpha')).resolves.toBe(index);
+
+    expect(loadIndex).toHaveBeenCalledTimes(1);
+  });
+
+  it('reloads when the persisted lexical index metadata changes', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lexical-cache-reload-'));
+    const faissDir = path.join(tempDir, 'faiss');
+    await writePersistedIndex(faissDir, 'alpha', '{"files":{"a":1}}', new Date('2026-01-01T00:00:00Z'));
+    const { LexicalIndexCache } = await freshCache(faissDir);
+    const first = fakeIndex(1);
+    const second = fakeIndex(2);
+    const loadIndex = jest.fn<() => Promise<LexicalIndex>>()
+      .mockResolvedValueOnce(first)
+      .mockResolvedValueOnce(second);
+    const cache = new LexicalIndexCache({ loadIndex });
+
+    await expect(cache.load('alpha', '/kb/alpha')).resolves.toBe(first);
+    await writePersistedIndex(
+      faissDir,
+      'alpha',
+      '{"files":{"a":1,"b":2}}',
+      new Date('2026-01-02T00:00:00Z'),
+    );
+    await expect(cache.load('alpha', '/kb/alpha')).resolves.toBe(second);
+
+    expect(loadIndex).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not cache missing persisted lexical index files', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lexical-cache-missing-'));
+    const faissDir = path.join(tempDir, 'faiss');
+    const { LexicalIndexCache } = await freshCache(faissDir);
+    const loadIndex = jest.fn(async () => fakeIndex(0));
+    const cache = new LexicalIndexCache({ loadIndex });
+
+    await cache.load('alpha', '/kb/alpha');
+    await cache.load('alpha', '/kb/alpha');
+
+    expect(loadIndex).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not cache empty parsed indexes even when an index file exists', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lexical-cache-empty-'));
+    const faissDir = path.join(tempDir, 'faiss');
+    await writePersistedIndex(faissDir, 'alpha', '{"files":{}}', new Date('2026-01-01T00:00:00Z'));
+    const { LexicalIndexCache } = await freshCache(faissDir);
+    const loadIndex = jest.fn(async () => fakeIndex(0));
+    const cache = new LexicalIndexCache({ loadIndex });
+
+    await cache.load('alpha', '/kb/alpha');
+    await cache.load('alpha', '/kb/alpha');
+
+    expect(loadIndex).toHaveBeenCalledTimes(2);
+  });
+
+  it('coalesces concurrent loads for the same unchanged lexical index file', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lexical-cache-concurrent-'));
+    const faissDir = path.join(tempDir, 'faiss');
+    await writePersistedIndex(faissDir, 'alpha', '{"files":{"a":1}}', new Date('2026-01-01T00:00:00Z'));
+    const { LexicalIndexCache } = await freshCache(faissDir);
+    const index = fakeIndex(1);
+    let releaseLoad!: () => void;
+    let markLoadStarted!: () => void;
+    const loadStarted = new Promise<void>((resolve) => {
+      markLoadStarted = resolve;
+    });
+    const loadIndex = jest.fn(async () => {
+      markLoadStarted();
+      await new Promise<void>((release) => {
+        releaseLoad = release;
+      });
+      return index;
+    });
+    const cache = new LexicalIndexCache({ loadIndex });
+
+    const first = cache.load('alpha', '/kb/alpha');
+    const second = cache.load('alpha', '/kb/alpha');
+    await loadStarted;
+    expect(loadIndex).toHaveBeenCalledTimes(1);
+    releaseLoad();
+    const [a, b] = await Promise.all([first, second]);
+
+    expect(a).toBe(index);
+    expect(b).toBe(index);
+    expect(loadIndex).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lexical-index-cache.ts
+++ b/src/lexical-index-cache.ts
@@ -1,0 +1,125 @@
+import * as fsp from 'fs/promises';
+import { LexicalIndex, lexicalIndexFilePath } from './lexical-index.js';
+
+interface LexicalIndexMetadata {
+  exists: boolean;
+  mtimeMs: number;
+  size: number;
+}
+
+interface CacheEntry {
+  index: LexicalIndex;
+  metadata: LexicalIndexMetadata;
+}
+
+interface InFlightLoad {
+  metadata: LexicalIndexMetadata;
+  promise: Promise<LexicalIndex>;
+}
+
+export interface LexicalIndexCacheOptions {
+  maxEntries?: number;
+  loadIndex?: (kbName: string, kbPath: string) => Promise<LexicalIndex>;
+}
+
+type FsError = NodeJS.ErrnoException & { code?: string };
+
+const DEFAULT_MAX_ENTRIES = 64;
+
+export class LexicalIndexCache {
+  private readonly maxEntries: number;
+  private readonly loadIndex: (kbName: string, kbPath: string) => Promise<LexicalIndex>;
+  private readonly entries = new Map<string, CacheEntry>();
+  private readonly inFlight = new Map<string, InFlightLoad>();
+
+  constructor(options: LexicalIndexCacheOptions = {}) {
+    this.maxEntries = Math.max(1, options.maxEntries ?? DEFAULT_MAX_ENTRIES);
+    this.loadIndex = options.loadIndex ?? LexicalIndex.load.bind(LexicalIndex);
+  }
+
+  async load(kbName: string, kbPath: string): Promise<LexicalIndex> {
+    const key = this.cacheKey(kbName, kbPath);
+    const metadata = await this.readMetadata(kbName);
+    const cached = this.entries.get(key);
+    if (cached && sameMetadata(cached.metadata, metadata)) {
+      this.entries.delete(key);
+      this.entries.set(key, cached);
+      return cached.index;
+    }
+
+    const pending = this.inFlight.get(key);
+    if (pending && sameMetadata(pending.metadata, metadata)) {
+      return pending.promise;
+    }
+
+    const promise = this.loadFresh(kbName, kbPath, key, metadata);
+    this.inFlight.set(key, { metadata, promise });
+    try {
+      return await promise;
+    } finally {
+      if (this.inFlight.get(key)?.promise === promise) {
+        this.inFlight.delete(key);
+      }
+    }
+  }
+
+  private async loadFresh(
+    kbName: string,
+    kbPath: string,
+    key: string,
+    initialMetadata: LexicalIndexMetadata,
+  ): Promise<LexicalIndex> {
+    let metadata = initialMetadata;
+    // Require the index file metadata to stay stable across parse. If a writer
+    // swaps the file mid-load, retry against the new metadata and avoid
+    // remembering an object whose parsed contents may not match the cache key.
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      const index = await this.loadIndex(kbName, kbPath);
+      const afterLoad = await this.readMetadata(kbName);
+      if (sameMetadata(metadata, afterLoad)) {
+        this.remember(key, index, afterLoad);
+        return index;
+      }
+      metadata = afterLoad;
+    }
+
+    const index = await this.loadIndex(kbName, kbPath);
+    const finalMetadata = await this.readMetadata(kbName);
+    if (sameMetadata(metadata, finalMetadata)) {
+      this.remember(key, index, finalMetadata);
+    }
+    return index;
+  }
+
+  private remember(key: string, index: LexicalIndex, metadata: LexicalIndexMetadata): void {
+    if (!metadata.exists || index.numFiles() === 0) return;
+    this.entries.delete(key);
+    this.entries.set(key, { index, metadata });
+    while (this.entries.size > this.maxEntries) {
+      const oldestKey = this.entries.keys().next().value;
+      if (oldestKey === undefined) break;
+      this.entries.delete(oldestKey);
+    }
+  }
+
+  private async readMetadata(kbName: string): Promise<LexicalIndexMetadata> {
+    try {
+      const stat = await fsp.stat(lexicalIndexFilePath(kbName));
+      return { exists: true, mtimeMs: stat.mtimeMs, size: stat.size };
+    } catch (error) {
+      const code = (error as FsError | undefined)?.code;
+      if (code === 'ENOENT' || code === 'ENOTDIR') {
+        return { exists: false, mtimeMs: 0, size: 0 };
+      }
+      throw error;
+    }
+  }
+
+  private cacheKey(kbName: string, kbPath: string): string {
+    return `${kbName}\0${kbPath}`;
+  }
+}
+
+function sameMetadata(a: LexicalIndexMetadata, b: LexicalIndexMetadata): boolean {
+  return a.exists === b.exists && a.mtimeMs === b.mtimeMs && a.size === b.size;
+}

--- a/src/lexical-index.ts
+++ b/src/lexical-index.ts
@@ -121,7 +121,7 @@ function lexicalKbDir(kbName: string): string {
   return path.join(lexicalRootDir(), kbName);
 }
 
-function lexicalIndexFilePath(kbName: string): string {
+export function lexicalIndexFilePath(kbName: string): string {
   return path.join(lexicalKbDir(kbName), 'index.json');
 }
 


### PR DESCRIPTION
## Summary
- add an in-process `LexicalIndexCache` keyed by KB/path and invalidated by persisted index mtime/size
- wire `kb serve` search handlers through a cached lexical loader while keeping one-shot CLI defaults unchanged
- forward the existing lexical loader seam through hybrid search and cover cache hit/reload/concurrent-load behavior

Closes #543.

## Verification
- `npm test -- src/lexical-index-cache.test.ts src/cli-serve.test.ts src/cli-search.test.ts src/hybrid-retrieval.test.ts`
- `npm run build`
- `git diff --check`

## Pre-PR review
- detected project type: npm
- type/build checks: passed
- tests: passed
- bug reproduction: skipped; unit coverage directly exercises the reported warm lexical cache path
- diff review: done
- portability check: clean by manual diff scan; repo has no `scripts/check-portability.sh` helper
- reviewer specialists: run; conventions/dead-code/test suggestions addressed; correctness had no findings
- OSS base-branch policy: skipped; same-repo PR
- gate file: created