### PR TITLE
retrieval: add opt-in multi-view indexing

### DIFF
--- a/benchmarks/beir/matrix.test.ts
+++ b/benchmarks/beir/matrix.test.ts
@@ -84,6 +84,7 @@ describe('captureRetrievalEnv', () => {
       chunk_size: '1000',
       chunk_overlap: '200',
       contextual: 'off',
+      retrieval_views: null,
     });
   });
 
@@ -121,13 +122,14 @@ describe('parseMatrixArgs', () => {
   it('parses overrides incl. --fail-fast', () => {
     const options = parseMatrixArgs([
       '--datasets=scifact,arguana', '--modes=lexical,hybrid,hybrid+rerank',
-      '--provider=ollama', '--model=nomic-embed-text', '--fail-fast',
+      '--provider=ollama', '--model=nomic-embed-text', '--retrieval-views=section,metadata', '--fail-fast',
     ]);
     expect(options).toMatchObject({
       datasets: ['scifact', 'arguana'],
       modes: ['lexical', 'hybrid', 'hybrid+rerank'],
       provider: 'ollama',
       model: 'nomic-embed-text',
+      retrievalViews: 'section,metadata',
       continueOnError: false,
     });
   });
@@ -215,6 +217,36 @@ describe('runBeirMatrix', () => {
     // Failed runs are NOT logged to the ledger.
     expect(loggedRuns).toEqual(['scifact:hybrid', 'fiqa:hybrid']);
 
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  it('forwards retrieval view flags to non-lexical BEIR cells', async () => {
+    const root = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-beir-matrix-views-'));
+    const seenArgv: string[][] = [];
+    const { deps } = stubDeps({
+      runBenchmark: async (argv) => {
+        seenArgv.push(argv);
+        const dataset = argv.find((a) => a.startsWith('--dataset='))?.split('=')[1] ?? 'unknown';
+        const mode = argv.find((a) => a.startsWith('--mode='))?.split('=')[1] ?? 'lexical';
+        return stubResult(dataset, mode);
+      },
+    });
+
+    await runBeirMatrix({
+      datasets: ['scifact'],
+      modes: ['lexical', 'hybrid'],
+      provider: 'fake',
+      model: 'fake-embeddings',
+      retrievalViews: 'section,metadata',
+      split: 'test',
+      outputDir: path.join(root, 'out'),
+      cacheDir: path.join(root, 'cache'),
+      workspaceRoot: path.join(root, 'ws'),
+      continueOnError: true,
+    }, deps);
+
+    expect(seenArgv.find((argv) => argv.includes('--mode=lexical'))).not.toContain('--retrieval-views=section,metadata');
+    expect(seenArgv.find((argv) => argv.includes('--mode=hybrid'))).toContain('--retrieval-views=section,metadata');
     await fsp.rm(root, { recursive: true, force: true });
   });
 

--- a/benchmarks/beir/matrix.ts
+++ b/benchmarks/beir/matrix.ts
@@ -74,6 +74,7 @@ export interface RetrievalEnvSnapshot {
   chunk_size: string;
   chunk_overlap: string;
   contextual: 'on' | 'off';
+  retrieval_views: string | null;
 }
 
 const PRODUCTION_RRF_C = '60';
@@ -96,6 +97,7 @@ export function captureRetrievalEnv(
     chunk_size: nonEmpty(env.KB_CHUNK_SIZE) ?? PRODUCTION_CHUNK_SIZE,
     chunk_overlap: nonEmpty(env.KB_CHUNK_OVERLAP) ?? PRODUCTION_CHUNK_OVERLAP,
     contextual: isOn(env.KB_CONTEXTUAL_RETRIEVAL) ? 'on' : 'off',
+    retrieval_views: nonEmpty(env.KB_RETRIEVAL_VIEWS) ?? null,
   };
 }
 
@@ -149,6 +151,7 @@ export interface MatrixOptions {
   modes: BeirMode[];
   provider?: string;
   model?: string;
+  retrievalViews?: string;
   split: string;
   outputDir: string;
   cacheDir: string;
@@ -332,6 +335,7 @@ function buildBeirArgv(options: MatrixOptions, dataset: string, mode: BeirMode):
   if (mode !== 'lexical') {
     if (options.provider !== undefined) argv.push(`--provider=${options.provider}`);
     if (options.model !== undefined) argv.push(`--model=${options.model}`);
+    if (options.retrievalViews !== undefined) argv.push(`--retrieval-views=${options.retrievalViews}`);
   }
   if (options.maxQueries !== undefined) argv.push(`--max-queries=${options.maxQueries}`);
   return argv;
@@ -494,6 +498,8 @@ export function parseMatrixArgs(argv: string[]): MatrixOptions {
       options.provider = readValue();
     } else if (flag === '--model') {
       options.model = readValue();
+    } else if (flag === '--retrieval-views') {
+      options.retrievalViews = readValue();
     } else if (flag === '--split') {
       options.split = readValue();
     } else if (flag === '--output-dir') {
@@ -546,6 +552,7 @@ Options:
   --modes=<...>        Comma list of ${MATRIX_MODES.join('|')}. Default: lexical,hybrid.
   --provider=<name>    Embedding provider for non-lexical modes. Default: $EMBEDDING_PROVIDER.
   --model=<name>       Embedding model. Real model required for meaningful numbers.
+  --retrieval-views=<v> Opt-in multi-view retrieval views for non-lexical modes.
   --split=<name>       Qrels split. Default: test.
   --output-dir=<path>  Matrix report directory.
   --max-queries=<n>    Deterministic subset for a quick smoke.

--- a/benchmarks/beir/run.ts
+++ b/benchmarks/beir/run.ts
@@ -102,6 +102,7 @@ interface Args {
   // `runBeirBenchmark` so a `--config` env block can still set them.
   provider?: string;
   model?: string;
+  retrievalViews?: string;
   outputDir: string;
   cacheDir: string;
   workspaceRoot: string;
@@ -121,6 +122,8 @@ type BeirConfigKey =
   | 'lexicalUnit'
   | 'provider'
   | 'model'
+  | 'retrieval_views'
+  | 'retrievalViews'
   | 'output_dir'
   | 'outputDir'
   | 'cache_dir'
@@ -218,6 +221,7 @@ export interface LoadSearchBackendInput {
   provider: string;
   modelName: string;
   kbName: string;
+  retrievalViews?: string;
 }
 
 interface BeirBenchmarkReport {
@@ -514,6 +518,7 @@ async function runDenseRetrieval(input: RetrievalInput): Promise<RetrievalOutcom
     provider: spec.provider,
     modelName: spec.model,
     kbName: prepared.kbName,
+    retrievalViews: args.retrievalViews,
   });
 
   const indexStarted = process.hrtime.bigint();
@@ -618,6 +623,17 @@ function applyStageEnvironment(mode: BeirMode): () => void {
       if (value === undefined) delete process.env[name];
       else process.env[name] = value;
     }
+  };
+}
+
+function applyRetrievalViewsEnvironment(retrievalViews: string | undefined): () => void {
+  const previous = process.env.KB_RETRIEVAL_VIEWS;
+  if (retrievalViews !== undefined && retrievalViews.trim() !== '') {
+    process.env.KB_RETRIEVAL_VIEWS = retrievalViews;
+  }
+  return () => {
+    if (previous === undefined) delete process.env.KB_RETRIEVAL_VIEWS;
+    else process.env.KB_RETRIEVAL_VIEWS = previous;
   };
 }
 
@@ -732,7 +748,7 @@ function buildCaveats(args: Args): string[] {
 // under `benchmarks/` rootDir without a static cross-tree import).
 interface FaissManagerLike {
   initialize(): Promise<void>;
-  updateIndex(specificKnowledgeBase?: string): Promise<void>;
+  updateIndex(specificKnowledgeBase?: string, options?: { force?: boolean }): Promise<void>;
   getLastIndexUpdateSummary(): { files_scanned: number; chunks_added: number };
   similaritySearch(
     query: string,
@@ -777,7 +793,12 @@ async function loadSearchBackend(input: LoadSearchBackendInput): Promise<BeirSea
       ? 'src/FaissIndexManager.similaritySearch (production dense path) via retrieval-eval.retrieveForRetrievalEvalCase'
       : 'src/hybrid-retrieval RRF fusion (production hybrid path) via retrieval-eval.retrieveForRetrievalEvalCase',
     prepare: async () => {
-      await manager.updateIndex();
+      const restoreViews = applyRetrievalViewsEnvironment(input.retrievalViews);
+      try {
+        await manager.updateIndex(undefined, { force: input.retrievalViews !== undefined });
+      } finally {
+        restoreViews();
+      }
       const summary = manager.getLastIndexUpdateSummary();
       return { files: summary.files_scanned, chunks: summary.chunks_added };
     },
@@ -793,6 +814,7 @@ async function loadSearchBackend(input: LoadSearchBackendInput): Promise<BeirSea
           forbiddenSources: [],
           expectedMetadata: [],
           stalePolicy: 'allow_stale',
+          ...(input.retrievalViews !== undefined ? { retrievalViews: input.retrievalViews } : {}),
         },
         { manager, defaultK: fetchK, defaultThreshold: Number.POSITIVE_INFINITY },
         input.mode,
@@ -857,6 +879,8 @@ export function parseArgs(argv: string[]): Args {
       args.provider = readValue();
     } else if (flag === '--model') {
       args.model = readValue();
+    } else if (flag === '--retrieval-views') {
+      args.retrievalViews = readValue();
     } else if (flag === '--dataset-dir') {
       args.datasetDir = path.resolve(readValue());
     } else if (flag === '--dataset-url') {
@@ -951,6 +975,8 @@ function applyBeirConfig(args: Args, beir: Partial<Record<BeirConfigKey, unknown
       args.provider = parseStringConfig(value, 'beir.provider');
     } else if (key === 'model') {
       args.model = parseStringConfig(value, 'beir.model');
+    } else if (key === 'retrieval_views' || key === 'retrievalViews') {
+      args.retrievalViews = parseStringConfig(value, `beir.${key}`);
     } else if (key === 'output_dir' || key === 'outputDir') {
       args.outputDir = path.resolve(parseStringConfig(value, `beir.${key}`));
     } else if (key === 'cache_dir' || key === 'cacheDir') {
@@ -1361,6 +1387,8 @@ Options:
                          fake is deterministic + network-free (self-test only).
   --model=<name>         Embedding model for dense/hybrid. Default: the provider
                          model env var (OLLAMA_MODEL / OPENAI_MODEL_NAME / ...).
+  --retrieval-views=<v>  Opt-in multi-view retrieval views for dense/hybrid
+                         runs, e.g. passage,section,metadata,summary or all.
   --dataset-dir=<path>   Existing BEIR directory with corpus.jsonl, queries.jsonl, qrels/.
   --dataset-url=<url>    Zip URL for a custom BEIR-shaped dataset.
   --output-dir=<path>    Directory for metrics JSON, TREC, and Markdown report.

--- a/benchmarks/bright/run.ts
+++ b/benchmarks/bright/run.ts
@@ -47,6 +47,7 @@ export interface BrightRunOptions {
   brightDir?: string;
   provider?: string;
   model?: string;
+  retrievalViews?: string;
   split: string;
   outputDir: string;
   datasetsDir: string;
@@ -159,6 +160,7 @@ function buildBeirArgv(options: BrightRunOptions, task: string, datasetDir: stri
   if (mode !== 'lexical') {
     if (options.provider !== undefined) argv.push(`--provider=${options.provider}`);
     if (options.model !== undefined) argv.push(`--model=${options.model}`);
+    if (options.retrievalViews !== undefined) argv.push(`--retrieval-views=${options.retrievalViews}`);
   }
   if (options.maxQueries !== undefined) argv.push(`--max-queries=${options.maxQueries}`);
   return argv;
@@ -198,6 +200,8 @@ export function parseBrightArgs(argv: string[]): BrightRunOptions {
       options.provider = readValue();
     } else if (flag === '--model') {
       options.model = readValue();
+    } else if (flag === '--retrieval-views') {
+      options.retrievalViews = readValue();
     } else if (flag === '--split') {
       options.split = readValue();
     } else if (flag === '--output-dir') {
@@ -252,6 +256,7 @@ Options:
   --bright-dir=<p>     Directory of converted BRIGHT tasks. Required for a real run.
   --provider=<name>    Embedding provider for dense/hybrid. Default: $EMBEDDING_PROVIDER.
   --model=<name>       Embedding model. Real model required — fake is plumbing only.
+  --retrieval-views=<v> Opt-in multi-view retrieval views for dense/hybrid.
   --split=<name>       Qrels split written by the adapter. Default: test.
   --output-dir=<p>     Report dir. Default: benchmarks/results/bright.
   --max-queries=<n>    Deterministic subset for a quick smoke.

--- a/src/FaissIndexManager.ts
+++ b/src/FaissIndexManager.ts
@@ -96,6 +96,12 @@ import {
   shouldRetryIngest,
 } from './ingest-quarantine.js';
 import { IngestSecretDetectedError } from './secret-scanner.js';
+import {
+  collapseRetrievalViewResults,
+  isRetrievalViewDocument,
+  shouldKeepForRetrievalViews,
+  type RetrievalViewKind,
+} from './retrieval-views.js';
 
 export { MigrationRefusedError } from './layout-bootstrap.js';
 
@@ -356,6 +362,11 @@ export interface SearchResultDocument extends Document {
   semanticMatch?: true;
   contextChunks?: NeighborContextChunk[];
   contextTruncated?: boolean;
+}
+
+export interface SimilaritySearchOptions {
+  noCache?: boolean;
+  retrievalViews?: RetrievalViewKind[];
 }
 
 const MAX_INDEX_UPDATE_FAILURES = 10;
@@ -2457,7 +2468,7 @@ export class FaissIndexManager {
     knowledgeBaseName?: string,
     filters?: SimilaritySearchFilters,
     timing?: SimilaritySearchTiming,
-    opts: { noCache?: boolean } = {},
+    opts: SimilaritySearchOptions = {},
   ): Promise<SearchResultDocument[]> {
     const totalStartedAt = Date.now();
     if (!this.faissIndex) {
@@ -2499,22 +2510,49 @@ export class FaissIndexManager {
         getQueryEmbedding,
       });
     };
+    const ntotal = this.faissIndex.totalVectors();
+    const hasViewDocuments = this.getDocstoreDocuments().some(isRetrievalViewDocument);
+    const viewFetchMultiplier = opts.retrievalViews !== undefined && opts.retrievalViews.length > 0
+      ? Math.max(4, opts.retrievalViews.length + 1)
+      : (hasViewDocuments ? 4 : 1);
+    const searchK = Math.min(ntotal, Math.max(k, k * viewFetchMultiplier));
+    const shapeResults = (rows: ScoredDocument[]): SearchResultDocument[] => {
+      const viewFiltered = rows
+        .filter(([doc]) => shouldKeepForRetrievalViews(doc, opts.retrievalViews))
+        .map(([doc, score]) => ({ ...doc, score }));
+      const shaped = opts.retrievalViews !== undefined && opts.retrievalViews.length > 0
+        ? collapseRetrievalViewResults(viewFiltered)
+        : viewFiltered;
+      return shaped.slice(0, k);
+    };
+    const hasViewFiltering = hasViewDocuments || (opts.retrievalViews !== undefined && opts.retrievalViews.length > 0);
 
     if (!postFilter.requiresOverfetch) {
       // No scope or metadata filter — FAISS top-k is already the final result
       // set (threshold is a cheap drop-in post-filter). One call.
-      if (timing) timing.fetch_k = k;
-      const resultsWithScore = await runFaissSearch(k);
-      const postFilterStartedAt = Date.now();
-      const filtered = postFilter.apply(resultsWithScore);
+      const fetchSizes = hasViewFiltering ? progressiveFetchSizes(k, ntotal) : [k];
+      let lastFetchK = k;
+      let cumulativePostFilterMs = 0;
+      let filtered: ScoredDocument[] = [];
+      let shaped: SearchResultDocument[] = [];
+      for (const fetchK of fetchSizes) {
+        lastFetchK = fetchK;
+        const resultsWithScore = await runFaissSearch(fetchK);
+        const postFilterStartedAt = Date.now();
+        filtered = postFilter.apply(resultsWithScore);
+        cumulativePostFilterMs += Date.now() - postFilterStartedAt;
+        shaped = shapeResults(filtered);
+        if (shaped.length >= k) break;
+        if (resultsWithScore.length < fetchK) break;
+      }
       if (timing) {
-        timing.post_filter_ms = Date.now() - postFilterStartedAt;
+        timing.fetch_k = lastFetchK;
+        timing.post_filter_ms = cumulativePostFilterMs;
+        timing.post_filter_kept = filtered.length;
         timing.total_ms = Date.now() - totalStartedAt;
       }
-      return filtered.slice(0, k).map(([doc, score]) => ({ ...doc, score }));
+      return shaped;
     }
-
-    const ntotal = this.faissIndex.totalVectors();
 
     // Issue #283 — predicate-pushdown fast-path. When a metadata-aware
     // filter is active and the per-model sidecar matches the live docstore
@@ -2550,7 +2588,7 @@ export class FaissIndexManager {
         return [];
       }
       const fastFetchK = recommendFastPathFetchK({
-        k,
+        k: searchK,
         candidates: candidates.length,
         ntotal,
       });
@@ -2559,8 +2597,10 @@ export class FaissIndexManager {
         const postFilterStartedAt = Date.now();
         filtered = postFilter.apply(resultsWithScore);
         cumulativePostFilterMs += Date.now() - postFilterStartedAt;
+        const shaped = shapeResults(filtered);
         const fastPathSatisfied =
-          filtered.length >= k || resultsWithScore.length < fastFetchK;
+          (hasViewFiltering ? shaped.length >= k : filtered.length >= searchK) ||
+          resultsWithScore.length < fastFetchK;
         if (fastPathSatisfied) {
           if (timing) {
             timing.fetch_k = fastFetchK;
@@ -2569,7 +2609,7 @@ export class FaissIndexManager {
             timing.sidecar_fast_path = 'hit';
             timing.total_ms = Date.now() - totalStartedAt;
           }
-          return filtered.slice(0, k).map(([doc, score]) => ({ ...doc, score }));
+          return shaped;
         }
         if (timing) timing.sidecar_fast_path = 'miss_underflow';
       } else if (timing) {
@@ -2584,15 +2624,17 @@ export class FaissIndexManager {
     // already returned its entire docstore (raw length below the requested
     // window ⇒ ntotal exhausted). Worst case ends at `ntotal` and matches
     // the pre-#229 cost; common filtered queries terminate at the first rung.
-    const fetchSizes = progressiveFetchSizes(k, ntotal);
-    let lastFetchK = k;
+    const fetchSizes = progressiveFetchSizes(searchK, ntotal);
+    let lastFetchK = searchK;
+    let shaped: SearchResultDocument[] = [];
     for (const fetchK of fetchSizes) {
       lastFetchK = fetchK;
       const resultsWithScore = await runFaissSearch(fetchK);
       const postFilterStartedAt = Date.now();
       filtered = postFilter.apply(resultsWithScore);
       cumulativePostFilterMs += Date.now() - postFilterStartedAt;
-      if (filtered.length >= k) break;
+      shaped = shapeResults(filtered);
+      if (hasViewFiltering ? shaped.length >= k : filtered.length >= searchK) break;
       if (resultsWithScore.length < fetchK) break;
     }
     if (timing) {
@@ -2602,7 +2644,7 @@ export class FaissIndexManager {
       timing.total_ms = Date.now() - totalStartedAt;
     }
 
-    return filtered.slice(0, k).map(([doc, score]) => ({ ...doc, score }));
+    return shaped.length > 0 ? shaped : shapeResults(filtered);
   }
 
   expandWithNeighborContext(

--- a/src/cli-search.ts
+++ b/src/cli-search.ts
@@ -118,6 +118,12 @@ import {
 } from './search-core.js';
 import { hashQuery, type CanonicalLogInput } from './canonical-log.js';
 import type { QueryCacheTelemetry } from './query-cache.js';
+import {
+  KB_RETRIEVAL_VIEWS_ENV,
+  formatRetrievalViews,
+  parseRetrievalViews,
+  type RetrievalViewKind,
+} from './retrieval-views.js';
 
 export const SEARCH_HELP = `kb search — semantic search across knowledge bases
 
@@ -151,6 +157,11 @@ Result tuning:
                         BM25 ranking unit for lexical and hybrid modes.
                         chunk ranks each chunk; source ranks each source file
                         and returns its best matching chunk (default: chunk).
+  --retrieval-views=<csv>
+                        Opt in to multi-view retrieval over a view-enriched
+                        index. Values: passage,section,metadata,summary,all.
+                        Requires --refresh or KB_RETRIEVAL_VIEWS at ingest time
+                        to create section/metadata/summary view records.
   --context-before=<n>  Include up to n preceding chunks from the same source
                         around each dense semantic match (0-${MAX_NEIGHBOR_CONTEXT_WINDOW}).
   --context-after=<n>   Include up to n following chunks from the same source
@@ -290,6 +301,7 @@ interface SearchArgs {
   taskContext?: string;
   taskContextFile?: string;
   lexicalUnit: LexicalRankingUnit;
+  retrievalViews?: RetrievalViewKind[];
 }
 
 export interface RunSearchDeps {
@@ -476,9 +488,12 @@ export async function runSearch(
       await withWriteLock(manager.modelDir, async () => {
         await printRefreshPreflightIfLarge(activeModelId, manager, parsed.kb, parsed.format);
         await manager.initialize();
-        await manager.updateIndex(parsed.kb, {
-          onProgress: createRefreshProgressReporter(timing),
-        });
+        await withRetrievalViewsForIngest(parsed.retrievalViews, () =>
+          manager.updateIndex(parsed.kb, {
+            onProgress: createRefreshProgressReporter(timing),
+            force: parsed.retrievalViews !== undefined,
+          }),
+        );
       });
     } else {
       await deps.loadWithJsonRetry(manager);
@@ -511,7 +526,7 @@ export async function runSearch(
         parsed.kb,
         undefined,
         denseTiming,
-        { noCache: parsed.noCache },
+        { noCache: parsed.noCache, retrievalViews: parsed.retrievalViews },
       );
       autoThresholdDecision = computeAutoThreshold(rawResults.map((r) => r.score));
       results = rawResults.slice(0, autoThresholdDecision.kept);
@@ -523,7 +538,7 @@ export async function runSearch(
         parsed.kb,
         undefined,
         denseTiming,
-        { noCache: parsed.noCache },
+        { noCache: parsed.noCache, retrievalViews: parsed.retrievalViews },
       );
     }
     if (parsed.neighborContext) {
@@ -628,6 +643,7 @@ export async function runSearch(
       gateVerdict,
       advancedRetrieval,
       queryCache: denseTiming.query_cache_telemetry,
+      retrievalViews: parsed.retrievalViews,
     });
     process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
   } else if (parsed.format === 'vimgrep') {
@@ -679,6 +695,30 @@ async function writeSearchOutput(
     stdout: process.stdout,
     stderr: process.stderr,
   });
+}
+
+async function withRetrievalViewsForIngest<T>(
+  views: readonly RetrievalViewKind[] | undefined,
+  fn: () => Promise<T>,
+): Promise<T> {
+  if (views === undefined || views.length === 0) return fn();
+  const previous = process.env[KB_RETRIEVAL_VIEWS_ENV];
+  process.env[KB_RETRIEVAL_VIEWS_ENV] = formatRetrievalViews(views);
+  try {
+    return await fn();
+  } finally {
+    if (previous === undefined) {
+      delete process.env[KB_RETRIEVAL_VIEWS_ENV];
+    } else {
+      process.env[KB_RETRIEVAL_VIEWS_ENV] = previous;
+    }
+  }
+}
+
+function retrievalViewsJson(views: readonly RetrievalViewKind[] | undefined): Record<string, unknown> | null {
+  return views !== undefined && views.length > 0
+    ? { enabled: true, views, collapsed: true }
+    : null;
 }
 
 /**
@@ -758,7 +798,7 @@ async function runAdvancedDenseSearch(input: {
       input.parsed.kb,
       undefined,
       input.denseTiming,
-      { noCache: input.parsed.noCache },
+      { noCache: input.parsed.noCache, retrievalViews: input.parsed.retrievalViews },
     );
     pools.push({ role, query, results });
   };
@@ -879,6 +919,11 @@ export function parseSearchArgs(rest: string[]): SearchArgs {
         throw new Error(`invalid --lexical-unit: ${raw} (expected 'chunk' or 'source')`);
       }
       out.lexicalUnit = v; continue;
+    }
+    if (raw.startsWith('--retrieval-views=')) {
+      out.retrievalViews = parseRetrievalViews(raw.slice('--retrieval-views='.length));
+      if (out.retrievalViews.length === 0) out.retrievalViews = undefined;
+      continue;
     }
     if (raw.startsWith('--threshold=')) {
       const v = raw.slice('--threshold='.length);
@@ -1227,6 +1272,7 @@ export interface DenseSearchJsonPayloadInput {
   gateVerdict?: RelevanceGateVerdict;
   advancedRetrieval?: AdvancedRetrievalMetadata | null;
   queryCache?: QueryCacheTelemetry;
+  retrievalViews?: RetrievalViewKind[];
 }
 
 export function buildDenseSearchJsonPayload(input: DenseSearchJsonPayloadInput): Record<string, unknown> {
@@ -1270,6 +1316,8 @@ export function buildDenseSearchJsonPayload(input: DenseSearchJsonPayloadInput):
   if (input.queryCache !== undefined) {
     payload.query_cache = input.queryCache;
   }
+  const retrievalViews = retrievalViewsJson(input.retrievalViews);
+  if (retrievalViews !== null) payload.retrieval_views = retrievalViews;
   if (input.timing) {
     payload.timing = compactTimingPayload(input.timing);
   }
@@ -2132,7 +2180,7 @@ async function runLexicalSearch(
     let refreshSummary: LexicalKbResult['refreshSummary'] = null;
     if (parsed.refresh || index.numFiles() === 0) {
       try {
-        refreshSummary = await index.refresh();
+        refreshSummary = await withRetrievalViewsForIngest(parsed.retrievalViews, () => index.refresh());
         await index.save();
       } catch (err) {
         perKb.push({ kbName, kbPath, refreshSummary: null, hits: [], error: err as Error });
@@ -2142,7 +2190,10 @@ async function runLexicalSearch(
 
     let hits: LexicalSearchResult[];
     try {
-      hits = await index.query(query, parsed.k, { unit: parsed.lexicalUnit });
+      hits = await index.query(query, parsed.k, {
+        unit: parsed.lexicalUnit,
+        retrievalViews: parsed.retrievalViews,
+      });
     } catch (err) {
       perKb.push({ kbName, kbPath, refreshSummary, hits: [], error: err as Error });
       continue;
@@ -2206,6 +2257,9 @@ async function runLexicalSearch(
         error: r.error ? r.error.message : null,
       })),
       lexical: { unit: parsed.lexicalUnit },
+      ...(retrievalViewsJson(parsed.retrievalViews) !== null
+        ? { retrieval_views: retrievalViewsJson(parsed.retrievalViews) }
+        : {}),
       ...(timing ? { timing: compactTimingPayload(timing) } : {}),
     };
     process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
@@ -2312,9 +2366,12 @@ async function runHybridSearch(
       await withWriteLock(manager.modelDir, async () => {
         await printRefreshPreflightIfLarge(activeModelId, manager, parsed.kb, parsed.format);
         await manager.initialize();
-        await manager.updateIndex(parsed.kb, {
-          onProgress: createRefreshProgressReporter(timing),
-        });
+        await withRetrievalViewsForIngest(parsed.retrievalViews, () =>
+          manager.updateIndex(parsed.kb, {
+            onProgress: createRefreshProgressReporter(timing),
+            force: parsed.retrievalViews !== undefined,
+          }),
+        );
       });
     } else {
       await deps.loadWithJsonRetry(manager);
@@ -2333,7 +2390,7 @@ async function runHybridSearch(
       parsed.kb,
       undefined,
       denseTiming,
-      { noCache: parsed.noCache },
+      { noCache: parsed.noCache, retrievalViews: parsed.retrievalViews },
     )
     .then((rs) => {
       if (timing) {
@@ -2359,17 +2416,20 @@ async function runHybridSearch(
   }
 
   const lexicalStartedAt = nowMs();
-  const lexicalPromise = (deps.runLexicalLeg ?? runLexicalLeg)({
-    kbs: lexicalKbs,
-    query,
-    fetchK,
-    refresh: parsed.refresh ? 'always' : 'when-empty',
-    rankingUnit: parsed.lexicalUnit,
-    loadIndex: deps.loadLexicalIndex,
-    onError: (kbName, err) => {
-      process.stderr.write(`kb search (hybrid lexical leg): ${kbName} — ${err.message}\n`);
-    },
-  }).then((row) => {
+  const lexicalPromise = withRetrievalViewsForIngest(parsed.retrievalViews, () =>
+    (deps.runLexicalLeg ?? runLexicalLeg)({
+      kbs: lexicalKbs,
+      query,
+      fetchK,
+      refresh: parsed.refresh ? 'always' : 'when-empty',
+      rankingUnit: parsed.lexicalUnit,
+      retrievalViews: parsed.retrievalViews,
+      loadIndex: deps.loadLexicalIndex,
+      onError: (kbName, err) => {
+        process.stderr.write(`kb search (hybrid lexical leg): ${kbName} — ${err.message}\n`);
+      },
+    }),
+  ).then((row) => {
     if (timing) timing.lexical_search_ms = elapsedMs(lexicalStartedAt);
     return row;
   });
@@ -2463,6 +2523,9 @@ async function runHybridSearch(
         },
       },
       rrf: { c: HYBRID_RRF_C, fetch_k: fetchK },
+      ...(retrievalViewsJson(parsed.retrievalViews) !== null
+        ? { retrieval_views: retrievalViewsJson(parsed.retrievalViews) }
+        : {}),
       rerank: {
         enabled: rerankResult.candidatesIn > 0,
         model: rerankResult.model,

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -171,6 +171,7 @@ export const CONFIG_SCHEMA: readonly ConfigSpec[] = [
   { name: 'KB_QUERY_CACHE_DISK_MAX_MB', kind: 'number', default: '64', min: 0.000001 },
 
   { name: 'KB_CONTEXTUAL_RETRIEVAL', kind: 'boolean', default: 'off', booleanValues: YES_NO_BOOL_VALUES, truthyValues: YES_NO_TRUTHY_VALUES },
+  { name: 'KB_RETRIEVAL_VIEWS', kind: 'csv', default: '' },
   { name: 'KB_CONTEXTUAL_MAX_TOKENS', kind: 'integer', default: '150', min: 20, max: 1000 },
   { name: 'KB_CONTEXTUAL_CONCURRENCY', kind: 'integer', default: '10', min: 1, max: 64 },
   { name: 'KB_LLM_ENDPOINT', kind: 'url', protocols: ['http:', 'https:', 'mock:'] },

--- a/src/contextual-preface.ts
+++ b/src/contextual-preface.ts
@@ -49,6 +49,7 @@ import { FAISS_INDEX_PATH } from './config/paths.js';
 import { KBError } from './errors.js';
 import { callChatCompletion, LlmClientError } from './llm-client.js';
 import { logger } from './logger.js';
+import { retrievalViewText } from './retrieval-views.js';
 import { withSidecarLock } from './write-lock.js';
 
 export const GENERATOR_VERSION = 'contextual-preface.v1';
@@ -78,6 +79,8 @@ const EMBEDDING_TEMPLATE_SEPARATOR = '\n\n';
  * on), not on a global flag in this helper.
  */
 export function embeddingText(doc: Document): string {
+  const viewText = retrievalViewText(doc);
+  if (viewText !== null) return viewText;
   const preface = (doc.metadata as { contextual_preface?: unknown } | undefined)?.contextual_preface;
   if (typeof preface !== 'string' || preface.length === 0) return doc.pageContent;
   return `${preface}${EMBEDDING_TEMPLATE_SEPARATOR}${doc.pageContent}`;

--- a/src/file-ingest.ts
+++ b/src/file-ingest.ts
@@ -33,6 +33,7 @@ import { parseFrontmatter } from './frontmatter.js';
 import { detectSiblingPdfPath, liftFrontmatter } from './frontmatter-lift.js';
 import { applyExtractedTextLimit } from './loaders.js';
 import { logger } from './logger.js';
+import { buildRetrievalViewDocuments, resolveRetrievalViews } from './retrieval-views.js';
 import { assertNoIngestSecrets, type SecretScanInput } from './secret-scanner.js';
 import { withSidecarLock } from './write-lock.js';
 
@@ -309,7 +310,7 @@ export async function buildChunkDocuments(
       ...(typeof preface === 'string' && preface.length > 0 ? { contextual_preface: preface } : {}),
     };
   }
-  return documents;
+  return buildRetrievalViewDocuments(documents, resolveRetrievalViews());
 }
 
 /**

--- a/src/hybrid-retrieval.ts
+++ b/src/hybrid-retrieval.ts
@@ -62,6 +62,7 @@ import { LexicalIndex, type LexicalRankingUnit, type LexicalSearchResult } from 
 import { KNOWLEDGE_BASES_ROOT_DIR } from './config/paths.js';
 import { listKnowledgeBases } from './kb-fs.js';
 import { chunkIdFromMetadata, reciprocalRankFusion, type RankedList } from './rrf.js';
+import type { RetrievalViewKind } from './retrieval-views.js';
 
 export const HYBRID_FETCH_MULTIPLIER = 4;
 export const HYBRID_FETCH_CAP = 200;
@@ -219,6 +220,7 @@ export interface LexicalLegOptions {
    */
   refresh: LexicalRefreshPolicy;
   rankingUnit?: LexicalRankingUnit;
+  retrievalViews?: RetrievalViewKind[];
   /**
    * Called when a per-KB load/refresh/query throws. Per-KB failures are not
    * fatal — the leg continues with the remaining KBs. The hook lets each
@@ -269,7 +271,10 @@ export async function runLexicalLeg(opts: LexicalLegOptions): Promise<LexicalLeg
         await idx.save();
         refreshed += 1;
       }
-      const hits = await idx.query(opts.query, opts.fetchK, { unit: opts.rankingUnit ?? 'chunk' });
+      const hits = await idx.query(opts.query, opts.fetchK, {
+        unit: opts.rankingUnit ?? 'chunk',
+        retrievalViews: opts.retrievalViews,
+      });
       for (const h of hits) all.push(h);
     } catch (err) {
       failed += 1;

--- a/src/lexical-index.ts
+++ b/src/lexical-index.ts
@@ -43,6 +43,13 @@ import { loadFile } from './loaders.js';
 import { logger } from './logger.js';
 import { toError } from './error-utils.js';
 import { LexicalBm25Ranker, type LexicalBm25Record } from './lexical-bm25.js';
+import {
+  collapseRetrievalViewResults,
+  formatRetrievalViews,
+  resolveRetrievalViews,
+  shouldKeepForRetrievalViews,
+  type RetrievalViewKind,
+} from './retrieval-views.js';
 
 // RFC 017 §3 — schema v2 splits BM25 scoring text from caller-output
 // text. v1 (pre-RFC-017) stored `pageContent` as both. v2 adds an
@@ -68,6 +75,7 @@ interface SerializedDocument {
 
 interface FileEntry {
   sha256: string;
+  retrievalViews?: string;
   chunks: SerializedDocument[];
 }
 
@@ -108,6 +116,7 @@ export interface LexicalQueryOptions {
    * chunk. Defaults to `max(k * 4, k)`.
    */
   candidateK?: number;
+  retrievalViews?: RetrievalViewKind[];
 }
 
 type ChunkRecordItem = { relPath: string; chunk: SerializedDocument };
@@ -148,8 +157,8 @@ export class LexicalIndex {
     public readonly kbName: string,
     public readonly kbPath: string,
     private entries: Map<string, FileEntry>,
-    private chunkRankerCache: LexicalBm25Ranker<ChunkRecordItem> | null = null,
-    private sourceRankerCache: LexicalBm25Ranker<SourceRecordItem> | null = null,
+    private chunkRankerCache: Map<string, LexicalBm25Ranker<ChunkRecordItem>> = new Map(),
+    private sourceRankerCache: Map<string, LexicalBm25Ranker<SourceRecordItem>> = new Map(),
   ) {}
 
   static async load(kbName: string, kbPath: string): Promise<LexicalIndex> {
@@ -242,6 +251,7 @@ export class LexicalIndex {
     );
     const filePaths = enumeration[0]?.filePaths ?? [];
     const seen = new Set<string>();
+    const retrievalViewsKey = formatRetrievalViews(resolveRetrievalViews());
 
     for (const absPath of filePaths) {
       const relPath = path.relative(this.kbPath, absPath).split(path.sep).join('/');
@@ -257,7 +267,7 @@ export class LexicalIndex {
       }
 
       const existing = this.entries.get(relPath);
-      if (existing && existing.sha256 === sha) {
+      if (existing && existing.sha256 === sha && (existing.retrievalViews ?? '') === retrievalViewsKey) {
         continue;
       }
 
@@ -296,7 +306,7 @@ export class LexicalIndex {
         }
         return entry;
       });
-      this.entries.set(relPath, { sha256: sha, chunks: serialized });
+      this.entries.set(relPath, { sha256: sha, retrievalViews: retrievalViewsKey, chunks: serialized });
       if (existing) {
         summary.updated += 1;
       } else {
@@ -317,8 +327,8 @@ export class LexicalIndex {
       chunkCount += entry.chunks.length;
     }
     summary.totalChunks = chunkCount;
-    this.chunkRankerCache = null;
-    this.sourceRankerCache = null;
+    this.chunkRankerCache.clear();
+    this.sourceRankerCache.clear();
     return summary;
   }
 
@@ -354,8 +364,8 @@ export class LexicalIndex {
     if (k <= 0 || this.entries.size === 0) return [];
     const unit = options.unit ?? 'chunk';
     return unit === 'source'
-      ? this.querySources(query, k, options.candidateK)
-      : this.queryChunks(query, k);
+      ? this.querySources(query, k, options)
+      : this.queryChunks(query, k, options);
   }
 
   numFiles(): number {
@@ -368,21 +378,28 @@ export class LexicalIndex {
     return n;
   }
 
-  private queryChunks(query: string, k: number): LexicalSearchResult[] {
-    const ranked = this.chunkRanker().query(query, k);
-    return ranked.map(({ item, score }) => ({
+  private queryChunks(query: string, k: number, options: LexicalQueryOptions): LexicalSearchResult[] {
+    const candidateK = options.retrievalViews !== undefined && options.retrievalViews.length > 0
+      ? Math.max(k * Math.max(4, options.retrievalViews.length + 1), k)
+      : k;
+    const ranked = this.chunkRanker(options.retrievalViews).query(query, candidateK);
+    const hits = ranked.map(({ item, score }) => ({
       pageContent: item.chunk.pageContent,
       metadata: item.chunk.metadata,
       score,
     }));
+    const collapsed = options.retrievalViews !== undefined && options.retrievalViews.length > 0
+      ? collapseRetrievalViewResults(hits, { scoreDirection: 'higher' })
+      : hits;
+    return collapsed.slice(0, k);
   }
 
-  private querySources(query: string, k: number, candidateK: number | undefined): LexicalSearchResult[] {
-    const rankedSources = this.sourceRanker().query(query, k);
+  private querySources(query: string, k: number, options: LexicalQueryOptions): LexicalSearchResult[] {
+    const rankedSources = this.sourceRanker(options.retrievalViews).query(query, k);
     if (rankedSources.length === 0) return [];
 
-    const chunkCandidateK = Math.max(candidateK ?? k * 4, k, this.numChunks());
-    const rankedChunks = this.chunkRanker().query(query, chunkCandidateK);
+    const chunkCandidateK = Math.max(options.candidateK ?? k * 4, k, this.numChunks());
+    const rankedChunks = this.chunkRanker(options.retrievalViews).query(query, chunkCandidateK);
     const bestChunkByRelPath = new Map<string, SerializedDocument>();
     for (const { item } of rankedChunks) {
       if (!bestChunkByRelPath.has(item.relPath)) {
@@ -404,20 +421,31 @@ export class LexicalIndex {
     });
   }
 
-  private chunkRanker(): LexicalBm25Ranker<ChunkRecordItem> {
-    this.chunkRankerCache ??= LexicalBm25Ranker.fromRecords(this.chunkRecords());
-    return this.chunkRankerCache;
+  private chunkRanker(retrievalViews?: readonly RetrievalViewKind[]): LexicalBm25Ranker<ChunkRecordItem> {
+    const key = retrievalViewCacheKey(retrievalViews);
+    let ranker = this.chunkRankerCache.get(key);
+    if (ranker === undefined) {
+      ranker = LexicalBm25Ranker.fromRecords(this.chunkRecords(retrievalViews));
+      this.chunkRankerCache.set(key, ranker);
+    }
+    return ranker;
   }
 
-  private sourceRanker(): LexicalBm25Ranker<SourceRecordItem> {
-    this.sourceRankerCache ??= LexicalBm25Ranker.fromRecords(this.sourceRecords());
-    return this.sourceRankerCache;
+  private sourceRanker(retrievalViews?: readonly RetrievalViewKind[]): LexicalBm25Ranker<SourceRecordItem> {
+    const key = retrievalViewCacheKey(retrievalViews);
+    let ranker = this.sourceRankerCache.get(key);
+    if (ranker === undefined) {
+      ranker = LexicalBm25Ranker.fromRecords(this.sourceRecords(retrievalViews));
+      this.sourceRankerCache.set(key, ranker);
+    }
+    return ranker;
   }
 
-  private chunkRecords(): Array<LexicalBm25Record<ChunkRecordItem>> {
+  private chunkRecords(retrievalViews?: readonly RetrievalViewKind[]): Array<LexicalBm25Record<ChunkRecordItem>> {
     const records: Array<LexicalBm25Record<ChunkRecordItem>> = [];
     for (const [relPath, entry] of this.entries) {
       for (const chunk of entry.chunks) {
+        if (!shouldKeepForRetrievalViews({ metadata: chunk.metadata }, retrievalViews)) continue;
         records.push({
           item: { relPath, chunk },
           title: titleFromMetadata(chunk.metadata) ?? path.basename(relPath, path.extname(relPath)),
@@ -428,19 +456,26 @@ export class LexicalIndex {
     return records;
   }
 
-  private sourceRecords(): Array<LexicalBm25Record<SourceRecordItem>> {
+  private sourceRecords(retrievalViews?: readonly RetrievalViewKind[]): Array<LexicalBm25Record<SourceRecordItem>> {
     const records: Array<LexicalBm25Record<SourceRecordItem>> = [];
     for (const [relPath, entry] of this.entries) {
-      const firstChunk = entry.chunks[0];
+      const chunks = entry.chunks.filter((chunk) => shouldKeepForRetrievalViews({ metadata: chunk.metadata }, retrievalViews));
+      const firstChunk = chunks[0];
       if (firstChunk === undefined) continue;
       records.push({
         item: { relPath, firstChunk },
         title: titleFromMetadata(firstChunk.metadata) ?? path.basename(relPath, path.extname(relPath)),
-        text: entry.chunks.map((chunk) => chunk.searchText ?? chunk.pageContent).join('\n\n'),
+        text: chunks.map((chunk) => chunk.searchText ?? chunk.pageContent).join('\n\n'),
       });
     }
     return records;
   }
+}
+
+function retrievalViewCacheKey(retrievalViews: readonly RetrievalViewKind[] | undefined): string {
+  return retrievalViews === undefined || retrievalViews.length === 0
+    ? 'default'
+    : `views:${retrievalViews.join(',')}`;
 }
 
 function titleFromMetadata(metadata: Record<string, unknown>): string | undefined {

--- a/src/retrieval-eval.ts
+++ b/src/retrieval-eval.ts
@@ -15,6 +15,13 @@ import {
   listLexicalKbs,
 } from './hybrid-retrieval.js';
 import { applyRerankerIfEnabled, resolveRerankerConfig } from './reranker.js';
+import {
+  KB_RETRIEVAL_VIEWS_ENV,
+  RETRIEVAL_VIEW_KINDS,
+  formatRetrievalViews,
+  parseRetrievalViews,
+  type RetrievalViewKind,
+} from './retrieval-views.js';
 
 export type StalePolicy = 'allow_stale' | 'fresh' | 'stale';
 
@@ -95,6 +102,7 @@ export interface RetrievalEvalCase {
   k?: number;
   threshold?: number;
   mode?: SearchMode;
+  retrievalViews?: RetrievalViewKind[];
   gate?: boolean;
   requiredSources: string[];
   forbiddenSources: string[];
@@ -118,6 +126,8 @@ export interface RetrievalEvalCaseInput {
   k?: number;
   threshold?: number;
   mode?: SearchMode;
+  retrieval_views?: string;
+  retrievalViews?: string;
   gate?: boolean;
   required_sources?: string[];
   forbidden_sources?: string[];
@@ -172,7 +182,12 @@ export interface RetrievalEvalSearchContext {
   manager: Pick<FaissIndexManager, 'similaritySearch'>;
   defaultK: number;
   defaultThreshold: number;
-  retrieveLexical?: (query: string, k: number, scopedKb?: string) => Promise<ScoredDocument[]>;
+  retrieveLexical?: (
+    query: string,
+    k: number,
+    scopedKb?: string,
+    retrievalViews?: RetrievalViewKind[],
+  ) => Promise<ScoredDocument[]>;
 }
 
 export interface RetrievalEvalSearchResult {
@@ -278,6 +293,7 @@ export async function retrieveForRetrievalEvalCase(
       fixtureCase.query,
       fixtureCase.k ?? context.defaultK,
       fixtureCase.kb,
+      retrievalViewsForCase(fixtureCase),
     );
   } else {
     results = await retrieveHybrid(fixtureCase, context);
@@ -456,6 +472,8 @@ function normalizeCase(raw: unknown, caseNumber: number): RetrievalEvalCase {
   const k = readOptionalPositiveInteger(raw, 'k');
   const threshold = readOptionalPositiveNumber(raw, 'threshold');
   const gate = readOptionalBoolean(raw, 'gate');
+  const retrievalViewsRaw = readOptionalString(raw, 'retrieval_views') ?? readOptionalString(raw, 'retrievalViews');
+  const retrievalViews = retrievalViewsRaw === undefined ? undefined : parseRetrievalViews(retrievalViewsRaw);
   const maxDuplicateGroups = readOptionalNonNegativeInteger(raw, 'max_duplicate_groups');
   const relevanceJudgments = normalizeRelevanceJudgments(raw, caseNumber);
   const expectedGateVerdict = normalizeExpectedGateVerdict(raw.expected_gate_verdict, caseNumber);
@@ -466,6 +484,7 @@ function normalizeCase(raw: unknown, caseNumber: number): RetrievalEvalCase {
     ...(k !== undefined ? { k } : {}),
     ...(threshold !== undefined ? { threshold } : {}),
     ...readOptionalSearchMode(raw, 'mode', `case ${caseNumber}`),
+    ...(retrievalViews !== undefined && retrievalViews.length > 0 ? { retrievalViews } : {}),
     ...(gate !== undefined ? { gate } : {}),
     requiredSources: readOptionalStringArray(raw, 'required_sources') ?? [],
     forbiddenSources: readOptionalStringArray(raw, 'forbidden_sources') ?? [],
@@ -535,11 +554,15 @@ async function retrieveDense(
   fixtureCase: RetrievalEvalCase,
   context: RetrievalEvalSearchContext,
 ): Promise<ScoredDocument[]> {
+  const retrievalViews = retrievalViewsForCase(fixtureCase);
   return context.manager.similaritySearch(
     fixtureCase.query,
     fixtureCase.k ?? context.defaultK,
     fixtureCase.threshold ?? context.defaultThreshold,
     fixtureCase.kb,
+    undefined,
+    undefined,
+    { retrievalViews },
   );
 }
 
@@ -547,6 +570,7 @@ async function retrieveLexical(
   query: string,
   k: number,
   scopedKb?: string,
+  retrievalViews?: RetrievalViewKind[],
 ): Promise<ScoredDocument[]> {
   const kbs = await listLexicalKbs(scopedKb);
   // The eval runner is strict about scope: a missing scoped KB is a fixture
@@ -560,10 +584,10 @@ async function retrieveLexical(
   for (const { kbName, kbPath } of kbs) {
     const index = await LexicalIndex.load(kbName, kbPath);
     if (index.numFiles() === 0) {
-      await index.refresh();
+      await withRetrievalViewsForEvalIngest(retrievalViews, () => index.refresh());
       await index.save();
     }
-    merged.push(...await index.query(query, k));
+    merged.push(...await index.query(query, k, { retrievalViews }));
   }
   merged.sort((a, b) => b.score - a.score);
   return merged.slice(0, k).map(toScoredDocument);
@@ -576,14 +600,18 @@ async function retrieveHybrid(
   const k = fixtureCase.k ?? context.defaultK;
   const fetchK = hybridFetchK(k);
   const retrieveLexicalFn = context.retrieveLexical ?? retrieveLexical;
+  const retrievalViews = retrievalViewsForCase(fixtureCase);
   const [denseResults, lexicalResults] = await Promise.all([
     context.manager.similaritySearch(
       fixtureCase.query,
       fetchK,
       Number.POSITIVE_INFINITY,
       fixtureCase.kb,
+      undefined,
+      undefined,
+      { retrievalViews },
     ),
-    retrieveLexicalFn(fixtureCase.query, fetchK, fixtureCase.kb),
+    retrieveLexicalFn(fixtureCase.query, fetchK, fixtureCase.kb, retrievalViews),
   ]);
   // Pass the scoped KB so the RFC 020 §9 skip-rerank fallback (per-domain gate)
   // is honored here too, and the fused candidate depth matches the real config.
@@ -602,6 +630,38 @@ async function retrieveHybrid(
     kbScope: fixtureCase.kb ?? null,
   });
   return reranked.results;
+}
+
+function retrievalViewsForCase(fixtureCase: RetrievalEvalCase): RetrievalViewKind[] | undefined {
+  const raw = (fixtureCase as RetrievalEvalCase & { retrieval_views?: unknown }).retrievalViews
+    ?? (fixtureCase as RetrievalEvalCase & { retrieval_views?: unknown }).retrieval_views;
+  if (raw === undefined) return undefined;
+  if (Array.isArray(raw)) return raw.filter((value): value is RetrievalViewKind =>
+    typeof value === 'string' && (RETRIEVAL_VIEW_KINDS as readonly string[]).includes(value),
+  );
+  if (typeof raw === 'string') {
+    const parsed = parseRetrievalViews(raw);
+    return parsed.length > 0 ? parsed : undefined;
+  }
+  return undefined;
+}
+
+async function withRetrievalViewsForEvalIngest<T>(
+  views: readonly RetrievalViewKind[] | undefined,
+  fn: () => Promise<T>,
+): Promise<T> {
+  if (views === undefined || views.length === 0) return fn();
+  const previous = process.env[KB_RETRIEVAL_VIEWS_ENV];
+  process.env[KB_RETRIEVAL_VIEWS_ENV] = formatRetrievalViews(views);
+  try {
+    return await fn();
+  } finally {
+    if (previous === undefined) {
+      delete process.env[KB_RETRIEVAL_VIEWS_ENV];
+    } else {
+      process.env[KB_RETRIEVAL_VIEWS_ENV] = previous;
+    }
+  }
 }
 
 function toScoredDocument(result: LexicalSearchResult): ScoredDocument {

--- a/src/retrieval-views.test.ts
+++ b/src/retrieval-views.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from '@jest/globals';
+import { Document } from '@langchain/core/documents';
+
+import { embeddingText } from './contextual-preface.js';
+import {
+  buildRetrievalViewDocuments,
+  collapseRetrievalViewResults,
+  parseRetrievalViews,
+  shouldKeepForRetrievalViews,
+} from './retrieval-views.js';
+
+function canonicalDoc(): Document {
+  return new Document({
+    pageContent: '## Rollback\n\nRollback approval requires the release lead.',
+    metadata: {
+      source: '/kb/ops/runbook.md',
+      relativePath: 'ops/runbook.md',
+      knowledgeBase: 'ops',
+      extension: '.md',
+      chunkIndex: 3,
+      tags: ['deploy'],
+      frontmatter: { title: 'Operations Runbook' },
+      contextual_preface: 'In section "Rollback", this chunk describes release rollback approval.',
+    },
+  });
+}
+
+describe('retrieval views', () => {
+  it('parses csv, all, and off retrieval-view flags', () => {
+    expect(parseRetrievalViews('passage,section,metadata,section')).toEqual([
+      'passage',
+      'section',
+      'metadata',
+    ]);
+    expect(parseRetrievalViews('all')).toEqual(['passage', 'section', 'metadata', 'summary']);
+    expect(parseRetrievalViews('off')).toEqual([]);
+    expect(() => parseRetrievalViews('passage,unknown')).toThrow(/invalid retrieval view/);
+  });
+
+  it('emits extra view documents mapped to the canonical chunk', () => {
+    const docs = buildRetrievalViewDocuments([canonicalDoc()], ['passage', 'section', 'metadata', 'summary']);
+    expect(docs).toHaveLength(4);
+    expect(docs[0].metadata.retrieval_view).toBeUndefined();
+
+    const views = docs.slice(1).map((doc) => doc.metadata.retrieval_view as Record<string, unknown>);
+    expect(views.map((view) => view.kind)).toEqual(['section', 'metadata', 'summary']);
+    expect(embeddingText(docs[1])).toContain('Source: Operations Runbook');
+    expect(embeddingText(docs[2])).toContain('Path: ops/runbook.md');
+    expect(embeddingText(docs[3])).toContain('Summary: In section "Rollback"');
+    for (const view of views) {
+      expect(view).toMatchObject({
+        schema_version: 'kb.retrieval-view.v1',
+        canonical_id: '/kb/ops/runbook.md#3',
+        canonical_source: '/kb/ops/runbook.md',
+        canonical_chunk_index: 3,
+      });
+    }
+  });
+
+  it('keeps view records out of default searches and includes requested views only when opted in', () => {
+    const [, section, metadata] = buildRetrievalViewDocuments([canonicalDoc()], ['section', 'metadata']);
+    expect(shouldKeepForRetrievalViews(canonicalDoc(), undefined)).toBe(true);
+    expect(shouldKeepForRetrievalViews(section, undefined)).toBe(false);
+    expect(shouldKeepForRetrievalViews(section, ['section'])).toBe(true);
+    expect(shouldKeepForRetrievalViews(metadata, ['section'])).toBe(false);
+    expect(shouldKeepForRetrievalViews(canonicalDoc(), ['metadata'])).toBe(false);
+  });
+
+  it('collapses multiple view hits into one canonical result with diagnostics', () => {
+    const [passage, section, metadata] = buildRetrievalViewDocuments([canonicalDoc()], ['section', 'metadata']);
+    const collapsed = collapseRetrievalViewResults([
+      { ...section, score: 0.8 },
+      { ...metadata, score: 0.7 },
+      { ...passage, score: 0.9 },
+    ]);
+
+    expect(collapsed).toHaveLength(1);
+    expect(collapsed[0].pageContent).toBe(passage.pageContent);
+    expect(collapsed[0].metadata.retrieval_view).toBeUndefined();
+    expect(collapsed[0].metadata.retrieval_view_collapse).toMatchObject({
+      canonical_id: '/kb/ops/runbook.md#3',
+      hit_count: 3,
+      hits: [
+        { view: 'section', rank: 1, score: 0.8 },
+        { view: 'metadata', rank: 2, score: 0.7 },
+        { view: 'passage', rank: 3, score: 0.9 },
+      ],
+      zoom_out: {
+        source_title: 'Operations Runbook',
+        section_title: 'Rollback',
+      },
+    });
+    expect(collapsed[0].score).toBeLessThan(0.7);
+  });
+
+  it('strengthens and sorts higher-is-better lexical scores correctly', () => {
+    const [passageA, sectionA] = buildRetrievalViewDocuments([canonicalDoc()], ['section']);
+    const [passageB, sectionB] = buildRetrievalViewDocuments([
+      new Document({
+        pageContent: '## Deploy\n\nDeploy notes.',
+        metadata: {
+          source: '/kb/ops/deploy.md',
+          relativePath: 'ops/deploy.md',
+          knowledgeBase: 'ops',
+          extension: '.md',
+          chunkIndex: 0,
+        },
+      }),
+    ], ['section']);
+
+    const collapsed = collapseRetrievalViewResults([
+      { ...sectionA, score: 4 },
+      { ...passageA, score: 3 },
+      { ...sectionB, score: 7 },
+      { ...passageB, score: 6 },
+    ], { scoreDirection: 'higher' });
+
+    expect(collapsed.map((doc) => doc.metadata.source)).toEqual([
+      '/kb/ops/deploy.md',
+      '/kb/ops/runbook.md',
+    ]);
+    expect(collapsed[0].score).toBeGreaterThan(7);
+  });
+});

--- a/src/retrieval-views.ts
+++ b/src/retrieval-views.ts
@@ -1,0 +1,378 @@
+import * as crypto from 'crypto';
+import * as path from 'path';
+import { Document } from '@langchain/core/documents';
+
+export const RETRIEVAL_VIEW_SCHEMA_VERSION = 'kb.retrieval-view.v1';
+export const KB_RETRIEVAL_VIEWS_ENV = 'KB_RETRIEVAL_VIEWS';
+
+export type RetrievalViewKind = 'passage' | 'section' | 'metadata' | 'summary';
+
+export const RETRIEVAL_VIEW_KINDS: readonly RetrievalViewKind[] = [
+  'passage',
+  'section',
+  'metadata',
+  'summary',
+];
+
+const EXTRA_VIEW_KINDS: readonly Exclude<RetrievalViewKind, 'passage'>[] = ['section', 'metadata', 'summary'];
+
+export interface RetrievalViewMetadata {
+  schema_version: typeof RETRIEVAL_VIEW_SCHEMA_VERSION;
+  kind: RetrievalViewKind;
+  view_id: string;
+  canonical_id: string;
+  canonical_source: string;
+  canonical_chunk_index: number;
+  text_hash: string;
+  parent?: RetrievalViewParentContext;
+}
+
+export interface RetrievalViewParentContext {
+  source_title?: string;
+  section_title?: string;
+  relative_path?: string;
+  summary?: string;
+}
+
+export interface RetrievalViewHitDiagnostic {
+  view: RetrievalViewKind;
+  rank: number;
+  score: number;
+}
+
+export interface RetrievalViewCollapseMetadata {
+  schema_version: typeof RETRIEVAL_VIEW_SCHEMA_VERSION;
+  canonical_id: string;
+  hit_count: number;
+  hits: RetrievalViewHitDiagnostic[];
+  zoom_out?: RetrievalViewParentContext;
+}
+
+export interface RetrievalViewCollapseOptions {
+  scoreDirection?: 'lower' | 'higher';
+}
+
+export function parseRetrievalViews(raw: string | undefined): RetrievalViewKind[] {
+  if (raw === undefined) return [];
+  const trimmed = raw.trim();
+  if (trimmed === '' || trimmed === 'off' || trimmed === 'none') return [];
+  if (trimmed === 'all') return [...RETRIEVAL_VIEW_KINDS];
+
+  const out: RetrievalViewKind[] = [];
+  const seen = new Set<RetrievalViewKind>();
+  for (const part of trimmed.split(',')) {
+    const value = part.trim().toLowerCase();
+    if (value === '') continue;
+    if (!isRetrievalViewKind(value)) {
+      throw new Error(
+        `invalid retrieval view "${part}" (expected ${RETRIEVAL_VIEW_KINDS.join(', ')}, all, none, or off)`,
+      );
+    }
+    if (!seen.has(value)) {
+      seen.add(value);
+      out.push(value);
+    }
+  }
+  return out;
+}
+
+export function resolveRetrievalViews(env: NodeJS.ProcessEnv = process.env): RetrievalViewKind[] {
+  return parseRetrievalViews(env[KB_RETRIEVAL_VIEWS_ENV]);
+}
+
+export function formatRetrievalViews(views: readonly RetrievalViewKind[]): string {
+  return views.join(',');
+}
+
+export function isRetrievalViewDocument(doc: Pick<Document, 'metadata'>): boolean {
+  return readRetrievalViewMetadata(doc.metadata as Record<string, unknown> | undefined) !== null;
+}
+
+export function readRetrievalViewMetadata(
+  metadata: Record<string, unknown> | undefined,
+): RetrievalViewMetadata | null {
+  if (metadata === undefined) return null;
+  const raw = metadata.retrieval_view;
+  if (!isRecord(raw)) return null;
+  if (raw.schema_version !== RETRIEVAL_VIEW_SCHEMA_VERSION) return null;
+  if (typeof raw.kind !== 'string' || !isRetrievalViewKind(raw.kind)) return null;
+  if (
+    typeof raw.view_id !== 'string' ||
+    typeof raw.canonical_id !== 'string' ||
+    typeof raw.canonical_source !== 'string' ||
+    typeof raw.canonical_chunk_index !== 'number' ||
+    !Number.isSafeInteger(raw.canonical_chunk_index) ||
+    typeof raw.text_hash !== 'string'
+  ) {
+    return null;
+  }
+  return raw as unknown as RetrievalViewMetadata;
+}
+
+export function retrievalViewText(doc: Pick<Document, 'metadata'>): string | null {
+  const raw = (doc.metadata as Record<string, unknown> | undefined)?.retrieval_view_text;
+  return typeof raw === 'string' && raw.trim() !== '' ? raw : null;
+}
+
+export function canonicalRetrievalId(metadata: Record<string, unknown>): string {
+  const view = readRetrievalViewMetadata(metadata);
+  if (view !== null) return view.canonical_id;
+  const source = typeof metadata.source === 'string' ? metadata.source : null;
+  const chunkIndex = typeof metadata.chunkIndex === 'number' ? metadata.chunkIndex : null;
+  if (source !== null && chunkIndex !== null) return `${source}#${chunkIndex}`;
+  return `meta:${JSON.stringify(metadata)}`;
+}
+
+export function buildRetrievalViewDocuments(
+  canonicalDocuments: readonly Document[],
+  views: readonly RetrievalViewKind[] = resolveRetrievalViews(),
+): Document[] {
+  if (canonicalDocuments.length === 0 || views.length === 0) {
+    return [...canonicalDocuments];
+  }
+
+  const requested = new Set(views);
+  const out = [...canonicalDocuments];
+  for (const doc of canonicalDocuments) {
+    const metadata = doc.metadata as Record<string, unknown>;
+    const source = typeof metadata.source === 'string' ? metadata.source : '';
+    const chunkIndex = typeof metadata.chunkIndex === 'number' ? metadata.chunkIndex : -1;
+    if (source === '' || chunkIndex < 0) continue;
+
+    const parent = parentContextFor(doc);
+    for (const kind of EXTRA_VIEW_KINDS) {
+      if (!requested.has(kind)) continue;
+      const text = textForView(kind, doc, parent);
+      if (text === null) continue;
+      out.push(new Document({
+        pageContent: doc.pageContent,
+        metadata: {
+          ...metadata,
+          retrieval_view: {
+            schema_version: RETRIEVAL_VIEW_SCHEMA_VERSION,
+            kind,
+            view_id: `${canonicalRetrievalId(metadata)}::${kind}`,
+            canonical_id: canonicalRetrievalId(metadata),
+            canonical_source: source,
+            canonical_chunk_index: chunkIndex,
+            text_hash: sha256(text),
+            ...(Object.keys(parent).length > 0 ? { parent } : {}),
+          } satisfies RetrievalViewMetadata,
+          retrieval_view_text: text,
+        },
+      }));
+    }
+  }
+  return out;
+}
+
+export function shouldKeepForRetrievalViews(
+  doc: Pick<Document, 'metadata'>,
+  views: readonly RetrievalViewKind[] | undefined,
+): boolean {
+  const view = readRetrievalViewMetadata(doc.metadata as Record<string, unknown> | undefined);
+  if (views === undefined || views.length === 0) {
+    return view === null;
+  }
+  const requested = new Set(views);
+  if (view === null) return requested.has('passage');
+  return requested.has(view.kind);
+}
+
+export function collapseRetrievalViewResults<T extends Document & { score?: number }>(
+  results: readonly T[],
+  options: RetrievalViewCollapseOptions = {},
+): T[] {
+  if (results.length === 0) return [];
+  const scoreDirection = options.scoreDirection ?? 'lower';
+
+  const groups = new Map<string, { representative: T; hits: Array<T & { rank: number; score: number }> }>();
+  results.forEach((result, index) => {
+    const metadata = result.metadata as Record<string, unknown>;
+    const id = canonicalRetrievalId(metadata);
+    const score = typeof result.score === 'number' ? result.score : 0;
+    const existing = groups.get(id);
+    const hit = { ...result, rank: index + 1, score };
+    if (existing === undefined) {
+      groups.set(id, { representative: result, hits: [hit] });
+      return;
+    }
+    existing.hits.push(hit);
+    if (isBetterRepresentative(result, existing.representative)) {
+      existing.representative = result;
+    }
+  });
+
+  const collapsed: T[] = [];
+  for (const [id, group] of groups) {
+    const scores = group.hits.map((hit) => hit.score);
+    const bestScore = scoreDirection === 'higher' ? Math.max(...scores) : Math.min(...scores);
+    const strengthMultiplier = 1 + Math.min(group.hits.length - 1, 6) * 0.05;
+    const strengthenedScore = scoreDirection === 'higher'
+      ? bestScore * strengthMultiplier
+      : bestScore / strengthMultiplier;
+    const sortedHits = [...group.hits].sort((a, b) => a.rank - b.rank);
+    const zoomOut = mergeParentContext(sortedHits);
+    const metadata = {
+      ...(group.representative.metadata as Record<string, unknown>),
+      retrieval_view_collapse: {
+        schema_version: RETRIEVAL_VIEW_SCHEMA_VERSION,
+        canonical_id: id,
+        hit_count: sortedHits.length,
+        hits: sortedHits.map((hit) => ({
+          view: readRetrievalViewMetadata(hit.metadata as Record<string, unknown>)?.kind ?? 'passage',
+          rank: hit.rank,
+          score: hit.score,
+        })),
+        ...(zoomOut !== undefined ? { zoom_out: zoomOut } : {}),
+      } satisfies RetrievalViewCollapseMetadata,
+    };
+    collapsed.push({
+      ...group.representative,
+      metadata,
+      score: strengthenedScore,
+    });
+  }
+
+  collapsed.sort((left, right) => {
+    const leftScore = typeof left.score === 'number' ? left.score : Number.POSITIVE_INFINITY;
+    const rightScore = typeof right.score === 'number' ? right.score : Number.POSITIVE_INFINITY;
+    return scoreDirection === 'higher' ? rightScore - leftScore : leftScore - rightScore;
+  });
+  return collapsed;
+}
+
+function isRetrievalViewKind(value: string): value is RetrievalViewKind {
+  return (RETRIEVAL_VIEW_KINDS as readonly string[]).includes(value);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isBetterRepresentative(candidate: Document, current: Document): boolean {
+  const candidateIsView = isRetrievalViewDocument(candidate);
+  const currentIsView = isRetrievalViewDocument(current);
+  if (currentIsView && !candidateIsView) return true;
+  return false;
+}
+
+function parentContextFor(doc: Document): RetrievalViewParentContext {
+  const metadata = doc.metadata as Record<string, unknown>;
+  const title = titleFromMetadata(metadata) ?? basenameTitle(metadata);
+  const sectionTitle = sectionTitleFromText(doc.pageContent) ?? sectionTitleFromPreface(metadata);
+  const summary = summaryFromDoc(doc, title, sectionTitle);
+  return {
+    ...(title !== undefined ? { source_title: title } : {}),
+    ...(sectionTitle !== undefined ? { section_title: sectionTitle } : {}),
+    ...(typeof metadata.relativePath === 'string' ? { relative_path: metadata.relativePath } : {}),
+    ...(summary !== undefined ? { summary } : {}),
+  };
+}
+
+function textForView(kind: Exclude<RetrievalViewKind, 'passage'>, doc: Document, parent: RetrievalViewParentContext): string | null {
+  const metadata = doc.metadata as Record<string, unknown>;
+  const preface = typeof metadata.contextual_preface === 'string' ? metadata.contextual_preface : '';
+  if (kind === 'metadata') {
+    const parts = [
+      parent.source_title ? `Title: ${parent.source_title}` : null,
+      parent.relative_path ? `Path: ${parent.relative_path}` : null,
+      typeof metadata.knowledgeBase === 'string' ? `Knowledge base: ${metadata.knowledgeBase}` : null,
+      typeof metadata.extension === 'string' ? `Extension: ${metadata.extension}` : null,
+      tagsText(metadata),
+      parent.section_title ? `Section: ${parent.section_title}` : null,
+    ].filter((part): part is string => part !== null);
+    return parts.length > 0 ? parts.join('\n') : null;
+  }
+  if (kind === 'section') {
+    const parts = [
+      parent.source_title ? `Source: ${parent.source_title}` : null,
+      parent.section_title ? `Section: ${parent.section_title}` : null,
+      preface !== '' ? preface : null,
+      snippet(doc.pageContent, 700),
+    ].filter((part): part is string => part !== null && part.trim() !== '');
+    return parts.length > 0 ? parts.join('\n\n') : null;
+  }
+  const summary = parent.summary ?? summaryFromDoc(doc, parent.source_title, parent.section_title);
+  return summary === undefined ? null : `Summary: ${summary}`;
+}
+
+function titleFromMetadata(metadata: Record<string, unknown>): string | undefined {
+  const frontmatter = metadata.frontmatter;
+  if (!isRecord(frontmatter)) return undefined;
+  const title = frontmatter.title;
+  return typeof title === 'string' && title.trim() !== '' ? title.trim() : undefined;
+}
+
+function basenameTitle(metadata: Record<string, unknown>): string | undefined {
+  const raw = typeof metadata.relativePath === 'string'
+    ? metadata.relativePath
+    : typeof metadata.source === 'string'
+      ? metadata.source
+      : undefined;
+  if (raw === undefined || raw.trim() === '') return undefined;
+  return path.basename(raw, path.extname(raw)).replace(/[-_]+/g, ' ');
+}
+
+function sectionTitleFromText(text: string): string | undefined {
+  const match = text.match(/^\s{0,3}#{1,6}\s+(.+?)\s*#*\s*$/m);
+  return match?.[1]?.trim();
+}
+
+function sectionTitleFromPreface(metadata: Record<string, unknown>): string | undefined {
+  const preface = metadata.contextual_preface;
+  if (typeof preface !== 'string') return undefined;
+  const match = preface.match(/(?:section|under)\s+"([^"]+)"/i);
+  return match?.[1]?.trim();
+}
+
+function summaryFromDoc(
+  doc: Document,
+  title: string | undefined,
+  sectionTitle: string | undefined,
+): string | undefined {
+  const metadata = doc.metadata as Record<string, unknown>;
+  const preface = typeof metadata.contextual_preface === 'string' ? metadata.contextual_preface.trim() : '';
+  if (preface !== '') return preface;
+  const firstSentence = doc.pageContent
+    .replace(/^\s{0,3}#{1,6}\s+.+$/gm, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .match(/^(.{20,320}?[.!?])(?:\s|$)/)?.[1]
+    ?.trim();
+  if (firstSentence !== undefined) {
+    return [title, sectionTitle, firstSentence].filter(Boolean).join(' - ');
+  }
+  const fallback = snippet(doc.pageContent, 240);
+  return fallback === null ? undefined : [title, sectionTitle, fallback].filter(Boolean).join(' - ');
+}
+
+function snippet(text: string, maxChars: number): string | null {
+  const normalized = text.replace(/\s+/g, ' ').trim();
+  if (normalized === '') return null;
+  return normalized.length <= maxChars ? normalized : `${normalized.slice(0, maxChars - 1).trim()}...`;
+}
+
+function tagsText(metadata: Record<string, unknown>): string | null {
+  const tags = metadata.tags;
+  if (!Array.isArray(tags)) return null;
+  const values = tags.filter((tag): tag is string => typeof tag === 'string' && tag.trim() !== '');
+  return values.length > 0 ? `Tags: ${values.join(', ')}` : null;
+}
+
+function mergeParentContext(hits: ReadonlyArray<Document>): RetrievalViewParentContext | undefined {
+  const out: RetrievalViewParentContext = {};
+  for (const hit of hits) {
+    const parent = readRetrievalViewMetadata(hit.metadata as Record<string, unknown>)?.parent;
+    if (parent === undefined) continue;
+    out.source_title ??= parent.source_title;
+    out.section_title ??= parent.section_title;
+    out.relative_path ??= parent.relative_path;
+    out.summary ??= parent.summary;
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+function sha256(text: string): string {
+  return crypto.createHash('sha256').update(text).digest('hex');
+}

--- a/src/rrf.ts
+++ b/src/rrf.ts
@@ -73,6 +73,11 @@ export const DEFAULT_C = 60;
  * `chunkIndex` for every chunk it emits, so the fallback is defense-in-depth.
  */
 export function chunkIdFromMetadata(meta: Record<string, unknown>): string {
+  const view = meta.retrieval_view;
+  if (typeof view === 'object' && view !== null && !Array.isArray(view)) {
+    const canonicalId = (view as Record<string, unknown>).canonical_id;
+    if (typeof canonicalId === 'string' && canonicalId.length > 0) return canonicalId;
+  }
   const source = typeof meta.source === 'string' ? meta.source : null;
   const chunkIndex = typeof meta.chunkIndex === 'number' ? meta.chunkIndex : null;
   if (source !== null && chunkIndex !== null) return `${source}#${chunkIndex}`;


### PR DESCRIPTION
## Summary

Closes #575.

Implements an opt-in multi-view retrieval path that keeps default search behavior unchanged while allowing a view-enriched index/search mode:

- adds `RetrievalView` records for `section`, `metadata`, and `summary` views, mapped back to canonical source/chunk ids
- keeps canonical passage content as the returned result text; view text is used only for dense/BM25 indexing
- filters view records out of default searches, even when an index contains view records
- collapses opt-in view hits back to one canonical result with `retrieval_view_collapse` diagnostics and zoom-out parent context metadata
- wires `--retrieval-views=passage,section,metadata,summary` / `all` through `kb search`, dense search, lexical search, hybrid RRF, retrieval-eval, BEIR matrix, and BRIGHT runners
- records `KB_RETRIEVAL_VIEWS` in config validation and benchmark env snapshots

## Benchmark Dependency

This PR depends on #573 for authoritative baseline/full-matrix numbers. It intentionally does not make multi-view default-on.

Evaluation attempted here:

- `npm run bench:beir -- --dataset=scifact --split=test --mode=hybrid --provider=ollama --model=nomic-embed-text:latest --max-queries=5 --output-dir=benchmarks/results/beir/issue575-sample-baseline --workspace-root=/tmp/kb-issue575-beir-baseline --cache-dir=/tmp/kb-beir-cache`
- Result: infeasible in this run because BEIR dataset download failed twice before retrieval with `TypeError: fetch failed` in `downloadBytes`. No metrics were fabricated.

Pending after #573/dataset availability:

- BEIR sample: SciFact, NFCorpus, FiQA, ArguAna, SciDocs baseline hybrid vs multi-view hybrid
- BRIGHT sample: biology/economics if task data is available
- RAG eval: HotpotQA sample if supporting-fact harness inputs are available
- Record nDCG@10, Recall@10, Recall@100, MAP@100, ingest time, index size, and latency p50/p95

## Verification

- `npm run build`
- `npm test -- --runInBand src/retrieval-views.test.ts src/retrieval-eval.test.ts src/hybrid-retrieval.test.ts src/cli-search.test.ts src/contextual-preface.test.ts benchmarks/beir/run.test.ts benchmarks/beir/matrix.test.ts benchmarks/bright/run.test.ts`

Note: tests emit existing MaxListeners warnings from the contextual-preface suite; the suite passes.

## Pre-PR Review

- detected project type: npm
- type/build checks: passed
- tests: passed
- bug reproduction: skipped (feature PR)
- diff review: done
- portability check: clean via manual added-line scan (helper script not present)
- reviewer specialists: run; blocking/suggestion findings addressed
- OSS base-branch policy: skipped (internal repo PR)
- gate file: created

## Sequential Handoff

Please review and merge this PR before any work starts on the next roadmap child (#576). After merge, re-check the base branch state before spawning/starting the next child task.
