### PR TITLE
feat(bench): M1 — hybrid+rerank/+contextual BEIR modes + significance comparator (bootstrap + Bonferroni/Holm + wild-cluster)

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -72,6 +72,74 @@ official BEIR leaderboard result. Optional MLflow logging is not required for
 the JSON/TREC artifacts and can be layered in by the separate bench
 observability hook.
 
+### Retrieval modes (RFC 020 M0/M1)
+
+`--mode` selects the retrieval-mode space the runner scores, each driving the
+**production `src/` path** — never a benchmark-only reimplementation:
+
+| Mode | Path exercised | Needs |
+| --- | --- | --- |
+| `lexical` | `LexicalIndex` BM25 | nothing (credential-free) |
+| `dense` | `FaissIndexManager.similaritySearch` | embedding provider |
+| `hybrid` | `+ src/hybrid-retrieval` RRF fusion | embedding provider |
+| `hybrid+rerank` | `+ src/reranker.ts` cross-encoder (`KB_RERANK`) | provider + rerank model |
+| `hybrid+rerank+contextual` | `+ RFC 017 contextual prefaces at ingest` (`KB_CONTEXTUAL_RETRIEVAL`) | provider + rerank model + LLM endpoint |
+
+The runner flips `KB_RERANK` / `KB_CONTEXTUAL_RETRIEVAL` per mode and restores
+them afterwards, so each run is self-contained even inside the sweep/baseline
+loops. The rerank model downloads on first use (transformers.js); the contextual
+stage costs one cached LLM call per chunk at ingest. `+contextual` fails loudly
+when no LLM endpoint is configured (set `KB_LLM_ENDPOINT`, or `KB_LLM_FAKE=on`
+for a deterministic, network-free self-test). The `rerank` / `contextual`
+provenance blocks in the report JSON record the exact model + topN + on/off.
+
+```bash
+# Each enabled stage's contribution, on the CI subset, via a real provider:
+npm run bench:beir -- --dataset=scifact --mode=hybrid                 --provider=ollama --model=nomic-embed-text --output-dir=/tmp/kb-beir
+npm run bench:beir -- --dataset=scifact --mode=hybrid+rerank          --provider=ollama --model=nomic-embed-text --output-dir=/tmp/kb-beir
+npm run bench:beir -- --dataset=scifact --mode=hybrid+rerank+contextual --provider=ollama --model=nomic-embed-text --output-dir=/tmp/kb-beir
+```
+
+## Significance comparator — `bench:beir:significance` (RFC 020 §3)
+
+A run-to-run delta is not evidence on its own. `bench:beir:significance` takes
+two BEIR run reports (the `per_query[].ndcgAt10` vectors), pairs them by query
+id over the same query set, and reports a **paired bootstrap** (10k resamples)
+CI on the mean ΔnDCG@10, a **paired t-test** p-value, and a verdict —
+`improvement` / `regression` / `no-significant-change` — at α = 0.05. It mirrors
+the `budget-diff` CLI shape and is fully deterministic (seeded bootstrap).
+
+```bash
+# One stage's contribution on one dataset:
+npm run bench:beir:significance -- \
+  --baseline /tmp/kb-beir/kb-scifact-hybrid-chunk-results.json \
+  --current  /tmp/kb-beir/kb-scifact-hybrid+rerank-chunk-results.json \
+  --label "hybrid -> hybrid+rerank"
+```
+
+Two corrections guard against false positives:
+
+- **Multiple-comparison correction** (`--correction bonferroni|holm`) across a
+  sweep family — a `--family <manifest.json>` of `{label, baseline, current}`
+  comparisons. Reporting every delta at α = 0.05 inflates the family-wise error
+  rate; Bonferroni/Holm control it.
+- **Wild-cluster bootstrap-t** (`--cluster-by-dataset`) for when queries cluster
+  by dataset/domain (the BEIR matrix does — per-query results within a dataset
+  are not independent). Comma-separate multiple dataset run files for one
+  "current"/"baseline"; each file's `dataset.name` becomes a cluster. The
+  cluster-aware p-value resamples whole datasets; the reported CI is the bounded
+  cluster-robust Wald-t interval (the percentile-t interval is numerically
+  unstable with BEIR's handful of clusters).
+
+```bash
+# Multi-domain stage contribution with wild-cluster + Holm correction:
+npm run bench:beir:significance -- --family /tmp/stage-contributions.json --correction holm
+```
+
+A non-significant dip is **reported, not failed** (matching the future CI gate
+in RFC 020 §4); pass `--fail-on-regression` to exit non-zero on a significant
+regression verdict.
+
 ## Result file naming
 
 Reports are written to `benchmarks/results/` with this naming pattern:

--- a/benchmarks/beir/baseline.ts
+++ b/benchmarks/beir/baseline.ts
@@ -152,9 +152,17 @@ export function parseBaselineArgs(argv: string[]): BaselineOptions {
   return options;
 }
 
+const BASELINE_MODES: readonly BeirMode[] = [
+  'lexical',
+  'dense',
+  'hybrid',
+  'hybrid+rerank',
+  'hybrid+rerank+contextual',
+];
+
 function parseMode(raw: string): BeirMode {
-  if (raw === 'lexical' || raw === 'dense' || raw === 'hybrid') return raw;
-  throw new Error('--modes entries must be one of: lexical, dense, hybrid');
+  if ((BASELINE_MODES as readonly string[]).includes(raw)) return raw as BeirMode;
+  throw new Error(`--modes entries must be one of: ${BASELINE_MODES.join(', ')}`);
 }
 
 function baselineHelpText(): string {

--- a/benchmarks/beir/run.rerank.test.ts
+++ b/benchmarks/beir/run.rerank.test.ts
@@ -1,0 +1,256 @@
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import * as fsp from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  parseArgs,
+  runBeirBenchmark,
+  type BeirSearchBackend,
+  type LoadSearchBackendInput,
+  type RunDependencies,
+} from './run.js';
+
+// RFC 020 M1 failure-mode test ("benchmark-only retrieval path drifts from
+// production"): the `hybrid+rerank` and `hybrid+rerank+contextual` modes must
+// drive the SHIPPED src/ paths — the cross-encoder in `src/reranker.ts` and the
+// RFC 017 contextual-preface ingest in `buildChunkDocuments` — not a
+// benchmark-only reimplementation. These tests run the production retrieval
+// entrypoint with the deterministic `fake` embedding provider, inject a fake
+// cross-encoder via the production `setRerankerFactoryForTests` seam (so no
+// model downloads), and assert (a) the production reranker is invoked for the
+// rerank modes and skipped for plain hybrid, and (b) the contextual ingest path
+// generated prefaces via the production sidecar.
+//
+// As in run.dense.test.ts, every production-path run shares ONE workspace root:
+// src/config/paths.ts freezes KNOWLEDGE_BASES_ROOT_DIR / FAISS_INDEX_PATH into
+// module-level consts on first import.
+
+const baseDeps = {
+  gitSha: async () => 'test-sha',
+  now: () => new Date('2026-06-08T00:00:00.000Z'),
+  pythonVersion: async () => null,
+  silenceServerLogger: async () => undefined,
+  loadLexicalIndex: async () => {
+    throw new Error('loadLexicalIndex should not be called for hybrid+rerank modes');
+  },
+} satisfies Omit<RunDependencies, 'loadSearchBackend'>;
+
+async function writeTinyBeirDataset(root: string): Promise<string> {
+  const datasetDir = path.join(root, 'tiny');
+  await fsp.mkdir(path.join(datasetDir, 'qrels'), { recursive: true });
+  await fsp.writeFile(path.join(datasetDir, 'corpus.jsonl'), [
+    JSON.stringify({ _id: 'doc-alpha', title: 'Alpha', text: 'Alpha gravity wave detection evidence and analysis.' }),
+    JSON.stringify({ _id: 'doc-beta', title: 'Beta', text: 'Beta culinary recipe for a hearty tomato soup.' }),
+    '',
+  ].join('\n'), 'utf-8');
+  await fsp.writeFile(path.join(datasetDir, 'queries.jsonl'), [
+    JSON.stringify({ _id: 'q1', text: 'alpha gravity wave detection' }),
+    '',
+  ].join('\n'), 'utf-8');
+  await fsp.writeFile(path.join(datasetDir, 'qrels', 'test.tsv'), [
+    'query-id corpus-id score',
+    'q1 doc-alpha 1',
+    '',
+  ].join('\n'), 'utf-8');
+  return datasetDir;
+}
+
+interface RerankProbe {
+  calls: Array<{ query: string; candidates: string[] }>;
+}
+
+// A unique reranker id per backend load keeps the production rerank-score cache
+// (`globalRerankScoreCache`, keyed by model id + query + candidate text) from
+// masking a fresh invocation: the pageContent is byte-identical across modes
+// (the contextual preface only changes the embedded text, not pageContent), so
+// without a unique id the second rerank run would be an all-cache-hit and never
+// call our probe.
+let rerankerInstanceCounter = 0;
+
+/**
+ * Build the production fake backend AND install a fake cross-encoder through the
+ * production `setRerankerFactoryForTests` seam. The returned `restore` undoes
+ * the factory swap. `probe.calls` records every production rerank invocation so
+ * a test can assert the shipped reranker actually ran.
+ */
+async function loadProductionRerankBackend(
+  input: LoadSearchBackendInput,
+  probe: RerankProbe,
+): Promise<{ backend: BeirSearchBackend; restoreReranker: () => void }> {
+  const fim = await import('../../src/FaissIndexManager.js');
+  const evalModule = await import('../../src/retrieval-eval.js');
+  const rerankerModule = await import('../../src/reranker.js');
+
+  // A deterministic cross-encoder: it scores by candidate length so order is
+  // stable, and records the call so the test can prove the production path
+  // reached `src/reranker.ts`.
+  rerankerInstanceCounter += 1;
+  const rerankerId = `fake-cross-encoder-${rerankerInstanceCounter}`;
+  const restoreReranker = rerankerModule.setRerankerFactoryForTests(async () => ({
+    id: rerankerId,
+    rerank: async (query: string, candidates: string[]): Promise<number[]> => {
+      probe.calls.push({ query, candidates });
+      return candidates.map((text) => 1 / (1 + text.length));
+    },
+  }));
+
+  await fim.FaissIndexManager.bootstrapLayout();
+  const manager = new fim.FaissIndexManager(
+    { provider: 'fake', modelName: input.modelName } as unknown as ConstructorParameters<typeof fim.FaissIndexManager>[0],
+  );
+  await manager.initialize();
+
+  const backend: BeirSearchBackend = {
+    implementation: `production ${input.mode} path (src/retrieval-eval + FaissIndexManager, fake provider)`,
+    prepare: async () => {
+      await manager.updateIndex();
+      const summary = manager.getLastIndexUpdateSummary();
+      return { files: summary.files_scanned, chunks: summary.chunks_added };
+    },
+    search: async (query, fetchK) => {
+      const result = await evalModule.retrieveForRetrievalEvalCase(
+        {
+          name: 'beir',
+          query,
+          kb: input.kbName,
+          k: fetchK,
+          threshold: Number.POSITIVE_INFINITY,
+          requiredSources: [],
+          forbiddenSources: [],
+          expectedMetadata: [],
+          stalePolicy: 'allow_stale',
+        },
+        { manager, defaultK: fetchK, defaultThreshold: Number.POSITIVE_INFINITY },
+        input.mode,
+      );
+      return result.results.map((r) => ({
+        metadata: r.metadata as Record<string, unknown>,
+        score: typeof r.score === 'number' ? r.score : 0,
+      }));
+    },
+  };
+  return { backend, restoreReranker };
+}
+
+describe('BEIR runner hybrid+rerank / +contextual modes (production paths)', () => {
+  let root: string;
+  let datasetDir: string;
+  let workspace: string;
+  let savedLogLevel: string | undefined;
+  let savedFake: string | undefined;
+
+  beforeAll(async () => {
+    savedLogLevel = process.env.LOG_LEVEL;
+    process.env.LOG_LEVEL = 'error';
+    // The +contextual mode generates prefaces at ingest; the fake LLM keeps that
+    // network-free and deterministic. The runner enables KB_CONTEXTUAL_RETRIEVAL
+    // itself per mode, but the endpoint (here, the fake) comes from the env.
+    savedFake = process.env.KB_LLM_FAKE;
+    process.env.KB_LLM_FAKE = 'on';
+    root = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-beir-rerank-'));
+    datasetDir = await writeTinyBeirDataset(root);
+    workspace = path.join(root, 'kb-beir-ws');
+  });
+
+  afterAll(async () => {
+    if (savedLogLevel === undefined) delete process.env.LOG_LEVEL;
+    else process.env.LOG_LEVEL = savedLogLevel;
+    if (savedFake === undefined) delete process.env.KB_LLM_FAKE;
+    else process.env.KB_LLM_FAKE = savedFake;
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  async function runMode(mode: string, probe: RerankProbe) {
+    let restoreReranker = (): void => undefined;
+    const loadSearchBackend = async (input: LoadSearchBackendInput): Promise<BeirSearchBackend> => {
+      const built = await loadProductionRerankBackend(input, probe);
+      restoreReranker = built.restoreReranker;
+      return built.backend;
+    };
+    const args = parseArgs([
+      '--dataset=tiny',
+      `--dataset-dir=${datasetDir}`,
+      `--mode=${mode}`,
+      '--provider=fake',
+      `--output-dir=${path.join(root, `out-${mode.replace(/\+/g, '_')}`)}`,
+      `--workspace-root=${workspace}`,
+      '--k=10',
+      '--chunk-k=20',
+      '--keep-workspace',
+    ]);
+    try {
+      return await runBeirBenchmark(args, { ...baseDeps, loadSearchBackend });
+    } finally {
+      restoreReranker();
+    }
+  }
+
+  it('drives the production src/reranker.ts cross-encoder for hybrid+rerank', async () => {
+    const probe: RerankProbe = { calls: [] };
+    const result = await runMode('hybrid+rerank', probe);
+
+    // The shipped reranker was invoked through the production hybrid path.
+    expect(probe.calls.length).toBeGreaterThan(0);
+    expect(probe.calls[0].query).toBe('alpha gravity wave detection');
+    expect(probe.calls[0].candidates.length).toBeGreaterThan(0);
+
+    // Provenance reflects the rerank stage.
+    expect(result.report.mode).toBe('hybrid+rerank');
+    expect(result.report.rerank).toMatchObject({ enabled: true, topN: 40 });
+    expect(result.report.contextual).toEqual({ enabled: false });
+    expect(result.report.ranking.implementation).toContain('src/reranker.ts');
+    expect(result.report.metrics.recallAt10).toBe(1);
+  }, 60_000);
+
+  it('does NOT rerank for plain hybrid (mode isolation of KB_RERANK)', async () => {
+    const probe: RerankProbe = { calls: [] };
+    const result = await runMode('hybrid', probe);
+    expect(probe.calls.length).toBe(0);
+    expect(result.report.rerank).toEqual({ enabled: false, model: expect.any(String), topN: 40 });
+    expect(result.report.contextual).toEqual({ enabled: false });
+  }, 60_000);
+
+  it('drives the production reranker AND the RFC 017 contextual ingest for hybrid+rerank+contextual', async () => {
+    const probe: RerankProbe = { calls: [] };
+    const result = await runMode('hybrid+rerank+contextual', probe);
+
+    expect(probe.calls.length).toBeGreaterThan(0);
+    expect(result.report.mode).toBe('hybrid+rerank+contextual');
+    expect(result.report.rerank?.enabled).toBe(true);
+    expect(result.report.contextual).toEqual({ enabled: true });
+    expect(result.report.ranking.implementation).toContain('contextual prefaces at ingest');
+
+    // The contextual ingest path actually generated prefaces via the production
+    // sidecar (proves it was the RFC 017 code, not a stub). Read through the
+    // production aggregator so we depend on the shipped on-disk contract.
+    const contextual = await import('../../src/contextual-preface.js');
+    const stats = await contextual.aggregateContextualSidecarStats('tiny');
+    expect(stats.sidecar_count).toBeGreaterThan(0);
+    expect(stats.covered_chunks).toBeGreaterThan(0);
+  }, 60_000);
+
+  it('fails loudly when +contextual has no LLM endpoint configured', async () => {
+    const saved = process.env.KB_LLM_FAKE;
+    delete process.env.KB_LLM_FAKE;
+    try {
+      const args = parseArgs([
+        '--dataset=tiny',
+        `--dataset-dir=${datasetDir}`,
+        '--mode=hybrid+rerank+contextual',
+        '--provider=fake',
+        `--output-dir=${path.join(root, 'out-noendpoint')}`,
+        `--workspace-root=${workspace}`,
+        '--k=10',
+      ]);
+      await expect(runBeirBenchmark(args, {
+        ...baseDeps,
+        loadSearchBackend: async () => {
+          throw new Error('backend should not load when the contextual endpoint check fails');
+        },
+      })).rejects.toThrow(/needs an LLM endpoint/);
+    } finally {
+      if (saved === undefined) delete process.env.KB_LLM_FAKE;
+      else process.env.KB_LLM_FAKE = saved;
+    }
+  });
+});

--- a/benchmarks/beir/run.ts
+++ b/benchmarks/beir/run.ts
@@ -36,24 +36,61 @@ const DATASET_URLS: Record<string, string> = {
   'webis-touche2020': 'https://public.ukp.informatik.tu-darmstadt.de/thakur/BEIR/datasets/webis-touche2020.zip',
 };
 
-// v2 (RFC 020 M0): added `dense`/`hybrid` modes (driven by the production
-// `src/` retrieval paths), precision@10 in the metric set, and the
-// `embedding` provenance block. v1 was lexical-only.
-const BENCHMARK_SCHEMA_VERSION = 'kb.beir-benchmark.v2';
+// v3 (RFC 020 M1): added `hybrid+rerank` / `hybrid+rerank+contextual` modes
+// (driven by the production `src/reranker.ts` cross-encoder and the RFC 017
+// contextual-preface ingest path) plus the `rerank` / `contextual` provenance
+// blocks. v2 added `dense`/`hybrid` + precision@10 + `embedding`; v1 was
+// lexical-only.
+const BENCHMARK_SCHEMA_VERSION = 'kb.beir-benchmark.v3';
 type LexicalUnit = 'chunk' | 'source';
 // RFC 020 §1 — the retrieval-mode space the runner can score. `lexical` is
-// credential-free (BM25 only); `dense` and `hybrid` drive the production
-// embedding + RRF paths in `src/` and therefore require an embedding provider.
-export type BeirMode = 'lexical' | 'dense' | 'hybrid';
-const BEIR_MODES: readonly BeirMode[] = ['lexical', 'dense', 'hybrid'];
+// credential-free (BM25 only); the rest drive the production embedding + RRF +
+// cross-encoder + contextual-preface paths in `src/` and therefore require an
+// embedding provider (and, for `+contextual`, an LLM endpoint at ingest).
+export type BeirMode =
+  | 'lexical'
+  | 'dense'
+  | 'hybrid'
+  | 'hybrid+rerank'
+  | 'hybrid+rerank+contextual';
+const BEIR_MODES: readonly BeirMode[] = [
+  'lexical',
+  'dense',
+  'hybrid',
+  'hybrid+rerank',
+  'hybrid+rerank+contextual',
+];
 
 function isBeirMode(value: string): value is BeirMode {
   return (BEIR_MODES as readonly string[]).includes(value);
 }
 
-function isDenseMode(mode: BeirMode): mode is 'dense' | 'hybrid' {
-  return mode === 'dense' || mode === 'hybrid';
+// Every non-lexical mode drives an embedding provider and the dense backend.
+function usesEmbeddingProvider(mode: BeirMode): boolean {
+  return mode !== 'lexical';
 }
+
+// The production `SearchMode` a BeirMode maps onto. The rerank/contextual
+// variants all retrieve through the hybrid RRF path; reranking is enabled via
+// the production `KB_RERANK` config and contextual prefaces via the production
+// `KB_CONTEXTUAL_RETRIEVAL` ingest path — never a benchmark-only reimplementation.
+function beirSearchMode(mode: BeirMode): 'dense' | 'hybrid' {
+  return mode === 'dense' ? 'dense' : 'hybrid';
+}
+
+function modeEnablesRerank(mode: BeirMode): boolean {
+  return mode === 'hybrid+rerank' || mode === 'hybrid+rerank+contextual';
+}
+
+function modeEnablesContextual(mode: BeirMode): boolean {
+  return mode === 'hybrid+rerank+contextual';
+}
+
+// Mirrors `src/config/reranker.ts` defaults. Recorded as provenance only; the
+// runner does not re-implement the reranker — it flips the production
+// `KB_RERANK` flag and the shipped hybrid path drives `src/reranker.ts`.
+const DEFAULT_RERANK_MODEL = 'Xenova/ms-marco-MiniLM-L-6-v2';
+const DEFAULT_RERANK_TOP_N = 40;
 
 interface Args {
   dataset: string;
@@ -206,6 +243,20 @@ interface BeirBenchmarkReport {
     provider: string;
     model: string;
   } | null;
+  // Cross-encoder rerank provenance (RFC 020 §3/§7 — baselines record the exact
+  // rerank model + topN). Present (enabled true) only for `hybrid+rerank[...]`
+  // modes; `enabled: false` for plain hybrid/dense; null for lexical.
+  rerank: {
+    enabled: boolean;
+    model: string;
+    topN: number;
+  } | null;
+  // RFC 017 contextual-preface provenance. `enabled` true only for
+  // `hybrid+rerank+contextual`; the prefaces are generated at ingest by the
+  // production `buildChunkDocuments` path and embedded into chunk + BM25 text.
+  contextual: {
+    enabled: boolean;
+  } | null;
   ranking: {
     unit: LexicalUnit;
     implementation: string;
@@ -294,10 +345,22 @@ export async function runBeirBenchmark(
   configureBenchmarkEnvironment(knowledgeBasesRootDir, faissIndexPath);
   await dependencies.silenceServerLogger(buildRoot);
 
-  const retrieval = isDenseMode(args.mode)
-    ? await runDenseRetrieval({ args, prepared, qrels, selectedQueries, buildRoot, dependencies })
-    : await runLexicalRetrieval({ args, prepared, qrels, selectedQueries, buildRoot, dependencies });
+  // RFC 020 §1 — flip the production stage flags (`KB_RERANK`,
+  // `KB_CONTEXTUAL_RETRIEVAL`) deterministically per mode so each run is
+  // self-contained even inside the in-process sweep/baseline loops, and restore
+  // them afterwards. The shipped hybrid path reads these via the production
+  // config resolvers, so the rerank/contextual stages run through `src/`.
+  const restoreStageEnv = applyStageEnvironment(args.mode);
+  let retrieval: RetrievalOutcome;
+  try {
+    retrieval = usesEmbeddingProvider(args.mode)
+      ? await runDenseRetrieval({ args, prepared, qrels, selectedQueries, buildRoot, dependencies })
+      : await runLexicalRetrieval({ args, prepared, qrels, selectedQueries, buildRoot, dependencies });
+  } finally {
+    restoreStageEnv();
+  }
   const { queryRows, perQuery, latenciesMs, indexMs, indexing, ranking: rankingMeta, embedding } = retrieval;
+  const stages = resolveStageProvenance(args.mode);
 
   const runTag = `kb-${args.dataset}-${args.mode}-${rankingMeta.unit}`;
   const trecPath = path.join(args.outputDir, `${runTag}-run.trec`);
@@ -322,6 +385,8 @@ export async function runBeirBenchmark(
     },
     mode: args.mode,
     embedding,
+    rerank: stages.rerank,
+    contextual: stages.contextual,
     ranking: {
       unit: rankingMeta.unit,
       implementation: rankingMeta.implementation,
@@ -427,13 +492,25 @@ async function runLexicalRetrieval(input: RetrievalInput): Promise<RetrievalOutc
 
 async function runDenseRetrieval(input: RetrievalInput): Promise<RetrievalOutcome> {
   const { args, prepared, qrels, selectedQueries, buildRoot, dependencies } = input;
-  if (!isDenseMode(args.mode)) {
+  if (!usesEmbeddingProvider(args.mode)) {
     throw new Error(`runDenseRetrieval called for non-dense mode ${args.mode}`);
+  }
+  // RFC 020 §1 — "+contextual" prefaces are generated at ingest by the LLM; a
+  // missing endpoint must fail loudly, not silently degrade to a non-contextual
+  // run that would mislabel its number (mirrors the no-provider check above).
+  if (modeEnablesContextual(args.mode) && !contextualEndpointConfigured()) {
+    throw new Error(
+      `BEIR --mode=${args.mode} needs an LLM endpoint to generate RFC 017 contextual prefaces at ingest, ` +
+        'but none is configured. Set KB_LLM_ENDPOINT (e.g. a local Ollama/OpenAI-compatible chat endpoint), ' +
+        'or set KB_LLM_FAKE=on for a deterministic, network-free self-test.',
+    );
   }
   const spec = resolveEmbeddingSpec(args);
   const backend = await dependencies.loadSearchBackend({
     buildRoot,
-    mode: args.mode,
+    // The production retrieval mode (dense vs hybrid RRF). Rerank/contextual are
+    // layered on by the stage flags, not by a distinct retrieval entrypoint.
+    mode: beirSearchMode(args.mode),
     provider: spec.provider,
     modelName: spec.model,
     kbName: prepared.kbName,
@@ -464,8 +541,83 @@ async function runDenseRetrieval(input: RetrievalInput): Promise<RetrievalOutcom
     latenciesMs,
     indexMs,
     indexing: { files: prep.files, chunks: prep.chunks },
-    ranking: { unit: 'chunk', implementation: backend.implementation },
+    ranking: { unit: 'chunk', implementation: describeImplementation(backend.implementation, args.mode) },
     embedding: { provider: spec.provider, model: spec.model },
+  };
+}
+
+// Append the active stage(s) to the backend's base implementation string so the
+// report names the exact production paths exercised (RFC 020 §1).
+function describeImplementation(base: string, mode: BeirMode): string {
+  const stages: string[] = [];
+  if (modeEnablesRerank(mode)) {
+    stages.push('+ src/reranker.ts cross-encoder rerank (production KB_RERANK path)');
+  }
+  if (modeEnablesContextual(mode)) {
+    stages.push('+ RFC 017 contextual prefaces at ingest (production buildChunkDocuments path)');
+  }
+  return stages.length === 0 ? base : `${base} ${stages.join(' ')}`;
+}
+
+// Read-only mirror of `src/config/contextual-preface.ts`
+// `resolveContextualLlmEndpoint`: an endpoint exists when the fake LLM is on or
+// KB_LLM_ENDPOINT is non-empty. Replicated locally so the runner module stays
+// free of any static `src/` import (the env vars it reads are the same).
+function contextualEndpointConfigured(): boolean {
+  const fake = (process.env.KB_LLM_FAKE ?? '').trim().toLowerCase();
+  if (fake === 'on' || fake === 'true' || fake === '1' || fake === 'yes') return true;
+  return (process.env.KB_LLM_ENDPOINT ?? '').trim() !== '';
+}
+
+interface StageProvenance {
+  rerank: BeirBenchmarkReport['rerank'];
+  contextual: BeirBenchmarkReport['contextual'];
+}
+
+// Provenance blocks recorded on the report. Derived from the mode (not from a
+// post-hoc env read) so the record is stable regardless of resolution order.
+function resolveStageProvenance(mode: BeirMode): StageProvenance {
+  if (!usesEmbeddingProvider(mode)) {
+    return { rerank: null, contextual: null };
+  }
+  const rerankEnabled = modeEnablesRerank(mode);
+  return {
+    rerank: {
+      enabled: rerankEnabled,
+      model: process.env.KB_RERANK_MODEL?.trim() || DEFAULT_RERANK_MODEL,
+      topN: rerankEnabled ? parseRerankTopNEnv(process.env.KB_RERANK_TOP_N) : DEFAULT_RERANK_TOP_N,
+    },
+    contextual: { enabled: modeEnablesContextual(mode) },
+  };
+}
+
+function parseRerankTopNEnv(raw: string | undefined): number {
+  if (raw === undefined || raw.trim() === '') return DEFAULT_RERANK_TOP_N;
+  const value = Number(raw.trim());
+  return Number.isInteger(value) && value > 0 ? value : DEFAULT_RERANK_TOP_N;
+}
+
+/**
+ * Flip the production stage flags for the requested mode and return a restore
+ * closure. The shipped hybrid path reads `KB_RERANK` (search-time rerank) and
+ * the ingest path reads `KB_CONTEXTUAL_RETRIEVAL` (preface generation); setting
+ * them explicitly — ON for the stage's modes, OFF otherwise — makes each run
+ * self-contained even when several modes run in one process (sweep/baseline).
+ */
+function applyStageEnvironment(mode: BeirMode): () => void {
+  const previous: Record<string, string | undefined> = {
+    KB_RERANK: process.env.KB_RERANK,
+    KB_CONTEXTUAL_RETRIEVAL: process.env.KB_CONTEXTUAL_RETRIEVAL,
+  };
+  if (usesEmbeddingProvider(mode)) {
+    process.env.KB_RERANK = modeEnablesRerank(mode) ? 'on' : 'off';
+    process.env.KB_CONTEXTUAL_RETRIEVAL = modeEnablesContextual(mode) ? 'on' : 'off';
+  }
+  return () => {
+    for (const [name, value] of Object.entries(previous)) {
+      if (value === undefined) delete process.env[name];
+      else process.env[name] = value;
+    }
   };
 }
 
@@ -558,6 +710,18 @@ function buildCaveats(args: Args): string[] {
       'Dense/hybrid require a real embedding provider; the fake provider is deterministic but has no ' +
         'semantic geometry, so fake-provider numbers are self-test smoke only — never a quality baseline.',
     );
+    if (modeEnablesRerank(args.mode)) {
+      caveats.push(
+        'Rerank is the production src/reranker.ts cross-encoder (enabled via KB_RERANK); the default ' +
+          'transformers.js model downloads on first use, so a rerank run needs network or a cached model.',
+      );
+    }
+    if (modeEnablesContextual(args.mode)) {
+      caveats.push(
+        'Contextual prefaces are the RFC 017 ingest path (KB_CONTEXTUAL_RETRIEVAL); each chunk costs an ' +
+          'LLM call at index time, cached in the sidecar. The fake LLM (KB_LLM_FAKE=on) is self-test only.',
+      );
+    }
   }
   return caveats;
 }
@@ -1084,7 +1248,7 @@ function formatBenchmarkCommand(args: Args): string {
     `--split=${args.split}`,
     `--mode=${args.mode}`,
   ];
-  if (isDenseMode(args.mode)) {
+  if (usesEmbeddingProvider(args.mode)) {
     if (args.provider !== undefined) parts.push(`--provider=${args.provider}`);
     if (args.model !== undefined) parts.push(`--model=${args.model}`);
   } else {
@@ -1109,9 +1273,12 @@ function portablePath(filePath: string): string {
 
 function formatMarkdownReport(report: BeirBenchmarkReport, trecPath: string, jsonPath: string): string {
   const { dataset, latency, metrics } = report;
+  const stageSuffix = report.rerank?.enabled
+    ? `, rerank: ${report.rerank.model} topN=${report.rerank.topN}${report.contextual?.enabled ? ', contextual: on' : ''}`
+    : '';
   const modeLine = report.embedding === null
     ? `- Mode: ${report.mode} (${report.ranking.unit})`
-    : `- Mode: ${report.mode} (provider: ${report.embedding.provider}, model: ${report.embedding.model})`;
+    : `- Mode: ${report.mode} (provider: ${report.embedding.provider}, model: ${report.embedding.model}${stageSuffix})`;
   return [
     `# BEIR/${dataset.name} local benchmark`,
     '',
@@ -1183,6 +1350,10 @@ Options:
   --mode=<mode>          Retrieval mode: ${BEIR_MODES.join(', ')}. Default: lexical.
                          lexical is credential-free (BM25). dense/hybrid drive
                          the production src/ retrieval path and need a provider.
+                         hybrid+rerank adds the src/reranker.ts cross-encoder
+                         (KB_RERANK); hybrid+rerank+contextual also enables the
+                         RFC 017 contextual-preface ingest path and needs an LLM
+                         endpoint (KB_LLM_ENDPOINT, or KB_LLM_FAKE=on for tests).
   --lexical-unit=<unit>  chunk or source. source maps to kb search --lexical-unit=source. Default: source.
                          (lexical mode only.)
   --provider=<name>      Embedding provider for dense/hybrid (ollama, openai,

--- a/benchmarks/beir/sweep.ts
+++ b/benchmarks/beir/sweep.ts
@@ -323,9 +323,17 @@ function parseNonNegativeInt(raw: string, flag: string): number {
   return parsed;
 }
 
+const SWEEP_MODES: readonly BeirMode[] = [
+  'lexical',
+  'dense',
+  'hybrid',
+  'hybrid+rerank',
+  'hybrid+rerank+contextual',
+];
+
 function parseSweepMode(raw: string): BeirMode {
-  if (raw === 'lexical' || raw === 'dense' || raw === 'hybrid') return raw;
-  throw new Error('--mode must be one of: lexical, dense, hybrid');
+  if ((SWEEP_MODES as readonly string[]).includes(raw)) return raw as BeirMode;
+  throw new Error(`--mode must be one of: ${SWEEP_MODES.join(', ')}`);
 }
 
 function sweepHelpText(): string {

--- a/benchmarks/significance.test.ts
+++ b/benchmarks/significance.test.ts
@@ -1,0 +1,358 @@
+import { describe, expect, it } from '@jest/globals';
+import * as fsp from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  adjustPValues,
+  compareFamily,
+  compareSamples,
+  loadRunScores,
+  pairScores,
+  pairedBootstrap,
+  pairedTTest,
+  studentTwoSidedCritical,
+  studentTwoSidedP,
+  wildClusterBootstrap,
+  type ComparisonResult,
+  type PairedSample,
+} from './significance.js';
+
+// Deterministic fixture helpers ------------------------------------------------
+
+/** Build paired samples from a flat delta list, single cluster. */
+function samplesFromDeltas(deltas: number[], cluster = 'all'): PairedSample[] {
+  return deltas.map((delta, i) => ({
+    queryId: `q${i}`,
+    baseline: 0,
+    current: delta,
+    delta,
+    cluster,
+  }));
+}
+
+/**
+ * Build clustered samples: one delta per (cluster, query). `clusterEffects` is
+ * the per-cluster mean; `withinNoise` adds a deterministic ±noise pattern so
+ * the cluster-robust variance estimator is non-degenerate (a zero-variance
+ * fixture makes both the t-test and the wild bootstrap ill-defined).
+ */
+function clusteredSamples(
+  clusterEffects: number[],
+  queriesPerCluster: number,
+  withinNoise = 0.01,
+): PairedSample[] {
+  const samples: PairedSample[] = [];
+  clusterEffects.forEach((effect, c) => {
+    for (let i = 0; i < queriesPerCluster; i += 1) {
+      const noise = withinNoise * ((i % 2 === 0 ? 1 : -1) + (i % 3) - 1);
+      const delta = effect + noise;
+      samples.push({ queryId: `c${c}-q${i}`, baseline: 0, current: delta, delta, cluster: `d${c}` });
+    }
+  });
+  return samples;
+}
+
+describe('pairScores', () => {
+  it('pairs by query id over the intersection and records dropped ids', () => {
+    const { samples, dropped } = pairScores(
+      [
+        { queryId: 'a', ndcgAt10: 0.5 },
+        { queryId: 'b', ndcgAt10: 0.6 },
+        { queryId: 'only-baseline', ndcgAt10: 0.1 },
+      ],
+      [
+        { queryId: 'a', ndcgAt10: 0.7 },
+        { queryId: 'b', ndcgAt10: 0.6 },
+        { queryId: 'only-current', ndcgAt10: 0.9 },
+      ],
+    );
+    expect(samples.map((s) => s.queryId)).toEqual(['a', 'b']);
+    expect(samples[0].delta).toBeCloseTo(0.2, 12);
+    expect(samples[1].delta).toBeCloseTo(0, 12);
+    expect(dropped.sort()).toEqual(['only-baseline', 'only-current']);
+  });
+
+  it('throws when the two run files share no query ids', () => {
+    expect(() => pairScores(
+      [{ queryId: 'a', ndcgAt10: 1 }],
+      [{ queryId: 'b', ndcgAt10: 1 }],
+    )).toThrow(/share no query ids/);
+  });
+});
+
+describe('pairedTTest', () => {
+  it('matches textbook two-sided critical values', () => {
+    // t = 0 -> p = 1.
+    expect(studentTwoSidedP(0, 4)).toBeCloseTo(1, 12);
+    // Classic df=4 critical values: t=2.776 -> p≈0.05, t=2.132 -> p≈0.10.
+    expect(studentTwoSidedP(2.776445, 4)).toBeCloseTo(0.05, 4);
+    expect(studentTwoSidedP(2.131847, 4)).toBeCloseTo(0.10, 4);
+    // Large df approaches the normal: t=1.959964 -> p≈0.05.
+    expect(studentTwoSidedP(1.959964, 1_000_000)).toBeCloseTo(0.05, 3);
+  });
+
+  it('treats a constant non-zero delta as a deterministic difference', () => {
+    const nonzero = pairedTTest([0.1, 0.1, 0.1, 0.1]);
+    expect(nonzero.pValue).toBe(0);
+    expect(nonzero.tStatistic).toBe(Infinity);
+    const zero = pairedTTest([0, 0, 0]);
+    expect(zero.pValue).toBe(1);
+    expect(zero.tStatistic).toBe(0);
+  });
+
+  it('computes the paired t-statistic for a known delta vector', () => {
+    // deltas mean=0.2, sample sd=0.158114, se=0.0707107 -> t=2.828427, df=4.
+    const result = pairedTTest([0.1, 0.2, 0.3, 0.0, 0.4]);
+    expect(result.degreesOfFreedom).toBe(4);
+    expect(result.tStatistic).toBeCloseTo(2.828427, 5);
+    expect(result.pValue).toBeCloseTo(0.0473, 3);
+  });
+
+  it('throws below two observations', () => {
+    expect(() => pairedTTest([0.3])).toThrow(/≥2 paired observations/);
+  });
+
+  it('inverts to textbook two-sided critical t-values', () => {
+    expect(studentTwoSidedCritical(4, 0.05)).toBeCloseTo(2.7764, 3);
+    expect(studentTwoSidedCritical(4, 0.10)).toBeCloseTo(2.1318, 3);
+    expect(studentTwoSidedCritical(1_000_000, 0.05)).toBeCloseTo(1.96, 2);
+  });
+});
+
+describe('pairedBootstrap', () => {
+  it('is deterministic for a fixed seed and brackets the mean delta', () => {
+    const deltas = [0.1, 0.2, 0.3, 0.0, 0.4];
+    const a = pairedBootstrap(deltas, 2000, 12345, 0.05);
+    const b = pairedBootstrap(deltas, 2000, 12345, 0.05);
+    expect(a).toEqual(b);
+    expect(a.meanDelta).toBeCloseTo(0.2, 12);
+    expect(a.ciLow).toBeLessThan(a.meanDelta);
+    expect(a.ciHigh).toBeGreaterThan(a.meanDelta);
+  });
+
+  it('produces a CI that excludes zero for a strongly positive shift', () => {
+    const deltas = Array.from({ length: 40 }, (_, i) => 0.25 + 0.02 * ((i % 5) - 2));
+    const ci = pairedBootstrap(deltas, 5000, 999, 0.05);
+    expect(ci.ciLow).toBeGreaterThan(0);
+  });
+
+  it('produces a CI that contains zero for a symmetric-around-zero shift', () => {
+    const deltas = Array.from({ length: 40 }, (_, i) => (i % 2 === 0 ? 0.2 : -0.2));
+    const ci = pairedBootstrap(deltas, 5000, 7, 0.05);
+    expect(ci.ciLow).toBeLessThan(0);
+    expect(ci.ciHigh).toBeGreaterThan(0);
+  });
+});
+
+describe('compareSamples verdicts', () => {
+  it('returns improvement when a positive shift is significant', () => {
+    const result = compareSamples(samplesFromDeltas(
+      Array.from({ length: 30 }, (_, i) => 0.2 + 0.03 * ((i % 4) - 1.5)),
+    ), { label: 'rerank gain' });
+    expect(result.verdict).toBe('improvement');
+    expect(result.meanDelta).toBeGreaterThan(0);
+    expect(result.pValue).toBeLessThan(0.05);
+  });
+
+  it('returns regression when a negative shift is significant', () => {
+    const result = compareSamples(samplesFromDeltas(
+      Array.from({ length: 30 }, (_, i) => -0.2 + 0.03 * ((i % 4) - 1.5)),
+    ));
+    expect(result.verdict).toBe('regression');
+    expect(result.meanDelta).toBeLessThan(0);
+  });
+
+  it('returns no-significant-change for a noisy near-zero shift', () => {
+    const result = compareSamples(samplesFromDeltas(
+      Array.from({ length: 30 }, (_, i) => (i % 2 === 0 ? 0.3 : -0.29)),
+    ));
+    expect(result.verdict).toBe('no-significant-change');
+  });
+});
+
+describe('wildClusterBootstrap', () => {
+  it('is deterministic for a fixed seed', () => {
+    const samples = clusteredSamples([0.4, -0.3, 0.45, -0.25, 0.5, -0.35, 0.4, -0.2, 0.3, -0.15, 0.25, -0.2], 8);
+    const a = wildClusterBootstrap(samples, 3000, 42, 0.05);
+    const b = wildClusterBootstrap(samples, 3000, 42, 0.05);
+    expect(a).toEqual(b);
+    expect(a.clusters).toBe(12);
+  });
+
+  it('is less significant than the naive t-test when queries cluster by domain', () => {
+    // 12 domains; effects are mixed-sign with high between-cluster spread but
+    // near-zero pooled mean. Treating all 96 queries as independent finds a
+    // confident effect; the wild-cluster bootstrap-t, resampling whole domains,
+    // does not — the honest answer when only 12 clusters disagree.
+    const effects = [0.6, -0.4, 0.55, -0.35, 0.5, -0.3, 0.62, -0.45, 0.48, -0.25, 0.4, -0.5];
+    const samples = clusteredSamples(effects, 8);
+
+    const naive = compareSamples(samples, { clusterByDataset: false });
+    const clustered = compareSamples(samples, { clusterByDataset: true });
+
+    expect(clustered.wildCluster).toBeDefined();
+    const wild = clustered.wildCluster!;
+    // Clustering strictly widens the interval and weakens significance.
+    expect(wild.pValue).toBeGreaterThan(naive.pValue);
+    const naiveWidth = naive.bootstrap.ciHigh - naive.bootstrap.ciLow;
+    const wildWidth = wild.ciHigh - wild.ciLow;
+    expect(wildWidth).toBeGreaterThan(naiveWidth);
+    // The cluster-aware verdict does not over-claim.
+    expect(wild.pValue).toBeGreaterThan(0.05);
+    expect(clustered.verdict).toBe('no-significant-change');
+    // The Wald-t cluster CI stays bounded (no percentile-t blow-up) and, here,
+    // straddles zero.
+    expect(Number.isFinite(wild.ciLow)).toBe(true);
+    expect(Number.isFinite(wild.ciHigh)).toBe(true);
+    expect(wild.ciLow).toBeLessThan(0);
+    expect(wild.ciHigh).toBeGreaterThan(0);
+  });
+
+  it('keeps the cluster CI bounded even with only two clusters', () => {
+    const samples = clusteredSamples([0.3, 0.05], 5);
+    const wild = wildClusterBootstrap(samples, 2000, 1, 0.05);
+    expect(wild.clusters).toBe(2);
+    expect(Number.isFinite(wild.ciLow)).toBe(true);
+    expect(Number.isFinite(wild.ciHigh)).toBe(true);
+    // A finite, sane interval — not the ±1e15 the percentile-t inversion gives.
+    expect(Math.abs(wild.ciLow)).toBeLessThan(100);
+    expect(Math.abs(wild.ciHigh)).toBeLessThan(100);
+  });
+
+  it('still finds improvement when every domain agrees on a positive gain', () => {
+    // All 12 clusters positive with modest spread -> robust even under
+    // cluster-level resampling.
+    const effects = [0.22, 0.25, 0.2, 0.28, 0.24, 0.21, 0.27, 0.23, 0.26, 0.2, 0.29, 0.22];
+    const samples = clusteredSamples(effects, 8);
+    const clustered = compareSamples(samples, { clusterByDataset: true });
+    expect(clustered.wildCluster).toBeDefined();
+    expect(clustered.wildCluster!.pValue).toBeLessThan(0.05);
+    expect(clustered.verdict).toBe('improvement');
+  });
+});
+
+describe('adjustPValues — multiple-comparison correction', () => {
+  const raw = [0.01, 0.02, 0.03, 0.04];
+
+  it('applies Bonferroni by scaling by the family size and clamping to 1', () => {
+    expect(adjustPValues(raw, 'bonferroni')).toEqual([0.04, 0.08, 0.12, 0.16]);
+    expect(adjustPValues([0.3, 0.4], 'bonferroni')).toEqual([0.6, 0.8]);
+    expect(adjustPValues([0.6, 0.7], 'bonferroni')).toEqual([1, 1]);
+  });
+
+  it('applies Holm step-down with monotonic non-decrease', () => {
+    // 0.01*4=0.04; 0.02*3=0.06; 0.03*2=0.06; 0.04*1=0.04 -> running max 0.06.
+    const holm = adjustPValues(raw, 'holm');
+    expect(holm[0]).toBeCloseTo(0.04, 12);
+    expect(holm[1]).toBeCloseTo(0.06, 12);
+    expect(holm[2]).toBeCloseTo(0.06, 12);
+    expect(holm[3]).toBeCloseTo(0.06, 12);
+  });
+
+  it('reproduces the KB-cited risk: naive marks all 4 significant, correction leaves 1', () => {
+    const uncorrectedSignificant = raw.filter((p) => p < 0.05).length;
+    expect(uncorrectedSignificant).toBe(4);
+    const bonferroniSignificant = adjustPValues(raw, 'bonferroni').filter((p) => p < 0.05).length;
+    const holmSignificant = adjustPValues(raw, 'holm').filter((p) => p < 0.05).length;
+    expect(bonferroniSignificant).toBe(1);
+    expect(holmSignificant).toBe(1);
+  });
+
+  it('preserves input order under Holm regardless of sort order', () => {
+    const unordered = [0.04, 0.01, 0.03, 0.02];
+    const holm = adjustPValues(unordered, 'holm');
+    // index 1 (raw 0.01) is the smallest -> 0.04; the largest raw 0.04 -> 0.06.
+    expect(holm[1]).toBeCloseTo(0.04, 12);
+    expect(holm[0]).toBeCloseTo(0.06, 12);
+  });
+});
+
+describe('compareFamily', () => {
+  function fakeComparison(label: string, meanDelta: number, pValue: number): ComparisonResult {
+    return {
+      label,
+      n: 50,
+      clusters: 1,
+      meanDelta,
+      tStatistic: 0,
+      degreesOfFreedom: 49,
+      pValue,
+      bootstrap: { resamples: 0, meanDelta, ciLow: meanDelta, ciHigh: meanDelta, pLessEqualZero: 0 },
+      verdict: pValue < 0.05 ? (meanDelta >= 0 ? 'improvement' : 'regression') : 'no-significant-change',
+    };
+  }
+
+  it('downgrades family members the correction no longer rejects', () => {
+    const family = compareFamily([
+      fakeComparison('dense->hybrid', 0.05, 0.01),
+      fakeComparison('hybrid->rerank', 0.03, 0.02),
+      fakeComparison('rerank->contextual', 0.02, 0.03),
+      fakeComparison('chunk-tweak', 0.01, 0.04),
+    ], 'holm', 0.05);
+
+    const verdicts = family.comparisons.map((c) => c.correctedVerdict);
+    // Only the strongest survives Holm at α=0.05.
+    expect(verdicts).toEqual([
+      'improvement',
+      'no-significant-change',
+      'no-significant-change',
+      'no-significant-change',
+    ]);
+    expect(family.comparisons[0].rejectedNull).toBe(true);
+    expect(family.comparisons[0].adjustedPValue).toBeCloseTo(0.04, 12);
+  });
+
+  it('prefers the wild-cluster p-value when a comparison carries one', () => {
+    const clustered = fakeComparison('multi-domain', 0.2, 0.001);
+    clustered.wildCluster = {
+      clusters: 3,
+      resamples: 1000,
+      meanDelta: 0.2,
+      tStatistic: 1,
+      clusterRobustStdError: 0.2,
+      ciLow: -0.1,
+      ciHigh: 0.5,
+      pValue: 0.4,
+    };
+    const family = compareFamily([clustered], 'bonferroni', 0.05);
+    // The cluster-aware p (0.4), not the naive 0.001, drives the verdict.
+    expect(family.comparisons[0].adjustedPValue).toBeCloseTo(0.4, 12);
+    expect(family.comparisons[0].correctedVerdict).toBe('no-significant-change');
+  });
+});
+
+describe('loadRunScores', () => {
+  it('reads per_query nDCG@10 vectors and namespaces ids by dataset cluster', async () => {
+    const dir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-sig-load-'));
+    const scifact = path.join(dir, 'scifact.json');
+    const nfcorpus = path.join(dir, 'nfcorpus.json');
+    await fsp.writeFile(scifact, JSON.stringify({
+      dataset: { name: 'scifact' },
+      per_query: [
+        { queryId: '1', ndcgAt10: 0.5 },
+        { queryId: '2', ndcgAt10: 0.6 },
+      ],
+    }), 'utf-8');
+    await fsp.writeFile(nfcorpus, JSON.stringify({
+      dataset: { name: 'nfcorpus' },
+      per_query: [{ queryId: '1', ndcgAt10: 0.4 }],
+    }), 'utf-8');
+
+    const scores = await loadRunScores([scifact, nfcorpus]);
+    expect(scores).toEqual([
+      { queryId: 'scifact:1', ndcgAt10: 0.5, cluster: 'scifact' },
+      { queryId: 'scifact:2', ndcgAt10: 0.6, cluster: 'scifact' },
+      { queryId: 'nfcorpus:1', ndcgAt10: 0.4, cluster: 'nfcorpus' },
+    ]);
+
+    await fsp.rm(dir, { recursive: true, force: true });
+  });
+
+  it('rejects a file that is not a BEIR run report', async () => {
+    const dir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-sig-bad-'));
+    const bad = path.join(dir, 'bad.json');
+    await fsp.writeFile(bad, JSON.stringify({ not: 'a-report' }), 'utf-8');
+    await expect(loadRunScores([bad])).rejects.toThrow(/no per_query array/);
+    await fsp.rm(dir, { recursive: true, force: true });
+  });
+});

--- a/benchmarks/significance.ts
+++ b/benchmarks/significance.ts
@@ -1,0 +1,921 @@
+// RFC 020 §3 — retrieval significance comparator.
+//
+// "Add a comparator that takes two run files (per-query nDCG@10 vectors over
+// the same query set) and reports a paired bootstrap (10k resamples) CI on the
+// mean delta, a paired t-test p-value, and a verdict (improvement / regression
+// / no-significant-change) at α = 0.05."
+//
+// This is the arbiter for every roadmap decision (M1+) and for the future CI
+// gate's "is this a real regression?" question. It lives next to
+// `benchmarks/budget-diff.ts` (the established two-run comparison pattern) and
+// reuses its CLI shape (`--baseline` / `--current` / `--fail-on-regression` /
+// `--summary`).
+//
+// Two correctness properties drive the design:
+//
+//   1. **Pairing.** nDCG@10 is compared per query, paired by query id over the
+//      intersection of the two run files. An unpaired (Welch) test would throw
+//      away the variance reduction that makes per-query deltas powerful and
+//      would silently compare different query subsets.
+//
+//   2. **Multiple comparisons.** A sweep compares many configs at once;
+//      reporting each delta at α = 0.05 inflates the family-wise error rate.
+//      `adjustPValues` applies Bonferroni or Holm across the comparison family.
+//      And because BEIR queries cluster by dataset/domain — per-query results
+//      within one dataset are not independent — the comparator also offers a
+//      **wild-cluster bootstrap-t** (Cameron–Gelbach–Miller) that resamples at
+//      the cluster level, so a family spanning several datasets gets a CI that
+//      respects the intra-dataset correlation instead of pretending every query
+//      is independent.
+//
+// Everything here is deterministic: the bootstrap uses a seeded PRNG (default
+// seed below), so a given pair of run files always yields the same CI and the
+// same verdict — a precondition for a reproducible ledger (RFC §7).
+
+import * as fsp from 'fs/promises';
+import * as path from 'path';
+
+export const DEFAULT_BOOTSTRAP_RESAMPLES = 10_000;
+export const DEFAULT_ALPHA = 0.05;
+// Fixed default seed keeps the CLI reproducible run-to-run (RFC §7 ledger).
+export const DEFAULT_BOOTSTRAP_SEED = 0x9e3779b9;
+
+export type Verdict = 'improvement' | 'regression' | 'no-significant-change';
+export type CorrectionMethod = 'bonferroni' | 'holm' | 'none';
+
+export interface PerQueryScore {
+  queryId: string;
+  ndcgAt10: number;
+  /** Cluster label (BEIR dataset/domain). Drives the wild-cluster bootstrap. */
+  cluster?: string;
+}
+
+export interface PairedSample {
+  queryId: string;
+  baseline: number;
+  current: number;
+  delta: number;
+  cluster: string;
+}
+
+export interface BootstrapCi {
+  resamples: number;
+  meanDelta: number;
+  ciLow: number;
+  ciHigh: number;
+  /** Fraction of resampled mean deltas that are ≤ 0 (one-sided diagnostic). */
+  pLessEqualZero: number;
+}
+
+export interface ComparisonResult {
+  label: string;
+  n: number;
+  clusters: number;
+  meanDelta: number;
+  /** Paired t-test. */
+  tStatistic: number;
+  degreesOfFreedom: number;
+  pValue: number;
+  bootstrap: BootstrapCi;
+  /** Present only when `clusterByDataset` is requested and >1 cluster exists. */
+  wildCluster?: WildClusterResult;
+  /** Verdict from the comparison alone (no family correction). */
+  verdict: Verdict;
+}
+
+export interface WildClusterResult {
+  clusters: number;
+  resamples: number;
+  meanDelta: number;
+  tStatistic: number;
+  clusterRobustStdError: number;
+  ciLow: number;
+  ciHigh: number;
+  pValue: number;
+}
+
+export interface FamilyComparison extends ComparisonResult {
+  adjustedPValue: number;
+  rejectedNull: boolean;
+  /** Verdict after family-wise multiple-comparison correction. */
+  correctedVerdict: Verdict;
+}
+
+export interface FamilyResult {
+  method: CorrectionMethod;
+  alpha: number;
+  comparisons: FamilyComparison[];
+}
+
+// ---------------------------------------------------------------------------
+// Pairing
+// ---------------------------------------------------------------------------
+
+/**
+ * Pair two per-query score vectors by query id over their intersection.
+ *
+ * Throws when the intersection is empty (comparing disjoint query sets is a
+ * caller bug, not a "no change" result). Query ids present in only one vector
+ * are dropped with their ids recorded on the returned `dropped` list so the
+ * caller can surface the mismatch. The cluster label is taken from the baseline
+ * vector (falling back to current), defaulting to `'all'` when neither carries
+ * one — i.e. the unclustered case collapses to a single cluster.
+ */
+export function pairScores(
+  baseline: readonly PerQueryScore[],
+  current: readonly PerQueryScore[],
+): { samples: PairedSample[]; dropped: string[] } {
+  const currentById = new Map<string, PerQueryScore>();
+  for (const row of current) currentById.set(row.queryId, row);
+  const baselineIds = new Set(baseline.map((row) => row.queryId));
+
+  const samples: PairedSample[] = [];
+  const dropped: string[] = [];
+  for (const baseRow of baseline) {
+    const curRow = currentById.get(baseRow.queryId);
+    if (curRow === undefined) {
+      dropped.push(baseRow.queryId);
+      continue;
+    }
+    samples.push({
+      queryId: baseRow.queryId,
+      baseline: baseRow.ndcgAt10,
+      current: curRow.ndcgAt10,
+      delta: curRow.ndcgAt10 - baseRow.ndcgAt10,
+      cluster: baseRow.cluster ?? curRow.cluster ?? 'all',
+    });
+  }
+  for (const curRow of current) {
+    if (!baselineIds.has(curRow.queryId)) dropped.push(curRow.queryId);
+  }
+  if (samples.length === 0) {
+    throw new Error('significance: the two run files share no query ids; cannot pair nDCG@10 vectors');
+  }
+  return { samples, dropped };
+}
+
+// ---------------------------------------------------------------------------
+// Single comparison
+// ---------------------------------------------------------------------------
+
+export interface CompareOptions {
+  label?: string;
+  resamples?: number;
+  seed?: number;
+  alpha?: number;
+  /** Add the wild-cluster bootstrap-t leg (queries cluster by dataset). */
+  clusterByDataset?: boolean;
+}
+
+export function compareScores(
+  baseline: readonly PerQueryScore[],
+  current: readonly PerQueryScore[],
+  options: CompareOptions = {},
+): ComparisonResult {
+  const { samples } = pairScores(baseline, current);
+  return compareSamples(samples, options);
+}
+
+export function compareSamples(
+  samples: readonly PairedSample[],
+  options: CompareOptions = {},
+): ComparisonResult {
+  const label = options.label ?? 'comparison';
+  const alpha = options.alpha ?? DEFAULT_ALPHA;
+  const resamples = options.resamples ?? DEFAULT_BOOTSTRAP_RESAMPLES;
+  const seed = options.seed ?? DEFAULT_BOOTSTRAP_SEED;
+  const deltas = samples.map((s) => s.delta);
+  const n = deltas.length;
+  const clusters = new Set(samples.map((s) => s.cluster)).size;
+
+  const meanDelta = mean(deltas);
+  const ttest = pairedTTest(deltas);
+  const bootstrap = pairedBootstrap(deltas, resamples, seed, alpha);
+  const wildCluster = options.clusterByDataset && clusters > 1
+    ? wildClusterBootstrap(samples, resamples, seed ^ 0x5bd1e995, alpha)
+    : undefined;
+
+  return {
+    label,
+    n,
+    clusters,
+    meanDelta,
+    tStatistic: ttest.tStatistic,
+    degreesOfFreedom: ttest.degreesOfFreedom,
+    pValue: ttest.pValue,
+    bootstrap,
+    ...(wildCluster !== undefined ? { wildCluster } : {}),
+    verdict: verdictFromResult(meanDelta, ttest.pValue, bootstrap, wildCluster, alpha),
+  };
+}
+
+/**
+ * Paired (one-sample on the deltas) two-sided t-test. With s = 0 the deltas are
+ * a constant: a non-zero constant is a deterministic difference (p → 0), a zero
+ * constant is no difference at all (p = 1).
+ */
+export function pairedTTest(deltas: readonly number[]): {
+  tStatistic: number;
+  degreesOfFreedom: number;
+  pValue: number;
+} {
+  const n = deltas.length;
+  if (n < 2) {
+    throw new Error(`significance: need ≥2 paired observations for a t-test, got ${n}`);
+  }
+  const m = mean(deltas);
+  const variance = deltas.reduce((acc, d) => acc + (d - m) ** 2, 0) / (n - 1);
+  const sd = Math.sqrt(variance);
+  const df = n - 1;
+  if (sd === 0) {
+    return { tStatistic: m === 0 ? 0 : Math.sign(m) * Infinity, degreesOfFreedom: df, pValue: m === 0 ? 1 : 0 };
+  }
+  const standardError = sd / Math.sqrt(n);
+  const tStatistic = m / standardError;
+  return { tStatistic, degreesOfFreedom: df, pValue: studentTwoSidedP(tStatistic, df) };
+}
+
+/**
+ * Paired bootstrap: resample the n deltas with replacement `resamples` times,
+ * record each resample's mean, and take the [α/2, 1−α/2] percentile interval
+ * on the mean delta. Deterministic given the seed.
+ */
+export function pairedBootstrap(
+  deltas: readonly number[],
+  resamples: number,
+  seed: number,
+  alpha: number,
+): BootstrapCi {
+  const n = deltas.length;
+  const meanDelta = mean(deltas);
+  if (n === 0) {
+    return { resamples, meanDelta: 0, ciLow: 0, ciHigh: 0, pLessEqualZero: 1 };
+  }
+  const random = mulberry32(seed >>> 0);
+  const means = new Float64Array(resamples);
+  let leZero = 0;
+  for (let b = 0; b < resamples; b += 1) {
+    let sum = 0;
+    for (let i = 0; i < n; i += 1) {
+      sum += deltas[(random() * n) | 0];
+    }
+    const resampleMean = sum / n;
+    means[b] = resampleMean;
+    if (resampleMean <= 0) leZero += 1;
+  }
+  const sorted = Array.from(means).sort((a, b) => a - b);
+  return {
+    resamples,
+    meanDelta,
+    ciLow: quantileSorted(sorted, alpha / 2),
+    ciHigh: quantileSorted(sorted, 1 - alpha / 2),
+    pLessEqualZero: leZero / resamples,
+  };
+}
+
+/**
+ * Wild-cluster bootstrap-t for the mean of clustered paired deltas (Cameron,
+ * Gelbach & Miller 2008). The mean delta is a one-parameter model; its
+ * cluster-robust (CR0) sandwich standard error is
+ *
+ *     SE = sqrt( Σ_g ( Σ_{i∈g} (dᵢ − d̄) )² ) / n.
+ *
+ * Each bootstrap replication draws one Rademacher weight wₘ ∈ {−1,+1} per
+ * cluster, perturbs the centered residuals as d*ᵢ = d̄ + w_{g(i)}·(dᵢ − d̄), and
+ * recomputes t* = (d̄* − d̄) / SE*. The reported **p-value** is the share of
+ * |t*| at least as extreme as the observed |t| — the cluster-aware inference,
+ * robust even with few clusters, which is the whole point for the BEIR matrix
+ * (queries within a dataset are not independent).
+ *
+ * The **CI**, by contrast, is the cluster-robust Wald interval d̄ ± t_{G−1}·SE,
+ * NOT the percentile-t inversion of the bootstrap t-distribution. With very few
+ * clusters (BEIR's CI subset is 3) the percentile-t interval is numerically
+ * unstable — a replication with SE* ≈ 0 sends a t* quantile to ±∞ and the
+ * interval explodes — whereas the Wald-t interval stays bounded and honest. The
+ * bootstrap is reserved for the p-value, where it is well-behaved; the interval
+ * uses the G−1 t-approximation that is standard for cluster-robust inference.
+ */
+export function wildClusterBootstrap(
+  samples: readonly PairedSample[],
+  resamples: number,
+  seed: number,
+  alpha: number,
+): WildClusterResult {
+  const n = samples.length;
+  const deltas = samples.map((s) => s.delta);
+  const meanDelta = mean(deltas);
+
+  // Group observation indices by cluster.
+  const clusterIndexes = new Map<string, number[]>();
+  for (let i = 0; i < samples.length; i += 1) {
+    const key = samples[i].cluster;
+    const bucket = clusterIndexes.get(key);
+    if (bucket === undefined) clusterIndexes.set(key, [i]);
+    else bucket.push(i);
+  }
+  const clusterGroups = [...clusterIndexes.values()];
+  const residuals = deltas.map((d) => d - meanDelta);
+  const seObserved = clusterRobustStdError(deltas, meanDelta, clusterGroups, n);
+  const tObserved = seObserved === 0 ? 0 : meanDelta / seObserved;
+
+  const random = mulberry32(seed >>> 0);
+  const absObserved = Math.abs(tObserved);
+  let extreme = 0;
+  for (let b = 0; b < resamples; b += 1) {
+    const starDeltas = deltas.slice();
+    for (const group of clusterGroups) {
+      const weight = random() < 0.5 ? -1 : 1;
+      for (const i of group) starDeltas[i] = meanDelta + weight * residuals[i];
+    }
+    const starMean = mean(starDeltas);
+    const starSe = clusterRobustStdError(starDeltas, starMean, clusterGroups, n);
+    const tStar = starSe === 0 ? 0 : (starMean - meanDelta) / starSe;
+    if (Math.abs(tStar) >= absObserved) extreme += 1;
+  }
+
+  // Cluster-robust Wald-t interval with G−1 degrees of freedom (bounded).
+  const dfCluster = Math.max(1, clusterGroups.length - 1);
+  const tCritical = studentTwoSidedCritical(dfCluster, alpha);
+  return {
+    clusters: clusterGroups.length,
+    resamples,
+    meanDelta,
+    tStatistic: tObserved,
+    clusterRobustStdError: seObserved,
+    ciLow: meanDelta - tCritical * seObserved,
+    ciHigh: meanDelta + tCritical * seObserved,
+    pValue: extreme / resamples,
+  };
+}
+
+function clusterRobustStdError(
+  deltas: readonly number[],
+  m: number,
+  clusterGroups: readonly number[][],
+  n: number,
+): number {
+  let sandwich = 0;
+  for (const group of clusterGroups) {
+    let clusterSum = 0;
+    for (const i of group) clusterSum += deltas[i] - m;
+    sandwich += clusterSum * clusterSum;
+  }
+  return Math.sqrt(sandwich) / n;
+}
+
+// ---------------------------------------------------------------------------
+// Multiple-comparison correction across a family
+// ---------------------------------------------------------------------------
+
+/**
+ * Family-wise adjusted p-values. `bonferroni` scales every p by the family size
+ * m; `holm` is the uniformly-more-powerful step-down variant (sort ascending,
+ * scale the k-th smallest by m−k+1, enforce monotonic non-decrease). Both clamp
+ * to ≤ 1 and preserve input order in the returned array.
+ */
+export function adjustPValues(pValues: readonly number[], method: CorrectionMethod): number[] {
+  const m = pValues.length;
+  if (m === 0) return [];
+  if (method === 'none') return pValues.map((p) => clamp01(p));
+  if (method === 'bonferroni') return pValues.map((p) => clamp01(p * m));
+
+  // Holm step-down.
+  const order = pValues
+    .map((p, index) => ({ p, index }))
+    .sort((a, b) => a.p - b.p);
+  const adjusted = new Array<number>(m);
+  let running = 0;
+  order.forEach((entry, rank) => {
+    const scaled = clamp01(entry.p * (m - rank));
+    running = Math.max(running, scaled);
+    adjusted[entry.index] = running;
+  });
+  return adjusted;
+}
+
+/**
+ * Run a family of comparisons and apply a multiple-comparison correction across
+ * them. Each comparison keeps its own (uncorrected) verdict; `correctedVerdict`
+ * downgrades to `no-significant-change` whenever the family-wise correction no
+ * longer rejects the null, and otherwise carries the sign of the mean delta.
+ */
+export function compareFamily(
+  comparisons: readonly ComparisonResult[],
+  method: CorrectionMethod = 'holm',
+  alpha: number = DEFAULT_ALPHA,
+): FamilyResult {
+  // Prefer the wild-cluster p-value when present (it is the honest one for
+  // clustered queries); fall back to the paired t-test p otherwise.
+  const pValues = comparisons.map((c) => c.wildCluster?.pValue ?? c.pValue);
+  const adjusted = adjustPValues(pValues, method);
+  const familyComparisons = comparisons.map((comparison, index) => {
+    const adjustedPValue = adjusted[index];
+    const rejectedNull = adjustedPValue < alpha;
+    const correctedVerdict: Verdict = rejectedNull
+      ? comparison.meanDelta >= 0 ? 'improvement' : 'regression'
+      : 'no-significant-change';
+    return { ...comparison, adjustedPValue, rejectedNull, correctedVerdict };
+  });
+  return { method, alpha, comparisons: familyComparisons };
+}
+
+// ---------------------------------------------------------------------------
+// Verdict
+// ---------------------------------------------------------------------------
+
+function verdictFromResult(
+  meanDelta: number,
+  pValue: number,
+  bootstrap: BootstrapCi,
+  wildCluster: WildClusterResult | undefined,
+  alpha: number,
+): Verdict {
+  // A change is "significant" when the bootstrap CI excludes zero AND the
+  // (cluster-aware, when available) test rejects at α. Requiring both the
+  // interval and the test agree keeps a borderline p from flipping the verdict
+  // on a CI that still straddles zero.
+  const testP = wildCluster?.pValue ?? pValue;
+  const ci = wildCluster ?? bootstrap;
+  const ciExcludesZero = ci.ciLow > 0 || ci.ciHigh < 0;
+  if (testP < alpha && ciExcludesZero) {
+    return meanDelta >= 0 ? 'improvement' : 'regression';
+  }
+  return 'no-significant-change';
+}
+
+// ---------------------------------------------------------------------------
+// Numeric helpers
+// ---------------------------------------------------------------------------
+
+function mean(values: readonly number[]): number {
+  if (values.length === 0) return 0;
+  let sum = 0;
+  for (const v of values) sum += v;
+  return sum / values.length;
+}
+
+/** Linear-interpolated quantile of an already-ascending array. */
+export function quantileSorted(sorted: readonly number[], q: number): number {
+  const n = sorted.length;
+  if (n === 0) return 0;
+  if (n === 1) return sorted[0];
+  const clamped = Math.min(1, Math.max(0, q));
+  const position = clamped * (n - 1);
+  const lower = Math.floor(position);
+  const upper = Math.ceil(position);
+  if (lower === upper) return sorted[lower];
+  const weight = position - lower;
+  return sorted[lower] * (1 - weight) + sorted[upper] * weight;
+}
+
+function clamp01(value: number): number {
+  if (value < 0) return 0;
+  if (value > 1) return 1;
+  return value;
+}
+
+/** mulberry32 — small, fast, deterministic 32-bit PRNG. */
+export function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/**
+ * Two-sided p-value for Student's t with `df` degrees of freedom, via the
+ * regularized incomplete beta identity p = I_{df/(df+t²)}(df/2, 1/2).
+ */
+export function studentTwoSidedP(t: number, df: number): number {
+  if (!Number.isFinite(t)) return 0;
+  if (df <= 0) return 1;
+  const x = df / (df + t * t);
+  return clamp01(regularizedIncompleteBeta(x, df / 2, 0.5));
+}
+
+/**
+ * Two-sided critical t-value for `df` degrees of freedom at level `alpha`: the
+ * positive t* solving `studentTwoSidedP(t*, df) = alpha`. Found by bisection on
+ * the monotone-decreasing tail; deterministic and dependency-free.
+ */
+export function studentTwoSidedCritical(df: number, alpha: number): number {
+  if (df <= 0 || alpha <= 0 || alpha >= 1) return Infinity;
+  let lo = 0;
+  let hi = 1e6;
+  for (let iter = 0; iter < 200; iter += 1) {
+    const mid = (lo + hi) / 2;
+    if (studentTwoSidedP(mid, df) > alpha) lo = mid;
+    else hi = mid;
+  }
+  return (lo + hi) / 2;
+}
+
+function regularizedIncompleteBeta(x: number, a: number, b: number): number {
+  if (x <= 0) return 0;
+  if (x >= 1) return 1;
+  const lnBeta = logGamma(a + b) - logGamma(a) - logGamma(b);
+  const front = Math.exp(lnBeta + a * Math.log(x) + b * Math.log(1 - x));
+  // Use the continued fraction for the faster-converging tail and the symmetry
+  // I_x(a,b) = 1 − I_{1−x}(b,a) for the other.
+  if (x < (a + 1) / (a + b + 2)) {
+    return (front * betaContinuedFraction(x, a, b)) / a;
+  }
+  return 1 - (front * betaContinuedFraction(1 - x, b, a)) / b;
+}
+
+function betaContinuedFraction(x: number, a: number, b: number): number {
+  const tiny = 1e-30;
+  const maxIterations = 300;
+  const epsilon = 3e-12;
+  let c = 1;
+  let d = 1 - ((a + b) * x) / (a + 1);
+  if (Math.abs(d) < tiny) d = tiny;
+  d = 1 / d;
+  let result = d;
+  for (let m = 1; m <= maxIterations; m += 1) {
+    const m2 = 2 * m;
+    let numerator = (m * (b - m) * x) / ((a + m2 - 1) * (a + m2));
+    d = 1 + numerator * d;
+    if (Math.abs(d) < tiny) d = tiny;
+    c = 1 + numerator / c;
+    if (Math.abs(c) < tiny) c = tiny;
+    d = 1 / d;
+    result *= d * c;
+
+    numerator = (-(a + m) * (a + b + m) * x) / ((a + m2) * (a + m2 + 1));
+    d = 1 + numerator * d;
+    if (Math.abs(d) < tiny) d = tiny;
+    c = 1 + numerator / c;
+    if (Math.abs(c) < tiny) c = tiny;
+    d = 1 / d;
+    const delta = d * c;
+    result *= delta;
+    if (Math.abs(delta - 1) < epsilon) break;
+  }
+  return result;
+}
+
+const LANCZOS_COEFFICIENTS = [
+  676.5203681218851,
+  -1259.1392167224028,
+  771.32342877765313,
+  -176.61502916214059,
+  12.507343278686905,
+  -0.13857109526572012,
+  9.9843695780195716e-6,
+  1.5056327351493116e-7,
+];
+
+export function logGamma(z: number): number {
+  if (z < 0.5) {
+    return Math.log(Math.PI / Math.sin(Math.PI * z)) - logGamma(1 - z);
+  }
+  const shifted = z - 1;
+  let x = 0.99999999999980993;
+  for (let i = 0; i < LANCZOS_COEFFICIENTS.length; i += 1) {
+    x += LANCZOS_COEFFICIENTS[i] / (shifted + i + 1);
+  }
+  const t = shifted + LANCZOS_COEFFICIENTS.length - 0.5;
+  return 0.5 * Math.log(2 * Math.PI) + (shifted + 0.5) * Math.log(t) - t + Math.log(x);
+}
+
+// ---------------------------------------------------------------------------
+// Run-file loading
+// ---------------------------------------------------------------------------
+
+interface BeirRunFileShape {
+  dataset?: { name?: unknown };
+  per_query?: unknown;
+}
+
+/**
+ * Load one or more BEIR run-report JSON files into a single per-query score
+ * vector. Each file contributes its `per_query[].{queryId, ndcgAt10}` rows;
+ * the file's `dataset.name` becomes the cluster label and is prefixed onto the
+ * query id (`<dataset>:<queryId>`) so ids stay unique across concatenated
+ * datasets — which is exactly the clustered structure the wild-cluster
+ * bootstrap consumes.
+ */
+export async function loadRunScores(paths: readonly string[]): Promise<PerQueryScore[]> {
+  const scores: PerQueryScore[] = [];
+  for (const filePath of paths) {
+    const raw = await fsp.readFile(filePath, 'utf-8');
+    const parsed = JSON.parse(raw) as BeirRunFileShape;
+    const datasetName = typeof parsed.dataset?.name === 'string' ? parsed.dataset.name : path.basename(filePath);
+    if (!Array.isArray(parsed.per_query)) {
+      throw new Error(`significance: ${filePath} has no per_query array (is it a BEIR run report?)`);
+    }
+    for (const row of parsed.per_query) {
+      if (typeof row !== 'object' || row === null) continue;
+      const record = row as { queryId?: unknown; ndcgAt10?: unknown };
+      if (typeof record.queryId !== 'string' || typeof record.ndcgAt10 !== 'number') {
+        throw new Error(`significance: ${filePath} per_query row missing queryId/ndcgAt10`);
+      }
+      scores.push({
+        queryId: `${datasetName}:${record.queryId}`,
+        ndcgAt10: record.ndcgAt10,
+        cluster: datasetName,
+      });
+    }
+  }
+  return scores;
+}
+
+// ---------------------------------------------------------------------------
+// Markdown rendering
+// ---------------------------------------------------------------------------
+
+export function renderComparisonMarkdown(
+  result: ComparisonResult,
+  options: { baselineLabel: string; currentLabel: string; alpha: number; dropped: number },
+): string {
+  const lines = [
+    '## Retrieval significance comparison',
+    '',
+    `Current: \`${options.currentLabel}\``,
+    `Baseline: \`${options.baselineLabel}\``,
+    `Paired queries: ${result.n}${options.dropped > 0 ? ` (${options.dropped} unpaired id(s) dropped)` : ''}`,
+    `Clusters (datasets): ${result.clusters}`,
+    `Verdict: **${result.verdict.toUpperCase()}** at α=${options.alpha}`,
+    '',
+    '| Statistic | Value |',
+    '| --- | ---: |',
+    `| Mean ΔnDCG@10 | ${signed(result.meanDelta)} |`,
+    `| Paired t | ${result.tStatistic.toFixed(4)} (df=${result.degreesOfFreedom}) |`,
+    `| Paired t-test p | ${formatP(result.pValue)} |`,
+    `| Bootstrap ${(100 * (1 - options.alpha)).toFixed(0)}% CI (${result.bootstrap.resamples} resamples) | [${signed(result.bootstrap.ciLow)}, ${signed(result.bootstrap.ciHigh)}] |`,
+  ];
+  if (result.wildCluster !== undefined) {
+    const wc = result.wildCluster;
+    lines.push(
+      `| Wild-cluster bootstrap-t p | ${formatP(wc.pValue)} (${wc.clusters} clusters) |`,
+      `| Wild-cluster ${(100 * (1 - options.alpha)).toFixed(0)}% CI | [${signed(wc.ciLow)}, ${signed(wc.ciHigh)}] |`,
+    );
+  }
+  lines.push('', 'A non-significant dip is reported, not failed (RFC 020 §3/§4).');
+  return `${lines.join('\n')}\n`;
+}
+
+export function renderFamilyMarkdown(family: FamilyResult): string {
+  const lines = [
+    '## Retrieval significance comparison (family)',
+    '',
+    `Correction: ${family.method} across ${family.comparisons.length} comparison(s) at α=${family.alpha}`,
+    '',
+    '| Comparison | n | Mean Δ | raw p | adj p | Verdict |',
+    '| --- | ---: | ---: | ---: | ---: | --- |',
+  ];
+  for (const comparison of family.comparisons) {
+    const rawP = comparison.wildCluster?.pValue ?? comparison.pValue;
+    lines.push([
+      comparison.label,
+      String(comparison.n),
+      signed(comparison.meanDelta),
+      formatP(rawP),
+      formatP(comparison.adjustedPValue),
+      comparison.correctedVerdict.toUpperCase(),
+    ].join(' | ').replace(/^/, '| ').replace(/$/, ' |'));
+  }
+  lines.push('', 'Non-significant rows are reported, not failed (RFC 020 §3/§4).');
+  return `${lines.join('\n')}\n`;
+}
+
+function signed(value: number): string {
+  return `${value >= 0 ? '+' : ''}${value.toFixed(4)}`;
+}
+
+function formatP(value: number): string {
+  if (value < 1e-4 && value > 0) return '<0.0001';
+  return value.toFixed(4);
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+interface CliOptions {
+  baselinePaths: string[];
+  currentPaths: string[];
+  familyPath?: string;
+  label: string;
+  alpha: number;
+  resamples: number;
+  seed: number;
+  method: CorrectionMethod;
+  clusterByDataset: boolean;
+  enforceFailures: boolean;
+  summaryPath?: string;
+  repoRoot: string;
+}
+
+interface FamilyManifestEntry {
+  label: string;
+  baseline: string | string[];
+  current: string | string[];
+  clusterByDataset?: boolean;
+}
+
+export function parseSignificanceArgs(argv: string[], env: NodeJS.ProcessEnv): CliOptions {
+  const options: CliOptions = {
+    baselinePaths: [],
+    currentPaths: [],
+    label: 'comparison',
+    alpha: DEFAULT_ALPHA,
+    resamples: DEFAULT_BOOTSTRAP_RESAMPLES,
+    seed: DEFAULT_BOOTSTRAP_SEED,
+    method: 'holm',
+    clusterByDataset: false,
+    enforceFailures: parseBool(env.BENCH_SIGNIFICANCE_FAIL),
+    summaryPath: env.GITHUB_STEP_SUMMARY,
+    repoRoot: process.cwd(),
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    const [flag, inlineValue] = token.includes('=') ? token.split(/=(.*)/s, 2) : [token, undefined];
+    const readValue = (): string => {
+      if (inlineValue !== undefined) return inlineValue;
+      i += 1;
+      const value = argv[i];
+      if (value === undefined || value.startsWith('--')) throw new Error(`${flag} requires a value`);
+      return value;
+    };
+    if (flag === '--baseline') {
+      options.baselinePaths = splitPaths(readValue());
+    } else if (flag === '--current') {
+      options.currentPaths = splitPaths(readValue());
+    } else if (flag === '--family') {
+      options.familyPath = path.resolve(readValue());
+    } else if (flag === '--label') {
+      options.label = readValue();
+    } else if (flag === '--alpha') {
+      options.alpha = parseUnitInterval(readValue(), '--alpha');
+    } else if (flag === '--bootstrap') {
+      options.resamples = parsePositiveInt(readValue(), '--bootstrap');
+    } else if (flag === '--seed') {
+      options.seed = parsePositiveInt(readValue(), '--seed');
+    } else if (flag === '--correction') {
+      options.method = parseCorrection(readValue());
+    } else if (flag === '--cluster-by-dataset') {
+      options.clusterByDataset = true;
+    } else if (flag === '--fail-on-regression') {
+      options.enforceFailures = true;
+    } else if (flag === '--summary') {
+      options.summaryPath = path.resolve(readValue());
+    } else if (flag === '--help' || flag === '-h') {
+      process.stdout.write(significanceHelpText());
+      process.exit(0);
+    } else {
+      throw new Error(`unknown argument: ${token}`);
+    }
+  }
+  return options;
+}
+
+function splitPaths(raw: string): string[] {
+  return raw.split(',').map((v) => v.trim()).filter((v) => v.length > 0);
+}
+
+async function runCli(): Promise<void> {
+  const options = parseSignificanceArgs(process.argv.slice(2), process.env);
+  const markdown = options.familyPath !== undefined
+    ? await runFamilyCli(options)
+    : await runSingleCli(options);
+
+  process.stdout.write(markdown.text);
+  if (options.summaryPath !== undefined) {
+    await fsp.appendFile(options.summaryPath, markdown.text, 'utf-8');
+  }
+  if (options.enforceFailures && markdown.hasRegression) {
+    process.exitCode = 1;
+  }
+}
+
+async function runSingleCli(options: CliOptions): Promise<{ text: string; hasRegression: boolean }> {
+  if (options.baselinePaths.length === 0 || options.currentPaths.length === 0) {
+    throw new Error('significance: --baseline and --current are required (or use --family)');
+  }
+  const baseline = await loadRunScores(options.baselinePaths);
+  const current = await loadRunScores(options.currentPaths);
+  const { samples, dropped } = pairScores(baseline, current);
+  const clusterByDataset = options.clusterByDataset
+    || new Set(samples.map((s) => s.cluster)).size > 1;
+  const result = compareSamples(samples, {
+    label: options.label,
+    alpha: options.alpha,
+    resamples: options.resamples,
+    seed: options.seed,
+    clusterByDataset,
+  });
+  const text = renderComparisonMarkdown(result, {
+    baselineLabel: options.baselinePaths.map((p) => path.relative(options.repoRoot, p)).join(', '),
+    currentLabel: options.currentPaths.map((p) => path.relative(options.repoRoot, p)).join(', '),
+    alpha: options.alpha,
+    dropped: dropped.length,
+  });
+  return { text, hasRegression: result.verdict === 'regression' };
+}
+
+async function runFamilyCli(options: CliOptions): Promise<{ text: string; hasRegression: boolean }> {
+  const raw = await fsp.readFile(options.familyPath as string, 'utf-8');
+  const parsed = JSON.parse(raw) as unknown;
+  if (!Array.isArray(parsed)) {
+    throw new Error('significance: --family manifest must be a JSON array of {label, baseline, current}');
+  }
+  const manifestDir = path.dirname(options.familyPath as string);
+  const comparisons: ComparisonResult[] = [];
+  for (const entry of parsed as FamilyManifestEntry[]) {
+    const baselinePaths = toPathList(entry.baseline).map((p) => path.resolve(manifestDir, p));
+    const currentPaths = toPathList(entry.current).map((p) => path.resolve(manifestDir, p));
+    const baseline = await loadRunScores(baselinePaths);
+    const current = await loadRunScores(currentPaths);
+    const { samples } = pairScores(baseline, current);
+    const clusterByDataset = (entry.clusterByDataset ?? options.clusterByDataset)
+      || new Set(samples.map((s) => s.cluster)).size > 1;
+    comparisons.push(compareSamples(samples, {
+      label: entry.label,
+      alpha: options.alpha,
+      resamples: options.resamples,
+      seed: options.seed,
+      clusterByDataset,
+    }));
+  }
+  const family = compareFamily(comparisons, options.method, options.alpha);
+  return {
+    text: renderFamilyMarkdown(family),
+    hasRegression: family.comparisons.some((c) => c.correctedVerdict === 'regression'),
+  };
+}
+
+function toPathList(value: string | string[]): string[] {
+  return Array.isArray(value) ? value : [value];
+}
+
+function parseBool(value: string | undefined): boolean {
+  if (value === undefined) return false;
+  return value === '1' || value.toLowerCase() === 'true' || value.toLowerCase() === 'yes';
+}
+
+function parsePositiveInt(raw: string, flag: string): number {
+  const parsed = Number(raw);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) throw new Error(`${flag} must be a positive integer`);
+  return parsed;
+}
+
+function parseUnitInterval(raw: string, flag: string): number {
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0 || parsed >= 1) throw new Error(`${flag} must be in (0, 1)`);
+  return parsed;
+}
+
+function parseCorrection(raw: string): CorrectionMethod {
+  if (raw === 'bonferroni' || raw === 'holm' || raw === 'none') return raw;
+  throw new Error('--correction must be one of: bonferroni, holm, none');
+}
+
+function significanceHelpText(): string {
+  return `kb retrieval significance comparator (RFC 020 §3)
+
+Usage:
+  npm run bench:beir:significance -- --baseline a.json --current b.json
+  npm run bench:beir:significance -- \\
+      --baseline scifact-hybrid.json,nfcorpus-hybrid.json \\
+      --current scifact-hybrid+rerank.json,nfcorpus-hybrid+rerank.json \\
+      --cluster-by-dataset
+  npm run bench:beir:significance -- --family stage-contributions.json --correction holm
+
+Inputs are BEIR run-report JSON files (the per_query[].ndcgAt10 vectors).
+Comma-separate multiple dataset files to compare a multi-domain run; each
+file's dataset.name becomes a cluster for the wild-cluster bootstrap.
+
+Options:
+  --baseline=<a.json[,b.json]>  Baseline run file(s).
+  --current=<a.json[,b.json]>   Current run file(s) (same query set).
+  --family=<manifest.json>      JSON array of {label, baseline, current,
+                                clusterByDataset?} for a corrected family sweep.
+  --label=<name>                Label for the single-comparison report.
+  --alpha=<p>                   Significance level. Default: 0.05.
+  --bootstrap=<n>               Bootstrap resamples. Default: 10000.
+  --seed=<n>                    Deterministic bootstrap seed.
+  --correction=<m>              bonferroni | holm | none (family). Default: holm.
+  --cluster-by-dataset          Force the wild-cluster bootstrap-t leg.
+  --fail-on-regression          Exit 1 on a significant regression verdict.
+  --summary=<path>              Append markdown to this file (CI step summary).
+`;
+}
+
+function isDirectRun(argvPath: string | undefined): boolean {
+  if (argvPath === undefined) return false;
+  return path.basename(argvPath) === 'significance.js';
+}
+
+if (isDirectRun(process.argv[1])) {
+  runCli().catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.stack ?? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "bench:beir": "npm run build && tsc -p tsconfig.bench.json && node build/benchmarks/beir/run.js",
     "bench:beir:sweep": "npm run build && tsc -p tsconfig.bench.json && node build/benchmarks/beir/sweep.js",
     "bench:beir:baseline": "npm run build && tsc -p tsconfig.bench.json && node build/benchmarks/beir/baseline.js",
+    "bench:beir:significance": "npm run build && tsc -p tsconfig.bench.json && node build/benchmarks/significance.js",
     "bench:compare": "npm run build && tsc -p tsconfig.bench.json && node build/benchmarks/compare/run.js",
     "bench:tune": "python3 benchmarks/optuna_tune.py",
     "docs:check-anchors": "node scripts/check-doc-anchors.mjs",


### PR DESCRIPTION
Closes #561. Part of epic #559 (RFC 020, milestone **M1**), building on M0 (#566).

## What this lands

### 1. New BEIR runner modes — production paths, not reimplementations
`--mode=hybrid+rerank` and `--mode=hybrid+rerank+contextual` (in `benchmarks/beir/run.ts`):

- **`hybrid+rerank`** retrieves through the hybrid RRF path and reranks with the production `src/reranker.ts` cross-encoder, enabled via the production `KB_RERANK` config.
- **`hybrid+rerank+contextual`** additionally turns on the RFC 017 contextual-preface ingest (`KB_CONTEXTUAL_RETRIEVAL`), so `buildChunkDocuments` generates and embeds per-chunk prefaces. It **fails loudly** when no LLM endpoint is configured — mirroring the existing no-provider check (mode availability is reported, not silently degraded, per RFC 020 §1).

The runner flips `KB_RERANK` / `KB_CONTEXTUAL_RETRIEVAL` per mode and restores them afterwards, so a run is self-contained even inside the in-process sweep/baseline loops. The report schema bumps to **v3** with `rerank` (enabled/model/topN) and `contextual` (enabled) provenance blocks for the RFC §7 ledger. The sweep and baseline mode parsers accept the new modes.

**Faithfulness test** (`benchmarks/beir/run.rerank.test.ts`): runs the production retrieval entrypoint with the deterministic `fake` embedding provider, injects a fake cross-encoder through the production `setRerankerFactoryForTests` seam (no model downloads), and asserts (a) the shipped reranker is invoked for the rerank modes and **skipped for plain hybrid**, and (b) the RFC 017 contextual ingest actually generated prefaces via the production sidecar (`aggregateContextualSidecarStats`).

### 2. Significance comparator (`benchmarks/significance.ts`, `npm run bench:beir:significance`)
Next to `budget-diff.ts`, mirroring its CLI shape. Pairs two BEIR run reports by query id over the same query set and reports:

- **Paired bootstrap** (10k resamples) CI on the mean ΔnDCG@10 + **paired t-test** p-value, with a verdict `improvement` / `regression` / `no-significant-change` at α=0.05. Deterministic via a seeded PRNG.
- **Multiple-comparison correction** — Bonferroni and step-down **Holm** — across a sweep family (`--family <manifest>` / `--correction`).
- **Wild-cluster bootstrap-t** (`--cluster-by-dataset`) for when queries cluster by dataset/domain (the BEIR matrix does): Rademacher cluster sign-flips give a cluster-aware p-value; the reported CI is the **bounded cluster-robust Wald-t** interval, because the percentile-t interval is numerically unstable with BEIR's handful of clusters.

Covered by deterministic unit fixtures (`benchmarks/significance.test.ts`), including textbook t critical values, Holm/Bonferroni order-preservation, the KB-cited case where a naive test marks all 4 comparisons significant but the correction leaves 1, and the wild-cluster behavior (less significant than naive under intra-domain correlation; still significant when every domain agrees).

## Acceptance metric — stage-contribution run is **pending a real corpus**
M1's acceptance metric ("each enabled stage's contribution on the CI subset, significance-tested with multiple-comparison correction") needs a real embedding model + the BEIR datasets + the cross-encoder model. **This was not feasible in the implementation environment** (no network to the BEIR dataset host or HuggingFace; the only local Ollama model is a chat model, not an embedding model). Per the issue's instruction, the harness + unit tests are landed and **no benchmark number is fabricated or hardcoded**. To produce the headline numbers, run on a host with Ollama + an embedding model + network:

```bash
npm run bench:beir -- --dataset=scifact --mode=hybrid                   --provider=ollama --model=nomic-embed-text --output-dir=/tmp/kb-beir
npm run bench:beir -- --dataset=scifact --mode=hybrid+rerank            --provider=ollama --model=nomic-embed-text --output-dir=/tmp/kb-beir
npm run bench:beir -- --dataset=scifact --mode=hybrid+rerank+contextual --provider=ollama --model=nomic-embed-text --output-dir=/tmp/kb-beir
npm run bench:beir:significance -- --family /tmp/stage-contributions.json --correction holm
```

## Verification
`npm run check` (build + 134 suites / 2139 tests + doc-anchor check) passes green. The significance comparator and both runner test files were also exercised individually; the compiled `significance.js` CLI was smoke-tested across single / multi-dataset (wild-cluster) / family-manifest paths.

## Follow-ups
- The real-corpus stage-contribution run above (and committing the resulting CI-subset baselines for the new modes) is the natural next step toward the M2 full-matrix sweep (#562).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
