### PR TITLE
feat(retrieval): add reranker bakeoff benchmark

### DIFF
--- a/benchmarks/beir/matrix.ts
+++ b/benchmarks/beir/matrix.ts
@@ -61,6 +61,9 @@ const MATRIX_MODES: readonly BeirMode[] = [
   'hybrid+late',
   'hybrid+rerank',
   'hybrid+rerank+contextual',
+  'hybrid+listwise-rerank',
+  'hybrid+hard-negative-rerank',
+  'hybrid+adaptive-rerank',
 ];
 
 // RFC 020 §7 reproducibility ledger — the full retrieval env recorded with the

--- a/benchmarks/beir/reranker-bakeoff-rerankers.test.ts
+++ b/benchmarks/beir/reranker-bakeoff-rerankers.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+  rerankWithBenchmarkReranker,
+  summarizeBenchmarkRerankerReports,
+  type BenchmarkRerankCandidate,
+} from './reranker-bakeoff-rerankers.js';
+
+function candidate(id: string, text: string, score: number): BenchmarkRerankCandidate {
+  return {
+    pageContent: text,
+    metadata: { relativePath: `${id}.md`, title: id },
+    score,
+  };
+}
+
+describe('issue #579 benchmark-only rerankers', () => {
+  it('listwise attention reranks top candidates using query-token evidence across the candidate set', () => {
+    const out = rerankWithBenchmarkReranker({
+      mode: 'hybrid+listwise-rerank',
+      query: 'gravity wave detection evidence',
+      candidates: [
+        candidate('near-miss', 'A tomato soup recipe with no scientific evidence.', 2),
+        candidate('relevant', 'The study reports gravity wave detection evidence from the experiment.', 1),
+      ],
+    });
+
+    expect(out.results[0].metadata.title).toBe('relevant');
+    expect(out.report.strategy).toBe('listwise-attention');
+    expect(out.report.candidates_reranked).toBe(2);
+  });
+
+  it('hard-negative head keeps a feature-based boundary separate from native rank', () => {
+    const out = rerankWithBenchmarkReranker({
+      mode: 'hybrid+hard-negative-rerank',
+      query: 'citation graph semantic matching',
+      candidates: [
+        candidate('native-top', 'Unrelated operational checklist with matching but shallow terms.', 4),
+        candidate('science', 'Citation graph analysis provides semantic matching evidence for related papers.', 1),
+      ],
+    });
+
+    expect(out.results[0].metadata.title).toBe('science');
+    expect(out.report.model).toBe('hard-negative-boundary-head-sim-v1');
+  });
+
+  it('adaptive mode skips a low-ambiguity query and reports the skipped route', () => {
+    const out = rerankWithBenchmarkReranker({
+      mode: 'hybrid+adaptive-rerank',
+      query: 'alpha',
+      candidates: [
+        candidate('clear', 'alpha alpha alpha exact match', 2),
+        candidate('other', 'beta gamma delta unrelated', 1),
+      ],
+    });
+
+    expect(out.results[0].metadata.title).toBe('clear');
+    expect(out.report.skipped).toBe(true);
+    expect(out.report.skip_reason).toBe('low_ambiguity');
+    expect(out.report.candidates_reranked).toBe(0);
+  });
+
+  it('summarizes per-query candidate counts and latency for reports', () => {
+    const first = rerankWithBenchmarkReranker({
+      mode: 'hybrid+listwise-rerank',
+      query: 'alpha beta',
+      candidates: [candidate('a', 'alpha', 1), candidate('b', 'beta', 0.5)],
+    }).report;
+    const second = rerankWithBenchmarkReranker({
+      mode: 'hybrid+listwise-rerank',
+      query: 'alpha beta',
+      candidates: [candidate('a', 'alpha', 1)],
+    }).report;
+
+    expect(summarizeBenchmarkRerankerReports([first, second])).toMatchObject({
+      strategy: 'listwise-attention',
+      queries: 2,
+      mean_candidates_in: 1.5,
+      mean_candidates_reranked: 1.5,
+    });
+  });
+});

