### PR TITLE
feat(metrics): export search latency histograms

### DIFF
--- a/docs/operations/metrics-export.md
+++ b/docs/operations/metrics-export.md
@@ -39,6 +39,9 @@ The v1 exporter keeps labels bounded:
 |---|---|---|
 | `kb` | `kb_knowledge_base_*` | registered knowledge bases |
 | `model_id` | `kb_provider_*` | registered embedding models observed by the process |
+| `mode` | `kb_search_*` | `dense`, `lexical`, `hybrid`, `auto`, `unknown` |
+| `stage` | `kb_search_stage_duration_ms` | fixed search timing stage names |
+| `status` | `kb_search_*` | `success`, `error` |
 
 There are no query text, file path, user, request id, source URL, or raw error
 labels.
@@ -49,11 +52,31 @@ labels.
 |---|---|
 | `kb_knowledge_base_*` | file counts, chunk counts, indexed bytes, quarantine counts by KB |
 | `kb_provider_*` | provider call counts, errors, token totals when reported, p50/p95/p99 latency |
+| `kb_search_requests_total` | daemon-served search request totals by mode/status |
+| `kb_search_request_duration_ms` | end-to-end daemon-served search request latency histogram |
+| `kb_search_stage_duration_ms` | per-stage daemon-served search latency histogram |
 | `kb_query_cache_*` | query embedding cache hits, misses, bypasses, disk usage |
 | `kb_relevance_gate_*` | relevance gate query and verdict counters |
 | `kb_remote_transport_*` | HTTP/SSE sessions, requests, auth failures, origin denials, status buckets |
 | `kb_server_uptime_ms` | process uptime for the serving process |
 | `kb_index_embedding_dimensions` | active dense index dimensionality, or `0` when unknown |
+
+Search latency histograms use the same millisecond bucket bounds as provider
+latency telemetry: `1`, `3`, `10`, `30`, `100`, `300`, `1000`, `3000`,
+`10000`, `30000`, and `+Inf`.
+
+Search timing scope is process-local and scrapeable only for searches served
+by the resident process:
+
+- MCP `retrieve_knowledge` on stdio, HTTP, or SSE transports.
+- `kb search --daemon` requests handled by `kb serve`.
+
+One-shot `kb search` processes are not exported: the process exits before a
+Prometheus scraper can reliably collect its in-memory timings. Stage labels
+come from the existing `--timing`/canonical-log vocabulary where practical
+(`embed_query`, `faiss_search`, `query_search`, `post_filter`,
+`lexical_search`, `fusion`, `rerank`, `gate`, `format`, and related setup
+stages).
 
 ## Prometheus Scrape
 

--- a/src/KnowledgeBaseServer.ts
+++ b/src/KnowledgeBaseServer.ts
@@ -99,6 +99,11 @@ import {
   type CanonicalLogInput,
 } from './canonical-log.js';
 import { formatKbStatsOpenMetrics } from './prometheus-export.js';
