### PR TITLE
feat(mcp): gate ingest tools with KB_INGEST_ENABLED

### DIFF
--- a/docs/architecture/threat-model.md
+++ b/docs/architecture/threat-model.md
@@ -95,6 +95,12 @@ The current path-taking surfaces are:
 | `reindex_knowledge_base` | optional `knowledge_base_name` only — no per-file path | n/a | Resolves the KB directory to validate the name; the rebuild is global (no per-vector deletion in this server). |
 | `resources/read` for `kb://<kb>/<rel-path>` | URI authority + path | `true` | URI parser additionally rejects encoded slash/backslash and `..` segments before per-segment decoding. PDFs are returned as base64 blobs; everything else as UTF-8 text. |
 
+Set `KB_INGEST_ENABLED=false` to run the MCP server without the ingest write
+tool surface: `add_document`, `delete_document`, and `reindex_knowledge_base`
+are not registered and do not appear in `tools/list`. Read-side tools and
+Resources continue to work. The flag gates MCP tool availability only; it does
+not restrict CLI commands or direct filesystem writes.
+
 `list_knowledge_bases` continues to read `KNOWLEDGE_BASES_ROOT_DIR` directly without taking any client path. `retrieve_knowledge` takes only `query`, optional `knowledge_base_name`, optional numeric filters, and never writes based on the name.
 
 **Requirement.** The KB root and every per-KB directory must not contain symlinks pointing outside `KNOWLEDGE_BASES_ROOT_DIR`. The realpath check would catch a jailbreak attempt at request time, but symlinks-out-of-root represent operator-side trust intent. Treat the KB root the way you'd treat a static-content directory served to anonymous callers — own every entry, even the symlink targets.

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -147,6 +147,7 @@ wrap-close vars below.
 | HuggingFace router provider | `HUGGINGFACE_PROVIDER` | `hf-inference` | HuggingFace embedding provider | Implemented | none | `EMBEDDING_PROVIDER=huggingface kb doctor` |
 | HuggingFace endpoint URL | `HUGGINGFACE_ENDPOINT_URL` | router URL for the selected model | HuggingFace embedding provider | Implemented | none | `HUGGINGFACE_ENDPOINT_URL=<url> kb doctor` |
 | HuggingFace API key | `HUGGINGFACE_API_KEY` | required for HuggingFace | HuggingFace embedding provider | Implemented | none | `EMBEDDING_PROVIDER=huggingface kb doctor` |
+| MCP ingest tool surface | `KB_INGEST_ENABLED` | `on` | MCP `add_document`, `delete_document`, and `reindex_knowledge_base` tool registration | Implemented | none | `KB_INGEST_ENABLED=false node build/index.js` then inspect `tools/list` |
 | Extra ingest extensions | `INGEST_EXTRA_EXTENSIONS` | empty | Ingest and refresh | Implemented | none | `INGEST_EXTRA_EXTENSIONS=.pdf kb search "known phrase" --refresh` |
 | Extra ingest exclusions | `INGEST_EXCLUDE_PATHS` | empty | Ingest and refresh | Implemented | none | `INGEST_EXCLUDE_PATHS="drafts/**" kb search "known phrase" --refresh` |
 | Refresh quiescence guard | `KB_REFRESH_QUIESCE_MS` | `0` | Ingest and refresh | Implemented, opt-in | none | `KB_REFRESH_QUIESCE_MS=1000 kb search "query" --refresh` |

