### PR TITLE
Add opt-in concurrency stress suite

### DIFF
--- a/docs/testing/INDEX.md
+++ b/docs/testing/INDEX.md
@@ -3,6 +3,7 @@
 - [Retrieval eval command](retrieval-eval.md)
 - [Retrieval eval methodology](retrieval-eval-methodology.md)
 - [Fake LLM fixture](fake-llm.md)
+- [Concurrency stress suite](../../tests/stress/README.md)
 - [Fixtures](fixtures/README.md)
 - RFC test surfaces:
   [RFC 017 contextual retrieval](../rfcs/017-contextual-retrieval.md),

--- a/jest.config.js
+++ b/jest.config.js
@@ -14,7 +14,11 @@ const e2eEnabled = process.env.KB_RUN_E2E === '1';
 export default {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  testMatch: ["**/src/**/*.test.ts", "**/benchmarks/**/*.test.ts"],
+  testMatch: [
+    "**/src/**/*.test.ts",
+    "**/benchmarks/**/*.test.ts",
+    "**/tests/stress/**/*.test.ts",
+  ],
   testPathIgnorePatterns: [
     '/node_modules/',
     ...(e2eEnabled ? [] : ['<rootDir>/src/e2e/']),

--- a/tests/stress/README.md
+++ b/tests/stress/README.md
@@ -1,0 +1,29 @@
+# Concurrency Stress Test Suite
+
+This suite covers concurrency invariants that are intentionally outside the
+default Jest run. It uses scoped temp directories, fake embeddings, and a fake
+FAISS store so scenarios do not need network providers or a persistent local
+knowledge base.
+
+The suite is opt-in:
+
+```bash
+KB_RUN_STRESS=1 npm test -- --runTestsByPath tests/stress/scenarios/search-during-refresh.test.ts --runInBand
+KB_RUN_STRESS=1 npm test -- --runTestsByPath tests/stress/scenarios/parallel-mcp-mutations.test.ts --runInBand
+```
+
+Without `KB_RUN_STRESS=1`, direct path runs skip the scenarios cleanly:
+
+```bash
+npm test -- --runTestsByPath tests/stress/scenarios/search-during-refresh.test.ts --runInBand
+```
+
+Current scenarios:
+
+| Scenario | Concurrency surface | Invariant |
+| --- | --- | --- |
+| `search-during-refresh.test.ts` | Read queries while a scoped refresh is blocked at atomic save | searches do not throw, return only well-formed documents from the target KB, and the refreshed document is visible after save completes |
+| `parallel-mcp-mutations.test.ts` | Parallel `add_document` calls through the MCP mutation handler | per-model write lock admits one refresh at a time, every mutation writes the expected document, and every tool result stays successful |
+
+Keep additions deterministic: prefer explicit barriers, fake providers, and
+state assertions over wall-clock sleeps or throughput thresholds.

--- a/tests/stress/scenarios/parallel-mcp-mutations.test.ts
+++ b/tests/stress/scenarios/parallel-mcp-mutations.test.ts
@@ -1,0 +1,157 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import * as fsp from 'fs/promises';
+import * as path from 'path';
+import type { FaissIndexManager } from '../../../src/FaissIndexManager.js';
+import type { DocumentMutationHandlerContext } from '../../../src/mcp-document-mutations.js';
+import {
+  createStressWorkspace,
+  parseTextPayload,
+  restoreStressEnv,
+  saveStressEnv,
+  type SavedStressEnv,
+  type StressWorkspace,
+} from '../stress-harness.js';
+
+const stressDescribe = process.env.KB_RUN_STRESS === '1' ? describe : describe.skip;
+
+interface MutationProbe {
+  readonly calls: string[];
+  readonly maxConcurrent: number;
+  updateIndex: (kb: string | undefined) => Promise<void>;
+  waitForCallCount(count: number): Promise<void>;
+  releaseOne(): void;
+}
+
+function createMutationProbe(): MutationProbe {
+  let active = 0;
+  let maxConcurrent = 0;
+  const calls: string[] = [];
+  const waiters: Array<() => void> = [];
+  const releases: Array<() => void> = [];
+  const notify = (): void => {
+    for (let i = waiters.length - 1; i >= 0; i -= 1) {
+      waiters.splice(i, 1)[0]();
+    }
+  };
+
+  const updateIndex = jest.fn(async (kb: string | undefined): Promise<void> => {
+    active += 1;
+    maxConcurrent = Math.max(maxConcurrent, active);
+    calls.push(kb ?? '<global>');
+    notify();
+    await new Promise<void>((resolve) => releases.push(resolve));
+    active -= 1;
+  });
+
+  return {
+    calls,
+    get maxConcurrent() {
+      return maxConcurrent;
+    },
+    updateIndex,
+    async waitForCallCount(count: number): Promise<void> {
+      while (calls.length < count) {
+        await new Promise<void>((resolve) => waiters.push(resolve));
+      }
+    },
+    releaseOne(): void {
+      const release = releases.shift();
+      if (release === undefined) {
+        throw new Error('no blocked mutation update to release');
+      }
+      release();
+    },
+  };
+}
+
+stressDescribe('parallel MCP mutation stress suite', () => {
+  let workspace: StressWorkspace;
+  let savedEnv: SavedStressEnv;
+
+  beforeEach(async () => {
+    savedEnv = saveStressEnv();
+    jest.resetModules();
+    workspace = await createStressWorkspace();
+  });
+
+  afterEach(async () => {
+    restoreStressEnv(savedEnv);
+    await fsp.rm(workspace.tempDir, { recursive: true, force: true });
+  });
+
+  it('serializes concurrent add_document mutations through the per-model write lock', async () => {
+    const probe = createMutationProbe();
+    const manager = {
+      modelDir: path.join(workspace.faissPath, 'models', 'fake__stress-fake'),
+      updateIndex: probe.updateIndex,
+      reloadPersistedIndex: jest.fn(async () => undefined),
+      getLastIndexUpdateSummary: jest.fn(() => ({
+        status: 'success',
+        scope: workspace.kbName,
+        model_id: 'fake__stress-fake',
+        started_at: null,
+        finished_at: null,
+        duration_ms: null,
+        files_scanned: 0,
+        files_changed: 0,
+        files_unchanged: 0,
+        files_skipped: 0,
+        chunks_attempted: 0,
+        chunks_added: 0,
+        index_mutated: false,
+        saved: false,
+        sidecars_written: false,
+        warning_count: 0,
+        warnings: [],
+        failure_count: 0,
+        failures: [],
+      })),
+    } as unknown as FaissIndexManager;
+    const canonicalBases: Array<Record<string, unknown>> = [];
+    const context: DocumentMutationHandlerContext = {
+      knowledgeBasesRootDir: workspace.kbRoot,
+      getActiveManagerForMutation: async () => manager,
+      withCanonicalTool: async <T extends CallToolResult>(
+        base: Parameters<DocumentMutationHandlerContext['withCanonicalTool']>[0],
+        operation: () => Promise<T>,
+      ): Promise<T> => {
+        canonicalBases.push(base);
+        return operation();
+      },
+    };
+    const { handleAddDocument } = await import('../../../src/mcp-document-mutations.js');
+    const mutationCount = 6;
+    const mutations = Array.from({ length: mutationCount }, (_, index) => ({
+      knowledge_base_name: workspace.kbName,
+      path: `parallel/doc-${index}.md`,
+      content: `# Parallel ${index}\n\nmutation ${index}\n`,
+    }));
+
+    const pending = mutations.map((mutation) => handleAddDocument(mutation, context));
+    for (let expectedCalls = 1; expectedCalls <= mutationCount; expectedCalls += 1) {
+      await probe.waitForCallCount(expectedCalls);
+      expect(probe.maxConcurrent).toBe(1);
+      probe.releaseOne();
+    }
+
+    const results = await Promise.all(pending);
+
+    expect(results.every((result) => result.isError !== true)).toBe(true);
+    expect(probe.calls).toHaveLength(mutationCount);
+    expect(probe.calls.every((kb) => kb === workspace.kbName)).toBe(true);
+    expect(probe.maxConcurrent).toBe(1);
+    expect(canonicalBases).toEqual(
+      Array.from({ length: mutationCount }, () => ({ tool: 'add_document', kb_scope: workspace.kbName })),
+    );
+
+    for (let index = 0; index < mutationCount; index += 1) {
+      const documentPath = path.join(workspace.kbPath, 'parallel', `doc-${index}.md`);
+      await expect(fsp.readFile(documentPath, 'utf-8')).resolves.toBe(`# Parallel ${index}\n\nmutation ${index}\n`);
+      expect(parseTextPayload<{ indexed: boolean; path: string }>(results[index])).toMatchObject({
+        indexed: true,
+        path: `parallel/doc-${index}.md`,
+      });
+    }
+  }, 20_000);
+});

--- a/tests/stress/scenarios/search-during-refresh.test.ts
+++ b/tests/stress/scenarios/search-during-refresh.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import * as fsp from 'fs/promises';
+import * as path from 'path';
+import {
+  createManualGate,
+  createStressWorkspace,
+  FakeFaissStore,
+  pathExists,
+  resetStressFakes,
+  restoreStressEnv,
+  saveStressEnv,
+  setFakeFaissSaveGate,
+  vectorForText,
+  writeStressNote,
+  type SavedStressEnv,
+  type StressWorkspace,
+} from '../stress-harness.js';
+
+const stressDescribe = process.env.KB_RUN_STRESS === '1' ? describe : describe.skip;
+
+jest.mock('@langchain/community/vectorstores/faiss', () => ({
+  __esModule: true,
+  FaissStore: FakeFaissStore,
+}));
+
+jest.mock('@langchain/community/embeddings/hf', () => ({
+  __esModule: true,
+  HuggingFaceInferenceEmbeddings: class MockEmbedding {
+    async embedDocuments(texts: string[]): Promise<number[][]> {
+      return texts.map(vectorForText);
+    }
+
+    async embedQuery(text: string): Promise<number[]> {
+      return vectorForText(text);
+    }
+  },
+}));
+
+stressDescribe('search-during-refresh stress suite', () => {
+  let workspace: StressWorkspace;
+  let savedEnv: SavedStressEnv;
+
+  beforeEach(async () => {
+    savedEnv = saveStressEnv();
+    resetStressFakes();
+    jest.resetModules();
+    workspace = await createStressWorkspace();
+  });
+
+  afterEach(async () => {
+    resetStressFakes();
+    restoreStressEnv(savedEnv);
+    await fsp.rm(workspace.tempDir, { recursive: true, force: true });
+  });
+
+  it('serves invariant-safe searches while a refresh is blocked at atomic save', async () => {
+    await writeStressNote(
+      workspace,
+      'seed.md',
+      '# Alpha runbook\n\nalpha queue recovery stays searchable during refresh.\n',
+    );
+
+    const { FaissIndexManager } = await import('../../../src/FaissIndexManager.js');
+    const manager = new FaissIndexManager();
+    await manager.initialize();
+    await manager.updateIndex(workspace.kbName);
+
+    const before = await manager.similaritySearch('alpha', 5, 2, workspace.kbName);
+    expect(before.map((result) => result.metadata.relativePath)).toContain(`${workspace.kbName}/seed.md`);
+
+    await writeStressNote(
+      workspace,
+      'refresh.md',
+      '# Bravo runbook\n\nbravo deploy rollback arrives while readers are active.\n',
+    );
+    const saveGate = createManualGate();
+    setFakeFaissSaveGate(saveGate);
+    const refresh = manager.updateIndex(workspace.kbName);
+    await saveGate.waitUntilBlocked();
+
+    const searches = await Promise.all(
+      Array.from({ length: 12 }, async (_, index) => {
+        const query = index % 2 === 0 ? 'alpha' : 'bravo';
+        return manager.similaritySearch(query, 5, 2, workspace.kbName);
+      }),
+    );
+
+    for (const results of searches) {
+      expect(results.length).toBeGreaterThan(0);
+      const relativePaths = results.map((result) => result.metadata.relativePath);
+      expect(new Set(relativePaths).size).toBe(relativePaths.length);
+      expect(relativePaths.every((relativePath) =>
+        relativePath === `${workspace.kbName}/seed.md` ||
+        relativePath === `${workspace.kbName}/refresh.md`,
+      )).toBe(true);
+      expect(results.every((result) =>
+        Number.isFinite(result.score) &&
+        result.metadata.knowledgeBase === workspace.kbName &&
+        typeof result.metadata.source === 'string',
+      )).toBe(true);
+    }
+
+    saveGate.release();
+    await refresh;
+
+    const after = await manager.similaritySearch('bravo', 5, 2, workspace.kbName);
+    expect(after.map((result) => result.metadata.relativePath)).toContain(`${workspace.kbName}/refresh.md`);
+    await expect(pathExists(path.join(workspace.faissPath, 'models', 'fake__stress-fake', 'index'))).resolves.toBe(true);
+  }, 20_000);
+});

--- a/tests/stress/stress-harness.ts
+++ b/tests/stress/stress-harness.ts
@@ -1,0 +1,216 @@
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import type { EmbeddingsInterface } from '@langchain/core/embeddings';
+import type { Document } from '@langchain/core/documents';
+import * as fsp from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+
+export const STRESS_MODEL_NAME = 'stress-fake';
+export const STRESS_MODEL_ID = 'fake__stress-fake';
+
+const ENV_KEYS = [
+  'NODE_ENV',
+  'KNOWLEDGE_BASES_ROOT_DIR',
+  'FAISS_INDEX_PATH',
+  'EMBEDDING_PROVIDER',
+  'HUGGINGFACE_MODEL_NAME',
+  'KB_FAKE_DIM',
+  'KB_FAISS_INDEX_TYPE',
+  'KB_INDEX_VERSION_RETENTION',
+  'KB_REFRESH_QUIESCE_MS',
+  'KB_LOG_FORMAT',
+  'KB_MUTATION_AUDIT_LOG',
+] as const;
+
+export interface StressWorkspace {
+  tempDir: string;
+  kbRoot: string;
+  faissPath: string;
+  kbName: string;
+  kbPath: string;
+}
+
+export type SavedStressEnv = Record<typeof ENV_KEYS[number], string | undefined>;
+
+export interface ManualGate {
+  wait(): Promise<void>;
+  waitUntilBlocked(): Promise<void>;
+  release(): void;
+  readonly blocked: boolean;
+}
+
+let saveGate: ManualGate | null = null;
+
+export function createManualGate(): ManualGate {
+  let blocked = false;
+  let blockedResolve: () => void = () => undefined;
+  let releaseResolve: () => void = () => undefined;
+  const blockedPromise = new Promise<void>((resolve) => {
+    blockedResolve = resolve;
+  });
+  const releasePromise = new Promise<void>((resolve) => {
+    releaseResolve = resolve;
+  });
+
+  return {
+    async wait(): Promise<void> {
+      blocked = true;
+      blockedResolve();
+      await releasePromise;
+    },
+    waitUntilBlocked: () => blockedPromise,
+    release: () => releaseResolve(),
+    get blocked() {
+      return blocked;
+    },
+  };
+}
+
+export function setFakeFaissSaveGate(gate: ManualGate | null): void {
+  saveGate = gate;
+}
+
+export function resetStressFakes(): void {
+  saveGate = null;
+}
+
+export function saveStressEnv(): SavedStressEnv {
+  return Object.fromEntries(ENV_KEYS.map((key) => [key, process.env[key]])) as SavedStressEnv;
+}
+
+export function restoreStressEnv(saved: SavedStressEnv): void {
+  for (const [key, value] of Object.entries(saved)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+}
+
+export async function createStressWorkspace(): Promise<StressWorkspace> {
+  const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-concurrency-stress-'));
+  const kbRoot = path.join(tempDir, 'kbs');
+  const faissPath = path.join(tempDir, '.faiss');
+  const kbName = 'alpha';
+  const kbPath = path.join(kbRoot, kbName);
+  await fsp.mkdir(kbPath, { recursive: true });
+
+  process.env.NODE_ENV = 'test';
+  process.env.KNOWLEDGE_BASES_ROOT_DIR = kbRoot;
+  process.env.FAISS_INDEX_PATH = faissPath;
+  process.env.EMBEDDING_PROVIDER = 'fake';
+  process.env.HUGGINGFACE_MODEL_NAME = STRESS_MODEL_NAME;
+  process.env.KB_FAKE_DIM = '8';
+  process.env.KB_FAISS_INDEX_TYPE = 'flat';
+  process.env.KB_INDEX_VERSION_RETENTION = '1';
+  process.env.KB_REFRESH_QUIESCE_MS = '0';
+  process.env.KB_LOG_FORMAT = 'text';
+  delete process.env.KB_MUTATION_AUDIT_LOG;
+
+  return { tempDir, kbRoot, faissPath, kbName, kbPath };
+}
+
+export async function writeStressNote(
+  workspace: StressWorkspace,
+  relativePath: string,
+  body: string,
+): Promise<string> {
+  const target = path.join(workspace.kbPath, relativePath);
+  await fsp.mkdir(path.dirname(target), { recursive: true });
+  await fsp.writeFile(target, body, 'utf-8');
+  return target;
+}
+
+export async function pathExists(target: string): Promise<boolean> {
+  try {
+    await fsp.stat(target);
+    return true;
+  } catch (error: unknown) {
+    const code = (error as NodeJS.ErrnoException | undefined)?.code;
+    if (code === 'ENOENT' || code === 'ENOTDIR') return false;
+    throw error;
+  }
+}
+
+export function parseTextPayload<T = unknown>(result: CallToolResult): T {
+  const content = result.content[0];
+  if (content.type !== 'text') {
+    throw new Error(`expected text content, got ${content.type}`);
+  }
+  return JSON.parse(String(content.text)) as T;
+}
+
+export function vectorForText(text: string): number[] {
+  let hash = 0;
+  for (let i = 0; i < text.length; i += 1) {
+    hash = Math.imul(hash ^ text.charCodeAt(i), 16_777_619);
+  }
+  return [
+    text.length % 97,
+    hash >>> 0,
+    text.includes('alpha') ? 1 : 0,
+    text.includes('bravo') ? 1 : 0,
+    text.includes('charlie') ? 1 : 0,
+    text.includes('delta') ? 1 : 0,
+    text.includes('echo') ? 1 : 0,
+    text.includes('foxtrot') ? 1 : 0,
+  ];
+}
+
+function scoreDocument(query: string, document: Document, ordinal: number): number {
+  const haystack = `${document.pageContent}\n${JSON.stringify(document.metadata ?? {})}`.toLowerCase();
+  const normalizedQuery = query.toLowerCase();
+  return haystack.includes(normalizedQuery) ? ordinal / 1000 : 1 + ordinal / 1000;
+}
+
+export class FakeFaissStore {
+  public docstore = { _docs: new Map<string, Document>() };
+  public index = {
+    _n: 0,
+    ntotal: () => this.index._n,
+    getDimension: () => 8,
+  };
+
+  constructor(public embeddings: EmbeddingsInterface) {}
+
+  async addVectors(vectors: number[][], documents: Document[]): Promise<void> {
+    const expectedDimension = vectors[0]?.length ?? 8;
+    for (const vector of vectors) {
+      if (vector.length !== expectedDimension || vector.some((value) => !Number.isFinite(value))) {
+        throw new Error('fake FAISS received malformed vectors');
+      }
+    }
+    documents.forEach((document) => {
+      this.docstore._docs.set(`doc-${this.index._n}`, document);
+      this.index._n += 1;
+    });
+  }
+
+  async save(directory: string): Promise<void> {
+    await saveGate?.wait();
+    await fsp.mkdir(directory, { recursive: true });
+    await fsp.writeFile(path.join(directory, 'faiss.index'), `vectors=${this.index._n}\n`, 'utf-8');
+    await fsp.writeFile(
+      path.join(directory, 'docstore.json'),
+      JSON.stringify(Array.from(this.docstore._docs.entries())),
+      'utf-8',
+    );
+  }
+
+  async similaritySearchWithScore(query: string, k: number): Promise<Array<[Document, number]>> {
+    return Array.from(this.docstore._docs.values())
+      .map((document, ordinal): [Document, number] => [document, scoreDocument(query, document, ordinal)])
+      .sort((a, b) => a[1] - b[1])
+      .slice(0, k);
+  }
+
+  static async load(directory: string, embeddings: EmbeddingsInterface): Promise<FakeFaissStore> {
+    const store = new FakeFaissStore(embeddings);
+    const raw = await fsp.readFile(path.join(directory, 'docstore.json'), 'utf-8');
+    const entries = JSON.parse(raw) as Array<[string, Document]>;
+    for (const [id, document] of entries) {
+      store.docstore._docs.set(id, document);
+    }
+    store.index._n = store.docstore._docs.size;
+    return store;
+  }
+}
+


### PR DESCRIPTION
Closes #601

## Implementation choice
- Added a `tests/stress` suite gated by `KB_RUN_STRESS=1` inside each scenario.
- Added a shared stress harness with scoped temp KB directories, fake embeddings, a fake FAISS store, and explicit promise barriers.
- Added deterministic scenarios for search during refresh and parallel MCP `add_document` mutations.
- Added `tests/stress` to Jest `testMatch` so the requested direct `--runTestsByPath tests/stress/...` commands discover the files; default direct runs still skip cleanly without `KB_RUN_STRESS=1`.

## Alternatives considered
- Reusing live providers or a real FAISS index was avoided to keep the suite hermetic and independent of network/local model state.
- Timing thresholds and sleeps were avoided; the scenarios use explicit barriers and state/probe assertions instead.
- Package manifest changes were avoided. The stress tests are run by direct Jest path commands documented in `tests/stress/README.md`.

## Flake controls
- Each scenario uses `fs.mkdtemp` workspaces and restores process env after the test.
- Search-during-refresh blocks at a fake atomic-save barrier before issuing concurrent searches.
- Parallel MCP mutations release each lock-held refresh explicitly and assert max concurrent refresh count is one.

## Verification
- `npm test -- --runTestsByPath tests/stress/scenarios/search-during-refresh.test.ts --runInBand` -> passed, 1 skipped.
- `KB_RUN_STRESS=1 npm test -- --runTestsByPath tests/stress/scenarios/search-during-refresh.test.ts --runInBand` -> passed.
- `KB_RUN_STRESS=1 npm test -- --runTestsByPath tests/stress/scenarios/parallel-mcp-mutations.test.ts --runInBand` -> passed.
- `npm test -- --runTestsByPath tests/stress/scenarios/parallel-mcp-mutations.test.ts --runInBand` -> passed, 1 skipped.
- `npm run build` -> passed.
- `npm run docs:check-anchors` -> passed.