+import { searchLatencyMetrics } from './metrics.js';
+import {
+  searchStageDurationsFromTiming,
+  type TimingPayload,
+} from './timing-core.js';
 import {
   formatDiffIndexMarkdown,
   resolveIndexVersionPath,
@@ -685,6 +690,7 @@ export class KnowledgeBaseServer {
     rerank?: 'on' | 'off';
   }): Promise<CallToolResult> {
     const canonical: Partial<CanonicalLogInput> = {};
+    const requestStartedAt = Date.now();
     const query: string = args.query;
     const knowledgeBaseName: string | undefined = args.knowledge_base_name;
     const threshold: number | undefined = args.threshold;
@@ -708,6 +714,11 @@ export class KnowledgeBaseServer {
     }, async () => {
       if (searchMode === 'hybrid') {
         if (hasNeighborContext(neighborContext)) {
+          searchLatencyMetrics.record({
+            mode: 'hybrid',
+            status: 'error',
+            totalMs: Date.now() - requestStartedAt,
+          });
           return {
             content: [{
               type: 'text',
@@ -747,6 +758,11 @@ export class KnowledgeBaseServer {
         activeModelId = await resolveActiveModel({ explicitOverride: modelNameOverride });
       } catch (err) {
         if (err instanceof ActiveModelResolutionError) {
+          searchLatencyMetrics.record({
+            mode: 'dense',
+            status: 'error',
+            totalMs: Date.now() - requestStartedAt,
+          });
           return {
             content: [{ type: 'text', text: err.message }],
             isError: true,
@@ -784,6 +800,7 @@ export class KnowledgeBaseServer {
       for (const result of similaritySearchResults) {
         denseDistanceById.set(chunkIdFromMetadata(result.metadata as Record<string, unknown>), result.score);
       }
+      const gateStartedAt = Date.now();
       const gate = await applyRelevanceGate({
         query,
         taskContext,
@@ -792,6 +809,7 @@ export class KnowledgeBaseServer {
         gateOverride,
         process: 'mcp',
       });
+      const gateMs = Date.now() - gateStartedAt;
       similaritySearchResults = gate.results;
       emitRelevanceGateDecision({
         process: 'mcp',
@@ -823,6 +841,20 @@ export class KnowledgeBaseServer {
         responseText = `${responseText}\n\n${formatGateVerdictFooter(gate.verdict)}`;
       }
       canonical.format_ms = Date.now() - formatStartedAt;
+      const stageTiming: TimingPayload = {
+        embed_query_ms: timing.embed_query_ms,
+        faiss_search_ms: timing.faiss_search_ms,
+        query_search_ms: timing.query_search_ms,
+        post_filter_ms: timing.post_filter_ms,
+        gate_ms: gateMs,
+        format_ms: canonical.format_ms,
+      };
+      searchLatencyMetrics.record({
+        mode: 'dense',
+        status: 'success',
+        totalMs: Date.now() - requestStartedAt,
+        stageDurationsMs: searchStageDurationsFromTiming(stageTiming),
+      });
 
       // RFC 013 M3 §4.5 + round-1 minimalist F5 — emit `model_id` on the
       // response envelope (NOT per-chunk) so an agent comparing two models
@@ -842,6 +874,11 @@ export class KnowledgeBaseServer {
       return withGateVerdict({ content: [content] }, gate.verdict);
     } catch (error: unknown) {
       const err = toError(error);
+      searchLatencyMetrics.record({
+        mode: 'dense',
+        status: 'error',
+        totalMs: Date.now() - requestStartedAt,
+      });
       logger.error('Error retrieving knowledge:', err);
       if (err.stack) {
         logger.error(err.stack);
@@ -943,6 +980,7 @@ export class KnowledgeBaseServer {
     const { query, knowledgeBaseName, modelNameOverride, filters, canonical, taskContext, gateOverride, rerankOverride } = input;
     const HYBRID_TOP_K = 10;
     const fetchK = hybridFetchK(HYBRID_TOP_K);
+    const requestStartedAt = Date.now();
 
     try {
       let activeModelId: string;
@@ -950,6 +988,11 @@ export class KnowledgeBaseServer {
         activeModelId = await resolveActiveModel({ explicitOverride: modelNameOverride });
       } catch (err) {
         if (err instanceof ActiveModelResolutionError) {
+          searchLatencyMetrics.record({
+            mode: 'hybrid',
+            status: 'error',
+            totalMs: Date.now() - requestStartedAt,
+          });
           return { content: [{ type: 'text', text: err.message }], isError: true };
         }
         throw err;
@@ -972,6 +1015,8 @@ export class KnowledgeBaseServer {
         ? [knowledgeBaseName]
         : await listKnowledgeBases(KNOWLEDGE_BASES_ROOT_DIR);
       const kbs = kbNames.map((kbName) => ({ kbName, kbPath: path.join(KNOWLEDGE_BASES_ROOT_DIR, kbName) }));
+      let lexicalSearchMs = 0;
+      const lexicalStartedAt = Date.now();
       const lexicalPromise = runLexicalLeg({
         kbs,
         query,
@@ -980,7 +1025,10 @@ export class KnowledgeBaseServer {
         onError: (kbName, err) => {
           logger.warn(`hybrid: lexical leg failed for KB "${kbName}": ${err.message}`);
         },
-      }).then((res) => res.hits);
+      }).then((res) => {
+        lexicalSearchMs = Date.now() - lexicalStartedAt;
+        return res.hits;
+      });
 
       const [denseResults, lexicalResults] = await Promise.all([densePromise, lexicalPromise]);
       if (canonical) {
@@ -989,12 +1037,15 @@ export class KnowledgeBaseServer {
       }
 
       const rerankConfig = resolveRerankerConfig(process.env, rerankOverride, knowledgeBaseName ?? null);
+      const fusionStartedAt = Date.now();
       const fusion = fuseHybridResultsWithDiagnostics({
         denseResults,
         lexicalResults,
         k: rerankConfig.enabled ? Math.max(HYBRID_TOP_K, rerankConfig.topN) : HYBRID_TOP_K,
       });
+      const fusionMs = Date.now() - fusionStartedAt;
       let ranked = fusion.results;
+      const rerankStartedAt = Date.now();
       const rerankResult = await applyRerankerIfEnabled({
         query,
         results: ranked,
@@ -1005,7 +1056,9 @@ export class KnowledgeBaseServer {
         searchMode: 'hybrid',
         kbScope: knowledgeBaseName ?? null,
       });
+      const rerankMs = rerankResult.tookMs ?? Date.now() - rerankStartedAt;
       ranked = rerankResult.results;
+      const gateStartedAt = Date.now();
       const gate = await applyRelevanceGate({
         query,
         taskContext,
@@ -1015,6 +1068,7 @@ export class KnowledgeBaseServer {
         gateOverride,
         process: 'mcp',
       });
+      const gateMs = Date.now() - gateStartedAt;
       ranked = gate.results;
       emitRelevanceGateDecision({
         process: 'mcp',
@@ -1037,6 +1091,24 @@ export class KnowledgeBaseServer {
         canonical.top_sources = topSourcesForCanonicalLog(ranked);
         canonical.format_ms = Date.now() - formatStartedAt;
       }
+      const stageTiming: TimingPayload = {
+        dense_search_ms: denseTiming.total_ms,
+        embed_query_ms: denseTiming.embed_query_ms,
+        faiss_search_ms: denseTiming.faiss_search_ms,
+        query_search_ms: denseTiming.query_search_ms,
+        post_filter_ms: denseTiming.post_filter_ms,
+        lexical_search_ms: lexicalSearchMs,
+        fusion_ms: fusionMs,
+        rerank_ms: rerankMs,
+        gate_ms: gateMs,
+        format_ms: canonical?.format_ms,
+      };
+      searchLatencyMetrics.record({
+        mode: 'hybrid',
+        status: 'success',
+        totalMs: Date.now() - requestStartedAt,
+        stageDurationsMs: searchStageDurationsFromTiming(stageTiming),
+      });
       const rerankHeader = rerankResult.candidatesIn > 0
         ? `; rerank ${rerankResult.model}${rerankResult.degraded ? ' degraded' : ''}`
         : '';
@@ -1049,6 +1121,11 @@ export class KnowledgeBaseServer {
       return withGateVerdict({ content: [content] }, gate.verdict);
     } catch (error: unknown) {
       const err = toError(error);
+      searchLatencyMetrics.record({
+        mode: 'hybrid',
+        status: 'error',
+        totalMs: Date.now() - requestStartedAt,
+      });
       logger.error('Error retrieving knowledge (hybrid):', err);
       if (err.stack) logger.error(err.stack);
       return { content: [mcpErrorContent(err)], isError: true };

--- a/src/cli-research.test.ts
+++ b/src/cli-research.test.ts
@@ -82,6 +82,10 @@ function statsPayload(overrides: Partial<KbStatsPayload> = {}): KbStatsPayload {
       uptime_ms: 1,
     },
     provider_calls: {},
+    search_latency: {
+      requests: {},
+      stages: {},
+    },
     query_cache: {
       hits: 0,
       misses: 0,

--- a/src/cli-search.ts
+++ b/src/cli-search.ts
@@ -351,6 +351,12 @@ export interface RunSearchDeps {
   listLexicalKbs?: typeof listLexicalKbs;
   loadLexicalIndex?: typeof LexicalIndex.load;
   runLexicalLeg?: typeof runLexicalLeg;
+  onSearchTiming?: (record: {
+    mode: EffectiveSearchMode;
+    status: 'success' | 'error';
+    totalMs: number;
+    timing: TimingPayload;
+  }) => void;
 }
 
 const DEFAULT_RUN_SEARCH_DEPS: RunSearchDeps = {
@@ -454,7 +460,8 @@ export async function runSearch(
   const effectiveMode: EffectiveSearchMode = autoModeDecision
     ? autoModeDecision.mode
     : (parsed.mode as EffectiveSearchMode);
-  const timing: TimingPayload | null = parsed.timing
+  const collectTiming = parsed.timing || deps.onSearchTiming !== undefined;
+  const timing: TimingPayload | null = collectTiming
     ? {
         requested_mode: parsed.mode,
         effective_mode: effectiveMode,
@@ -611,6 +618,7 @@ export async function runSearch(
   }
   let gateVerdict: RelevanceGateVerdict;
   try {
+    const gateStartedAt = nowMs();
     const gate = await applyRelevanceGate({
       query,
       taskContext: parsed.taskContext,
@@ -619,6 +627,7 @@ export async function runSearch(
       gateOverride: parsed.gateOverride,
       process: 'cli',
     });
+    if (timing) timing.gate_ms = elapsedMs(gateStartedAt);
     results = gate.results;
     if (advancedRetrieval !== null) {
       advancedRetrieval = filterAdvancedRetrievalMetadata(advancedRetrieval, results);
@@ -663,6 +672,14 @@ export async function runSearch(
       : null;
 
   if (timing) timing.total_ms = elapsedMs(totalStartedAt);
+  if (timing && deps.onSearchTiming !== undefined) {
+    deps.onSearchTiming({
+      mode: effectiveMode,
+      status: 'success',
+      totalMs: typeof timing.total_ms === 'number' ? timing.total_ms : elapsedMs(totalStartedAt),
+      timing,
+    });
+  }
   recordDenseSearchCanonicalTelemetry({
     query,
     activeModelId,
@@ -678,6 +695,8 @@ export async function runSearch(
     return runPicker({ results: results as ScoredDocument[] });
   }
 
+  const outputTiming = parsed.timing ? timing : null;
+  const outputFilterDiagnostics = parsed.timing ? filterDiagnostics : null;
   if (parsed.format === 'json') {
     const payload = buildDenseSearchJsonPayload({
       results,
@@ -690,8 +709,8 @@ export async function runSearch(
       query,
       staleness,
       autoThresholdDecision,
-      timing,
-      filterDiagnostics,
+      timing: outputTiming,
+      filterDiagnostics: outputFilterDiagnostics,
       explainEmptyDiagnostics,
       gateVerdict,
       advancedRetrieval,
@@ -709,8 +728,8 @@ export async function runSearch(
       staleness,
       refreshed: parsed.refresh,
       gateVerdict,
-      timing,
-      filterDiagnostics,
+      timing: outputTiming,
+      filterDiagnostics: outputFilterDiagnostics,
     }));
   } else {
     await writeSearchOutput(parsed, deps, formatDenseSearchMarkdownOutput({
@@ -722,8 +741,8 @@ export async function runSearch(
       query,
       autoModeDecision,
       autoThresholdDecision,
-      timing,
-      filterDiagnostics,
+      timing: outputTiming,
+      filterDiagnostics: outputFilterDiagnostics,
       explainEmptyDiagnostics,
       gateVerdict,
       explain: parsed.explain,
@@ -2350,6 +2369,14 @@ async function runLexicalSearch(
   for (const e of errors) {
     process.stderr.write(`kb search (lexical): ${e.kbName} — ${e.error?.message ?? 'unknown error'}\n`);
   }
+  if (errors.length === 0 && timing && deps.onSearchTiming !== undefined) {
+    deps.onSearchTiming({
+      mode: 'lexical',
+      status: 'success',
+      totalMs: typeof timing.total_ms === 'number' ? timing.total_ms : elapsedMs(totalStartedAt),
+      timing,
+    });
+  }
 
   // For format reuse, transform LexicalSearchResult into the dense
   // shape `{...Document, score}` that formatRetrievalAs* expect.
@@ -2391,7 +2418,7 @@ async function runLexicalSearch(
       ...(retrievalViewsJson(parsed.retrievalViews) !== null
         ? { retrieval_views: retrievalViewsJson(parsed.retrievalViews) }
         : {}),
-      ...(timing ? { timing: compactTimingPayload(timing) } : {}),
+      ...(parsed.timing && timing ? { timing: compactTimingPayload(timing) } : {}),
     };
     process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
   } else if (parsed.format === 'vimgrep') {
@@ -2409,7 +2436,7 @@ async function runLexicalSearch(
     })}\n`;
     const summary = `${perKb.length} KB(s), ${errors.length} error(s), unit=${parsed.lexicalUnit}`;
     output += `> _Lexical status: ${summary}._\n`;
-    if (timing) {
+    if (parsed.timing && timing) {
       output += `${formatTimingFooter('Timing', timing)}\n`;
     }
     await writeSearchOutput(parsed, deps, output);
@@ -2441,7 +2468,7 @@ async function runLexicalSearch(
       return `- ${r.kbName}: ${counts}`;
     });
     output += `> _Lexical index status:_\n${summaryLines.join('\n')}\n`;
-    if (timing) {
+    if (parsed.timing && timing) {
       output += `\n${formatTimingFooter('Timing', timing)}\n`;
     }
     await writeSearchOutput(parsed, deps, output);
@@ -2709,6 +2736,7 @@ async function runHybridSearch(
 
   let gateVerdict: RelevanceGateVerdict;
   try {
+    const gateStartedAt = nowMs();
     const gate = await applyRelevanceGate({
       query,
       taskContext: parsed.taskContext,
@@ -2718,6 +2746,7 @@ async function runHybridSearch(
       gateOverride: parsed.gateOverride,
       process: 'cli',
     });
+    if (timing) timing.gate_ms = elapsedMs(gateStartedAt);
     ranked = gate.results;
     gateVerdict = gate.verdict;
     emitRelevanceGateDecision({
@@ -2732,6 +2761,15 @@ async function runHybridSearch(
     return reportFailure(classifyKbSearchError(err), parsed.format);
   }
   ranked = ranked.slice(0, parsed.k);
+  if (timing) timing.total_ms = elapsedMs(totalStartedAt);
+  if (timing && deps.onSearchTiming !== undefined) {
+    deps.onSearchTiming({
+      mode: 'hybrid',
+      status: 'success',
+      totalMs: typeof timing.total_ms === 'number' ? timing.total_ms : elapsedMs(totalStartedAt),
+      timing,
+    });
+  }
 
   if (shouldUsePicker(parsed)) {
     return runPicker({ results: ranked as ScoredDocument[] });
@@ -2772,7 +2810,7 @@ async function runHybridSearch(
         degrade_reason: rerankResult.degradeReason,
       },
       gate_verdict: gateVerdict,
-      ...(timing ? { timing: compactTimingPayload(timing) } : {}),
+      ...(parsed.timing && timing ? { timing: compactTimingPayload(timing) } : {}),
     };
     process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
   } else if (parsed.format === 'vimgrep') {
@@ -2805,7 +2843,7 @@ async function runHybridSearch(
     if (parsed.explain) {
       output += `${formatGateDroppedList(gateVerdict)}\n`;
     }
-    if (timing) {
+    if (parsed.timing && timing) {
       output += `${formatTimingFooter('Timing', timing)}\n`;
     }
     await writeSearchOutput(parsed, deps, output);
@@ -2842,7 +2880,7 @@ async function runHybridSearch(
     if (parsed.explain) {
       output += `${formatGateDroppedList(gateVerdict)}\n`;
     }
-    if (timing) {
+    if (parsed.timing && timing) {
       output += `${formatTimingFooter('Timing', timing)}\n`;
     }
     await writeSearchOutput(parsed, deps, output);

--- a/src/cli-serve.test.ts
+++ b/src/cli-serve.test.ts
@@ -11,6 +11,7 @@ import type { DaemonRunResult } from './daemon-client.js';
 import type { KbStatsPayload } from './kb-stats.js';
 import type { RunSearchDeps } from './cli-search.js';
 import type { LexicalIndex } from './lexical-index.js';
+import { searchLatencyMetrics } from './metrics.js';
 
 interface RawResponse {
   statusCode: number;
@@ -49,6 +50,7 @@ describe('kb serve daemon', () => {
   const originalMetricsExport = process.env.KB_METRICS_EXPORT;
 
   afterEach(() => {
+    searchLatencyMetrics.reset();
     if (originalMetricsExport === undefined) delete process.env.KB_METRICS_EXPORT;
     else process.env.KB_METRICS_EXPORT = originalMetricsExport;
   });
@@ -134,6 +136,44 @@ describe('kb serve daemon', () => {
     expect(lexicalIndexLoader).toHaveBeenCalledWith('alpha', '/kb/alpha');
   });
 
+  it('records successful daemon-served search timings through the search deps hook', async () => {
+    const runSearchImpl = jest.fn(async (_args: string[], deps: RunSearchDeps = {} as RunSearchDeps) => {
+      deps.onSearchTiming?.({
+        mode: 'hybrid',
+        status: 'success',
+        totalMs: 50,
+        timing: {
+          total_ms: 50,
+          dense_search_ms: 30,
+          fusion_ms: 4,
+        },
+      });
+      return 0;
+    });
+    const handlers = createDaemonCommandHandlers({ runSearchImpl });
+
+    const result = await handlers.search(['query', '--mode=hybrid']);
+
+    expect(result).toEqual({ exitCode: 0, stdout: '', stderr: '' });
+    const snap = searchLatencyMetrics.snapshot();
+    expect(snap.requests.hybrid?.success).toMatchObject({ count: 1, sum_ms: 50 });
+    expect(snap.stages.hybrid?.dense_search?.success).toMatchObject({ count: 1, sum_ms: 30 });
+    expect(snap.stages.hybrid?.fusion?.success).toMatchObject({ count: 1, sum_ms: 4 });
+  });
+
+  it('records failed daemon-served search exits by requested mode', async () => {
+    const runSearchImpl = jest.fn(async () => 2);
+    const handlers = createDaemonCommandHandlers({ runSearchImpl });
+
+    const result = await handlers.search(['query', '--mode=lexical']);
+
+    expect(result.exitCode).toBe(2);
+    const snap = searchLatencyMetrics.snapshot();
+    expect(snap.requests.lexical?.error).toMatchObject({ count: 1 });
+    expect(snap.requests.lexical?.error?.sum_ms).toBeGreaterThanOrEqual(0);
+    expect(snap.stages).toEqual({});
+  });
+
   it('exposes OpenMetrics text only when KB_METRICS_EXPORT is enabled', async () => {
     const daemon = await startDaemonServer({
       port: 0,
@@ -205,6 +245,10 @@ describe('kb serve metrics formatting', () => {
         uptime_ms: 1,
       },
       provider_calls: {},
+      search_latency: {
+        requests: {},
+        stages: {},
+      },
       query_cache: {
         hits: 0,
         misses: 0,

--- a/src/cli-serve.ts
+++ b/src/cli-serve.ts
@@ -16,6 +16,8 @@ import {
   type DaemonRunResult,
 } from './daemon-client.js';
 import { formatKbStatsOpenMetrics } from './prometheus-export.js';
+import { searchLatencyMetrics, type SearchLatencyMode } from './metrics.js';
+import { searchStageDurationsFromTiming } from './timing-core.js';
 import type { KbStatsPayload } from './kb-stats.js';
 import { LexicalIndexCache } from './lexical-index-cache.js';
 import type { LexicalIndex } from './lexical-index.js';
@@ -327,15 +329,48 @@ export function parseServeArgs(rest: string[]): ServeArgs {
 export function createDaemonCommandHandlers(options: DaemonCommandHandlerOptions = {}): DaemonCommandHandlers {
   const cache = new LexicalIndexCache();
   const loadLexicalIndex = options.lexicalIndexLoader ?? cache.load.bind(cache);
-  const searchDeps: RunSearchDeps = createRunSearchDeps({ loadLexicalIndex });
+  const searchDeps: RunSearchDeps = createRunSearchDeps({
+    loadLexicalIndex,
+    onSearchTiming: (record) => {
+      searchLatencyMetrics.record({
+        mode: record.mode,
+        status: record.status,
+        totalMs: record.totalMs,
+        stageDurationsMs: searchStageDurationsFromTiming(record.timing),
+      });
+    },
+  });
   const runSearchImpl = options.runSearchImpl ?? runSearch;
   const runListImpl = options.runListImpl ?? runList;
   const runStatsImpl = options.runStatsImpl ?? runStats;
   return {
-    search: async (args) => captureProcessOutput(() => runSearchImpl(args, searchDeps)),
+    search: async (args) => {
+      const startedAt = Date.now();
+      const result = await captureProcessOutput(() => runSearchImpl(args, searchDeps));
+      if (result.exitCode !== 0) {
+        searchLatencyMetrics.record({
+          mode: requestedSearchModeFromArgs(args),
+          status: 'error',
+          totalMs: Date.now() - startedAt,
+        });
+      }
+      return result;
+    },
     list: async (args) => captureProcessOutput(() => runListImpl(args)),
     stats: async (args) => captureProcessOutput(() => runStatsImpl(args)),
   };
+}
+
+function requestedSearchModeFromArgs(args: readonly string[]): SearchLatencyMode {
+  const modeFlag = args.find((arg) => arg === '--mode' || arg.startsWith('--mode='));
+  if (modeFlag === undefined) return 'dense';
+  const raw = modeFlag === '--mode'
+    ? args[args.indexOf(modeFlag) + 1]
+    : modeFlag.slice('--mode='.length);
+  if (raw === 'dense' || raw === 'lexical' || raw === 'hybrid' || raw === 'auto') {
+    return raw;
+  }
+  return 'unknown';
 }
 
 async function handleRequest(

--- a/src/cli-stats.test.ts
+++ b/src/cli-stats.test.ts
@@ -69,6 +69,10 @@ function payload(): KbStatsPayload {
     // per-model provider call telemetry. Empty `{}` matches a fresh
     // process where the active provider has not been called yet.
     provider_calls: {},
+    search_latency: {
+      requests: {},
+      stages: {},
+    },
     query_cache: {
       hits: 0,
       misses: 0,

--- a/src/kb-stats.ts
+++ b/src/kb-stats.ts
@@ -37,8 +37,11 @@ import {
 import { logger } from './logger.js';
 import {
   providerCallMetrics,
+  searchLatencyMetrics,
   type ProviderCallMetrics,
   type ProviderCallSnapshot,
+  type SearchLatencyMetrics,
+  type SearchLatencyMetricsSnapshot,
 } from './metrics.js';
 import { countIngestQuarantine } from './ingest-quarantine.js';
 import { queryEmbeddingCache, type QueryCacheStats } from './query-cache.js';
@@ -108,6 +111,12 @@ export interface KbStatsPayload {
    * `provider_calls` keep working.
    */
   provider_calls: Record<string, ProviderCallSnapshot>;
+  /**
+   * Issue #597 — process-lifetime latency histograms for daemon-served
+   * search requests and their bounded per-stage timings. Empty until this
+   * serving process handles a search request.
+   */
+  search_latency: SearchLatencyMetricsSnapshot;
   query_cache: QueryCacheStats;
   relevance_gate: RelevanceGateMetricsSnapshot;
   /**
@@ -131,6 +140,8 @@ export interface ComputeKbStatsOptions {
    * singleton is read.
    */
   metrics?: ProviderCallMetrics;
+  /** Issue #597 — test seam for daemon-served search latency telemetry. */
+  searchMetrics?: SearchLatencyMetrics;
   /** Process-local HTTP/SSE counters, supplied by KnowledgeBaseServer when active. */
   remoteTransportStats?: TransportRuntimeStatsSnapshot;
 }
@@ -211,6 +222,7 @@ export async function computeKbStats(
   }
 
   const metricsSource = options.metrics ?? providerCallMetrics;
+  const searchMetricsSource = options.searchMetrics ?? searchLatencyMetrics;
   const managerSummary = manager.getLastIndexUpdateSummary();
   const readPersistedSummary = FaissIndexManager.readPersistedIndexUpdateSummary;
   const lastIndexUpdate = managerSummary.status === 'never_run'
@@ -239,6 +251,7 @@ export async function computeKbStats(
       uptime_ms: Date.now() - options.startedAt,
     },
     provider_calls: metricsSource.snapshot(),
+    search_latency: searchMetricsSource.snapshot(),
     query_cache: await queryEmbeddingCache.stats(),
     relevance_gate: relevanceGateMetrics.snapshot(),
     ...(options.remoteTransportStats !== undefined

--- a/src/metrics.test.ts
+++ b/src/metrics.test.ts
@@ -5,6 +5,7 @@ import {
   LATENCY_BUCKET_BOUNDS_MS,
   ProviderCallMetrics,
   quantileFromBuckets,
+  SearchLatencyMetrics,
 } from './metrics.js';
 
 describe('bucketIndexForLatency (issue #210 — fixed-bucket histogram)', () => {
@@ -139,6 +140,49 @@ describe('ProviderCallMetrics', () => {
     metrics.reset();
     expect(metrics.snapshot()).toEqual({});
     expect(metrics.knownModelIds()).toEqual([]);
+  });
+});
+
+describe('SearchLatencyMetrics', () => {
+  it('records request and stage histograms by bounded mode/status/stage labels', () => {
+    const metrics = new SearchLatencyMetrics({ now: () => 1_700_000_000_000 });
+    metrics.record({
+      mode: 'hybrid',
+      status: 'success',
+      totalMs: 125,
+      stageDurationsMs: {
+        embed_query: 12,
+        faiss_search: 30,
+        lexical_search: 40,
+        fusion: 3,
+      },
+    });
+    metrics.record({
+      mode: 'hybrid',
+      status: 'error',
+      totalMs: 4,
+    });
+
+    const snap = metrics.snapshot();
+    expect(snap.requests.hybrid?.success).toMatchObject({
+      count: 1,
+      sum_ms: 125,
+      since_started_at: '2023-11-14T22:13:20.000Z',
+    });
+    expect(snap.requests.hybrid?.error).toMatchObject({ count: 1, sum_ms: 4 });
+    expect(snap.stages.hybrid?.embed_query?.success).toMatchObject({ count: 1, sum_ms: 12 });
+    expect(snap.stages.hybrid?.faiss_search?.success).toMatchObject({ count: 1, sum_ms: 30 });
+    expect(snap.stages.hybrid?.lexical_search?.success).toMatchObject({ count: 1, sum_ms: 40 });
+    expect(snap.stages.hybrid?.fusion?.success).toMatchObject({ count: 1, sum_ms: 3 });
+    expect(snap.stages.hybrid?.fusion?.error).toBeUndefined();
+  });
+
+  it('reset() clears search latency state', () => {
+    const metrics = new SearchLatencyMetrics({ now: () => 1 });
+    metrics.record({ mode: 'dense', status: 'success', totalMs: 1 });
+    expect(metrics.snapshot().requests.dense?.success?.count).toBe(1);
+    metrics.reset();
+    expect(metrics.snapshot()).toEqual({ requests: {}, stages: {} });
   });
 });
 

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -8,6 +8,8 @@
 // per-query labels. RFC 008 §6.8 capped `/health` at `{status:"ok"}`, so
 // runtime histograms live on the existing `kb_stats` MCP tool surface.
 
+import type { SearchLatencyStage } from './timing-core.js';
+
 /**
  * Fixed log-spaced latency bucket upper bounds, in milliseconds. 10 bucket
  * cap (issue #210 spec) — one per decade-ish step from sub-millisecond
@@ -54,6 +56,38 @@ interface MetricsState {
   startedAtMs: number;
 }
 
+interface HistogramState {
+  buckets: number[];
+  count: number;
+  sumMs: number;
+  startedAtMs: number;
+}
+
+export interface LatencyHistogramSnapshot {
+  buckets: number[];
+  count: number;
+  sum_ms: number;
+  since_started_at: string;
+}
+
+export type SearchLatencyMode = 'dense' | 'lexical' | 'hybrid' | 'auto' | 'unknown';
+export type SearchLatencyStatus = 'success' | 'error';
+
+export interface SearchLatencyRecord {
+  mode: SearchLatencyMode;
+  status: SearchLatencyStatus;
+  totalMs: number;
+  stageDurationsMs?: Partial<Record<SearchLatencyStage, number>>;
+}
+
+export interface SearchLatencyMetricsSnapshot {
+  requests: Partial<Record<SearchLatencyMode, Partial<Record<SearchLatencyStatus, LatencyHistogramSnapshot>>>>;
+  stages: Partial<Record<
+    SearchLatencyMode,
+    Partial<Record<SearchLatencyStage, Partial<Record<SearchLatencyStatus, LatencyHistogramSnapshot>>>>
+  >>;
+}
+
 function emptyState(now: number): MetricsState {
   return {
     buckets: new Array<number>(LATENCY_BUCKET_BOUNDS_MS.length + 1).fill(0),
@@ -62,6 +96,31 @@ function emptyState(now: number): MetricsState {
     tokensInSum: 0,
     tokensReported: false,
     startedAtMs: now,
+  };
+}
+
+function emptyHistogramState(now: number): HistogramState {
+  return {
+    buckets: new Array<number>(LATENCY_BUCKET_BOUNDS_MS.length + 1).fill(0),
+    count: 0,
+    sumMs: 0,
+    startedAtMs: now,
+  };
+}
+
+function recordHistogramSample(state: HistogramState, latencyMs: number): void {
+  const safe = !Number.isFinite(latencyMs) || latencyMs < 0 ? 0 : latencyMs;
+  state.count += 1;
+  state.sumMs += safe;
+  state.buckets[bucketIndexForLatency(safe)] += 1;
+}
+
+function snapshotHistogram(state: HistogramState): LatencyHistogramSnapshot {
+  return {
+    buckets: [...state.buckets],
+    count: state.count,
+    sum_ms: roundLatency(state.sumMs),
+    since_started_at: new Date(state.startedAtMs).toISOString(),
   };
 }
 
@@ -199,6 +258,80 @@ export class ProviderCallMetrics {
 }
 
 /**
+ * Process-lifetime search request latency registry for daemon-scrapeable
+ * search paths. Labels are intentionally bounded to mode/status/stage:
+ * no query text, KB name, path, request id, or error message is recorded.
+ */
+export class SearchLatencyMetrics {
+  private readonly requestStates = new Map<string, HistogramState>();
+  private readonly stageStates = new Map<string, HistogramState>();
+  private readonly now: () => number;
+
+  constructor(options: { now?: () => number } = {}) {
+    this.now = options.now ?? Date.now;
+  }
+
+  record(sample: SearchLatencyRecord): void {
+    const requestState = this.getRequestState(sample.mode, sample.status);
+    recordHistogramSample(requestState, sample.totalMs);
+
+    for (const [stage, value] of Object.entries(sample.stageDurationsMs ?? {}) as Array<[SearchLatencyStage, number]>) {
+      if (typeof value !== 'number') continue;
+      const stageState = this.getStageState(sample.mode, stage, sample.status);
+      recordHistogramSample(stageState, value);
+    }
+  }
+
+  snapshot(): SearchLatencyMetricsSnapshot {
+    const requests: SearchLatencyMetricsSnapshot['requests'] = {};
+    for (const [key, state] of this.requestStates.entries()) {
+      const [mode, status] = key.split('|') as [SearchLatencyMode, SearchLatencyStatus];
+      requests[mode] ??= {};
+      requests[mode]![status] = snapshotHistogram(state);
+    }
+
+    const stages: SearchLatencyMetricsSnapshot['stages'] = {};
+    for (const [key, state] of this.stageStates.entries()) {
+      const [mode, stage, status] = key.split('|') as [SearchLatencyMode, SearchLatencyStage, SearchLatencyStatus];
+      stages[mode] ??= {};
+      stages[mode]![stage] ??= {};
+      stages[mode]![stage]![status] = snapshotHistogram(state);
+    }
+
+    return { requests, stages };
+  }
+
+  reset(): void {
+    this.requestStates.clear();
+    this.stageStates.clear();
+  }
+
+  private getRequestState(mode: SearchLatencyMode, status: SearchLatencyStatus): HistogramState {
+    const key = `${mode}|${status}`;
+    let state = this.requestStates.get(key);
+    if (state === undefined) {
+      state = emptyHistogramState(this.now());
+      this.requestStates.set(key, state);
+    }
+    return state;
+  }
+
+  private getStageState(
+    mode: SearchLatencyMode,
+    stage: SearchLatencyStage,
+    status: SearchLatencyStatus,
+  ): HistogramState {
+    const key = `${mode}|${stage}|${status}`;
+    let state = this.stageStates.get(key);
+    if (state === undefined) {
+      state = emptyHistogramState(this.now());
+      this.stageStates.set(key, state);
+    }
+    return state;
+  }
+}
+
+/**
  * Round a latency to 3 significant decimal places. The histogram
  * resolution is bounded by bucket width, so reporting full
  * floating-point precision overstates accuracy; one decimal in
@@ -213,6 +346,8 @@ function roundLatency(latencyMs: number): number {
  * fresh `ProviderCallMetrics` or call `reset()` between cases.
  */
 export const providerCallMetrics = new ProviderCallMetrics();
+
+export const searchLatencyMetrics = new SearchLatencyMetrics();
 
 /**
  * Wrap a langchain-shaped embeddings client so every `embedQuery` /

--- a/src/prometheus-export.test.ts
+++ b/src/prometheus-export.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from '@jest/globals';
 import type { KbStatsPayload } from './kb-stats.js';
+import {
+  bucketIndexForLatency,
+  LATENCY_BUCKET_BOUNDS_MS,
+} from './metrics.js';
 import { formatKbStatsOpenMetrics } from './prometheus-export.js';
 
 describe('formatKbStatsOpenMetrics', () => {
@@ -14,6 +18,15 @@ describe('formatKbStatsOpenMetrics', () => {
     expect(text).toContain('kb_provider_calls_total{model_id="ollama__nomic-embed-text-latest"} 11');
     expect(text).not.toContain('kb_provider_tokens_in_total');
     expect(text).toContain('kb_provider_call_latency_p95_ms{model_id="ollama__nomic-embed-text-latest"} 123.4');
+    expect(text).toContain('kb_search_requests_total{mode="dense",status="success"} 1');
+    expect(text).toContain('# TYPE kb_search_request_duration_ms histogram');
+    expect(text).toContain('kb_search_request_duration_ms_bucket{le="100",mode="dense",status="success"} 1');
+    expect(text).toContain('kb_search_request_duration_ms_bucket{le="+Inf",mode="dense",status="success"} 1');
+    expect(text).toContain('kb_search_request_duration_ms_sum{mode="dense",status="success"} 80');
+    expect(text).toContain('kb_search_request_duration_ms_count{mode="dense",status="success"} 1');
+    expect(text).toContain('# TYPE kb_search_stage_duration_ms histogram');
+    expect(text).toContain('kb_search_stage_duration_ms_bucket{le="30",mode="dense",stage="embed_query",status="success"} 1');
+    expect(text).toContain('kb_search_stage_duration_ms_sum{mode="dense",stage="embed_query",status="success"} 12');
     expect(text).toContain('kb_remote_transport_requests_total 9');
     expect(text).toContain('# TYPE kb_remote_transport_responses_4xx counter');
     expect(text).toContain('kb_remote_transport_responses_4xx_total 2');
@@ -91,6 +104,20 @@ function samplePayload(): KbStatsPayload {
         since_started_at: '2026-05-21T00:00:00.000Z',
       },
     },
+    search_latency: {
+      requests: {
+        dense: {
+          success: histogramSnapshot(80),
+        },
+      },
+      stages: {
+        dense: {
+          embed_query: {
+            success: histogramSnapshot(12),
+          },
+        },
+      },
+    },
     query_cache: {
       hits: 5,
       misses: 6,
@@ -138,5 +165,16 @@ function samplePayload(): KbStatsPayload {
       origin_denials: 1,
       last_error: null,
     },
+  };
+}
+
+function histogramSnapshot(value: number) {
+  const buckets = new Array<number>(LATENCY_BUCKET_BOUNDS_MS.length + 1).fill(0);
+  buckets[bucketIndexForLatency(value)] = 1;
+  return {
+    buckets,
+    count: 1,
+    sum_ms: value,
+    since_started_at: '2026-05-21T00:00:00.000Z',
   };
 }

--- a/src/prometheus-export.ts
+++ b/src/prometheus-export.ts
@@ -1,4 +1,11 @@
 import type { KbStatsPayload } from './kb-stats.js';
+import {
+  LATENCY_BUCKET_BOUNDS_MS,
+  type LatencyHistogramSnapshot,
+  type SearchLatencyMetricsSnapshot,
+  type SearchLatencyMode,
+  type SearchLatencyStatus,
+} from './metrics.js';
 
 interface MetricSample {
   name: string;
@@ -103,6 +110,7 @@ export function formatKbStatsOpenMetrics(payload: KbStatsPayload): string {
         })),
     },
     ...providerLatencyMetrics(payload),
+    ...searchLatencyCounterMetrics(payload.search_latency),
     {
       name: 'kb_query_cache_hits_total',
       help: 'Query embedding cache hits.',
@@ -173,6 +181,7 @@ export function formatKbStatsOpenMetrics(payload: KbStatsPayload): string {
       lines.push(`${sample.name}${formatLabels(sample.labels)} ${formatNumber(sample.value)}`);
     }
   }
+  lines.push(...searchLatencyHistogramLines(payload.search_latency));
   lines.push('# EOF');
   return `${lines.join('\n')}\n`;
 }
@@ -274,6 +283,111 @@ function remoteTransportMetrics(payload: KbStatsPayload): MetricDefinition[] {
       }],
     })),
   ];
+}
+
+function searchLatencyCounterMetrics(snapshot: SearchLatencyMetricsSnapshot): MetricDefinition[] {
+  const samples: MetricSample[] = [];
+  for (const [mode, byStatus] of Object.entries(snapshot.requests)) {
+    for (const [status, histogram] of Object.entries(byStatus)) {
+      if (histogram === undefined) continue;
+      samples.push({
+        name: 'kb_search_requests_total',
+        labels: { mode, status },
+        value: histogram.count,
+      });
+    }
+  }
+  return [{
+    name: 'kb_search_requests_total',
+    help: 'Daemon-served search requests by effective mode and status.',
+    type: 'counter',
+    samples,
+  }];
+}
+
+function searchLatencyHistogramLines(snapshot: SearchLatencyMetricsSnapshot): string[] {
+  const lines: string[] = [];
+  lines.push(...renderHistogramFamily({
+    name: 'kb_search_request_duration_ms',
+    help: 'End-to-end daemon-served search request latency in milliseconds.',
+    rows: requestHistogramRows(snapshot),
+  }));
+  lines.push(...renderHistogramFamily({
+    name: 'kb_search_stage_duration_ms',
+    help: 'Daemon-served search stage latency in milliseconds.',
+    rows: stageHistogramRows(snapshot),
+  }));
+  return lines;
+}
+
+function requestHistogramRows(snapshot: SearchLatencyMetricsSnapshot): HistogramRow[] {
+  const rows: HistogramRow[] = [];
+  for (const [mode, byStatus] of Object.entries(snapshot.requests)) {
+    for (const [status, histogram] of Object.entries(byStatus)) {
+      if (histogram === undefined) continue;
+      rows.push({
+        labels: {
+          mode: mode as SearchLatencyMode,
+          status: status as SearchLatencyStatus,
+        },
+        histogram,
+      });
+    }
+  }
+  return rows;
+}
+
+function stageHistogramRows(snapshot: SearchLatencyMetricsSnapshot): HistogramRow[] {
+  const rows: HistogramRow[] = [];
+  for (const [mode, byStage] of Object.entries(snapshot.stages)) {
+    for (const [stage, byStatus] of Object.entries(byStage)) {
+      if (byStatus === undefined) continue;
+      for (const [status, histogram] of Object.entries(byStatus)) {
+        if (histogram === undefined) continue;
+        rows.push({
+          labels: {
+            mode,
+            stage,
+            status,
+          },
+          histogram,
+        });
+      }
+    }
+  }
+  return rows;
+}
+
+interface HistogramRow {
+  labels: Record<string, string>;
+  histogram: LatencyHistogramSnapshot;
+}
+
+function renderHistogramFamily(input: {
+  name: string;
+  help: string;
+  rows: HistogramRow[];
+}): string[] {
+  if (input.rows.length === 0) return [];
+  const lines: string[] = [
+    `# HELP ${input.name} ${input.help}`,
+    `# TYPE ${input.name} histogram`,
+  ];
+  for (const row of input.rows) {
+    let cumulative = 0;
+    for (let index = 0; index < LATENCY_BUCKET_BOUNDS_MS.length; index += 1) {
+      cumulative += row.histogram.buckets[index] ?? 0;
+      lines.push(
+        `${input.name}_bucket${formatLabels({ ...row.labels, le: String(LATENCY_BUCKET_BOUNDS_MS[index]) })} ${formatNumber(cumulative)}`,
+      );
+    }
+    lines.push(
+      `${input.name}_bucket${formatLabels({ ...row.labels, le: '+Inf' })} ${formatNumber(row.histogram.count)}`,
+    );
+    lines.push(`${input.name}_sum${formatLabels(row.labels)} ${formatNumber(row.histogram.sum_ms)}`);
+    lines.push(`${input.name}_count${formatLabels(row.labels)} ${formatNumber(row.histogram.count)}`);
+  }
+  return lines;
 }
 
 function formatLabels(labels: Record<string, string> | undefined): string {

--- a/src/timing-core.ts
+++ b/src/timing-core.ts
@@ -1,6 +1,24 @@
 export type TimingValue = number | string | boolean | null;
 
 export type TimingPayload = Record<string, TimingValue | undefined>;
+export type SearchLatencyStage =
+  | 'bootstrap'
+  | 'model_resolution'
+  | 'manager_load'
+  | 'index_load'
+  | 'dense_search'
+  | 'embed_query'
+  | 'faiss_search'
+  | 'query_search'
+  | 'post_filter'
+  | 'lexical_kb_list'
+  | 'lexical_search'
+  | 'high_recall_filter'
+  | 'fusion'
+  | 'rerank'
+  | 'freshness_scan'
+  | 'gate'
+  | 'format';
 export type RefreshTimingPhase = 'embed' | 'save' | 'sidecar' | 'manifest';
 export type FreshnessScanScope = 'global' | 'scoped';
 export type FreshnessScanSource = 'filesystem' | 'manifest' | 'none';
@@ -50,6 +68,39 @@ export function compactTimingPayload(timing: TimingPayload): Record<string, Timi
   const out: Record<string, TimingValue> = {};
   for (const [key, value] of Object.entries(timing)) {
     if (value !== undefined) out[key] = typeof value === 'number' ? Math.round(value) : value;
+  }
+  return out;
+}
+
+const SEARCH_LATENCY_STAGE_TIMING_KEYS: ReadonlyArray<readonly [string, SearchLatencyStage]> = [
+  ['bootstrap_ms', 'bootstrap'],
+  ['model_resolution_ms', 'model_resolution'],
+  ['manager_load_ms', 'manager_load'],
+  ['index_load_ms', 'index_load'],
+  ['dense_search_ms', 'dense_search'],
+  ['embed_query_ms', 'embed_query'],
+  ['faiss_search_ms', 'faiss_search'],
+  ['query_search_ms', 'query_search'],
+  ['post_filter_ms', 'post_filter'],
+  ['lexical_kb_list_ms', 'lexical_kb_list'],
+  ['lexical_search_ms', 'lexical_search'],
+  ['high_recall_filter_ms', 'high_recall_filter'],
+  ['fusion_ms', 'fusion'],
+  ['rerank_ms', 'rerank'],
+  ['freshness_scan_ms', 'freshness_scan'],
+  ['gate_ms', 'gate'],
+  ['format_ms', 'format'],
+];
+
+export function searchStageDurationsFromTiming(
+  timing: TimingPayload,
+): Partial<Record<SearchLatencyStage, number>> {
+  const out: Partial<Record<SearchLatencyStage, number>> = {};
+  for (const [key, stage] of SEARCH_LATENCY_STAGE_TIMING_KEYS) {
+    const value = timing[key];
+    if (typeof value === 'number' && Number.isFinite(value) && value >= 0) {
+      out[stage] = value;
+    }
   }
   return out;
 }


### PR DESCRIPTION
## Summary

Closes #597.

Adds daemon-scrapeable search latency telemetry to `/metrics`:

- `kb_search_requests_total{mode,status}` request totals.
- `kb_search_request_duration_ms{mode,status}` end-to-end histograms.
- `kb_search_stage_duration_ms{mode,stage,status}` per-stage histograms.

The histograms reuse the existing millisecond bucket bounds from provider telemetry and keep labels bounded to `mode`, `status`, and fixed `stage` names.

## Implementation Choice

I scoped recording to search requests served by resident processes that Prometheus can scrape:

- MCP `retrieve_knowledge` dense/hybrid paths in `KnowledgeBaseServer`.
- `kb search --daemon` handled by `kb serve`, via a hidden `onSearchTiming` hook on `runSearch`.

One-shot CLI process timings are intentionally not exported because the process exits before a scraper can reliably collect in-memory state. I also omitted `kb` labels to avoid unbounded per-install cardinality; KB-specific breakdowns can be added later behind a cap or allowlist.

## Alternatives Considered

- Export quantile gauges only: rejected because Prometheus histograms are more useful for alerting and aggregation.
- Add `kb` labels immediately: deferred to keep the initial contract low-cardinality.
- Instrument only `FaissIndexManager`: rejected because it would miss mode/status and non-dense stages like lexical, fusion, rerank, gate, and format.

## Verification

- `npm test -- --runTestsByPath src/prometheus-export.test.ts src/metrics.test.ts src/search-core.test.ts --runInBand` - passed, 59 tests.
- `npm test -- --runTestsByPath src/prometheus-export.test.ts src/metrics.test.ts src/search-core.test.ts src/cli-serve.test.ts src/KnowledgeBaseServer.test.ts --runInBand` - passed, 152 tests.
- `npm run build` - passed.
- `git diff --check origin/main..HEAD` - passed.
- Docs anchor check not run: the docs edit added no anchors or links.

## Pre-PR Review

- conventions specialist: fixed duplicated bucket mapping in `prometheus-export.test.ts` by using `bucketIndexForLatency` / `LATENCY_BUCKET_BOUNDS_MS`.
- test specialist: added daemon-handler tests for successful timing hook recording and failed search exit recording.
- dead-code specialist: no dead code introduced.
- correctness specialist: no correctness findings.
