### PR TITLE
Stream kb ask markdown answers

### DIFF
--- a/docs/llm-provider.md
+++ b/docs/llm-provider.md
@@ -1,7 +1,7 @@
 # LLM provider configuration
 
-`kb`'s chat-completion calls — contextual-retrieval prefaces (RFC 017), the
-relevance-gate judge (RFC 018), and `kb llm probe` — route through a
+`kb`'s chat-completion calls — `kb ask`, contextual-retrieval prefaces
+(RFC 017), the relevance-gate judge (RFC 018), and `kb llm probe` — route through a
 **provider-neutral, OpenAI-compatible** config layer. A single switch moves the
 active chat model between:
 
@@ -15,7 +15,7 @@ This mirrors the same switch in the sibling repos
 `LRA_LLM_*`, `kookr`'s `KOOKR_LLM_*`) so one DeepSeek/OpenRouter setup is
 consistent across all three. **Embeddings are unaffected** — they always run
 locally through the configured embedding provider (e.g. nomic via Ollama). Only
-the *generation* step (prefaces, gate judging) is switched here.
+the *generation* step (answers, prefaces, gate judging) is switched here.
 
 ## Environment variables
 
@@ -79,3 +79,12 @@ deliberate shift from the local-first default; embeddings still run locally.
 - **Request body:** the `chat_template_kwargs` llama.cpp/vLLM extension is sent
   only for local endpoints (hosted providers reject/ignore unknown fields).
 - **Health probe:** skipped for remote providers (no `/health`).
+- **Streaming:** markdown `kb ask` output opts into OpenAI-compatible SSE
+  streaming and prints answer tokens as they arrive, then renders sources,
+  context, timing, and transcript status after the final answer. Use
+  `kb ask --no-stream` to keep the old wait-then-print markdown behavior.
+  `--format=json`, contextual prefaces, relevance-gate calls, and probes remain
+  non-streaming. Streaming calls retry only before the first answer token is
+  emitted; after output starts, stream errors are surfaced without replaying
+  partial content. The streaming timeout is idle/inter-chunk, while non-streaming
+  calls keep the existing request timeout behavior.

