### PR TITLE
bench: add MDE noise floor gates

### DIFF
--- a/benchmarks/adjudication/adjudicate.test.ts
+++ b/benchmarks/adjudication/adjudicate.test.ts
@@ -39,7 +39,7 @@ function regressingDomain(domain: string): DomainEvidence {
   };
 }
 
-/** A domain whose per-query deltas cancel → no significant change. */
+/** A domain whose per-query deltas cancel below the noise floor. */
 function flatDomain(domain: string): DomainEvidence {
   return {
     domain,
@@ -77,12 +77,12 @@ describe('adjudicateRerank — per-domain gate + e2e veto (RFC 020 §3/§5/§9)'
       KB_RERANK_SKIP_DOMAINS: 'code,skills',
     });
     // The improving domain rejects the null after family correction; the flat
-    // one does not.
+    // one is below the MDE/2x-SE noise floor and remains skipped.
     const byDomain = Object.fromEntries(result.domains.map((d) => [d.domain, d]));
     expect(byDomain.scifact.verdict).toBe('improvement');
     expect(byDomain.scifact.action).toBe('enable');
     expect(byDomain.code.verdict).toBe('regression');
-    expect(byDomain.skills.verdict).toBe('no-significant-change');
+    expect(byDomain.skills.verdict).toBe('inconclusive-below-noise-floor');
     expect(byDomain.skills.action).toBe('skip');
   });
 

--- a/benchmarks/adjudication/adjudicate.ts
+++ b/benchmarks/adjudication/adjudicate.ts
@@ -154,9 +154,10 @@ export function adjudicateRerank(input: AdjudicateRerankInput): RerankAdjudicati
   const family = compareFamily(comparisons, correction, alpha);
 
   // 2. Per-domain gate (§9): enable rerank only where it is a *significant*
