### PR TITLE
feat(retrieval): add late-interaction BEIR mode

### DIFF
--- a/benchmarks/beir/baseline.ts
+++ b/benchmarks/beir/baseline.ts
@@ -94,7 +94,7 @@ function buildBeirArgv(options: BaselineOptions, dataset: string, mode: BeirMode
     `--cache-dir=${options.cacheDir}`,
     `--workspace-root=${options.workspaceRoot}`,
   ];
-  if (mode !== 'lexical') {
+  if (mode !== 'lexical' && mode !== 'late') {
     if (options.provider !== undefined) argv.push(`--provider=${options.provider}`);
     if (options.model !== undefined) argv.push(`--model=${options.model}`);
   }
@@ -154,8 +154,10 @@ export function parseBaselineArgs(argv: string[]): BaselineOptions {
 
 const BASELINE_MODES: readonly BeirMode[] = [
   'lexical',
+  'late',
   'dense',
   'hybrid',
+  'hybrid+late',
   'hybrid+rerank',
   'hybrid+rerank+contextual',
 ];
@@ -174,7 +176,8 @@ Usage:
 
 Options:
   --datasets=<a,b,c>   CI subset. Default: scifact,nfcorpus,fiqa.
-  --modes=<...>        Comma list of lexical|dense|hybrid. Default: lexical,hybrid.
+  --modes=<...>        Comma list of lexical|late|dense|hybrid|hybrid+late|hybrid+rerank|hybrid+rerank+contextual.
+                       Default: lexical,hybrid.
   --provider=<name>    Embedding provider for dense/hybrid. Default: $EMBEDDING_PROVIDER.
   --model=<name>       Embedding model. Real model required for dense/hybrid.
   --split=<name>       Qrels split. Default: test.

--- a/benchmarks/beir/late-interaction.test.ts
+++ b/benchmarks/beir/late-interaction.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+  LATE_INTERACTION_SCHEMA_VERSION,
+  LateInteractionIndex,
+  tokenize,
+} from './late-interaction.js';
+
+describe('late interaction benchmark adapter', () => {
+  it('tokenizes normalized word pieces for token-level matching', () => {
+    expect(tokenize('Alpha gravity-wave detection, v2.')).toEqual([
+      'alpha',
+      'gravity-wave',
+      'detection',
+      'v2.',
+    ]);
+  });
+
+  it('ranks by ColBERT-style query-token MaxSim', () => {
+    const index = LateInteractionIndex.build([
+      {
+        id: 'doc-alpha',
+        text: 'Alpha gravity wave detection evidence and analysis.',
+        metadata: { relativePath: 'tiny/doc-alpha.md' },
+      },
+      {
+        id: 'doc-beta',
+        text: 'Beta culinary recipe for a hearty tomato soup.',
+        metadata: { relativePath: 'tiny/doc-beta.md' },
+      },
+    ]);
+
+    const hits = index.search('alpha gravity wave detection', 2);
+
+    expect(hits.map((hit) => hit.id)).toEqual(['doc-alpha', 'doc-beta']);
+    expect(hits[0].score).toBeGreaterThan(hits[1].score);
+    expect(index.resourceReport('standalone', null)).toMatchObject({
+      schema_version: LATE_INTERACTION_SCHEMA_VERSION,
+      enabled: true,
+      mode: 'standalone',
+      model: 'hashed-token-maxsim-v1',
+      documents_indexed: 2,
+      gpu_requirement: expect.stringContaining('None'),
+    });
+  });
+
+  it('reranks only a provided candidate set', () => {
+    const index = LateInteractionIndex.build([
+      {
+        id: 'doc-alpha',
+        text: 'Alpha gravity wave detection evidence.',
+        metadata: { relativePath: 'tiny/doc-alpha.md' },
+      },
+      {
+        id: 'doc-beta',
+        text: 'Beta culinary recipe.',
+        metadata: { relativePath: 'tiny/doc-beta.md' },
+      },
+    ]);
+
+    const hits = index.rerank('tomato soup recipe', [
+      {
+        id: 'candidate-alpha',
+        text: 'Alpha gravity wave detection evidence.',
+        metadata: { relativePath: 'tiny/doc-alpha.md' },
+      },
+      {
+        id: 'candidate-beta',
+        text: 'Tomato soup recipe with basil.',
+        metadata: { relativePath: 'tiny/doc-beta.md' },
+      },
+    ], 2);
+
+    expect(hits.map((hit) => hit.id)).toEqual(['candidate-beta', 'candidate-alpha']);
+  });
+});

--- a/benchmarks/beir/late-interaction.ts
+++ b/benchmarks/beir/late-interaction.ts
@@ -1,0 +1,246 @@
+import * as fsp from 'fs/promises';
+import * as path from 'path';
+
+export const LATE_INTERACTION_SCHEMA_VERSION = 'kb.beir.late-interaction.v1';
+export const LATE_INTERACTION_TOKEN_DIMENSIONS = 64;
+export const LATE_INTERACTION_MODEL_ID = 'hashed-token-maxsim-v1';
+
+export interface LateInteractionDocument {
+  id: string;
+  text: string;
+  metadata: Record<string, unknown>;
+}
+
+export interface LateInteractionHit {
+  id: string;
+  score: number;
+  metadata: Record<string, unknown>;
+  text: string;
+}
+
+export interface LateInteractionResourceReport {
+  schema_version: typeof LATE_INTERACTION_SCHEMA_VERSION;
+  enabled: true;
+  mode: 'standalone' | 'rerank';
+  implementation: string;
+  model: string;
+  token_dimensions: number;
+  documents_indexed: number;
+  token_vectors: number;
+  index_size_bytes_estimate: number;
+  build_ms: number;
+  cpu_requirement: string;
+  gpu_requirement: string;
+  memory_requirement: string;
+  candidate_source: string | null;
+}
+
+interface IndexedLateInteractionDocument extends LateInteractionDocument {
+  tokens: string[];
+  tokenVectors: Float32Array[];
+}
+
+export class LateInteractionIndex {
+  private readonly docs: IndexedLateInteractionDocument[];
+  private readonly idf: Map<string, number>;
+  readonly buildMs: number;
+
+  private constructor(docs: IndexedLateInteractionDocument[], idf: Map<string, number>, buildMs: number) {
+    this.docs = docs;
+    this.idf = idf;
+    this.buildMs = buildMs;
+  }
+
+  static build(documents: readonly LateInteractionDocument[]): LateInteractionIndex {
+    const started = process.hrtime.bigint();
+    const tokenized = documents.map((doc) => ({ doc, tokens: tokenize(doc.text) }));
+    const idf = computeIdf(tokenized.map((row) => row.tokens));
+    const docs = tokenized.map(({ doc, tokens }) => ({
+      ...doc,
+      tokens,
+      tokenVectors: tokens.map((token) => tokenVector(token)),
+    }));
+    return new LateInteractionIndex(docs, idf, elapsedMs(started));
+  }
+
+  static async fromKnowledgeBase(kbName: string, kbPath: string): Promise<LateInteractionIndex> {
+    return LateInteractionIndex.build(await readKnowledgeBaseDocuments(kbName, kbPath));
+  }
+
+  search(query: string, k: number): LateInteractionHit[] {
+    assertPositiveInteger(k, 'k');
+    return this.scoreDocuments(query, this.docs).slice(0, k);
+  }
+
+  rerank(query: string, candidates: readonly LateInteractionDocument[], k: number): LateInteractionHit[] {
+    assertPositiveInteger(k, 'k');
+    const indexed = candidates.map((doc) => {
+      const tokens = tokenize(doc.text);
+      return {
+        ...doc,
+        tokens,
+        tokenVectors: tokens.map((token) => tokenVector(token)),
+      };
+    });
+    return this.scoreDocuments(query, indexed).slice(0, k);
+  }
+
+  resourceReport(mode: 'standalone' | 'rerank', candidateSource: string | null): LateInteractionResourceReport {
+    const tokenVectors = this.docs.reduce((sum, doc) => sum + doc.tokenVectors.length, 0);
+    const indexBytes = tokenVectors * LATE_INTERACTION_TOKEN_DIMENSIONS * Float32Array.BYTES_PER_ELEMENT;
+    return {
+      schema_version: LATE_INTERACTION_SCHEMA_VERSION,
+      enabled: true,
+      mode,
+      implementation: 'Benchmark-only ColBERT-style MaxSim over hashed token/character-ngram vectors',
+      model: LATE_INTERACTION_MODEL_ID,
+      token_dimensions: LATE_INTERACTION_TOKEN_DIMENSIONS,
+      documents_indexed: this.docs.length,
+      token_vectors: tokenVectors,
+      index_size_bytes_estimate: indexBytes,
+      build_ms: Number(this.buildMs.toFixed(3)),
+      cpu_requirement: 'CPU-only JavaScript prototype; no native ANN index',
+      gpu_requirement: 'None for this prototype; a production ColBERTv2/PLAID tier would normally prefer GPU at indexing time',
+      memory_requirement: `~${formatBytes(indexBytes)} for float32 token vectors before JS object overhead`,
+      candidate_source: candidateSource,
+    };
+  }
+
+  private scoreDocuments(query: string, docs: readonly IndexedLateInteractionDocument[]): LateInteractionHit[] {
+    const queryTokens = tokenize(query);
+    if (queryTokens.length === 0) return [];
+    const queryVectors = queryTokens.map((token) => tokenVector(token));
+    const weightedQuery = queryTokens.map((token, index) => ({
+      token,
+      vector: queryVectors[index],
+      weight: this.idf.get(token) ?? 1,
+    }));
+
+    return docs
+      .map((doc) => {
+        const score = maxSimScore(weightedQuery, doc.tokenVectors);
+        return { id: doc.id, score, metadata: doc.metadata, text: doc.text };
+      })
+      .filter((hit) => Number.isFinite(hit.score))
+      .sort((left, right) => right.score - left.score || left.id.localeCompare(right.id));
+  }
+}
+
+export async function readKnowledgeBaseDocuments(kbName: string, kbPath: string): Promise<LateInteractionDocument[]> {
+  const entries = await fsp.readdir(kbPath, { withFileTypes: true });
+  const docs: LateInteractionDocument[] = [];
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith('.md')) continue;
+    const filePath = path.join(kbPath, entry.name);
+    const relativePath = `${kbName}/${entry.name}`;
+    docs.push({
+      id: relativePath,
+      text: await fsp.readFile(filePath, 'utf-8'),
+      metadata: {
+        source: filePath,
+        relativePath,
+      },
+    });
+  }
+  docs.sort((left, right) => left.id.localeCompare(right.id));
+  return docs;
+}
+
+export function tokenize(text: string): string[] {
+  const tokens = text
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .match(/[a-z0-9][a-z0-9._-]{1,}/g);
+  return tokens ?? [];
+}
+
+function computeIdf(tokenLists: readonly string[][]): Map<string, number> {
+  const df = new Map<string, number>();
+  for (const tokens of tokenLists) {
+    for (const token of new Set(tokens)) {
+      df.set(token, (df.get(token) ?? 0) + 1);
+    }
+  }
+  const docs = Math.max(tokenLists.length, 1);
+  const idf = new Map<string, number>();
+  for (const [token, count] of df) {
+    idf.set(token, Math.log(1 + (docs + 1) / (count + 1)));
+  }
+  return idf;
+}
+
+function maxSimScore(
+  query: readonly { token: string; vector: Float32Array; weight: number }[],
+  docVectors: readonly Float32Array[],
+): number {
+  if (docVectors.length === 0) return Number.NEGATIVE_INFINITY;
+  let weightedSum = 0;
+  let weightTotal = 0;
+  for (const q of query) {
+    let best = 0;
+    for (const docVector of docVectors) {
+      const sim = dot(q.vector, docVector);
+      if (sim > best) best = sim;
+    }
+    weightedSum += best * q.weight;
+    weightTotal += q.weight;
+  }
+  return weightTotal === 0 ? Number.NEGATIVE_INFINITY : weightedSum / weightTotal;
+}
+
+function tokenVector(token: string): Float32Array {
+  const vector = new Float32Array(LATE_INTERACTION_TOKEN_DIMENSIONS);
+  for (const feature of tokenFeatures(token)) {
+    const hash = hashFeature(feature);
+    const bucket = hash % LATE_INTERACTION_TOKEN_DIMENSIONS;
+    vector[bucket] += (hash & 0x80000000) === 0 ? 1 : -1;
+  }
+  let norm = 0;
+  for (const value of vector) norm += value * value;
+  norm = Math.sqrt(norm);
+  if (norm === 0) return vector;
+  for (let i = 0; i < vector.length; i += 1) vector[i] /= norm;
+  return vector;
+}
+
+function tokenFeatures(token: string): string[] {
+  const padded = `^${token}$`;
+  const features = [`tok:${token}`];
+  for (let i = 0; i < padded.length - 2; i += 1) {
+    features.push(`tri:${padded.slice(i, i + 3)}`);
+  }
+  return features;
+}
+
+function hashFeature(value: string): number {
+  let hash = 2166136261;
+  for (let i = 0; i < value.length; i += 1) {
+    hash ^= value.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+function dot(left: Float32Array, right: Float32Array): number {
+  let sum = 0;
+  for (let i = 0; i < left.length; i += 1) sum += left[i] * right[i];
+  return sum;
+}
+
+function elapsedMs(started: bigint): number {
+  return Number(process.hrtime.bigint() - started) / 1_000_000;
+}
+
+function assertPositiveInteger(value: number, label: string): void {
+  if (!Number.isInteger(value) || value < 1) {
+    throw new Error(`${label} must be a positive integer`);
+  }
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  const kib = bytes / 1024;
+  if (kib < 1024) return `${kib.toFixed(1)} KiB`;
+  return `${(kib / 1024).toFixed(1)} MiB`;
+}

--- a/benchmarks/beir/matrix.ts
+++ b/benchmarks/beir/matrix.ts
@@ -55,8 +55,10 @@ const DEFAULT_MATRIX_MODES: readonly BeirMode[] = ['lexical', 'hybrid'];
 
 const MATRIX_MODES: readonly BeirMode[] = [
   'lexical',
+  'late',
   'dense',
   'hybrid',
+  'hybrid+late',
   'hybrid+rerank',
   'hybrid+rerank+contextual',
 ];
@@ -332,7 +334,7 @@ function buildBeirArgv(options: MatrixOptions, dataset: string, mode: BeirMode):
     `--cache-dir=${options.cacheDir}`,
     `--workspace-root=${options.workspaceRoot}`,
   ];
-  if (mode !== 'lexical') {
+  if (mode !== 'lexical' && mode !== 'late') {
     if (options.provider !== undefined) argv.push(`--provider=${options.provider}`);
     if (options.model !== undefined) argv.push(`--model=${options.model}`);
     if (options.retrievalViews !== undefined) argv.push(`--retrieval-views=${options.retrievalViews}`);

--- a/benchmarks/beir/run.late.test.ts
+++ b/benchmarks/beir/run.late.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import * as fsp from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  parseArgs,
+  runBeirBenchmark,
+  type BeirSearchBackend,
+  type LoadSearchBackendInput,
+  type RunDependencies,
+} from './run.js';
+
+const baseDeps = {
+  gitSha: async () => 'test-sha',
+  now: () => new Date('2026-06-08T00:00:00.000Z'),
+  pythonVersion: async () => null,
+  silenceServerLogger: async () => undefined,
+  loadLexicalIndex: async () => {
+    throw new Error('loadLexicalIndex should not be called for late modes');
+  },
+} satisfies Omit<RunDependencies, 'loadSearchBackend'>;
+
+async function writeTinyBeirDataset(root: string): Promise<string> {
+  const datasetDir = path.join(root, 'tiny');
+  await fsp.mkdir(path.join(datasetDir, 'qrels'), { recursive: true });
+  await fsp.writeFile(path.join(datasetDir, 'corpus.jsonl'), [
+    JSON.stringify({ _id: 'doc-alpha', title: 'Alpha', text: 'Alpha gravity wave detection evidence and analysis.' }),
+    JSON.stringify({ _id: 'doc-beta', title: 'Beta', text: 'Beta culinary recipe for a hearty tomato soup.' }),
+    '',
+  ].join('\n'), 'utf-8');
+  await fsp.writeFile(path.join(datasetDir, 'queries.jsonl'), [
+    JSON.stringify({ _id: 'q1', text: 'alpha gravity wave detection' }),
+    '',
+  ].join('\n'), 'utf-8');
+  await fsp.writeFile(path.join(datasetDir, 'qrels', 'test.tsv'), [
+    'query-id corpus-id score',
+    'q1 doc-alpha 1',
+    '',
+  ].join('\n'), 'utf-8');
+  return datasetDir;
+}
+
+describe('BEIR runner late-interaction modes', () => {
+  it('runs standalone late mode without embedding provider or production search', async () => {
+    const root = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-beir-late-'));
+    const datasetDir = await writeTinyBeirDataset(root);
+    const loadSearchBackend = jest.fn(async (): Promise<BeirSearchBackend> => {
+      throw new Error('loadSearchBackend should not be called for late mode');
+    });
+    const args = parseArgs([
+      '--dataset=tiny',
+      `--dataset-dir=${datasetDir}`,
+      '--mode=late',
+      `--output-dir=${path.join(root, 'out')}`,
+      `--workspace-root=${path.join(root, 'kb-beir-ws')}`,
+      '--k=10',
+    ]);
+
+    const result = await runBeirBenchmark(args, { ...baseDeps, loadSearchBackend });
+
+    expect(loadSearchBackend).not.toHaveBeenCalled();
+    expect(result.report.mode).toBe('late');
+    expect(result.report.embedding).toBeNull();
+    expect(result.report.ranking.unit).toBe('source');
+    expect(result.report.command).not.toContain('--lexical-unit');
+    expect(result.report.late_interaction).toMatchObject({
+      enabled: true,
+      mode: 'standalone',
+      model: 'hashed-token-maxsim-v1',
+      documents_indexed: 2,
+    });
+    expect(result.report.metrics.ndcgAt10).toBe(1);
+    expect(await fsp.readFile(result.reportPath, 'utf-8')).toContain('Late interaction: standalone');
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  it('reranks hybrid candidates with late interaction for hybrid+late', async () => {
+    const root = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-beir-hybrid-late-'));
+    const datasetDir = await writeTinyBeirDataset(root);
+    const search = jest.fn(async (_query: string, _fetchK: number) => {
+      const kbDir = path.join(process.env.KNOWLEDGE_BASES_ROOT_DIR ?? '', 'tiny');
+      const files = await fsp.readdir(kbDir);
+      const alpha = files.find((file) => file.includes('doc-alpha'));
+      const beta = files.find((file) => file.includes('doc-beta'));
+      return [
+        {
+          pageContent: 'Beta culinary recipe for a hearty tomato soup.',
+          metadata: { relativePath: `tiny/${beta}`, chunkIndex: 0 },
+          score: 2,
+        },
+        {
+          pageContent: 'Alpha gravity wave detection evidence and analysis.',
+          metadata: { relativePath: `tiny/${alpha}`, chunkIndex: 0 },
+          score: 1,
+        },
+      ];
+    });
+    const loadSearchBackend = jest.fn(async (input: LoadSearchBackendInput): Promise<BeirSearchBackend> => {
+      expect(input.mode).toBe('hybrid');
+      expect(input.provider).toBe('fake');
+      return {
+        implementation: 'spy hybrid backend',
+        prepare: async () => ({ files: 2, chunks: 2 }),
+        search,
+      };
+    });
+    const args = parseArgs([
+      '--dataset=tiny',
+      `--dataset-dir=${datasetDir}`,
+      '--mode=hybrid+late',
+      '--provider=fake',
+      `--output-dir=${path.join(root, 'out')}`,
+      `--workspace-root=${path.join(root, 'kb-beir-ws')}`,
+      '--k=10',
+      '--chunk-k=20',
+    ]);
+
+    const result = await runBeirBenchmark(args, { ...baseDeps, loadSearchBackend });
+
+    expect(search).toHaveBeenCalledWith('alpha gravity wave detection', 20);
+    expect(result.report.mode).toBe('hybrid+late');
+    expect(result.report.embedding).toEqual({ provider: 'fake', model: 'fake-embeddings' });
+    expect(result.report.ranking.implementation).toContain('late-interaction.ts');
+    expect(result.report.late_interaction).toMatchObject({
+      enabled: true,
+      mode: 'rerank',
+      candidate_source: 'hybrid top-20 candidates',
+    });
+    expect(result.report.metrics.ndcgAt10).toBe(1);
+    const trec = await fsp.readFile(result.trecPath, 'utf-8');
+    expect(trec.startsWith('q1 Q0 doc-alpha 1')).toBe(true);
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+});

--- a/benchmarks/beir/run.ts
+++ b/benchmarks/beir/run.ts
@@ -16,6 +16,11 @@ import {
   type RankedDocument,
   type QueryMetric,
 } from './metrics.js';
+import {
+  LateInteractionIndex,
+  type LateInteractionDocument,
+  type LateInteractionResourceReport,
+} from './late-interaction.js';
 import { durationMs, ensureDirectory, gitSha, resetDirectory, writeJsonFile } from '../utils.js';
 
 const execFileAsync = promisify(execFile);
@@ -36,29 +41,35 @@ const DATASET_URLS: Record<string, string> = {
   'webis-touche2020': 'https://public.ukp.informatik.tu-darmstadt.de/thakur/BEIR/datasets/webis-touche2020.zip',
 };
 
-// v4 (retrieval frontier #577): added optional query-decomposition summary and
-// per-query trace artifacts. v3 added `hybrid+rerank` / `hybrid+rerank+contextual`
+// v5 (retrieval frontier #578): added benchmark-only late-interaction
+// standalone and hybrid candidate-rerank modes. v4 added optional
+// query-decomposition summary and per-query trace artifacts. v3 added
+// `hybrid+rerank` / `hybrid+rerank+contextual`
 // modes plus `rerank` / `contextual` provenance blocks. v2 added `dense`/`hybrid`
 // + precision@10 + `embedding`; v1 was lexical-only.
-const BENCHMARK_SCHEMA_VERSION = 'kb.beir-benchmark.v4';
+const BENCHMARK_SCHEMA_VERSION = 'kb.beir-benchmark.v5';
 type LexicalUnit = 'chunk' | 'source';
 // RFC 020 §1 — the retrieval-mode space the runner can score. `lexical` is
-// credential-free (BM25 only); the rest drive the production embedding + RRF +
-// cross-encoder + contextual-preface paths in `src/` and therefore require an
-// embedding provider. `hybrid+decompose` uses bounded rule-based query loops,
-// and `+contextual` additionally needs an LLM endpoint at ingest.
+// credential-free (BM25 only), and `late` is a credential-free benchmark-only
+// MaxSim prototype; the rest drive the production embedding + RRF +
+// cross-encoder/contextual-preface paths in `src/` and therefore require an
+// embedding provider.
 export type BeirMode =
   | 'lexical'
+  | 'late'
   | 'dense'
   | 'hybrid'
   | 'hybrid+decompose'
+  | 'hybrid+late'
   | 'hybrid+rerank'
   | 'hybrid+rerank+contextual';
 const BEIR_MODES: readonly BeirMode[] = [
   'lexical',
+  'late',
   'dense',
   'hybrid',
   'hybrid+decompose',
+  'hybrid+late',
   'hybrid+rerank',
   'hybrid+rerank+contextual',
 ];
@@ -67,9 +78,9 @@ function isBeirMode(value: string): value is BeirMode {
   return (BEIR_MODES as readonly string[]).includes(value);
 }
 
-// Every non-lexical mode drives an embedding provider and the dense backend.
+// Every non-lexical/non-late mode drives an embedding provider and the dense backend.
 function usesEmbeddingProvider(mode: BeirMode): boolean {
-  return mode !== 'lexical';
+  return mode !== 'lexical' && mode !== 'late';
 }
 
 // The production `SearchMode` a BeirMode maps onto. The rerank/contextual
@@ -78,6 +89,10 @@ function usesEmbeddingProvider(mode: BeirMode): boolean {
 // `KB_CONTEXTUAL_RETRIEVAL` ingest path — never a benchmark-only reimplementation.
 function beirSearchMode(mode: BeirMode): 'dense' | 'hybrid' {
   return mode === 'dense' ? 'dense' : 'hybrid';
+}
+
+function modeEnablesLateInteraction(mode: BeirMode): boolean {
+  return mode === 'late' || mode === 'hybrid+late';
 }
 
 function modeEnablesRerank(mode: BeirMode): boolean {
@@ -271,6 +286,9 @@ interface BeirBenchmarkReport {
   contextual: {
     enabled: boolean;
   } | null;
+  // Benchmark-only late-interaction provenance for issue #578. Present for
+  // `late` standalone and `hybrid+late` candidate rerank modes; null otherwise.
+  late_interaction: LateInteractionResourceReport | null;
   ranking: {
     unit: LexicalUnit;
     implementation: string;
@@ -382,13 +400,26 @@ export async function runBeirBenchmark(
   const restoreStageEnv = applyStageEnvironment(args.mode);
   let retrieval: RetrievalOutcome;
   try {
-    retrieval = usesEmbeddingProvider(args.mode)
-      ? await runDenseRetrieval({ args, prepared, qrels, selectedQueries, buildRoot, dependencies })
-      : await runLexicalRetrieval({ args, prepared, qrels, selectedQueries, buildRoot, dependencies });
+    retrieval = args.mode === 'late'
+      ? await runLateInteractionRetrieval({ args, prepared, qrels, selectedQueries, buildRoot, dependencies })
+      : usesEmbeddingProvider(args.mode)
+        ? await runDenseRetrieval({ args, prepared, qrels, selectedQueries, buildRoot, dependencies })
+        : await runLexicalRetrieval({ args, prepared, qrels, selectedQueries, buildRoot, dependencies });
   } finally {
     restoreStageEnv();
   }
-  const { queryRows, perQuery, candidatePerQuery, decompositionTraces, latenciesMs, indexMs, indexing, ranking: rankingMeta, embedding } = retrieval;
+  const {
+    queryRows,
+    perQuery,
+    candidatePerQuery,
+    decompositionTraces,
+    latenciesMs,
+    indexMs,
+    indexing,
+    ranking: rankingMeta,
+    embedding,
+    lateInteraction,
+  } = retrieval;
   const stages = resolveStageProvenance(args.mode);
 
   const runTag = `kb-${args.dataset}-${args.mode}-${rankingMeta.unit}`;
@@ -427,6 +458,7 @@ export async function runBeirBenchmark(
     embedding,
     rerank: stages.rerank,
     contextual: stages.contextual,
+    late_interaction: lateInteraction ?? null,
     ranking: {
       unit: rankingMeta.unit,
       implementation: rankingMeta.implementation,
@@ -499,6 +531,7 @@ interface RetrievalOutcome {
   };
   ranking: { unit: LexicalUnit; implementation: string };
   embedding: BeirBenchmarkReport['embedding'];
+  lateInteraction?: LateInteractionResourceReport;
 }
 
 interface QueryDecompositionRuntime {
@@ -607,12 +640,16 @@ async function runDenseRetrieval(input: RetrievalInput): Promise<RetrievalOutcom
 
   const indexStarted = process.hrtime.bigint();
   const prep = await backend.prepare();
+  const lateIndex = modeEnablesLateInteraction(args.mode)
+    ? await LateInteractionIndex.fromKnowledgeBase(prepared.kbName, prepared.kbPath)
+    : null;
   const indexMs = durationMs(indexStarted, process.hrtime.bigint());
 
   const queryRows: Array<{ queryId: string; ranking: RankedDocument[] }> = [];
   const perQuery: QueryMetric[] = [];
   const candidatePerQuery: QueryMetric[] = [];
   const decompositionTraces: Array<{ query_id: string; trace: Record<string, unknown> }> = [];
+  const candidateTextCache = new Map<string, string>();
   const decompositionRuntime = modeEnablesDecompose(args.mode)
     ? await (dependencies.loadQueryDecompositionRuntime ?? loadQueryDecompositionRuntime)(buildRoot)
     : null;
@@ -630,13 +667,22 @@ async function runDenseRetrieval(input: RetrievalInput): Promise<RetrievalOutcom
           k: args.candidatePoolK ?? args.chunkK,
           traceSink: (trace) => decompositionTraces.push({ query_id: query._id, trace }),
         });
+    const rankedChunks = lateIndex === null
+      ? chunks
+      : await rerankBeirChunksWithLateInteraction({
+          query: query.text,
+          chunks,
+          lateIndex,
+          prepared,
+          textCache: candidateTextCache,
+        });
     latenciesMs.push(durationMs(started, process.hrtime.bigint()));
-    const ranking = collapseRankedChunksToDocuments(chunks, prepared.docIdByRelativePath, args.k);
+    const ranking = collapseRankedChunksToDocuments(rankedChunks, prepared.docIdByRelativePath, args.k);
     queryRows.push({ queryId: query._id, ranking });
     const scored = scoreQuery(query._id, ranking, qrels);
     if (scored !== null) perQuery.push(scored);
     if (args.candidatePoolK !== undefined) {
-      const candidateRanking = collapseRankedChunksToDocuments(chunks, prepared.docIdByRelativePath, 100);
+      const candidateRanking = collapseRankedChunksToDocuments(rankedChunks, prepared.docIdByRelativePath, 100);
       const candidateScored = scoreQuery(query._id, candidateRanking, qrels);
       if (candidateScored !== null) candidatePerQuery.push(candidateScored);
     }
@@ -652,6 +698,51 @@ async function runDenseRetrieval(input: RetrievalInput): Promise<RetrievalOutcom
     indexing: { files: prep.files, chunks: prep.chunks },
     ranking: { unit: 'chunk', implementation: describeImplementation(backend.implementation, args.mode) },
     embedding: { provider: spec.provider, model: spec.model },
+    ...(lateIndex !== null
+      ? { lateInteraction: lateIndex.resourceReport('rerank', `${beirSearchMode(args.mode)} top-${args.candidatePoolK ?? args.chunkK} candidates`) }
+      : {}),
+  };
+}
+
+async function runLateInteractionRetrieval(input: RetrievalInput): Promise<RetrievalOutcome> {
+  const { args, prepared, qrels, selectedQueries } = input;
+  const indexStarted = process.hrtime.bigint();
+  const lateIndex = await LateInteractionIndex.fromKnowledgeBase(prepared.kbName, prepared.kbPath);
+  const indexMs = durationMs(indexStarted, process.hrtime.bigint());
+
+  const queryRows: Array<{ queryId: string; ranking: RankedDocument[] }> = [];
+  const perQuery: QueryMetric[] = [];
+  const candidatePerQuery: QueryMetric[] = [];
+  const latenciesMs: number[] = [];
+  for (const query of selectedQueries) {
+    const started = process.hrtime.bigint();
+    const fetchK = args.candidatePoolK ?? args.k;
+    const hits = lateIndex.search(query.text, Math.max(fetchK, args.k));
+    latenciesMs.push(durationMs(started, process.hrtime.bigint()));
+    const ranking = collapseChunksToDocuments(hits, prepared.docIdByRelativePath, args.k);
+    queryRows.push({ queryId: query._id, ranking });
+    const scored = scoreQuery(query._id, ranking, qrels);
+    if (scored !== null) perQuery.push(scored);
+    if (args.candidatePoolK !== undefined) {
+      const candidateRanking = collapseChunksToDocuments(hits, prepared.docIdByRelativePath, 100);
+      const candidateScored = scoreQuery(query._id, candidateRanking, qrels);
+      if (candidateScored !== null) candidatePerQuery.push(candidateScored);
+    }
+  }
+
+  return {
+    queryRows,
+    perQuery,
+    ...(args.candidatePoolK !== undefined ? { candidatePerQuery } : {}),
+    latenciesMs,
+    indexMs,
+    indexing: { files: prepared.documents, chunks: prepared.documents },
+    ranking: {
+      unit: 'source',
+      implementation: 'benchmarks/beir/late-interaction.ts standalone MaxSim over BEIR document Markdown',
+    },
+    embedding: null,
+    lateInteraction: lateIndex.resourceReport('standalone', null),
   };
 }
 
@@ -661,6 +752,9 @@ function describeImplementation(base: string, mode: BeirMode): string {
   const stages: string[] = [];
   if (modeEnablesDecompose(mode)) {
     stages.push('+ src/query-decomposition.ts bounded rule provider (per-query trace persisted)');
+  }
+  if (mode === 'hybrid+late') {
+    stages.push('+ benchmarks/beir/late-interaction.ts ColBERT-style MaxSim candidate rerank (benchmark-only)');
   }
   if (modeEnablesRerank(mode)) {
     stages.push('+ src/reranker.ts cross-encoder rerank (production KB_RERANK path)');
@@ -704,6 +798,66 @@ async function runBeirDecomposedSearch(input: {
     metadata: chunk.metadata,
     score: typeof chunk.score === 'number' ? chunk.score : 0,
   }));
+}
+
+async function rerankBeirChunksWithLateInteraction(input: {
+  query: string;
+  chunks: readonly BeirRankedChunk[];
+  lateIndex: LateInteractionIndex;
+  prepared: CorpusPreparation;
+  textCache: Map<string, string>;
+}): Promise<BeirRankedChunk[]> {
+  const candidates = await Promise.all(input.chunks.map((chunk, index) =>
+    lateDocumentFromChunk(chunk, index, input.prepared, input.textCache),
+  ));
+  const hits = input.lateIndex.rerank(input.query, candidates, candidates.length);
+  return hits.map((hit) => ({
+    ...(typeof hit.text === 'string' ? { pageContent: hit.text } : {}),
+    metadata: hit.metadata,
+    score: hit.score,
+  }));
+}
+
+async function lateDocumentFromChunk(
+  chunk: BeirRankedChunk,
+  index: number,
+  prepared: CorpusPreparation,
+  textCache: Map<string, string>,
+): Promise<LateInteractionDocument> {
+  const relativePath = typeof chunk.metadata.relativePath === 'string' ? chunk.metadata.relativePath : null;
+  const chunkIndex = typeof chunk.metadata.chunkIndex === 'number' ? chunk.metadata.chunkIndex : index;
+  const id = relativePath === null ? `candidate-${index}` : `${relativePath}#${chunkIndex}`;
+  const fallbackText = await resolveChunkText(chunk, prepared, textCache);
+  return {
+    id,
+    text: fallbackText,
+    metadata: chunk.metadata,
+  };
+}
+
+async function resolveChunkText(
+  chunk: BeirRankedChunk,
+  prepared: CorpusPreparation,
+  textCache: Map<string, string>,
+): Promise<string> {
+  if (typeof chunk.pageContent === 'string' && chunk.pageContent.trim() !== '') return chunk.pageContent;
+  const relativePath = typeof chunk.metadata.relativePath === 'string' ? chunk.metadata.relativePath : null;
+  if (relativePath !== null) {
+    const cached = textCache.get(relativePath);
+    if (cached !== undefined) return cached;
+    const prefix = `${prepared.kbName}/`;
+    const pathInsideKb = relativePath.startsWith(prefix) ? relativePath.slice(prefix.length) : relativePath;
+    const fullPath = path.join(prepared.kbPath, pathInsideKb);
+    try {
+      const text = await fsp.readFile(fullPath, 'utf-8');
+      textCache.set(relativePath, text);
+      return text;
+    } catch {
+      // Keep benchmark reranking robust for custom injected backends that only
+      // provide metadata; an empty text candidate will naturally score low.
+    }
+  }
+  return '';
 }
 
 async function loadQueryDecompositionRuntime(buildRoot: string): Promise<QueryDecompositionRuntime> {
@@ -884,6 +1038,12 @@ function buildCaveats(args: Args): string[] {
   if (args.mode === 'lexical') {
     caveats.push('Lexical mode requires no provider credentials.');
     caveats.push('Source ranking is the same public lexical unit exposed by kb search --lexical-unit=source.');
+  } else if (args.mode === 'late') {
+    caveats.push('Late mode is benchmark-only and requires no provider credentials.');
+    caveats.push(
+      'This prototype uses hashed token/character-ngram vectors with ColBERT-style MaxSim; ' +
+        'it is a runnable architecture spike, not a trained ColBERTv2 quality claim.',
+    );
   } else {
     caveats.push(
       'Dense/hybrid retrieval is driven by the production src/ paths ' +
@@ -909,6 +1069,12 @@ function buildCaveats(args: Args): string[] {
       caveats.push(
         'Query decomposition is opt-in and bounded; traces are persisted per query. ' +
           'The rule provider is deterministic and intended as a baseline before local-LLM evaluation.',
+      );
+    }
+    if (modeEnablesLateInteraction(args.mode)) {
+      caveats.push(
+        'Hybrid+late first retrieves candidates through the existing production hybrid path, then reorders those ' +
+          'candidates with the benchmark-only MaxSim adapter. It does not change production search defaults.',
       );
     }
   }
@@ -1458,7 +1624,7 @@ function formatBenchmarkCommand(args: Args): string {
   if (usesEmbeddingProvider(args.mode)) {
     if (args.provider !== undefined) parts.push(`--provider=${args.provider}`);
     if (args.model !== undefined) parts.push(`--model=${args.model}`);
-  } else {
+  } else if (args.mode === 'lexical') {
     parts.push(`--lexical-unit=${args.lexicalUnit}`);
   }
   parts.push(`--output-dir=${portablePath(args.outputDir)}`);
@@ -1515,6 +1681,16 @@ function formatMarkdownReport(report: BeirBenchmarkReport, trecPath: string, jso
             `mean retrieval calls=${report.query_decomposition.retrieval_calls_mean}`,
         ]
       : []),
+    ...(report.late_interaction !== null
+      ? [
+          `- Late interaction: ${report.late_interaction.mode}, model=${report.late_interaction.model}, ` +
+            `vectors=${report.late_interaction.token_vectors}, ` +
+            `index~${report.late_interaction.index_size_bytes_estimate} bytes, ` +
+            `build ${report.late_interaction.build_ms} ms`,
+          `- Late interaction resources: CPU=${report.late_interaction.cpu_requirement}; ` +
+            `GPU=${report.late_interaction.gpu_requirement}`,
+        ]
+      : []),
     `- Query latency: p50 ${latency.p50Ms} ms, p95 ${latency.p95Ms} ms, p99 ${latency.p99Ms} ms`,
     '',
     '## Artifacts',
@@ -1531,9 +1707,11 @@ function formatMarkdownReport(report: BeirBenchmarkReport, trecPath: string, jso
     report.command,
     '```',
     '',
-    report.embedding === null
+    report.mode === 'lexical'
       ? 'Lexical mode requires no provider credentials. The runner builds a temporary KB corpus and maps kb lexical hits to BEIR document IDs for scoring.'
-      : 'Dense/hybrid modes drive the production src/ retrieval path (FaissIndexManager + src/hybrid-retrieval RRF). The runner builds a temporary KB corpus, indexes it with the configured embedding provider, and maps kb hits to BEIR document IDs for scoring.',
+      : report.mode === 'late'
+        ? 'Late mode requires no provider credentials. The runner builds a temporary KB corpus, indexes per-document token vectors in the benchmark adapter, and maps MaxSim hits to BEIR document IDs for scoring.'
+        : 'Dense/hybrid modes drive the production src/ retrieval path (FaissIndexManager + src/hybrid-retrieval RRF). The runner builds a temporary KB corpus, indexes it with the configured embedding provider, and maps kb hits to BEIR document IDs for scoring.',
     '',
   ].join('\n');
 }
@@ -1571,10 +1749,15 @@ Options:
   --config=<path>        JSON config with env overrides and BEIR runner args.
   --split=<name>         Qrels split under qrels/<split>.tsv. Default: test.
   --mode=<mode>          Retrieval mode: ${BEIR_MODES.join(', ')}. Default: lexical.
-                         lexical is credential-free (BM25). dense/hybrid drive
-                         the production src/ retrieval path and need a provider.
+                         lexical is credential-free (BM25). late is a
+                         credential-free benchmark-only MaxSim prototype.
+                         dense/hybrid drive the production src/ retrieval path
+                         and need a provider.
                          hybrid+decompose adds bounded rule-based query loops and
                          persists per-query traces.
+                         hybrid+late retrieves production hybrid candidates,
+                         then reorders them with the benchmark-only MaxSim
+                         adapter.
                          hybrid+rerank adds the src/reranker.ts cross-encoder
                          (KB_RERANK); hybrid+rerank+contextual also enables the
                          RFC 017 contextual-preface ingest path and needs an LLM

--- a/benchmarks/results/late-interaction-issue578-evaluation.md
+++ b/benchmarks/results/late-interaction-issue578-evaluation.md
@@ -1,0 +1,139 @@
+# Late-Interaction Retrieval Evaluation (#578)
+
+Generated: 2026-06-09
+
+## Scope
+
+This note records the design choice and evaluation status for the experimental
+late-interaction retrieval tier added for #578. It does not change production
+search defaults and does not fabricate benchmark numbers.
+
+## Design Options Compared
+
+### ColBERTv2 / PLAID External Index
+
+- Best fit for a production late-interaction tier: trained token embeddings,
+  compressed residual vectors, ANN-style candidate traversal, and published
+  evidence for quality/latency tradeoffs.
+- Operational cost is highest: Python service, model/index lifecycle, GPU is
+  strongly preferred for indexing, and the index format is separate from the
+  current FAISS single-vector store.
+- Recommendation for now: evaluate after the benchmark adapter proves a Pareto
+  target that a real ColBERT backend must beat.
+
+### Small Local Late-Interaction Sidecar
+
+- Middle path: keep TypeScript search unchanged and call a local Python sidecar
+  for token embeddings and MaxSim reranking.
+- Easier to prototype with sentence-transformers or ColBERT libraries than a
+  native TypeScript implementation, but adds service lifecycle and resource
+  reporting requirements.
+- Recommendation for now: viable next milestone if real BEIR results justify
+  continuing.
+
+### Rerank-Only Late Interaction Over Top-N Candidates
+
+- Lowest-risk first milestone: keep BM25/dense/hybrid candidate generation as
+  is, then reorder a bounded candidate set with token-level MaxSim.
+- It tests whether token-level evidence helps before committing to a new
+  production index.
+- Implemented here as `hybrid+late`, alongside `late` standalone retrieval.
+
+## Implemented
+
+- `benchmarks/beir/late-interaction.ts`: benchmark-only ColBERT-style MaxSim
+  adapter using hashed token and character-ngram vectors.
+- `benchmarks/beir/run.ts` modes:
+  - `late`: standalone credential-free MaxSim over BEIR document Markdown.
+  - `hybrid+late`: production hybrid candidates, reranked by the benchmark-only
+    MaxSim adapter.
+- JSON/Markdown report field: `late_interaction`, recording model id, token
+  dimensions, documents indexed, token vector count, estimated index size,
+  build time, CPU/GPU requirements, and candidate source.
+- Matrix/baseline mode parsing accepts `late` and `hybrid+late` without adding
+  them to the default sweeps.
+
+## Measured Smoke Results
+
+These are fixture-plumbing numbers on
+`benchmarks/beir/fixtures/gate/gate-fixture`, not semantic quality claims. The
+fixture is intentionally small and deterministic.
+
+| dataset | mode | provider | queries | nDCG@10 | MAP@100 | Recall@100 | p50 / p95 latency | index build | estimated late index |
+| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| gate-fixture | `late` | none | 10 | 1.000000 | 1.000000 | 1.000000 | 0.515 / 2.163 ms | 5.394 ms | 112,640 bytes |
+| gate-fixture | `hybrid+late` | fake | 10 | 1.000000 | 1.000000 | 1.000000 | 8.881 / 37.199 ms | 7.645 ms late, 226.859 ms total | 112,640 bytes |
+
+Commands run:
+
+```bash
+npm run bench:beir -- --dataset=gate-fixture \
+  --dataset-dir=benchmarks/beir/fixtures/gate/gate-fixture \
+  --split=test --mode=late \
+  --output-dir=/tmp/kb-beir-issue578-gate-late \
+  --workspace-root=/tmp/kb-beir-issue578-gate-late-ws
+
+npm run bench:beir -- --dataset=gate-fixture \
+  --dataset-dir=benchmarks/beir/fixtures/gate/gate-fixture \
+  --split=test --mode=hybrid+late --provider=fake \
+  --output-dir=/tmp/kb-beir-issue578-gate-hybrid-late \
+  --workspace-root=/tmp/kb-beir-issue578-gate-hybrid-late-ws
+```
+
+## Comparison Against #573 Baselines
+
+Committed #573 SciFact baselines in
+`benchmarks/results/beir/baseline/README.md`:
+
+| dataset | mode | provider/model | nDCG@10 | MAP@100 | Recall@100 | p50 / p95 latency |
+| --- | --- | --- | ---: | ---: | ---: | ---: |
+| SciFact | `lexical` | none | 0.668981 | 0.630274 | 0.895889 | 24.967 / 44.327 ms |
+| SciFact | `dense` | ollama / nomic-embed-text | 0.491414 | 0.456433 | 0.808333 | 154.787 / 174.126 ms |
+| SciFact | `hybrid` | ollama / nomic-embed-text | 0.610915 | 0.566212 | 0.921333 | 910.036 / 1043.893 ms |
+
+Additional local artifact present at `/tmp/qwen3-smoke`:
+
+| dataset | mode | provider/model | nDCG@10 | MAP@100 | Recall@100 | p50 / p95 latency |
+| --- | --- | --- | ---: | ---: | ---: | ---: |
+| SciFact | `dense` | ollama / dengcao/Qwen3-Embedding-0.6B:Q8_0 | 0.641350 | 0.596610 | 0.918333 | 463.062 / 579.364 ms |
+
+No committed #573 `hybrid+rerank` baseline artifact is present in this
+worktree, so `hybrid+late vs hybrid+cross-encoder` remains pending.
+
+## Blocked Real BEIR Run
+
+Attempted:
+
+```bash
+npm run bench:beir -- --dataset=scifact --split=test --mode=late \
+  --max-queries=10 \
+  --output-dir=/tmp/kb-beir-issue578-scifact-late \
+  --workspace-root=/tmp/kb-beir-issue578-late-ws
+```
+
+Result: failed during dataset download with `TypeError: fetch failed` from the
+canonical BEIR UKP host. This matches the #573 note that the host can be
+unreachable from this environment. The previous Hugging Face-converted
+`/tmp/beir-hf/scifact` directory was not present.
+
+## Required Sample Status
+
+- SciFact: supported by the runner; live run blocked by dataset availability in
+  this session.
+- NFCorpus, FiQA, ArguAna, SciDocs: mode is wired and selectable; real runs
+  pending dataset availability and, for `hybrid+late`, real embedding provider
+  time.
+- BRIGHT sample: not attempted; setup cost was not reasonable before a real
+  BEIR late-interaction result exists.
+
+## Recommendation
+
+Keep this as a benchmark-only experiment and do not promote it to production.
+
+The implemented path proves the benchmark surface and records the required
+resource metadata, but the current hashed-vector adapter is not a trained
+semantic late-interaction model. The next useful decision point is a real BEIR
+run on SciFact plus at least NFCorpus/FiQA with either ColBERTv2/PLAID or a
+small Python sidecar. Promote only if `hybrid+late` improves quality over
+`hybrid` at materially lower latency than `hybrid+rerank`; otherwise abandon
+standalone `late` and keep only a rerank-tier experiment.


### PR DESCRIPTION
## Summary

Closes #578.

Adds a benchmark-only late-interaction retrieval path for the retrieval frontier roadmap:

- `late`: credential-free standalone ColBERT-style MaxSim over BEIR document Markdown
- `hybrid+late`: production hybrid candidates reranked by the benchmark-only MaxSim adapter
- BEIR report provenance for model id, token dimensions, token vectors, estimated index size, build time, CPU/GPU/memory requirements, and candidate source
- baseline/matrix mode parsing for `late` and `hybrid+late` without changing default sweeps or production search behavior

## Dependency on #573

This PR uses the committed #573 SciFact baseline outputs in `benchmarks/results/beir/baseline/README.md` as comparison context. It does not fabricate missing numbers. No committed #573 `hybrid+rerank` artifact is present in this worktree, so the `hybrid+late` versus cross-encoder rerank comparison remains pending until that baseline is available.

## Evaluation Notes

Added `benchmarks/results/late-interaction-issue578-evaluation.md` with:

- design comparison of ColBERTv2/PLAID, a Python sidecar, and rerank-only late interaction
- fixture smoke metrics for `late` and `hybrid+late`
- resource measurements for the implemented adapter
- real BEIR run status
- recommendation to keep this benchmark-only for now, not promote it to production

Fixture smoke results on `benchmarks/beir/fixtures/gate/gate-fixture`:

- `late`: nDCG@10 1.000000, MAP@100 1.000000, Recall@100 1.000000, p50/p95 0.515/2.163 ms, late build 5.394 ms, estimated late index 112,640 bytes
- `hybrid+late` with fake provider: nDCG@10 1.000000, MAP@100 1.000000, Recall@100 1.000000, p50/p95 8.881/37.199 ms, late build 7.645 ms, estimated late index 112,640 bytes

Attempted real SciFact `late` run failed during BEIR dataset download with `TypeError: fetch failed` from the canonical UKP host; `/tmp/beir-hf/scifact` was not present in this session.

## Verification

- `npm run build`
- `npx tsc -p tsconfig.bench.json`
- `npm test -- --runTestsByPath benchmarks/beir/late-interaction.test.ts benchmarks/beir/run.late.test.ts --runInBand`
- `npm run docs:check-anchors`
- `npm test -- --runInBand`
- `npm run bench:beir -- --dataset=gate-fixture --dataset-dir=benchmarks/beir/fixtures/gate/gate-fixture --split=test --mode=late --output-dir=/tmp/kb-beir-issue578-gate-late --workspace-root=/tmp/kb-beir-issue578-gate-late-ws`
- `npm run bench:beir -- --dataset=gate-fixture --dataset-dir=benchmarks/beir/fixtures/gate/gate-fixture --split=test --mode=hybrid+late --provider=fake --output-dir=/tmp/kb-beir-issue578-gate-hybrid-late --workspace-root=/tmp/kb-beir-issue578-gate-hybrid-late-ws`
