### PR TITLE
fix(contextual-preface): recover oversized in-window chunks

### DIFF
--- a/src/contextual-preface.test.ts
+++ b/src/contextual-preface.test.ts
@@ -11,6 +11,8 @@ import * as fsp from 'fs/promises';
 import * as os from 'os';
 import * as path from 'path';
 
+import { CONTEXTUAL_DOCUMENT_TRUNCATION_CHARS } from './config/contextual-preface.js';
+
 const FETCH_MOCK = jest.fn();
 
 // The contextual-preface module is loaded dynamically per-test so it
@@ -198,6 +200,127 @@ describe('resolveContextualPrefaces — LLM call + sidecar', () => {
     FETCH_MOCK.mockClear();
     await resolveContextualPrefaces({ ...base, documentHash: 'h2' });
     expect(FETCH_MOCK).toHaveBeenCalledTimes(1);
+  });
+
+  it('generates prefaces for oversized-document chunks that fit in the context prefix', async () => {
+    FETCH_MOCK.mockImplementation(async () => llmResponse('oversized preface'));
+    const { GENERATOR_VERSION, resolveContextualPrefaces, sidecarPathFor } = await loadModule();
+    const source = '/tmp/alpha/oversized.md';
+    const inWindowChunk = 'in-window chunk';
+    const boundaryChunk = 'boundary chunk';
+    const outOfWindowChunk = 'out-of-window chunk';
+    const firstOffset = 100;
+    const boundaryStart = CONTEXTUAL_DOCUMENT_TRUNCATION_CHARS - boundaryChunk.length;
+    const documentBody = [
+      'a'.repeat(firstOffset),
+      inWindowChunk,
+      'b'.repeat(boundaryStart - firstOffset - inWindowChunk.length),
+      boundaryChunk,
+      outOfWindowChunk,
+    ].join('');
+
+    expect(documentBody.indexOf(boundaryChunk) + boundaryChunk.length)
+      .toBe(CONTEXTUAL_DOCUMENT_TRUNCATION_CHARS);
+    expect(documentBody.length).toBeGreaterThan(CONTEXTUAL_DOCUMENT_TRUNCATION_CHARS);
+
+    const result = await resolveContextualPrefaces({
+      source,
+      knowledgeBaseName: 'alpha',
+      documentHash: 'oversized-doc-hash',
+      documentBody,
+      chunks: [inWindowChunk, boundaryChunk, outOfWindowChunk],
+    });
+
+    expect(result).toEqual(['oversized preface', 'oversized preface', null]);
+    expect(FETCH_MOCK).toHaveBeenCalledTimes(2);
+    for (const call of FETCH_MOCK.mock.calls) {
+      const body = JSON.parse((call[1] as RequestInit).body as string) as {
+        messages: Array<{ role: string; content: string }>;
+      };
+      const userMessage = body.messages.find((message) => message.role === 'user')?.content ?? '';
+      expect(userMessage).toContain(boundaryChunk);
+      expect(userMessage).not.toContain(outOfWindowChunk);
+    }
+
+    const parsed = JSON.parse(await fsp.readFile(sidecarPathFor(source, 'alpha'), 'utf-8'));
+    expect(parsed.generator).toBe(GENERATOR_VERSION);
+    expect(parsed.chunks[0]).toMatchObject({ preface: 'oversized preface' });
+    expect(parsed.chunks[1]).toMatchObject({ preface: 'oversized preface' });
+    expect(parsed.chunks[2]).toMatchObject({ preface: null, error_code: 'truncated_doc' });
+  });
+
+  it('records truncated_doc for repeated chunk text that also occurs beyond the context prefix', async () => {
+    FETCH_MOCK.mockImplementation(async () => llmResponse('should not be used'));
+    const { resolveContextualPrefaces, sidecarPathFor } = await loadModule();
+    const source = '/tmp/alpha/repeated-oversized.md';
+    const repeatedChunk = 'ambiguous repeated chunk';
+    const documentBody = [
+      repeatedChunk,
+      'x'.repeat(CONTEXTUAL_DOCUMENT_TRUNCATION_CHARS - repeatedChunk.length),
+      repeatedChunk,
+    ].join('');
+
+    const result = await resolveContextualPrefaces({
+      source,
+      knowledgeBaseName: 'alpha',
+      documentHash: 'repeated-oversized-doc-hash',
+      documentBody,
+      chunks: [repeatedChunk],
+    });
+
+    expect(result).toEqual([null]);
+    expect(FETCH_MOCK).not.toHaveBeenCalled();
+
+    const parsed = JSON.parse(await fsp.readFile(sidecarPathFor(source, 'alpha'), 'utf-8'));
+    expect(parsed.chunks[0]).toMatchObject({ preface: null, error_code: 'truncated_doc' });
+  });
+
+  it('invalidates old v1 truncated_doc entries so in-prefix chunks self-heal', async () => {
+    FETCH_MOCK.mockImplementation(async () => llmResponse('recovered preface'));
+    const { GENERATOR_VERSION, resolveContextualPrefaces, sha256, sidecarPathFor } = await loadModule();
+    const source = '/tmp/alpha/stale-oversized.md';
+    const chunk = 'recoverable in-prefix chunk';
+    const documentBody = `${chunk}${'x'.repeat(CONTEXTUAL_DOCUMENT_TRUNCATION_CHARS)}`;
+    const sidecarPath = sidecarPathFor(source, 'alpha');
+    await fsp.mkdir(path.dirname(sidecarPath), { recursive: true });
+    await fsp.writeFile(
+      sidecarPath,
+      JSON.stringify({
+        schema_version: 'contextual-preface.sidecar.v1',
+        source,
+        knowledge_base: 'alpha',
+        document_hash: 'stale-doc-hash',
+        generator: 'contextual-preface.v1',
+        model: 'old-model',
+        chunk_size: 1000,
+        chunk_overlap: 200,
+        chunks: [{
+          chunk_index: 0,
+          chunk_hash: sha256(chunk),
+          preface: null,
+          error_code: 'truncated_doc',
+          next_retry_after: '275760-09-13T00:00:00.000Z',
+        }],
+      }),
+      'utf-8',
+    );
+
+    const result = await resolveContextualPrefaces({
+      source,
+      knowledgeBaseName: 'alpha',
+      documentHash: 'stale-doc-hash',
+      documentBody,
+      chunks: [chunk],
+    });
+
+    expect(result).toEqual(['recovered preface']);
+    expect(FETCH_MOCK).toHaveBeenCalledTimes(1);
+
+    const parsed = JSON.parse(await fsp.readFile(sidecarPath, 'utf-8'));
+    expect(parsed.generator).toBe(GENERATOR_VERSION);
+    expect(parsed.chunks[0]).toMatchObject({ preface: 'recovered preface' });
+    expect(parsed.chunks[0].error_code).toBeUndefined();
+    expect(parsed.chunks[0].next_retry_after).toBeUndefined();
   });
 
   it('records a failure entry with next_retry_after when the LLM errors', async () => {

--- a/src/contextual-preface.ts
+++ b/src/contextual-preface.ts
@@ -52,7 +52,7 @@ import { logger } from './logger.js';
 import { retrievalViewText } from './retrieval-views.js';
 import { withSidecarLock } from './write-lock.js';
 
-export const GENERATOR_VERSION = 'contextual-preface.v1';
+export const GENERATOR_VERSION = 'contextual-preface.v2';
 const SIDECAR_SCHEMA_VERSION = 'contextual-preface.sidecar.v1';
 const SIDECAR_ROOT_DIRNAME = '.contextual-prefaces';
 
@@ -151,8 +151,13 @@ export async function resolveContextualPrefaces(
   // failures, and document-truncation failures. Collect the chunks that still
   // need an LLM call so pass 2 can issue them with bounded concurrency.
   const pending: { index: number; chunkHash: string }[] = [];
+  let nextChunkSearchFrom = 0;
   for (let i = 0; i < args.chunks.length; i += 1) {
     const chunkHash = sha256(args.chunks[i]);
+    const chunkSpan = docWasTruncated
+      ? findChunkDocumentSpan(args.documentBody, args.chunks[i], nextChunkSearchFrom)
+      : null;
+    if (chunkSpan !== null) nextChunkSearchFrom = chunkSpan.start + 1;
 
     const cached: SidecarChunkEntry | undefined = existing?.chunks[i];
     const cacheValid =
@@ -184,9 +189,10 @@ export async function resolveContextualPrefaces(
       }
     }
 
-    // Document-truncation case: no point calling the LLM with a chunk that
-    // can never be fully situated. Record the failure, schedule no retry.
-    if (docWasTruncated) {
+    // Oversized-document case: the LLM sees only the leading document prefix.
+    // Chunks fully inside that prefix can still be situated; chunks outside it
+    // cannot, so keep recording those as non-retryable truncation failures.
+    if (docWasTruncated && (chunkSpan === null || chunkSpan.end > CONTEXTUAL_DOCUMENT_TRUNCATION_CHARS)) {
       newEntries[i] = makeFailureEntry(i, chunkHash, 'truncated_doc');
       resolved[i] = null;
       failures += 1;
@@ -879,6 +885,28 @@ function isTimeoutError(err: unknown): boolean {
 
 export function sha256(value: string): string {
   return crypto.createHash('sha256').update(value, 'utf-8').digest('hex');
+}
+
+function findChunkDocumentSpan(
+  documentBody: string,
+  chunkText: string,
+  searchFrom: number,
+): { start: number; end: number } | null {
+  if (chunkText.length === 0) return null;
+  const start = documentBody.indexOf(chunkText, searchFrom);
+  if (start === -1) return null;
+  const end = start + chunkText.length;
+  if (end <= CONTEXTUAL_DOCUMENT_TRUNCATION_CHARS) {
+    // If the same text also occurs beyond the prefix, we cannot prove which
+    // occurrence this chunk represents from text alone. Fail closed rather than
+    // caching a preface for a chunk the LLM may not actually see in context.
+    let nextStart = documentBody.indexOf(chunkText, start + 1);
+    while (nextStart !== -1) {
+      if (nextStart + chunkText.length > CONTEXTUAL_DOCUMENT_TRUNCATION_CHARS) return null;
+      nextStart = documentBody.indexOf(chunkText, nextStart + 1);
+    }
+  }
+  return { start, end };
 }
 
 function parseIsoToMs(iso: string): number | null {


### PR DESCRIPTION
## Summary

- recover contextual prefaces for oversized-document chunks whose inferred span is fully inside the 48k document prefix
- keep `truncated_doc` for chunks outside the prefix, or when repeated chunk text makes the span ambiguous
- bump `GENERATOR_VERSION` to `contextual-preface.v2` so old all-or-nothing `truncated_doc` sidecars self-heal on reindex

Closes #590.

## Design Choice

This uses the smallest partial-coverage fix: infer chunk spans from the chunk text in document order and continue using the existing shared leading document prefix. I did not add a larger prompt budget or a sliding-window prompt. If the same chunk text appears both inside and beyond the prefix, the resolver fails closed with `truncated_doc` because text alone cannot prove which occurrence the chunk represents.

## Verification

- `npm test -- --runTestsByPath /home/jean/git/knowledge-base-mcp-server-issue-590-contextual-prefaces-1-184-chunks-per/src/contextual-preface.test.ts --runInBand`
- `npm run build`
- `env -u KB_LOG_FORMAT -u LOG_FILE npm test -- --runTestsByPath src/cli-search.test.ts src/cli-ask.test.ts src/relevance-gate.test.ts --runInBand`

I also ran full `npm test`; it failed only in `src/cli-search.test.ts`, `src/cli-ask.test.ts`, and `src/relevance-gate.test.ts` because this local shell sets `KB_LOG_FORMAT=both` and `LOG_FILE=/home/jean/.kookr/server.log`, so stderr log-capture assertions saw empty stderr. The same three suites pass with those env vars unset, as listed above.