-  //    improvement; skip everywhere else (regression OR no-significant-change),
-  //    because the cross-encoder costs latency and the KB survey shows it can
-  //    silently degrade high-precision/lexical corpora.
+  //    improvement; skip everywhere else (regression, no-significant-change, or
+  //    inconclusive-below-noise-floor), because the cross-encoder costs latency
+  //    and the KB survey shows it can silently degrade high-precision/lexical
+  //    corpora.
   const domains: DomainAdjudication[] = family.comparisons.map((comparison, index) => {
     const evidence = input.domains[index];
     const verdict = comparison.correctedVerdict;

--- a/benchmarks/beir/quality-gate.test.ts
+++ b/benchmarks/beir/quality-gate.test.ts
@@ -78,12 +78,12 @@ describe('evaluateGateComparison', () => {
     expect(summarizeGateRows([row]).worstStatus).toBe('fail');
   });
 
-  it('does NOT fail a non-significant dip below tolerance (reported, not failed)', () => {
+  it('marks a below-tolerance dip under the noise floor as inconclusive, not failed', () => {
     const n = 60;
     const base = baselineVector(n);
     // Mixed-sign per-query deltas: the mean is slightly negative (a dip) but the
     // spread is wide, so the drop is not statistically significant. With a zero
-    // tolerance it is below the band, yet the gate must WARN, not FAIL.
+    // tolerance it is below the band, yet the gate must be inconclusive, not FAIL.
     const current = report({
       ndcg: base.map((v, i) => clamp01(v + (i % 2 === 0 ? -0.4 : 0.36))),
     });
@@ -97,9 +97,10 @@ describe('evaluateGateComparison', () => {
 
     expect(row.belowTolerance).toBe(true);
     expect(row.significant).toBe(false);
-    expect(row.status).toBe('warn');
+    expect(row.status).toBe('inconclusive-below-noise-floor');
     expect(row.status).not.toBe('fail');
     expect(summarizeGateRows([row]).worstStatus).not.toBe('fail');
+    expect(row.noiseFloorPassed).toBe(false);
   });
 
   it('PASSES a dip that stays within tolerance even if measurable', () => {
@@ -163,8 +164,9 @@ describe('summarizeGateRows + renderGateMarkdown', () => {
       baselineLabel: 'benchmarks/results/beir/baseline',
     });
     expect(markdown).toContain('## Retrieval quality gate');
-    expect(markdown).toContain('| Status | Dataset | Mode | Baseline | Current | Δ nDCG@10 | Tolerance | Significance | Verdict |');
+    expect(markdown).toContain('| Status | Dataset | Mode | Baseline | Current | Δ nDCG@10 | Tolerance | MDE | 2×SE | Significance | Verdict |');
     expect(markdown).toContain('Overall: FAIL');
+    expect(markdown).toContain('Noise floor: MDE=2×bounded SE and delta must exceed 2×paired SE');
     expect(markdown).toContain('enforcing FAIL rows');
   });
 });
@@ -276,8 +278,16 @@ describe('parseQualityGateArgs', () => {
     expect(options.thresholds.relativeTolerance).toBeCloseTo(0.03, 6);
     expect(options.thresholds.absoluteTolerance).toBeCloseTo(0.005, 6);
     expect(options.thresholds.alpha).toBeCloseTo(0.01, 6);
+    expect(options.thresholds.minimumDetectableEffectMultiplier).toBe(2);
+    expect(options.thresholds.standardErrorMultiplier).toBe(2);
     expect(options.modes).toEqual(['lexical']);
     expect(options.enforceFailures).toBe(true);
+  });
+
+  it('parses explicit MDE and paired-SE multipliers', () => {
+    const options = parseQualityGateArgs(['--mde-multiplier=3', '--se-multiplier=2.5'], {});
+    expect(options.thresholds.minimumDetectableEffectMultiplier).toBe(3);
+    expect(options.thresholds.standardErrorMultiplier).toBe(2.5);
   });
 });
 

--- a/benchmarks/beir/quality-gate.ts
+++ b/benchmarks/beir/quality-gate.ts
@@ -13,12 +13,12 @@
 //      datasets (RFC §4 / Open-question 2); AND
 //   2. the drop is **statistically significant** per `significance.ts` — the
 //      paired bootstrap CI on the per-query ΔnDCG@10 excludes zero and the
-//      paired t-test rejects at α.
+//      paired t-test rejects at α, and the observed delta clears the stated MDE
+//      plus the 2x-standard-error noise floor.
 //
-// A dip that clears the tolerance, or one that is within noise (not
-// significant), is reported as PASS/WARN, never failed — this is the explicit
-// anti-flake property the RFC calls for ("a non-significant dip is reported, not
-// failed — avoids flaky gates").
+// A dip that clears the tolerance, or one that is within noise, is reported as
+// PASS/INCONCLUSIVE, never failed — this is the explicit anti-flake property the
+// RFC calls for while also preventing sub-noise deltas from being accepted.
 //
 // Like the latency baselines, BEIR baselines are only ever updated by an
 // explicit, reviewed commit (`chore(bench): update BEIR baseline`); this gate
@@ -34,6 +34,7 @@ import {
   DEFAULT_ALPHA,
   DEFAULT_BOOTSTRAP_RESAMPLES,
   DEFAULT_BOOTSTRAP_SEED,
+  minimumDetectableEffectForBoundedMetric,
   type PerQueryScore,
   type Verdict,
 } from '../significance.js';
@@ -45,7 +46,7 @@ import {
 } from './run.js';
 import { baselineFileName, CI_SUBSET } from './baseline.js';
 
-export type QualityGateStatus = 'pass' | 'warn' | 'fail' | 'skip';
+export type QualityGateStatus = 'pass' | 'inconclusive-below-noise-floor' | 'fail' | 'skip';
 
 // Default tolerance: a relative fraction of the baseline nDCG@10, with an
 // absolute floor so a tiny baseline cannot make the band collapse to ~0 (RFC §4,
@@ -64,6 +65,8 @@ export interface QualityGateThresholds {
   alpha: number;
   resamples: number;
   seed: number;
+  minimumDetectableEffectMultiplier: number;
+  standardErrorMultiplier: number;
 }
 
 export const DEFAULT_GATE_THRESHOLDS: QualityGateThresholds = {
@@ -72,6 +75,8 @@ export const DEFAULT_GATE_THRESHOLDS: QualityGateThresholds = {
   alpha: DEFAULT_ALPHA,
   resamples: DEFAULT_BOOTSTRAP_RESAMPLES,
   seed: DEFAULT_BOOTSTRAP_SEED,
+  minimumDetectableEffectMultiplier: 2,
+  standardErrorMultiplier: 2,
 };
 
 /**
@@ -100,6 +105,11 @@ export interface QualityGateRow {
   verdict?: Verdict;
   pValue?: number;
   meanDelta?: number;
+  standardError?: number;
+  minimumDetectableEffect?: number;
+  twoStandardErrors?: number;
+  noiseFloor?: number;
+  noiseFloorPassed?: boolean;
   ciLow?: number;
   ciHigh?: number;
   pairedQueries?: number;
@@ -148,6 +158,14 @@ export function evaluateGateComparison(
     };
   }
 
+  const baselineNdcg = baseline.metrics.ndcgAt10;
+  const currentNdcg = current.metrics.ndcgAt10;
+  const approximatePairedQueries = Math.min(baseline.per_query.length, current.per_query.length);
+  const minimumDetectableEffect = minimumDetectableEffectForBoundedMetric(
+    baselineNdcg,
+    Math.max(1, approximatePairedQueries),
+    thresholds.minimumDetectableEffectMultiplier,
+  );
   let comparison;
   try {
     comparison = compareScores(perQueryScores(baseline), perQueryScores(current), {
@@ -155,6 +173,8 @@ export function evaluateGateComparison(
       alpha: thresholds.alpha,
       resamples: thresholds.resamples,
       seed: thresholds.seed,
+      minimumDetectableEffect,
+      standardErrorMultiplier: thresholds.standardErrorMultiplier,
     });
   } catch (error) {
     return {
@@ -167,21 +187,19 @@ export function evaluateGateComparison(
     };
   }
 
-  const baselineNdcg = baseline.metrics.ndcgAt10;
-  const currentNdcg = current.metrics.ndcgAt10;
   const delta = Number((currentNdcg - baselineNdcg).toFixed(6));
   const tolerance = toleranceFor(baselineNdcg, thresholds);
   const belowTolerance = currentNdcg < baselineNdcg - tolerance;
   const significant = comparison.verdict === 'regression';
 
   // Fail only on a tolerance-clearing AND statistically-significant drop. A dip
-  // within tolerance passes; a below-tolerance dip that is not significant warns
-  // (reported, never failed) so the gate does not flake on noise.
+  // within tolerance passes; a below-tolerance dip that does not clear the
+  // MDE/2x-SE floor is inconclusive (reported, never passed or failed).
   const status: QualityGateStatus = !belowTolerance
     ? 'pass'
     : significant
       ? 'fail'
-      : 'warn';
+      : 'inconclusive-below-noise-floor';
 
   return {
     dataset,
@@ -196,34 +214,39 @@ export function evaluateGateComparison(
     verdict: comparison.verdict,
     pValue: comparison.pValue,
     meanDelta: comparison.meanDelta,
+    standardError: comparison.standardError,
+    minimumDetectableEffect: comparison.minimumDetectableEffect,
+    twoStandardErrors: comparison.twoStandardErrors,
+    noiseFloor: comparison.noiseFloor,
+    noiseFloorPassed: comparison.noiseFloorPassed,
     ciLow: comparison.bootstrap.ciLow,
     ciHigh: comparison.bootstrap.ciHigh,
     pairedQueries: comparison.n,
-    note: status === 'warn'
-      ? 'below tolerance but not statistically significant — reported, not failed'
+    note: status === 'inconclusive-below-noise-floor'
+      ? 'below tolerance but delta is below the MDE/2x-SE noise floor — inconclusive, not failed'
       : undefined,
   };
 }
 
 export function summarizeGateRows(rows: readonly QualityGateRow[]): {
   fail: number;
+  inconclusive: number;
   pass: number;
   skip: number;
-  warn: number;
   worstStatus: QualityGateStatus;
 } {
   const counts = {
     fail: rows.filter((row) => row.status === 'fail').length,
+    inconclusive: rows.filter((row) => row.status === 'inconclusive-below-noise-floor').length,
     pass: rows.filter((row) => row.status === 'pass').length,
     skip: rows.filter((row) => row.status === 'skip').length,
-    warn: rows.filter((row) => row.status === 'warn').length,
   };
   return {
     ...counts,
     worstStatus: counts.fail > 0
       ? 'fail'
-      : counts.warn > 0
-        ? 'warn'
+      : counts.inconclusive > 0
+        ? 'inconclusive-below-noise-floor'
         : counts.skip === rows.length
           ? 'skip'
           : 'pass',
@@ -245,11 +268,12 @@ export function renderGateMarkdown(options: RenderGateOptions): string {
     '',
     options.baselineLabel ? `Baseline: \`${options.baselineLabel}\`` : 'Baseline: committed BEIR CI-subset baselines',
     `Tolerance: −${(thresholds.relativeTolerance * 100).toFixed(1)}% (abs floor ${thresholds.absoluteTolerance.toFixed(3)}); significance at α=${thresholds.alpha}`,
+    `Noise floor: MDE=${thresholds.minimumDetectableEffectMultiplier}×bounded SE and delta must exceed ${thresholds.standardErrorMultiplier}×paired SE`,
     `Mode: ${options.enforceFailures ? 'enforcing FAIL rows' : 'advisory'}`,
-    `Overall: ${summary.worstStatus.toUpperCase()} (${summary.fail} fail, ${summary.warn} warn, ${summary.pass} pass, ${summary.skip} skipped)`,
+    `Overall: ${summary.worstStatus.toUpperCase()} (${summary.fail} fail, ${summary.inconclusive} inconclusive, ${summary.pass} pass, ${summary.skip} skipped)`,
     '',
-    '| Status | Dataset | Mode | Baseline | Current | Δ nDCG@10 | Tolerance | Significance | Verdict |',
-    '| --- | --- | --- | ---: | ---: | ---: | ---: | --- | --- |',
+    '| Status | Dataset | Mode | Baseline | Current | Δ nDCG@10 | Tolerance | MDE | 2×SE | Significance | Verdict |',
+    '| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- |',
   ];
 
   for (const row of options.rows) {
@@ -261,6 +285,8 @@ export function renderGateMarkdown(options: RenderGateOptions): string {
       formatScore(row.currentNdcg),
       formatDelta(row.delta),
       row.tolerance === undefined ? '-' : `−${row.tolerance.toFixed(4)}`,
+      row.minimumDetectableEffect === undefined ? '-' : row.minimumDetectableEffect.toFixed(4),
+      row.twoStandardErrors === undefined ? '-' : row.twoStandardErrors.toFixed(4),
       formatSignificance(row),
       row.verdict ?? (row.note ?? '-'),
     ].join(' | ').replace(/^/, '| ').replace(/$/, ' |'));
@@ -269,8 +295,9 @@ export function renderGateMarkdown(options: RenderGateOptions): string {
   lines.push(
     '',
     'A cell FAILS only when nDCG@10 drops below `baseline − tolerance` **and** the',
-    'drop is statistically significant; a non-significant dip is reported, not failed',
-    '(RFC 020 §4). FAIL rows fail the job only when `BENCH_QUALITY_GATE_FAIL=1`.',
+    'drop is statistically significant **and** the absolute delta exceeds both the stated',
+    'MDE and 2× paired standard error. A below-tolerance dip under that noise floor is',
+    'INCONCLUSIVE-BELOW-NOISE-FLOOR, not PASS or FAIL (RFC 020 §4). FAIL rows fail the job only when `BENCH_QUALITY_GATE_FAIL=1`.',
     'Baseline updates are an explicit, reviewed commit — never automatic.',
   );
   return `${lines.join('\n')}\n`;
@@ -291,7 +318,9 @@ function formatSignificance(row: QualityGateRow): string {
   const ci = row.ciLow !== undefined && row.ciHigh !== undefined
     ? ` CI[${row.ciLow.toFixed(4)}, ${row.ciHigh.toFixed(4)}]`
     : '';
-  return `p=${p}${ci}`;
+  const se = row.standardError === undefined ? '' : ` SE=${row.standardError.toFixed(4)}`;
+  const floor = row.noiseFloor === undefined ? '' : ` floor=${row.noiseFloor.toFixed(4)}`;
+  return `p=${p}${se}${floor}${ci}`;
 }
 
 // ---------------------------------------------------------------------------
@@ -475,6 +504,10 @@ export function parseQualityGateArgs(argv: string[], env: NodeJS.ProcessEnv): Cl
       options.thresholds.resamples = parsePositiveInt(readValue(), '--bootstrap');
     } else if (flag === '--seed') {
       options.thresholds.seed = parsePositiveInt(readValue(), '--seed');
+    } else if (flag === '--mde-multiplier') {
+      options.thresholds.minimumDetectableEffectMultiplier = parsePositive(readValue(), '--mde-multiplier');
+    } else if (flag === '--se-multiplier') {
+      options.thresholds.standardErrorMultiplier = parsePositive(readValue(), '--se-multiplier');
     } else if (flag === '--max-queries') {
       options.maxQueries = parsePositiveInt(readValue(), '--max-queries');
     } else if (flag === '--fail-on-regression') {
@@ -521,6 +554,12 @@ function parseNonNegative(raw: string, flag: string): number {
   return parsed;
 }
 
+function parsePositive(raw: string, flag: string): number {
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) throw new Error(`${flag} must be a positive number`);
+  return parsed;
+}
+
 function isMissingFileError(error: unknown): boolean {
   return typeof error === 'object' && error !== null && 'code' in error
     && (error as { code?: string }).code === 'ENOENT';
@@ -549,6 +588,8 @@ Options:
   --tolerance=<f>      Relative tolerance (0,1). Default: ${DEFAULT_RELATIVE_TOLERANCE}.
   --abs-tolerance=<f>  Absolute floor. Default: ${DEFAULT_ABSOLUTE_TOLERANCE}.
   --alpha=<p>          Significance level. Default: ${DEFAULT_ALPHA}.
+  --mde-multiplier=<n> MDE multiplier over bounded-metric SE. Default: 2.
+  --se-multiplier=<n>  Paired-SE multiplier. Default: 2.
   --max-queries=<n>    Deterministic subset for a quick smoke.
   --fail-on-regression Exit 1 when any cell is FAIL (env: BENCH_QUALITY_GATE_FAIL=1).
   --summary=<path>     Append markdown to this file (CI step summary).

--- a/benchmarks/beir/run.reranker-bakeoff.test.ts
+++ b/benchmarks/beir/run.reranker-bakeoff.test.ts
@@ -103,7 +103,7 @@ describe('BEIR runner issue #579 reranker bakeoff modes', () => {
 
     const result = await runBeirBenchmark(args, { ...baseDeps, loadSearchBackend: loadBakeoffBackend });
 
-    expect(result.report.schema_version).toBe('kb.beir-benchmark.v6');
+    expect(result.report.schema_version).toBe('kb.beir-benchmark.v7');
     expect(result.report.mode).toBe(mode);
     expect(result.report.reranker_bakeoff).toMatchObject({
       strategy,

--- a/benchmarks/beir/run.test.ts
+++ b/benchmarks/beir/run.test.ts
@@ -90,6 +90,11 @@ describe('BEIR benchmark runner', () => {
     const json = JSON.parse(await fsp.readFile(result.jsonPath, 'utf-8')) as {
       git_sha: string;
       metrics: { ndcgAt10: number; mapAt100: number; recallAt10: number; recallAt100: number };
+      metrics_uncertainty: {
+        schema_version: string;
+        observations: number;
+        metrics: { ndcgAt10: { standard_error: number; ci_low: number; ci_high: number; minimum_detectable_effect: number } };
+      };
       high_recall_candidates: {
         schema_version: string;
         candidate_pool_k: number;
@@ -115,6 +120,16 @@ describe('BEIR benchmark runner', () => {
       recallAt10: 1,
       recallAt100: 1,
     });
+    expect(json.metrics_uncertainty).toMatchObject({
+      schema_version: 'kb.beir.metric-uncertainty.v1',
+      observations: 1,
+    });
+    expect(json.metrics_uncertainty.metrics.ndcgAt10).toMatchObject({
+      standard_error: 0,
+      ci_low: 1,
+      ci_high: 1,
+      minimum_detectable_effect: 0,
+    });
     expect(json.high_recall_candidates).toMatchObject({
       schema_version: 'kb.beir.high-recall-candidates.v1',
       candidate_pool_k: 10,
@@ -128,6 +143,7 @@ describe('BEIR benchmark runner', () => {
     expect(report).toContain('This is a local BEIR benchmark run, not an official leaderboard submission.');
     expect(report).toContain('--lexical-unit=source');
     expect(report).toContain('Candidate Recall@100: 1 (pool=10, final k=10)');
+    expect(report).toContain('nDCG@10 uncertainty: SE=0, CI[1, 1], MDE=0');
     await expect(fsp.stat(workspaceRoot)).rejects.toMatchObject({ code: 'ENOENT' });
   });
 

--- a/benchmarks/beir/run.ts
+++ b/benchmarks/beir/run.ts
@@ -12,6 +12,7 @@ import {
   parseQrelsTsv,
   scoreQuery,
   summarizeLatencies,
+  type AggregateMetrics,
   type Qrels,
   type RankedDocument,
   type QueryMetric,
@@ -31,6 +32,11 @@ import {
   type BenchmarkRerankerSummary,
 } from './reranker-bakeoff-rerankers.js';
 import { durationMs, ensureDirectory, gitSha, resetDirectory, writeJsonFile } from '../utils.js';
+import {
+  minimumDetectableEffectForBoundedMetric,
+  sampleStandardError,
+  studentTwoSidedCritical,
+} from '../significance.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -50,6 +56,7 @@ const DATASET_URLS: Record<string, string> = {
   'webis-touche2020': 'https://public.ukp.informatik.tu-darmstadt.de/thakur/BEIR/datasets/webis-touche2020.zip',
 };
 
+// v7 (issue #603): added per-metric SE/CI/MDE noise-floor reporting.
 // v6 (retrieval frontier #579): added benchmark-only listwise, hard-negative,
 // and adaptive rerank bakeoff modes. v5 (retrieval frontier #578): added
 // benchmark-only late-interaction
@@ -58,7 +65,7 @@ const DATASET_URLS: Record<string, string> = {
 // `hybrid+rerank` / `hybrid+rerank+contextual`
 // modes plus `rerank` / `contextual` provenance blocks. v2 added `dense`/`hybrid`
 // + precision@10 + `embedding`; v1 was lexical-only.
-const BENCHMARK_SCHEMA_VERSION = 'kb.beir-benchmark.v6';
+const BENCHMARK_SCHEMA_VERSION = 'kb.beir-benchmark.v7';
 type LexicalUnit = 'chunk' | 'source';
 // RFC 020 §1 — the retrieval-mode space the runner can score. `lexical` is
 // credential-free (BM25 only), and `late` is a credential-free benchmark-only
@@ -350,6 +357,7 @@ interface BeirBenchmarkReport {
     chunks: number;
   };
   metrics: ReturnType<typeof aggregateQueryMetrics>;
+  metrics_uncertainty: MetricUncertaintySummary;
   high_recall_candidates?: {
     schema_version: 'kb.beir.high-recall-candidates.v1';
     candidate_pool_k: number;
@@ -367,6 +375,21 @@ interface BeirBenchmarkReport {
   latency: ReturnType<typeof summarizeLatencies>;
   per_query: QueryMetric[];
   caveats: string[];
+}
+
+type MetricName = Exclude<keyof AggregateMetrics, 'judgedQueries'>;
+
+interface MetricUncertaintySummary {
+  schema_version: 'kb.beir.metric-uncertainty.v1';
+  observations: number;
+  alpha: number;
+  note: string;
+  metrics: Record<MetricName, {
+    standard_error: number;
+    ci_low: number;
+    ci_high: number;
+    minimum_detectable_effect: number;
+  }>;
 }
 
 export interface BeirBenchmarkRunResult {
@@ -478,6 +501,7 @@ export async function runBeirBenchmark(
     });
   }
 
+  const aggregateMetrics = aggregateQueryMetrics(perQuery);
   const report: BeirBenchmarkReport = {
     schema_version: BENCHMARK_SCHEMA_VERSION,
     generated_at: dependencies.now().toISOString(),
@@ -522,7 +546,8 @@ export async function runBeirBenchmark(
       files: indexing.files,
       chunks: indexing.chunks,
     },
-    metrics: aggregateQueryMetrics(perQuery),
+    metrics: aggregateMetrics,
+    metrics_uncertainty: summarizeMetricUncertainty(aggregateMetrics, perQuery),
     ...(candidatePerQuery !== undefined && args.candidatePoolK !== undefined
       ? {
           high_recall_candidates: {
@@ -559,6 +584,46 @@ export async function runBeirBenchmark(
   }
 
   return { jsonPath, trecPath, reportPath, report };
+}
+
+function summarizeMetricUncertainty(
+  aggregateMetrics: AggregateMetrics,
+  perQuery: readonly QueryMetric[],
+  alpha = 0.05,
+): MetricUncertaintySummary {
+  const observations = perQuery.length;
+  const metricNames: MetricName[] = ['ndcgAt10', 'mapAt100', 'precisionAt10', 'recallAt10', 'recallAt100'];
+  const metrics = Object.fromEntries(metricNames.map((metric) => {
+    const values = perQuery.map((row) => row[metric]);
+    const standardError = sampleStandardError(values);
+    const tCritical = observations >= 2 ? studentTwoSidedCritical(observations - 1, alpha) : 0;
+    const meanValue = aggregateMetrics[metric];
+    const margin = tCritical * standardError;
+    return [metric, {
+      standard_error: roundReportMetric(standardError),
+      ci_low: roundReportMetric(clampUnit(meanValue - margin)),
+      ci_high: roundReportMetric(clampUnit(meanValue + margin)),
+      minimum_detectable_effect: roundReportMetric(minimumDetectableEffectForBoundedMetric(
+        meanValue,
+        Math.max(1, observations),
+      )),
+    }];
+  })) as MetricUncertaintySummary['metrics'];
+  return {
+    schema_version: 'kb.beir.metric-uncertainty.v1',
+    observations,
+    alpha,
+    note: 'SE/CI are estimated across per-query metric values; MDE is 2x bounded-metric SE for the evaluated query count.',
+    metrics,
+  };
+}
+
+function clampUnit(value: number): number {
+  return Math.min(1, Math.max(0, value));
+}
+
+function roundReportMetric(value: number): number {
+  return Number(value.toFixed(6));
 }
 
 interface RetrievalOutcome {
@@ -1800,6 +1865,9 @@ function formatMarkdownReport(report: BeirBenchmarkReport, trecPath: string, jso
     `- MAP@100: ${metrics.mapAt100}`,
     `- Recall@10: ${metrics.recallAt10}`,
     `- Recall@100: ${metrics.recallAt100}`,
+    `- nDCG@10 uncertainty: SE=${report.metrics_uncertainty.metrics.ndcgAt10.standard_error}, ` +
+      `CI[${report.metrics_uncertainty.metrics.ndcgAt10.ci_low}, ${report.metrics_uncertainty.metrics.ndcgAt10.ci_high}], ` +
+      `MDE=${report.metrics_uncertainty.metrics.ndcgAt10.minimum_detectable_effect}`,
     ...(report.high_recall_candidates !== undefined
       ? [
           `- Candidate Recall@100: ${report.high_recall_candidates.candidate_recall_at100} ` +

--- a/benchmarks/rag-eval/model-metrics.test.ts
+++ b/benchmarks/rag-eval/model-metrics.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from '@jest/globals';
 import {
+  evaluateMetricGate,
   faithfulnessScore,
   semanticScore,
   splitClaims,
@@ -61,5 +62,35 @@ describe('semanticScore (stub BERTScore)', () => {
     const model = tokenOverlapSimilarityModel();
     expect(await semanticScore('paris', ['london', 'paris'], model)).toBe(1);
     expect(await semanticScore('paris', [], model)).toBe(0);
+  });
+});
+
+describe('evaluateMetricGate', () => {
+  it('marks a small deterministic fixture delta as inconclusive below the noise floor', () => {
+    const result = evaluateMetricGate({
+      metric: 'faithfulness',
+      baseline: 0.8,
+      current: 0.82,
+      observations: 25,
+    });
+    expect(result.delta).toBeCloseTo(0.02, 6);
+    expect(result.noiseFloor).toBeCloseTo(0.16, 6);
+    expect(result.noiseFloorPassed).toBe(false);
+    expect(result.status).toBe('inconclusive-below-noise-floor');
+  });
+
+  it('fails a regression only after it exceeds the stated MDE and 2x SE', () => {
+    const result = evaluateMetricGate({
+      metric: 'semantic',
+      baseline: 0.8,
+      current: 0.6,
+      observations: 25,
+      minimumDetectableEffect: 0.05,
+      standardError: 0.04,
+    });
+    expect(result.twoStandardErrors).toBeCloseTo(0.08, 6);
+    expect(result.noiseFloor).toBeCloseTo(0.08, 6);
+    expect(result.noiseFloorPassed).toBe(true);
+    expect(result.status).toBe('fail');
   });
 });

--- a/benchmarks/rag-eval/model-metrics.ts
+++ b/benchmarks/rag-eval/model-metrics.ts
@@ -17,6 +17,7 @@
 import { normalizedTokens, tokenF1Pair } from './reference.js';
 import { clampUnit, roundUnit } from './types.js';
 import type { RetrievedContext } from './types.js';
+import { boundedMetricStandardError, minimumDetectableEffectForBoundedMetric } from '../significance.js';
 
 export type EntailmentLabel = 'entailment' | 'neutral' | 'contradiction';
 
@@ -39,6 +40,33 @@ export interface SemanticSimilarityModel {
   similarity(candidate: string, reference: string): Promise<number>;
 }
 
+export type MetricGateStatus = 'pass' | 'fail' | 'inconclusive-below-noise-floor';
+
+export interface MetricGateInput {
+  metric: string;
+  baseline: number;
+  current: number;
+  observations: number;
+  /** Defaults to true because RAG quality metrics are unit scores where higher is better. */
+  higherIsBetter?: boolean;
+  minimumDetectableEffect?: number;
+  standardError?: number;
+  standardErrorMultiplier?: number;
+}
+
+export interface MetricGateResult {
+  metric: string;
+  status: MetricGateStatus;
+  baseline: number;
+  current: number;
+  delta: number;
+  minimumDetectableEffect: number;
+  standardError: number;
+  twoStandardErrors: number;
+  noiseFloor: number;
+  noiseFloorPassed: boolean;
+}
+
 export interface FaithfulnessOptions {
   /** Entailment score at/above which a claim counts as supported. */
   entailmentThreshold?: number;
@@ -58,6 +86,34 @@ export interface FaithfulnessResult {
 }
 
 export const DEFAULT_ENTAILMENT_THRESHOLD = 0.5;
+
+export function evaluateMetricGate(input: MetricGateInput): MetricGateResult {
+  const higherIsBetter = input.higherIsBetter ?? true;
+  const delta = input.current - input.baseline;
+  const standardError = input.standardError ?? boundedMetricStandardError(input.baseline, input.observations);
+  const minimumDetectableEffect = input.minimumDetectableEffect
+    ?? minimumDetectableEffectForBoundedMetric(input.baseline, input.observations);
+  const twoStandardErrors = (input.standardErrorMultiplier ?? 2) * standardError;
+  const noiseFloor = Math.max(minimumDetectableEffect, twoStandardErrors);
+  const noiseFloorPassed = Math.abs(delta) > noiseFloor;
+  const status: MetricGateStatus = !noiseFloorPassed
+    ? 'inconclusive-below-noise-floor'
+    : (higherIsBetter ? delta >= 0 : delta <= 0)
+      ? 'pass'
+      : 'fail';
+  return {
+    metric: input.metric,
+    status,
+    baseline: roundUnit(input.baseline),
+    current: roundUnit(input.current),
+    delta: Number(delta.toFixed(6)),
+    minimumDetectableEffect: Number(minimumDetectableEffect.toFixed(6)),
+    standardError: Number(standardError.toFixed(6)),
+    twoStandardErrors: Number(twoStandardErrors.toFixed(6)),
+    noiseFloor: Number(noiseFloor.toFixed(6)),
+    noiseFloorPassed,
+  };
+}
 
 /** Split an answer into claim-sized units (sentences) for claim-wise NLI. */
 export function splitClaims(answer: string): string[] {

--- a/benchmarks/significance.test.ts
+++ b/benchmarks/significance.test.ts
@@ -4,12 +4,15 @@ import * as os from 'os';
 import * as path from 'path';
 import {
   adjustPValues,
+  boundedMetricStandardError,
   compareFamily,
   compareSamples,
   loadRunScores,
+  minimumDetectableEffectForBoundedMetric,
   pairScores,
   pairedBootstrap,
   pairedTTest,
+  sampleStandardError,
   studentTwoSidedCritical,
   studentTwoSidedP,
   wildClusterBootstrap,
@@ -162,11 +165,41 @@ describe('compareSamples verdicts', () => {
     expect(result.meanDelta).toBeLessThan(0);
   });
 
-  it('returns no-significant-change for a noisy near-zero shift', () => {
+  it('returns inconclusive-below-noise-floor for a noisy near-zero shift', () => {
     const result = compareSamples(samplesFromDeltas(
       Array.from({ length: 30 }, (_, i) => (i % 2 === 0 ? 0.3 : -0.29)),
     ));
-    expect(result.verdict).toBe('no-significant-change');
+    expect(result.verdict).toBe('inconclusive-below-noise-floor');
+  });
+
+  it('returns inconclusive-below-noise-floor when the mean delta does not clear the stated MDE', () => {
+    const result = compareSamples(samplesFromDeltas(
+      Array.from({ length: 40 }, (_, i) => 0.03 + 0.001 * ((i % 4) - 1.5)),
+    ), { minimumDetectableEffect: 0.05 });
+    expect(result.meanDelta).toBeGreaterThan(0);
+    expect(result.noiseFloor).toBeCloseTo(0.05, 12);
+    expect(result.noiseFloorPassed).toBe(false);
+    expect(result.verdict).toBe('inconclusive-below-noise-floor');
+  });
+
+  it('requires the mean delta to exceed 2x standard error before accepting a change', () => {
+    const result = compareSamples(samplesFromDeltas([0.1, 0.1, 0.1, -0.05, -0.05, -0.05]));
+    expect(result.meanDelta).toBeCloseTo(0.025, 12);
+    expect(result.standardError).toBeCloseTo(sampleStandardError([0.1, 0.1, 0.1, -0.05, -0.05, -0.05]), 12);
+    expect(result.twoStandardErrors).toBeGreaterThan(Math.abs(result.meanDelta));
+    expect(result.verdict).toBe('inconclusive-below-noise-floor');
+  });
+});
+
+describe('bounded metric MDE helpers', () => {
+  it('computes binomial-style SE and MDE from a bounded point estimate and corpus size', () => {
+    expect(boundedMetricStandardError(0.75, 100)).toBeCloseTo(Math.sqrt(0.75 * 0.25 / 100), 12);
+    expect(minimumDetectableEffectForBoundedMetric(0.75, 100)).toBeCloseTo(2 * Math.sqrt(0.75 * 0.25 / 100), 12);
+  });
+
+  it('rejects invalid corpus sizes and multipliers', () => {
+    expect(() => boundedMetricStandardError(0.5, 0)).toThrow(/positive integer/);
+    expect(() => minimumDetectableEffectForBoundedMetric(0.5, 10, 0)).toThrow(/multiplier/);
   });
 });
 
@@ -197,9 +230,10 @@ describe('wildClusterBootstrap', () => {
     const naiveWidth = naive.bootstrap.ciHigh - naive.bootstrap.ciLow;
     const wildWidth = wild.ciHigh - wild.ciLow;
     expect(wildWidth).toBeGreaterThan(naiveWidth);
-    // The cluster-aware verdict does not over-claim.
+    // The cluster-aware verdict does not over-claim; the observed delta is also
+    // below the 2x-SE floor, so the comparator calls it inconclusive.
     expect(wild.pValue).toBeGreaterThan(0.05);
-    expect(clustered.verdict).toBe('no-significant-change');
+    expect(clustered.verdict).toBe('inconclusive-below-noise-floor');
     // The Wald-t cluster CI stays bounded (no percentile-t blow-up) and, here,
     // straddles zero.
     expect(Number.isFinite(wild.ciLow)).toBe(true);
@@ -274,6 +308,11 @@ describe('compareFamily', () => {
       n: 50,
       clusters: 1,
       meanDelta,
+      standardError: 0,
+      minimumDetectableEffect: 0,
+      twoStandardErrors: 0,
+      noiseFloor: 0,
+      noiseFloorPassed: true,
       tStatistic: 0,
       degreesOfFreedom: 49,
       pValue,

--- a/benchmarks/significance.ts
+++ b/benchmarks/significance.ts
@@ -2,8 +2,9 @@
 //
 // "Add a comparator that takes two run files (per-query nDCG@10 vectors over
 // the same query set) and reports a paired bootstrap (10k resamples) CI on the
-// mean delta, a paired t-test p-value, and a verdict (improvement / regression
-// / no-significant-change) at α = 0.05."
+// mean delta, a paired t-test p-value, the stated MDE + 2x-SE noise floor, and a
+// verdict (improvement / regression / no-significant-change /
+// inconclusive-below-noise-floor) at α = 0.05."
 //
 // This is the arbiter for every roadmap decision (M1+) and for the future CI
 // gate's "is this a real regression?" question. It lives next to
@@ -40,7 +41,7 @@ export const DEFAULT_ALPHA = 0.05;
 // Fixed default seed keeps the CLI reproducible run-to-run (RFC §7 ledger).
 export const DEFAULT_BOOTSTRAP_SEED = 0x9e3779b9;
 
-export type Verdict = 'improvement' | 'regression' | 'no-significant-change';
+export type Verdict = 'improvement' | 'regression' | 'no-significant-change' | 'inconclusive-below-noise-floor';
 export type CorrectionMethod = 'bonferroni' | 'holm' | 'none';
 
 export interface PerQueryScore {
@@ -72,6 +73,15 @@ export interface ComparisonResult {
   n: number;
   clusters: number;
   meanDelta: number;
+  /** Standard error of the paired mean delta. */
+  standardError: number;
+  /** The stated minimum detectable effect for this metric/corpus. */
+  minimumDetectableEffect: number;
+  /** The benchmark contract's 2x-standard-error threshold. */
+  twoStandardErrors: number;
+  /** max(minimumDetectableEffect, twoStandardErrors). */
+  noiseFloor: number;
+  noiseFloorPassed: boolean;
   /** Paired t-test. */
   tStatistic: number;
   degreesOfFreedom: number;
@@ -163,6 +173,10 @@ export interface CompareOptions {
   resamples?: number;
   seed?: number;
   alpha?: number;
+  /** Stated MDE for the metric. Acceptance gates should set this explicitly. */
+  minimumDetectableEffect?: number;
+  /** Multiplier for the standard-error floor. Defaults to the issue #603 2x rule. */
+  standardErrorMultiplier?: number;
   /** Add the wild-cluster bootstrap-t leg (queries cluster by dataset). */
   clusterByDataset?: boolean;
 }
@@ -189,6 +203,11 @@ export function compareSamples(
   const clusters = new Set(samples.map((s) => s.cluster)).size;
 
   const meanDelta = mean(deltas);
+  const standardError = sampleStandardError(deltas);
+  const minimumDetectableEffect = options.minimumDetectableEffect ?? 0;
+  const twoStandardErrors = (options.standardErrorMultiplier ?? 2) * standardError;
+  const noiseFloor = Math.max(minimumDetectableEffect, twoStandardErrors);
+  const noiseFloorPassed = Math.abs(meanDelta) > noiseFloor;
   const ttest = pairedTTest(deltas);
   const bootstrap = pairedBootstrap(deltas, resamples, seed, alpha);
   const wildCluster = options.clusterByDataset && clusters > 1
@@ -200,12 +219,17 @@ export function compareSamples(
     n,
     clusters,
     meanDelta,
+    standardError,
+    minimumDetectableEffect,
+    twoStandardErrors,
+    noiseFloor,
+    noiseFloorPassed,
     tStatistic: ttest.tStatistic,
     degreesOfFreedom: ttest.degreesOfFreedom,
     pValue: ttest.pValue,
     bootstrap,
     ...(wildCluster !== undefined ? { wildCluster } : {}),
-    verdict: verdictFromResult(meanDelta, ttest.pValue, bootstrap, wildCluster, alpha),
+    verdict: verdictFromResult(meanDelta, ttest.pValue, bootstrap, wildCluster, alpha, noiseFloor, noiseFloorPassed),
   };
 }
 
@@ -230,9 +254,36 @@ export function pairedTTest(deltas: readonly number[]): {
   if (sd === 0) {
     return { tStatistic: m === 0 ? 0 : Math.sign(m) * Infinity, degreesOfFreedom: df, pValue: m === 0 ? 1 : 0 };
   }
-  const standardError = sd / Math.sqrt(n);
+  const standardError = sampleStandardError(deltas);
   const tStatistic = m / standardError;
   return { tStatistic, degreesOfFreedom: df, pValue: studentTwoSidedP(tStatistic, df) };
+}
+
+export function sampleStandardError(values: readonly number[]): number {
+  const n = values.length;
+  if (n < 2) return 0;
+  const m = mean(values);
+  const variance = values.reduce((acc, value) => acc + (value - m) ** 2, 0) / (n - 1);
+  return Math.sqrt(variance) / Math.sqrt(n);
+}
+
+export function boundedMetricStandardError(pointEstimate: number, observations: number): number {
+  if (!Number.isSafeInteger(observations) || observations <= 0) {
+    throw new Error(`significance: observations must be a positive integer, got ${observations}`);
+  }
+  const p = clamp01(pointEstimate);
+  return Math.sqrt((p * (1 - p)) / observations);
+}
+
+export function minimumDetectableEffectForBoundedMetric(
+  pointEstimate: number,
+  observations: number,
+  multiplier = 2,
+): number {
+  if (!Number.isFinite(multiplier) || multiplier <= 0) {
+    throw new Error(`significance: multiplier must be positive, got ${multiplier}`);
+  }
+  return multiplier * boundedMetricStandardError(pointEstimate, observations);
 }
 
 /**
@@ -411,9 +462,11 @@ export function compareFamily(
   const familyComparisons = comparisons.map((comparison, index) => {
     const adjustedPValue = adjusted[index];
     const rejectedNull = adjustedPValue < alpha;
-    const correctedVerdict: Verdict = rejectedNull
-      ? comparison.meanDelta >= 0 ? 'improvement' : 'regression'
-      : 'no-significant-change';
+    const correctedVerdict: Verdict = !comparison.noiseFloorPassed
+      ? 'inconclusive-below-noise-floor'
+      : rejectedNull
+        ? comparison.meanDelta >= 0 ? 'improvement' : 'regression'
+        : 'no-significant-change';
     return { ...comparison, adjustedPValue, rejectedNull, correctedVerdict };
   });
   return { method, alpha, comparisons: familyComparisons };
@@ -429,7 +482,12 @@ function verdictFromResult(
   bootstrap: BootstrapCi,
   wildCluster: WildClusterResult | undefined,
   alpha: number,
+  noiseFloor: number,
+  noiseFloorPassed: boolean,
 ): Verdict {
+  if (noiseFloor > 0 && !noiseFloorPassed) {
+    return 'inconclusive-below-noise-floor';
+  }
   // A change is "significant" when the bootstrap CI excludes zero AND the
   // (cluster-aware, when available) test rejects at α. Requiring both the
   // interval and the test agree keeps a borderline p from flipping the verdict

--- a/docs/rfcs/020-retrieval-eval-benchmark-strategy.md
+++ b/docs/rfcs/020-retrieval-eval-benchmark-strategy.md
@@ -89,7 +89,8 @@ Output is one row per `(dataset × mode)` and a per-mode mean across datasets. T
 Per-query metrics are already computed (`QueryMetric` in `benchmarks/beir/metrics.ts`). Add a comparator that takes two run files (per-query nDCG@10 vectors over the same query set) and reports:
 
 - **Paired bootstrap** (10k resamples) confidence interval on the mean delta, and a **paired t-test** p-value.
-- A verdict: `improvement` / `regression` / `no-significant-change` at α = 0.05.
+- A stated **minimum detectable effect (MDE)** for each metric/corpus, derived from the evaluated query count. For bounded recall-like metrics use the binomial approximation `SE = sqrt(p(1-p)/n)` and `MDE = 2 * SE`; paired comparisons also report the empirical paired-delta SE.
+- A verdict: `improvement` / `regression` / `no-significant-change` / `inconclusive-below-noise-floor` at α = 0.05. A delta is actionable only when its absolute value exceeds both the stated MDE and `2 * paired SE`; otherwise the comparator is inconclusive even if the point estimate looks favorable.
 - **Multiple-comparison correction.** A sweep compares many configs at once; reporting each delta at α = 0.05 inflates false positives. Apply **Bonferroni** (or Holm) correction across the comparison family. The risk is concrete, not theoretical: in the KB survey, a study of ranking comparisons found a naive binomial test marked all 4 primary comparisons significant, while a corrected **wild-cluster bootstrap** left only 1 surviving Bonferroni (`[KB: llm-as-judge/2605.27789]`). We adopt the wild-cluster variant when queries cluster by dataset/domain (the BEIR matrix does), since per-query results within a dataset are not independent.
 - **Noisy-label correction for the §5 LLM-grader leg.** Bootstrap over LLM-graded labels (not human qrels) is biased: an AI-generated-label study measured naive-bootstrap CI coverage as low as **15%** vs the nominal 95%, fixed by a coupled-label bootstrap with variance correction (`[KB: labor-market-intel/2604.23770]`). The §5 e2e comparator therefore uses the bias-corrected variant; the §3 BEIR comparator (human qrels) keeps the plain paired bootstrap.
 
@@ -100,7 +101,7 @@ This is the arbiter for every roadmap decision and for the gate's "is this a rea
 Mirror the latency `budget-diff` gate for quality:
 
 - A committed **baseline** under `benchmarks/results/beir/baseline/` per `(dataset × mode)` for the CI subset (§2), tagged with the commit + env that produced it.
-- On every PR touching retrieval code (`src/search-core.ts`, `src/hybrid-retrieval.ts`, `src/reranker.ts`, `src/lexical-*.ts`, `src/faiss-*.ts`, chunking config), CI runs the CI-subset sweep (lexical + dense via `fake`/Ollama as available) and fails if **nDCG@10 drops below `baseline − tolerance`** on any subset dataset, where the drop is **statistically significant** per §3 (a non-significant dip is reported, not failed — avoids flaky gates).
+- On every PR touching retrieval code (`src/search-core.ts`, `src/hybrid-retrieval.ts`, `src/reranker.ts`, `src/lexical-*.ts`, `src/faiss-*.ts`, chunking config), CI runs the CI-subset sweep (lexical + dense via `fake`/Ollama as available) and fails if **nDCG@10 drops below `baseline − tolerance`** on any subset dataset, where the drop is **statistically significant** per §3 and clears the MDE/`2 * SE` noise floor. A below-tolerance dip below that floor is reported as `inconclusive-below-noise-floor`, not pass or fail — avoids flaky gates and prevents accepting noise as signal.
 - Baseline updates are an explicit, reviewed commit (`chore(bench): update BEIR baseline`), never automatic — the same discipline as latency baselines.
 
 The gate runs the credential-free path (lexical always; dense via `fake` provider for determinism) so it is hermetic. Full-provider sweeps are a manual/release job, not per-PR.
@@ -136,6 +137,7 @@ The product promise is *general knowledge research*. The program is structured s
 1. **Tune on dev, report on test.** Hyperparameter search (RRF `c`, rerank `topN`, chunk size, fetch multiplier) runs on dev splits only via the existing Optuna integration (`bench:tune`), pointed at BEIR dev. Reported numbers are test-split. A config tuned on test is a defect.
 2. **Headline = multi-domain mean.** Per §2, the quoted number is the average across the BEIR matrix. This is the anti-overfitting metric by construction.
 3. **The e2e RAG eval (§5) is a hard veto.** No retrieval change ships if it regresses faithfulness/answer-correctness on the held-out product eval.
+   The veto must use the same MDE/`2 * SE` noise-floor contract for aggregate scorecard metrics: below-floor deltas are inconclusive, not pass/fail evidence.
 4. **Zero-shot only, until proven otherwise.** BEIR and BRIGHT are zero-shot benchmarks; we run them zero-shot. Any future domain adaptation / fine-tuning is gated behind a separate RFC that must report zero-shot BEIR *and* e2e RAG numbers side-by-side with the adapted numbers.
 
 Per the KB survey, the four checks above are necessary but **not sufficient** — "tune on dev, report on test" still permits *within-zero-shot* overfitting (tuning on BEIR dev for the express purpose of climbing BEIR test). Practitioners harden this with explicit structural probes (`[KB: llm-generalization/2605.16819]`, `[KB: llm-generalization/2605.11518]`):
@@ -184,7 +186,7 @@ Each item below is gated by §3/§5 and (for the large ones) deferred to its own
 | **M2** | Full BEIR matrix sweep + MLflow ledger + `compare/` leaderboard view; **BEIR headline** report; per-domain breakdown + Δ_g vs unseen-generality set (§6) | Multi-domain mean nDCG@10 for the shipped pipeline recorded and reproducible from commit+env; Δ_g reported |
 | **M3** | CI quality gate live; **BRIGHT** adapter + report | Gate fails a seeded regression in test; BRIGHT nDCG recorded for hybrid+rerank vs dense baseline |
 | **M4** | End-to-end RAG eval, **fully human-label-free** (Tier 1 gold-answer/supporting-fact metrics → Tier 2 NLI/semantic → Tier 3 multi-judge panel w/ unsupervised self-consistency calibration → Tier 4 automated bias probes — §5); **MTEB** submission of active embedding model | e2e scorecard recorded on held-out gold-bearing QA; panel self-consistency confidence + per-judge probe-measured bias coefficients reported (no human labels); MTEB result obtained for the default model |
-| **M5** | First Tier-1 technique adjudicated through the full harness | A ship/no-ship decision backed by §3 significance + §5 e2e veto (+ per-domain gate for reranker changes) |
+| **M5** | First Tier-1 technique adjudicated through the full harness | A ship/no-ship decision backed by §3 significance, stated MDE, observed delta vs `2 * SE`, and §5 e2e veto (+ per-domain gate for reranker changes) |
 
 ### M4 implementation note
 

--- a/docs/testing/retrieval-eval.md
+++ b/docs/testing/retrieval-eval.md
@@ -52,6 +52,16 @@ means across judged cases. When positive judgments carry `group`, `groups`,
 alpha-nDCG@k. Cases without judgments preserve the original binary pass/fail
 output shape, plus the source diversity diagnostics.
 
+Benchmark acceptance gates must state a minimum detectable effect (MDE) and the
+observed delta versus `2 * SE`. BEIR run reports include per-metric SE/CI/MDE
+from the per-query metric vectors, and the quality gate reports
+`INCONCLUSIVE-BELOW-NOISE-FLOOR` when a below-tolerance delta does not exceed
+both the stated MDE and `2 * paired SE`. RAG scorecard metric gates use the same
+pass/fail/inconclusive contract. The unit tests use deterministic worked
+fixtures for the noise-floor cases instead of re-running a historical benchmark,
+because the historical comparisons require model/provider state that is too
+expensive and environment-dependent for focused command tests.
+
 For authoring guidance, see [Retrieval eval fixture methodology](retrieval-eval-methodology.md).
 
 ### TS-RETRIEVAL-EVAL-509: Replayable Benchmark Tuning


### PR DESCRIPTION
Closes #603

## Implementation choice
- Added MDE/noise-floor fields to the shared significance comparator: paired mean SE, stated MDE, `2 * SE`, effective noise floor, and `inconclusive-below-noise-floor` verdicts.
- Wired the BEIR quality gate to compute a per-cell MDE from the bounded-metric SE approximation and to report below-floor regressions as `INCONCLUSIVE-BELOW-NOISE-FLOOR`, not pass/fail.
- Added BEIR run-report `metrics_uncertainty` output with per-metric SE/CI/MDE from per-query metric vectors.
- Added a RAG scorecard metric-gate helper with the same pass/fail/inconclusive contract.
- Updated the rerank adjudication fixture to preserve skip behavior while recognizing below-floor domains as inconclusive.
- Used deterministic worked fixtures for the noise-floor examples instead of re-running a historical comparison, because historical re-evaluation depends on model/provider state and is too expensive/environment-dependent for focused tests.

## Alternatives considered
- Full multi-run/multi-seed orchestration: deferred as heavier than needed for this gate contract; the current harness already has per-query paired vectors and deterministic bootstrap support.
- Treating below-floor deltas as pass: rejected because the issue explicitly requires inconclusive output when deltas are below the noise floor.
- Fixed global MDE: rejected because corpus/query count changes the detectable effect size.

## Verification
- `npm ci` completed to populate the fresh worktree dependencies.
- `npm test -- --runTestsByPath benchmarks/significance.test.ts benchmarks/beir/quality-gate.test.ts --runInBand` passed: 2 suites, 46 tests.
- `npm test -- --runTestsByPath benchmarks/beir/run.test.ts benchmarks/beir/run.reranker-bakeoff.test.ts benchmarks/rag-eval/model-metrics.test.ts --runInBand` passed: 3 suites, 14 tests.
- `npm test -- --runTestsByPath benchmarks/adjudication/adjudicate.test.ts benchmarks/significance.test.ts benchmarks/beir/quality-gate.test.ts --runInBand` passed: 3 suites, 56 tests.
- `npm run build` passed.
- Full local `npm test -- --runInBand` was attempted before the adjudication fix, but an unrelated `src/FaissIndexManager.test.ts` provider-construction test timed out at 5000 ms and the Jest process then hung; it was interrupted after no further output. CI runs the full suite on GitHub.