### PR TITLE
feat(bench): M2 — full BEIR matrix sweep + MLflow ledger + leaderboard view + per-domain/Δ_g report

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -140,6 +140,46 @@ A non-significant dip is **reported, not failed** (matching the future CI gate
 in RFC 020 §4); pass `--fail-on-regression` to exit non-zero on a significant
 regression verdict.
 
+## Full BEIR matrix — `bench:beir:matrix` (RFC 020 M2)
+
+The **headline** deliverable. `bench:beir:matrix` sweeps the retrieval pipeline
+over the `(dataset × mode)` matrix from the dataset registry
+(`benchmarks/beir/registry.ts`) and reports, per mode, the **multi-domain mean
+nDCG@10** — the metric the field quotes and the one §2/§6 call anti-overfitting
+(averaging across domains lowers anything that overfits a single corpus). It also
+emits the per-domain breakdown and **Δ_g = (seen − unseen) / seen** between the
+tuned datasets and a reserved unseen-generality set, plus a per-dataset
+contamination note. Every cell is wired into the MLflow ledger (RFC 020 §7).
+
+```bash
+# Full auto-downloadable matrix, all shipped modes (Ollama running):
+npm run bench:beir:matrix -- --provider=ollama --model=nomic-embed-text \
+  --modes=lexical,dense,hybrid,hybrid+rerank,hybrid+rerank+contextual
+
+# A tuned+unseen slice that still yields a real Δ_g, fewer datasets:
+npm run bench:beir:matrix -- --provider=ollama --model=nomic-embed-text \
+  --datasets=scifact,nfcorpus,fiqa,arguana,scidocs,webis-touche2020 \
+  --modes=lexical,hybrid
+```
+
+Output: `benchmarks/results/beir/matrix/beir-matrix.{json,md}`. Missing or failed
+cells (e.g. an uncached dataset) are recorded and **excluded from the mean** —
+the report never fabricates a number for a dataset that did not run. See
+`benchmarks/results/beir/matrix/README.md` for the headline status.
+
+## Cross-run leaderboard — `bench:beir:leaderboard` (RFC 020 §7)
+
+Turns the recorded matrix runs into the human-facing leaderboard view: a
+self-contained HTML page ranking runs by the per-mode multi-domain mean nDCG@10,
+showing Δ_g, and recording the commit + env for each run (the reproducibility
+contract a public ranking claim rests on).
+
+```bash
+npm run bench:beir:leaderboard -- \
+  --inputs=run1/beir-matrix.json,run2/beir-matrix.json \
+  --output=benchmarks/results/beir/leaderboard.html
+```
+
 ## Result file naming
 
 Reports are written to `benchmarks/results/` with this naming pattern:

--- a/benchmarks/beir/generalization.test.ts
+++ b/benchmarks/beir/generalization.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+  computeDeltaG,
+  computeDomainBreakdown,
+  computeGeneralizationReport,
+  formatDeltaG,
+  type GeneralizationCell,
+} from './generalization.js';
+
+// Registry-grounded fixtures: scifact/nfcorpus/fiqa are tuned ("seen");
+// arguana/scidocs/webis-touche2020 are reserved unseen-generality.
+function cell(dataset: string, mode: string, ndcg: number, precision = 0.1): GeneralizationCell {
+  return { dataset, mode, ndcgAt10: ndcg, precisionAt10: precision, queriesEvaluated: 10 };
+}
+
+describe('computeDeltaG', () => {
+  it('computes Δ_g = (seen − unseen)/seen over the registry partition', () => {
+    const cells = [
+      cell('scifact', 'hybrid', 0.80),
+      cell('nfcorpus', 'hybrid', 0.60),
+      cell('fiqa', 'hybrid', 0.40), // seen mean = 0.60
+      cell('arguana', 'hybrid', 0.50),
+      cell('scidocs', 'hybrid', 0.30),
+      cell('webis-touche2020', 'hybrid', 0.40), // unseen mean = 0.40
+    ];
+    const result = computeDeltaG(cells, 'hybrid');
+    expect(result.seenMeanNdcgAt10).toBeCloseTo(0.6, 6);
+    expect(result.unseenMeanNdcgAt10).toBeCloseTo(0.4, 6);
+    // (0.6 - 0.4) / 0.6 = 0.3333...
+    expect(result.deltaG).toBeCloseTo(0.333333, 5);
+  });
+
+  it('returns deltaG=null when the unseen side was not run (honest partial sweep)', () => {
+    const cells = [cell('scifact', 'hybrid', 0.8), cell('nfcorpus', 'hybrid', 0.6)];
+    const result = computeDeltaG(cells, 'hybrid');
+    expect(result.seenMeanNdcgAt10).toBeCloseTo(0.7, 6);
+    expect(result.unseenMeanNdcgAt10).toBeNull();
+    expect(result.deltaG).toBeNull();
+  });
+
+  it('returns deltaG=null when the seen mean is zero (undefined ratio)', () => {
+    const cells = [cell('scifact', 'lexical', 0), cell('arguana', 'lexical', 0.2)];
+    expect(computeDeltaG(cells, 'lexical').deltaG).toBeNull();
+  });
+
+  it('honors a custom partition', () => {
+    const cells = [cell('a', 'm', 1.0), cell('b', 'm', 0.5)];
+    const result = computeDeltaG(cells, 'm', { tuned: ['a'], unseen: ['b'] });
+    expect(result.deltaG).toBeCloseTo(0.5, 6);
+  });
+});
+
+describe('computeDomainBreakdown', () => {
+  it('averages nDCG@10/precision@10 per registry domain for one mode', () => {
+    const cells = [
+      cell('scifact', 'hybrid', 0.8, 0.2), // scientific fact-checking
+      cell('nfcorpus', 'hybrid', 0.6, 0.1), // bio-medical
+      cell('trec-covid', 'hybrid', 0.4, 0.3), // bio-medical
+      cell('fiqa', 'dense', 0.9), // other mode — excluded
+    ];
+    const rows = computeDomainBreakdown(cells, 'hybrid');
+    const bio = rows.find((r) => r.domain === 'bio-medical');
+    expect(bio?.datasets).toEqual(['nfcorpus', 'trec-covid']);
+    expect(bio?.meanNdcgAt10).toBeCloseTo(0.5, 6);
+    expect(bio?.meanPrecisionAt10).toBeCloseTo(0.2, 6);
+    expect(bio?.queriesEvaluated).toBe(20);
+    // Rows are sorted by domain.
+    expect(rows.map((r) => r.domain)).toEqual([...rows.map((r) => r.domain)].sort());
+  });
+
+  it('buckets unregistered datasets under "unknown" rather than dropping them', () => {
+    const rows = computeDomainBreakdown([cell('mystery', 'hybrid', 0.5)], 'hybrid');
+    expect(rows.some((r) => r.domain === 'unknown')).toBe(true);
+  });
+});
+
+describe('computeGeneralizationReport', () => {
+  it('reports per-domain + Δ_g for every requested mode', () => {
+    const cells = [
+      cell('scifact', 'hybrid', 0.8),
+      cell('arguana', 'hybrid', 0.4),
+      cell('scifact', 'lexical', 0.6),
+    ];
+    const report = computeGeneralizationReport(cells, ['hybrid', 'lexical']);
+    expect(report.modes.map((m) => m.mode)).toEqual(['hybrid', 'lexical']);
+    expect(report.tunedDatasets).toContain('scifact');
+    expect(report.unseenGeneralityDatasets).toContain('arguana');
+    const hybrid = report.modes.find((m) => m.mode === 'hybrid');
+    expect(hybrid?.deltaG.deltaG).toBeCloseTo(0.5, 6);
+  });
+});
+
+describe('formatDeltaG', () => {
+  it('renders a signed percentage or n/a', () => {
+    expect(formatDeltaG(0.3333)).toBe('+33.33%');
+    expect(formatDeltaG(-0.05)).toBe('-5.00%');
+    expect(formatDeltaG(null)).toBe('n/a');
+  });
+});

--- a/benchmarks/beir/generalization.ts
+++ b/benchmarks/beir/generalization.ts
@@ -1,0 +1,175 @@
+// RFC 020 §6 — the generalization guardrail (per-domain breakdown + Δ_g).
+//
+// The product promise is *general* knowledge research, so the program is built
+// so leaderboard climbing cannot quietly erode generality. The headline
+// multi-domain mean (§2) is the first anti-overfitting metric; this module adds
+// the two §6 structural probes that a mean alone hides:
+//
+//   1. **Per-domain breakdown.** The same mode can win on QA and lose on
+//      argument retrieval; averaging buries that. The breakdown reports the mean
+//      nDCG@10 / precision@10 per domain bucket so a domain-localized regression
+//      is visible.
+//
+//   2. **Δ_g = (score_seen − score_unseen) / score_seen.** Reported between the
+//      tuned/dev datasets ("seen") and a reserved unseen-generality set
+//      ("unseen") that is *never tuned on* and distinct from the per-dataset
+//      test split used for the headline. A widening Δ_g is the overfitting alarm
+//      a multi-domain mean cannot surface — a config can lift the mean while
+//      pulling further ahead on the corpora it was tuned against.
+//
+// Everything here is a pure function over already-scored matrix cells, so it is
+// deterministic and unit-testable from stub inputs (no datasets, no model).
+// `significance.ts` is the companion tool: Δ_g answers "is the gap widening?",
+// while a paired comparator over two modes' per-query vectors answers "is the
+// difference real?". The two compose — Δ_g flags the suspect, significance
+// convicts it.
+
+import { domainOf, tunedDatasets, unseenGeneralityDatasets } from './registry.js';
+
+/** The minimal per-(dataset × mode) shape the generalization math needs. */
+export interface GeneralizationCell {
+  dataset: string;
+  mode: string;
+  ndcgAt10: number;
+  precisionAt10: number;
+  queriesEvaluated: number;
+}
+
+export interface DomainBreakdownRow {
+  domain: string;
+  datasets: string[];
+  meanNdcgAt10: number;
+  meanPrecisionAt10: number;
+  queriesEvaluated: number;
+}
+
+export interface DeltaGResult {
+  mode: string;
+  seenDatasets: string[];
+  unseenDatasets: string[];
+  /** Mean nDCG@10 over the tuned ("seen") datasets present in the cells. */
+  seenMeanNdcgAt10: number | null;
+  /** Mean nDCG@10 over the reserved unseen-generality datasets present. */
+  unseenMeanNdcgAt10: number | null;
+  /**
+   * Δ_g = (seen − unseen) / seen. null when either side is absent from the run
+   * or the seen mean is 0 (the ratio is undefined). A higher Δ_g means the mode
+   * does relatively worse on held-out domains — the overfitting direction.
+   */
+  deltaG: number | null;
+}
+
+export interface ModeGeneralization {
+  mode: string;
+  domains: DomainBreakdownRow[];
+  deltaG: DeltaGResult;
+}
+
+export interface GeneralizationReport {
+  modes: ModeGeneralization[];
+  /** Echo of the registry partition the Δ_g used, for the ledger/provenance. */
+  tunedDatasets: string[];
+  unseenGeneralityDatasets: string[];
+}
+
+function mean(values: readonly number[]): number | null {
+  if (values.length === 0) return null;
+  let sum = 0;
+  for (const v of values) sum += v;
+  return round(sum / values.length);
+}
+
+function round(value: number): number {
+  return Number(value.toFixed(6));
+}
+
+/**
+ * Per-domain mean nDCG@10 / precision@10 for one mode. Domains are taken from
+ * the registry; cells for an unregistered dataset fall into the 'unknown'
+ * bucket rather than being dropped, so a typo'd dataset name is visible instead
+ * of silently missing. Rows are sorted by domain for stable output.
+ */
+export function computeDomainBreakdown(
+  cells: readonly GeneralizationCell[],
+  mode: string,
+): DomainBreakdownRow[] {
+  const byDomain = new Map<string, GeneralizationCell[]>();
+  for (const cell of cells) {
+    if (cell.mode !== mode) continue;
+    const domain = domainOf(cell.dataset);
+    const bucket = byDomain.get(domain);
+    if (bucket === undefined) byDomain.set(domain, [cell]);
+    else bucket.push(cell);
+  }
+  const rows: DomainBreakdownRow[] = [];
+  for (const [domain, domainCells] of byDomain) {
+    rows.push({
+      domain,
+      datasets: domainCells.map((c) => c.dataset).sort(),
+      meanNdcgAt10: mean(domainCells.map((c) => c.ndcgAt10)) ?? 0,
+      meanPrecisionAt10: mean(domainCells.map((c) => c.precisionAt10)) ?? 0,
+      queriesEvaluated: domainCells.reduce((acc, c) => acc + c.queriesEvaluated, 0),
+    });
+  }
+  return rows.sort((a, b) => a.domain.localeCompare(b.domain));
+}
+
+/**
+ * Δ_g for one mode over the registry's tuned vs unseen-generality partition.
+ * Only datasets actually present in `cells` contribute, so a partial run (e.g.
+ * the CI subset alone, with no unseen datasets) yields `deltaG: null` rather
+ * than a fabricated number — the report says "not computable", which is the
+ * honest answer when the unseen side wasn't run.
+ */
+export function computeDeltaG(
+  cells: readonly GeneralizationCell[],
+  mode: string,
+  partition: { tuned: readonly string[]; unseen: readonly string[] } = {
+    tuned: tunedDatasets(),
+    unseen: unseenGeneralityDatasets(),
+  },
+): DeltaGResult {
+  const tunedSet = new Set(partition.tuned);
+  const unseenSet = new Set(partition.unseen);
+  const seenCells = cells.filter((c) => c.mode === mode && tunedSet.has(c.dataset));
+  const unseenCells = cells.filter((c) => c.mode === mode && unseenSet.has(c.dataset));
+
+  const seenMean = mean(seenCells.map((c) => c.ndcgAt10));
+  const unseenMean = mean(unseenCells.map((c) => c.ndcgAt10));
+  const deltaG = seenMean !== null && unseenMean !== null && seenMean !== 0
+    ? round((seenMean - unseenMean) / seenMean)
+    : null;
+
+  return {
+    mode,
+    seenDatasets: seenCells.map((c) => c.dataset).sort(),
+    unseenDatasets: unseenCells.map((c) => c.dataset).sort(),
+    seenMeanNdcgAt10: seenMean,
+    unseenMeanNdcgAt10: unseenMean,
+    deltaG,
+  };
+}
+
+export function computeGeneralizationReport(
+  cells: readonly GeneralizationCell[],
+  modes: readonly string[],
+  partition: { tuned: readonly string[]; unseen: readonly string[] } = {
+    tuned: tunedDatasets(),
+    unseen: unseenGeneralityDatasets(),
+  },
+): GeneralizationReport {
+  return {
+    modes: modes.map((mode) => ({
+      mode,
+      domains: computeDomainBreakdown(cells, mode),
+      deltaG: computeDeltaG(cells, mode, partition),
+    })),
+    tunedDatasets: [...partition.tuned],
+    unseenGeneralityDatasets: [...partition.unseen],
+  };
+}
+
+export function formatDeltaG(value: number | null): string {
+  if (value === null) return 'n/a';
+  return `${value >= 0 ? '+' : ''}${(value * 100).toFixed(2)}%`;
+}