--- a/benchmarks/beir/reranker-bakeoff-rerankers.ts
+++ b/benchmarks/beir/reranker-bakeoff-rerankers.ts
@@ -1,0 +1,304 @@
+import { tokenize } from './late-interaction.js';
+
+export const RERANKER_BAKEOFF_SCHEMA_VERSION = 'kb.beir.reranker-bakeoff-reranker.v1';
+export const RERANKER_BAKEOFF_TOP_N = 50;
+
+export type BenchmarkRerankerMode =
+  | 'hybrid+listwise-rerank'
+  | 'hybrid+hard-negative-rerank'
+  | 'hybrid+adaptive-rerank';
+
+export type BenchmarkRerankerStrategy =
+  | 'listwise-attention'
+  | 'hard-negative-head'
+  | 'adaptive-listwise-attention';
+
+export interface BenchmarkRerankCandidate {
+  pageContent?: string;
+  metadata: Record<string, unknown>;
+  score: number;
+}
+
+export interface BenchmarkRerankerQueryReport {
+  schema_version: typeof RERANKER_BAKEOFF_SCHEMA_VERSION;
+  enabled: true;
+  strategy: BenchmarkRerankerStrategy;
+  model: string;
+  top_n: number;
+  candidates_in: number;
+  candidates_reranked: number;
+  skipped: boolean;
+  skip_reason: string | null;
+  latency_ms: number;
+  ambiguity: {
+    top_overlap: number;
+    second_overlap: number;
+    gap: number;
+  };
+}
+
+export interface BenchmarkRerankerSummary {
+  schema_version: 'kb.beir.reranker-bakeoff-summary.v1';
+  enabled: true;
+  strategy: BenchmarkRerankerStrategy;
+  model: string;
+  top_n: number;
+  queries: number;
+  mean_candidates_in: number;
+  mean_candidates_reranked: number;
+  skipped_queries: number;
+  mean_latency_ms: number;
+}
+
+export function isBenchmarkRerankerMode(mode: string): mode is BenchmarkRerankerMode {
+  return mode === 'hybrid+listwise-rerank' ||
+    mode === 'hybrid+hard-negative-rerank' ||
+    mode === 'hybrid+adaptive-rerank';
+}
+
+function benchmarkRerankerStrategyForMode(mode: BenchmarkRerankerMode): BenchmarkRerankerStrategy {
+  switch (mode) {
+    case 'hybrid+listwise-rerank':
+      return 'listwise-attention';
+    case 'hybrid+hard-negative-rerank':
+      return 'hard-negative-head';
+    case 'hybrid+adaptive-rerank':
+      return 'adaptive-listwise-attention';
+  }
+}
+
+export function rerankWithBenchmarkReranker<T extends BenchmarkRerankCandidate>(input: {
+  mode: BenchmarkRerankerMode;
+  query: string;
+  candidates: readonly T[];
+  topN?: number;
+}): { results: T[]; report: BenchmarkRerankerQueryReport } {
+  const started = process.hrtime.bigint();
+  const strategy = benchmarkRerankerStrategyForMode(input.mode);
+  const topN = Math.min(input.topN ?? RERANKER_BAKEOFF_TOP_N, input.candidates.length);
+  const block = input.candidates.slice(0, topN);
+  const tail = input.candidates.slice(topN);
+  const ambiguity = computeAmbiguity(input.query, block);
+
+  if (strategy === 'adaptive-listwise-attention' && !shouldRerankAdaptively(input.query, ambiguity, block.length)) {
+    return {
+      results: input.candidates.slice(),
+      report: buildQueryReport({
+        strategy,
+        topN,
+        candidatesIn: input.candidates.length,
+        candidatesReranked: 0,
+        skipped: true,
+        skipReason: 'low_ambiguity',
+        ambiguity,
+        started,
+      }),
+    };
+  }
+
+  const scored = block.map((candidate, index) => ({
+    candidate,
+    index,
+    score: strategy === 'hard-negative-head'
+      ? hardNegativeHeadScore(input.query, candidate, index, block.length)
+      : listwiseAttentionScore(input.query, candidate, index, block),
+  }));
+  scored.sort((left, right) => right.score - left.score || left.index - right.index);
+
+  return {
+    results: [...scored.map((row) => row.candidate), ...tail],
+    report: buildQueryReport({
+      strategy,
+      topN,
+      candidatesIn: input.candidates.length,
+      candidatesReranked: block.length,
+      skipped: false,
+      skipReason: null,
+      ambiguity,
+      started,
+    }),
+  };
+}
+
+export function summarizeBenchmarkRerankerReports(
+  reports: readonly BenchmarkRerankerQueryReport[],
+): BenchmarkRerankerSummary | null {
+  if (reports.length === 0) return null;
+  const first = reports[0];
+  return {
+    schema_version: 'kb.beir.reranker-bakeoff-summary.v1',
+    enabled: true,
+    strategy: first.strategy,
+    model: first.model,
+    top_n: first.top_n,
+    queries: reports.length,
+    mean_candidates_in: mean(reports.map((r) => r.candidates_in)),
+    mean_candidates_reranked: mean(reports.map((r) => r.candidates_reranked)),
+    skipped_queries: reports.filter((r) => r.skipped).length,
+    mean_latency_ms: mean(reports.map((r) => r.latency_ms)),
+  };
+}
+
+function buildQueryReport(input: {
+  strategy: BenchmarkRerankerStrategy;
+  topN: number;
+  candidatesIn: number;
+  candidatesReranked: number;
+  skipped: boolean;
+  skipReason: string | null;
+  ambiguity: BenchmarkRerankerQueryReport['ambiguity'];
+  started: bigint;
+}): BenchmarkRerankerQueryReport {
+  return {
+    schema_version: RERANKER_BAKEOFF_SCHEMA_VERSION,
+    enabled: true,
+    strategy: input.strategy,
+    model: modelId(input.strategy),
+    top_n: input.topN,
+    candidates_in: input.candidatesIn,
+    candidates_reranked: input.candidatesReranked,
+    skipped: input.skipped,
+    skip_reason: input.skipReason,
+    latency_ms: Number(elapsedMs(input.started).toFixed(3)),
+    ambiguity: input.ambiguity,
+  };
+}
+
+function modelId(strategy: BenchmarkRerankerStrategy): string {
+  switch (strategy) {
+    case 'listwise-attention':
+      return 'qr-style-token-attention-v1';
+    case 'hard-negative-head':
+      return 'hard-negative-boundary-head-sim-v1';
+    case 'adaptive-listwise-attention':
+      return 'adaptive-qr-style-token-attention-v1';
+  }
+}
+
+function listwiseAttentionScore(
+  query: string,
+  candidate: BenchmarkRerankCandidate,
+  index: number,
+  candidates: readonly BenchmarkRerankCandidate[],
+): number {
+  const queryTokens = uniqueTokens(query);
+  const candidateTokens = uniqueTokens(candidate.pageContent ?? '');
+  const candidateTokenSets = candidates.map((c) => uniqueTokens(c.pageContent ?? ''));
+  const idf = computeCandidateIdf(candidateTokenSets);
+  const overlap = weightedOverlap(queryTokens, candidateTokens, idf);
+  const queryWeight = sumTokenWeights(queryTokens, idf);
+  const coverage = queryTokens.size === 0 || queryWeight === 0 ? 0 : overlap / queryWeight;
+  const centrality = mean(candidateTokenSets.map((tokens) => jaccard(candidateTokens, tokens)));
+  const rankPrior = 1 / (1 + index);
+  const lengthPenalty = Math.min(Math.abs(candidateTokens.size - 80) / 300, 0.25);
+  // Deterministic prototype heuristic: reward query coverage, candidate-set
+  // centrality, and original-rank confidence while lightly penalizing outlier
+  // length. These weights are benchmark knobs, not trained model parameters.
+  return 0.62 * coverage + 0.22 * centrality + 0.16 * rankPrior - lengthPenalty;
+}
+
+function hardNegativeHeadScore(query: string, candidate: BenchmarkRerankCandidate, index: number, total: number): number {
+  const queryTokens = uniqueTokens(query);
+  const body = candidate.pageContent ?? '';
+  const candidateTokens = uniqueTokens(body);
+  const title = typeof candidate.metadata.title === 'string' ? candidate.metadata.title : '';
+  const titleTokens = uniqueTokens(title);
+  const overlap = queryTokens.size === 0 ? 0 : intersectionSize(queryTokens, candidateTokens) / queryTokens.size;
+  const titleOverlap = queryTokens.size === 0 ? 0 : intersectionSize(queryTokens, titleTokens) / queryTokens.size;
+  const missingTerms = Math.max(0, queryTokens.size - intersectionSize(queryTokens, candidateTokens)) / Math.max(queryTokens.size, 1);
+  const scienceCue = /\b(citation|experiment|evidence|study|dataset|analysis|hypothesis|method)\b/i.test(body) ? 1 : 0;
+  const negationCue = /\b(not|never|without|fails?|rejects?|contradicts?)\b/i.test(body) ? 1 : 0;
+  const rankPrior = total <= 1 ? 1 : 1 - index / (total - 1);
+  const lengthPenalty = Math.min(Math.max(candidateTokens.size - 220, 0) / 600, 0.35);
+  // Simulated boundary classifier over hand-built hard-negative features:
+  // query/title overlap and scientific evidence cues lift candidates, while
+  // missing terms, negation cues, and long distractors push them down.
+  return 1.42 * overlap + 0.35 * titleOverlap + 0.18 * scienceCue + 0.12 * rankPrior - 0.35 * missingTerms - 0.12 * negationCue - lengthPenalty;
+}
+
+function shouldRerankAdaptively(
+  query: string,
+  ambiguity: BenchmarkRerankerQueryReport['ambiguity'],
+  candidates: number,
+): boolean {
+  if (candidates < 2) return false;
+  const queryLength = uniqueTokens(query).size;
+  if (queryLength >= 6) return true;
+  if (ambiguity.top_overlap === 0) return true;
+  // Skip when the leading candidate has a clear lexical-evidence gap; rerank
+  // when evidence is missing or the top candidates are close enough to be
+  // ambiguous.
+  return ambiguity.gap <= 0.15;
+}
+
+function computeAmbiguity(
+  query: string,
+  candidates: readonly BenchmarkRerankCandidate[],
+): BenchmarkRerankerQueryReport['ambiguity'] {
+  const queryTokens = uniqueTokens(query);
+  const overlaps = candidates
+    .map((candidate) => {
+      const candidateTokens = uniqueTokens(candidate.pageContent ?? '');
+      return queryTokens.size === 0 ? 0 : intersectionSize(queryTokens, candidateTokens) / queryTokens.size;
+    })
+    .sort((a, b) => b - a);
+  const top = overlaps[0] ?? 0;
+  const second = overlaps[1] ?? 0;
+  return {
+    top_overlap: Number(top.toFixed(6)),
+    second_overlap: Number(second.toFixed(6)),
+    gap: Number((top - second).toFixed(6)),
+  };
+}
+
+function uniqueTokens(text: string): Set<string> {
+  return new Set(tokenize(text).filter((token) => token.length > 1));
+}
+
+function computeCandidateIdf(tokenSets: readonly Set<string>[]): Map<string, number> {
+  const df = new Map<string, number>();
+  for (const tokens of tokenSets) {
+    for (const token of tokens) df.set(token, (df.get(token) ?? 0) + 1);
+  }
+  const docs = Math.max(tokenSets.length, 1);
+  const idf = new Map<string, number>();
+  for (const [token, count] of df) idf.set(token, Math.log(1 + (docs + 1) / (count + 1)));
+  return idf;
+}
+
+function weightedOverlap(left: Set<string>, right: Set<string>, weights: Map<string, number>): number {
+  let total = 0;
+  for (const token of left) {
+    if (right.has(token)) total += weights.get(token) ?? 1;
+  }
+  return total;
+}
+
+function sumTokenWeights(tokens: Set<string>, weights: Map<string, number>): number {
+  let total = 0;
+  for (const token of tokens) total += weights.get(token) ?? 1;
+  return total;
+}
+
+function intersectionSize(left: Set<string>, right: Set<string>): number {
+  let count = 0;
+  for (const token of left) {
+    if (right.has(token)) count += 1;
+  }
+  return count;
+}
+
+function jaccard(left: Set<string>, right: Set<string>): number {
+  if (left.size === 0 && right.size === 0) return 1;
+  const intersection = intersectionSize(left, right);
+  return intersection / (left.size + right.size - intersection);
+}
+
+function mean(values: readonly number[]): number {
+  if (values.length === 0) return 0;
+  return Number((values.reduce((sum, value) => sum + value, 0) / values.length).toFixed(6));
+}
+
+function elapsedMs(started: bigint): number {
+  return Number(process.hrtime.bigint() - started) / 1_000_000;
+}