--- a/src/KnowledgeBaseServer.test.ts
+++ b/src/KnowledgeBaseServer.test.ts
@@ -72,7 +72,7 @@ jest.mock('./FaissIndexManager.js', () => ({
 
 // Each KnowledgeBaseServer constructor registers a SIGINT listener; the
 // default cap of 10 would warn once we cross it across the suite.
-process.setMaxListeners(50);
+process.setMaxListeners(100);
 
 describe('KnowledgeBaseServer handlers', () => {
   const originalEnv = {
@@ -89,6 +89,7 @@ describe('KnowledgeBaseServer handlers', () => {
     ASK_KNOWLEDGE_DESCRIPTION: process.env.ASK_KNOWLEDGE_DESCRIPTION,
     RETRIEVE_KNOWLEDGE_DESCRIPTION: process.env.RETRIEVE_KNOWLEDGE_DESCRIPTION,
     LIST_KNOWLEDGE_BASES_DESCRIPTION: process.env.LIST_KNOWLEDGE_BASES_DESCRIPTION,
+    KB_INGEST_ENABLED: process.env.KB_INGEST_ENABLED,
     INGEST_EXTRA_EXTENSIONS: process.env.INGEST_EXTRA_EXTENSIONS,
     INGEST_EXCLUDE_PATHS: process.env.INGEST_EXCLUDE_PATHS,
   };
@@ -2002,6 +2003,45 @@ describe('KnowledgeBaseServer handlers', () => {
     expect(registered[toolName]).toBeDefined();
     return registered[toolName].description ?? '';
   }
+
+  function registeredToolNames(server: any): string[] {
+    const registered = server['mcp']._registeredTools as Record<string, unknown>;
+    expect(registered).toBeDefined();
+    return Object.keys(registered);
+  }
+
+  it('KB_INGEST_ENABLED=false hides MCP ingest tools while preserving read tools and resources', async () => {
+    const tempDir = await setRetrieveEnv();
+    await fsp.mkdir(path.join(tempDir, 'alpha'));
+    await fsp.writeFile(path.join(tempDir, 'alpha', 'note.md'), '# Alpha\n');
+
+    delete process.env.KB_INGEST_ENABLED;
+    const defaultServer = await freshServer();
+    expect(registeredToolNames(defaultServer)).toEqual(expect.arrayContaining([
+      'add_document',
+      'delete_document',
+      'reindex_knowledge_base',
+    ]));
+
+    process.env.KB_INGEST_ENABLED = 'false';
+    const readOnlyServer = await freshServer();
+    const tools = registeredToolNames(readOnlyServer);
+
+    expect(tools).toEqual(expect.arrayContaining([
+      'list_knowledge_bases',
+      'retrieve_knowledge',
+      'ask_knowledge',
+      'list_models',
+      'kb_stats',
+      'diff_index',
+    ]));
+    expect(tools).not.toContain('add_document');
+    expect(tools).not.toContain('delete_document');
+    expect(tools).not.toContain('reindex_knowledge_base');
+
+    const resources = await readOnlyServer['handleListResources']();
+    expect(resources.resources.map((resource: { uri: string }) => resource.uri)).toContain('kb://alpha/note.md');
+  });
 
   it('with neither override env set, tool descriptions match the legacy hard-coded strings', async () => {
     delete process.env.RETRIEVE_KNOWLEDGE_DESCRIPTION;

--- a/src/KnowledgeBaseServer.ts
+++ b/src/KnowledgeBaseServer.ts
@@ -43,6 +43,7 @@ import {
 import {
   INGEST_EXCLUDE_PATHS,
   INGEST_EXTRA_EXTENSIONS,
+  KB_INGEST_ENABLED,
 } from './config/ingest.js';
 import {
   KB_FS_WATCH,
@@ -327,38 +328,40 @@ export class KnowledgeBaseServer {
       async (args) => this.handleDiffIndex(args)
     );
 
-    mcp.tool(
-      'add_document',
-      ADD_DOCUMENT_DESCRIPTION,
-      {
-        knowledge_base_name: z.string().describe('The name of the knowledge base to write into.'),
-        path: z.string().describe('KB-relative document path to create or overwrite. Parent directories are created as needed.'),
-        content: z.string().describe('UTF-8 text content to write.'),
-      },
-      async (args) => this.handleAddDocument(args)
-    );
+    if (KB_INGEST_ENABLED) {
+      mcp.tool(
+        'add_document',
+        ADD_DOCUMENT_DESCRIPTION,
+        {
+          knowledge_base_name: z.string().describe('The name of the knowledge base to write into.'),
+          path: z.string().describe('KB-relative document path to create or overwrite. Parent directories are created as needed.'),
+          content: z.string().describe('UTF-8 text content to write.'),
+        },
+        async (args) => this.handleAddDocument(args)
+      );
 
-    mcp.tool(
-      'delete_document',
-      DELETE_DOCUMENT_DESCRIPTION,
-      {
-        knowledge_base_name: z.string().describe('The name of the knowledge base to delete from.'),
-        path: z.string().describe('KB-relative document path to delete.'),
-      },
-      async (args) => this.handleDeleteDocument(args)
-    );
+      mcp.tool(
+        'delete_document',
+        DELETE_DOCUMENT_DESCRIPTION,
+        {
+          knowledge_base_name: z.string().describe('The name of the knowledge base to delete from.'),
+          path: z.string().describe('KB-relative document path to delete.'),
+        },
+        async (args) => this.handleDeleteDocument(args)
+      );
 
-    mcp.tool(
-      'reindex_knowledge_base',
-      REINDEX_KNOWLEDGE_BASE_DESCRIPTION,
-      {
-        knowledge_base_name: z
-          .string()
-          .optional()
-          .describe('Name of a single KB to force re-index. If omitted, every registered KB is re-indexed.'),
-      },
-      async (args) => this.handleReindexKnowledgeBase(args)
-    );
+      mcp.tool(
+        'reindex_knowledge_base',
+        REINDEX_KNOWLEDGE_BASE_DESCRIPTION,
+        {
+          knowledge_base_name: z
+            .string()
+            .optional()
+            .describe('Name of a single KB to force re-index. If omitted, every registered KB is re-indexed.'),
+        },
+        async (args) => this.handleReindexKnowledgeBase(args)
+      );
+    }
   }
 
   private async withCanonicalTool<T extends CallToolResult>(

--- a/src/config/ingest.ts
+++ b/src/config/ingest.ts
@@ -11,6 +11,11 @@ function parseOnOff(raw: string | undefined): boolean {
   return normalized === 'on' || normalized === '1' || normalized === 'true' || normalized === 'yes';
 }
 
+function parseDefaultOn(raw: string | undefined): boolean {
+  if (raw === undefined || raw.trim() === '') return true;
+  return parseOnOff(raw);
+}
+
 // ---------------------------------------------------------------------------
 // Ingest filter configuration (RFC 011 section5.2.3).
 // Operator-extensible extras; the base allowlist and exclusion rules in
@@ -24,6 +29,8 @@ export const INGEST_EXTRA_EXTENSIONS: readonly string[] = parseCommaSeparatedLis
 export const INGEST_EXCLUDE_PATHS: readonly string[] = parseCommaSeparatedList(
   process.env.INGEST_EXCLUDE_PATHS,
 );
+
+export const KB_INGEST_ENABLED: boolean = parseDefaultOn(process.env.KB_INGEST_ENABLED);
 
 // ---------------------------------------------------------------------------
 // Large-file ingest bounds (#285).

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -163,6 +163,7 @@ export const CONFIG_SCHEMA: readonly ConfigSpec[] = [
   { name: 'KB_MAX_EXTRACTED_TEXT_BYTES', kind: 'integer', default: String(16 * 1024 * 1024), min: 1 },
   { name: 'KB_LARGE_FILE_POLICY', kind: 'enum', values: ['skip', 'truncate', 'error'], default: 'skip' },
   { name: 'KB_REFRESH_QUIESCE_MS', kind: 'duration', default: '0', min: 0 },
+  { name: 'KB_INGEST_ENABLED', kind: 'boolean', default: 'on', booleanValues: YES_NO_BOOL_VALUES, truthyValues: YES_NO_TRUTHY_VALUES },
   { name: 'KB_INGEST_SECRET_SCAN', kind: 'boolean', default: 'off', booleanValues: YES_NO_BOOL_VALUES, truthyValues: YES_NO_TRUTHY_VALUES },
   { name: 'KB_SECRET_SCAN_BYPASS_KBS', kind: 'csv', default: '' },
 


### PR DESCRIPTION
## Summary
- Add default-on `KB_INGEST_ENABLED` config parsing and schema validation.
- Hide MCP ingest/write tools from registration when `KB_INGEST_ENABLED=false`.
- Document the read-only MCP mode in the feature flag matrix and threat model.

## Design choice
RFC 010 names the refresh tool as `refresh_knowledge_base`, but this repository's shipped tool is `reindex_knowledge_base`. This implementation gates `add_document`, `delete_document`, and `reindex_knowledge_base` so the actual write/index mutation surface disappears from `tools/list`.

## Validation
- `npm test -- --runTestsByPath /home/jean/git/knowledge-base-mcp-server-issue-600-implement-the-rfc-010-5-4-6-kb-inges/src/KnowledgeBaseServer.test.ts --runInBand`
- `npm run build`

Closes #600