--- a/benchmarks/beir/matrix.test.ts
+++ b/benchmarks/beir/matrix.test.ts
@@ -1,0 +1,286 @@
+import { describe, expect, it } from '@jest/globals';
+import * as os from 'os';
+import * as path from 'path';
+import * as fsp from 'fs/promises';
+import {
+  captureRetrievalEnv,
+  formatMatrixMarkdown,
+  parseMatrixArgs,
+  runBeirMatrix,
+  type MatrixDependencies,
+  type MatrixReport,
+} from './matrix.js';
+import type { BeirBenchmarkRunResult } from './run.js';
+
+// Synthetic per-(dataset × mode) nDCG: hybrid beats lexical, and tuned datasets
+// score higher than the reserved unseen set, so Δ_g is a clean positive number.
+const SCORES: Record<string, Record<string, number>> = {
+  scifact: { lexical: 0.60, hybrid: 0.80 },
+  nfcorpus: { lexical: 0.50, hybrid: 0.70 },
+  fiqa: { lexical: 0.40, hybrid: 0.60 }, // tuned mean: lexical .50, hybrid .70
+  arguana: { lexical: 0.30, hybrid: 0.50 },
+  scidocs: { lexical: 0.20, hybrid: 0.40 },
+  'webis-touche2020': { lexical: 0.40, hybrid: 0.50 }, // unseen mean: lex .30, hyb .4667
+};
+
+function stubResult(dataset: string, mode: string): BeirBenchmarkRunResult {
+  const ndcg = SCORES[dataset]?.[mode] ?? 0.1;
+  return {
+    jsonPath: `/tmp/${dataset}-${mode}.json`,
+    trecPath: `/tmp/${dataset}-${mode}.trec`,
+    reportPath: `/tmp/${dataset}-${mode}.md`,
+    report: {
+      git_sha: 'matrix-sha',
+      dataset: { name: dataset, split: 'test', queries_evaluated: 10 },
+      mode,
+      embedding: mode === 'lexical' ? null : { provider: 'fake', model: 'fake-embeddings' },
+      rerank: null,
+      contextual: null,
+      chunking: { KB_CHUNK_SIZE: null, KB_CHUNK_OVERLAP: null },
+      metrics: {
+        judgedQueries: 10,
+        ndcgAt10: ndcg,
+        mapAt100: ndcg * 0.9,
+        precisionAt10: 0.1,
+        recallAt10: ndcg + 0.1,
+        recallAt100: ndcg + 0.2,
+      },
+      latency: { queries: 10, p50Ms: 5, p95Ms: 9, p99Ms: 11, meanMs: 6 },
+    } as unknown as BeirBenchmarkRunResult['report'],
+  };
+}
+
+function stubDeps(overrides: Partial<MatrixDependencies> = {}): {
+  deps: MatrixDependencies;
+  loggedRuns: string[];
+  loggedMatrix: MatrixReport[];
+} {
+  const loggedRuns: string[] = [];
+  const loggedMatrix: MatrixReport[] = [];
+  const deps: MatrixDependencies = {
+    runBenchmark: async (argv) => {
+      const dataset = argv.find((a) => a.startsWith('--dataset='))?.split('=')[1] ?? 'unknown';
+      const mode = argv.find((a) => a.startsWith('--mode='))?.split('=')[1] ?? 'lexical';
+      return stubResult(dataset, mode);
+    },
+    gitSha: async () => 'matrix-sha',
+    now: () => new Date('2026-06-08T00:00:00.000Z'),
+    logRun: async (report) => { loggedRuns.push(`${report.dataset.name}:${report.mode}`); },
+    logMatrix: async (report) => { loggedMatrix.push(report); },
+    ...overrides,
+  };
+  return { deps, loggedRuns, loggedMatrix };
+}
+
+describe('captureRetrievalEnv', () => {
+  it('records the full retrieval env, defaulting to production constants', () => {
+    const env = captureRetrievalEnv({ provider: 'ollama', model: 'nomic-embed-text' }, {});
+    expect(env).toEqual({
+      embedding_provider: 'ollama',
+      embedding_model: 'nomic-embed-text',
+      rrf_c: '60',
+      rerank_model: 'Xenova/ms-marco-MiniLM-L-6-v2',
+      rerank_top_n: '40',
+      chunk_size: '1000',
+      chunk_overlap: '200',
+      contextual: 'off',
+    });
+  });
+
+  it('reads overrides from env', () => {
+    const env = captureRetrievalEnv({}, {
+      EMBEDDING_PROVIDER: 'ollama',
+      KB_RRF_C: '90',
+      KB_RERANK_MODEL: 'BAAI/bge-reranker-v2-m3',
+      KB_RERANK_TOP_N: '20',
+      KB_CHUNK_SIZE: '1500',
+      KB_CHUNK_OVERLAP: '300',
+      KB_CONTEXTUAL_RETRIEVAL: 'on',
+    });
+    expect(env).toMatchObject({
+      embedding_provider: 'ollama',
+      rrf_c: '90',
+      rerank_model: 'BAAI/bge-reranker-v2-m3',
+      rerank_top_n: '20',
+      chunk_size: '1500',
+      chunk_overlap: '300',
+      contextual: 'on',
+    });
+  });
+});
+
+describe('parseMatrixArgs', () => {
+  it('defaults to the downloadable full set and lexical,hybrid', () => {
+    const options = parseMatrixArgs([]);
+    expect(options.modes).toEqual(['lexical', 'hybrid']);
+    expect(options.datasets).toContain('scifact');
+    expect(options.datasets).not.toContain('cqadupstack'); // no single-zip download
+    expect(options.continueOnError).toBe(true);
+  });
+
+  it('parses overrides incl. --fail-fast', () => {
+    const options = parseMatrixArgs([
+      '--datasets=scifact,arguana', '--modes=lexical,hybrid,hybrid+rerank',
+      '--provider=ollama', '--model=nomic-embed-text', '--fail-fast',
+    ]);
+    expect(options).toMatchObject({
+      datasets: ['scifact', 'arguana'],
+      modes: ['lexical', 'hybrid', 'hybrid+rerank'],
+      provider: 'ollama',
+      model: 'nomic-embed-text',
+      continueOnError: false,
+    });
+  });
+
+  it('rejects an unknown mode', () => {
+    expect(() => parseMatrixArgs(['--modes=lexical,bogus'])).toThrow(/must be one of/);
+  });
+});
+
+describe('runBeirMatrix', () => {
+  it('produces one cell per (dataset × mode), the per-mode mean, Δ_g, and logs every run', async () => {
+    const root = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-beir-matrix-test-'));
+    const { deps, loggedRuns, loggedMatrix } = stubDeps();
+    const datasets = ['scifact', 'nfcorpus', 'fiqa', 'arguana', 'scidocs', 'webis-touche2020'];
+
+    const { report, reportPath, markdownPath } = await runBeirMatrix({
+      datasets,
+      modes: ['lexical', 'hybrid'],
+      provider: 'fake',
+      model: 'fake-embeddings',
+      split: 'test',
+      outputDir: path.join(root, 'out'),
+      cacheDir: path.join(root, 'cache'),
+      workspaceRoot: path.join(root, 'kb-beir-ws'),
+      continueOnError: true,
+    }, deps);
+
+    // 6 datasets × 2 modes = 12 cells, all ok.
+    expect(report.cells).toHaveLength(12);
+    expect(report.cells.every((c) => c.status === 'ok')).toBe(true);
+
+    // Headline: hybrid mean over the 6 datasets = (.8+.7+.6+.5+.4+.5)/6 = 0.5833..
+    const hybrid = report.perMode.find((m) => m.mode === 'hybrid');
+    expect(hybrid?.datasetsEvaluated).toBe(6);
+    expect(hybrid?.multiDomainMeanNdcgAt10).toBeCloseTo(0.583333, 5);
+
+    // Δ_g for hybrid: seen mean .70, unseen mean .46667 → (.7-.46667)/.7 = .3333
+    const hybridGen = report.generalization.modes.find((m) => m.mode === 'hybrid');
+    expect(hybridGen?.deltaG.deltaG).toBeCloseTo(0.333333, 4);
+
+    // Every run wired into the ledger; the matrix logged once.
+    expect(loggedRuns).toHaveLength(12);
+    expect(loggedRuns).toContain('scifact:hybrid');
+    expect(loggedMatrix).toHaveLength(1);
+
+    // Artifacts written; markdown carries the headline section.
+    expect(JSON.parse(await fsp.readFile(reportPath, 'utf-8')).schema_version).toBe('kb.beir-matrix.v1');
+    const md = await fsp.readFile(markdownPath, 'utf-8');
+    expect(md).toContain('multi-domain mean nDCG@10');
+    expect(md).toContain('Δ_g');
+
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  it('records a failed cell, excludes it from the mean, and keeps going', async () => {
+    const root = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-beir-matrix-err-'));
+    const { deps, loggedRuns } = stubDeps({
+      runBenchmark: async (argv) => {
+        const dataset = argv.find((a) => a.startsWith('--dataset='))?.split('=')[1] ?? 'unknown';
+        const mode = argv.find((a) => a.startsWith('--mode='))?.split('=')[1] ?? 'lexical';
+        if (dataset === 'nfcorpus') throw new Error('dataset not cached');
+        return stubResult(dataset, mode);
+      },
+    });
+
+    const { report } = await runBeirMatrix({
+      datasets: ['scifact', 'nfcorpus', 'fiqa'],
+      modes: ['hybrid'],
+      provider: 'fake',
+      model: 'fake-embeddings',
+      split: 'test',
+      outputDir: path.join(root, 'out'),
+      cacheDir: path.join(root, 'cache'),
+      workspaceRoot: path.join(root, 'ws'),
+      continueOnError: true,
+    }, deps);
+
+    const failed = report.cells.find((c) => c.dataset === 'nfcorpus');
+    expect(failed?.status).toBe('error');
+    expect(failed?.error).toMatch(/not cached/);
+    // Mean over the 2 successful datasets only (scifact .8, fiqa .6 → .7).
+    const hybrid = report.perMode.find((m) => m.mode === 'hybrid');
+    expect(hybrid?.datasetsEvaluated).toBe(2);
+    expect(hybrid?.multiDomainMeanNdcgAt10).toBeCloseTo(0.7, 6);
+    // Failed runs are NOT logged to the ledger.
+    expect(loggedRuns).toEqual(['scifact:hybrid', 'fiqa:hybrid']);
+
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  it('--fail-fast (continueOnError=false) re-throws the first cell error', async () => {
+    const root = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-beir-matrix-ff-'));
+    const { deps } = stubDeps({
+      runBenchmark: async () => { throw new Error('boom'); },
+    });
+    await expect(runBeirMatrix({
+      datasets: ['scifact'],
+      modes: ['hybrid'],
+      split: 'test',
+      outputDir: path.join(root, 'out'),
+      cacheDir: path.join(root, 'cache'),
+      workspaceRoot: path.join(root, 'ws'),
+      continueOnError: false,
+    }, deps)).rejects.toThrow(/boom/);
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+});
+
+describe('formatMatrixMarkdown', () => {
+  it('renders the headline, contamination, and excluded-cell sections', () => {
+    const report: MatrixReport = {
+      schema_version: 'kb.beir-matrix.v1',
+      generated_at: '2026-06-08T00:00:00.000Z',
+      git_sha: 'abc',
+      modes: ['hybrid'],
+      datasets: ['scifact', 'nfcorpus'],
+      env: captureRetrievalEnv({ provider: 'ollama', model: 'nomic-embed-text' }, {}),
+      cells: [
+        {
+          dataset: 'scifact', domain: 'scientific fact-checking', mode: 'hybrid', status: 'ok',
+          ndcgAt10: 0.8, precisionAt10: 0.2, mapAt100: 0.7, recallAt10: 0.9, recallAt100: 1,
+          queriesEvaluated: 10, latencyP50Ms: 5, latencyP95Ms: 9, latencyP99Ms: 11,
+          jsonPath: 'a.json', trecPath: 'a.trec',
+        },
+        {
+          dataset: 'nfcorpus', domain: 'bio-medical', mode: 'hybrid', status: 'error',
+          ndcgAt10: 0, precisionAt10: 0, mapAt100: 0, recallAt10: 0, recallAt100: 0,
+          queriesEvaluated: 0, latencyP50Ms: 0, latencyP95Ms: 0, latencyP99Ms: 0,
+          jsonPath: null, trecPath: null, error: 'not cached',
+        },
+      ],
+      perMode: [{
+        mode: 'hybrid', datasetsEvaluated: 1, datasetsRequested: 2,
+        multiDomainMeanNdcgAt10: 0.8, multiDomainMeanPrecisionAt10: 0.2, multiDomainMeanRecallAt10: 0.9,
+      }],
+      generalization: {
+        modes: [{
+          mode: 'hybrid',
+          domains: [{ domain: 'scientific fact-checking', datasets: ['scifact'], meanNdcgAt10: 0.8, meanPrecisionAt10: 0.2, queriesEvaluated: 10 }],
+          deltaG: { mode: 'hybrid', seenDatasets: ['scifact'], unseenDatasets: [], seenMeanNdcgAt10: 0.8, unseenMeanNdcgAt10: null, deltaG: null },
+        }],
+        tunedDatasets: ['scifact', 'nfcorpus', 'fiqa'],
+        unseenGeneralityDatasets: ['arguana', 'scidocs', 'webis-touche2020'],
+      },
+      contamination: [
+        { dataset: 'scifact', knownInPretraining: false, qrels: 'expert', note: 'expert claims' },
+        { dataset: 'nfcorpus', knownInPretraining: false, qrels: 'expert', note: 'medical' },
+      ],
+    };
+    const md = formatMatrixMarkdown(report);
+    expect(md).toContain('| hybrid | 1/2 | 0.8000 |');
+    expect(md).toContain('Contamination notes');
+    expect(md).toContain('Excluded cells');
+    expect(md).toContain('not cached');
+  });
+});

--- a/benchmarks/beir/matrix.ts
+++ b/benchmarks/beir/matrix.ts
@@ -1,0 +1,581 @@
+// RFC 020 §2/§7/§8 M2 — the full BEIR matrix sweep.
+//
+// The headline deliverable: run the production retrieval pipeline over the
+// (dataset × mode) matrix and report, per mode, the **multi-domain mean
+// nDCG@10** — the metric the field quotes and the one §6 calls anti-overfitting
+// by construction (averaging across domains *lowers* the score of anything that
+// overfits a single corpus). One row per (dataset × mode); one mean per mode.
+//
+// This is the matrix-scale sibling of `baseline.ts` (CI subset) and `sweep.ts`
+// (chunk grid): same DI seam (`runBenchmark`), same "all cells share one
+// workspace root" discipline (src/config/paths resolves the KB root into a
+// module-level const on first import). It composes the dataset registry
+// (`registry.ts`), the generalization machinery (`generalization.ts` — per-domain
+// breakdown + Δ_g), and the reproducibility ledger (every cell carries the env
+// that produced it and is wired into MLflow via observability/mlflow.ts).
+//
+// Honesty constraints baked in:
+//   * A real full-matrix run needs every BEIR dataset downloaded AND a real
+//     embedding model. When a dataset is missing or a cell errors, the cell is
+//     recorded as a failure (with the error) and EXCLUDED from the mean — the
+//     report never fabricates a number for a dataset that did not run.
+//   * The mean is reported alongside the dataset count it averaged, so a partial
+//     sweep is self-labelling ("mean over 3 of 14 datasets").
+
+import * as os from 'os';
+import * as path from 'path';
+import {
+  parseArgs as parseBeirArgs,
+  runBeirBenchmark,
+  type BeirBenchmarkRunResult,
+  type BeirMode,
+} from './run.js';
+import {
+  downloadableDatasets,
+  getRegistryEntry,
+  domainOf,
+  assertRegistryInvariants,
+} from './registry.js';
+import {
+  computeGeneralizationReport,
+  formatDeltaG,
+  type GeneralizationCell,
+  type GeneralizationReport,
+} from './generalization.js';
+import { ensureDirectory, gitSha, writeJsonFile } from '../utils.js';
+import {
+  logBeirRunToMlflow,
+  logBeirMatrixToMlflow,
+  type BeirLedgerReport,
+} from '../observability/mlflow.js';
+
+export const MATRIX_SCHEMA_VERSION = 'kb.beir-matrix.v1';
+
+const DEFAULT_MATRIX_MODES: readonly BeirMode[] = ['lexical', 'hybrid'];
+
+const MATRIX_MODES: readonly BeirMode[] = [
+  'lexical',
+  'dense',
+  'hybrid',
+  'hybrid+rerank',
+  'hybrid+rerank+contextual',
+];
+
+// RFC 020 §7 reproducibility ledger — the full retrieval env recorded with the
+// run so a third party can reproduce the headline from commit + env. Read from
+// the same env vars the production config resolvers consume; defaults mirror the
+// production constants (RRF c=60 per src/hybrid-retrieval.ts HYBRID_RRF_C).
+export interface RetrievalEnvSnapshot {
+  embedding_provider: string | null;
+  embedding_model: string | null;
+  rrf_c: string;
+  rerank_model: string;
+  rerank_top_n: string;
+  chunk_size: string;
+  chunk_overlap: string;
+  contextual: 'on' | 'off';
+}
+
+const PRODUCTION_RRF_C = '60';
+const PRODUCTION_RERANK_MODEL = 'Xenova/ms-marco-MiniLM-L-6-v2';
+const PRODUCTION_RERANK_TOP_N = '40';
+const PRODUCTION_CHUNK_SIZE = '1000';
+const PRODUCTION_CHUNK_OVERLAP = '200';
+
+export function captureRetrievalEnv(
+  options: { provider?: string; model?: string },
+  env: NodeJS.ProcessEnv = process.env,
+): RetrievalEnvSnapshot {
+  const provider = options.provider ?? emptyToNull(env.EMBEDDING_PROVIDER);
+  return {
+    embedding_provider: provider,
+    embedding_model: options.model ?? null,
+    rrf_c: nonEmpty(env.KB_RRF_C) ?? PRODUCTION_RRF_C,
+    rerank_model: nonEmpty(env.KB_RERANK_MODEL) ?? PRODUCTION_RERANK_MODEL,
+    rerank_top_n: nonEmpty(env.KB_RERANK_TOP_N) ?? PRODUCTION_RERANK_TOP_N,
+    chunk_size: nonEmpty(env.KB_CHUNK_SIZE) ?? PRODUCTION_CHUNK_SIZE,
+    chunk_overlap: nonEmpty(env.KB_CHUNK_OVERLAP) ?? PRODUCTION_CHUNK_OVERLAP,
+    contextual: isOn(env.KB_CONTEXTUAL_RETRIEVAL) ? 'on' : 'off',
+  };
+}
+
+export interface MatrixCellResult {
+  dataset: string;
+  domain: string;
+  mode: BeirMode;
+  status: 'ok' | 'error';
+  ndcgAt10: number;
+  precisionAt10: number;
+  mapAt100: number;
+  recallAt10: number;
+  recallAt100: number;
+  queriesEvaluated: number;
+  latencyP50Ms: number;
+  latencyP95Ms: number;
+  latencyP99Ms: number;
+  /** Relative paths to the per-cell artifacts (run report JSON + TREC run). */
+  jsonPath: string | null;
+  trecPath: string | null;
+  /** Set only when status === 'error'. */
+  error?: string;
+}
+
+export interface MatrixModeSummary {
+  mode: BeirMode;
+  /** Datasets that produced a usable cell (the mean's denominator). */
+  datasetsEvaluated: number;
+  datasetsRequested: number;
+  /** THE HEADLINE METRIC — mean nDCG@10 across the evaluated datasets. */
+  multiDomainMeanNdcgAt10: number | null;
+  multiDomainMeanPrecisionAt10: number | null;
+  multiDomainMeanRecallAt10: number | null;
+}
+
+export interface MatrixReport {
+  schema_version: typeof MATRIX_SCHEMA_VERSION;
+  generated_at: string;
+  git_sha: string;
+  modes: BeirMode[];
+  datasets: string[];
+  env: RetrievalEnvSnapshot;
+  cells: MatrixCellResult[];
+  perMode: MatrixModeSummary[];
+  generalization: GeneralizationReport;
+  contamination: Array<{ dataset: string; knownInPretraining: boolean; qrels: string; note: string }>;
+}
+
+export interface MatrixOptions {
+  datasets: string[];
+  modes: BeirMode[];
+  provider?: string;
+  model?: string;
+  split: string;
+  outputDir: string;
+  cacheDir: string;
+  workspaceRoot: string;
+  maxQueries?: number;
+  /** Continue the sweep when one cell throws (default true). */
+  continueOnError: boolean;
+}
+
+export interface MatrixDependencies {
+  runBenchmark(beirArgv: string[]): Promise<BeirBenchmarkRunResult>;
+  gitSha(repoRoot: string): Promise<string>;
+  now(): Date;
+  /**
+   * Wire one finished cell into the MLflow ledger (RFC 020 §7). Defaults to the
+   * real MLflow logger, which is a no-op unless BENCH_MLFLOW_* is configured;
+   * tests stub it to assert "every run is logged" without spawning Python.
+   */
+  logRun(report: BeirLedgerReport, jsonPath: string, trecPath: string): Promise<void>;
+  /** Wire the matrix headline (per-mode means + Δ_g) into the ledger. */
+  logMatrix(report: MatrixReport, jsonPath: string, markdownPath: string): Promise<void>;
+}
+
+const defaultMatrixDependencies: MatrixDependencies = {
+  runBenchmark: (beirArgv) => runBeirBenchmark(parseBeirArgs(beirArgv)),
+  gitSha,
+  now: () => new Date(),
+  logRun: (report, jsonPath, trecPath) =>
+    logBeirRunToMlflow({ report, jsonPath, trecPath, repoRoot: process.cwd() }),
+  logMatrix: (report, jsonPath, markdownPath) =>
+    logBeirMatrixToMlflow({
+      report: {
+        git_sha: report.git_sha,
+        modes: report.modes,
+        datasets: report.datasets,
+        env: Object.fromEntries(Object.entries(report.env)),
+        perMode: report.perMode,
+        generalization: report.generalization,
+      },
+      jsonPath,
+      markdownPath,
+      repoRoot: process.cwd(),
+    }),
+};
+
+export async function runBeirMatrix(
+  options: MatrixOptions,
+  dependencies: MatrixDependencies = defaultMatrixDependencies,
+): Promise<{ reportPath: string; markdownPath: string; report: MatrixReport }> {
+  assertRegistryInvariants();
+  await ensureDirectory(options.outputDir);
+
+  const cells: MatrixCellResult[] = [];
+  // Mode-major: every dataset for one mode, then the next mode. Keeps a mode's
+  // cells contiguous in the report and means a half-finished sweep still has a
+  // complete mode to report on.
+  for (const mode of options.modes) {
+    for (const dataset of options.datasets) {
+      cells.push(await runCell(options, dataset, mode, dependencies));
+    }
+  }
+
+  const okCells = cells.filter((c) => c.status === 'ok');
+  const perMode = options.modes.map((mode) => summarizeMode(mode, options.datasets.length, okCells));
+  const generalizationCells: GeneralizationCell[] = okCells.map((c) => ({
+    dataset: c.dataset,
+    mode: c.mode,
+    ndcgAt10: c.ndcgAt10,
+    precisionAt10: c.precisionAt10,
+    queriesEvaluated: c.queriesEvaluated,
+  }));
+  const generalization = computeGeneralizationReport(generalizationCells, options.modes);
+
+  const report: MatrixReport = {
+    schema_version: MATRIX_SCHEMA_VERSION,
+    generated_at: dependencies.now().toISOString(),
+    git_sha: await dependencies.gitSha(process.cwd()),
+    modes: [...options.modes],
+    datasets: [...options.datasets],
+    env: captureRetrievalEnv({ provider: options.provider, model: options.model }),
+    cells,
+    perMode,
+    generalization,
+    contamination: options.datasets.map((dataset) => {
+      const entry = getRegistryEntry(dataset);
+      return {
+        dataset,
+        knownInPretraining: entry?.contamination.knownInPretraining ?? false,
+        qrels: entry?.contamination.qrels ?? 'unknown',
+        note: entry?.contamination.note ?? 'not in registry',
+      };
+    }),
+  };
+
+  const reportPath = path.join(options.outputDir, 'beir-matrix.json');
+  await writeJsonFile(reportPath, report);
+  const markdownPath = path.join(options.outputDir, 'beir-matrix.md');
+  const { writeFile } = await import('fs/promises');
+  await writeFile(markdownPath, formatMatrixMarkdown(report), 'utf-8');
+  await dependencies.logMatrix(report, reportPath, markdownPath);
+  return { reportPath, markdownPath, report };
+}
+
+async function runCell(
+  options: MatrixOptions,
+  dataset: string,
+  mode: BeirMode,
+  dependencies: MatrixDependencies,
+): Promise<MatrixCellResult> {
+  const base: Omit<MatrixCellResult, 'status' | 'ndcgAt10' | 'precisionAt10' | 'mapAt100' | 'recallAt10' | 'recallAt100' | 'queriesEvaluated' | 'latencyP50Ms' | 'latencyP95Ms' | 'latencyP99Ms' | 'jsonPath' | 'trecPath'> = {
+    dataset,
+    domain: domainOf(dataset),
+    mode,
+  };
+  try {
+    const result = await dependencies.runBenchmark(buildBeirArgv(options, dataset, mode));
+    const { metrics, latency } = result.report;
+    // RFC 020 §7 — wire EVERY run into the ledger as it finishes.
+    await dependencies.logRun(result.report, result.jsonPath, result.trecPath);
+    return {
+      ...base,
+      status: 'ok',
+      ndcgAt10: metrics.ndcgAt10,
+      precisionAt10: metrics.precisionAt10,
+      mapAt100: metrics.mapAt100,
+      recallAt10: metrics.recallAt10,
+      recallAt100: metrics.recallAt100,
+      queriesEvaluated: result.report.dataset.queries_evaluated,
+      latencyP50Ms: latency.p50Ms,
+      latencyP95Ms: latency.p95Ms,
+      latencyP99Ms: latency.p99Ms,
+      jsonPath: relativeOrAbsolute(result.jsonPath),
+      trecPath: relativeOrAbsolute(result.trecPath),
+    };
+  } catch (error) {
+    if (!options.continueOnError) throw error;
+    return {
+      ...base,
+      status: 'error',
+      ndcgAt10: 0,
+      precisionAt10: 0,
+      mapAt100: 0,
+      recallAt10: 0,
+      recallAt100: 0,
+      queriesEvaluated: 0,
+      latencyP50Ms: 0,
+      latencyP95Ms: 0,
+      latencyP99Ms: 0,
+      jsonPath: null,
+      trecPath: null,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+function summarizeMode(
+  mode: BeirMode,
+  datasetsRequested: number,
+  okCells: readonly MatrixCellResult[],
+): MatrixModeSummary {
+  const modeCells = okCells.filter((c) => c.mode === mode);
+  return {
+    mode,
+    datasetsEvaluated: modeCells.length,
+    datasetsRequested,
+    multiDomainMeanNdcgAt10: meanOrNull(modeCells.map((c) => c.ndcgAt10)),
+    multiDomainMeanPrecisionAt10: meanOrNull(modeCells.map((c) => c.precisionAt10)),
+    multiDomainMeanRecallAt10: meanOrNull(modeCells.map((c) => c.recallAt10)),
+  };
+}
+
+function buildBeirArgv(options: MatrixOptions, dataset: string, mode: BeirMode): string[] {
+  const argv = [
+    `--dataset=${dataset}`,
+    `--split=${options.split}`,
+    `--mode=${mode}`,
+    `--output-dir=${options.outputDir}`,
+    `--cache-dir=${options.cacheDir}`,
+    `--workspace-root=${options.workspaceRoot}`,
+  ];
+  if (mode !== 'lexical') {
+    if (options.provider !== undefined) argv.push(`--provider=${options.provider}`);
+    if (options.model !== undefined) argv.push(`--model=${options.model}`);
+  }
+  if (options.maxQueries !== undefined) argv.push(`--max-queries=${options.maxQueries}`);
+  return argv;
+}
+
+function meanOrNull(values: readonly number[]): number | null {
+  if (values.length === 0) return null;
+  let sum = 0;
+  for (const v of values) sum += v;
+  return Number((sum / values.length).toFixed(6));
+}
+
+function relativeOrAbsolute(filePath: string): string {
+  const relative = path.relative(process.cwd(), filePath);
+  return relative !== '' && !relative.startsWith('..') && !path.isAbsolute(relative) ? relative : filePath;
+}
+
+function emptyToNull(value: string | undefined): string | null {
+  return value !== undefined && value.trim() !== '' ? value.trim() : null;
+}
+
+function nonEmpty(value: string | undefined): string | undefined {
+  return value !== undefined && value.trim() !== '' ? value.trim() : undefined;
+}
+
+function isOn(value: string | undefined): boolean {
+  const raw = (value ?? '').trim().toLowerCase();
+  return raw === 'on' || raw === 'true' || raw === '1' || raw === 'yes';
+}
+
+// ---------------------------------------------------------------------------
+// Markdown
+// ---------------------------------------------------------------------------
+
+export function formatMatrixMarkdown(report: MatrixReport): string {
+  const lines: string[] = [
+    '# BEIR full-matrix sweep',
+    '',
+    'Local BEIR matrix run, not an official leaderboard submission. The headline',
+    'is the per-mode **multi-domain mean nDCG@10** — averaging across domains is',
+    'the anti-overfitting metric (RFC 020 §2/§6).',
+    '',
+    `- Generated: ${report.generated_at}`,
+    `- Commit: \`${report.git_sha}\``,
+    `- Embedding: ${report.env.embedding_provider ?? '(lexical/none)'} / ${report.env.embedding_model ?? '(default)'}`,
+    `- RRF c=${report.env.rrf_c}, rerank=${report.env.rerank_model} topN=${report.env.rerank_top_n}, ` +
+      `chunk=${report.env.chunk_size}/${report.env.chunk_overlap}, contextual=${report.env.contextual}`,
+    '',
+    '## Headline — multi-domain mean nDCG@10',
+    '',
+    '| Mode | datasets | mean nDCG@10 | mean P@10 | mean R@10 |',
+    '| --- | ---: | ---: | ---: | ---: |',
+  ];
+  for (const summary of report.perMode) {
+    lines.push(
+      `| ${summary.mode} | ${summary.datasetsEvaluated}/${summary.datasetsRequested} | ` +
+        `${fmt(summary.multiDomainMeanNdcgAt10)} | ${fmt(summary.multiDomainMeanPrecisionAt10)} | ` +
+        `${fmt(summary.multiDomainMeanRecallAt10)} |`,
+    );
+  }
+  lines.push('', '## Per-(dataset × mode) nDCG@10', '');
+  lines.push(...renderCellTable(report));
+  lines.push('', '## Per-domain breakdown & Δ_g (generalization, §6)', '');
+  lines.push(...renderGeneralization(report.generalization));
+  lines.push('', '## Contamination notes (§6.6)', '');
+  lines.push('| Dataset | known-in-pretraining | qrels | note |');
+  lines.push('| --- | --- | --- | --- |');
+  for (const row of report.contamination) {
+    lines.push(`| ${row.dataset} | ${row.knownInPretraining ? 'yes' : 'no'} | ${row.qrels} | ${row.note} |`);
+  }
+  const failures = report.cells.filter((c) => c.status === 'error');
+  if (failures.length > 0) {
+    lines.push('', '## Excluded cells (errors — not in any mean)', '');
+    for (const cell of failures) {
+      lines.push(`- \`${cell.dataset} × ${cell.mode}\`: ${cell.error}`);
+    }
+  }
+  return `${lines.join('\n')}\n`;
+}
+
+function renderCellTable(report: MatrixReport): string[] {
+  const header = ['dataset', ...report.modes.map(String)];
+  const rows: string[][] = [];
+  for (const dataset of report.datasets) {
+    const row = [dataset];
+    for (const mode of report.modes) {
+      const cell = report.cells.find((c) => c.dataset === dataset && c.mode === mode);
+      row.push(cell === undefined ? '—' : cell.status === 'error' ? 'ERR' : cell.ndcgAt10.toFixed(4));
+    }
+    rows.push(row);
+  }
+  const toRow = (cells: string[]): string => `| ${cells.join(' | ')} |`;
+  return [toRow(header), toRow(header.map(() => '---')), ...rows.map(toRow)];
+}
+
+function renderGeneralization(generalization: GeneralizationReport): string[] {
+  const lines: string[] = [
+    `Δ_g = (seen − unseen) / seen. Seen (tuned): ${generalization.tunedDatasets.join(', ') || '(none)'}. ` +
+      `Unseen (reserved): ${generalization.unseenGeneralityDatasets.join(', ') || '(none)'}.`,
+    '',
+    '| Mode | seen mean nDCG@10 | unseen mean nDCG@10 | Δ_g |',
+    '| --- | ---: | ---: | ---: |',
+  ];
+  for (const modeGen of generalization.modes) {
+    const dg = modeGen.deltaG;
+    lines.push(
+      `| ${modeGen.mode} | ${fmt(dg.seenMeanNdcgAt10)} | ${fmt(dg.unseenMeanNdcgAt10)} | ${formatDeltaG(dg.deltaG)} |`,
+    );
+  }
+  for (const modeGen of generalization.modes) {
+    if (modeGen.domains.length === 0) continue;
+    lines.push('', `### ${modeGen.mode} — per-domain`, '');
+    lines.push('| Domain | datasets | mean nDCG@10 | mean P@10 |');
+    lines.push('| --- | --- | ---: | ---: |');
+    for (const domainRow of modeGen.domains) {
+      lines.push(
+        `| ${domainRow.domain} | ${domainRow.datasets.join(', ')} | ` +
+          `${domainRow.meanNdcgAt10.toFixed(4)} | ${domainRow.meanPrecisionAt10.toFixed(4)} |`,
+      );
+    }
+  }
+  return lines;
+}
+
+function fmt(value: number | null): string {
+  return value === null ? 'n/a' : value.toFixed(4);
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+export function parseMatrixArgs(argv: string[]): MatrixOptions {
+  const repoRoot = process.cwd();
+  const options: MatrixOptions = {
+    // Default to the auto-downloadable full set (CQADupStack has no single zip).
+    datasets: downloadableDatasets(),
+    modes: [...DEFAULT_MATRIX_MODES],
+    split: 'test',
+    outputDir: path.join(repoRoot, 'benchmarks', 'results', 'beir', 'matrix'),
+    cacheDir: process.env.BEIR_CACHE_DIR ?? path.join(os.tmpdir(), 'kb-beir-cache'),
+    workspaceRoot: path.join(os.tmpdir(), `kb-beir-matrix-${process.pid}`),
+    continueOnError: true,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    const [flag, inlineValue] = token.includes('=') ? token.split(/=(.*)/s, 2) : [token, undefined];
+    const readValue = (): string => {
+      if (inlineValue !== undefined) return inlineValue;
+      i += 1;
+      const value = argv[i];
+      if (value === undefined || value.startsWith('--')) throw new Error(`${flag} requires a value`);
+      return value;
+    };
+    if (flag === '--datasets') {
+      options.datasets = splitList(readValue());
+    } else if (flag === '--modes') {
+      options.modes = splitList(readValue()).map(parseMatrixMode);
+    } else if (flag === '--provider') {
+      options.provider = readValue();
+    } else if (flag === '--model') {
+      options.model = readValue();
+    } else if (flag === '--split') {
+      options.split = readValue();
+    } else if (flag === '--output-dir') {
+      options.outputDir = path.resolve(readValue());
+    } else if (flag === '--cache-dir') {
+      options.cacheDir = path.resolve(readValue());
+    } else if (flag === '--workspace-root') {
+      options.workspaceRoot = path.resolve(readValue());
+    } else if (flag === '--max-queries') {
+      options.maxQueries = parsePositiveInt(readValue(), '--max-queries');
+    } else if (flag === '--fail-fast') {
+      options.continueOnError = false;
+    } else if (flag === '--help' || flag === '-h') {
+      process.stdout.write(matrixHelpText());
+      process.exit(0);
+    } else {
+      throw new Error(`unknown argument: ${token}`);
+    }
+  }
+  return options;
+}
+
+function splitList(raw: string): string[] {
+  return raw.split(',').map((v) => v.trim()).filter((v) => v.length > 0);
+}
+
+function parsePositiveInt(raw: string, flag: string): number {
+  const parsed = Number(raw);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) throw new Error(`${flag} must be a positive integer`);
+  return parsed;
+}
+
+function parseMatrixMode(raw: string): BeirMode {
+  if ((MATRIX_MODES as readonly string[]).includes(raw)) return raw as BeirMode;
+  throw new Error(`--modes entries must be one of: ${MATRIX_MODES.join(', ')}`);
+}
+
+function matrixHelpText(): string {
+  return `kb BEIR full-matrix sweep (RFC 020 M2)
+
+Usage:
+  npm run bench:beir:matrix -- --provider=ollama --model=nomic-embed-text \\
+      --modes=lexical,hybrid,hybrid+rerank
+
+Output: benchmarks/results/beir/matrix/beir-matrix.{json,md}. The headline is the
+per-mode multi-domain mean nDCG@10 plus the per-domain breakdown and Δ_g (§6).
+
+Options:
+  --datasets=<a,b,c>   Datasets to sweep. Default: all auto-downloadable BEIR sets.
+  --modes=<...>        Comma list of ${MATRIX_MODES.join('|')}. Default: lexical,hybrid.
+  --provider=<name>    Embedding provider for non-lexical modes. Default: $EMBEDDING_PROVIDER.
+  --model=<name>       Embedding model. Real model required for meaningful numbers.
+  --split=<name>       Qrels split. Default: test.
+  --output-dir=<path>  Matrix report directory.
+  --max-queries=<n>    Deterministic subset for a quick smoke.
+  --fail-fast          Abort on the first cell error instead of recording + skipping.
+
+A real full-matrix run needs every BEIR dataset cached AND a real embedding
+model; missing/failed cells are recorded and excluded from the mean — the report
+never fabricates a number for a dataset that did not run.
+`;
+}
+
+async function main(): Promise<void> {
+  const options = parseMatrixArgs(process.argv.slice(2));
+  const { reportPath, markdownPath, report } = await runBeirMatrix(options);
+  for (const summary of report.perMode) {
+    process.stdout.write(
+      `${summary.mode}\tmean nDCG@10=${fmt(summary.multiDomainMeanNdcgAt10)}\t` +
+        `(${summary.datasetsEvaluated}/${summary.datasetsRequested} datasets)\n`,
+    );
+  }
+  process.stdout.write(`${reportPath}\n${markdownPath}\n`);
+}
+
+const cliEntry = process.argv[1] !== undefined ? path.normalize(process.argv[1]) : '';
+if (
+  cliEntry.endsWith(path.join('benchmarks', 'beir', 'matrix.js')) ||
+  cliEntry.endsWith(path.join('benchmarks', 'beir', 'matrix.ts'))
+) {
+  main().catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.stack ?? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/benchmarks/beir/registry.test.ts
+++ b/benchmarks/beir/registry.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+  BEIR_REGISTRY,
+  assertRegistryInvariants,
+  ciSubsetDatasets,
+  downloadableDatasets,
+  fullMatrixDatasets,
+  getRegistryEntry,
+  tunedDatasets,
+  unseenGeneralityDatasets,
+  domainOf,
+} from './registry.js';
+import { CI_SUBSET } from './baseline.js';
+
+describe('BEIR dataset registry', () => {
+  it('covers the RFC §2 full public BEIR set', () => {
+    const names = new Set(fullMatrixDatasets());
+    for (const expected of [
+      'trec-covid', 'nfcorpus', 'nq', 'hotpotqa', 'fiqa', 'arguana', 'webis-touche2020',
+      'quora', 'dbpedia-entity', 'scidocs', 'fever', 'climate-fever', 'scifact', 'cqadupstack',
+    ]) {
+      expect(names.has(expected)).toBe(true);
+    }
+  });
+
+  it('mirrors baseline.ts CI_SUBSET as the tuned/CI datasets', () => {
+    expect(ciSubsetDatasets().sort()).toEqual([...CI_SUBSET].sort());
+    // The tuned ("seen") side of Δ_g is exactly the CI subset.
+    expect(tunedDatasets().sort()).toEqual([...CI_SUBSET].sort());
+  });
+
+  it('reserves a non-empty unseen-generality set disjoint from the tuned set', () => {
+    const tuned = new Set(tunedDatasets());
+    const unseen = unseenGeneralityDatasets();
+    expect(unseen.length).toBeGreaterThan(0);
+    for (const name of unseen) expect(tuned.has(name)).toBe(false);
+  });
+
+  it('treats CQADupStack as a registry entry without a single-zip URL', () => {
+    const entry = getRegistryEntry('cqadupstack');
+    expect(entry).toBeDefined();
+    expect(entry?.url).toBeNull();
+    // downloadableDatasets() excludes it (no auto-download).
+    expect(downloadableDatasets()).not.toContain('cqadupstack');
+    expect(downloadableDatasets().length).toBe(BEIR_REGISTRY.length - 1);
+  });
+
+  it('carries a contamination note for every dataset', () => {
+    for (const entry of BEIR_REGISTRY) {
+      expect(entry.contamination.note.length).toBeGreaterThan(0);
+      expect(['expert', 'crowdsourced', 'automatic', 'mixed']).toContain(entry.contamination.qrels);
+    }
+    // Wikipedia-derived sets are flagged as pretraining-leakage risks.
+    expect(getRegistryEntry('nq')?.contamination.knownInPretraining).toBe(true);
+    expect(getRegistryEntry('scifact')?.contamination.knownInPretraining).toBe(false);
+  });
+
+  it('resolves domains, defaulting unknown datasets to "unknown"', () => {
+    expect(domainOf('fiqa')).toBe('finance');
+    expect(domainOf('not-a-dataset')).toBe('unknown');
+  });
+
+  it('passes the disjoint/non-empty Δ_g invariants', () => {
+    expect(() => assertRegistryInvariants()).not.toThrow();
+  });
+
+  it('rejects an overlapping tuned/unseen partition', () => {
+    expect(() => assertRegistryInvariants([
+      { ...BEIR_REGISTRY[0], generalityRole: 'tuned' },
+      { ...BEIR_REGISTRY[0], name: 'dup', generalityRole: 'unseen-generality' },
+      { ...BEIR_REGISTRY[3], name: 'overlap', generalityRole: 'tuned' },
+      { ...BEIR_REGISTRY[3], name: 'overlap', generalityRole: 'unseen-generality' },
+    ])).toThrow(/duplicate|overlap/);
+  });
+});

--- a/benchmarks/beir/registry.ts
+++ b/benchmarks/beir/registry.ts
@@ -1,0 +1,342 @@
+// RFC 020 §2/§6 — the BEIR dataset registry.
+//
+// A single dataset is overfittable; the field quotes the multi-dataset mean, so
+// the headline metric (M2) is a per-mode mean across the full public BEIR set.
+// This registry is the single source of truth for that set: the dataset names,
+// their domains, the qrels split the headline reports on, and — per §6 — two
+// orthogonal classifications that the generalization machinery consumes:
+//
+//   * `ciSubset`        — the small, fast, domain-diverse gate subset
+//                         (SciFact / NFCorpus / FiQA), mirrored from
+//                         `baseline.ts` CI_SUBSET. Runs per-PR.
+//   * `generalityRole`  — the Δ_g partition (§6.5):
+//                           'tuned'              the dev-tuned datasets (the
+//                                                "seen" side of Δ_g; == CI subset)
+//                           'unseen-generality'  a reserved set NEVER tuned on,
+//                                                distinct from the per-dataset
+//                                                test split, drives the Δ_g alarm
+//                           'headline-only'      contributes to the multi-domain
+//                                                mean but is neither tuned nor
+//                                                reserved for the Δ_g gap
+//
+// Each entry also carries a contamination note (§6.6): public benchmarks leak
+// into pretraining corpora, and qrels provenance (expert vs crowdsourced)
+// changes how much to trust a delta. The note travels with every reported
+// number. Dataset *names* are recorded here for provenance only — they are
+// excluded from any LLM-grader/judge prompt (§6.6 contamination control).
+
+export type GeneralityRole = 'tuned' | 'unseen-generality' | 'headline-only';
+
+export type QrelsProvenance = 'expert' | 'crowdsourced' | 'automatic' | 'mixed';
+
+export interface BeirContaminationNote {
+  /**
+   * Whether the corpus/queries are widely known to appear in LLM pretraining
+   * corpora (Wikipedia-derived sets especially). A contaminated set flatters a
+   * model that memorized it, so a gain there is weaker evidence than the same
+   * gain on an obscure or expert-curated set.
+   */
+  knownInPretraining: boolean;
+  qrels: QrelsProvenance;
+  note: string;
+}
+
+export interface BeirDatasetRegistryEntry {
+  /** Registry key; matches the `DATASET_URLS` keys in `run.ts`. */
+  name: string;
+  /** Human-facing label for reports. */
+  title: string;
+  /** Coarse domain bucket — the axis the multi-domain mean averages over. */
+  domain: string;
+  /** Qrels split the headline reports on. */
+  split: string;
+  /**
+   * Single-zip download URL, or null when the dataset is not a single BEIR zip
+   * (CQADupStack is a family of sub-forums fetched separately). A null URL
+   * means the dataset must be supplied via `--dataset-dir`.
+   */
+  url: string | null;
+  /** Part of the fast per-PR CI gate subset. */
+  ciSubset: boolean;
+  /** Δ_g partition role (§6.5). */
+  generalityRole: GeneralityRole;
+  contamination: BeirContaminationNote;
+}
+
+const BEIR_ZIP_BASE = 'https://public.ukp.informatik.tu-darmstadt.de/thakur/BEIR/datasets';
+
+function zip(name: string): string {
+  return `${BEIR_ZIP_BASE}/${name}.zip`;
+}
+
+// The standard public BEIR set (RFC §2 "BEIR full"). Order is the canonical
+// report order: CI subset first (so the gate datasets head every table), then
+// the rest grouped loosely by domain. The Δ_g reserved set
+// (arguana / scidocs / webis-touche2020) is deliberately spread across distinct
+// domains (argumentation / scientific-citation / debate) that the tuned QA/bio/
+// finance subset never touches, so a widening Δ_g is a real generality alarm
+// rather than an artifact of one domain.
+export const BEIR_REGISTRY: readonly BeirDatasetRegistryEntry[] = [
+  // --- CI subset / tuned ("seen" side of Δ_g) ---
+  {
+    name: 'scifact',
+    title: 'SciFact',
+    domain: 'scientific fact-checking',
+    split: 'test',
+    url: zip('scifact'),
+    ciSubset: true,
+    generalityRole: 'tuned',
+    contamination: {
+      knownInPretraining: false,
+      qrels: 'expert',
+      note: 'Expert (scientist) claim↔evidence annotations; small corpus, low pretraining-leakage risk.',
+    },
+  },
+  {
+    name: 'nfcorpus',
+    title: 'NFCorpus',
+    domain: 'bio-medical',
+    split: 'test',
+    url: zip('nfcorpus'),
+    ciSubset: true,
+    generalityRole: 'tuned',
+    contamination: {
+      knownInPretraining: false,
+      qrels: 'expert',
+      note: 'Medical nutrition queries with expert/relevance-graded links; niche corpus, low leakage risk.',
+    },
+  },
+  {
+    name: 'fiqa',
+    title: 'FiQA-2018',
+    domain: 'finance',
+    split: 'test',
+    url: zip('fiqa'),
+    ciSubset: true,
+    generalityRole: 'tuned',
+    contamination: {
+      knownInPretraining: false,
+      qrels: 'crowdsourced',
+      note: 'Financial opinion QA over StackExchange/forum text; crowdsourced relevance.',
+    },
+  },
+  // --- Reserved unseen-generality set ("unseen" side of Δ_g) ---
+  {
+    name: 'arguana',
+    title: 'ArguAna',
+    domain: 'argument retrieval',
+    split: 'test',
+    url: zip('arguana'),
+    ciSubset: false,
+    generalityRole: 'unseen-generality',
+    contamination: {
+      knownInPretraining: false,
+      qrels: 'crowdsourced',
+      note: 'Counter-argument retrieval; query IS a full argument. Distinct task shape from QA — held out for Δ_g.',
+    },
+  },
+  {
+    name: 'scidocs',
+    title: 'SciDocs',
+    domain: 'scientific citation',
+    split: 'test',
+    url: zip('scidocs'),
+    ciSubset: false,
+    generalityRole: 'unseen-generality',
+    contamination: {
+      knownInPretraining: false,
+      qrels: 'automatic',
+      note: 'Citation/co-read prediction; relevance derived from citation graph (automatic). Held out for Δ_g.',
+    },
+  },
+  {
+    name: 'webis-touche2020',
+    title: 'Touché-2020',
+    domain: 'argument retrieval',
+    split: 'test',
+    url: zip('webis-touche2020'),
+    ciSubset: false,
+    generalityRole: 'unseen-generality',
+    contamination: {
+      knownInPretraining: false,
+      qrels: 'expert',
+      note: 'Controversial-topic argument retrieval; expert-graded. Distinct from tuned QA — held out for Δ_g.',
+    },
+  },
+  // --- Headline-only (contribute to the multi-domain mean) ---
+  {
+    name: 'trec-covid',
+    title: 'TREC-COVID',
+    domain: 'bio-medical',
+    split: 'test',
+    url: zip('trec-covid'),
+    ciSubset: false,
+    generalityRole: 'headline-only',
+    contamination: {
+      knownInPretraining: false,
+      qrels: 'expert',
+      note: 'COVID-19 literature; expert TREC pooled judgments, deep per-query relevance.',
+    },
+  },
+  {
+    name: 'nq',
+    title: 'NQ',
+    domain: 'open-domain QA (Wikipedia)',
+    split: 'test',
+    url: zip('nq'),
+    ciSubset: false,
+    generalityRole: 'headline-only',
+    contamination: {
+      knownInPretraining: true,
+      qrels: 'crowdsourced',
+      note: 'Natural Questions over Wikipedia; Wikipedia is heavily represented in pretraining — leakage risk high.',
+    },
+  },
+  {
+    name: 'hotpotqa',
+    title: 'HotpotQA',
+    domain: 'multi-hop QA (Wikipedia)',
+    split: 'test',
+    url: zip('hotpotqa'),
+    ciSubset: false,
+    generalityRole: 'headline-only',
+    contamination: {
+      knownInPretraining: true,
+      qrels: 'crowdsourced',
+      note: 'Multi-hop Wikipedia QA with gold supporting facts; Wikipedia leakage risk high.',
+    },
+  },
+  {
+    name: 'quora',
+    title: 'Quora',
+    domain: 'duplicate-question retrieval',
+    split: 'test',
+    url: zip('quora'),
+    ciSubset: false,
+    generalityRole: 'headline-only',
+    contamination: {
+      knownInPretraining: true,
+      qrels: 'crowdsourced',
+      note: 'Duplicate-question detection; the Quora dataset is widely scraped — leakage risk high.',
+    },
+  },
+  {
+    name: 'dbpedia-entity',
+    title: 'DBPedia-Entity',
+    domain: 'entity retrieval',
+    split: 'test',
+    url: zip('dbpedia-entity'),
+    ciSubset: false,
+    generalityRole: 'headline-only',
+    contamination: {
+      knownInPretraining: true,
+      qrels: 'expert',
+      note: 'Entity retrieval over DBPedia abstracts (Wikipedia-derived); graded relevance, leakage risk high.',
+    },
+  },
+  {
+    name: 'fever',
+    title: 'FEVER',
+    domain: 'fact verification (Wikipedia)',
+    split: 'test',
+    url: zip('fever'),
+    ciSubset: false,
+    generalityRole: 'headline-only',
+    contamination: {
+      knownInPretraining: true,
+      qrels: 'crowdsourced',
+      note: 'Wikipedia fact verification; evidence-sentence annotations. Wikipedia leakage risk high.',
+    },
+  },
+  {
+    name: 'climate-fever',
+    title: 'Climate-FEVER',
+    domain: 'fact verification (climate)',
+    split: 'test',
+    url: zip('climate-fever'),
+    ciSubset: false,
+    generalityRole: 'headline-only',
+    contamination: {
+      knownInPretraining: true,
+      qrels: 'crowdsourced',
+      note: 'Climate-claim verification over Wikipedia; noisier crowdsourced labels, Wikipedia leakage risk high.',
+    },
+  },
+  {
+    name: 'cqadupstack',
+    title: 'CQADupStack',
+    domain: 'community QA (multi-forum)',
+    split: 'test',
+    // Not a single BEIR zip — a family of 12 StackExchange sub-forums. Supply
+    // each sub-forum via --dataset-dir; the registry records it for the matrix
+    // and contamination ledger but cannot auto-download it.
+    url: null,
+    ciSubset: false,
+    generalityRole: 'headline-only',
+    contamination: {
+      knownInPretraining: true,
+      qrels: 'crowdsourced',
+      note: '12 StackExchange sub-forums (the headline averages them). StackExchange is scraped — leakage risk high. No single-zip download; supply via --dataset-dir.',
+    },
+  },
+];
+
+const REGISTRY_BY_NAME: ReadonlyMap<string, BeirDatasetRegistryEntry> = new Map(
+  BEIR_REGISTRY.map((entry) => [entry.name, entry]),
+);
+
+export function getRegistryEntry(name: string): BeirDatasetRegistryEntry | undefined {
+  return REGISTRY_BY_NAME.get(name);
+}
+
+/** All registered dataset names, in canonical report order. */
+export function fullMatrixDatasets(): string[] {
+  return BEIR_REGISTRY.map((entry) => entry.name);
+}
+
+/** Datasets that auto-download (have a single-zip URL) — the runnable matrix. */
+export function downloadableDatasets(): string[] {
+  return BEIR_REGISTRY.filter((entry) => entry.url !== null).map((entry) => entry.name);
+}
+
+export function ciSubsetDatasets(): string[] {
+  return BEIR_REGISTRY.filter((entry) => entry.ciSubset).map((entry) => entry.name);
+}
+
+export function tunedDatasets(): string[] {
+  return BEIR_REGISTRY.filter((entry) => entry.generalityRole === 'tuned').map((entry) => entry.name);
+}
+
+export function unseenGeneralityDatasets(): string[] {
+  return BEIR_REGISTRY
+    .filter((entry) => entry.generalityRole === 'unseen-generality')
+    .map((entry) => entry.name);
+}
+
+export function domainOf(name: string): string {
+  return getRegistryEntry(name)?.domain ?? 'unknown';
+}
+
+/**
+ * Invariant check used by tests and (defensively) the matrix runner: the Δ_g
+ * partition is meaningful only when the tuned and unseen sets are non-empty and
+ * disjoint. Throws on a misconfigured registry so a generality report is never
+ * silently computed from an empty or overlapping split.
+ */
+export function assertRegistryInvariants(registry: readonly BeirDatasetRegistryEntry[] = BEIR_REGISTRY): void {
+  const names = new Set<string>();
+  for (const entry of registry) {
+    if (names.has(entry.name)) {
+      throw new Error(`registry: duplicate dataset name "${entry.name}"`);
+    }
+    names.add(entry.name);
+  }
+  const tuned = registry.filter((e) => e.generalityRole === 'tuned').map((e) => e.name);
+  const unseen = registry.filter((e) => e.generalityRole === 'unseen-generality').map((e) => e.name);
+  if (tuned.length === 0) throw new Error('registry: no tuned datasets — Δ_g has no "seen" side');
+  if (unseen.length === 0) throw new Error('registry: no unseen-generality datasets — Δ_g has no "unseen" side');
+  const overlap = tuned.filter((name) => unseen.includes(name));
+  if (overlap.length > 0) {
+    throw new Error(`registry: tuned/unseen Δ_g groups overlap on ${overlap.join(', ')} — they must be disjoint`);
+  }
+}

--- a/benchmarks/compare/leaderboard-template.html
+++ b/benchmarks/compare/leaderboard-template.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>{{TITLE}}</title>
+<style>
+  :root {
+    --bg: #fafafa;
+    --fg: #222;
+    --muted: #666;
+    --rule: #ddd;
+    --best-bg: #e7f7ec;
+    --warn-bg: #fdecec;
+  }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+    background: var(--bg);
+    color: var(--fg);
+    margin: 0 auto;
+    padding: 24px;
+    max-width: 1080px;
+    line-height: 1.5;
+  }
+  h1 { font-size: 22px; margin: 0 0 4px 0; }
+  h2 { font-size: 16px; margin: 32px 0 8px 0; padding-bottom: 4px; border-bottom: 1px solid var(--rule); }
+  .meta { color: var(--muted); font-size: 12px; margin-bottom: 16px; }
+  .meta code { background: #eef; padding: 1px 4px; border-radius: 3px; }
+  table { border-collapse: collapse; width: 100%; font-size: 13px; margin-bottom: 8px; }
+  th, td { border-bottom: 1px solid var(--rule); padding: 6px 10px; text-align: right; }
+  th:first-child, td:first-child { text-align: left; }
+  th { background: #f2f2f2; font-weight: 600; }
+  td.best { background: var(--best-bg); font-weight: 600; }
+  td.warn { background: var(--warn-bg); }
+  code { background: #eef; padding: 1px 4px; border-radius: 3px; font-size: 12px; }
+  .note { color: var(--muted); font-size: 12px; }
+</style>
+</head>
+<body>
+<h1>{{TITLE}}</h1>
+<div class="meta">{{META}}</div>
+
+<h2>Headline — multi-domain mean nDCG@10 by run × mode</h2>
+<p class="note">Each cell is the per-mode mean nDCG@10 across the datasets that run evaluated (the headline metric, RFC 020 §2). Best per mode is highlighted.</p>
+<table>
+<thead>{{HEADLINE_HEAD}}</thead>
+<tbody>{{HEADLINE_ROWS}}</tbody>
+</table>
+
+<h2>Generalization gap — Δ_g by run × mode</h2>
+<p class="note">Δ_g = (seen − unseen) / seen (RFC 020 §6). Higher = worse on held-out domains (overfitting direction); the lowest Δ_g per mode is highlighted.</p>
+<table>
+<thead>{{DELTAG_HEAD}}</thead>
+<tbody>{{DELTAG_ROWS}}</tbody>
+</table>
+
+<h2>Run provenance (commit + env)</h2>
+<p class="note">A public ranking claim is only credible if reproducible from commit + env (RFC 020 §7).</p>
+<table>
+<thead><tr><th>Run</th><th>commit</th><th>generated</th><th>embedding</th><th>RRF c</th><th>rerank</th><th>chunk</th><th>contextual</th></tr></thead>
+<tbody>{{PROVENANCE_ROWS}}</tbody>
+</table>
+
+<p class="note">Local BEIR reproductions, not official leaderboard submissions.</p>
+</body>
+</html>

--- a/benchmarks/compare/leaderboard.test.ts
+++ b/benchmarks/compare/leaderboard.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from '@jest/globals';
+import { matrixReportToRun, renderLeaderboard, type LeaderboardRun } from './leaderboard.js';
+
+const MATRIX_JSON = {
+  schema_version: 'kb.beir-matrix.v1',
+  generated_at: '2026-06-08T00:00:00.000Z',
+  git_sha: 'deadbeef',
+  modes: ['lexical', 'hybrid'],
+  datasets: ['scifact', 'arguana'],
+  env: {
+    embedding_provider: 'ollama',
+    embedding_model: 'nomic-embed-text',
+    rrf_c: '60',
+    rerank_model: 'Xenova/ms-marco-MiniLM-L-6-v2',
+    rerank_top_n: '40',
+    chunk_size: '1000',
+    chunk_overlap: '200',
+    contextual: 'off',
+  },
+  perMode: [
+    { mode: 'lexical', datasetsEvaluated: 2, datasetsRequested: 2, multiDomainMeanNdcgAt10: 0.55, multiDomainMeanPrecisionAt10: 0.1, multiDomainMeanRecallAt10: 0.6 },
+    { mode: 'hybrid', datasetsEvaluated: 2, datasetsRequested: 2, multiDomainMeanNdcgAt10: 0.70, multiDomainMeanPrecisionAt10: 0.12, multiDomainMeanRecallAt10: 0.75 },
+  ],
+  generalization: {
+    modes: [
+      { mode: 'lexical', deltaG: { deltaG: 0.20, seenMeanNdcgAt10: 0.6, unseenMeanNdcgAt10: 0.48 } },
+      { mode: 'hybrid', deltaG: { deltaG: 0.10, seenMeanNdcgAt10: 0.8, unseenMeanNdcgAt10: 0.72 } },
+    ],
+  },
+};
+
+describe('matrixReportToRun', () => {
+  it('maps a matrix report JSON onto the leaderboard run shape', () => {
+    const run = matrixReportToRun(MATRIX_JSON, 'run-A');
+    expect(run.label).toBe('run-A');
+    expect(run.gitSha).toBe('deadbeef');
+    expect(run.env.embedding_provider).toBe('ollama');
+    const hybrid = run.modes.find((m) => m.mode === 'hybrid');
+    expect(hybrid?.multiDomainMeanNdcgAt10).toBe(0.70);
+    expect(hybrid?.deltaG).toBe(0.10);
+  });
+
+  it('tolerates missing fields without throwing', () => {
+    const run = matrixReportToRun({ perMode: [{ mode: 'lexical' }] }, 'sparse');
+    expect(run.gitSha).toBe('unknown');
+    expect(run.modes[0].multiDomainMeanNdcgAt10).toBeNull();
+    expect(run.modes[0].deltaG).toBeNull();
+  });
+
+  it('rejects a non-object report', () => {
+    expect(() => matrixReportToRun(null, 'x')).toThrow(/not an object/);
+  });
+});
+
+describe('renderLeaderboard', () => {
+  function run(label: string, gitSha: string, hybridNdcg: number, hybridDeltaG: number): LeaderboardRun {
+    return {
+      label,
+      gitSha,
+      generatedAt: '2026-06-08T00:00:00.000Z',
+      env: {
+        embedding_provider: 'ollama', embedding_model: 'nomic-embed-text', rrf_c: '60',
+        rerank_model: 'm', rerank_top_n: '40', chunk_size: '1000', chunk_overlap: '200', contextual: 'off',
+      },
+      modes: [
+        { mode: 'lexical', multiDomainMeanNdcgAt10: 0.55, datasetsEvaluated: 2, datasetsRequested: 2, deltaG: 0.2 },
+        { mode: 'hybrid', multiDomainMeanNdcgAt10: hybridNdcg, datasetsEvaluated: 2, datasetsRequested: 2, deltaG: hybridDeltaG },
+      ],
+    };
+  }
+
+  it('renders an HTML leaderboard, highlighting the best run per mode', async () => {
+    const html = await renderLeaderboard({
+      runs: [run('old', 'aaa111', 0.66, 0.18), run('new', 'bbb222', 0.72, 0.09)],
+      generatedAt: '2026-06-08T12:00:00.000Z',
+    });
+    expect(html).toContain('<!DOCTYPE html>');
+    expect(html).toContain('BEIR retrieval leaderboard');
+    // Headline cells present for both runs.
+    expect(html).toContain('0.7200');
+    expect(html).toContain('0.6600');
+    // The higher hybrid nDCG (0.72) is marked best; the lower is not.
+    expect(html).toMatch(/class="best"[^>]*>0\.7200/);
+    // Provenance carries the commit.
+    expect(html).toContain('bbb222');
+    // Δ_g rendered as a signed percentage.
+    expect(html).toContain('+9.00%');
+  });
+
+  it('renders a placeholder when there are no runs', async () => {
+    const html = await renderLeaderboard({ runs: [], generatedAt: '2026-06-08T12:00:00.000Z' });
+    expect(html).toContain('no runs');
+  });
+});

--- a/benchmarks/compare/leaderboard.ts
+++ b/benchmarks/compare/leaderboard.ts
@@ -1,0 +1,311 @@
+// RFC 020 §7 — the cross-run leaderboard view.
+//
+// "The existing benchmarks/compare/ HTML report becomes the human-facing
+// leaderboard view across runs." Where compare/render.ts compares two embedding
+// models on one fixture, this renders the BEIR matrix headline ACROSS RUNS: each
+// row is a recorded matrix run (a commit + env), each column a retrieval mode,
+// each cell the multi-domain mean nDCG@10 (the headline metric). It surfaces the
+// best run per mode, the Δ_g generality gap, and the full commit+env provenance
+// — the reproducibility contract a public ranking claim rests on.
+//
+// The renderer is a pure function over already-loaded matrix reports (string in,
+// string out, no I/O) so it is deterministic and unit-testable from stubs; a
+// thin loader maps a matrix-report JSON onto the leaderboard run shape.
+
+import * as fsp from 'fs/promises';
+import * as path from 'path';
+
+export interface LeaderboardRunEnv {
+  embedding_provider: string | null;
+  embedding_model: string | null;
+  rrf_c: string;
+  rerank_model: string;
+  rerank_top_n: string;
+  chunk_size: string;
+  chunk_overlap: string;
+  contextual: string;
+}
+
+export interface LeaderboardModeStat {
+  mode: string;
+  multiDomainMeanNdcgAt10: number | null;
+  datasetsEvaluated: number;
+  datasetsRequested: number;
+  deltaG: number | null;
+}
+
+export interface LeaderboardRun {
+  label: string;
+  gitSha: string;
+  generatedAt: string;
+  env: LeaderboardRunEnv;
+  modes: LeaderboardModeStat[];
+}
+
+export interface LeaderboardInput {
+  runs: LeaderboardRun[];
+  generatedAt: string;
+}
+
+/**
+ * Map a parsed BEIR matrix report (matrix.ts MatrixReport JSON) onto a
+ * leaderboard run. Tolerant of the structural subset it needs so a future
+ * schema bump that adds fields does not break the leaderboard.
+ */
+export function matrixReportToRun(report: unknown, label: string): LeaderboardRun {
+  if (!isRecord(report)) throw new Error('leaderboard: matrix report is not an object');
+  const env = isRecord(report.env) ? report.env : {};
+  const perMode = Array.isArray(report.perMode) ? report.perMode : [];
+  const deltaGByMode = new Map<string, number | null>();
+  const generalization = isRecord(report.generalization) ? report.generalization : {};
+  if (Array.isArray(generalization.modes)) {
+    for (const modeGen of generalization.modes) {
+      if (!isRecord(modeGen) || typeof modeGen.mode !== 'string') continue;
+      const dg = isRecord(modeGen.deltaG) ? modeGen.deltaG : {};
+      deltaGByMode.set(modeGen.mode, typeof dg.deltaG === 'number' ? dg.deltaG : null);
+    }
+  }
+  const modes: LeaderboardModeStat[] = perMode
+    .filter(isRecord)
+    .map((summary) => {
+      const mode = typeof summary.mode === 'string' ? summary.mode : 'unknown';
+      return {
+        mode,
+        multiDomainMeanNdcgAt10:
+          typeof summary.multiDomainMeanNdcgAt10 === 'number' ? summary.multiDomainMeanNdcgAt10 : null,
+        datasetsEvaluated: typeof summary.datasetsEvaluated === 'number' ? summary.datasetsEvaluated : 0,
+        datasetsRequested: typeof summary.datasetsRequested === 'number' ? summary.datasetsRequested : 0,
+        deltaG: deltaGByMode.get(mode) ?? null,
+      };
+    });
+  return {
+    label,
+    gitSha: typeof report.git_sha === 'string' ? report.git_sha : 'unknown',
+    generatedAt: typeof report.generated_at === 'string' ? report.generated_at : 'unknown',
+    env: {
+      embedding_provider: strOrNull(env.embedding_provider),
+      embedding_model: strOrNull(env.embedding_model),
+      rrf_c: str(env.rrf_c, 'default'),
+      rerank_model: str(env.rerank_model, 'default'),
+      rerank_top_n: str(env.rerank_top_n, 'default'),
+      chunk_size: str(env.chunk_size, 'default'),
+      chunk_overlap: str(env.chunk_overlap, 'default'),
+      contextual: str(env.contextual, 'off'),
+    },
+    modes,
+  };
+}
+
+export async function loadMatrixRun(jsonPath: string, label?: string): Promise<LeaderboardRun> {
+  const raw = await fsp.readFile(jsonPath, 'utf-8');
+  const fallbackLabel = path.basename(path.dirname(jsonPath)) || path.basename(jsonPath);
+  return matrixReportToRun(JSON.parse(raw), label ?? fallbackLabel);
+}
+
+/** Stable union of all modes seen across runs, in first-seen order. */
+function allModes(runs: readonly LeaderboardRun[]): string[] {
+  const seen: string[] = [];
+  for (const run of runs) {
+    for (const modeStat of run.modes) {
+      if (!seen.includes(modeStat.mode)) seen.push(modeStat.mode);
+    }
+  }
+  return seen;
+}
+
+function statFor(run: LeaderboardRun, mode: string): LeaderboardModeStat | undefined {
+  return run.modes.find((m) => m.mode === mode);
+}
+
+export async function renderLeaderboard(input: LeaderboardInput): Promise<string> {
+  const template = await loadTemplate();
+  const modes = allModes(input.runs);
+
+  // Best (highest) mean nDCG@10 per mode, and best (lowest) Δ_g per mode.
+  const bestNdcgByMode = new Map<string, number>();
+  const bestDeltaGByMode = new Map<string, number>();
+  for (const mode of modes) {
+    for (const run of input.runs) {
+      const stat = statFor(run, mode);
+      if (stat?.multiDomainMeanNdcgAt10 != null) {
+        const prev = bestNdcgByMode.get(mode);
+        if (prev === undefined || stat.multiDomainMeanNdcgAt10 > prev) {
+          bestNdcgByMode.set(mode, stat.multiDomainMeanNdcgAt10);
+        }
+      }
+      if (stat?.deltaG != null) {
+        const prev = bestDeltaGByMode.get(mode);
+        if (prev === undefined || stat.deltaG < prev) bestDeltaGByMode.set(mode, stat.deltaG);
+      }
+    }
+  }
+
+  const headHtml = `<tr><th>Run</th>${modes.map((m) => `<th>${escHtml(m)}</th>`).join('')}</tr>`;
+  const headlineRows = input.runs.map((run) => {
+    const cells = modes.map((mode) => {
+      const stat = statFor(run, mode);
+      if (stat?.multiDomainMeanNdcgAt10 == null) return '<td>—</td>';
+      const isBest = bestNdcgByMode.get(mode) === stat.multiDomainMeanNdcgAt10;
+      const label = `${stat.multiDomainMeanNdcgAt10.toFixed(4)} <span class="note">(${stat.datasetsEvaluated}/${stat.datasetsRequested})</span>`;
+      return `<td class="${isBest ? 'best' : ''}">${label}</td>`;
+    });
+    return `<tr><td>${escHtml(run.label)}</td>${cells.join('')}</tr>`;
+  }).join('');
+
+  const deltaGRows = input.runs.map((run) => {
+    const cells = modes.map((mode) => {
+      const stat = statFor(run, mode);
+      if (stat?.deltaG == null) return '<td>—</td>';
+      const isBest = bestDeltaGByMode.get(mode) === stat.deltaG;
+      return `<td class="${isBest ? 'best' : ''}">${formatPct(stat.deltaG)}</td>`;
+    });
+    return `<tr><td>${escHtml(run.label)}</td>${cells.join('')}</tr>`;
+  }).join('');
+
+  const provenanceRows = input.runs.map((run) => {
+    const e = run.env;
+    const embedding = e.embedding_provider
+      ? `${escHtml(e.embedding_provider)}/${escHtml(e.embedding_model ?? 'default')}`
+      : 'lexical/none';
+    return `<tr>` +
+      `<td>${escHtml(run.label)}</td>` +
+      `<td><code>${escHtml(run.gitSha)}</code></td>` +
+      `<td>${escHtml(run.generatedAt)}</td>` +
+      `<td>${embedding}</td>` +
+      `<td>${escHtml(e.rrf_c)}</td>` +
+      `<td>${escHtml(e.rerank_model)} topN=${escHtml(e.rerank_top_n)}</td>` +
+      `<td>${escHtml(e.chunk_size)}/${escHtml(e.chunk_overlap)}</td>` +
+      `<td>${escHtml(e.contextual)}</td>` +
+      `</tr>`;
+  }).join('');
+
+  return template
+    .replace(/\{\{TITLE\}\}/g, escHtml('BEIR retrieval leaderboard (local reproductions)'))
+    .replace('{{META}}', `Generated ${escHtml(input.generatedAt)} • ${input.runs.length} run(s) • ${modes.length} mode(s)`)
+    .replace('{{HEADLINE_HEAD}}', headHtml)
+    .replace('{{HEADLINE_ROWS}}', headlineRows || '<tr><td colspan="99" class="note">no runs</td></tr>')
+    .replace('{{DELTAG_HEAD}}', headHtml)
+    .replace('{{DELTAG_ROWS}}', deltaGRows || '<tr><td colspan="99" class="note">no runs</td></tr>')
+    .replace('{{PROVENANCE_ROWS}}', provenanceRows || '<tr><td colspan="8" class="note">no runs</td></tr>');
+}
+
+async function loadTemplate(): Promise<string> {
+  // The template is a static asset under benchmarks/compare/ that tsc does not
+  // copy into build/. It is resolved relative to process.cwd() (the repo root,
+  // for both the `bench:beir:leaderboard` npm script and the jest suite) rather
+  // than import.meta.url, so this module stays importable under ts-jest's CJS
+  // transform — the seam compare/render.ts cannot use because it is never
+  // imported by a test.
+  const candidates = [
+    path.resolve(process.cwd(), 'benchmarks', 'compare', 'leaderboard-template.html'),
+    path.resolve(process.cwd(), '..', 'benchmarks', 'compare', 'leaderboard-template.html'),
+  ];
+  for (const candidate of candidates) {
+    try {
+      return await fsp.readFile(candidate, 'utf-8');
+    } catch {
+      // try next
+    }
+  }
+  throw new Error(`leaderboard: could not locate leaderboard-template.html in any of: ${candidates.join(', ')}`);
+}
+
+function formatPct(value: number): string {
+  return `${value >= 0 ? '+' : ''}${(value * 100).toFixed(2)}%`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function str(value: unknown, fallback: string): string {
+  return typeof value === 'string' && value.trim() !== '' ? value : fallback;
+}
+
+function strOrNull(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() !== '' ? value : null;
+}
+
+function escHtml(s: string): string {
+  return s.replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]!));
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+interface LeaderboardCliOptions {
+  inputs: string[];
+  outputPath: string;
+  now: string;
+}
+
+export function parseLeaderboardArgs(argv: string[], now: string): LeaderboardCliOptions {
+  const options: LeaderboardCliOptions = {
+    inputs: [],
+    outputPath: path.join(process.cwd(), 'benchmarks', 'results', 'beir', 'leaderboard.html'),
+    now,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    const [flag, inlineValue] = token.includes('=') ? token.split(/=(.*)/s, 2) : [token, undefined];
+    const readValue = (): string => {
+      if (inlineValue !== undefined) return inlineValue;
+      i += 1;
+      const value = argv[i];
+      if (value === undefined || value.startsWith('--')) throw new Error(`${flag} requires a value`);
+      return value;
+    };
+    if (flag === '--inputs') {
+      options.inputs = readValue().split(',').map((v) => v.trim()).filter(Boolean).map((p) => path.resolve(p));
+    } else if (flag === '--output') {
+      options.outputPath = path.resolve(readValue());
+    } else if (flag === '--help' || flag === '-h') {
+      process.stdout.write(leaderboardHelpText());
+      process.exit(0);
+    } else {
+      throw new Error(`unknown argument: ${token}`);
+    }
+  }
+  if (options.inputs.length === 0) {
+    throw new Error('leaderboard: --inputs=<matrix.json[,matrix2.json]> is required');
+  }
+  return options;
+}
+
+function leaderboardHelpText(): string {
+  return `kb BEIR cross-run leaderboard (RFC 020 §7)
+
+Usage:
+  npm run bench:beir:leaderboard -- --inputs=run1/beir-matrix.json,run2/beir-matrix.json \\
+      --output=benchmarks/results/beir/leaderboard.html
+
+Each input is a beir-matrix.json produced by bench:beir:matrix. The leaderboard
+ranks runs by the per-mode multi-domain mean nDCG@10, shows Δ_g, and records the
+commit + env for each run.
+
+Options:
+  --inputs=<a.json[,b.json]>  Matrix report JSON files (one per run). Required.
+  --output=<path>             Output HTML. Default: benchmarks/results/beir/leaderboard.html.
+`;
+}
+
+async function main(): Promise<void> {
+  const options = parseLeaderboardArgs(process.argv.slice(2), new Date().toISOString());
+  const runs = await Promise.all(options.inputs.map((input) => loadMatrixRun(input)));
+  const html = await renderLeaderboard({ runs, generatedAt: options.now });
+  await fsp.mkdir(path.dirname(options.outputPath), { recursive: true });
+  await fsp.writeFile(options.outputPath, html, 'utf-8');
+  process.stdout.write(`${options.outputPath}\n`);
+}
+
+const cliEntry = process.argv[1] !== undefined ? path.normalize(process.argv[1]) : '';
+if (
+  cliEntry.endsWith(path.join('benchmarks', 'compare', 'leaderboard.js')) ||
+  cliEntry.endsWith(path.join('benchmarks', 'compare', 'leaderboard.ts'))
+) {
+  main().catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.stack ?? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/benchmarks/observability/mlflow.test.ts
+++ b/benchmarks/observability/mlflow.test.ts
@@ -1,4 +1,12 @@
-import { flattenMetrics, flattenParams, readMlflowConfig } from './mlflow.js';
+import {
+  beirMatrixMlflowPayload,
+  beirRunMlflowPayload,
+  flattenMetrics,
+  flattenParams,
+  logBeirRunToMlflow,
+  readMlflowConfig,
+  type MlflowConfig,
+} from './mlflow.js';
 
 describe('benchmark MLflow observability', () => {
   it('stays disabled unless MLflow env is configured', () => {
@@ -45,5 +53,100 @@ describe('benchmark MLflow observability', () => {
       version: '1',
       models: 'a,b',
     });
+  });
+});
+
+describe('BEIR ledger (RFC 020 §7)', () => {
+  const config: MlflowConfig = {
+    experimentName: 'kb-beir',
+    tags: { suite: 'beir' },
+    python: 'python3',
+  };
+
+  it('builds a per-run payload with commit + full env params, metrics, and the TREC artifact', () => {
+    const payload = beirRunMlflowPayload({
+      report: {
+        git_sha: 'cafe',
+        dataset: { name: 'scifact', split: 'test', queries_evaluated: 300 },
+        mode: 'hybrid+rerank',
+        embedding: { provider: 'ollama', model: 'nomic-embed-text' },
+        rerank: { enabled: true, model: 'Xenova/ms-marco-MiniLM-L-6-v2', topN: 40 },
+        contextual: { enabled: false },
+        chunking: { KB_CHUNK_SIZE: '1000', KB_CHUNK_OVERLAP: '200' },
+        metrics: { ndcgAt10: 0.74, mapAt100: 0.6, precisionAt10: 0.09, recallAt10: 0.8, recallAt100: 0.9 },
+        latency: { p50Ms: 12, p95Ms: 40, p99Ms: 55, meanMs: 18 },
+      },
+      jsonPath: '/tmp/scifact.json',
+      trecPath: '/tmp/scifact.trec',
+      repoRoot: '/repo',
+    }, config);
+
+    expect(payload.params).toMatchObject({
+      kind: 'beir',
+      git_sha: 'cafe',
+      dataset: 'scifact',
+      mode: 'hybrid+rerank',
+      provider: 'ollama',
+      model: 'nomic-embed-text',
+      rerank_enabled: 'true',
+      rerank_top_n: '40',
+      chunk_size: '1000',
+      chunk_overlap: '200',
+    });
+    expect(payload.metrics).toMatchObject({
+      ndcg_at_10: 0.74,
+      precision_at_10: 0.09,
+      latency_p99_ms: 55,
+      queries_evaluated: 300,
+    });
+    expect(payload.artifacts).toEqual(['/tmp/scifact.json', '/tmp/scifact.trec']);
+  });
+
+  it('logging is a no-op when MLflow is unconfigured', async () => {
+    await expect(logBeirRunToMlflow({
+      report: {
+        git_sha: 'x',
+        dataset: { name: 'd', split: 'test', queries_evaluated: 1 },
+        mode: 'lexical',
+        embedding: null,
+        rerank: null,
+        contextual: null,
+        chunking: { KB_CHUNK_SIZE: null, KB_CHUNK_OVERLAP: null },
+        metrics: { ndcgAt10: 0, mapAt100: 0, precisionAt10: 0, recallAt10: 0, recallAt100: 0 },
+        latency: { p50Ms: 0, p95Ms: 0, p99Ms: 0, meanMs: 0 },
+      },
+      jsonPath: '/tmp/a.json',
+      trecPath: '/tmp/a.trec',
+      repoRoot: '/repo',
+    }, undefined)).resolves.toBeUndefined();
+  });
+
+  it('builds a matrix payload with per-mode headline means and Δ_g metrics', () => {
+    const payload = beirMatrixMlflowPayload({
+      report: {
+        git_sha: 'matrix1',
+        modes: ['lexical', 'hybrid'],
+        datasets: ['scifact', 'arguana'],
+        env: { embedding_provider: 'ollama', rrf_c: '60', contextual: 'off' },
+        perMode: [
+          { mode: 'lexical', datasetsEvaluated: 2, datasetsRequested: 2, multiDomainMeanNdcgAt10: 0.55, multiDomainMeanPrecisionAt10: 0.1, multiDomainMeanRecallAt10: 0.6 },
+          { mode: 'hybrid', datasetsEvaluated: 2, datasetsRequested: 2, multiDomainMeanNdcgAt10: 0.70, multiDomainMeanPrecisionAt10: 0.12, multiDomainMeanRecallAt10: 0.75 },
+        ],
+        generalization: {
+          modes: [
+            { mode: 'lexical', deltaG: { deltaG: 0.2, seenMeanNdcgAt10: 0.6, unseenMeanNdcgAt10: 0.48 } },
+            { mode: 'hybrid', deltaG: { deltaG: 0.1, seenMeanNdcgAt10: 0.8, unseenMeanNdcgAt10: 0.72 } },
+          ],
+        },
+      },
+      jsonPath: '/tmp/matrix.json',
+      markdownPath: '/tmp/matrix.md',
+      repoRoot: '/repo',
+    }, config);
+
+    expect(payload.params).toMatchObject({ kind: 'beir-matrix', git_sha: 'matrix1', rrf_c: '60' });
+    expect(payload.metrics['headline.hybrid.mean_ndcg_at_10']).toBe(0.70);
+    expect(payload.metrics['delta_g.hybrid']).toBe(0.1);
+    expect(payload.artifacts).toEqual(['/tmp/matrix.json', '/tmp/matrix.md']);
   });
 });

--- a/benchmarks/observability/mlflow.ts
+++ b/benchmarks/observability/mlflow.ts
@@ -35,6 +35,66 @@ export interface MlflowCompareInput {
   repoRoot: string;
 }
 
+// RFC 020 §7 — the reproducibility ledger. A BEIR run is an MLflow run logged
+// with the git SHA, the full retrieval env (model IDs, RRF c, rerank model/topN,
+// chunk size/overlap, contextual on/off), the per-dataset metrics, the latency
+// percentiles, and the TREC run-file artifact. The shapes below are the subset
+// of `BeirBenchmarkReport` / `MatrixReport` the ledger consumes — declared
+// structurally so this module stays decoupled from the benchmark runner.
+export interface BeirLedgerReport {
+  git_sha: string;
+  command?: string;
+  dataset: { name: string; split: string; corpus_documents?: number; queries_evaluated: number };
+  mode: string;
+  embedding: { provider: string; model: string } | null;
+  rerank: { enabled: boolean; model: string; topN: number } | null;
+  contextual: { enabled: boolean } | null;
+  chunking: { KB_CHUNK_SIZE: string | null; KB_CHUNK_OVERLAP: string | null };
+  metrics: {
+    ndcgAt10: number;
+    mapAt100: number;
+    precisionAt10: number;
+    recallAt10: number;
+    recallAt100: number;
+  };
+  latency: { p50Ms: number; p95Ms: number; p99Ms: number; meanMs: number };
+}
+
+export interface MlflowBeirRunInput {
+  report: BeirLedgerReport;
+  jsonPath: string;
+  trecPath: string;
+  repoRoot: string;
+}
+
+export interface MatrixLedgerReport {
+  git_sha: string;
+  modes: string[];
+  datasets: string[];
+  env: Record<string, string | null>;
+  perMode: Array<{
+    mode: string;
+    datasetsEvaluated: number;
+    datasetsRequested: number;
+    multiDomainMeanNdcgAt10: number | null;
+    multiDomainMeanPrecisionAt10: number | null;
+    multiDomainMeanRecallAt10: number | null;
+  }>;
+  generalization: {
+    modes: Array<{
+      mode: string;
+      deltaG: { deltaG: number | null; seenMeanNdcgAt10: number | null; unseenMeanNdcgAt10: number | null };
+    }>;
+  };
+}
+
+export interface MlflowBeirMatrixInput {
+  report: MatrixLedgerReport;
+  jsonPath: string;
+  markdownPath: string;
+  repoRoot: string;
+}
+
 const DEFAULT_EXPERIMENT = 'kb-benchmarks';
 
 export function readMlflowConfig(env: NodeJS.ProcessEnv = process.env): MlflowConfig | undefined {
@@ -104,6 +164,100 @@ export async function logCompareToMlflow(
     metrics,
     artifacts: [input.jsonPath, input.htmlPath],
   }, input.repoRoot, config.python);
+}
+
+/**
+ * Build the MLflow payload for one BEIR run (RFC 020 §7). Pure + exported so the
+ * ledger contract is unit-testable without spawning Python: params carry the
+ * commit + full retrieval env; metrics carry per-dataset quality + latency
+ * percentiles; artifacts are the metrics JSON and the TREC run file.
+ */
+export function beirRunMlflowPayload(input: MlflowBeirRunInput, config: MlflowConfig): MlflowPayload {
+  const { report } = input;
+  return {
+    ...basePayload(config),
+    params: flattenParams({
+      kind: 'beir',
+      git_sha: report.git_sha,
+      dataset: report.dataset.name,
+      split: report.dataset.split,
+      mode: report.mode,
+      provider: report.embedding?.provider ?? 'none',
+      model: report.embedding?.model ?? 'none',
+      rerank_enabled: report.rerank?.enabled ?? false,
+      rerank_model: report.rerank?.model ?? 'none',
+      rerank_top_n: report.rerank?.topN ?? 0,
+      contextual: report.contextual?.enabled ?? false,
+      chunk_size: report.chunking.KB_CHUNK_SIZE ?? 'default',
+      chunk_overlap: report.chunking.KB_CHUNK_OVERLAP ?? 'default',
+    }),
+    metrics: flattenMetrics({
+      ndcg_at_10: report.metrics.ndcgAt10,
+      map_at_100: report.metrics.mapAt100,
+      precision_at_10: report.metrics.precisionAt10,
+      recall_at_10: report.metrics.recallAt10,
+      recall_at_100: report.metrics.recallAt100,
+      queries_evaluated: report.dataset.queries_evaluated,
+      latency_p50_ms: report.latency.p50Ms,
+      latency_p95_ms: report.latency.p95Ms,
+      latency_p99_ms: report.latency.p99Ms,
+      latency_mean_ms: report.latency.meanMs,
+    }),
+    artifacts: [input.jsonPath, input.trecPath],
+  };
+}
+
+export async function logBeirRunToMlflow(
+  input: MlflowBeirRunInput,
+  config = readMlflowConfig(),
+): Promise<void> {
+  if (!config) return;
+  await runMlflowLogger(beirRunMlflowPayload(input, config), input.repoRoot, config.python);
+}
+
+/**
+ * Build the MLflow payload for a full-matrix sweep (RFC 020 §2/§6/§7): one row
+ * per mode for the headline multi-domain mean nDCG@10, plus the Δ_g generality
+ * gap. Pure + exported for the same testability reason as the per-run builder.
+ */
+export function beirMatrixMlflowPayload(input: MlflowBeirMatrixInput, config: MlflowConfig): MlflowPayload {
+  const { report } = input;
+  const metrics: Record<string, unknown> = {};
+  for (const summary of report.perMode) {
+    const key = sanitizeKeySegment(summary.mode);
+    metrics[`headline.${key}.mean_ndcg_at_10`] = summary.multiDomainMeanNdcgAt10 ?? undefined;
+    metrics[`headline.${key}.mean_precision_at_10`] = summary.multiDomainMeanPrecisionAt10 ?? undefined;
+    metrics[`headline.${key}.mean_recall_at_10`] = summary.multiDomainMeanRecallAt10 ?? undefined;
+    metrics[`headline.${key}.datasets_evaluated`] = summary.datasetsEvaluated;
+  }
+  for (const modeGen of report.generalization.modes) {
+    const key = sanitizeKeySegment(modeGen.mode);
+    if (modeGen.deltaG.deltaG !== null) metrics[`delta_g.${key}`] = modeGen.deltaG.deltaG;
+  }
+  return {
+    ...basePayload(config),
+    params: flattenParams({
+      kind: 'beir-matrix',
+      git_sha: report.git_sha,
+      modes: report.modes,
+      datasets: report.datasets,
+      ...report.env,
+    }),
+    metrics: flattenMetrics(metrics),
+    artifacts: [input.jsonPath, input.markdownPath],
+  };
+}
+
+export async function logBeirMatrixToMlflow(
+  input: MlflowBeirMatrixInput,
+  config = readMlflowConfig(),
+): Promise<void> {
+  if (!config) return;
+  await runMlflowLogger(beirMatrixMlflowPayload(input, config), input.repoRoot, config.python);
+}
+
+function sanitizeKeySegment(value: string): string {
+  return value.replace(/[^A-Za-z0-9]+/g, '_');
 }
 
 export function flattenMetrics(value: unknown, prefix = ''): Record<string, number> {

--- a/benchmarks/results/beir/matrix/README.md
+++ b/benchmarks/results/beir/matrix/README.md
@@ -1,0 +1,82 @@
+# BEIR full-matrix sweep (RFC 020 §2/§6/§7, milestone M2)
+
+This directory holds the output of `bench:beir:matrix` — the full BEIR
+`(dataset × mode)` sweep whose **headline metric is the per-mode multi-domain
+mean nDCG@10** (RFC 020 §2). Averaging across domains is the anti-overfitting
+metric by construction: anything tuned to a single corpus *lowers* the mean.
+
+Two artifacts are produced (gitignored until a maintainer commits a real run):
+
+```
+beir-matrix.json   full report — one cell per (dataset × mode), per-mode means,
+                   per-domain breakdown, Δ_g, contamination notes, and the env
+                   that produced it (git SHA + model IDs + RRF c + rerank
+                   model/topN + chunk size/overlap + contextual on/off)
+beir-matrix.md     human-readable headline + per-domain + Δ_g tables
+```
+
+## What the matrix reports
+
+- **Headline** — `perMode[].multiDomainMeanNdcgAt10`, the mean across the
+  datasets that actually ran (the mean is labelled with its denominator, e.g.
+  `mean over 3 of 14 datasets`, so a partial sweep is self-describing).
+- **Per-domain breakdown** (§6) — mean nDCG@10 / precision@10 per registry
+  domain bucket, so a domain-localized regression a single mean would bury is
+  visible.
+- **Δ_g = (seen − unseen) / seen** (§6.5) — the generalization gap between the
+  tuned/dev datasets (`scifact`, `nfcorpus`, `fiqa`) and a **reserved
+  unseen-generality set** that is never tuned on (`arguana`, `scidocs`,
+  `webis-touche2020`). A widening Δ_g is the overfitting alarm a multi-domain
+  mean alone hides. `significance.ts` is the companion arbiter: Δ_g flags the
+  suspect, the paired bootstrap convicts it.
+- **Contamination notes** (§6.6) — per-dataset known-in-pretraining flag and
+  qrels provenance, carried from `benchmarks/beir/registry.ts`. Dataset names
+  are recorded here for provenance only and are excluded from any LLM-grader
+  prompt.
+
+Every run is wired into the MLflow ledger (`bench:beir:matrix` calls
+`logBeirRunToMlflow` per cell and `logBeirMatrixToMlflow` for the headline; both
+no-op unless `BENCH_MLFLOW_*` is configured). The cross-run **leaderboard view**
+(`bench:beir:leaderboard`) ranks recorded `beir-matrix.json` runs side by side.
+
+## Status of the as-shipped headline ⚠️ — full sweep pending
+
+The full-matrix headline for the shipped pipeline (`hybrid+rerank+contextual`)
+requires **every BEIR dataset downloaded** *and* a **real embedding model**
+(Ollama) plus the cross-encoder. None of those is available in the CI/build
+sandbox used to land this milestone (no dataset host egress, no Ollama daemon),
+so **no real full-matrix number is committed here yet** — and, per the RFC's
+"honestly-measured" principle, none is fabricated.
+
+What *is* landed and verified:
+
+- The full machinery — dataset registry, matrix runner, per-domain breakdown,
+  Δ_g, MLflow ledger wiring, and the cross-run leaderboard view — with unit
+  tests that exercise the aggregation, the Δ_g math, the ledger payloads, and
+  the leaderboard render from deterministic stub inputs.
+- The per-(dataset × mode) BEIR runner itself produces real, committed,
+  reproducible numbers (see `../baseline/README.md` for the recorded SciFact
+  lexical/dense/hybrid baselines on `ollama / nomic-embed-text`).
+
+To produce the real headline (maintainer, with Ollama running and dataset host
+reachable):
+
+```bash
+# Full auto-downloadable matrix, all shipped modes:
+npm run bench:beir:matrix -- --provider=ollama --model=nomic-embed-text \
+  --modes=lexical,dense,hybrid,hybrid+rerank,hybrid+rerank+contextual
+
+# A faster tuned+unseen slice that still yields a real Δ_g:
+npm run bench:beir:matrix -- --provider=ollama --model=nomic-embed-text \
+  --datasets=scifact,nfcorpus,fiqa,arguana,scidocs,webis-touche2020 \
+  --modes=lexical,hybrid
+
+# Then render the leaderboard across runs:
+npm run bench:beir:leaderboard -- \
+  --inputs=benchmarks/results/beir/matrix/beir-matrix.json \
+  --output=benchmarks/results/beir/leaderboard.html
+```
+
+When the host is unreachable, supply each dataset via `--dataset-dir` from the
+Hugging Face `BeIR` mirror (the same workaround used for the baselines), then
+re-run the matrix per dataset and merge.

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "bench:beir": "npm run build && tsc -p tsconfig.bench.json && node build/benchmarks/beir/run.js",
     "bench:beir:sweep": "npm run build && tsc -p tsconfig.bench.json && node build/benchmarks/beir/sweep.js",
     "bench:beir:baseline": "npm run build && tsc -p tsconfig.bench.json && node build/benchmarks/beir/baseline.js",
+    "bench:beir:matrix": "npm run build && tsc -p tsconfig.bench.json && node build/benchmarks/beir/matrix.js",
+    "bench:beir:leaderboard": "npm run build && tsc -p tsconfig.bench.json && node build/benchmarks/compare/leaderboard.js",
     "bench:beir:significance": "npm run build && tsc -p tsconfig.bench.json && node build/benchmarks/significance.js",
     "bench:compare": "npm run build && tsc -p tsconfig.bench.json && node build/benchmarks/compare/run.js",
     "bench:tune": "python3 benchmarks/optuna_tune.py",


### PR DESCRIPTION
Closes #562. Part of epic #559 (RFC 020, milestone **M2**). Builds on merged M0 (#560) and M1 (#561).

## 🎯 What this delivers

| Deliverable | Where |
|---|---|
| Dataset registry over the full public BEIR set + per-dataset contamination/qrels notes | `benchmarks/beir/registry.ts` |
| Matrix sweep runner — one row per `(dataset × mode)` + per-mode **multi-domain mean nDCG@10** (headline) | `benchmarks/beir/matrix.ts` |
| MLflow ledger wiring — git SHA, full env, per-dataset metrics, latency percentiles, TREC artifact | `benchmarks/observability/mlflow.ts` |
| Cross-run **leaderboard view** | `benchmarks/compare/leaderboard.ts` + template |
| Per-domain breakdown + **Δ_g = (seen − unseen)/seen** vs a reserved unseen-generality set | `benchmarks/beir/generalization.ts` |

## Design notes

- **Headline = multi-domain mean** (RFC §2/§6). The matrix reports the per-mode mean nDCG@10 across the datasets that ran, *labelled with its denominator* (`mean over N of M datasets`), so a partial sweep is self-describing. Failed/uncached cells are recorded and **excluded from the mean** — never fabricated.
- **Δ_g partition** (§6.5): tuned ("seen") = `scifact`/`nfcorpus`/`fiqa` (the CI subset); reserved unseen-generality = `arguana`/`scidocs`/`webis-touche2020`, distinct domains never tuned on. Disjointness is invariant-checked. Δ_g is `null` when the unseen side wasn't run (honest partial sweep), composing with `significance.ts` (Δ_g flags the suspect; the paired bootstrap convicts it).
- **Ledger** (§7): `logBeirRunToMlflow` per cell + `logBeirMatrixToMlflow` for the headline; both no-op unless `BENCH_MLFLOW_*` is set. Pure payload builders are exported and unit-tested without spawning Python. The captured env covers model IDs, RRF c, rerank model/topN, chunk size/overlap, contextual on/off.
- **Contamination controls** (§6.6): dataset names are recorded for provenance only and excluded from any judge prompt; Wikipedia-derived sets are flagged as pretraining-leakage risks.
- New scripts: `bench:beir:matrix`, `bench:beir:leaderboard`.

## ⚠️ Acceptance metric — machinery landed, real full sweep pending

> Multi-domain mean nDCG@10 for the shipped pipeline recorded and reproducible from commit+env; Δ_g reported.

The full-matrix headline for the shipped pipeline (`hybrid+rerank+contextual`) needs **every BEIR dataset downloaded** *and* a **real embedding model** (Ollama) + cross-encoder. The build sandbox has **no dataset-host egress** (`curl` → `http=000`) and **no Ollama daemon**, so a real full sweep is infeasible here. Per RFC 020's "honestly-measured" principle, **no benchmark numbers are fabricated**.

What is landed and verified:
- Full machinery (registry, matrix runner, per-domain/Δ_g, MLflow ledger, leaderboard) with unit tests exercising the aggregation, Δ_g math, ledger payloads, and leaderboard render from deterministic stub inputs.
- CLIs smoke-tested end-to-end from the build output (matrix `--help`, leaderboard HTML render).
- The pending real run + reproduce instructions are documented in `benchmarks/results/beir/matrix/README.md`.

## ✅ Verification

- `npm run build` ✓, `tsc -p tsconfig.bench.json` ✓, `npm run docs:check-anchors` ✓ (0 stale anchors).
- `npm test` ✓ — 2172 passed (a 2nd full run; `src/triggerWatcher.test.ts` is a pre-existing real-timer flake under full-suite load, passes 18/18 in isolation and on re-run, untouched by this benchmarks-only change).
- New tests: `registry.test.ts`, `generalization.test.ts`, `matrix.test.ts`, `compare/leaderboard.test.ts`, extended `observability/mlflow.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)