--- a/benchmarks/beir/reranker-bakeoff.test.ts
+++ b/benchmarks/beir/reranker-bakeoff.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from '@jest/globals';
+import * as fsp from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  formatRerankerBakeoffMarkdown,
+  runRerankerBakeoff,
+  type RerankerBakeoffDependencies,
+} from './reranker-bakeoff.js';
+import type { BeirBenchmarkRunResult } from './run.js';
+
+function stubResult(dataset: string, mode: string): BeirBenchmarkRunResult {
+  const isBaseline = mode === 'hybrid';
+  const ndcg = isBaseline ? 0.5 : 0.55;
+  return {
+    jsonPath: `/tmp/${dataset}-${mode}.json`,
+    trecPath: `/tmp/${dataset}-${mode}.trec`,
+    reportPath: `/tmp/${dataset}-${mode}.md`,
+    report: {
+      dataset: { name: dataset, split: 'test', queries_evaluated: 2 },
+      mode,
+      metrics: {
+        judgedQueries: 2,
+        ndcgAt10: ndcg,
+        mapAt100: ndcg,
+        precisionAt10: 0.1,
+        recallAt10: ndcg,
+        recallAt100: ndcg + 0.2,
+      },
+      latency: { queries: 2, p50Ms: 1, p95Ms: isBaseline ? 4 : 6, p99Ms: 6, meanMs: 2 },
+      reranker_bakeoff: isBaseline ? null : {
+        schema_version: 'kb.beir.reranker-bakeoff-summary.v1',
+        enabled: true,
+        strategy: 'listwise-attention',
+        model: 'qr-style-token-attention-v1',
+        top_n: 50,
+        queries: 2,
+        mean_candidates_in: 50,
+        mean_candidates_reranked: 50,
+        skipped_queries: 0,
+        mean_latency_ms: 1.5,
+      },
+    } as unknown as BeirBenchmarkRunResult['report'],
+  };
+}
+
+describe('reranker bakeoff report runner', () => {
+  it('records hybrid baselines, skipped optional model rows, and win/loss deltas', async () => {
+    const root = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-reranker-bakeoff-test-'));
+    const savedQwen = process.env.KB_RERANK_QWEN3_MODEL;
+    const savedPrism = process.env.KB_RERANK_PRISM_MODEL;
+    process.env.KB_RERANK_QWEN3_MODEL = '   ';
+    delete process.env.KB_RERANK_PRISM_MODEL;
+    const calls: Array<{ argv: string[]; env?: Record<string, string> }> = [];
+    const deps: RerankerBakeoffDependencies = {
+      runBenchmark: async (argv, env) => {
+        calls.push({ argv, env });
+        const dataset = argv.find((a) => a.startsWith('--dataset='))?.split('=')[1] ?? 'unknown';
+        const mode = argv.find((a) => a.startsWith('--mode='))?.split('=')[1] ?? 'hybrid';
+        return stubResult(dataset, mode);
+      },
+      gitSha: async () => 'bakeoff-sha',
+      now: () => new Date('2026-06-09T00:00:00.000Z'),
+    };
+
+    try {
+      const { report, markdownPath } = await runRerankerBakeoff({
+        datasets: ['scifact'],
+        provider: 'fake',
+        model: 'fake-embeddings',
+        split: 'test',
+        outputDir: path.join(root, 'out'),
+        cacheDir: path.join(root, 'cache'),
+        workspaceRoot: path.join(root, 'ws'),
+        maxQueries: 2,
+      }, deps);
+
+      expect(report.cells.find((cell) => cell.variant === 'hybrid-baseline')).toMatchObject({
+        dataset: 'scifact',
+        status: 'ok',
+        ndcgAt10: 0.5,
+      });
+      expect(report.cells.find((cell) => cell.variant === 'qwen3-reranker')).toMatchObject({
+        status: 'skipped',
+        error: expect.stringContaining('KB_RERANK_QWEN3_MODEL'),
+      });
+      expect(report.cells.find((cell) => cell.variant === 'prism-reranker')).toMatchObject({
+        status: 'skipped',
+        error: expect.stringContaining('KB_RERANK_PRISM_MODEL'),
+      });
+      expect(report.cells.map((cell) => `${cell.variant}:${cell.mode}:${cell.status}`)).toEqual([
+        'hybrid-baseline:hybrid:ok',
+        'current-cross-encoder:hybrid+rerank:ok',
+        'qwen3-reranker:hybrid+rerank:skipped',
+        'prism-reranker:hybrid+rerank:skipped',
+        'listwise-attention:hybrid+listwise-rerank:ok',
+        'hard-negative-head:hybrid+hard-negative-rerank:ok',
+        'adaptive-listwise:hybrid+adaptive-rerank:ok',
+      ]);
+      expect(calls.map((call) => call.argv.find((arg) => arg.startsWith('--mode=')))).toEqual([
+        '--mode=hybrid',
+        '--mode=hybrid+rerank',
+        '--mode=hybrid+listwise-rerank',
+        '--mode=hybrid+hard-negative-rerank',
+        '--mode=hybrid+adaptive-rerank',
+      ]);
+      expect(calls.every((call) => call.argv.includes('--provider=fake'))).toBe(true);
+      expect(calls.every((call) => call.env === undefined)).toBe(true);
+      expect(report.win_loss.find((row) => row.variant === 'listwise-attention')).toMatchObject({
+        outcome: 'win',
+        ndcgDelta: 0.05,
+        latencyP95DeltaMs: 2,
+      });
+      expect(await fsp.readFile(markdownPath, 'utf-8')).toContain('hybrid-baseline');
+      expect(formatRerankerBakeoffMarkdown(report)).toContain('Default change: none');
+    } finally {
+      if (savedQwen === undefined) delete process.env.KB_RERANK_QWEN3_MODEL;
+      else process.env.KB_RERANK_QWEN3_MODEL = savedQwen;
+      if (savedPrism === undefined) delete process.env.KB_RERANK_PRISM_MODEL;
+      else process.env.KB_RERANK_PRISM_MODEL = savedPrism;
+      await fsp.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('passes configured optional model overrides through to cross-encoder cells', async () => {
+    const root = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-reranker-bakeoff-env-test-'));
+    const savedQwen = process.env.KB_RERANK_QWEN3_MODEL;
+    const savedPrism = process.env.KB_RERANK_PRISM_MODEL;
+    process.env.KB_RERANK_QWEN3_MODEL = 'local/qwen-reranker';
+    process.env.KB_RERANK_PRISM_MODEL = 'local/prism-reranker';
+    const calls: Array<{ argv: string[]; env?: Record<string, string> }> = [];
+    const deps: RerankerBakeoffDependencies = {
+      runBenchmark: async (argv, env) => {
+        calls.push({ argv, env });
+        const dataset = argv.find((a) => a.startsWith('--dataset='))?.split('=')[1] ?? 'unknown';
+        const mode = argv.find((a) => a.startsWith('--mode='))?.split('=')[1] ?? 'hybrid';
+        return stubResult(dataset, mode);
+      },
+      gitSha: async () => 'bakeoff-sha',
+      now: () => new Date('2026-06-09T00:00:00.000Z'),
+    };
+    try {
+      const { report } = await runRerankerBakeoff({
+        datasets: ['scifact'],
+        provider: 'fake',
+        model: 'fake-embeddings',
+        split: 'test',
+        outputDir: path.join(root, 'out'),
+        cacheDir: path.join(root, 'cache'),
+        workspaceRoot: path.join(root, 'ws'),
+      }, deps);
+      expect(report.cells.find((cell) => cell.variant === 'qwen3-reranker')).toMatchObject({
+        status: 'ok',
+        model: 'local/qwen-reranker',
+      });
+      expect(report.cells.find((cell) => cell.variant === 'prism-reranker')).toMatchObject({
+        status: 'ok',
+        model: 'local/prism-reranker',
+      });
+      expect(calls.find((call) => call.env?.KB_RERANK_MODEL === 'local/qwen-reranker')).toBeDefined();
+      expect(calls.find((call) => call.env?.KB_RERANK_MODEL === 'local/prism-reranker')).toBeDefined();
+    } finally {
+      if (savedQwen === undefined) delete process.env.KB_RERANK_QWEN3_MODEL;
+      else process.env.KB_RERANK_QWEN3_MODEL = savedQwen;
+      if (savedPrism === undefined) delete process.env.KB_RERANK_PRISM_MODEL;
+      else process.env.KB_RERANK_PRISM_MODEL = savedPrism;
+      await fsp.rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/benchmarks/beir/reranker-bakeoff.ts
+++ b/benchmarks/beir/reranker-bakeoff.ts
@@ -1,0 +1,470 @@
+import * as fsp from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  parseArgs as parseBeirArgs,
+  runBeirBenchmark,
+  type BeirBenchmarkRunResult,
+  type BeirMode,
+} from './run.js';
+import { ensureDirectory, gitSha, writeJsonFile } from '../utils.js';
+
+export const RERANKER_BAKEOFF_REPORT_SCHEMA_VERSION = 'kb.beir.reranker-bakeoff-report.v1';
+
+type VariantStatus = 'ok' | 'error' | 'skipped';
+
+interface BakeoffVariant {
+  id: string;
+  label: string;
+  mode: BeirMode;
+  model: string | null;
+  env?: Record<string, string>;
+  skipReason?: string;
+}
+
+interface BakeoffCell {
+  dataset: string;
+  variant: string;
+  label: string;
+  mode: BeirMode;
+  status: VariantStatus;
+  model: string | null;
+  ndcgAt10: number | null;
+  mapAt100: number | null;
+  recallAt10: number | null;
+  recallAt100: number | null;
+  latencyP50Ms: number | null;
+  latencyP95Ms: number | null;
+  candidatesMeanIn: number | null;
+  candidatesMeanReranked: number | null;
+  skippedQueries: number | null;
+  jsonPath: string | null;
+  reportPath: string | null;
+  error: string | null;
+}
+
+interface BakeoffWinLoss {
+  dataset: string;
+  variant: string;
+  ndcgDelta: number | null;
+  mapDelta: number | null;
+  recall10Delta: number | null;
+  recall100Delta: number | null;
+  latencyP95DeltaMs: number | null;
+  outcome: 'win' | 'loss' | 'tie' | 'missing';
+}
+
+export interface RerankerBakeoffReport {
+  schema_version: typeof RERANKER_BAKEOFF_REPORT_SCHEMA_VERSION;
+  generated_at: string;
+  git_sha: string;
+  datasets: string[];
+  variants: Array<{ id: string; label: string; mode: BeirMode; model: string | null; status_hint: string | null }>;
+  cells: BakeoffCell[];
+  win_loss: BakeoffWinLoss[];
+  recommendation: {
+    default_change: 'none';
+    quality: string;
+    latency: string;
+    resource_feasibility: string;
+  };
+}
+
+export interface RerankerBakeoffOptions {
+  datasets: string[];
+  provider?: string;
+  model?: string;
+  split: string;
+  outputDir: string;
+  cacheDir: string;
+  workspaceRoot: string;
+  maxQueries?: number;
+}
+
+export interface RerankerBakeoffDependencies {
+  runBenchmark(argv: string[], env?: Record<string, string>): Promise<BeirBenchmarkRunResult>;
+  gitSha(repoRoot: string): Promise<string>;
+  now(): Date;
+}
+
+const defaultDependencies: RerankerBakeoffDependencies = {
+  runBenchmark: (argv, env) => withTemporaryEnv(env ?? {}, () => runBeirBenchmark(parseBeirArgs(argv))),
+  gitSha,
+  now: () => new Date(),
+};
+
+export async function runRerankerBakeoff(
+  options: RerankerBakeoffOptions,
+  dependencies: RerankerBakeoffDependencies = defaultDependencies,
+): Promise<{ reportPath: string; markdownPath: string; report: RerankerBakeoffReport }> {
+  await ensureDirectory(options.outputDir);
+  const variants = resolveVariants(process.env);
+  const cells: BakeoffCell[] = [];
+
+  for (const dataset of options.datasets) {
+    for (const variant of variants) {
+      cells.push(await runBakeoffCell(options, dataset, variant, dependencies));
+    }
+  }
+
+  const report: RerankerBakeoffReport = {
+    schema_version: RERANKER_BAKEOFF_REPORT_SCHEMA_VERSION,
+    generated_at: dependencies.now().toISOString(),
+    git_sha: await dependencies.gitSha(process.cwd()),
+    datasets: [...options.datasets],
+    variants: variants.map((variant) => ({
+      id: variant.id,
+      label: variant.label,
+      mode: variant.mode,
+      model: variant.model,
+      status_hint: variant.skipReason ?? null,
+    })),
+    cells,
+    win_loss: buildWinLoss(cells),
+    recommendation: {
+      default_change: 'none',
+      quality: 'Use this as a diagnostic bakeoff; promote only a variant that beats hybrid on hard domains without an ArguAna-style regression.',
+      latency: 'Separate model quality from latency: cross-encoder/Qwen/Prism variants need real local model timing, while deterministic listwise/head variants report CPU-only overhead.',
+      resource_feasibility: 'Qwen3/Prism rows are skipped unless explicitly configured with local model ids; skipped rows are not quality evidence.',
+    },
+  };
+
+  const reportPath = path.join(options.outputDir, 'reranker-bakeoff.json');
+  const markdownPath = path.join(options.outputDir, 'reranker-bakeoff.md');
+  await writeJsonFile(reportPath, report);
+  await fsp.writeFile(markdownPath, formatRerankerBakeoffMarkdown(report), 'utf-8');
+  return { reportPath, markdownPath, report };
+}
+
+function resolveVariants(env: NodeJS.ProcessEnv): BakeoffVariant[] {
+  const qwen3Model = nonEmpty(env.KB_RERANK_QWEN3_MODEL);
+  const prismModel = nonEmpty(env.KB_RERANK_PRISM_MODEL);
+  const variants: BakeoffVariant[] = [
+    { id: 'hybrid-baseline', label: 'Hybrid baseline (no rerank)', mode: 'hybrid', model: null },
+    { id: 'current-cross-encoder', label: 'Current cross-encoder', mode: 'hybrid+rerank', model: env.KB_RERANK_MODEL ?? 'Xenova/ms-marco-MiniLM-L-6-v2' },
+    {
+      id: 'qwen3-reranker',
+      label: 'Qwen3 reranker override',
+      mode: 'hybrid+rerank',
+      model: qwen3Model ?? null,
+      env: qwen3Model === undefined ? undefined : { KB_RERANK_MODEL: qwen3Model },
+      skipReason: qwen3Model === undefined ? 'set KB_RERANK_QWEN3_MODEL to a locally available transformers.js-compatible reranker' : undefined,
+    },
+    {
+      id: 'prism-reranker',
+      label: 'Prism-style reranker override',
+      mode: 'hybrid+rerank',
+      model: prismModel ?? null,
+      env: prismModel === undefined ? undefined : { KB_RERANK_MODEL: prismModel },
+      skipReason: prismModel === undefined ? 'set KB_RERANK_PRISM_MODEL to a locally available transformers.js-compatible reranker' : undefined,
+    },
+    { id: 'listwise-attention', label: 'QR-style listwise attention scorer', mode: 'hybrid+listwise-rerank', model: 'qr-style-token-attention-v1' },
+    { id: 'hard-negative-head', label: 'Lightweight hard-negative boundary head', mode: 'hybrid+hard-negative-rerank', model: 'hard-negative-boundary-head-sim-v1' },
+    { id: 'adaptive-listwise', label: 'Adaptive skip-rerank + listwise scorer', mode: 'hybrid+adaptive-rerank', model: 'adaptive-qr-style-token-attention-v1' },
+  ];
+  return variants;
+}
+
+function nonEmpty(value: string | undefined): string | undefined {
+  if (value === undefined) return undefined;
+  const trimmed = value.trim();
+  return trimmed.length === 0 ? undefined : trimmed;
+}
+
+async function runBakeoffCell(
+  options: RerankerBakeoffOptions,
+  dataset: string,
+  variant: BakeoffVariant,
+  dependencies: RerankerBakeoffDependencies,
+): Promise<BakeoffCell> {
+  const base = {
+    dataset,
+    variant: variant.id,
+    label: variant.label,
+    mode: variant.mode,
+    model: variant.model,
+  };
+  if (variant.skipReason !== undefined) {
+    return emptyCell(base, 'skipped', variant.skipReason);
+  }
+  try {
+    const result = await dependencies.runBenchmark(buildBeirArgv(options, dataset, variant), variant.env);
+    const bakeoff = result.report.reranker_bakeoff;
+    return {
+      ...base,
+      status: 'ok',
+      ndcgAt10: result.report.metrics.ndcgAt10,
+      mapAt100: result.report.metrics.mapAt100,
+      recallAt10: result.report.metrics.recallAt10,
+      recallAt100: result.report.metrics.recallAt100,
+      latencyP50Ms: result.report.latency.p50Ms,
+      latencyP95Ms: result.report.latency.p95Ms,
+      candidatesMeanIn: bakeoff?.mean_candidates_in ?? null,
+      candidatesMeanReranked: bakeoff?.mean_candidates_reranked ?? null,
+      skippedQueries: bakeoff?.skipped_queries ?? null,
+      jsonPath: relativeOrAbsolute(result.jsonPath),
+      reportPath: relativeOrAbsolute(result.reportPath),
+      error: null,
+    };
+  } catch (error) {
+    return emptyCell(base, 'error', error instanceof Error ? error.message : String(error));
+  }
+}
+
+function buildBeirArgv(options: RerankerBakeoffOptions, dataset: string, variant: BakeoffVariant): string[] {
+  const outDir = path.join(options.outputDir, dataset, variant.id);
+  const argv = [
+    `--dataset=${dataset}`,
+    `--split=${options.split}`,
+    `--mode=${variant.mode}`,
+    `--output-dir=${outDir}`,
+    `--cache-dir=${options.cacheDir}`,
+    `--workspace-root=${options.workspaceRoot}`,
+    '--candidate-pool-k=100',
+    '--chunk-k=100',
+  ];
+  if (variant.mode !== 'lexical' && variant.mode !== 'late') {
+    if (options.provider !== undefined) argv.push(`--provider=${options.provider}`);
+    if (options.model !== undefined) argv.push(`--model=${options.model}`);
+  }
+  if (options.maxQueries !== undefined) argv.push(`--max-queries=${options.maxQueries}`);
+  return argv;
+}
+
+function emptyCell(
+  base: Pick<BakeoffCell, 'dataset' | 'variant' | 'label' | 'mode' | 'model'>,
+  status: 'error' | 'skipped',
+  error: string,
+): BakeoffCell {
+  return {
+    ...base,
+    status,
+    ndcgAt10: null,
+    mapAt100: null,
+    recallAt10: null,
+    recallAt100: null,
+    latencyP50Ms: null,
+    latencyP95Ms: null,
+    candidatesMeanIn: null,
+    candidatesMeanReranked: null,
+    skippedQueries: null,
+    jsonPath: null,
+    reportPath: null,
+    error,
+  };
+}
+
+function buildWinLoss(cells: readonly BakeoffCell[]): BakeoffWinLoss[] {
+  const out: BakeoffWinLoss[] = [];
+  for (const cell of cells) {
+    if (cell.variant === 'hybrid-baseline') continue;
+    const baseline = cells.find((candidate) =>
+      candidate.dataset === cell.dataset &&
+      candidate.variant === 'hybrid-baseline' &&
+      candidate.status === 'ok'
+    );
+    if (baseline === undefined || cell.status !== 'ok') {
+      out.push({
+        dataset: cell.dataset,
+        variant: cell.variant,
+        ndcgDelta: null,
+        mapDelta: null,
+        recall10Delta: null,
+        recall100Delta: null,
+        latencyP95DeltaMs: null,
+        outcome: 'missing',
+      });
+      continue;
+    }
+    const ndcgDelta = delta(cell.ndcgAt10, baseline.ndcgAt10);
+    const mapDelta = delta(cell.mapAt100, baseline.mapAt100);
+    const recall10Delta = delta(cell.recallAt10, baseline.recallAt10);
+    const recall100Delta = delta(cell.recallAt100, baseline.recallAt100);
+    out.push({
+      dataset: cell.dataset,
+      variant: cell.variant,
+      ndcgDelta,
+      mapDelta,
+      recall10Delta,
+      recall100Delta,
+      latencyP95DeltaMs: delta(cell.latencyP95Ms, baseline.latencyP95Ms),
+      outcome: ndcgDelta === null
+        ? 'missing'
+        : ndcgDelta > 0.000001
+          ? 'win'
+          : ndcgDelta < -0.000001
+            ? 'loss'
+            : 'tie',
+    });
+  }
+  return out;
+}
+
+export function formatRerankerBakeoffMarkdown(report: RerankerBakeoffReport): string {
+  const lines = [
+    '# Reranker upgrade bakeoff',
+    '',
+    'Local diagnostic bakeoff for issue #579. This report never fabricates missing rows:',
+    'failed or unconfigured variants are marked `error` or `skipped` and excluded from win/loss evidence.',
+    '',
+    `- Generated: ${report.generated_at}`,
+    `- Commit: \`${report.git_sha}\``,
+    `- Datasets: ${report.datasets.join(', ')}`,
+    '- Required baseline: every dataset includes `hybrid-baseline` when the cell can run.',
+    '',
+    '## Cells',
+    '',
+    '| Dataset | Variant | Status | nDCG@10 | MAP@100 | R@10 | R@100 | p95 ms | candidates reranked | error |',
+    '| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |',
+  ];
+  for (const cell of report.cells) {
+    lines.push(
+      `| ${cell.dataset} | ${cell.variant} | ${cell.status} | ${fmt(cell.ndcgAt10)} | ${fmt(cell.mapAt100)} | ` +
+        `${fmt(cell.recallAt10)} | ${fmt(cell.recallAt100)} | ${fmt(cell.latencyP95Ms)} | ` +
+        `${fmt(cell.candidatesMeanReranked)} | ${cell.error ?? ''} |`,
+    );
+  }
+  lines.push('', '## Win/loss vs hybrid baseline', '');
+  lines.push('| Dataset | Variant | Outcome | Δ nDCG@10 | Δ MAP@100 | Δ R@10 | Δ R@100 | Δ p95 ms |');
+  lines.push('| --- | --- | --- | ---: | ---: | ---: | ---: | ---: |');
+  for (const row of report.win_loss) {
+    lines.push(
+      `| ${row.dataset} | ${row.variant} | ${row.outcome} | ${fmtDelta(row.ndcgDelta)} | ` +
+        `${fmtDelta(row.mapDelta)} | ${fmtDelta(row.recall10Delta)} | ${fmtDelta(row.recall100Delta)} | ` +
+        `${fmtDelta(row.latencyP95DeltaMs)} |`,
+    );
+  }
+  lines.push('', '## Recommendation', '');
+  lines.push(`- Default change: ${report.recommendation.default_change}`);
+  lines.push(`- Quality: ${report.recommendation.quality}`);
+  lines.push(`- Latency: ${report.recommendation.latency}`);
+  lines.push(`- Resource feasibility: ${report.recommendation.resource_feasibility}`);
+  return `${lines.join('\n')}\n`;
+}
+
+function delta(left: number | null, right: number | null): number | null {
+  if (left === null || right === null) return null;
+  return Number((left - right).toFixed(6));
+}
+
+function fmt(value: number | null): string {
+  return value === null ? 'n/a' : value.toFixed(4);
+}
+
+function fmtDelta(value: number | null): string {
+  if (value === null) return 'n/a';
+  return value >= 0 ? `+${value.toFixed(4)}` : value.toFixed(4);
+}
+
+function relativeOrAbsolute(filePath: string): string {
+  const relative = path.relative(process.cwd(), filePath);
+  return relative !== '' && !relative.startsWith('..') && !path.isAbsolute(relative) ? relative : filePath;
+}
+
+async function withTemporaryEnv<T>(env: Record<string, string>, fn: () => Promise<T>): Promise<T> {
+  const previous: Record<string, string | undefined> = {};
+  for (const [key, value] of Object.entries(env)) {
+    previous[key] = process.env[key];
+    process.env[key] = value;
+  }
+  try {
+    return await fn();
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+}
+
+function parseRerankerBakeoffArgs(argv: string[]): RerankerBakeoffOptions {
+  const repoRoot = process.cwd();
+  const options: RerankerBakeoffOptions = {
+    datasets: ['scifact', 'arguana', 'scidocs', 'hotpotqa'],
+    split: 'test',
+    outputDir: path.join(repoRoot, 'benchmarks', 'results', 'beir', 'reranker-bakeoff'),
+    cacheDir: process.env.BEIR_CACHE_DIR ?? path.join(os.tmpdir(), 'kb-beir-cache'),
+    workspaceRoot: path.join(os.tmpdir(), `kb-beir-reranker-bakeoff-${process.pid}`),
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    const [flag, inlineValue] = token.includes('=') ? token.split(/=(.*)/s, 2) : [token, undefined];
+    const readValue = (): string => {
+      if (inlineValue !== undefined) return inlineValue;
+      i += 1;
+      const value = argv[i];
+      if (value === undefined || value.startsWith('--')) throw new Error(`${flag} requires a value`);
+      return value;
+    };
+    if (flag === '--datasets') {
+      options.datasets = splitList(readValue());
+    } else if (flag === '--provider') {
+      options.provider = readValue();
+    } else if (flag === '--model') {
+      options.model = readValue();
+    } else if (flag === '--split') {
+      options.split = readValue();
+    } else if (flag === '--output-dir') {
+      options.outputDir = path.resolve(readValue());
+    } else if (flag === '--cache-dir') {
+      options.cacheDir = path.resolve(readValue());
+    } else if (flag === '--workspace-root') {
+      options.workspaceRoot = path.resolve(readValue());
+    } else if (flag === '--max-queries') {
+      options.maxQueries = parsePositiveInt(readValue(), '--max-queries');
+    } else if (flag === '--help' || flag === '-h') {
+      process.stdout.write(helpText());
+      process.exit(0);
+    } else {
+      throw new Error(`unknown argument: ${token}`);
+    }
+  }
+  return options;
+}
+
+function splitList(raw: string): string[] {
+  return raw.split(',').map((value) => value.trim()).filter((value) => value.length > 0);
+}
+
+function parsePositiveInt(raw: string, flag: string): number {
+  const parsed = Number(raw);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) throw new Error(`${flag} must be a positive integer`);
+  return parsed;
+}
+
+function helpText(): string {
+  return `kb BEIR reranker bakeoff (issue #579)
+
+Usage:
+  npm run bench:beir:reranker-bakeoff -- --provider=ollama --model=nomic-embed-text:latest
+
+Options:
+  --datasets=<a,b,c>   Diagnostic datasets. Default: scifact,arguana,scidocs,hotpotqa.
+  --provider=<name>    Embedding provider for hybrid candidate generation.
+  --model=<name>       Embedding model for hybrid candidate generation.
+  --split=<name>       Qrels split. Default: test.
+  --output-dir=<path>  Report directory.
+  --max-queries=<n>    Deterministic quick sample.
+
+Optional stronger model rows:
+  KB_RERANK_QWEN3_MODEL=<model-id>   Enables qwen3-reranker row.
+  KB_RERANK_PRISM_MODEL=<model-id>   Enables prism-reranker row.
+`;
+}
+
+async function main(): Promise<void> {
+  const { reportPath, markdownPath, report } = await runRerankerBakeoff(parseRerankerBakeoffArgs(process.argv.slice(2)));
+  process.stdout.write(`${report.cells.filter((cell) => cell.status === 'ok').length}/${report.cells.length} cells ok\n`);
+  process.stdout.write(`${reportPath}\n${markdownPath}\n`);
+}
+
+const cliEntry = process.argv[1] !== undefined ? path.normalize(process.argv[1]) : '';
+if (
+  cliEntry.endsWith(path.join('benchmarks', 'beir', 'reranker-bakeoff.js')) ||
+  cliEntry.endsWith(path.join('benchmarks', 'beir', 'reranker-bakeoff.ts'))
+) {
+  main().catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.stack ?? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/benchmarks/beir/run.reranker-bakeoff.test.ts
+++ b/benchmarks/beir/run.reranker-bakeoff.test.ts
@@ -1,0 +1,120 @@
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import * as fsp from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  parseArgs,
+  runBeirBenchmark,
+  type BeirSearchBackend,
+  type LoadSearchBackendInput,
+  type RunDependencies,
+} from './run.js';
+
+const baseDeps = {
+  gitSha: async () => 'test-sha',
+  now: () => new Date('2026-06-09T00:00:00.000Z'),
+  pythonVersion: async () => null,
+  silenceServerLogger: async () => undefined,
+  loadLexicalIndex: async () => {
+    throw new Error('loadLexicalIndex should not be called for benchmark rerank modes');
+  },
+} satisfies Omit<RunDependencies, 'loadSearchBackend'>;
+
+async function writeTinyBeirDataset(root: string): Promise<string> {
+  const datasetDir = path.join(root, 'tiny');
+  await fsp.mkdir(path.join(datasetDir, 'qrels'), { recursive: true });
+  await fsp.writeFile(path.join(datasetDir, 'corpus.jsonl'), [
+    JSON.stringify({ _id: 'doc-alpha', title: 'Alpha', text: 'Alpha gravity wave detection evidence and analysis.' }),
+    JSON.stringify({ _id: 'doc-beta', title: 'Beta', text: 'Beta culinary recipe for a hearty tomato soup.' }),
+    '',
+  ].join('\n'), 'utf-8');
+  await fsp.writeFile(path.join(datasetDir, 'queries.jsonl'), [
+    JSON.stringify({ _id: 'q1', text: 'alpha gravity wave detection evidence analysis' }),
+    '',
+  ].join('\n'), 'utf-8');
+  await fsp.writeFile(path.join(datasetDir, 'qrels', 'test.tsv'), [
+    'query-id corpus-id score',
+    'q1 doc-alpha 1',
+    '',
+  ].join('\n'), 'utf-8');
+  return datasetDir;
+}
+
+async function loadBakeoffBackend(input: LoadSearchBackendInput): Promise<BeirSearchBackend> {
+  const relativeByDoc = new Map<string, string>();
+  return {
+    implementation: 'test production hybrid candidate generator',
+    prepare: async () => {
+      const kbRoot = process.env.KNOWLEDGE_BASES_ROOT_DIR;
+      if (kbRoot === undefined) throw new Error('KNOWLEDGE_BASES_ROOT_DIR missing');
+      const kbPath = path.join(kbRoot, input.kbName);
+      const files = await fsp.readdir(kbPath);
+      for (const file of files) {
+        const text = await fsp.readFile(path.join(kbPath, file), 'utf-8');
+        if (text.includes('Alpha gravity')) relativeByDoc.set('doc-alpha', `${input.kbName}/${file}`);
+        if (text.includes('Beta culinary')) relativeByDoc.set('doc-beta', `${input.kbName}/${file}`);
+      }
+      return { files: files.length, chunks: files.length };
+    },
+    search: async () => [
+      {
+        pageContent: 'Beta culinary recipe for a hearty tomato soup.',
+        metadata: { relativePath: relativeByDoc.get('doc-beta') },
+        score: 2,
+      },
+      {
+        pageContent: 'Alpha gravity wave detection evidence and analysis.',
+        metadata: { relativePath: relativeByDoc.get('doc-alpha') },
+        score: 1,
+      },
+    ],
+  };
+}
+
+describe('BEIR runner issue #579 reranker bakeoff modes', () => {
+  let root: string;
+  let datasetDir: string;
+
+  beforeAll(async () => {
+    root = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-beir-reranker-bakeoff-'));
+    datasetDir = await writeTinyBeirDataset(root);
+  });
+
+  afterAll(async () => {
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  it.each([
+    ['hybrid+listwise-rerank', 'listwise-attention', 'qr-style-token-attention-v1'],
+    ['hybrid+hard-negative-rerank', 'hard-negative-head', 'hard-negative-boundary-head-sim-v1'],
+    ['hybrid+adaptive-rerank', 'adaptive-listwise-attention', 'adaptive-qr-style-token-attention-v1'],
+  ])('runs benchmark-only %s over hybrid candidates and records candidate diagnostics', async (mode, strategy, model) => {
+    const args = parseArgs([
+      '--dataset=tiny',
+      `--dataset-dir=${datasetDir}`,
+      `--mode=${mode}`,
+      '--provider=fake',
+      `--output-dir=${path.join(root, `out-${mode}`)}`,
+      `--workspace-root=${path.join(root, `kb-beir-ws-${mode}`)}`,
+      '--k=2',
+      '--chunk-k=2',
+      '--candidate-pool-k=2',
+    ]);
+
+    const result = await runBeirBenchmark(args, { ...baseDeps, loadSearchBackend: loadBakeoffBackend });
+
+    expect(result.report.schema_version).toBe('kb.beir-benchmark.v6');
+    expect(result.report.mode).toBe(mode);
+    expect(result.report.reranker_bakeoff).toMatchObject({
+      strategy,
+      model,
+      queries: 1,
+      mean_candidates_in: 2,
+      mean_candidates_reranked: 2,
+      skipped_queries: 0,
+    });
+    expect(result.report.metrics.ndcgAt10).toBe(1);
+    const trec = await fsp.readFile(result.trecPath, 'utf-8');
+    expect(trec.split(/\r?\n/)[0]).toContain('doc-alpha');
+  });
+});

--- a/benchmarks/beir/run.ts
+++ b/benchmarks/beir/run.ts
@@ -21,6 +21,15 @@ import {
   type LateInteractionDocument,
   type LateInteractionResourceReport,
 } from './late-interaction.js';
+import {
+  isBenchmarkRerankerMode,
+  rerankWithBenchmarkReranker,
+  summarizeBenchmarkRerankerReports,
+  RERANKER_BAKEOFF_TOP_N,
+  type BenchmarkRerankerMode,
+  type BenchmarkRerankerQueryReport,
+  type BenchmarkRerankerSummary,
+} from './reranker-bakeoff-rerankers.js';
 import { durationMs, ensureDirectory, gitSha, resetDirectory, writeJsonFile } from '../utils.js';
 
 const execFileAsync = promisify(execFile);
@@ -41,13 +50,15 @@ const DATASET_URLS: Record<string, string> = {
   'webis-touche2020': 'https://public.ukp.informatik.tu-darmstadt.de/thakur/BEIR/datasets/webis-touche2020.zip',
 };
 
-// v5 (retrieval frontier #578): added benchmark-only late-interaction
+// v6 (retrieval frontier #579): added benchmark-only listwise, hard-negative,
+// and adaptive rerank bakeoff modes. v5 (retrieval frontier #578): added
+// benchmark-only late-interaction
 // standalone and hybrid candidate-rerank modes. v4 added optional
 // query-decomposition summary and per-query trace artifacts. v3 added
 // `hybrid+rerank` / `hybrid+rerank+contextual`
 // modes plus `rerank` / `contextual` provenance blocks. v2 added `dense`/`hybrid`
 // + precision@10 + `embedding`; v1 was lexical-only.
-const BENCHMARK_SCHEMA_VERSION = 'kb.beir-benchmark.v5';
+const BENCHMARK_SCHEMA_VERSION = 'kb.beir-benchmark.v6';
 type LexicalUnit = 'chunk' | 'source';
 // RFC 020 §1 — the retrieval-mode space the runner can score. `lexical` is
 // credential-free (BM25 only), and `late` is a credential-free benchmark-only
@@ -62,7 +73,10 @@ export type BeirMode =
   | 'hybrid+decompose'
   | 'hybrid+late'
   | 'hybrid+rerank'
-  | 'hybrid+rerank+contextual';
+  | 'hybrid+rerank+contextual'
+  | 'hybrid+listwise-rerank'
+  | 'hybrid+hard-negative-rerank'
+  | 'hybrid+adaptive-rerank';
 const BEIR_MODES: readonly BeirMode[] = [
   'lexical',
   'late',
@@ -72,6 +86,9 @@ const BEIR_MODES: readonly BeirMode[] = [
   'hybrid+late',
   'hybrid+rerank',
   'hybrid+rerank+contextual',
+  'hybrid+listwise-rerank',
+  'hybrid+hard-negative-rerank',
+  'hybrid+adaptive-rerank',
 ];
 
 function isBeirMode(value: string): value is BeirMode {
@@ -105,6 +122,10 @@ function modeEnablesContextual(mode: BeirMode): boolean {
 
 function modeEnablesDecompose(mode: BeirMode): boolean {
   return mode === 'hybrid+decompose';
+}
+
+function modeEnablesBenchmarkReranker(mode: BeirMode): boolean {
+  return isBenchmarkRerankerMode(mode);
 }
 
 // Mirrors `src/config/reranker.ts` defaults. Recorded as provenance only; the
@@ -289,6 +310,9 @@ interface BeirBenchmarkReport {
   // Benchmark-only late-interaction provenance for issue #578. Present for
   // `late` standalone and `hybrid+late` candidate rerank modes; null otherwise.
   late_interaction: LateInteractionResourceReport | null;
+  // Benchmark-only reranker upgrade provenance for issue #579. Present for the
+  // listwise, hard-negative, and adaptive rerank bakeoff modes; null otherwise.
+  reranker_bakeoff: BenchmarkRerankerSummary | null;
   ranking: {
     unit: LexicalUnit;
     implementation: string;
@@ -419,6 +443,7 @@ export async function runBeirBenchmark(
     ranking: rankingMeta,
     embedding,
     lateInteraction,
+    rerankerBakeoff,
   } = retrieval;
   const stages = resolveStageProvenance(args.mode);
 
@@ -459,6 +484,7 @@ export async function runBeirBenchmark(
     rerank: stages.rerank,
     contextual: stages.contextual,
     late_interaction: lateInteraction ?? null,
+    reranker_bakeoff: rerankerBakeoff ?? null,
     ranking: {
       unit: rankingMeta.unit,
       implementation: rankingMeta.implementation,
@@ -532,6 +558,7 @@ interface RetrievalOutcome {
   ranking: { unit: LexicalUnit; implementation: string };
   embedding: BeirBenchmarkReport['embedding'];
   lateInteraction?: LateInteractionResourceReport;
+  rerankerBakeoff?: BenchmarkRerankerSummary;
 }
 
 interface QueryDecompositionRuntime {
@@ -654,6 +681,7 @@ async function runDenseRetrieval(input: RetrievalInput): Promise<RetrievalOutcom
     ? await (dependencies.loadQueryDecompositionRuntime ?? loadQueryDecompositionRuntime)(buildRoot)
     : null;
   const latenciesMs: number[] = [];
+  const benchmarkRerankReports: BenchmarkRerankerQueryReport[] = [];
   for (const query of selectedQueries) {
     const started = process.hrtime.bigint();
     // Fetch at chunk depth, then collapse to BEIR documents. The production
@@ -667,11 +695,21 @@ async function runDenseRetrieval(input: RetrievalInput): Promise<RetrievalOutcom
           k: args.candidatePoolK ?? args.chunkK,
           traceSink: (trace) => decompositionTraces.push({ query_id: query._id, trace }),
         });
-    const rankedChunks = lateIndex === null
+    const benchmarkReranked = !modeEnablesBenchmarkReranker(args.mode)
       ? chunks
-      : await rerankBeirChunksWithLateInteraction({
+      : await rerankBeirChunksWithBenchmarkReranker({
+          mode: args.mode as BenchmarkRerankerMode,
           query: query.text,
           chunks,
+          prepared,
+          textCache: candidateTextCache,
+          reportSink: (report) => benchmarkRerankReports.push(report),
+        });
+    const rankedChunks = lateIndex === null
+      ? benchmarkReranked
+      : await rerankBeirChunksWithLateInteraction({
+          query: query.text,
+          chunks: benchmarkReranked,
           lateIndex,
           prepared,
           textCache: candidateTextCache,
@@ -698,6 +736,9 @@ async function runDenseRetrieval(input: RetrievalInput): Promise<RetrievalOutcom
     indexing: { files: prep.files, chunks: prep.chunks },
     ranking: { unit: 'chunk', implementation: describeImplementation(backend.implementation, args.mode) },
     embedding: { provider: spec.provider, model: spec.model },
+    ...(benchmarkRerankReports.length > 0
+      ? { rerankerBakeoff: summarizeBenchmarkRerankerReports(benchmarkRerankReports) ?? undefined }
+      : {}),
     ...(lateIndex !== null
       ? { lateInteraction: lateIndex.resourceReport('rerank', `${beirSearchMode(args.mode)} top-${args.candidatePoolK ?? args.chunkK} candidates`) }
       : {}),
@@ -759,10 +800,40 @@ function describeImplementation(base: string, mode: BeirMode): string {
   if (modeEnablesRerank(mode)) {
     stages.push('+ src/reranker.ts cross-encoder rerank (production KB_RERANK path)');
   }
+  if (modeEnablesBenchmarkReranker(mode)) {
+    stages.push('+ benchmarks/beir/reranker-bakeoff-rerankers.ts benchmark-only rerank provider');
+  }
   if (modeEnablesContextual(mode)) {
     stages.push('+ RFC 017 contextual prefaces at ingest (production buildChunkDocuments path)');
   }
   return stages.length === 0 ? base : `${base} ${stages.join(' ')}`;
+}
+
+async function rerankBeirChunksWithBenchmarkReranker(input: {
+  mode: BenchmarkRerankerMode;
+  query: string;
+  chunks: readonly BeirRankedChunk[];
+  prepared: CorpusPreparation;
+  textCache: Map<string, string>;
+  reportSink(report: BenchmarkRerankerQueryReport): void;
+}): Promise<BeirRankedChunk[]> {
+  const candidates = await Promise.all(input.chunks.map(async (chunk) => ({
+    pageContent: await resolveChunkText(chunk, input.prepared, input.textCache),
+    metadata: chunk.metadata,
+    score: chunk.score,
+  })));
+  const out = rerankWithBenchmarkReranker({
+    mode: input.mode,
+    query: input.query,
+    candidates,
+    topN: RERANKER_BAKEOFF_TOP_N,
+  });
+  input.reportSink(out.report);
+  return out.results.map((result) => ({
+    ...(typeof result.pageContent === 'string' ? { pageContent: result.pageContent } : {}),
+    metadata: result.metadata,
+    score: result.score,
+  }));
 }
 
 async function runBeirDecomposedSearch(input: {
@@ -1070,6 +1141,17 @@ function buildCaveats(args: Args): string[] {
         'Query decomposition is opt-in and bounded; traces are persisted per query. ' +
           'The rule provider is deterministic and intended as a baseline before local-LLM evaluation.',
       );
+    }
+    if (modeEnablesBenchmarkReranker(args.mode)) {
+      caveats.push(
+        'Issue #579 benchmark reranker modes are experimental and benchmark-only: they reorder top-50 ' +
+          'production hybrid candidates with deterministic local scorers and do not change production search defaults.',
+      );
+      if (args.mode === 'hybrid+adaptive-rerank') {
+        caveats.push(
+          'Adaptive rerank mode records skipped queries when the candidate list has a clear lexical-confidence winner.',
+        );
+      }
     }
     if (modeEnablesLateInteraction(args.mode)) {
       caveats.push(
@@ -1691,6 +1773,16 @@ function formatMarkdownReport(report: BeirBenchmarkReport, trecPath: string, jso
             `GPU=${report.late_interaction.gpu_requirement}`,
         ]
       : []),
+    ...(report.reranker_bakeoff !== null
+      ? [
+          `- Reranker bakeoff: ${report.reranker_bakeoff.strategy}, model=${report.reranker_bakeoff.model}, ` +
+            `topN=${report.reranker_bakeoff.top_n}`,
+          `- Reranker candidates: mean in=${report.reranker_bakeoff.mean_candidates_in}, ` +
+            `mean reranked=${report.reranker_bakeoff.mean_candidates_reranked}, ` +
+            `skipped queries=${report.reranker_bakeoff.skipped_queries}/${report.reranker_bakeoff.queries}, ` +
+            `mean rerank latency=${report.reranker_bakeoff.mean_latency_ms} ms`,
+        ]
+      : []),
     `- Query latency: p50 ${latency.p50Ms} ms, p95 ${latency.p95Ms} ms, p99 ${latency.p99Ms} ms`,
     '',
     '## Artifacts',
@@ -1762,6 +1854,9 @@ Options:
                          (KB_RERANK); hybrid+rerank+contextual also enables the
                          RFC 017 contextual-preface ingest path and needs an LLM
                          endpoint (KB_LLM_ENDPOINT, or KB_LLM_FAKE=on for tests).
+                         hybrid+listwise-rerank, hybrid+hard-negative-rerank,
+                         and hybrid+adaptive-rerank are issue #579 benchmark-only
+                         top-50 reranker bakeoff modes.
   --lexical-unit=<unit>  chunk or source. source maps to kb search --lexical-unit=source. Default: source.
                          (lexical mode only.)
   --provider=<name>      Embedding provider for dense/hybrid (ollama, openai,

--- a/benchmarks/results/reranker-bakeoff-issue579-evaluation.md
+++ b/benchmarks/results/reranker-bakeoff-issue579-evaluation.md
@@ -1,0 +1,81 @@
+# Reranker upgrade and listwise reranking bakeoff (#579)
+
+## Scope
+
+This is a benchmark-first implementation report for the retrieval frontier
+roadmap. It adds experimental reranker bakeoff modes, but does not change the
+default production search behavior.
+
+## Implemented benchmark surface
+
+- `hybrid+listwise-rerank`: production hybrid candidates reordered by a
+  QRRanker-style token-attention scorer over the top candidate set.
+- `hybrid+hard-negative-rerank`: production hybrid candidates reordered by a
+  lightweight simulated hard-negative boundary head over query/document
+  features.
+- `hybrid+adaptive-rerank`: same listwise scorer, but routed through a
+  confidence/ambiguity gate that can skip rerank for low-ambiguity queries.
+- `bench:beir:reranker-bakeoff`: diagnostic runner that compares hybrid
+  baseline, current cross-encoder, optional Qwen3/Prism model overrides, and
+  the benchmark-only rerankers. Qwen3/Prism rows are skipped unless
+  `KB_RERANK_QWEN3_MODEL` or `KB_RERANK_PRISM_MODEL` is set to a locally
+  available transformers.js-compatible reranker.
+
+## #573 baseline availability
+
+Committed #573 BEIR baselines are present only for SciFact plus the hermetic
+gate fixture:
+
+| Dataset | Mode | nDCG@10 | MAP@100 | Recall@10 | Recall@100 | Source |
+| --- | --- | ---: | ---: | ---: | ---: | --- |
+| SciFact | lexical | 0.6690 | see JSON | 0.7923 | 0.8959 | `benchmarks/results/beir/baseline/scifact-lexical.json` |
+| SciFact | dense | 0.4914 | see JSON | 0.6107 | 0.8083 | `benchmarks/results/beir/baseline/scifact-dense.json` |
+| SciFact | hybrid | 0.6109 | see JSON | 0.7629 | 0.9213 | `benchmarks/results/beir/baseline/scifact-hybrid.json` |
+
+No committed #573 no-rerank/hybrid baselines were found for ArguAna, SciDocs,
+or HotpotQA/BRIGHT in this worktree. Cached BEIR-shaped datasets are available
+locally under `$HOME/.cache/kb-beir-cache` for ArguAna and SciDocs, but a
+real reranker bakeoff over those corpora would require rebuilding or reusing
+real embedding indexes and, for cross-encoder/Qwen/Prism, locally cached or
+downloadable reranker models. This report does not fabricate those rows.
+
+## Diagnostic smoke run
+
+The hermetic gate fixture is not quality evidence because it uses the `fake`
+embedding provider, but it proves the report path, candidate accounting, and
+reranker latency fields without network or model downloads.
+
+Commands:
+
+```bash
+node build/benchmarks/beir/run.js --dataset=gate-fixture --dataset-dir=benchmarks/beir/fixtures/gate/gate-fixture --split=test --mode=hybrid --provider=fake --output-dir=/tmp/kb-beir-issue579-gate-hybrid --workspace-root=/tmp/kb-beir-issue579-gate-hybrid-ws --k=10 --chunk-k=40 --candidate-pool-k=40
+node build/benchmarks/beir/run.js --dataset=gate-fixture --dataset-dir=benchmarks/beir/fixtures/gate/gate-fixture --split=test --mode=hybrid+listwise-rerank --provider=fake --output-dir=/tmp/kb-beir-issue579-gate-listwise --workspace-root=/tmp/kb-beir-issue579-gate-listwise-ws --k=10 --chunk-k=40 --candidate-pool-k=40
+node build/benchmarks/beir/run.js --dataset=gate-fixture --dataset-dir=benchmarks/beir/fixtures/gate/gate-fixture --split=test --mode=hybrid+hard-negative-rerank --provider=fake --output-dir=/tmp/kb-beir-issue579-gate-hard --workspace-root=/tmp/kb-beir-issue579-gate-hard-ws --k=10 --chunk-k=40 --candidate-pool-k=40
+node build/benchmarks/beir/run.js --dataset=gate-fixture --dataset-dir=benchmarks/beir/fixtures/gate/gate-fixture --split=test --mode=hybrid+adaptive-rerank --provider=fake --output-dir=/tmp/kb-beir-issue579-gate-adaptive --workspace-root=/tmp/kb-beir-issue579-gate-adaptive-ws --k=10 --chunk-k=40 --candidate-pool-k=40
+```
+
+Measured fixture results:
+
+| Variant | nDCG@10 | MAP@100 | Recall@10 | Recall@100 | p50 ms | p95 ms | Mean candidates in | Mean candidates reranked | Mean rerank latency ms |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| hybrid baseline | 1.0000 | 1.0000 | 1.0000 | 1.0000 | 11.717 | 28.609 | n/a | n/a | n/a |
+| listwise attention | 1.0000 | 1.0000 | 1.0000 | 1.0000 | 10.815 | 31.895 | 12 | 12 | 3.236 |
+| hard-negative head | 1.0000 | 1.0000 | 1.0000 | 1.0000 | 7.654 | 33.833 | 12 | 12 | 0.540 |
+| adaptive listwise | 1.0000 | 1.0000 | 1.0000 | 1.0000 | 10.869 | 31.954 | 12 | 12 | 3.139 |
+
+## Recommendation
+
+No default reranker change should ship from this PR. The benchmark surface is
+ready to run the diagnostic sample before any full matrix, but the only real
+committed baseline currently available here is SciFact hybrid from #573. The
+next real bakeoff should run:
+
+```bash
+npm run bench:beir:reranker-bakeoff -- --datasets=scifact,arguana,scidocs --provider=ollama --model=nomic-embed-text:latest --cache-dir=$HOME/.cache/kb-beir-cache --max-queries=<time-boxed sample>
+```
+
+For Qwen3/Prism reranker rows, set `KB_RERANK_QWEN3_MODEL` and/or
+`KB_RERANK_PRISM_MODEL` to locally available reranker model ids first. Treat
+model quality and latency/resource feasibility separately: deterministic
+listwise/head rows are CPU-only prototypes, while cross-encoder/Qwen/Prism rows
+must include model-load/cache state and per-candidate latency before promotion.

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "bench:beir:sweep": "npm run build && tsc -p tsconfig.bench.json && node build/benchmarks/beir/sweep.js",
     "bench:beir:baseline": "npm run build && tsc -p tsconfig.bench.json && node build/benchmarks/beir/baseline.js",
     "bench:beir:matrix": "npm run build && tsc -p tsconfig.bench.json && node build/benchmarks/beir/matrix.js",
+    "bench:beir:reranker-bakeoff": "npm run build && tsc -p tsconfig.bench.json && node build/benchmarks/beir/reranker-bakeoff.js",
     "bench:beir:leaderboard": "npm run build && tsc -p tsconfig.bench.json && node build/benchmarks/compare/leaderboard.js",
     "bench:beir:significance": "npm run build && tsc -p tsconfig.bench.json && node build/benchmarks/significance.js",
     "bench:beir:quality-gate": "npm run build && tsc -p tsconfig.bench.json && node build/benchmarks/beir/quality-gate.js",


### PR DESCRIPTION
## Summary

Closes #579.

Adds a benchmark-first reranker upgrade bakeoff for the retrieval frontier roadmap:

- new BEIR modes: `hybrid+listwise-rerank`, `hybrid+hard-negative-rerank`, and `hybrid+adaptive-rerank`
- a `bench:beir:reranker-bakeoff` runner that compares hybrid baseline, current cross-encoder, optional Qwen3/Prism overrides, listwise rerank, hard-negative head, and adaptive routing
- per-query and summary provenance for candidate count, reranked count, skipped adaptive queries, and rerank latency
- issue #579 evaluation note with real #573 baseline availability, smoke results, and no default behavior change

## Dependency on #573

This PR uses the committed #573 BEIR baseline artifacts as the source of truth. In this worktree those committed baselines cover SciFact plus the hermetic gate fixture; ArguAna, SciDocs, and HotpotQA/BRIGHT no-rerank baselines are not committed here, so the evaluation report explicitly marks them pending rather than fabricating rows.

## Evaluation Notes

Fixture smoke results on `benchmarks/beir/fixtures/gate/gate-fixture` with `--provider=fake`:

| Variant | nDCG@10 | MAP@100 | Recall@10 | Recall@100 | p50 ms | p95 ms | Mean rerank latency ms |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| hybrid baseline | 1.0000 | 1.0000 | 1.0000 | 1.0000 | 11.717 | 28.609 | n/a |
| listwise attention | 1.0000 | 1.0000 | 1.0000 | 1.0000 | 10.815 | 31.895 | 3.236 |
| hard-negative head | 1.0000 | 1.0000 | 1.0000 | 1.0000 | 7.654 | 33.833 | 0.540 |
| adaptive listwise | 1.0000 | 1.0000 | 1.0000 | 1.0000 | 10.869 | 31.954 | 3.139 |

These are hermetic plumbing/smoke numbers only because the fake provider has no semantic geometry. No default reranker change ships from this PR.

Optional Qwen3/Prism rows are skipped unless `KB_RERANK_QWEN3_MODEL` or `KB_RERANK_PRISM_MODEL` is set to a non-empty local reranker model id, preventing mislabeled default cross-encoder evidence.

## Verification

- `npm run build`
- `npx tsc -p tsconfig.bench.json`
- `npm test -- --runTestsByPath benchmarks/beir/reranker-bakeoff-rerankers.test.ts benchmarks/beir/reranker-bakeoff.test.ts benchmarks/beir/run.reranker-bakeoff.test.ts benchmarks/beir/run.rerank.test.ts benchmarks/beir/matrix.test.ts --runInBand`
- `npm run docs:check-anchors`
- `npm test -- --runInBand` (166 suites passed; 2336 tests passed; 4 skipped; 1 todo)
- Kookr pre-PR reviewer specialists: conventions, correctness, deadcode, test; findings addressed before commit
