### PR TITLE
retrieval: add high-recall hybrid candidate filtering

### DIFF
--- a/benchmarks/beir/run.test.ts
+++ b/benchmarks/beir/run.test.ts
@@ -49,6 +49,7 @@ describe('BEIR benchmark runner', () => {
       `--workspace-root=${workspaceRoot}`,
       '--k=10',
       '--chunk-k=10',
+      '--candidate-pool-k=10',
     ]);
 
     const result = await runBeirBenchmark(args, {
@@ -89,6 +90,12 @@ describe('BEIR benchmark runner', () => {
     const json = JSON.parse(await fsp.readFile(result.jsonPath, 'utf-8')) as {
       git_sha: string;
       metrics: { ndcgAt10: number; mapAt100: number; recallAt10: number; recallAt100: number };
+      high_recall_candidates: {
+        schema_version: string;
+        candidate_pool_k: number;
+        final_k: number;
+        candidate_recall_at100: number;
+      };
       dataset: { corpus_documents: number; queries_evaluated: number };
       command: string;
       ranking: { unit: string; implementation: string; trec_run: string };
@@ -96,6 +103,7 @@ describe('BEIR benchmark runner', () => {
     expect(json.git_sha).toBe('test-sha');
     expect(json.dataset).toMatchObject({ corpus_documents: 2, queries_evaluated: 1 });
     expect(json.command).toContain('--lexical-unit=source');
+    expect(json.command).toContain('--candidate-pool-k=10');
     expect(json.ranking).toMatchObject({
       unit: 'source',
       implementation: 'LexicalIndex source BM25 over whole files, returning one representative chunk per source',
@@ -107,12 +115,19 @@ describe('BEIR benchmark runner', () => {
       recallAt10: 1,
       recallAt100: 1,
     });
+    expect(json.high_recall_candidates).toMatchObject({
+      schema_version: 'kb.beir.high-recall-candidates.v1',
+      candidate_pool_k: 10,
+      final_k: 10,
+      candidate_recall_at100: 1,
+    });
     await expect(fsp.readFile(result.trecPath, 'utf-8')).resolves.toBe(
       'q1 Q0 doc-alpha 1 42.000000 kb-tiny-lexical-source\n',
     );
     const report = await fsp.readFile(result.reportPath, 'utf-8');
     expect(report).toContain('This is a local BEIR benchmark run, not an official leaderboard submission.');
     expect(report).toContain('--lexical-unit=source');
+    expect(report).toContain('Candidate Recall@100: 1 (pool=10, final k=10)');
     await expect(fsp.stat(workspaceRoot)).rejects.toMatchObject({ code: 'ENOENT' });
   });
 

--- a/benchmarks/beir/run.ts
+++ b/benchmarks/beir/run.ts
@@ -110,6 +110,7 @@ interface Args {
   datasetUrl?: string;
   k: number;
   chunkK: number;
+  candidatePoolK?: number;
   maxQueries?: number;
   keepWorkspace: boolean;
 }
@@ -137,6 +138,8 @@ type BeirConfigKey =
   | 'k'
   | 'chunk_k'
   | 'chunkK'
+  | 'candidate_pool_k'
+  | 'candidatePoolK'
   | 'max_queries'
   | 'maxQueries'
   | 'keep_workspace'
@@ -288,6 +291,13 @@ interface BeirBenchmarkReport {
     chunks: number;
   };
   metrics: ReturnType<typeof aggregateQueryMetrics>;
+  high_recall_candidates?: {
+    schema_version: 'kb.beir.high-recall-candidates.v1';
+    candidate_pool_k: number;
+    final_k: number;
+    candidate_recall_at100: number;
+    candidate_metrics: ReturnType<typeof aggregateQueryMetrics>;
+  };
   latency: ReturnType<typeof summarizeLatencies>;
   per_query: QueryMetric[];
   caveats: string[];
@@ -363,7 +373,7 @@ export async function runBeirBenchmark(
   } finally {
     restoreStageEnv();
   }
-  const { queryRows, perQuery, latenciesMs, indexMs, indexing, ranking: rankingMeta, embedding } = retrieval;
+  const { queryRows, perQuery, candidatePerQuery, latenciesMs, indexMs, indexing, ranking: rankingMeta, embedding } = retrieval;
   const stages = resolveStageProvenance(args.mode);
 
   const runTag = `kb-${args.dataset}-${args.mode}-${rankingMeta.unit}`;
@@ -415,6 +425,17 @@ export async function runBeirBenchmark(
       chunks: indexing.chunks,
     },
     metrics: aggregateQueryMetrics(perQuery),
+    ...(candidatePerQuery !== undefined && args.candidatePoolK !== undefined
+      ? {
+          high_recall_candidates: {
+            schema_version: 'kb.beir.high-recall-candidates.v1',
+            candidate_pool_k: args.candidatePoolK,
+            final_k: args.k,
+            candidate_recall_at100: aggregateQueryMetrics(candidatePerQuery).recallAt100,
+            candidate_metrics: aggregateQueryMetrics(candidatePerQuery),
+          },
+        }
+      : {}),
     latency: summarizeLatencies(latenciesMs),
     per_query: perQuery,
     caveats: buildCaveats(args),
@@ -433,6 +454,7 @@ export async function runBeirBenchmark(
 interface RetrievalOutcome {
   queryRows: Array<{ queryId: string; ranking: RankedDocument[] }>;
   perQuery: QueryMetric[];
+  candidatePerQuery?: QueryMetric[];
   latenciesMs: number[];
   indexMs: number;
   indexing: {
@@ -463,24 +485,31 @@ async function runLexicalRetrieval(input: RetrievalInput): Promise<RetrievalOutc
 
   const queryRows: Array<{ queryId: string; ranking: RankedDocument[] }> = [];
   const perQuery: QueryMetric[] = [];
+  const candidatePerQuery: QueryMetric[] = [];
   const latenciesMs: number[] = [];
   for (const query of selectedQueries) {
     const started = process.hrtime.bigint();
-    const fetchK = args.lexicalUnit === 'source' ? args.k : args.chunkK;
+    const fetchK = args.candidatePoolK ?? (args.lexicalUnit === 'source' ? args.k : args.chunkK);
     const chunks = await lexicalIndex.query(query.text, fetchK, {
       unit: args.lexicalUnit,
-      candidateK: args.chunkK,
+      candidateK: args.candidatePoolK ?? args.chunkK,
     });
     latenciesMs.push(durationMs(started, process.hrtime.bigint()));
     const ranking = collapseChunksToDocuments(chunks, prepared.docIdByRelativePath, args.k);
     queryRows.push({ queryId: query._id, ranking });
     const scored = scoreQuery(query._id, ranking, qrels);
     if (scored !== null) perQuery.push(scored);
+    if (args.candidatePoolK !== undefined) {
+      const candidateRanking = collapseChunksToDocuments(chunks, prepared.docIdByRelativePath, 100);
+      const candidateScored = scoreQuery(query._id, candidateRanking, qrels);
+      if (candidateScored !== null) candidatePerQuery.push(candidateScored);
+    }
   }
 
   return {
     queryRows,
     perQuery,
+    ...(args.candidatePoolK !== undefined ? { candidatePerQuery } : {}),
     latenciesMs,
     indexMs,
     indexing: { refresh, files: lexicalIndex.numFiles(), chunks: lexicalIndex.numChunks() },
@@ -527,22 +556,29 @@ async function runDenseRetrieval(input: RetrievalInput): Promise<RetrievalOutcom
 
   const queryRows: Array<{ queryId: string; ranking: RankedDocument[] }> = [];
   const perQuery: QueryMetric[] = [];
+  const candidatePerQuery: QueryMetric[] = [];
   const latenciesMs: number[] = [];
   for (const query of selectedQueries) {
     const started = process.hrtime.bigint();
     // Fetch at chunk depth, then collapse to BEIR documents. The production
     // path returns chunks best-first; collapse preserves that order.
-    const chunks = await backend.search(query.text, args.chunkK);
+    const chunks = await backend.search(query.text, args.candidatePoolK ?? args.chunkK);
     latenciesMs.push(durationMs(started, process.hrtime.bigint()));
     const ranking = collapseRankedChunksToDocuments(chunks, prepared.docIdByRelativePath, args.k);
     queryRows.push({ queryId: query._id, ranking });
     const scored = scoreQuery(query._id, ranking, qrels);
     if (scored !== null) perQuery.push(scored);
+    if (args.candidatePoolK !== undefined) {
+      const candidateRanking = collapseRankedChunksToDocuments(chunks, prepared.docIdByRelativePath, 100);
+      const candidateScored = scoreQuery(query._id, candidateRanking, qrels);
+      if (candidateScored !== null) candidatePerQuery.push(candidateScored);
+    }
   }
 
   return {
     queryRows,
     perQuery,
+    ...(args.candidatePoolK !== undefined ? { candidatePerQuery } : {}),
     latenciesMs,
     indexMs,
     indexing: { files: prep.files, chunks: prep.chunks },
@@ -895,6 +931,8 @@ export function parseArgs(argv: string[]): Args {
       args.k = parsePositiveInteger(readValue(), '--k');
     } else if (flag === '--chunk-k') {
       args.chunkK = parsePositiveInteger(readValue(), '--chunk-k');
+    } else if (flag === '--candidate-pool-k') {
+      args.candidatePoolK = parsePositiveInteger(readValue(), '--candidate-pool-k');
     } else if (flag === '--max-queries') {
       args.maxQueries = parsePositiveInteger(readValue(), '--max-queries');
     } else if (flag === '--keep-workspace') {
@@ -913,6 +951,9 @@ export function parseArgs(argv: string[]): Args {
     throw new Error(`unsupported dataset "${args.dataset}"; pass --dataset-dir or --dataset-url for custom BEIR data`);
   }
   args.chunkK = Math.max(args.chunkK, args.k);
+  if (args.candidatePoolK !== undefined && args.candidatePoolK < args.k) {
+    throw new Error(`--candidate-pool-k must be >= --k (got ${args.candidatePoolK} < ${args.k})`);
+  }
   return args;
 }
 
@@ -991,6 +1032,8 @@ function applyBeirConfig(args: Args, beir: Partial<Record<BeirConfigKey, unknown
       args.k = parsePositiveIntegerConfig(value, 'beir.k');
     } else if (key === 'chunk_k' || key === 'chunkK') {
       args.chunkK = parsePositiveIntegerConfig(value, `beir.${key}`);
+    } else if (key === 'candidate_pool_k' || key === 'candidatePoolK') {
+      args.candidatePoolK = parsePositiveIntegerConfig(value, `beir.${key}`);
     } else if (key === 'max_queries' || key === 'maxQueries') {
       args.maxQueries = parsePositiveIntegerConfig(value, `beir.${key}`);
     } else if (key === 'keep_workspace' || key === 'keepWorkspace') {
@@ -1285,6 +1328,7 @@ function formatBenchmarkCommand(args: Args): string {
   if (args.datasetUrl !== undefined) parts.push(`--dataset-url=${args.datasetUrl}`);
   if (args.k !== 100) parts.push(`--k=${args.k}`);
   if (args.chunkK !== 1000) parts.push(`--chunk-k=${args.chunkK}`);
+  if (args.candidatePoolK !== undefined) parts.push(`--candidate-pool-k=${args.candidatePoolK}`);
   if (args.maxQueries !== undefined) parts.push(`--max-queries=${args.maxQueries}`);
   if (args.keepWorkspace) parts.push('--keep-workspace');
   return parts.join(' ');
@@ -1321,6 +1365,12 @@ function formatMarkdownReport(report: BeirBenchmarkReport, trecPath: string, jso
     `- MAP@100: ${metrics.mapAt100}`,
     `- Recall@10: ${metrics.recallAt10}`,
     `- Recall@100: ${metrics.recallAt100}`,
+    ...(report.high_recall_candidates !== undefined
+      ? [
+          `- Candidate Recall@100: ${report.high_recall_candidates.candidate_recall_at100} ` +
+            `(pool=${report.high_recall_candidates.candidate_pool_k}, final k=${report.high_recall_candidates.final_k})`,
+        ]
+      : []),
     `- Query latency: p50 ${latency.p50Ms} ms, p95 ${latency.p95Ms} ms, p99 ${latency.p99Ms} ms`,
     '',
     '## Artifacts',
@@ -1396,6 +1446,9 @@ Options:
   --workspace-root=<p>   Temporary KB/index workspace. Removed unless --keep-workspace.
   --k=<n>                Document run depth. Default: 100.
   --chunk-k=<n>          Lexical chunk candidates before doc collapse. Default: 1000.
+  --candidate-pool-k=<n> Opt-in high-recall candidate pool depth independent
+                         of --k. Reports candidate Recall@100 before final
+                         document top-k scoring. Must be >= --k.
   --max-queries=<n>      Deterministic smoke-test subset.
   --keep-workspace       Keep the temporary KB/index workspace for inspection.
 `;

--- a/docs/cli-json-contracts.md
+++ b/docs/cli-json-contracts.md
@@ -306,6 +306,13 @@ Stable hybrid fields are `mode`, `results`, `retrievers.dense.fetched`,
 `rerank.cache_hits`, `rerank.degraded`, and `rerank.degrade_reason` are stable
 when the `rerank` object is present.
 
+When `kb search --mode=hybrid --candidate-pool-k=<n> --format=json` is used,
+the payload also includes `high_recall` with schema version
+`kb.search.high-recall-candidates.v1`. Stable child fields are
+`candidate_pool_k`, `final_k`, `pre_filter_count`, `post_filter_count`,
+`reason_counts`, `collapsed_groups[]`, `removed[]`, `recall_candidates`,
+`anchor_filter_relaxed`, and `neighbor_expansion_matches`.
+
 Stable error envelope for dense and hybrid JSON mode:
 
 ```json

--- a/src/cli-search.test.ts
+++ b/src/cli-search.test.ts
@@ -214,6 +214,20 @@ describe('parseSearchArgs reranker (RFC 019)', () => {
   });
 });
 
+describe('parseSearchArgs high-recall candidates (#576)', () => {
+  it('accepts the hybrid candidate-pool control', () => {
+    expect(parseSearchArgs(['query', '--mode=hybrid', '--candidate-pool-k=200'])).toMatchObject({
+      mode: 'hybrid',
+      candidatePoolK: 200,
+    });
+  });
+
+  it('rejects malformed candidate-pool controls', () => {
+    expect(() => parseSearchArgs(['query', '--candidate-pool-k=0'])).toThrow(/invalid --candidate-pool-k/);
+    expect(() => parseSearchArgs(['query', '--candidate-pool-k=nope'])).toThrow(/invalid --candidate-pool-k/);
+  });
+});
+
 describe('parseSearchArgs advanced retrieval operators (#450)', () => {
   it('accepts additive advanced retrieval flags', () => {
     expect(parseSearchArgs([
@@ -1192,6 +1206,15 @@ describe('runSearch timing guard (#331)', () => {
     expect(out.stderr).toContain('advanced retrieval operators are only supported with --mode=dense');
   });
 
+  it('rejects candidate-pool controls outside hybrid mode', async () => {
+    const { deps } = makeDeps();
+
+    const out = await captureSearchOutput(['query', '--mode=dense', '--candidate-pool-k=20'], deps);
+
+    expect(out.code).toBe(2);
+    expect(out.stderr).toContain('--candidate-pool-k is only supported with --mode=hybrid');
+  });
+
   it('renders compact dense search output without changing retrieval semantics', async () => {
     const { deps, manager } = makeDeps();
     manager.similaritySearch.mockResolvedValueOnce([
@@ -1466,6 +1489,111 @@ describe('runSearch timing guard (#331)', () => {
     expect(lexicalIndex.refresh).not.toHaveBeenCalled();
     expect(payload.retrievers.lexical).toMatchObject({ fetched: 1, refreshed: 0, failed: 0 });
     expect(payload.results[0]?.metadata.relativePath).toBe('alpha/warm.md');
+  });
+
+  it('uses --candidate-pool-k to filter a wide hybrid pool before rerank and JSON output', async () => {
+    const manager = {
+      modelDir: '/tmp/kb-test-model',
+      initialize: jest.fn(async () => {}),
+      updateIndex: jest.fn(async () => {}),
+      similaritySearch: jest.fn(async () => [
+        {
+          pageContent: 'dense alpha kinase pathway evidence',
+          metadata: { source: '/kb/a.md', chunkIndex: 0 },
+          score: 0.1,
+        },
+        {
+          pageContent: 'dense alpha kinase pathway evidence',
+          metadata: { source: '/kb/a.md', chunkIndex: 1 },
+          score: 0.2,
+        },
+        {
+          pageContent: 'unanchored weather note',
+          metadata: { source: '/kb/weather.md', chunkIndex: 0 },
+          score: 0.3,
+        },
+      ]),
+    } as unknown as FaissIndexManager & { similaritySearch: jest.Mock };
+    const deps: RunSearchDeps = {
+      bootstrapLayout: jest.fn(async () => {}),
+      resolveActiveModel: jest.fn(async () => 'ollama__nomic-embed-text-latest'),
+      loadManagerForModel: jest.fn(async () => manager),
+      loadWithJsonRetry: jest.fn(async () => {}),
+      listLexicalKbs: jest.fn(async () => [{ kbName: 'alpha', kbPath: '/kb/alpha' }]),
+      runLexicalLeg: jest.fn(async () => ({
+        refreshed: 0,
+        failed: 0,
+        hits: [
+          {
+            pageContent: 'lexical kinase pathway winner',
+            metadata: { source: '/kb/lexical.md', chunkIndex: 0 },
+            score: 9,
+          },
+        ],
+      })),
+    };
+    const restoreFactory = setRerankerFactoryForTests(async () => ({
+      id: 'stub-reranker',
+      rerank: async (_query, candidates) =>
+        candidates.map((candidate) => (candidate.includes('winner') ? 10 : 1)),
+    }));
+    const previousRerank = process.env.KB_RERANK;
+    const previousTopN = process.env.KB_RERANK_TOP_N;
+    process.env.KB_RERANK = 'on';
+    process.env.KB_RERANK_TOP_N = '10';
+
+    try {
+      const out = await captureSearchOutput(
+        [
+          'kinase pathway',
+          '--mode=hybrid',
+          '--candidate-pool-k=4',
+          '--k=2',
+          '--format=json',
+          '--timing',
+          '--no-freshness',
+        ],
+        deps,
+      );
+
+      expect(out.code).toBe(0);
+      expect(manager.similaritySearch).toHaveBeenCalledWith(
+        'kinase pathway',
+        4,
+        Number.POSITIVE_INFINITY,
+        undefined,
+        undefined,
+        expect.any(Object),
+        { noCache: false },
+      );
+      expect(deps.runLexicalLeg).toHaveBeenCalledWith(expect.objectContaining({
+        query: 'kinase pathway',
+        fetchK: 4,
+      }));
+      const payload = JSON.parse(out.stdout);
+      expect(payload.high_recall).toMatchObject({
+        schema_version: 'kb.search.high-recall-candidates.v1',
+        candidate_pool_k: 4,
+        final_k: 2,
+        pre_filter_count: 4,
+        reason_counts: {
+          duplicate_collapse: 1,
+          anchor_filter: 1,
+        },
+      });
+      expect(payload.rerank.candidates).toBe(2);
+      expect(payload.results.map((result: { content: string }) => result.content)).toEqual([
+        'lexical kinase pathway winner',
+        'dense alpha kinase pathway evidence',
+      ]);
+      expect(payload.timing.high_recall_filter_ms).toEqual(expect.any(Number));
+    } finally {
+      restoreFactory();
+      if (previousRerank === undefined) delete process.env.KB_RERANK;
+      else process.env.KB_RERANK = previousRerank;
+      if (previousTopN === undefined) delete process.env.KB_RERANK_TOP_N;
+      else process.env.KB_RERANK_TOP_N = previousTopN;
+    }
   });
 
   it('includes gate_verdict in JSON output when --gate is used', async () => {

--- a/src/cli-search.ts
+++ b/src/cli-search.ts
@@ -59,6 +59,12 @@ import {
   type HybridChunk,
 } from './hybrid-retrieval.js';
 import {
+  applyHighRecallCandidateFilters,
+  highRecallDiagnosticsToJson,
+  resolveCandidatePoolK,
+  type HighRecallFilterDiagnostics,
+} from './high-recall-candidates.js';
+import {
   applyAdvancedRetrieval,
   computeAdvancedCandidateK,
   filterAdvancedRetrievalMetadata,
@@ -150,6 +156,10 @@ Result tuning:
   --threshold=<float>   Max similarity score; lower = closer match (default 2).
   --threshold=auto      Pick a knee-based cutoff from the top-K score curve.
   --k=<int>             Top-K results (default 10).
+  --candidate-pool-k=<int>
+                        Hybrid-only opt-in: fetch and fuse this many dense and
+                        lexical candidates before cheap duplicate/anchor/source
+                        filters and final top-k/rerank.
   --mode=dense|lexical|hybrid|auto
                         Retrieval mode (default: dense). \`hybrid\` fuses
                         dense + BM25 via reciprocal rank fusion (#206).
@@ -302,6 +312,7 @@ interface SearchArgs {
   taskContextFile?: string;
   lexicalUnit: LexicalRankingUnit;
   retrievalViews?: RetrievalViewKind[];
+  candidatePoolK?: number;
 }
 
 export interface RunSearchDeps {
@@ -427,6 +438,18 @@ export async function runSearch(
   if (hasNeighborContext(parsed) && effectiveMode !== 'dense') {
     process.stderr.write('kb search: neighbor context expansion is only supported with --mode=dense\n');
     return 2;
+  }
+  if (parsed.candidatePoolK !== undefined && effectiveMode !== 'hybrid') {
+    process.stderr.write('kb search: --candidate-pool-k is only supported with --mode=hybrid\n');
+    return 2;
+  }
+  if (parsed.candidatePoolK !== undefined) {
+    try {
+      resolveCandidatePoolK(parsed.k, parsed.candidatePoolK);
+    } catch (err) {
+      process.stderr.write(`kb search: ${(err as Error).message}\n`);
+      return 2;
+    }
   }
   if (hasAdvancedRetrieval(parsed) && effectiveMode !== 'dense') {
     process.stderr.write('kb search: advanced retrieval operators are only supported with --mode=dense\n');
@@ -936,6 +959,11 @@ export function parseSearchArgs(rest: string[]): SearchArgs {
       const n = Number(raw.slice('--k='.length));
       if (!Number.isInteger(n) || n <= 0) throw new Error(`invalid --k: ${raw}`);
       out.k = n; continue;
+    }
+    if (raw.startsWith('--candidate-pool-k=')) {
+      const n = Number(raw.slice('--candidate-pool-k='.length));
+      if (!Number.isInteger(n) || n <= 0) throw new Error(`invalid --candidate-pool-k: ${raw}`);
+      out.candidatePoolK = n; continue;
     }
     if (raw.startsWith('--format=')) {
       const v = raw.slice('--format='.length);
@@ -1557,6 +1585,18 @@ function formatFilterSelectivityDiagnosticsFooter(
 function formatFilterDiagnosticValue(key: string, value: string | number): string {
   if (typeof value === 'number' && key.endsWith('_ms')) return `${Math.round(value)}ms`;
   return String(value);
+}
+
+function formatHighRecallDiagnosticsFooter(diagnostics: HighRecallFilterDiagnostics): string {
+  const removed = Object.entries(diagnostics.reasonCounts)
+    .filter(([, count]) => count > 0)
+    .map(([reason, count]) => `${reason}=${count}`)
+    .join(', ');
+  const removedText = removed === '' ? 'no removals' : removed;
+  const relaxed = diagnostics.anchorFilterRelaxed ? '; anchor filter relaxed' : '';
+  return `> _High-recall candidates: pool=${diagnostics.candidatePoolK}, ` +
+    `pre=${diagnostics.preFilterCount}, post=${diagnostics.postFilterCount}, ` +
+    `${removedText}, neighbor_matches=${diagnostics.neighborExpansionMatches}${relaxed}._`;
 }
 
 function defaultBypassedGateVerdict(count: number): RelevanceGateVerdict {
@@ -2336,7 +2376,9 @@ async function runHybridSearch(
   }
 
   const query = parsed.query as string;
-  const fetchK = hybridFetchK(parsed.k);
+  const candidatePoolK = resolveCandidatePoolK(parsed.k, parsed.candidatePoolK);
+  const highRecallEnabled = candidatePoolK !== null;
+  const fetchK = candidatePoolK ?? hybridFetchK(parsed.k);
 
   // -- dense leg -----------------------------------------------------------
   let densePromise: Promise<HybridChunk[]>;
@@ -2448,13 +2490,30 @@ async function runHybridSearch(
   } catch (err) {
     return reportFailure(classifyKbSearchError(err), parsed.format);
   }
-  const fusionK = rerankConfig.enabled ? Math.max(parsed.k, rerankConfig.topN) : parsed.k;
+  const fusionK = highRecallEnabled
+    ? fetchK
+    : rerankConfig.enabled ? Math.max(parsed.k, rerankConfig.topN) : parsed.k;
   const fusion = fuseHybridResultsWithDiagnostics({
     denseResults,
     lexicalResults,
     k: fusionK,
   });
   let ranked = fusion.results;
+  let highRecallDiagnostics: HighRecallFilterDiagnostics | null = null;
+  if (highRecallEnabled) {
+    const highRecallStartedAt = nowMs();
+    const highRecall = applyHighRecallCandidateFilters({
+      query,
+      candidates: ranked,
+      k: parsed.k,
+      candidatePoolK: fetchK,
+      denseDistanceById: fusion.denseDistanceById,
+      lexicalHitIds: fusion.lexicalHitIds,
+    });
+    ranked = highRecall.results;
+    highRecallDiagnostics = highRecall.diagnostics;
+    if (timing) timing.high_recall_filter_ms = elapsedMs(highRecallStartedAt);
+  }
   if (timing) timing.fusion_ms = elapsedMs(fusionStartedAt);
   const rerankResult = await applyRerankerIfEnabled({
     query,
@@ -2523,6 +2582,9 @@ async function runHybridSearch(
         },
       },
       rrf: { c: HYBRID_RRF_C, fetch_k: fetchK },
+      ...(highRecallDiagnostics !== null
+        ? { high_recall: highRecallDiagnosticsToJson(highRecallDiagnostics) }
+        : {}),
       ...(retrievalViewsJson(parsed.retrievalViews) !== null
         ? { retrieval_views: retrievalViewsJson(parsed.retrievalViews) }
         : {}),
@@ -2552,6 +2614,9 @@ async function runHybridSearch(
       width: process.stdout.columns,
     })}\n`;
     output += `> _Hybrid status: dense ${denseResults.length}, lexical ${lexicalResults.length} (${parsed.lexicalUnit}), refreshed ${lexicalResultsRow.refreshed}, failed ${lexicalResultsRow.failed}, RRF c=${HYBRID_RRF_C}._\n`;
+    if (highRecallDiagnostics !== null) {
+      output += `${formatHighRecallDiagnosticsFooter(highRecallDiagnostics)}\n`;
+    }
     if (rerankResult.candidatesIn > 0) {
       const degraded = rerankResult.degraded ? '; degraded to fused order' : '';
       output += `> _Rerank: ${rerankResult.model}; rescored ${rerankResult.candidatesIn} candidate(s), cache hits ${rerankResult.cacheHits}${degraded}._\n`;
@@ -2583,6 +2648,9 @@ async function runHybridSearch(
       )}\n\n`;
     }
     output += `> _Hybrid status: dense fetched ${denseResults.length}, lexical fetched ${lexicalResults.length} with unit=${parsed.lexicalUnit} (refreshed ${lexicalResultsRow.refreshed}, ${lexicalResultsRow.failed} failed); fused via RRF (c=${HYBRID_RRF_C}, fetch_k=${fetchK})._\n`;
+    if (highRecallDiagnostics !== null) {
+      output += `${formatHighRecallDiagnosticsFooter(highRecallDiagnostics)}\n`;
+    }
     if (rerankResult.candidatesIn > 0) {
       const degraded = rerankResult.degraded ? '; degraded to fused order' : '';
       output += `> _Rerank: ${rerankResult.model}; rescored ${rerankResult.candidatesIn} candidate(s), cache hits ${rerankResult.cacheHits}${degraded}._\n`;

--- a/src/high-recall-candidates.test.ts
+++ b/src/high-recall-candidates.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+  applyHighRecallCandidateFilters,
+  highRecallDiagnosticsToJson,
+  resolveCandidatePoolK,
+} from './high-recall-candidates.js';
+import type { HybridChunk } from './hybrid-retrieval.js';
+
+function candidate(source: string, chunkIndex: number, body: string, score = 1): HybridChunk {
+  return {
+    pageContent: body,
+    metadata: { source, chunkIndex },
+    score,
+  };
+}
+
+describe('resolveCandidatePoolK', () => {
+  it('keeps the default path opt-out when no pool is supplied', () => {
+    expect(resolveCandidatePoolK(10, undefined)).toBeNull();
+  });
+
+  it('rejects candidate pools smaller than final k', () => {
+    expect(() => resolveCandidatePoolK(10, 5)).toThrow(/candidatePoolK must be >= k/);
+  });
+});
+
+describe('applyHighRecallCandidateFilters', () => {
+  it('collapses byte-near duplicate chunks and records diagnostic groups', () => {
+    const input = [
+      candidate('a.md', 0, 'Alpha deployment rollback evidence.'),
+      candidate('a.md', 1, 'Alpha deployment rollback evidence.'),
+      candidate('b.md', 0, 'Alpha deployment canary evidence.'),
+    ];
+    const out = applyHighRecallCandidateFilters({
+      query: 'deployment rollback',
+      candidates: input,
+      k: 2,
+      candidatePoolK: 3,
+      lexicalHitIds: new Set(['a.md#0', 'a.md#1', 'b.md#0']),
+    });
+
+    expect(out.results.map((hit) => hit.metadata.chunkIndex)).toEqual([0, 0]);
+    expect(out.diagnostics.reasonCounts.duplicate_collapse).toBe(1);
+    expect(out.diagnostics.collapsedGroups).toEqual([{
+      keptId: 'a.md#0',
+      collapsedIds: ['a.md#1'],
+      source: 'a.md',
+      reason: 'duplicate_collapse',
+    }]);
+  });
+
+  it('caps overrepresented sources after the final-k floor has enough candidates', () => {
+    const input = [
+      candidate('a.md', 0, 'Alpha rollback one.'),
+      candidate('a.md', 1, 'Alpha rollback two.'),
+      candidate('b.md', 0, 'Alpha rollback three.'),
+      candidate('a.md', 2, 'Alpha rollback four.'),
+      candidate('c.md', 0, 'Alpha rollback five.'),
+    ];
+    const out = applyHighRecallCandidateFilters({
+      query: 'alpha rollback',
+      candidates: input,
+      k: 3,
+      candidatePoolK: 5,
+      sourceDiversityCap: 2,
+      lexicalHitIds: new Set(input.map((hit) => `${hit.metadata.source}#${hit.metadata.chunkIndex}`)),
+    });
+
+    expect(out.results.map((hit) => `${hit.metadata.source}:${hit.metadata.chunkIndex}`)).toEqual([
+      'a.md:0',
+      'a.md:1',
+      'b.md:0',
+      'c.md:0',
+    ]);
+    expect(out.diagnostics.reasonCounts.source_diversity_cap).toBe(1);
+    expect(out.diagnostics.removed).toEqual([
+      expect.objectContaining({ id: 'a.md#2', reason: 'source_diversity_cap' }),
+    ]);
+  });
+
+  it('filters unanchored candidates when enough anchored candidates remain', () => {
+    const input = [
+      candidate('a.md', 0, 'Alpha kinase pathway evidence.'),
+      candidate('b.md', 0, 'Beta kinase pathway evidence.'),
+      candidate('c.md', 0, 'Unrelated weather paragraph.'),
+    ];
+    const out = applyHighRecallCandidateFilters({
+      query: 'kinase pathway',
+      candidates: input,
+      k: 2,
+      candidatePoolK: 3,
+    });
+
+    expect(out.results.map((hit) => hit.metadata.source)).toEqual(['a.md', 'b.md']);
+    expect(out.diagnostics.reasonCounts.anchor_filter).toBe(1);
+    expect(out.diagnostics.anchorFilterRelaxed).toBe(false);
+  });
+
+  it('keeps adjacent same-source chunks as cheap neighbor expansion evidence', () => {
+    const input = [
+      candidate('paper.md', 4, 'Kinase pathway direct anchor.'),
+      candidate('paper.md', 5, 'Continuation paragraph without query terms.'),
+      candidate('other.md', 0, 'Unrelated weather paragraph.'),
+    ];
+    const out = applyHighRecallCandidateFilters({
+      query: 'kinase pathway',
+      candidates: input,
+      k: 2,
+      candidatePoolK: 3,
+    });
+
+    expect(out.results.map((hit) => `${hit.metadata.source}:${hit.metadata.chunkIndex}`)).toEqual([
+      'paper.md:4',
+      'paper.md:5',
+    ]);
+    expect(out.diagnostics.neighborExpansionMatches).toBe(1);
+    expect(out.diagnostics.reasonCounts.anchor_filter).toBe(1);
+  });
+
+  it('reports dense/lexical provenance counts in JSON diagnostics', () => {
+    const input = [
+      candidate('a.md', 0, 'Alpha evidence.'),
+      candidate('b.md', 0, 'Alpha evidence.'),
+    ];
+    const out = applyHighRecallCandidateFilters({
+      query: 'alpha',
+      candidates: input,
+      k: 1,
+      candidatePoolK: 2,
+      denseDistanceById: new Map([['a.md#0', 0.1], ['b.md#0', 0.2]]),
+      lexicalHitIds: new Set(['b.md#0']),
+    });
+
+    expect(highRecallDiagnosticsToJson(out.diagnostics)).toMatchObject({
+      schema_version: 'kb.search.high-recall-candidates.v1',
+      candidate_pool_k: 2,
+      recall_candidates: { dense: 2, lexical: 1, both: 1 },
+    });
+  });
+});

--- a/src/high-recall-candidates.ts
+++ b/src/high-recall-candidates.ts
@@ -1,0 +1,391 @@
+import { createHash } from 'crypto';
+import type { HybridChunk } from './hybrid-retrieval.js';
+import { chunkIdFromMetadata } from './rrf.js';
+
+export const HIGH_RECALL_CANDIDATE_SCHEMA_VERSION = 'kb.search.high-recall-candidates.v1';
+
+export type HighRecallFilterReason =
+  | 'duplicate_collapse'
+  | 'source_diversity_cap'
+  | 'anchor_filter';
+
+export interface HighRecallFilterOptions {
+  query: string;
+  candidates: readonly HybridChunk[];
+  k: number;
+  candidatePoolK: number;
+  denseDistanceById?: ReadonlyMap<string, number>;
+  lexicalHitIds?: ReadonlySet<string>;
+  sourceDiversityCap?: number;
+  maxDiagnosticCandidates?: number;
+}
+
+export interface HighRecallCandidateDiagnostic {
+  id: string;
+  source: string | null;
+  chunkIndex: number | null;
+  retrievers: Array<'dense' | 'lexical'>;
+  reason: HighRecallFilterReason;
+}
+
+export interface HighRecallCollapsedGroup {
+  keptId: string;
+  collapsedIds: string[];
+  source: string | null;
+  reason: 'duplicate_collapse';
+}
+
+export interface HighRecallFilterDiagnostics {
+  schemaVersion: typeof HIGH_RECALL_CANDIDATE_SCHEMA_VERSION;
+  enabled: true;
+  candidatePoolK: number;
+  finalK: number;
+  sourceDiversityCap: number;
+  queryAnchors: string[];
+  preFilterCount: number;
+  postFilterCount: number;
+  collapsedGroups: HighRecallCollapsedGroup[];
+  removed: HighRecallCandidateDiagnostic[];
+  reasonCounts: Record<HighRecallFilterReason, number>;
+  anchorFilterRelaxed: boolean;
+  neighborExpansionMatches: number;
+  recallCandidates: {
+    dense: number;
+    lexical: number;
+    both: number;
+  };
+}
+
+export interface HighRecallFilterResult {
+  results: HybridChunk[];
+  diagnostics: HighRecallFilterDiagnostics;
+}
+
+const DEFAULT_SOURCE_DIVERSITY_CAP = 3;
+const DEFAULT_MAX_DIAGNOSTIC_CANDIDATES = 50;
+
+const STOPWORDS = new Set([
+  'about',
+  'after',
+  'again',
+  'against',
+  'also',
+  'and',
+  'are',
+  'because',
+  'before',
+  'between',
+  'but',
+  'can',
+  'could',
+  'does',
+  'for',
+  'from',
+  'has',
+  'have',
+  'how',
+  'into',
+  'not',
+  'our',
+  'that',
+  'the',
+  'their',
+  'then',
+  'there',
+  'this',
+  'through',
+  'was',
+  'what',
+  'when',
+  'where',
+  'which',
+  'with',
+  'would',
+]);
+
+export function resolveCandidatePoolK(finalK: number, candidatePoolK: number | undefined): number | null {
+  if (candidatePoolK === undefined) return null;
+  assertPositiveInteger(finalK, 'k');
+  assertPositiveInteger(candidatePoolK, 'candidatePoolK');
+  if (candidatePoolK < finalK) {
+    throw new Error(`candidatePoolK must be >= k (got candidatePoolK=${candidatePoolK}, k=${finalK})`);
+  }
+  return candidatePoolK;
+}
+
+export function applyHighRecallCandidateFilters(input: HighRecallFilterOptions): HighRecallFilterResult {
+  assertPositiveInteger(input.k, 'k');
+  assertPositiveInteger(input.candidatePoolK, 'candidatePoolK');
+  if (input.candidatePoolK < input.k) {
+    throw new Error(`candidatePoolK must be >= k (got candidatePoolK=${input.candidatePoolK}, k=${input.k})`);
+  }
+  const sourceDiversityCap = input.sourceDiversityCap ?? DEFAULT_SOURCE_DIVERSITY_CAP;
+  assertPositiveInteger(sourceDiversityCap, 'sourceDiversityCap');
+  const maxDiagnostics = input.maxDiagnosticCandidates ?? DEFAULT_MAX_DIAGNOSTIC_CANDIDATES;
+  assertPositiveInteger(maxDiagnostics, 'maxDiagnosticCandidates');
+
+  const candidates = input.candidates.slice(0, input.candidatePoolK);
+  const queryAnchors = extractAnchorTerms(input.query);
+  const reasonCounts: Record<HighRecallFilterReason, number> = {
+    duplicate_collapse: 0,
+    source_diversity_cap: 0,
+    anchor_filter: 0,
+  };
+  const removed: HighRecallCandidateDiagnostic[] = [];
+  const collapsedGroups: HighRecallCollapsedGroup[] = [];
+  const duplicateByFingerprint = new Map<string, { id: string; source: string | null }>();
+  const sourceCounts = new Map<string, number>();
+  const dedupedAndCapped: HybridChunk[] = [];
+
+  const recordRemoval = (candidate: HybridChunk, reason: HighRecallFilterReason): void => {
+    reasonCounts[reason] += 1;
+    if (removed.length >= maxDiagnostics) return;
+    removed.push(candidateDiagnostic(candidate, reason, input));
+  };
+
+  for (const candidate of candidates) {
+    const fingerprint = duplicateFingerprint(candidate);
+    const duplicate = duplicateByFingerprint.get(fingerprint);
+    if (duplicate !== undefined) {
+      recordRemoval(candidate, 'duplicate_collapse');
+      const existing = collapsedGroups.find((group) => group.keptId === duplicate.id);
+      const id = chunkIdFromMetadata(candidate.metadata);
+      if (existing !== undefined) {
+        existing.collapsedIds.push(id);
+      } else {
+        collapsedGroups.push({
+          keptId: duplicate.id,
+          collapsedIds: [id],
+          source: duplicate.source,
+          reason: 'duplicate_collapse',
+        });
+      }
+      continue;
+    }
+    duplicateByFingerprint.set(fingerprint, {
+      id: chunkIdFromMetadata(candidate.metadata),
+      source: sourceKey(candidate.metadata),
+    });
+
+    const source = sourceKey(candidate.metadata) ?? '<unknown>';
+    const sourceCount = sourceCounts.get(source) ?? 0;
+    if (sourceCount >= sourceDiversityCap && dedupedAndCapped.length >= input.k) {
+      recordRemoval(candidate, 'source_diversity_cap');
+      continue;
+    }
+    sourceCounts.set(source, sourceCount + 1);
+    dedupedAndCapped.push(candidate);
+  }
+
+  let anchorFilterRelaxed = false;
+  let neighborExpansionMatches = 0;
+  let filtered = dedupedAndCapped;
+  if (queryAnchors.length > 0) {
+    const anchoredKeys = anchoredChunkKeys(dedupedAndCapped, queryAnchors, input);
+    const anchoredOrNeighbor = dedupedAndCapped.filter((candidate) => {
+      const key = sourceChunkKey(candidate.metadata);
+      if (key === null) return isAnchoredCandidate(candidate, queryAnchors, input);
+      if (anchoredKeys.has(key)) return true;
+      if (isNeighborOfAnchoredChunk(key, anchoredKeys)) {
+        neighborExpansionMatches += 1;
+        return true;
+      }
+      return isAnchoredCandidate(candidate, queryAnchors, input);
+    });
+    if (anchoredOrNeighbor.length >= Math.min(input.k, dedupedAndCapped.length)) {
+      const keptIds = new Set(anchoredOrNeighbor.map((candidate) => chunkIdFromMetadata(candidate.metadata)));
+      for (const candidate of dedupedAndCapped) {
+        if (!keptIds.has(chunkIdFromMetadata(candidate.metadata))) {
+          recordRemoval(candidate, 'anchor_filter');
+        }
+      }
+      filtered = anchoredOrNeighbor;
+    } else {
+      anchorFilterRelaxed = true;
+    }
+  }
+
+  const diagnostics: HighRecallFilterDiagnostics = {
+    schemaVersion: HIGH_RECALL_CANDIDATE_SCHEMA_VERSION,
+    enabled: true,
+    candidatePoolK: input.candidatePoolK,
+    finalK: input.k,
+    sourceDiversityCap,
+    queryAnchors,
+    preFilterCount: candidates.length,
+    postFilterCount: filtered.length,
+    collapsedGroups,
+    removed,
+    reasonCounts,
+    anchorFilterRelaxed,
+    neighborExpansionMatches,
+    recallCandidates: countRetrieverProvenance(candidates, input),
+  };
+
+  return { results: filtered, diagnostics };
+}
+
+export function highRecallDiagnosticsToJson(
+  diagnostics: HighRecallFilterDiagnostics,
+): Record<string, unknown> {
+  return {
+    schema_version: diagnostics.schemaVersion,
+    enabled: diagnostics.enabled,
+    candidate_pool_k: diagnostics.candidatePoolK,
+    final_k: diagnostics.finalK,
+    source_diversity_cap: diagnostics.sourceDiversityCap,
+    query_anchors: diagnostics.queryAnchors,
+    pre_filter_count: diagnostics.preFilterCount,
+    post_filter_count: diagnostics.postFilterCount,
+    collapsed_groups: diagnostics.collapsedGroups.map((group) => ({
+      kept_id: group.keptId,
+      collapsed_ids: group.collapsedIds,
+      source: group.source,
+      reason: group.reason,
+    })),
+    removed: diagnostics.removed.map((candidate) => ({
+      id: candidate.id,
+      source: candidate.source,
+      chunk_index: candidate.chunkIndex,
+      retrievers: candidate.retrievers,
+      reason: candidate.reason,
+    })),
+    reason_counts: diagnostics.reasonCounts,
+    anchor_filter_relaxed: diagnostics.anchorFilterRelaxed,
+    neighbor_expansion_matches: diagnostics.neighborExpansionMatches,
+    recall_candidates: diagnostics.recallCandidates,
+  };
+}
+
+function assertPositiveInteger(value: number, label: string): void {
+  if (!Number.isSafeInteger(value) || value < 1) {
+    throw new Error(`${label} must be a positive integer`);
+  }
+}
+
+function extractAnchorTerms(text: string): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  const tokens = text.normalize('NFKC').match(/[\p{L}\p{N}_./:@+-]+/gu) ?? [];
+  for (const raw of tokens) {
+    const token = raw.toLocaleLowerCase();
+    if (token.length < 3) continue;
+    if (STOPWORDS.has(token)) continue;
+    if (!/[\p{L}\p{N}]/u.test(token)) continue;
+    if (seen.has(token)) continue;
+    seen.add(token);
+    out.push(token);
+  }
+  return out;
+}
+
+function candidateDiagnostic(
+  candidate: HybridChunk,
+  reason: HighRecallFilterReason,
+  input: Pick<HighRecallFilterOptions, 'denseDistanceById' | 'lexicalHitIds'>,
+): HighRecallCandidateDiagnostic {
+  const id = chunkIdFromMetadata(candidate.metadata);
+  return {
+    id,
+    source: sourceKey(candidate.metadata),
+    chunkIndex: chunkIndex(candidate.metadata),
+    retrievers: retrieversForId(id, input),
+    reason,
+  };
+}
+
+function countRetrieverProvenance(
+  candidates: readonly HybridChunk[],
+  input: Pick<HighRecallFilterOptions, 'denseDistanceById' | 'lexicalHitIds'>,
+): HighRecallFilterDiagnostics['recallCandidates'] {
+  let dense = 0;
+  let lexical = 0;
+  let both = 0;
+  for (const candidate of candidates) {
+    const retrievers = retrieversForId(chunkIdFromMetadata(candidate.metadata), input);
+    if (retrievers.includes('dense')) dense += 1;
+    if (retrievers.includes('lexical')) lexical += 1;
+    if (retrievers.length === 2) both += 1;
+  }
+  return { dense, lexical, both };
+}
+
+function retrieversForId(
+  id: string,
+  input: Pick<HighRecallFilterOptions, 'denseDistanceById' | 'lexicalHitIds'>,
+): Array<'dense' | 'lexical'> {
+  const out: Array<'dense' | 'lexical'> = [];
+  if (input.denseDistanceById?.has(id)) out.push('dense');
+  if (input.lexicalHitIds?.has(id)) out.push('lexical');
+  return out;
+}
+
+function anchoredChunkKeys(
+  candidates: readonly HybridChunk[],
+  queryAnchors: readonly string[],
+  input: Pick<HighRecallFilterOptions, 'denseDistanceById' | 'lexicalHitIds'>,
+): Set<string> {
+  const keys = new Set<string>();
+  for (const candidate of candidates) {
+    if (!isAnchoredCandidate(candidate, queryAnchors, input)) continue;
+    const key = sourceChunkKey(candidate.metadata);
+    if (key !== null) keys.add(key);
+  }
+  return keys;
+}
+
+function isAnchoredCandidate(
+  candidate: HybridChunk,
+  queryAnchors: readonly string[],
+  input: Pick<HighRecallFilterOptions, 'denseDistanceById' | 'lexicalHitIds'>,
+): boolean {
+  const id = chunkIdFromMetadata(candidate.metadata);
+  if (input.lexicalHitIds?.has(id)) return true;
+  const text = `${candidate.pageContent} ${sourceKey(candidate.metadata) ?? ''}`.toLocaleLowerCase();
+  return queryAnchors.some((anchor) => text.includes(anchor));
+}
+
+function isNeighborOfAnchoredChunk(key: string, anchoredKeys: ReadonlySet<string>): boolean {
+  const splitAt = key.lastIndexOf('#');
+  if (splitAt < 0) return false;
+  const source = key.slice(0, splitAt);
+  const index = Number(key.slice(splitAt + 1));
+  if (!Number.isSafeInteger(index)) return false;
+  return anchoredKeys.has(`${source}#${index - 1}`) || anchoredKeys.has(`${source}#${index + 1}`);
+}
+
+function sourceChunkKey(metadata: Record<string, unknown>): string | null {
+  const source = sourceKey(metadata);
+  const index = chunkIndex(metadata);
+  if (source === null || index === null) return null;
+  return `${source}#${index}`;
+}
+
+function duplicateFingerprint(candidate: HybridChunk): string {
+  const source = sourceKey(candidate.metadata) ?? '';
+  const normalizedContent = candidate.pageContent
+    .normalize('NFKC')
+    .toLocaleLowerCase()
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, 800);
+  return createHash('sha1').update(source).update('\0').update(normalizedContent).digest('hex');
+}
+
+function sourceKey(metadata: Record<string, unknown>): string | null {
+  const relativePath = metadata.relativePath;
+  if (typeof relativePath === 'string' && relativePath.length > 0) return relativePath;
+  const source = metadata.source;
+  if (typeof source === 'string' && source.length > 0) return source;
+  return null;
+}
+
+function chunkIndex(metadata: Record<string, unknown>): number | null {
+  const raw = metadata.chunkIndex;
+  if (typeof raw === 'number' && Number.isSafeInteger(raw)) return raw;
+  if (typeof raw === 'string') {
+    const parsed = Number(raw);
+    if (Number.isSafeInteger(parsed)) return parsed;
+  }
+  return null;
+}

--- a/src/lexical-index.ts
+++ b/src/lexical-index.ts
@@ -423,6 +423,7 @@ export class LexicalIndex {
 
   private chunkRanker(retrievalViews?: readonly RetrievalViewKind[]): LexicalBm25Ranker<ChunkRecordItem> {
     const key = retrievalViewCacheKey(retrievalViews);
+    this.chunkRankerCache ??= new Map();
     let ranker = this.chunkRankerCache.get(key);
     if (ranker === undefined) {
       ranker = LexicalBm25Ranker.fromRecords(this.chunkRecords(retrievalViews));
@@ -433,6 +434,7 @@ export class LexicalIndex {
 
   private sourceRanker(retrievalViews?: readonly RetrievalViewKind[]): LexicalBm25Ranker<SourceRecordItem> {
     const key = retrievalViewCacheKey(retrievalViews);
+    this.sourceRankerCache ??= new Map();
     let ranker = this.sourceRankerCache.get(key);
     if (ranker === undefined) {
       ranker = LexicalBm25Ranker.fromRecords(this.sourceRecords(retrievalViews));


### PR DESCRIPTION
## Summary

- Adds opt-in `kb search --mode=hybrid --candidate-pool-k=<n>` candidate-pool expansion before final top-k/rerank.
- Applies cheap duplicate collapse, query-anchor filtering, source diversity capping, and adjacent chunk expansion while preserving dense/lexical provenance.
- Emits JSON `high_recall` diagnostics and documents the stable contract.
- Adds BEIR benchmark `--candidate-pool-k` reporting for candidate Recall@100 before final top-k scoring.

Closes #576
Depends on benchmark parent #573 for official baseline comparisons.

## Evaluation Notes

Official #573 baseline comparison data was not rerun in this task; the implementation keeps the new behavior opt-in and reports candidate-level diagnostics so those sweeps can compare against #573 outputs without fabricating numbers.

Feasible local sample run:

```sh
node build/benchmarks/beir/run.js --dataset=gate-fixture --dataset-dir=benchmarks/beir/fixtures/gate/gate-fixture --mode=hybrid --provider=fake --output-dir=/tmp/kb-beir-issue576 --workspace-root=/tmp/kb-beir-issue576-ws --k=10 --chunk-k=20 --candidate-pool-k=20 --max-queries=5
```

Local fixture results:

- judged queries: 5
- nDCG@10: 1
- MAP@100: 1
- Recall@10: 1
- Recall@100: 1
- Candidate Recall@100: 1
- latency: p50 9.015133 ms, p95 28.60669 ms, p99 28.60669 ms

On this tiny fake-provider fixture, both Candidate Recall@100 and nDCG@10 are perfect, so it does not expose a recall-vs-ordering failure. It does verify that candidate-pool reporting is wired end to end.

## Verification

- `npm run check`
- `npx tsc -p tsconfig.bench.json`
- focused tests for high-recall candidates, CLI search JSON diagnostics, BEIR candidate-pool reporting, and the retrieval metamorphic property test