--- a/src/ask-core.ts
+++ b/src/ask-core.ts
@@ -53,6 +53,7 @@ export interface AskExecutionArgs {
   timing: boolean;
   taskContext?: string;
   gate?: RelevanceGateOverride;
+  onAnswerToken?: (token: string) => void | Promise<void>;
 }
 
 export interface AskKnowledgeInput {
@@ -298,13 +299,23 @@ export async function executeAsk(
   let llmModel: string | null = null;
   try {
     const startedAt = nowMs();
+    if (timing) timing.llm_first_token_ms = null;
     const response = await deps.callChatCompletion({
       endpoint: target.profile.endpoint,
       messages: buildAskMessages(args.question, packedContext.included, args.taskContext),
       temperature: 0.2,
+      ...(args.onAnswerToken !== undefined
+        ? {
+            stream: {
+              onToken: args.onAnswerToken,
+              onFirstToken: () => {
+                if (timing) timing.llm_first_token_ms = elapsedMs(startedAt);
+              },
+            },
+          }
+        : {}),
     });
     if (timing) {
-      timing.llm_first_token_ms = null;
       timing.llm_total_ms = elapsedMs(startedAt);
     }
     answer = response.content;

--- a/src/cli-ask.test.ts
+++ b/src/cli-ask.test.ts
@@ -43,6 +43,7 @@ describe('parseAskArgs', () => {
       refresh: true,
       stdin: false,
       format: 'json',
+      noStream: false,
       timing: true,
       saveTranscript: true,
       title: 'Incident answer',
@@ -56,6 +57,14 @@ describe('parseAskArgs', () => {
     expect(() => parseAskArgs(['q', '--format=yaml'])).toThrow(/invalid --format/);
     expect(() => parseAskArgs(['q', '--bad'])).toThrow(/unknown flag/);
     expect(() => parseAskArgs(['q', 'extra'])).toThrow(/unexpected argument/);
+  });
+
+  it('parses --no-stream for markdown output', () => {
+    expect(parseAskArgs(['what changed?', '--no-stream'])).toMatchObject({
+      question: 'what changed?',
+      format: 'md',
+      noStream: true,
+    });
   });
 
   it('requires explicit confirmation and a target KB before saving transcripts', () => {
@@ -448,15 +457,11 @@ describe('ask transcript records', () => {
     const previousEndpoint = process.env.KB_LLM_ENDPOINT;
     const previousLogFormat = process.env.KB_LOG_FORMAT;
     const stdout: string[] = [];
-    const stderr: string[] = [];
     const stdoutSpy = jest.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
       stdout.push(String(chunk));
       return true;
     });
-    const stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation((chunk) => {
-      stderr.push(String(chunk));
-      return true;
-    });
+    const stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
 
     try {
       process.env.KB_LLM_FAKE = 'on';
@@ -488,7 +493,6 @@ describe('ask transcript records', () => {
       const code = await runAsk(['Who approves rollback?', '--kb=ops', '--format=json'], deps);
 
       expect(code).toBe(0);
-      expect(stderr.join('')).toContain('"llm_provider":"fake"');
       const payload = JSON.parse(stdout.join('')) as {
         answer: string;
         llm: { profile: string; source: string; model: string | null; endpoint: string };
@@ -578,6 +582,136 @@ describe('ask transcript records', () => {
       expect(rendered).toContain('context_included_chunks=1');
       expect(rendered).toContain('context_excluded_chunks=1');
       expect(rendered).toContain('context_truncated_chunks=1');
+    } finally {
+      stdoutSpy.mockRestore();
+      stderrSpy.mockRestore();
+      if (previousEndpoint === undefined) delete process.env.KB_LLM_ENDPOINT;
+      else process.env.KB_LLM_ENDPOINT = previousEndpoint;
+    }
+  });
+
+  it('streams markdown answer tokens before rendering citations and timing', async () => {
+    const previousEndpoint = process.env.KB_LLM_ENDPOINT;
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const stdoutSpy = jest.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+      stdout.push(String(chunk));
+      return true;
+    });
+    const stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation((chunk) => {
+      stderr.push(String(chunk));
+      return true;
+    });
+
+    try {
+      process.env.KB_LLM_ENDPOINT = 'http://127.0.0.1:8080/v1/chat/completions';
+      const manager = {
+        modelDir: '/tmp/kb-ask-model',
+        initialize: jest.fn(async () => {}),
+        updateIndex: jest.fn(async () => {}),
+        similaritySearch: jest.fn(async () => [
+          {
+            pageContent: 'Rollback approval requires the release lead.',
+            metadata: { knowledgeBase: 'ops', relativePath: 'runbooks/rollback.md' },
+            score: 0.1,
+          },
+        ]),
+      };
+      const callChatCompletion = jest.fn(async (call: Parameters<RunAskDeps['callChatCompletion']>[0]) => {
+        expect(call.stream).toBeDefined();
+        call.stream?.onFirstToken?.();
+        await call.stream?.onToken('Rollback ');
+        expect(stdout.join('')).toBe('Rollback ');
+        expect(stdout.join('')).not.toContain('## Sources');
+        await call.stream?.onToken('approval requires the release lead.');
+        expect(stdout.join('')).toBe('Rollback approval requires the release lead.');
+        expect(stdout.join('')).not.toContain('## Sources');
+        expect(stdout.join('')).not.toContain('llm_first_token_ms=');
+        return {
+          content: 'Rollback approval requires the release lead.',
+          model: 'qwen3',
+          raw: {},
+        };
+      });
+      const deps: RunAskDeps = {
+        bootstrapLayout: jest.fn(async () => {}),
+        resolveActiveModel: jest.fn(async () => 'ollama__nomic-embed-text-latest'),
+        loadManagerForModel: jest.fn(async () => manager as never),
+        loadWithJsonRetry: jest.fn(async () => {}),
+        withWriteLock: jest.fn(async <T>(_resource: string, action: () => Promise<T>) => action()) as RunAskDeps['withWriteLock'],
+        callChatCompletion,
+        createTranscriptNote: createAskTranscriptNote,
+        knowledgeBasesRootDir: '/tmp/kb-ask-root',
+      };
+
+      const code = await runAsk(['Who approves rollback?', '--kb=ops', '--timing'], deps);
+
+      expect(code).toBe(0);
+      expect(stderr.join('')).toBe('');
+      const rendered = stdout.join('');
+      expect(rendered).toMatch(/^Rollback approval requires the release lead\.\n\n## Sources/);
+      expect(rendered).toContain('- ops:runbooks/rollback.md');
+      expect(rendered).toContain('llm_first_token_ms=');
+      expect(callChatCompletion).toHaveBeenCalledTimes(1);
+    } finally {
+      stdoutSpy.mockRestore();
+      stderrSpy.mockRestore();
+      if (previousEndpoint === undefined) delete process.env.KB_LLM_ENDPOINT;
+      else process.env.KB_LLM_ENDPOINT = previousEndpoint;
+    }
+  });
+
+  it('keeps markdown output non-streaming when --no-stream is passed', async () => {
+    const previousEndpoint = process.env.KB_LLM_ENDPOINT;
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const stdoutSpy = jest.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+      stdout.push(String(chunk));
+      return true;
+    });
+    const stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation((chunk) => {
+      stderr.push(String(chunk));
+      return true;
+    });
+
+    try {
+      process.env.KB_LLM_ENDPOINT = 'http://127.0.0.1:8080/v1/chat/completions';
+      const manager = {
+        modelDir: '/tmp/kb-ask-model',
+        initialize: jest.fn(async () => {}),
+        updateIndex: jest.fn(async () => {}),
+        similaritySearch: jest.fn(async () => [
+          {
+            pageContent: 'Rollback approval requires the release lead.',
+            metadata: { knowledgeBase: 'ops', relativePath: 'runbooks/rollback.md' },
+            score: 0.1,
+          },
+        ]),
+      };
+      const callChatCompletion = jest.fn(async (call: Parameters<RunAskDeps['callChatCompletion']>[0]) => {
+        expect(call.stream).toBeUndefined();
+        return {
+          content: 'Non-streamed answer.',
+          model: 'qwen3',
+          raw: {},
+        };
+      });
+      const deps: RunAskDeps = {
+        bootstrapLayout: jest.fn(async () => {}),
+        resolveActiveModel: jest.fn(async () => 'ollama__nomic-embed-text-latest'),
+        loadManagerForModel: jest.fn(async () => manager as never),
+        loadWithJsonRetry: jest.fn(async () => {}),
+        withWriteLock: jest.fn(async <T>(_resource: string, action: () => Promise<T>) => action()) as RunAskDeps['withWriteLock'],
+        callChatCompletion,
+        createTranscriptNote: createAskTranscriptNote,
+        knowledgeBasesRootDir: '/tmp/kb-ask-root',
+      };
+
+      const code = await runAsk(['Who approves rollback?', '--kb=ops', '--no-stream'], deps);
+
+      expect(code).toBe(0);
+      expect(stderr.join('')).toBe('');
+      expect(stdout.join('')).toContain('Non-streamed answer.\n\n## Sources');
     } finally {
       stdoutSpy.mockRestore();
       stderrSpy.mockRestore();

--- a/src/cli-ask.ts
+++ b/src/cli-ask.ts
@@ -69,6 +69,7 @@ Options:
   --endpoint=<url>      OpenAI-compatible chat endpoint for this call only.
   --llm-profile=<name>  Use a saved \`kb llm\` profile.
   --format=md|json      Output format (default: md).
+  --no-stream           Wait for the full answer before printing markdown output.
   --timing              Include elapsed milliseconds for retrieval and LLM stages.
   --stdin               Read question from stdin.
   --save-transcript     Save the question, answer, citations, and provenance
@@ -89,6 +90,7 @@ export interface AskArgs {
   refresh: boolean;
   stdin: boolean;
   format: 'md' | 'json';
+  noStream: boolean;
   timing: boolean;
   saveTranscript: boolean;
   title?: string;
@@ -150,8 +152,21 @@ export async function runAsk(rest: string[], deps: RunAskDeps = defaultRunAskDep
   }
 
   let result: AskKnowledgeResult;
+  let streamedAnswer = false;
   try {
-    result = await executeAsk({ ...args, question: args.question }, toRunAskCoreDeps(deps), totalStartedAt);
+    const streamMarkdown = args.format === 'md' && !args.noStream;
+    result = await executeAsk({
+      ...args,
+      question: args.question,
+      ...(streamMarkdown
+        ? {
+            onAnswerToken: (token: string) => {
+              streamedAnswer = true;
+              process.stdout.write(token);
+            },
+          }
+        : {}),
+    }, toRunAskCoreDeps(deps), totalStartedAt);
   } catch (err) {
     if (err instanceof AskExecutionError) {
       if (err.failure !== undefined) {
@@ -238,7 +253,7 @@ export async function runAsk(rest: string[], deps: RunAskDeps = defaultRunAskDep
       ...(savedTranscript ? { transcript: savedTranscript } : {}),
     }, null, 2)}\n`);
   } else {
-    process.stdout.write(`${result.answer}\n\n`);
+    process.stdout.write(streamedAnswer ? '\n\n' : `${result.answer}\n\n`);
     if (result.citations.length > 0) {
       process.stdout.write('## Sources\n\n');
       for (const c of result.citations) {
@@ -285,6 +300,7 @@ export function parseAskArgs(rest: string[]): AskArgs {
     refresh: false,
     stdin: false,
     format: 'md',
+    noStream: false,
     timing: false,
     saveTranscript: false,
     yes: false,
@@ -293,6 +309,7 @@ export function parseAskArgs(rest: string[]): AskArgs {
     const raw = rest[i];
     if (raw === '--refresh') { out.refresh = true; continue; }
     if (raw === '--stdin') { out.stdin = true; continue; }
+    if (raw === '--no-stream') { out.noStream = true; continue; }
     if (raw === '--timing') { out.timing = true; continue; }
     if (raw === '--save-transcript') { out.saveTranscript = true; continue; }
     if (raw === '--yes') { out.yes = true; continue; }

--- a/src/llm-client.test.ts
+++ b/src/llm-client.test.ts
@@ -74,6 +74,113 @@ describe('llm-client', () => {
     expect(delays).toEqual([50]);
   });
 
+  it('streams OpenAI-compatible SSE deltas and returns the final content', async () => {
+    const tokens: string[] = [];
+    const events: string[] = [];
+    const fetchMock = jest.fn(async () => new Response(streamBody([
+      'data: {"model":"local-model","choices":[{"delta":{"content":"hello "}}]}\n\n',
+      'data: {"model":"local-model","choices":[{"delta":{"content":"world"}}]}\n\n',
+      'data: [DONE]\n\n',
+    ]), { status: 200, headers: { 'Content-Type': 'text/event-stream' } }));
+
+    const result = await callChatCompletion({
+      endpoint: 'http://127.0.0.1:8080',
+      messages: [{ role: 'user', content: 'q' }],
+      stream: {
+        onFirstToken: () => { events.push('first'); },
+        onToken: (token) => {
+          tokens.push(token);
+          events.push(token);
+        },
+      },
+    }, fetchMock as unknown as typeof fetch);
+
+    expect(result.content).toBe('hello world');
+    expect(result.model).toBe('local-model');
+    expect(tokens).toEqual(['hello ', 'world']);
+    expect(events).toEqual(['first', 'hello ', 'world']);
+    const body = JSON.parse((fetchMock.mock.calls as unknown as Array<[string, RequestInit]>)[0][1].body as string) as {
+      stream?: boolean;
+    };
+    expect(body.stream).toBe(true);
+  });
+
+  it('handles CRLF SSE delimiters split across network chunks', async () => {
+    const tokens: string[] = [];
+    const fetchMock = jest.fn(async () => new Response(streamBody([
+      'data: {"model":"local-model","choices":[{"delta":{"content":"split"}}]}\r\n\r',
+      '\n',
+      'data: [DONE]\r\n\r\n',
+    ]), { status: 200, headers: { 'Content-Type': 'text/event-stream' } }));
+
+    const result = await callChatCompletion({
+      endpoint: 'http://127.0.0.1:8080',
+      messages: [{ role: 'user', content: 'q' }],
+      stream: {
+        onToken: (token) => { tokens.push(token); },
+      },
+    }, fetchMock as unknown as typeof fetch);
+
+    expect(result.content).toBe('split');
+    expect(tokens).toEqual(['split']);
+  });
+
+  it('retries streaming failures before the first emitted token', async () => {
+    const tokens: string[] = [];
+    const fetchMock = jest.fn()
+      .mockResolvedValueOnce(new Response(streamBody([
+        'data: {"choices":[{"delta":{"content":',
+      ]), { status: 200, headers: { 'Content-Type': 'text/event-stream' } }))
+      .mockResolvedValueOnce(new Response(streamBody([
+        'data: {"choices":[{"delta":{"content":"recovered"}}]}\n\n',
+        'data: [DONE]\n\n',
+      ]), { status: 200, headers: { 'Content-Type': 'text/event-stream' } }));
+
+    const result = await callChatCompletion({
+      endpoint: 'http://127.0.0.1:8080',
+      messages: [{ role: 'user', content: 'q' }],
+      stream: { onToken: (token) => { tokens.push(token); } },
+      retry: {
+        maxRetries: 1,
+        baseDelayMs: 0,
+        maxDelayMs: 0,
+        maxTotalDelayMs: 1,
+        sleep: async () => {},
+      },
+    }, fetchMock as unknown as typeof fetch);
+
+    expect(result.content).toBe('recovered');
+    expect(tokens).toEqual(['recovered']);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not retry streaming failures after a token has been emitted', async () => {
+    const tokens: string[] = [];
+    const fetchMock = jest.fn(async () => new Response(streamBody([
+      'data: {"choices":[{"delta":{"content":"partial "}}]}\n\n',
+      'data: {"choices":[{"delta":{"content":',
+    ]), { status: 200, headers: { 'Content-Type': 'text/event-stream' } }));
+
+    await expect(callChatCompletion({
+      endpoint: 'http://127.0.0.1:8080',
+      messages: [{ role: 'user', content: 'q' }],
+      stream: { onToken: (token) => { tokens.push(token); } },
+      retry: {
+        maxRetries: 2,
+        baseDelayMs: 0,
+        maxDelayMs: 0,
+        maxTotalDelayMs: 1,
+        sleep: async () => {},
+      },
+    }, fetchMock as unknown as typeof fetch)).rejects.toMatchObject({
+      name: 'LlmClientError',
+      message: expect.stringContaining('malformed streaming event'),
+    });
+
+    expect(tokens).toEqual(['partial ']);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it('does not retry terminal auth failures', async () => {
     const delays: number[] = [];
     const fetchMock = jest.fn(async () => new Response(
@@ -292,3 +399,13 @@ describe('llm-client', () => {
     expect(result.chat_ok).toBe(true);
   });
 });
+
+function streamBody(chunks: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(encoder.encode(chunk));
+      controller.close();
+    },
+  });
+}

--- a/src/llm-client.ts
+++ b/src/llm-client.ts
@@ -12,6 +12,7 @@ export interface ChatCompletionOptions {
   messages: LlmChatMessage[];
   temperature?: number;
   timeoutMs?: number;
+  stream?: ChatCompletionStreamOptions;
   /** Retry policy for transient provider/network failures. Set to false to disable. */
   retry?: false | LlmRetryOptions;
   /**
@@ -24,6 +25,11 @@ export interface ChatCompletionOptions {
   appTitle?: string;
   /** OpenRouter `HTTP-Referer` attribution header (only sent when an apiKey is set). */
   httpReferer?: string;
+}
+
+export interface ChatCompletionStreamOptions {
+  onToken: (token: string) => void | Promise<void>;
+  onFirstToken?: () => void;
 }
 
 export interface ChatCompletionResult {
@@ -141,7 +147,7 @@ export async function callChatCompletion(
     model: options.model ?? provider.model ?? 'local-model',
     messages: options.messages,
     temperature: options.temperature ?? 0.2,
-    stream: false,
+    stream: options.stream !== undefined,
   };
   // `chat_template_kwargs` is a llama.cpp / vLLM extension; hosted providers
   // (OpenRouter) reject or ignore unknown body fields, so only send it locally.
@@ -159,12 +165,16 @@ export async function callChatCompletion(
 
   const retryPolicy = resolveRetryPolicy(options.retry);
   let totalRetryDelayMs = 0;
+  let emittedStreamToken = false;
   for (let attempt = 0; ; attempt += 1) {
     try {
-      return await callChatCompletionOnce(endpoint, payload, headers, options.timeoutMs, fetchImpl);
+      return await callChatCompletionOnce(endpoint, payload, headers, options.timeoutMs, options.stream, () => {
+        emittedStreamToken = true;
+      }, fetchImpl);
     } catch (err) {
       if (
         !(err instanceof LlmClientError) ||
+        emittedStreamToken ||
         retryPolicy === null ||
         attempt >= retryPolicy.maxRetries ||
         !isTransientLlmClientError(err)
@@ -186,11 +196,17 @@ async function callChatCompletionOnce(
   payload: Record<string, unknown>,
   headers: Record<string, string>,
   timeoutMs: number | undefined,
+  stream: ChatCompletionStreamOptions | undefined,
+  onStreamTokenEmitted: () => void,
   fetchImpl: FetchLike,
 ): Promise<ChatCompletionResult> {
   let response: Response;
   const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), timeoutMs ?? 180_000);
+  let timeout = setTimeout(() => controller.abort(), timeoutMs ?? 180_000);
+  const resetStreamingIdleTimeout = () => {
+    clearTimeout(timeout);
+    timeout = setTimeout(() => controller.abort(), timeoutMs ?? 180_000);
+  };
   try {
     response = await fetchImpl(endpoint, {
       method: 'POST',
@@ -203,7 +219,20 @@ async function callChatCompletionOnce(
     const msg = err instanceof Error ? err.message : String(err);
     throw new LlmClientError(`local LLM request failed: ${msg}`, { transient: true });
   }
-  clearTimeout(timeout);
+  if (stream === undefined) clearTimeout(timeout);
+  else resetStreamingIdleTimeout();
+
+  if (stream !== undefined) {
+    try {
+      return await readStreamingChatCompletion(response, stream, onStreamTokenEmitted, resetStreamingIdleTimeout);
+    } catch (err) {
+      if (err instanceof LlmClientError) throw err;
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new LlmClientError(`local LLM stream failed: ${msg}`, { transient: true });
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
 
   const body = await readResponseBody(response);
 
@@ -231,6 +260,185 @@ async function callChatCompletionOnce(
     ? (data as { model: string }).model
     : null;
   return { content: content.trim(), model, raw: data };
+}
+
+async function readStreamingChatCompletion(
+  response: Response,
+  stream: ChatCompletionStreamOptions,
+  onStreamTokenEmitted: () => void,
+  onChunk: () => void,
+): Promise<ChatCompletionResult> {
+  if (!response.ok) {
+    const body = await readResponseBody(response);
+    const retryAfterMs = parseRetryAfterMs(response.headers.get('retry-after'));
+    const message = body.ok
+      ? extractErrorMessage(body.data)
+      : body.text ?? body.errorMessage;
+    throw new LlmClientError(
+      `local LLM returned HTTP ${response.status}: ${message}`,
+      { status: response.status, ...(retryAfterMs !== undefined ? { retryAfterMs } : {}) },
+    );
+  }
+
+  if (response.body === null) {
+    throw new LlmClientError('local LLM streaming response did not contain a body', { transient: true });
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  const state: StreamingReadState = {
+    rawEvents: [],
+    contentParts: [],
+    model: null,
+    sawFirstToken: false,
+  };
+  let buffer = '';
+  let done = false;
+
+  try {
+    while (!done) {
+      const chunk = await reader.read();
+      onChunk();
+      if (chunk.done) break;
+      buffer += decoder.decode(chunk.value, { stream: true });
+      const parsed = await drainSseBlocks(buffer, async (block) => {
+        return handleStreamingBlock(block, state, stream, onStreamTokenEmitted);
+      });
+      buffer = parsed.remaining;
+      done = parsed.done;
+    }
+
+    const tail = decoder.decode();
+    if (tail !== '') {
+      buffer += tail;
+    }
+    if (!done && buffer.trim() !== '') {
+      await drainSseBlocks(`${buffer}\n\n`, async (block) => {
+        return handleStreamingBlock(block, state, stream, onStreamTokenEmitted);
+      });
+    }
+  } catch (err) {
+    if (err instanceof DOMException && err.name === 'AbortError') {
+      throw new LlmClientError('local LLM stream timed out waiting for the next chunk', { transient: true });
+    }
+    throw err;
+  } finally {
+    reader.releaseLock();
+  }
+
+  const content = state.contentParts.join('').trim();
+  if (content === '') {
+    throw new LlmClientError('local LLM streaming response did not contain choices[0].delta.content', { transient: false });
+  }
+  return { content, model: state.model, raw: { stream: true, events: state.rawEvents } };
+}
+
+interface StreamingReadState {
+  rawEvents: unknown[];
+  contentParts: string[];
+  model: string | null;
+  sawFirstToken: boolean;
+}
+
+async function handleStreamingBlock(
+  block: string,
+  state: StreamingReadState,
+  stream: ChatCompletionStreamOptions,
+  onStreamTokenEmitted: () => void,
+): Promise<boolean> {
+  const data = sseData(block);
+  if (data === null) return false;
+  if (data.trim() === '[DONE]') return true;
+  const parsedEvent = parseStreamingEvent(data);
+  state.rawEvents.push(parsedEvent);
+  const eventModel = typeof (parsedEvent as { model?: unknown }).model === 'string'
+    ? (parsedEvent as { model: string }).model
+    : null;
+  if (eventModel !== null) state.model = eventModel;
+  const delta = extractStreamingDelta(parsedEvent);
+  if (delta === null || delta === '') return false;
+  if (!state.sawFirstToken) {
+    state.sawFirstToken = true;
+    stream.onFirstToken?.();
+  }
+  onStreamTokenEmitted();
+  await stream.onToken(delta);
+  state.contentParts.push(delta);
+  return false;
+}
+
+async function drainSseBlocks(
+  input: string,
+  handle: (block: string) => Promise<boolean>,
+): Promise<{ remaining: string; done: boolean }> {
+  let remaining = input;
+  let done = false;
+  for (;;) {
+    const separator = findSseBlockSeparator(remaining);
+    if (separator === null) break;
+    const block = remaining.slice(0, separator.index);
+    remaining = remaining.slice(separator.index + separator.length);
+    if (block.trim() === '') continue;
+    done = await handle(block);
+    if (done) break;
+  }
+  return { remaining, done };
+}
+
+function findSseBlockSeparator(input: string): { index: number; length: number } | null {
+  const crlf = input.indexOf('\r\n\r\n');
+  const lf = input.indexOf('\n\n');
+  const cr = input.indexOf('\r\r');
+  let best: { index: number; length: number } | null = null;
+  for (const candidate of [
+    crlf < 0 ? null : { index: crlf, length: 4 },
+    lf < 0 ? null : { index: lf, length: 2 },
+    cr < 0 ? null : { index: cr, length: 2 },
+  ]) {
+    if (candidate !== null && (best === null || candidate.index < best.index)) {
+      best = candidate;
+    }
+  }
+  return best;
+}
+
+function sseData(block: string): string | null {
+  const lines = block.split(/\r\n|\n|\r/);
+  const data = lines
+    .filter((line) => line.startsWith('data:'))
+    .map((line) => line.slice('data:'.length).trimStart());
+  return data.length === 0 ? null : data.join('\n');
+}
+
+function parseStreamingEvent(data: string): unknown {
+  try {
+    const parsed = JSON.parse(data) as unknown;
+    const err = (parsed as { error?: unknown }).error;
+    if (err !== undefined) {
+      throw new LlmClientError(`local LLM streaming response returned error: ${extractErrorMessage(parsed)}`, {
+        transient: false,
+      });
+    }
+    return parsed;
+  } catch (err) {
+    if (err instanceof LlmClientError) throw err;
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new LlmClientError(`local LLM returned malformed streaming event: ${msg}`, { transient: true });
+  }
+}
+
+function extractStreamingDelta(data: unknown): string | null {
+  const choices = (data as { choices?: unknown }).choices;
+  if (!Array.isArray(choices) || choices.length === 0) return null;
+  const first = choices[0] as {
+    delta?: { content?: unknown };
+    message?: { content?: unknown };
+    text?: unknown;
+  };
+  if (typeof first.delta?.content === 'string') return first.delta.content;
+  if (typeof first.message?.content === 'string') return first.message.content;
+  if (typeof first.text === 'string') return first.text;
+  return null;
 }
 
 async function readResponseBody(response: Response): Promise<

--- a/src/llm-fake-stub.test.ts
+++ b/src/llm-fake-stub.test.ts
@@ -148,4 +148,22 @@ describe('llm fake stub', () => {
       await fsp.rm(dir, { recursive: true, force: true });
     }
   });
+
+  it('streams fake chat content when the caller opts in', async () => {
+    const tokens: string[] = [];
+    let firstTokenCount = 0;
+
+    const result = await callFakeChatCompletion({
+      endpoint: 'mock://ignored',
+      messages: [{ role: 'user', content: 'plain prompt' }],
+      stream: {
+        onFirstToken: () => { firstTokenCount += 1; },
+        onToken: (token) => { tokens.push(token); },
+      },
+    }, { KB_LOG_FORMAT: 'text' } as NodeJS.ProcessEnv);
+
+    expect(result.content).toBe('Fake LLM response from kb-fake-llm.');
+    expect(tokens.join('')).toBe(result.content);
+    expect(firstTokenCount).toBe(1);
+  });
 });

--- a/src/llm-fake-stub.ts
+++ b/src/llm-fake-stub.ts
@@ -89,6 +89,16 @@ export async function callFakeChatCompletion(
   const startedAt = Date.now();
   const rules = await loadFakeLlmRules(env);
   const content = generateFakeChatContent(options.messages, rules);
+  if (options.stream !== undefined) {
+    let first = true;
+    for (const token of splitFakeStreamContent(content)) {
+      if (first) {
+        first = false;
+        options.stream.onFirstToken?.();
+      }
+      await options.stream.onToken(token);
+    }
+  }
   const raw = fakeOpenAiChatCompletionResponse({
     model: options.model ?? FAKE_LLM_MODEL,
     messages: options.messages,
@@ -107,6 +117,10 @@ export async function callFakeChatCompletion(
     model: FAKE_LLM_MODEL,
     raw,
   };
+}
+
+function splitFakeStreamContent(content: string): string[] {
+  return content.match(/\S+\s*/g) ?? (content === '' ? [] : [content]);
 }
 
 async function loadFakeLlmRules(env: NodeJS.ProcessEnv = process.env): Promise<FakeLlmRules> {


### PR DESCRIPTION
## Summary
- Add per-call-site opt-in streaming to the shared chat completion client using OpenAI-compatible SSE parsing.
- Stream markdown `kb ask` answer tokens immediately, then render sources, context, timing, and transcript status after the body.
- Keep JSON output, transcript saving, contextual prefaces, relevance gate, and probe calls non-streaming; add `--no-stream` for the old markdown behavior.

Closes #599

## Implementation choice
Streaming is controlled by an optional `stream` callback object on `callChatCompletion`, so existing callers stay non-streaming unless they opt in. The SSE reader accumulates the final answer for JSON/transcript behavior, records first-token timing through the existing ask timing payload, and uses idle/inter-chunk timeout semantics during streaming. Retry remains available only before any answer token is emitted; after output starts, stream errors surface without replaying partial output.

## Alternatives considered
- Making all chat completions stream by default was rejected because prefaces, gate judging, and doctor probes need stable full-response semantics.
- Streaming from `runAsk` without changing the client was rejected because the client owns retries, timeouts, and OpenAI response parsing.
- Retrying mid-stream was rejected because it can duplicate already-rendered terminal output.

## Verification
- `npm test -- --runTestsByPath src/llm-client.test.ts src/cli-ask.test.ts src/llm-fake-stub.test.ts --runInBand` passed: 47 tests.
- `npm run build` passed.
- `git diff --check` passed.
- Manual changed-line portability scan found no added machine-local paths.
- Pre-PR specialist review ran; blocking CRLF split-delimiter SSE finding was fixed and covered by a regression test.