### PR TITLE
feat(bench): M5 — adjudicate first Tier-1 technique (reranker upgrade) through the full harness (#565)

### DIFF
--- a/benchmarks/adjudication/README.md
+++ b/benchmarks/adjudication/README.md
@@ -1,0 +1,63 @@
+# Tier-1 technique adjudication (RFC 020 M5 · issue #565)
+
+The final milestone of RFC 020: take **one** Tier-1 retrieval technique through
+the full harness (M0–M4) and produce a documented **ship / no-ship** decision
+backed by evidence — not a single-run eyeballed delta.
+
+The technique adjudicated here is the **reranker upgrade**: the default
+cross-encoder `Xenova/ms-marco-MiniLM-L-6-v2` → a stronger model such as
+`BAAI/bge-reranker-v2-m3` / `Qwen3-Reranker`, selectable through the existing
+`KB_RERANK_MODEL` plug point. Per RFC §9 the upgrade is **not a universal win**
+(the KB survey found cross-encoders *degrade* high-precision/lexical domains like
+code and skills), so it ships only behind:
+
+- a **per-domain measurement gate** — measure nDCG@10 per domain (not just the
+  BEIR mean) and enable rerank only where it is a *significant* improvement; and
+- a **skip-rerank fallback** — `KB_RERANK_SKIP_DOMAINS` keeps the cheaper,
+  un-reranked path for domains where the cross-encoder regresses or shows no
+  significant gain.
+
+## What this module does
+
+`adjudicate.ts` consumes:
+
+1. **Per-domain BEIR evidence** — paired per-query nDCG@10 vectors (baseline
+   reranker vs candidate reranker), compared with the §3 significance machinery
+   in `benchmarks/significance.ts` (paired bootstrap + t-test, Bonferroni/Holm
+   family correction, wild-cluster bootstrap when queries cluster by dataset).
+2. **The §5 e2e RAG veto** — faithfulness / answer-correctness numbers from the
+   human-label-free cascade (`benchmarks/rag-eval/`). A regression past tolerance
+   hard-vetoes the ship even when BEIR improves.
+
+and emits a structured decision plus the per-domain policy and the recommended
+`KB_RERANK_MODEL` + `KB_RERANK_SKIP_DOMAINS` config to realize it.
+
+### Decision rule
+
+| Decision | When |
+|---|---|
+| **NO-SHIP** | the §5 e2e veto fires, **or** no domain shows a significant nDCG@10 gain (incl. "no per-domain evidence supplied") |
+| **SHIP-GATED** | some domains improve and others are gated out via the skip-rerank fallback; e2e veto passes |
+| **SHIP** | every measured domain improves significantly and the e2e veto passes (empty skip list) |
+
+## Running it
+
+```bash
+npm run bench:adjudicate -- --manifest <manifest.json> \
+    --output-dir benchmarks/results/adjudication \
+    --report-name reranker-bge-v2-m3-adjudication
+```
+
+The manifest declares the candidate/baseline models, the per-domain BEIR run
+files to compare, and the e2e veto inputs (inline numbers or rag-eval scorecard
+paths). See `adjudicate.ts` `--help` for the full schema.
+
+## Honesty contract
+
+This module **never fabricates a benchmark number**. A real run needs BEIR
+datasets + a real embedding model + the candidate cross-encoder + (for the e2e
+leg) ≥3 live judge families. Where any of those is missing the adjudication is
+marked **provisional** and the missing evidence is listed in `pending`; the
+decision machinery + unit tests still ship, and the report self-describes what is
+outstanding. See `../results/adjudication/` for the produced (provisional)
+report and the hermetic e2e self-test.

--- a/benchmarks/adjudication/adjudicate.test.ts
+++ b/benchmarks/adjudication/adjudicate.test.ts
@@ -1,0 +1,245 @@
+import { afterAll, describe, expect, it } from '@jest/globals';
+import * as fsp from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import type { PerQueryScore } from '../significance.js';
+import {
+  adjudicateRerank,
+  loadAdjudicationInput,
+  numericAtPath,
+  parseAdjudicateArgs,
+  renderAdjudicationMarkdown,
+  runAdjudicateCli,
+  type DomainEvidence,
+} from './adjudicate.js';
+
+// Deterministic per-query fixtures -------------------------------------------
+
+function scores(prefix: string, values: number[]): PerQueryScore[] {
+  return values.map((ndcgAt10, i) => ({ queryId: `${prefix}-q${i}`, ndcgAt10 }));
+}
+
+/** A domain where the candidate is uniformly better → significant improvement. */
+function improvingDomain(domain: string): DomainEvidence {
+  return {
+    domain,
+    mode: 'hybrid+rerank',
+    baseline: scores(domain, [0.50, 0.50, 0.50, 0.50, 0.50]),
+    candidate: scores(domain, [0.70, 0.70, 0.70, 0.70, 0.70]),
+  };
+}
+
+/** A domain where the candidate is uniformly worse → significant regression. */
+function regressingDomain(domain: string): DomainEvidence {
+  return {
+    domain,
+    mode: 'hybrid+rerank',
+    baseline: scores(domain, [0.70, 0.70, 0.70, 0.70, 0.70]),
+    candidate: scores(domain, [0.50, 0.50, 0.50, 0.50, 0.50]),
+  };
+}
+
+/** A domain whose per-query deltas cancel → no significant change. */
+function flatDomain(domain: string): DomainEvidence {
+  return {
+    domain,
+    mode: 'hybrid+rerank',
+    baseline: scores(domain, [0.50, 0.50, 0.50, 0.50]),
+    candidate: scores(domain, [0.60, 0.40, 0.55, 0.45]),
+  };
+}
+
+const tmpDirs: string[] = [];
+async function makeTmpDir(): Promise<string> {
+  const dir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-adjudicate-'));
+  tmpDirs.push(dir);
+  return dir;
+}
+afterAll(async () => {
+  for (const dir of tmpDirs) await fsp.rm(dir, { recursive: true, force: true });
+});
+
+describe('adjudicateRerank — per-domain gate + e2e veto (RFC 020 §3/§5/§9)', () => {
+  it('SHIP-GATEs: enable on improving domains, skip-fallback on regressing/flat ones', () => {
+    const result = adjudicateRerank({
+      candidateModel: 'BAAI/bge-reranker-v2-m3',
+      baselineModel: 'Xenova/ms-marco-MiniLM-L-6-v2',
+      domains: [improvingDomain('scifact'), regressingDomain('code'), flatDomain('skills')],
+      e2e: [{ metric: 'faithfulness', baseline: 0.90, candidate: 0.905, tolerance: 0.01 }],
+    });
+
+    expect(result.decision).toBe('ship-gated');
+    expect(result.enabledDomains).toEqual(['scifact']);
+    expect(result.skipDomains).toEqual(['code', 'skills']);
+    expect(result.e2eVetoed).toBe(false);
+    expect(result.recommendedConfig).toEqual({
+      KB_RERANK_MODEL: 'BAAI/bge-reranker-v2-m3',
+      KB_RERANK_SKIP_DOMAINS: 'code,skills',
+    });
+    // The improving domain rejects the null after family correction; the flat
+    // one does not.
+    const byDomain = Object.fromEntries(result.domains.map((d) => [d.domain, d]));
+    expect(byDomain.scifact.verdict).toBe('improvement');
+    expect(byDomain.scifact.action).toBe('enable');
+    expect(byDomain.code.verdict).toBe('regression');
+    expect(byDomain.skills.verdict).toBe('no-significant-change');
+    expect(byDomain.skills.action).toBe('skip');
+  });
+
+  it('SHIPs (no skip) when every measured domain improves and the e2e veto passes', () => {
+    const result = adjudicateRerank({
+      candidateModel: 'BAAI/bge-reranker-v2-m3',
+      baselineModel: 'Xenova/ms-marco-MiniLM-L-6-v2',
+      domains: [improvingDomain('scifact'), improvingDomain('nfcorpus')],
+      e2e: [{ metric: 'accuracy', baseline: 0.80, candidate: 0.81 }],
+    });
+    expect(result.decision).toBe('ship');
+    expect(result.skipDomains).toEqual([]);
+    expect(result.enabledDomains).toEqual(['scifact', 'nfcorpus']);
+    expect(result.recommendedConfig.KB_RERANK_SKIP_DOMAINS).toBe('');
+  });
+
+  it('NO-SHIPs when the §5 e2e veto fires, even if BEIR improves', () => {
+    const result = adjudicateRerank({
+      candidateModel: 'BAAI/bge-reranker-v2-m3',
+      baselineModel: 'Xenova/ms-marco-MiniLM-L-6-v2',
+      domains: [improvingDomain('scifact'), improvingDomain('nfcorpus')],
+      e2e: [{ metric: 'faithfulness', baseline: 0.90, candidate: 0.80, tolerance: 0.01 }],
+    });
+    expect(result.decision).toBe('no-ship');
+    expect(result.e2eVetoed).toBe(true);
+    // No-ship stays on the baseline reranker and gates nothing.
+    expect(result.recommendedConfig.KB_RERANK_MODEL).toBe('Xenova/ms-marco-MiniLM-L-6-v2');
+    expect(result.recommendedConfig.KB_RERANK_SKIP_DOMAINS).toBe('');
+  });
+
+  it('NO-SHIPs when no domain shows a significant improvement', () => {
+    const result = adjudicateRerank({
+      candidateModel: 'BAAI/bge-reranker-v2-m3',
+      baselineModel: 'Xenova/ms-marco-MiniLM-L-6-v2',
+      domains: [regressingDomain('code'), flatDomain('skills')],
+    });
+    expect(result.decision).toBe('no-ship');
+    expect(result.enabledDomains).toEqual([]);
+  });
+
+  it('marks the decision provisional when evidence is pending (never fabricated)', () => {
+    const result = adjudicateRerank({
+      candidateModel: 'BAAI/bge-reranker-v2-m3',
+      baselineModel: 'Xenova/ms-marco-MiniLM-L-6-v2',
+      domains: [improvingDomain('scifact')],
+      pending: ['real BEIR runs outstanding (needs datasets + embedding model + candidate reranker)'],
+    });
+    expect(result.provisional).toBe(true);
+    expect(result.summary).toMatch(/^PROVISIONAL/);
+    expect(renderAdjudicationMarkdown(result)).toContain('Pending evidence');
+  });
+
+  it('honors the Bonferroni correction (a single weak win can be downgraded)', () => {
+    // A marginal improvement that survives uncorrected but is killed by a large
+    // family. We build one weakly-improving domain alongside many noisy ones.
+    const weak: DomainEvidence = {
+      domain: 'weak',
+      baseline: scores('weak', [0.50, 0.51, 0.49, 0.50, 0.50, 0.50]),
+      candidate: scores('weak', [0.55, 0.55, 0.55, 0.55, 0.55, 0.55]),
+    };
+    const family = [weak, flatDomain('a'), flatDomain('b'), flatDomain('c'), flatDomain('d')];
+    const holm = adjudicateRerank({
+      candidateModel: 'c',
+      baselineModel: 'b',
+      domains: family,
+      correction: 'holm',
+    });
+    const none = adjudicateRerank({
+      candidateModel: 'c',
+      baselineModel: 'b',
+      domains: family,
+      correction: 'none',
+    });
+    // The correction can only make a verdict *less* significant, never more.
+    const holmWeak = holm.domains.find((d) => d.domain === 'weak');
+    const noneWeak = none.domains.find((d) => d.domain === 'weak');
+    expect(holmWeak?.adjustedPValue).toBeGreaterThanOrEqual(noneWeak?.adjustedPValue ?? 0);
+  });
+});
+
+describe('numericAtPath', () => {
+  it('reads dotted numeric paths and returns null for missing/non-numeric', () => {
+    const root = { correctness: { accuracy: 0.83 }, tier1: { tokenF1: 0.7 }, note: 'x' };
+    expect(numericAtPath(root, 'correctness.accuracy')).toBe(0.83);
+    expect(numericAtPath(root, 'tier1.tokenF1')).toBe(0.7);
+    expect(numericAtPath(root, 'correctness.missing')).toBeNull();
+    expect(numericAtPath(root, 'note')).toBeNull();
+    expect(numericAtPath(null, 'a.b')).toBeNull();
+  });
+});
+
+describe('loadAdjudicationInput + runAdjudicateCli (manifest → report)', () => {
+  async function writeRunFile(dir: string, name: string, dataset: string, values: number[]): Promise<string> {
+    const file = path.join(dir, name);
+    await fsp.writeFile(
+      file,
+      JSON.stringify({
+        dataset: { name: dataset },
+        per_query: values.map((ndcgAt10, i) => ({ queryId: `q${i}`, ndcgAt10 })),
+      }),
+      'utf-8',
+    );
+    return name;
+  }
+
+  it('loads BEIR run files + e2e scorecards and writes a JSON + markdown report', async () => {
+    const dir = await makeTmpDir();
+    await writeRunFile(dir, 'scifact-base.json', 'scifact', [0.50, 0.50, 0.50, 0.50]);
+    await writeRunFile(dir, 'scifact-cand.json', 'scifact', [0.70, 0.70, 0.70, 0.70]);
+    await writeRunFile(dir, 'code-base.json', 'code', [0.70, 0.70, 0.70, 0.70]);
+    await writeRunFile(dir, 'code-cand.json', 'code', [0.50, 0.50, 0.50, 0.50]);
+
+    // Two e2e scorecards (rag-eval shape) — candidate holds faithfulness.
+    await fsp.writeFile(path.join(dir, 'rag-base.json'), JSON.stringify({ correctness: { accuracy: 0.80 } }), 'utf-8');
+    await fsp.writeFile(path.join(dir, 'rag-cand.json'), JSON.stringify({ correctness: { accuracy: 0.805 } }), 'utf-8');
+
+    const manifest = {
+      candidateModel: 'BAAI/bge-reranker-v2-m3',
+      baselineModel: 'Xenova/ms-marco-MiniLM-L-6-v2',
+      correction: 'holm' as const,
+      domains: [
+        { domain: 'scifact', mode: 'hybrid+rerank', baseline: 'scifact-base.json', candidate: 'scifact-cand.json' },
+        { domain: 'code', mode: 'hybrid+rerank', baseline: 'code-base.json', candidate: 'code-cand.json' },
+      ],
+      e2eScorecards: { metrics: ['correctness.accuracy'], baseline: 'rag-base.json', candidate: 'rag-cand.json', tolerance: 0.02 },
+    };
+    const manifestPath = path.join(dir, 'manifest.json');
+    await fsp.writeFile(manifestPath, JSON.stringify(manifest), 'utf-8');
+
+    const input = await loadAdjudicationInput(manifest, dir);
+    expect(input.domains).toHaveLength(2);
+    expect(input.e2e).toEqual([{ metric: 'correctness.accuracy', baseline: 0.80, candidate: 0.805, tolerance: 0.02 }]);
+
+    const outputDir = path.join(dir, 'out');
+    const { adjudication, jsonPath, markdownPath } = await runAdjudicateCli(
+      parseAdjudicateArgs(['--manifest', manifestPath, '--output-dir', outputDir, '--report-name', 'r'], {}),
+    );
+    expect(adjudication.decision).toBe('ship-gated');
+    expect(adjudication.enabledDomains).toEqual(['scifact']);
+    expect(adjudication.skipDomains).toEqual(['code']);
+    const writtenJson = JSON.parse(await fsp.readFile(jsonPath, 'utf-8'));
+    expect(writtenJson.decision).toBe('ship-gated');
+    expect(await fsp.readFile(markdownPath, 'utf-8')).toContain('Reranker upgrade adjudication');
+  });
+});
+
+describe('parseAdjudicateArgs', () => {
+  it('requires --manifest', () => {
+    expect(() => parseAdjudicateArgs([], {})).toThrow(/--manifest is required/);
+  });
+  it('parses output options and the fail flag', () => {
+    const opts = parseAdjudicateArgs(
+      ['--manifest', 'm.json', '--report-name', 'foo', '--fail-on-no-ship'],
+      {},
+    );
+    expect(opts.reportName).toBe('foo');
+    expect(opts.enforceFailures).toBe(true);
+    expect(opts.manifestPath.endsWith('m.json')).toBe(true);
+  });
+});

--- a/benchmarks/adjudication/adjudicate.ts
+++ b/benchmarks/adjudication/adjudicate.ts
@@ -1,0 +1,627 @@
+// RFC 020 milestone M5 (issue #565) — take ONE Tier-1 technique through the full
+// harness and produce a documented ship/no-ship decision backed by evidence.
+//
+// The Tier-1 candidate adjudicated here is the **reranker upgrade** (the default
+// cross-encoder `Xenova/ms-marco-MiniLM-L-6-v2` → a stronger model such as
+// `BAAI/bge-reranker-v2-m3` / `Qwen3-Reranker`), selectable through the existing
+// `KB_RERANK_MODEL` plug point. Per RFC §9 the upgrade is NOT a universal win —
+// the KB survey found cross-encoders *degrade* high-precision/lexical domains
+// (code, skills). So the upgrade ships only behind:
+//
+//   (a) a **per-domain measurement gate** — measure nDCG@10 per domain, not just
+//       the BEIR mean, and enable rerank only where it significantly improves;
+//   (b) a **skip-rerank fallback** — domains where it regresses (or shows no
+//       significant gain) are added to `KB_RERANK_SKIP_DOMAINS` and keep the
+//       cheaper, un-reranked path.
+//
+// This module is the adjudicator. It consumes:
+//   - per-domain BEIR per-query nDCG@10 vectors (baseline reranker vs candidate
+//     reranker), compared with the §3 significance machinery (paired bootstrap /
+//     t-test + Bonferroni/Holm family correction, wild-cluster when clustered);
+//   - the §5 human-label-free e2e RAG veto numbers (faithfulness / answer
+//     correctness), which hard-veto a ship even when BEIR improves.
+//
+// It emits a structured decision (`ship` / `ship-gated` / `no-ship`), the
+// resulting per-domain policy (which domains enable rerank, which skip), the
+// recommended `KB_RERANK_MODEL` + `KB_RERANK_SKIP_DOMAINS` config to realize it,
+// and a markdown adjudication report.
+//
+// Honesty contract (issue #565 step 4): this module never fabricates a benchmark
+// number. A real run needs BEIR datasets + a real embedding model + the candidate
+// cross-encoder + (for the e2e leg) live judges. Where any of those is missing
+// the adjudication is marked **provisional** and the missing evidence is listed
+// in `pending` — the decision machinery + unit tests still ship, and the report
+// self-describes what is outstanding.
+
+import * as fsp from 'fs/promises';
+import * as path from 'path';
+import {
+  compareSamples,
+  compareFamily,
+  loadRunScores,
+  pairScores,
+  type ComparisonResult,
+  type CorrectionMethod,
+  type PerQueryScore,
+  type Verdict,
+  DEFAULT_ALPHA,
+} from '../significance.js';
+
+export const DEFAULT_BASELINE_RERANK_MODEL = 'Xenova/ms-marco-MiniLM-L-6-v2';
+export const DEFAULT_CANDIDATE_RERANK_MODEL = 'BAAI/bge-reranker-v2-m3';
+// A drop larger than this on a §5 e2e metric vetoes the ship (RFC §5 — "a
+// retrieval gain that drops faithfulness/correctness does not ship").
+export const DEFAULT_E2E_VETO_TOLERANCE = 0.01;
+
+export type DomainAction = 'enable' | 'skip';
+export type ShipDecision = 'ship' | 'ship-gated' | 'no-ship';
+
+/** Per-domain BEIR evidence: paired per-query nDCG@10 for baseline vs candidate. */
+export interface DomainEvidence {
+  /** Domain/dataset name; also the value that lands on KB_RERANK_SKIP_DOMAINS. */
+  domain: string;
+  /** Retrieval mode (informational, e.g. `hybrid+rerank`). */
+  mode?: string | null;
+  baseline: readonly PerQueryScore[];
+  candidate: readonly PerQueryScore[];
+}
+
+export interface DomainAdjudication {
+  domain: string;
+  mode: string | null;
+  n: number;
+  meanDelta: number;
+  rawPValue: number;
+  adjustedPValue: number;
+  /** Verdict after family-wise multiple-comparison correction (§3). */
+  verdict: Verdict;
+  action: DomainAction;
+  rationale: string;
+}
+
+/** One §5 e2e metric the candidate must not regress past tolerance. */
+export interface E2eMetricInput {
+  metric: string;
+  baseline: number;
+  candidate: number;
+  /** Allowed drop before the veto fires. Defaults to DEFAULT_E2E_VETO_TOLERANCE. */
+  tolerance?: number;
+}
+
+export interface E2eVeto {
+  metric: string;
+  baseline: number;
+  candidate: number;
+  tolerance: number;
+  delta: number;
+  vetoed: boolean;
+}
+
+export interface AdjudicateRerankInput {
+  candidateModel: string;
+  baselineModel: string;
+  domains: readonly DomainEvidence[];
+  e2e?: readonly E2eMetricInput[];
+  correction?: CorrectionMethod;
+  alpha?: number;
+  /** Use the wild-cluster bootstrap-t per domain (queries cluster by dataset). */
+  clusterByDataset?: boolean;
+  /** Outstanding evidence that makes the decision provisional (never fabricated). */
+  pending?: readonly string[];
+  /** Force the provisional flag even if `pending` is empty (e.g. fake-provider runs). */
+  provisional?: boolean;
+}
+
+export interface RerankAdjudication {
+  schema_version: 'kb.rerank-adjudication.v1';
+  candidateModel: string;
+  baselineModel: string;
+  decision: ShipDecision;
+  correction: CorrectionMethod;
+  alpha: number;
+  domains: DomainAdjudication[];
+  enabledDomains: string[];
+  skipDomains: string[];
+  e2e: E2eVeto[];
+  e2eVetoed: boolean;
+  provisional: boolean;
+  pending: string[];
+  recommendedConfig: { KB_RERANK_MODEL: string; KB_RERANK_SKIP_DOMAINS: string };
+  meanDelta: number | null;
+  summary: string;
+}
+
+/**
+ * Adjudicate the reranker upgrade across domains + the e2e veto. Pure and
+ * deterministic (the significance bootstrap is seeded), so the same evidence
+ * always yields the same decision — the property the unit tests and a
+ * reproducible report both depend on.
+ */
+export function adjudicateRerank(input: AdjudicateRerankInput): RerankAdjudication {
+  const correction: CorrectionMethod = input.correction ?? 'holm';
+  const alpha = input.alpha ?? DEFAULT_ALPHA;
+
+  // 1. Per-domain significance comparison (§3), then family correction across
+  //    the domains so comparing many at once does not inflate false positives.
+  const comparisons: ComparisonResult[] = input.domains.map((domain) => {
+    const { samples } = pairScores(domain.baseline, domain.candidate);
+    return compareSamples(samples, {
+      label: domain.domain,
+      alpha,
+      clusterByDataset: input.clusterByDataset ?? false,
+    });
+  });
+  const family = compareFamily(comparisons, correction, alpha);
+
+  // 2. Per-domain gate (§9): enable rerank only where it is a *significant*
+  //    improvement; skip everywhere else (regression OR no-significant-change),
+  //    because the cross-encoder costs latency and the KB survey shows it can
+  //    silently degrade high-precision/lexical corpora.
+  const domains: DomainAdjudication[] = family.comparisons.map((comparison, index) => {
+    const evidence = input.domains[index];
+    const verdict = comparison.correctedVerdict;
+    const action: DomainAction = verdict === 'improvement' ? 'enable' : 'skip';
+    return {
+      domain: evidence.domain,
+      mode: evidence.mode ?? null,
+      n: comparison.n,
+      meanDelta: round(comparison.meanDelta),
+      rawPValue: comparison.wildCluster?.pValue ?? comparison.pValue,
+      adjustedPValue: comparison.adjustedPValue,
+      verdict,
+      action,
+      rationale: domainRationale(verdict, comparison.meanDelta),
+    };
+  });
+
+  const enabledDomains = domains.filter((d) => d.action === 'enable').map((d) => d.domain);
+  const skipDomains = domains.filter((d) => d.action === 'skip').map((d) => d.domain);
+
+  // 3. §5 e2e veto — a faithfulness/correctness regression past tolerance kills
+  //    the ship regardless of BEIR gains (the hard product-protection veto).
+  const e2e: E2eVeto[] = (input.e2e ?? []).map((metric) => {
+    const tolerance = metric.tolerance ?? DEFAULT_E2E_VETO_TOLERANCE;
+    const delta = round(metric.candidate - metric.baseline);
+    return {
+      metric: metric.metric,
+      baseline: metric.baseline,
+      candidate: metric.candidate,
+      tolerance,
+      delta,
+      vetoed: metric.candidate < metric.baseline - tolerance,
+    };
+  });
+  const e2eVetoed = e2e.some((v) => v.vetoed);
+
+  // 4. Overall decision.
+  const decision: ShipDecision = e2eVetoed
+    ? 'no-ship'
+    : enabledDomains.length === 0
+      ? 'no-ship'
+      : skipDomains.length === 0
+        ? 'ship'
+        : 'ship-gated';
+
+  const pending = [...(input.pending ?? [])];
+  const provisional = (input.provisional ?? false) || pending.length > 0;
+
+  const shipped = decision !== 'no-ship';
+  const recommendedConfig = {
+    KB_RERANK_MODEL: shipped ? input.candidateModel : input.baselineModel,
+    // On a ship/ship-gated, the skip list is the domains the gate excluded. On a
+    // no-ship there is nothing to gate (we stay on the baseline model).
+    KB_RERANK_SKIP_DOMAINS: shipped ? skipDomains.join(',') : '',
+  };
+
+  const meanDelta = domains.length === 0
+    ? null
+    : round(domains.reduce((sum, d) => sum + d.meanDelta, 0) / domains.length);
+
+  return {
+    schema_version: 'kb.rerank-adjudication.v1',
+    candidateModel: input.candidateModel,
+    baselineModel: input.baselineModel,
+    decision,
+    correction,
+    alpha,
+    domains,
+    enabledDomains,
+    skipDomains,
+    e2e,
+    e2eVetoed,
+    provisional,
+    pending,
+    recommendedConfig,
+    meanDelta,
+    summary: buildSummary({
+      decision,
+      domainsMeasured: domains.length,
+      enabledDomains,
+      skipDomains,
+      e2eVetoed,
+      provisional,
+    }),
+  };
+}
+
+function domainRationale(verdict: Verdict, meanDelta: number): string {
+  switch (verdict) {
+    case 'improvement':
+      return `significant nDCG@10 gain (Δ=${signed(meanDelta)}) after family correction → enable rerank`;
+    case 'regression':
+      return `significant nDCG@10 regression (Δ=${signed(meanDelta)}) → skip-rerank fallback (RFC §9)`;
+    default:
+      return `no significant change (Δ=${signed(meanDelta)}) → skip (rerank latency unjustified without a measured gain)`;
+  }
+}
+
+function buildSummary(parts: {
+  decision: ShipDecision;
+  domainsMeasured: number;
+  enabledDomains: readonly string[];
+  skipDomains: readonly string[];
+  e2eVetoed: boolean;
+  provisional: boolean;
+}): string {
+  const prefix = parts.provisional ? 'PROVISIONAL ' : '';
+  if (parts.decision === 'no-ship') {
+    const why = parts.e2eVetoed
+      ? 'the e2e RAG veto fired (faithfulness/correctness regressed past tolerance)'
+      : parts.domainsMeasured === 0
+        ? 'no per-domain BEIR evidence was supplied — the load-bearing runs are pending'
+        : 'no domain showed a significant nDCG@10 improvement';
+    return `${prefix}NO-SHIP — ${why}; stay on the baseline reranker.`;
+  }
+  const enabled = parts.enabledDomains.join(', ') || '(none)';
+  if (parts.decision === 'ship') {
+    return `${prefix}SHIP — every measured domain improved significantly and the e2e veto passed; enable the candidate on: ${enabled}.`;
+  }
+  const skipped = parts.skipDomains.join(', ') || '(none)';
+  return `${prefix}SHIP-GATED — enable the candidate on [${enabled}] and keep the skip-rerank fallback on [${skipped}] (RFC §9 per-domain gate); e2e veto passed.`;
+}
+
+// ---------------------------------------------------------------------------
+// Markdown report
+// ---------------------------------------------------------------------------
+
+export function renderAdjudicationMarkdown(adjudication: RerankAdjudication): string {
+  const lines: string[] = [
+    '# Reranker upgrade adjudication — RFC 020 M5 (issue #565)',
+    '',
+    `**Decision: ${adjudication.decision.toUpperCase()}**${adjudication.provisional ? ' _(provisional)_' : ''}`,
+    '',
+    adjudication.summary,
+    '',
+    '| Field | Value |',
+    '| --- | --- |',
+    `| Candidate reranker | \`${adjudication.candidateModel}\` |`,
+    `| Baseline reranker | \`${adjudication.baselineModel}\` |`,
+    `| Multiple-comparison correction | ${adjudication.correction} (α=${adjudication.alpha}) |`,
+    `| Domains measured | ${adjudication.domains.length} |`,
+    `| e2e veto | ${adjudication.e2eVetoed ? 'TRIGGERED' : adjudication.e2e.length > 0 ? 'passed' : 'not measured'} |`,
+    '',
+    '## Per-domain gate (§3 significance + §9 per-domain measurement)',
+    '',
+  ];
+
+  if (adjudication.domains.length === 0) {
+    lines.push('_No per-domain BEIR evidence supplied — see pending evidence below._', '');
+  } else {
+    lines.push(
+      '| Domain | Mode | n | Mean ΔnDCG@10 | adj p | Verdict | Action |',
+      '| --- | --- | ---: | ---: | ---: | --- | --- |',
+    );
+    for (const d of adjudication.domains) {
+      lines.push([
+        d.domain,
+        d.mode ?? '-',
+        String(d.n),
+        signed(d.meanDelta),
+        formatP(d.adjustedPValue),
+        d.verdict.toUpperCase(),
+        d.action === 'enable' ? 'ENABLE rerank' : 'SKIP (fallback)',
+      ].join(' | ').replace(/^/, '| ').replace(/$/, ' |'));
+    }
+    lines.push('');
+  }
+
+  lines.push('## End-to-end RAG veto (§5)', '');
+  if (adjudication.e2e.length === 0) {
+    lines.push('_No e2e metrics supplied — the §5 veto is PENDING (needs gold-QA answers + the judge panel)._', '');
+  } else {
+    lines.push(
+      '| Metric | Baseline | Candidate | Δ | Tolerance | Veto |',
+      '| --- | ---: | ---: | ---: | ---: | --- |',
+    );
+    for (const v of adjudication.e2e) {
+      lines.push([
+        v.metric,
+        v.baseline.toFixed(4),
+        v.candidate.toFixed(4),
+        signed(v.delta),
+        `−${v.tolerance.toFixed(4)}`,
+        v.vetoed ? '**VETO**' : 'ok',
+      ].join(' | ').replace(/^/, '| ').replace(/$/, ' |'));
+    }
+    lines.push('');
+  }
+
+  lines.push(
+    '## Recommended configuration',
+    '',
+    'To realize this decision through the production plug points:',
+    '',
+    '```bash',
+    `export KB_RERANK=on`,
+    `export KB_RERANK_MODEL=${adjudication.recommendedConfig.KB_RERANK_MODEL}`,
+    adjudication.recommendedConfig.KB_RERANK_SKIP_DOMAINS !== ''
+      ? `export KB_RERANK_SKIP_DOMAINS=${adjudication.recommendedConfig.KB_RERANK_SKIP_DOMAINS}`
+      : `# KB_RERANK_SKIP_DOMAINS: (none — no domain was gated out)`,
+    '```',
+    '',
+  );
+
+  if (adjudication.pending.length > 0) {
+    lines.push('## Pending evidence (decision is provisional)', '');
+    for (const item of adjudication.pending) lines.push(`- ${item}`);
+    lines.push('');
+  }
+
+  lines.push(
+    '---',
+    '',
+    'Decision rule: **NO-SHIP** if the §5 e2e veto fires or no domain shows a',
+    'significant nDCG@10 gain; **SHIP-GATED** if some domains improve and others',
+    'are gated out via the skip-rerank fallback; **SHIP** only if every measured',
+    'domain improves and the e2e veto passes. No benchmark number is fabricated —',
+    'a provisional decision lists its outstanding evidence above (issue #565).',
+  );
+  return `${lines.join('\n')}\n`;
+}
+
+// ---------------------------------------------------------------------------
+// Evidence loading (BEIR run files + e2e scorecards)
+// ---------------------------------------------------------------------------
+
+export interface DomainManifestEntry {
+  domain: string;
+  mode?: string | null;
+  baseline: string | string[];
+  candidate: string | string[];
+}
+
+export interface E2eScorecardVeto {
+  /** Scorecard metrics to compare: dotted paths into the RagScorecard. */
+  metrics: string[];
+  baseline: string;
+  candidate: string;
+  tolerance?: number;
+}
+
+export interface AdjudicationManifest {
+  candidateModel?: string;
+  baselineModel?: string;
+  correction?: CorrectionMethod;
+  alpha?: number;
+  clusterByDataset?: boolean;
+  domains?: DomainManifestEntry[];
+  e2e?: E2eMetricInput[];
+  e2eScorecards?: E2eScorecardVeto;
+  pending?: string[];
+  provisional?: boolean;
+}
+
+/** Resolve a manifest into a ready-to-adjudicate input (loads run files). */
+export async function loadAdjudicationInput(
+  manifest: AdjudicationManifest,
+  manifestDir: string,
+): Promise<AdjudicateRerankInput> {
+  const domains: DomainEvidence[] = [];
+  for (const entry of manifest.domains ?? []) {
+    const baseline = await loadRunScores(toPathList(entry.baseline).map((p) => path.resolve(manifestDir, p)));
+    const candidate = await loadRunScores(toPathList(entry.candidate).map((p) => path.resolve(manifestDir, p)));
+    domains.push({ domain: entry.domain, mode: entry.mode ?? null, baseline, candidate });
+  }
+
+  const e2e: E2eMetricInput[] = [...(manifest.e2e ?? [])];
+  if (manifest.e2eScorecards !== undefined) {
+    const spec = manifest.e2eScorecards;
+    const baselineCard = await readJson(path.resolve(manifestDir, spec.baseline));
+    const candidateCard = await readJson(path.resolve(manifestDir, spec.candidate));
+    for (const metric of spec.metrics) {
+      const baseline = numericAtPath(baselineCard, metric);
+      const candidate = numericAtPath(candidateCard, metric);
+      if (baseline === null || candidate === null) {
+        // A pending/unscored metric is not fabricated — it is skipped and the
+        // caller's `pending` list should note it.
+        continue;
+      }
+      e2e.push({ metric, baseline, candidate, ...(spec.tolerance !== undefined ? { tolerance: spec.tolerance } : {}) });
+    }
+  }
+
+  return {
+    candidateModel: manifest.candidateModel ?? DEFAULT_CANDIDATE_RERANK_MODEL,
+    baselineModel: manifest.baselineModel ?? DEFAULT_BASELINE_RERANK_MODEL,
+    domains,
+    e2e,
+    ...(manifest.correction !== undefined ? { correction: manifest.correction } : {}),
+    ...(manifest.alpha !== undefined ? { alpha: manifest.alpha } : {}),
+    ...(manifest.clusterByDataset !== undefined ? { clusterByDataset: manifest.clusterByDataset } : {}),
+    ...(manifest.pending !== undefined ? { pending: manifest.pending } : {}),
+    ...(manifest.provisional !== undefined ? { provisional: manifest.provisional } : {}),
+  };
+}
+
+/** Read a dotted numeric path out of a parsed JSON object; null when absent/non-numeric. */
+export function numericAtPath(root: unknown, dottedPath: string): number | null {
+  let current: unknown = root;
+  for (const key of dottedPath.split('.')) {
+    if (typeof current !== 'object' || current === null) return null;
+    current = (current as Record<string, unknown>)[key];
+  }
+  return typeof current === 'number' && Number.isFinite(current) ? current : null;
+}
+
+async function readJson(filePath: string): Promise<unknown> {
+  return JSON.parse(await fsp.readFile(filePath, 'utf-8'));
+}
+
+function toPathList(value: string | string[]): string[] {
+  return Array.isArray(value) ? value : [value];
+}
+
+// ---------------------------------------------------------------------------
+// Numeric helpers
+// ---------------------------------------------------------------------------
+
+function round(value: number): number {
+  return Number(value.toFixed(6));
+}
+
+function signed(value: number): string {
+  return `${value >= 0 ? '+' : ''}${value.toFixed(4)}`;
+}
+
+function formatP(value: number): string {
+  if (value < 1e-4 && value > 0) return '<0.0001';
+  return value.toFixed(4);
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+interface CliOptions {
+  manifestPath: string;
+  outputDir: string;
+  reportName: string;
+  enforceFailures: boolean;
+  summaryPath?: string;
+  repoRoot: string;
+}
+
+export function parseAdjudicateArgs(argv: string[], env: NodeJS.ProcessEnv): CliOptions {
+  const repoRoot = process.cwd();
+  const options: CliOptions = {
+    manifestPath: '',
+    outputDir: path.join(repoRoot, 'benchmarks', 'results', 'adjudication'),
+    reportName: 'reranker-adjudication',
+    enforceFailures: parseBool(env.BENCH_ADJUDICATION_FAIL),
+    summaryPath: env.GITHUB_STEP_SUMMARY,
+    repoRoot,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    const [flag, inlineValue] = token.includes('=') ? token.split(/=(.*)/s, 2) : [token, undefined];
+    const readValue = (): string => {
+      if (inlineValue !== undefined) return inlineValue;
+      i += 1;
+      const value = argv[i];
+      if (value === undefined || value.startsWith('--')) throw new Error(`${flag} requires a value`);
+      return value;
+    };
+    if (flag === '--manifest') {
+      options.manifestPath = path.resolve(readValue());
+    } else if (flag === '--output-dir') {
+      options.outputDir = path.resolve(readValue());
+    } else if (flag === '--report-name') {
+      options.reportName = readValue();
+    } else if (flag === '--fail-on-no-ship') {
+      options.enforceFailures = true;
+    } else if (flag === '--summary') {
+      options.summaryPath = path.resolve(readValue());
+    } else if (flag === '--help' || flag === '-h') {
+      process.stdout.write(adjudicateHelpText());
+      process.exit(0);
+    } else {
+      throw new Error(`unknown argument: ${token}`);
+    }
+  }
+  if (options.manifestPath === '') throw new Error('adjudicate: --manifest is required');
+  return options;
+}
+
+function parseBool(value: string | undefined): boolean {
+  if (value === undefined) return false;
+  return value === '1' || value.toLowerCase() === 'true' || value.toLowerCase() === 'yes';
+}
+
+function adjudicateHelpText(): string {
+  return `kb reranker-upgrade adjudicator — RFC 020 M5 (issue #565)
+
+Usage:
+  npm run bench:adjudicate -- --manifest benchmarks/results/adjudication/manifest.json
+
+Takes ONE Tier-1 reranker upgrade through the full harness and emits a
+ship/no-ship decision: per-domain §3 significance (with Bonferroni/Holm family
+correction) + the §5 e2e RAG veto + the §9 per-domain gate / skip-rerank
+fallback. Writes <report-name>.json and <report-name>.md under --output-dir.
+
+Manifest (JSON):
+  {
+    "candidateModel": "BAAI/bge-reranker-v2-m3",
+    "baselineModel": "Xenova/ms-marco-MiniLM-L-6-v2",
+    "correction": "holm", "alpha": 0.05, "clusterByDataset": false,
+    "domains": [
+      { "domain": "scifact", "mode": "hybrid+rerank",
+        "baseline": "scifact-baseline-results.json",
+        "candidate": "scifact-candidate-results.json" }
+    ],
+    "e2e": [ { "metric": "faithfulness", "baseline": 0.90, "candidate": 0.89, "tolerance": 0.01 } ],
+    "e2eScorecards": { "metrics": ["correctness.accuracy"], "baseline": "base.json", "candidate": "cand.json" },
+    "pending": ["real BEIR runs outstanding"], "provisional": true
+  }
+
+Options:
+  --manifest=<path>     Adjudication manifest (required).
+  --output-dir=<path>   Report dir. Default: benchmarks/results/adjudication.
+  --report-name=<name>  Basename for the .json/.md report. Default: reranker-adjudication.
+  --fail-on-no-ship     Exit 1 on a NO-SHIP decision (env: BENCH_ADJUDICATION_FAIL=1).
+  --summary=<path>      Append markdown to this file (CI step summary).
+`;
+}
+
+export interface RunAdjudicateResult {
+  adjudication: RerankAdjudication;
+  jsonPath: string;
+  markdownPath: string;
+}
+
+export async function runAdjudicateCli(options: CliOptions): Promise<RunAdjudicateResult> {
+  const manifest = (await readJson(options.manifestPath)) as AdjudicationManifest;
+  const input = await loadAdjudicationInput(manifest, path.dirname(options.manifestPath));
+  const adjudication = adjudicateRerank(input);
+
+  await fsp.mkdir(options.outputDir, { recursive: true });
+  const jsonPath = path.join(options.outputDir, `${options.reportName}.json`);
+  const markdownPath = path.join(options.outputDir, `${options.reportName}.md`);
+  await fsp.writeFile(jsonPath, `${JSON.stringify(adjudication, null, 2)}\n`, 'utf-8');
+  const markdown = renderAdjudicationMarkdown(adjudication);
+  await fsp.writeFile(markdownPath, markdown, 'utf-8');
+  if (options.summaryPath !== undefined) {
+    await fsp.appendFile(options.summaryPath, markdown, 'utf-8');
+  }
+  return { adjudication, jsonPath, markdownPath };
+}
+
+async function main(): Promise<void> {
+  const options = parseAdjudicateArgs(process.argv.slice(2), process.env);
+  const { adjudication, jsonPath, markdownPath } = await runAdjudicateCli(options);
+  process.stdout.write(`${jsonPath}\n${markdownPath}\n`);
+  process.stdout.write(`decision=${adjudication.decision}${adjudication.provisional ? ' (provisional)' : ''}\n`);
+  if (options.enforceFailures && adjudication.decision === 'no-ship') {
+    process.exitCode = 1;
+  }
+}
+
+const cliEntry = process.argv[1] !== undefined ? path.normalize(process.argv[1]) : '';
+if (
+  cliEntry.endsWith(path.join('benchmarks', 'adjudication', 'adjudicate.js')) ||
+  cliEntry.endsWith(path.join('benchmarks', 'adjudication', 'adjudicate.ts'))
+) {
+  main().catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.stack ?? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/benchmarks/results/adjudication/README.md
+++ b/benchmarks/results/adjudication/README.md
@@ -1,0 +1,95 @@
+# Reranker upgrade — ship/no-ship adjudication (RFC 020 M5 · issue #565)
+
+This directory holds the **first Tier-1 technique adjudicated through the full
+RFC 020 harness**: the reranker upgrade
+`Xenova/ms-marco-MiniLM-L-6-v2` → `BAAI/bge-reranker-v2-m3`.
+
+## Decision
+
+**PROVISIONAL — NO-SHIP pending the load-bearing benchmark runs.**
+
+The adjudication machinery (per-domain §3 significance gate + §5 e2e veto + §9
+skip-rerank fallback) is implemented, tested, and wired. The numeric evidence it
+needs cannot be produced in this offline, model-free environment, so **no ship
+decision is made on real numbers and none is fabricated**. The conservative,
+RFC-aligned posture until the evidence arrives is *do not enable the candidate*.
+
+See the machine-generated decision in
+[`reranker-bge-v2-m3-adjudication.md`](reranker-bge-v2-m3-adjudication.md)
+(and `.json`), produced by:
+
+```bash
+npm run bench:adjudicate -- \
+    --manifest benchmarks/results/adjudication/reranker-bge-v2-m3-manifest.json \
+    --output-dir benchmarks/results/adjudication \
+    --report-name reranker-bge-v2-m3-adjudication
+```
+
+## How the candidate ships (the gate, once evidence exists)
+
+Per RFC §9 a reranker upgrade is **never on by default for all corpora**. The
+wiring landed in this PR makes the candidate selectable and gateable:
+
+- **Model selection** — `KB_RERANK_MODEL=BAAI/bge-reranker-v2-m3` routes the
+  production `src/reranker.ts` cross-encoder to the candidate. No code change.
+- **Per-domain gate / skip-rerank fallback** — `KB_RERANK_SKIP_DOMAINS=code,skills`
+  force-disables reranking for the listed KB scopes even under `KB_RERANK=on`.
+  This is enforced at the single execution seam (`applyRerankerIfEnabled`) and
+  honored by the CLI, MCP, and retrieval-eval paths, so a domain the survey/gate
+  flags as cross-encoder-degraded keeps the cheaper un-reranked path.
+
+The adjudicator turns measured per-domain verdicts into exactly this config:
+improving domains → `ENABLE`, regressing/no-change domains → the skip list.
+
+## Evidence status
+
+| Leg | Status | Notes |
+|---|---|---|
+| Per-domain BEIR (§3 significance, per-domain gate §9) | **PENDING** | Needs SciFact/NFCorpus/FiQA + a code/skills domain, a real embedding provider (Ollama), and the candidate cross-encoder downloaded. Compares baseline vs candidate per-query nDCG@10 with Bonferroni/Holm + wild-cluster correction. |
+| e2e RAG veto (§5) | **PENDING** (leg proven) | The hermetic `--fake` cascade ran end-to-end (see below). A real veto needs baseline-vs-candidate rag-eval over gold-QA with ≥3 live judge families. |
+
+### Hermetic e2e self-test (proves the §5 leg runs)
+
+`./e2e-selftest/` holds a **real** four-tier-cascade scorecard produced offline
+from the committed gold fixture `./e2e-selftest-gold/hotpotqa.jsonl`:
+
+```bash
+node build/benchmarks/rag-eval/run.js --fake --datasets=hotpotqa \
+    --data-dir=benchmarks/results/adjudication/e2e-selftest-gold \
+    --output-dir=benchmarks/results/adjudication/e2e-selftest
+```
+
+It scores Tier-1 items=3, exact-match/token-F1/context-recall/precision = 1.0,
+accuracy = 1.0. **This is a plumbing self-test** (the `--fake` answerer echoes
+the gold answers), *not* a quality measurement and *not* a veto delta — it only
+demonstrates the cascade is wired and runnable.
+
+## Reproducing the full adjudication (when datasets + models are available)
+
+```bash
+# 1. Per-domain BEIR: baseline vs candidate reranker (real provider + models).
+for d in scifact nfcorpus fiqa code; do
+  KB_RERANK_MODEL=Xenova/ms-marco-MiniLM-L-6-v2 \
+    npm run bench:beir -- --dataset=$d --mode=hybrid+rerank --provider=ollama \
+      --output-dir=benchmarks/results/adjudication/beir/baseline
+  KB_RERANK_MODEL=BAAI/bge-reranker-v2-m3 \
+    npm run bench:beir -- --dataset=$d --mode=hybrid+rerank --provider=ollama \
+      --output-dir=benchmarks/results/adjudication/beir/candidate
+done
+
+# 2. e2e RAG veto: baseline vs candidate, ≥3 live judge families.
+#    (run bench:rag-eval twice with --judges=judges.json, one per reranker model)
+
+# 3. Point the manifest's `domains[]` at the run JSONs from step 1 and
+#    `e2eScorecards`/`e2e[]` at step 2, clear `pending`/`provisional`, then:
+npm run bench:adjudicate -- --manifest benchmarks/results/adjudication/reranker-bge-v2-m3-manifest.json
+```
+
+The adjudicator will then emit a **final** SHIP / SHIP-GATED / NO-SHIP decision
+and the per-domain `KB_RERANK_SKIP_DOMAINS` policy to apply.
+
+## Worked examples
+
+The decision logic across all paths (ship, ship-gated, no-ship, e2e veto,
+Bonferroni/Holm correction, manifest loading) is exercised by
+`benchmarks/adjudication/adjudicate.test.ts`.

--- a/benchmarks/results/adjudication/e2e-selftest-gold/hotpotqa.jsonl
+++ b/benchmarks/results/adjudication/e2e-selftest-gold/hotpotqa.jsonl
@@ -1,0 +1,3 @@
+{"id": "hp-1", "question": "What is the capital of France?", "answer": "Paris", "supporting_facts": ["Paris is the capital and most populous city of France."]}
+{"id": "hp-2", "question": "Who wrote the play Hamlet?", "answer": "William Shakespeare", "supporting_facts": ["Hamlet was written by William Shakespeare around 1600."]}
+{"id": "hp-3", "question": "What is the chemical symbol for gold?", "answer": "Au", "supporting_facts": ["Gold has the chemical symbol Au, from the Latin aurum."]}

--- a/benchmarks/results/adjudication/e2e-selftest/rag-eval-scorecard.json
+++ b/benchmarks/results/adjudication/e2e-selftest/rag-eval-scorecard.json
@@ -1,0 +1,121 @@
+{
+  "schema_version": "kb.rag-eval-scorecard.v1",
+  "generated_at": "2026-06-08T05:15:46.571Z",
+  "git_sha": "7c48945",
+  "datasets": [
+    "hotpotqa"
+  ],
+  "config": {
+    "provider": "ollama",
+    "embeddingModel": null,
+    "answererModel": null,
+    "thresholds": {
+      "samples": 5
+    },
+    "tier2Families": {
+      "entailment": "stub-nli",
+      "semantic": "stub-semantic"
+    }
+  },
+  "panel": {
+    "judges": [
+      {
+        "name": "stub-judge-1",
+        "family": "stub-alpha"
+      },
+      {
+        "name": "stub-judge-2",
+        "family": "stub-beta"
+      },
+      {
+        "name": "stub-judge-3",
+        "family": "stub-gamma"
+      }
+    ],
+    "distinctFamilies": 3,
+    "selfConsistencyK": 5,
+    "calibrationMethod": null,
+    "abstentionThreshold": 0.5
+  },
+  "tier1": {
+    "items": 3,
+    "exactMatch": 1,
+    "tokenF1": 1,
+    "contextRecall": 1,
+    "contextPrecision": 1,
+    "itemsWithGoldFacts": 3
+  },
+  "routing": {
+    "items": 3,
+    "tier1Decided": 3,
+    "tier2Decided": 0,
+    "tier3Decided": 0,
+    "tier3Abstained": 0,
+    "pending": 0
+  },
+  "correctness": {
+    "scored": 3,
+    "correct": 3,
+    "accuracy": 1
+  },
+  "panelConfidence": {
+    "meanSelfConsistency": null,
+    "meanCalibratedConfidence": null,
+    "abstentionRate": null
+  },
+  "biasProfiles": [],
+  "decisions": [
+    {
+      "id": "hp-1",
+      "dataset": "hotpotqa",
+      "decidedBy": "tier1",
+      "correct": true,
+      "reference": {
+        "id": "hp-1",
+        "dataset": "hotpotqa",
+        "exactMatch": 1,
+        "tokenF1": 1,
+        "contextRecall": 1,
+        "contextPrecision": 1,
+        "hasGoldAnswer": true,
+        "hasGoldFacts": true
+      }
+    },
+    {
+      "id": "hp-2",
+      "dataset": "hotpotqa",
+      "decidedBy": "tier1",
+      "correct": true,
+      "reference": {
+        "id": "hp-2",
+        "dataset": "hotpotqa",
+        "exactMatch": 1,
+        "tokenF1": 1,
+        "contextRecall": 1,
+        "contextPrecision": 1,
+        "hasGoldAnswer": true,
+        "hasGoldFacts": true
+      }
+    },
+    {
+      "id": "hp-3",
+      "dataset": "hotpotqa",
+      "decidedBy": "tier1",
+      "correct": true,
+      "reference": {
+        "id": "hp-3",
+        "dataset": "hotpotqa",
+        "exactMatch": 1,
+        "tokenF1": 1,
+        "contextRecall": 1,
+        "contextPrecision": 1,
+        "hasGoldAnswer": true,
+        "hasGoldFacts": true
+      }
+    }
+  ],
+  "caveats": [
+    "Human-label-free: correctness comes from gold-bearing QA + automated cross-checks (RFC 020 §5), never human annotation.",
+    "Deterministic-first cascade: Tier 1 (gold EM/F1 + context recall/precision) carries the weight; the judge panel only adjudicates the residue."
+  ]
+}

--- a/benchmarks/results/adjudication/e2e-selftest/rag-eval-scorecard.md
+++ b/benchmarks/results/adjudication/e2e-selftest/rag-eval-scorecard.md
@@ -1,0 +1,53 @@
+# End-to-end RAG eval scorecard — human-label-free
+
+Four-tier cascade (RFC 020 §5, milestone M4). No human-annotated labels.
+
+- Datasets: hotpotqa
+- Provider/model: ollama / (default)
+- Answerer (kb ask LLM): (unset)
+- git SHA: 7c48945
+
+## Tier 1 — deterministic reference metrics
+
+| Metric | Value |
+| --- | ---: |
+| Items | 3 |
+| Exact-match | 1.0000 |
+| Token-F1 | 1.0000 |
+| Context recall | 1.0000 |
+| Context precision | 1.0000 |
+| Items with gold facts | 3 |
+
+## Cascade routing (deterministic-first)
+
+| Decided by | Items |
+| --- | ---: |
+| Tier 1 (deterministic) | 3 |
+| Tier 2 (NLI + semantic) | 0 |
+| Tier 3 (judge panel) | 0 |
+| Tier 3 abstained | 0 |
+| Pending (tier not wired) | 0 |
+
+## Correctness (scored items only)
+
+- Scored: 3 / 3
+- Correct: 3
+- Accuracy: 1.0000
+
+## Tier 3 — panel self-consistency confidence
+
+- Distinct judge families: 3 (RFC requires ≥3)
+- Self-consistency K: 5
+- Calibration: (none)
+- Mean self-consistency: —
+- Mean calibrated confidence: —
+- Abstention rate: —
+
+## Tier 4 — per-judge probe-measured bias coefficients
+
+No bias probes run (judge panel not wired in this run).
+
+## Caveats
+
+- Human-label-free: correctness comes from gold-bearing QA + automated cross-checks (RFC 020 §5), never human annotation.
+- Deterministic-first cascade: Tier 1 (gold EM/F1 + context recall/precision) carries the weight; the judge panel only adjudicates the residue.

--- a/benchmarks/results/adjudication/reranker-bge-v2-m3-adjudication.json
+++ b/benchmarks/results/adjudication/reranker-bge-v2-m3-adjudication.json
@@ -1,0 +1,25 @@
+{
+  "schema_version": "kb.rerank-adjudication.v1",
+  "candidateModel": "BAAI/bge-reranker-v2-m3",
+  "baselineModel": "Xenova/ms-marco-MiniLM-L-6-v2",
+  "decision": "no-ship",
+  "correction": "holm",
+  "alpha": 0.05,
+  "domains": [],
+  "enabledDomains": [],
+  "skipDomains": [],
+  "e2e": [],
+  "e2eVetoed": false,
+  "provisional": true,
+  "pending": [
+    "BEIR per-domain runs: hybrid+rerank with the baseline cross-encoder (Xenova/ms-marco-MiniLM-L-6-v2) vs the candidate (BAAI/bge-reranker-v2-m3) across SciFact / NFCorpus / FiQA and at least one high-precision/lexical domain (code or skills), using a real embedding provider (Ollama) and the candidate reranker downloaded. Not runnable in this offline, model-free environment.",
+    "Per-domain §3 significance needs the per-query nDCG@10 vectors produced by the BEIR runs above (paired baseline-vs-candidate over the same query set).",
+    "e2e RAG veto (§5): baseline-vs-candidate rag-eval scorecards over gold-bearing QA with >=3 live judge families. The hermetic --fake scorecard under ./e2e-selftest proves the leg runs end-to-end but echoes gold answers (a plumbing self-test, accuracy=1.0), so it is NOT a quality measurement and supplies no veto delta."
+  ],
+  "recommendedConfig": {
+    "KB_RERANK_MODEL": "Xenova/ms-marco-MiniLM-L-6-v2",
+    "KB_RERANK_SKIP_DOMAINS": ""
+  },
+  "meanDelta": null,
+  "summary": "PROVISIONAL NO-SHIP — no per-domain BEIR evidence was supplied — the load-bearing runs are pending; stay on the baseline reranker."
+}

--- a/benchmarks/results/adjudication/reranker-bge-v2-m3-adjudication.md
+++ b/benchmarks/results/adjudication/reranker-bge-v2-m3-adjudication.md
@@ -1,0 +1,45 @@
+# Reranker upgrade adjudication — RFC 020 M5 (issue #565)
+
+**Decision: NO-SHIP** _(provisional)_
+
+PROVISIONAL NO-SHIP — no per-domain BEIR evidence was supplied — the load-bearing runs are pending; stay on the baseline reranker.
+
+| Field | Value |
+| --- | --- |
+| Candidate reranker | `BAAI/bge-reranker-v2-m3` |
+| Baseline reranker | `Xenova/ms-marco-MiniLM-L-6-v2` |
+| Multiple-comparison correction | holm (α=0.05) |
+| Domains measured | 0 |
+| e2e veto | not measured |
+
+## Per-domain gate (§3 significance + §9 per-domain measurement)
+
+_No per-domain BEIR evidence supplied — see pending evidence below._
+
+## End-to-end RAG veto (§5)
+
+_No e2e metrics supplied — the §5 veto is PENDING (needs gold-QA answers + the judge panel)._
+
+## Recommended configuration
+
+To realize this decision through the production plug points:
+
+```bash
+export KB_RERANK=on
+export KB_RERANK_MODEL=Xenova/ms-marco-MiniLM-L-6-v2
+# KB_RERANK_SKIP_DOMAINS: (none — no domain was gated out)
+```
+
+## Pending evidence (decision is provisional)
+
+- BEIR per-domain runs: hybrid+rerank with the baseline cross-encoder (Xenova/ms-marco-MiniLM-L-6-v2) vs the candidate (BAAI/bge-reranker-v2-m3) across SciFact / NFCorpus / FiQA and at least one high-precision/lexical domain (code or skills), using a real embedding provider (Ollama) and the candidate reranker downloaded. Not runnable in this offline, model-free environment.
+- Per-domain §3 significance needs the per-query nDCG@10 vectors produced by the BEIR runs above (paired baseline-vs-candidate over the same query set).
+- e2e RAG veto (§5): baseline-vs-candidate rag-eval scorecards over gold-bearing QA with >=3 live judge families. The hermetic --fake scorecard under ./e2e-selftest proves the leg runs end-to-end but echoes gold answers (a plumbing self-test, accuracy=1.0), so it is NOT a quality measurement and supplies no veto delta.
+
+---
+
+Decision rule: **NO-SHIP** if the §5 e2e veto fires or no domain shows a
+significant nDCG@10 gain; **SHIP-GATED** if some domains improve and others
+are gated out via the skip-rerank fallback; **SHIP** only if every measured
+domain improves and the e2e veto passes. No benchmark number is fabricated —
+a provisional decision lists its outstanding evidence above (issue #565).

--- a/benchmarks/results/adjudication/reranker-bge-v2-m3-manifest.json
+++ b/benchmarks/results/adjudication/reranker-bge-v2-m3-manifest.json
@@ -1,0 +1,15 @@
+{
+  "candidateModel": "BAAI/bge-reranker-v2-m3",
+  "baselineModel": "Xenova/ms-marco-MiniLM-L-6-v2",
+  "correction": "holm",
+  "alpha": 0.05,
+  "clusterByDataset": true,
+  "domains": [],
+  "e2e": [],
+  "provisional": true,
+  "pending": [
+    "BEIR per-domain runs: hybrid+rerank with the baseline cross-encoder (Xenova/ms-marco-MiniLM-L-6-v2) vs the candidate (BAAI/bge-reranker-v2-m3) across SciFact / NFCorpus / FiQA and at least one high-precision/lexical domain (code or skills), using a real embedding provider (Ollama) and the candidate reranker downloaded. Not runnable in this offline, model-free environment.",
+    "Per-domain §3 significance needs the per-query nDCG@10 vectors produced by the BEIR runs above (paired baseline-vs-candidate over the same query set).",
+    "e2e RAG veto (§5): baseline-vs-candidate rag-eval scorecards over gold-bearing QA with >=3 live judge families. The hermetic --fake scorecard under ./e2e-selftest proves the leg runs end-to-end but echoes gold answers (a plumbing self-test, accuracy=1.0), so it is NOT a quality measurement and supplies no veto delta."
+  ]
+}

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -92,6 +92,7 @@ provider load or scoring failures degrade to the fused order.
 | Cross-encoder reranker | `KB_RERANK` | `off` | CLI hybrid search, MCP hybrid retrieval, retrieval eval | Implemented, opt-in | `kb search --rerank`, `kb search --no-rerank`, MCP `rerank: "on"\|"off"` | `KB_RERANK=on kb search "query" --mode=hybrid --timing --format=json` |
 | Reranker model | `KB_RERANK_MODEL` | `Xenova/ms-marco-MiniLM-L-6-v2` | Local `@huggingface/transformers` provider | Implemented | none | `KB_RERANK=on kb doctor --format=json` |
 | Rerank candidate count | `KB_RERANK_TOP_N` | `40` | Reranker stage | Implemented | none | `KB_RERANK_TOP_N=20 KB_RERANK=on kb search "query" --mode=hybrid --timing` |
+| Skip-rerank fallback (per-domain gate) | `KB_RERANK_SKIP_DOMAINS` | _(empty)_ | Reranker stage (CLI/MCP/eval) | Implemented | none | `KB_RERANK=on KB_RERANK_SKIP_DOMAINS=code,skills kb search "query" --kb code --mode=hybrid --timing` |
 
 ## Untrusted Content Hardening
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "bench:beir:leaderboard": "npm run build && tsc -p tsconfig.bench.json && node build/benchmarks/compare/leaderboard.js",
     "bench:beir:significance": "npm run build && tsc -p tsconfig.bench.json && node build/benchmarks/significance.js",
     "bench:beir:quality-gate": "npm run build && tsc -p tsconfig.bench.json && node build/benchmarks/beir/quality-gate.js",
+    "bench:adjudicate": "npm run build && tsc -p tsconfig.bench.json && node build/benchmarks/adjudication/adjudicate.js",
     "bench:bright": "npm run build && tsc -p tsconfig.bench.json && node build/benchmarks/bright/run.js",
     "bench:rag-eval": "npm run build && tsc -p tsconfig.bench.json && node build/benchmarks/rag-eval/run.js",
     "bench:mteb": "npm run build && tsc -p tsconfig.bench.json && node build/benchmarks/mteb/run.js",

--- a/src/KnowledgeBaseServer.ts
+++ b/src/KnowledgeBaseServer.ts
@@ -985,7 +985,7 @@ export class KnowledgeBaseServer {
         canonical.faiss_ms = denseTiming.faiss_search_ms ?? denseTiming.query_search_ms;
       }
 
-      const rerankConfig = resolveRerankerConfig(process.env, rerankOverride);
+      const rerankConfig = resolveRerankerConfig(process.env, rerankOverride, knowledgeBaseName ?? null);
       const fusion = fuseHybridResultsWithDiagnostics({
         denseResults,
         lexicalResults,

--- a/src/cli-search.ts
+++ b/src/cli-search.ts
@@ -2384,7 +2384,7 @@ async function runHybridSearch(
   const fusionStartedAt = nowMs();
   let rerankConfig: RerankerConfig;
   try {
-    rerankConfig = resolveRerankerConfig(process.env, parsed.rerankOverride);
+    rerankConfig = resolveRerankerConfig(process.env, parsed.rerankOverride, parsed.kb ?? null);
   } catch (err) {
     return reportFailure(classifyKbSearchError(err), parsed.format);
   }

--- a/src/config/reranker.test.ts
+++ b/src/config/reranker.test.ts
@@ -3,8 +3,10 @@ import { describe, expect, it } from '@jest/globals';
 import {
   DEFAULT_RERANK_MODEL,
   DEFAULT_RERANK_TOP_N,
+  isRerankSkippedForDomain,
   parseRerankFlag,
   parseRerankTopN,
+  parseSkipRerankDomains,
   resolveRerankerConfig,
 } from './reranker.js';
 
@@ -60,5 +62,49 @@ describe('reranker config (RFC 019)', () => {
       topN: DEFAULT_RERANK_TOP_N,
     });
     expect(() => resolveRerankerConfig({ KB_RERANK: 'on', KB_RERANK_TOP_N: 'nope' })).toThrow(/KB_RERANK_TOP_N/);
+  });
+
+  it('selects the reranker model from KB_RERANK_MODEL (the upgrade plug point)', () => {
+    // RFC 020 §9 / issue #565 — a Tier-1 reranker upgrade is selected purely by
+    // pointing KB_RERANK_MODEL at the candidate; no code change is needed to try
+    // bge-reranker-v2-m3 / Qwen3-Reranker through the production path.
+    expect(resolveRerankerConfig({ KB_RERANK: 'on', KB_RERANK_MODEL: 'BAAI/bge-reranker-v2-m3' }).model)
+      .toBe('BAAI/bge-reranker-v2-m3');
+    // Blank model falls back to the default rather than an empty id.
+    expect(resolveRerankerConfig({ KB_RERANK: 'on', KB_RERANK_MODEL: '   ' }).model).toBe(DEFAULT_RERANK_MODEL);
+  });
+});
+
+describe('per-domain skip-rerank fallback (RFC 020 §9)', () => {
+  it('parses KB_RERANK_SKIP_DOMAINS into a normalized, deduplicated list', () => {
+    expect(parseSkipRerankDomains(undefined)).toEqual([]);
+    expect(parseSkipRerankDomains('')).toEqual([]);
+    expect(parseSkipRerankDomains('  ,  ,')).toEqual([]);
+    expect(parseSkipRerankDomains('code, Skills , CODE')).toEqual(['code', 'skills']);
+  });
+
+  it('matches the scoped domain case-insensitively', () => {
+    const env = { KB_RERANK_SKIP_DOMAINS: 'code,skills' };
+    expect(isRerankSkippedForDomain(env, 'code')).toBe(true);
+    expect(isRerankSkippedForDomain(env, 'Code')).toBe(true);
+    expect(isRerankSkippedForDomain(env, 'prose')).toBe(false);
+    // An unscoped search (no domain) is never skipped — the fallback only fires
+    // for an explicitly scoped KB.
+    expect(isRerankSkippedForDomain(env, null)).toBe(false);
+    expect(isRerankSkippedForDomain(env, undefined)).toBe(false);
+    expect(isRerankSkippedForDomain({}, 'code')).toBe(false);
+  });
+
+  it('force-disables reranking for a skip domain even under KB_RERANK=on or override=on', () => {
+    const env = { KB_RERANK: 'on', KB_RERANK_SKIP_DOMAINS: 'code,skills' };
+    // Enabled for a non-skip domain...
+    expect(resolveRerankerConfig(env, undefined, 'prose').enabled).toBe(true);
+    // ...skipped for a listed high-precision/lexical domain (the §9 fallback),
+    // and the skip is authoritative: an explicit override=on does not re-enable it.
+    expect(resolveRerankerConfig(env, undefined, 'code').enabled).toBe(false);
+    expect(resolveRerankerConfig(env, 'on', 'skills').enabled).toBe(false);
+    // A null/omitted domain (unscoped search) is unaffected.
+    expect(resolveRerankerConfig(env, undefined, null).enabled).toBe(true);
+    expect(resolveRerankerConfig(env).enabled).toBe(true);
   });
 });

--- a/src/config/reranker.ts
+++ b/src/config/reranker.ts
@@ -15,6 +15,13 @@ export interface RerankerEnv {
   KB_RERANK?: string;
   KB_RERANK_MODEL?: string;
   KB_RERANK_TOP_N?: string;
+  // RFC 020 §9 — the per-domain "skip-rerank fallback". A comma-separated list
+  // of KB/domain names where the cross-encoder is force-disabled even when
+  // KB_RERANK=on. The KB survey found cross-encoders degrade high-precision /
+  // lexical domains (code, skills), so a reranker upgrade "ships only behind a
+  // per-domain measurement gate + a skip-rerank fallback — never on by default
+  // for all corpora." This env var is that fallback.
+  KB_RERANK_SKIP_DOMAINS?: string;
 }
 
 export class RerankerConfigError extends Error {
@@ -47,15 +54,65 @@ export function parseRerankTopN(raw: string | undefined): number {
   return value;
 }
 
+/**
+ * Normalize a KB/domain name for skip-list matching: trimmed + lower-cased so a
+ * skip list of `Code,Skills` matches a search scoped to `code` regardless of how
+ * the corpus was named or cased.
+ */
+export function normalizeRerankDomain(domain: string): string {
+  return domain.trim().toLowerCase();
+}
+
+/**
+ * Parse `KB_RERANK_SKIP_DOMAINS` into a deduplicated, normalized list. Empty,
+ * blank, and duplicate entries are dropped. Never throws — a malformed list just
+ * yields fewer skip domains, and the worst case (an empty list) is the safe
+ * "no domain is skipped" default.
+ */
+export function parseSkipRerankDomains(raw: string | undefined): string[] {
+  if (raw === undefined) return [];
+  const seen = new Set<string>();
+  for (const part of raw.split(',')) {
+    const normalized = normalizeRerankDomain(part);
+    if (normalized !== '') seen.add(normalized);
+  }
+  return [...seen];
+}
+
+/**
+ * Whether the cross-encoder must be skipped for `domain` per the per-domain
+ * skip-rerank fallback (RFC 020 §9). A null/undefined domain (an unscoped
+ * search) is never skipped — the fallback only fires for an explicitly scoped
+ * KB whose name is on the list.
+ */
+export function isRerankSkippedForDomain(
+  env: RerankerEnv = process.env,
+  domain: string | null | undefined,
+): boolean {
+  if (domain === null || domain === undefined) return false;
+  const skip = parseSkipRerankDomains(env.KB_RERANK_SKIP_DOMAINS);
+  if (skip.length === 0) return false;
+  return skip.includes(normalizeRerankDomain(domain));
+}
+
 export function resolveRerankerConfig(
   env: RerankerEnv = process.env,
   override?: RerankOverride,
+  // RFC 020 §9 — the KB/domain a search is scoped to. When supplied and present
+  // on KB_RERANK_SKIP_DOMAINS, the reranker is force-disabled (skip-rerank
+  // fallback) regardless of how it was otherwise enabled. Omitting it preserves
+  // the legacy two-argument behavior exactly.
+  domain?: string | null,
 ): RerankerConfig {
-  const enabled = override === 'on'
+  const enabledByRequest = override === 'on'
     ? true
     : override === 'off'
       ? false
       : parseRerankFlag(env.KB_RERANK);
+  // The skip-rerank fallback is authoritative: a domain known to be degraded by
+  // the cross-encoder stays un-reranked even under an explicit `on`. To measure
+  // or force a skip domain, remove it from KB_RERANK_SKIP_DOMAINS.
+  const enabled = enabledByRequest && !isRerankSkippedForDomain(env, domain);
   const model = env.KB_RERANK_MODEL?.trim() || DEFAULT_RERANK_MODEL;
   const topN = enabled ? parseRerankTopN(env.KB_RERANK_TOP_N) : DEFAULT_RERANK_TOP_N;
   return { enabled, model, topN };

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -200,6 +200,7 @@ export const CONFIG_SCHEMA: readonly ConfigSpec[] = [
   { name: 'KB_RERANK', kind: 'boolean', default: 'off' },
   { name: 'KB_RERANK_MODEL', kind: 'string', default: DEFAULT_RERANK_MODEL },
   { name: 'KB_RERANK_TOP_N', kind: 'integer', default: String(DEFAULT_RERANK_TOP_N), min: 1, max: MAX_RERANK_TOP_N, integerSyntax: 'digits' },
+  { name: 'KB_RERANK_SKIP_DOMAINS', kind: 'csv' },
 
   { name: 'KB_INJECTION_GUARD', kind: 'enum', values: ['off', 'tag', 'wrap', 'both'], default: 'tag' },
   { name: 'KB_INJECTION_GUARD_BYPASS_KBS', kind: 'csv' },

--- a/src/reranker.test.ts
+++ b/src/reranker.test.ts
@@ -1,9 +1,11 @@
-import { describe, expect, it, jest } from '@jest/globals';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 
 import {
+  applyRerankerIfEnabled,
   InMemoryRerankScoreCache,
   rerankFusedResults,
   scoresFromSequenceClassifierOutput,
+  setRerankerFactoryForTests,
   type Reranker,
   type RerankableDocument,
 } from './reranker.js';
@@ -101,6 +103,75 @@ describe('rerankFusedResults (RFC 019)', () => {
     expect(out.degraded).toBe(true);
     expect(out.degradeReason).toMatch(/expected 2 scores, got 1/);
     expect(out.results).toEqual(fused);
+  });
+});
+
+describe('applyRerankerIfEnabled — per-domain skip-rerank fallback (RFC 020 §9)', () => {
+  const ENV_KEYS = ['KB_RERANK', 'KB_RERANK_MODEL', 'KB_RERANK_TOP_N', 'KB_RERANK_SKIP_DOMAINS'] as const;
+  let saved: Record<string, string | undefined>;
+
+  function setEnv(values: Partial<Record<(typeof ENV_KEYS)[number], string>>): void {
+    for (const key of ENV_KEYS) delete process.env[key];
+    for (const [key, value] of Object.entries(values)) process.env[key] = value;
+  }
+
+  beforeEach(() => {
+    saved = {};
+    for (const key of ENV_KEYS) saved[key] = process.env[key];
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      if (saved[key] === undefined) delete process.env[key];
+      else process.env[key] = saved[key];
+    }
+  });
+
+  it('does NOT invoke the cross-encoder when the scoped domain is on KB_RERANK_SKIP_DOMAINS', async () => {
+    const reranker = stubReranker([0.9, 0.1]);
+    const restore = setRerankerFactoryForTests(async () => reranker);
+    try {
+      setEnv({ KB_RERANK: 'on', KB_RERANK_SKIP_DOMAINS: 'code,skills' });
+      const fused = [doc('a.md', 0.030), doc('b.md', 0.020)];
+
+      const out = await applyRerankerIfEnabled({
+        query: 'q',
+        results: fused,
+        k: 2,
+        kbScope: 'code',
+      });
+
+      // Reranker is bypassed; fused order is returned unchanged, no degrade.
+      expect(reranker.rerank).not.toHaveBeenCalled();
+      expect(out.degraded).toBe(false);
+      expect(out.candidatesIn).toBe(0);
+      expect(out.results.map((r) => r.metadata.source)).toEqual(['a.md', 'b.md']);
+    } finally {
+      restore();
+    }
+  });
+
+  it('DOES invoke the cross-encoder for a domain not on the skip list', async () => {
+    const reranker = stubReranker([0.1, 0.9]);
+    const restore = setRerankerFactoryForTests(async () => reranker);
+    try {
+      setEnv({ KB_RERANK: 'on', KB_RERANK_SKIP_DOMAINS: 'code,skills' });
+      const fused = [doc('a.md', 0.030), doc('b.md', 0.020)];
+
+      const out = await applyRerankerIfEnabled({
+        query: 'q',
+        results: fused,
+        k: 2,
+        kbScope: 'prose',
+      });
+
+      expect(reranker.rerank).toHaveBeenCalledTimes(1);
+      expect(out.degraded).toBe(false);
+      // b.md outscores a.md after reranking.
+      expect(out.results.map((r) => r.metadata.source)).toEqual(['b.md', 'a.md']);
+    } finally {
+      restore();
+    }
   });
 });
 

--- a/src/reranker.ts
+++ b/src/reranker.ts
@@ -4,8 +4,11 @@ import { emitCanonicalLog, type CanonicalProcess, type CanonicalSearchMode } fro
 import {
   DEFAULT_RERANK_MODEL,
   DEFAULT_RERANK_TOP_N,
+  isRerankSkippedForDomain,
+  normalizeRerankDomain,
   parseRerankFlag,
   parseRerankTopN,
+  parseSkipRerankDomains,
   resolveRerankerConfig,
   RerankerConfigError,
   type RerankOverride,
@@ -16,8 +19,11 @@ import { logger } from './logger.js';
 export {
   DEFAULT_RERANK_MODEL,
   DEFAULT_RERANK_TOP_N,
+  isRerankSkippedForDomain,
+  normalizeRerankDomain,
   parseRerankFlag,
   parseRerankTopN,
+  parseSkipRerankDomains,
   resolveRerankerConfig,
   RerankerConfigError,
   type RerankOverride,
@@ -130,8 +136,13 @@ export async function getDefaultReranker(config: RerankerConfig): Promise<Rerank
 export async function applyRerankerIfEnabled<T extends RerankableDocument>(
   input: ApplyRerankerInput<T>,
 ): Promise<RerankFusedResultsOutput<T>> {
-  const config = input.config ?? resolveRerankerConfig(process.env, input.override);
-  if (!config.enabled) {
+  const config = input.config ?? resolveRerankerConfig(process.env, input.override, input.kbScope ?? undefined);
+  // RFC 020 §9 skip-rerank fallback, enforced here as the single execution seam
+  // so it holds even when a caller resolved `config` without the domain: a KB on
+  // KB_RERANK_SKIP_DOMAINS is never reranked. Treated as a disable (not a
+  // degrade) — the cross-encoder simply does not run for this corpus.
+  const skippedForDomain = input.kbScope != null && isRerankSkippedForDomain(process.env, input.kbScope);
+  if (!config.enabled || skippedForDomain) {
     return {
       results: input.results.slice(0, input.k),
       degraded: false,

--- a/src/retrieval-eval.ts
+++ b/src/retrieval-eval.ts
@@ -585,7 +585,9 @@ async function retrieveHybrid(
     ),
     retrieveLexicalFn(fixtureCase.query, fetchK, fixtureCase.kb),
   ]);
-  const rerankConfig = resolveRerankerConfig();
+  // Pass the scoped KB so the RFC 020 §9 skip-rerank fallback (per-domain gate)
+  // is honored here too, and the fused candidate depth matches the real config.
+  const rerankConfig = resolveRerankerConfig(process.env, undefined, fixtureCase.kb);
   const fused = fuseHybridResults({
     denseResults,
     lexicalResults,
@@ -595,7 +597,9 @@ async function retrieveHybrid(
     query: fixtureCase.query,
     results: fused,
     k,
+    config: rerankConfig,
     searchMode: 'hybrid',
+    kbScope: fixtureCase.kb ?? null,
   });
   return reranked.results;
 }


### PR DESCRIPTION
Closes #565 — RFC 020 milestone **M5** (the final one), part of epic #559.

Takes **one Tier-1 technique** — the reranker upgrade `Xenova/ms-marco-MiniLM-L-6-v2` → `BAAI/bge-reranker-v2-m3` (selectable via the existing `KB_RERANK_MODEL` plug point) — through the full M0–M4 harness and produces a documented **ship/no-ship** decision backed by evidence, with the RFC §9 per-domain gate + skip-rerank fallback.

## What landed

### 1. Per-domain skip-rerank fallback (the gate's enforcement half) — `src/`
Per RFC §9 a reranker upgrade ships "never on by default for all corpora" (the KB survey found cross-encoders *degrade* high-precision/lexical domains like code & skills). New wiring:
- **`KB_RERANK_SKIP_DOMAINS`** (csv) force-disables reranking for the listed KB scopes even under `KB_RERANK=on`. `resolveRerankerConfig()` gains an optional `domain` arg; the skip is authoritative (an explicit `override=on` does not re-enable a skipped domain).
- Enforced at the single execution seam (`applyRerankerIfEnabled`) and threaded through the **CLI** (`parsed.kb`), **MCP** (`knowledgeBaseName`), and **retrieval-eval** (`fixtureCase.kb`) call sites — every production path honors it.
- Registered in the env schema (`kind: csv`) and documented in `docs/feature-flags.md`.
- Default behavior unchanged (empty list → nothing skipped).

### 2. Adjudication harness — `benchmarks/adjudication/adjudicate.ts`
Consumes per-domain BEIR per-query nDCG@10 (baseline vs candidate reranker) + the §5 e2e veto numbers and emits a structured decision:
- **Per-domain gate** via `benchmarks/significance.ts` (paired bootstrap/t-test + Bonferroni/Holm family correction + wild-cluster when clustered). Improving domains → `ENABLE`; regressing/no-change → the **skip-rerank fallback**. Materialized as the exact `KB_RERANK_MODEL` + `KB_RERANK_SKIP_DOMAINS` config.
- **e2e veto (§5)**: a faithfulness/correctness drop past tolerance hard-vetoes the ship regardless of BEIR gains.
- Decision: **NO-SHIP / SHIP-GATED / SHIP**, with a manifest loader (BEIR run files + rag-eval scorecards) + markdown report renderer. New `npm run bench:adjudicate`.

### 3. The adjudication decision (committed under `benchmarks/results/adjudication/`)
**PROVISIONAL — NO-SHIP pending the load-bearing benchmark runs.** Per the issue's honesty constraint, **no benchmark number is fabricated**: real per-domain BEIR (needs a real embedding model + the candidate cross-encoder downloaded) and the live-judge e2e leg are not runnable in this offline environment. The machinery + unit tests ship, the report self-describes exactly what is pending, and a **real hermetic four-tier e2e cascade** was run (`--fake` over a committed gold fixture) and committed under `results/adjudication/e2e-selftest/` to prove the §5 leg runs end-to-end (a plumbing self-test, *not* a quality measurement). The README documents the exact commands to produce the real evidence and flip the decision to a final SHIP-GATED/SHIP/NO-SHIP.

## Verification
- `npm run check` green: **158 suites / 2298 tests pass**, **0 stale doc anchors**.
- New tests: `benchmarks/adjudication/adjudicate.test.ts` (ship / ship-gated / no-ship / e2e-veto / correction / manifest / CLI) and reranker config + skip-enforcement tests in `src/config/reranker.test.ts` + `src/reranker.test.ts`.
- No tests deleted or skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)