### PR TITLE
feat(stats): surface flat search latency advisory

### DIFF
--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -130,6 +130,7 @@ wrap-close vars below.
 | Config schema validation | `kb config validate` | process environment | CLI preflight / CI | Implemented | `--file=<path>` | `kb config validate --file=.env --format=json` |
 | Mutation audit log | `KB_MUTATION_AUDIT_LOG` | unset | KB write paths | Implemented, opt-in | none | `KB_MUTATION_AUDIT_LOG=/tmp/kb-mutations.jsonl kb remember --kb=<name> --title="..." --stdin --yes` |
 | OpenMetrics export | `KB_METRICS_EXPORT` | `off` | `kb serve` and HTTP/SSE transport `/metrics` | Implemented, opt-in | none | `KB_METRICS_EXPORT=on kb serve` then `curl http://127.0.0.1:17799/metrics` |
+| Flat-search latency advisory threshold | `KB_FLAT_SEARCH_P95_ADVISORY_MS` | `50` | `kb doctor`, `kb stats` | Implemented, hint only; never changes indexing behavior | none | `KB_FLAT_SEARCH_P95_ADVISORY_MS=50 kb stats` |
 | Tool description overrides | `RETRIEVE_KNOWLEDGE_DESCRIPTION`, `LIST_KNOWLEDGE_BASES_DESCRIPTION`, `LIST_MODELS_DESCRIPTION`, `KB_STATS_DESCRIPTION` | built-in descriptions | MCP server tool metadata | Implemented | none; set before server start | restart MCP server and inspect tool descriptions |
 
 ## Ingest and Storage

--- a/src/cli-doctor.test.ts
+++ b/src/cli-doctor.test.ts
@@ -13,6 +13,7 @@ const originalEnv = {
   HUGGINGFACE_API_KEY: process.env.HUGGINGFACE_API_KEY,
   KB_ACTIVE_MODEL: process.env.KB_ACTIVE_MODEL,
   KB_INDEX_VERSION_RETENTION: process.env.KB_INDEX_VERSION_RETENTION,
+  KB_FLAT_SEARCH_P95_ADVISORY_MS: process.env.KB_FLAT_SEARCH_P95_ADVISORY_MS,
   KB_AGE_BUDGET_HOURS: process.env.KB_AGE_BUDGET_HOURS,
   KB_AGE_BUDGET_HOURS_ALPHA: process.env.KB_AGE_BUDGET_HOURS_ALPHA,
   KB_AGE_BUDGET_HOURS_BETA: process.env.KB_AGE_BUDGET_HOURS_BETA,
@@ -460,6 +461,7 @@ describe('kb doctor', () => {
         packageVersion: '9.9.9',
         llmEndpointProbe: healthyLlmProbe,
         lastIndexUpdateSummary: persistedSuccessSummary(),
+        daemonStatsPayload: async () => null,
       });
 
       expect(fetchMock).toHaveBeenCalledTimes(1);
@@ -1873,6 +1875,206 @@ describe('kb doctor', () => {
         const md = formatDoctorMarkdown(report);
         expect(md).toContain('model=ollama__nomic calls=10 errors=8');
         expect(md).toMatch(/p50=\d+(\.\d+)?ms p95=\d+(\.\d+)?ms p99=\d+(\.\d+)?ms tokens=n\/a, WARN/);
+      } finally {
+        await fsp.rm(tempDir, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe('dense flat-search latency advisory (issue #604)', () => {
+    it('reports active index type/factory and warns only with a suggest-only hint above threshold', async () => {
+      const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-doctor-flat-latency-warn-'));
+      try {
+        const { rootDir, faissDir } = await seedDoctorBase(tempDir);
+        const { buildDoctorReport, formatDoctorMarkdown } = await freshDoctor({
+          KNOWLEDGE_BASES_ROOT_DIR: rootDir,
+          FAISS_INDEX_PATH: faissDir,
+          EMBEDDING_PROVIDER: 'huggingface',
+          HUGGINGFACE_MODEL_NAME: MODEL_NAME,
+          HUGGINGFACE_API_KEY: 'test-key',
+          KB_FLAT_SEARCH_P95_ADVISORY_MS: '50',
+        });
+        const { SearchLatencyMetrics } = await import('./metrics.js');
+        const searchMetrics = new SearchLatencyMetrics({ now: () => 1_700_000_000_000 });
+        searchMetrics.record({
+          mode: 'dense',
+          status: 'success',
+          totalMs: 130,
+          stageDurationsMs: { faiss_search: 80 },
+        });
+        searchMetrics.record({
+          mode: 'dense',
+          status: 'success',
+          totalMs: 180,
+          stageDurationsMs: { faiss_search: 140 },
+        });
+
+        const report = await buildDoctorReport({
+          backendHealthCheck: async () => ({ healthy: true, detail: 'ok' }),
+          packageRoot: tempDir,
+          invokedPath: null,
+          packageVersion: '9.9.9',
+          llmEndpointProbe: healthyLlmProbe,
+          searchMetrics,
+        });
+
+        expect(report.index.type).toBe('flat');
+        expect(report.index.factory).toBe('Flat');
+        expect(report.dense_search_latency).toMatchObject({
+          active_index: { type: 'flat', factory: 'Flat' },
+          sample_count: 2,
+          threshold_ms: 50,
+          advisory: {
+            code: 'FLAT_SCAN_P95_ABOVE_THRESHOLD',
+            docs: expect.arrayContaining([
+              'docs/operations/index-quantization.md#hnsw--ann-status',
+              'https://github.com/jeanibarz/knowledge-base-mcp-server/issues/596',
+            ]),
+          },
+        });
+        const latencyCheck = report.checks.find((c) => c.name === 'flat_search_latency');
+        expect(latencyCheck?.status).toBe('warn');
+        expect(latencyCheck?.detail).toContain('not auto-enabled');
+        expect(latencyCheck?.detail).toContain('issue #596 is blocked');
+        const markdown = formatDoctorMarkdown(report);
+        expect(markdown).toContain('Index type: flat');
+        expect(markdown).toContain('Index factory: Flat');
+        expect(markdown).toContain('Dense search latency:');
+        expect(markdown).toContain('HINT Dense flat-search p95');
+        expect(markdown).toContain('docs/architecture/adr/0010-hnsw-binding-evaluation.md');
+      } finally {
+        await fsp.rm(tempDir, { recursive: true, force: true });
+      }
+    });
+
+    it('uses daemon stats latency when the doctor process has no local search histogram', async () => {
+      const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-doctor-flat-latency-daemon-'));
+      try {
+        const { rootDir, faissDir } = await seedDoctorBase(tempDir);
+        const { buildDoctorReport } = await freshDoctor({
+          KNOWLEDGE_BASES_ROOT_DIR: rootDir,
+          FAISS_INDEX_PATH: faissDir,
+          EMBEDDING_PROVIDER: 'huggingface',
+          HUGGINGFACE_MODEL_NAME: MODEL_NAME,
+          HUGGINGFACE_API_KEY: 'test-key',
+          KB_FLAT_SEARCH_P95_ADVISORY_MS: '50',
+        });
+
+        const report = await buildDoctorReport({
+          backendHealthCheck: async () => ({ healthy: true, detail: 'ok' }),
+          packageRoot: tempDir,
+          invokedPath: null,
+          packageVersion: '9.9.9',
+          llmEndpointProbe: healthyLlmProbe,
+          daemonStatsPayload: async () => ({
+            dense_search_latency: {
+              mode: 'dense',
+              stage: 'faiss_search',
+              status: 'success',
+              active_index: { type: 'flat', factory: 'Flat' },
+              sample_count: 5,
+              p50_ms: 25,
+              p95_ms: 90,
+              threshold_ms: 50,
+              since_started_at: '2026-06-12T10:00:00.000Z',
+              advisory: {
+                code: 'FLAT_SCAN_P95_ABOVE_THRESHOLD',
+                message: 'daemon p95 warning',
+                docs: ['docs/architecture/adr/0010-hnsw-binding-evaluation.md'],
+              },
+            },
+          }),
+        });
+
+        expect(report.dense_search_latency).toMatchObject({
+          sample_count: 5,
+          p95_ms: 90,
+          advisory: { message: 'daemon p95 warning' },
+        });
+        expect(report.checks).toContainEqual({
+          name: 'flat_search_latency',
+          status: 'warn',
+          detail: 'daemon p95 warning',
+        });
+      } finally {
+        await fsp.rm(tempDir, { recursive: true, force: true });
+      }
+    });
+
+    it('keeps missing dense latency quiet in doctor checks', async () => {
+      const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-doctor-flat-latency-empty-'));
+      try {
+        const { rootDir, faissDir } = await seedDoctorBase(tempDir);
+        const { buildDoctorReport, formatDoctorMarkdown } = await freshDoctor({
+          KNOWLEDGE_BASES_ROOT_DIR: rootDir,
+          FAISS_INDEX_PATH: faissDir,
+          EMBEDDING_PROVIDER: 'huggingface',
+          HUGGINGFACE_MODEL_NAME: MODEL_NAME,
+          HUGGINGFACE_API_KEY: 'test-key',
+        });
+        const { SearchLatencyMetrics } = await import('./metrics.js');
+
+        const report = await buildDoctorReport({
+          backendHealthCheck: async () => ({ healthy: true, detail: 'ok' }),
+          packageRoot: tempDir,
+          invokedPath: null,
+          packageVersion: '9.9.9',
+          llmEndpointProbe: healthyLlmProbe,
+          searchMetrics: new SearchLatencyMetrics({ now: () => 0 }),
+        });
+
+        expect(report.dense_search_latency).toBeNull();
+        expect(report.checks.some((c) => c.name === 'flat_search_latency')).toBe(false);
+        expect(formatDoctorMarkdown(report)).toContain(
+          'Dense search latency:\n  (no dense faiss_search latency observed)',
+        );
+      } finally {
+        await fsp.rm(tempDir, { recursive: true, force: true });
+      }
+    });
+
+    it('keeps below-threshold observed dense latency quiet in doctor checks', async () => {
+      const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-doctor-flat-latency-ok-'));
+      try {
+        const { rootDir, faissDir } = await seedDoctorBase(tempDir);
+        const { buildDoctorReport, formatDoctorMarkdown } = await freshDoctor({
+          KNOWLEDGE_BASES_ROOT_DIR: rootDir,
+          FAISS_INDEX_PATH: faissDir,
+          EMBEDDING_PROVIDER: 'huggingface',
+          HUGGINGFACE_MODEL_NAME: MODEL_NAME,
+          HUGGINGFACE_API_KEY: 'test-key',
+          KB_FLAT_SEARCH_P95_ADVISORY_MS: '50',
+        });
+        const { SearchLatencyMetrics } = await import('./metrics.js');
+        const searchMetrics = new SearchLatencyMetrics({ now: () => 1_700_000_000_000 });
+        searchMetrics.record({
+          mode: 'dense',
+          status: 'success',
+          totalMs: 200,
+          stageDurationsMs: { faiss_search: 12 },
+        });
+
+        const report = await buildDoctorReport({
+          backendHealthCheck: async () => ({ healthy: true, detail: 'ok' }),
+          packageRoot: tempDir,
+          invokedPath: null,
+          packageVersion: '9.9.9',
+          llmEndpointProbe: healthyLlmProbe,
+          searchMetrics,
+        });
+
+        expect(report.dense_search_latency).toMatchObject({
+          active_index: { type: 'flat', factory: 'Flat' },
+          sample_count: 1,
+          threshold_ms: 50,
+          advisory: null,
+        });
+        expect(report.dense_search_latency?.p95_ms).toBeLessThanOrEqual(50);
+        expect(report.checks.some((c) => c.name === 'flat_search_latency')).toBe(false);
+        const markdown = formatDoctorMarkdown(report);
+        expect(markdown).toContain('Dense search latency:');
+        expect(markdown).toContain('p95=');
+        expect(markdown).not.toContain('HINT Dense flat-search p95');
       } finally {
         await fsp.rm(tempDir, { recursive: true, force: true });
       }

--- a/src/cli-doctor.ts
+++ b/src/cli-doctor.ts
@@ -16,6 +16,7 @@ import {
   modelsRoot,
   parseModelId,
   readModelIndexStorage,
+  readStoredIndexType,
   resolveActiveModel,
   resolveFaissIndexBinaryPath,
 } from './active-model.js';
@@ -58,11 +59,19 @@ import {
   formatAgeHours,
   type AgeBudgetStatus,
 } from './age-budget.js';
-import { maxMtimeIso } from './kb-stats.js';
+import {
+  indexFactoryForType,
+  maxMtimeIso,
+  summarizeDenseSearchLatency,
+  type KbStatsDenseSearchLatencySummary,
+  type KbStatsPayload,
+} from './kb-stats.js';
 import {
   providerCallMetrics,
+  searchLatencyMetrics,
   type ProviderCallMetrics,
   type ProviderCallSnapshot,
+  type SearchLatencyMetrics,
 } from './metrics.js';
 import { countIngestQuarantine } from './ingest-quarantine.js';
 import {
@@ -79,6 +88,8 @@ import {
   type LlmProfile,
 } from './llm-profiles.js';
 import { resolveRerankerConfig } from './config/reranker.js';
+import { resolveFlatSearchP95AdvisoryMs, type FaissIndexType } from './config/indexing.js';
+import { tryReadDaemonStatsPayload } from './cli-stats.js';
 import {
   daemonUrlFromEnv,
   fetchDaemonHealth,
@@ -179,6 +190,7 @@ export interface DoctorArgs {
 
 export type HealthStatus = 'ok' | 'warn' | 'error';
 export type EndpointHealthStatus = HealthStatus | 'skipped';
+type DoctorDaemonStatsPayload = Pick<KbStatsPayload, 'dense_search_latency'>;
 
 export interface EndpointReadinessEntry {
   name: 'mcp_bind' | 'kb_daemon' | 'embedding_ollama' | 'llm_endpoint';
@@ -274,6 +286,8 @@ export interface DoctorReport {
     binary_path: string | null;
     version: string | null;
     mtime: string | null;
+    type: FaissIndexType | null;
+    factory: string | null;
     storage: {
       active_version_bytes: number | null;
       inactive_version_count: number;
@@ -428,6 +442,7 @@ export interface DoctorReport {
    * model_id; otherwise it is OK.
    */
   provider_calls: Record<string, ProviderCallSnapshot>;
+  dense_search_latency: KbStatsDenseSearchLatencySummary | null;
   /** Non-null only when kb doctor is invoked with --integrity or --slow. */
   integrity: IntegrityReport | null;
 }
@@ -444,6 +459,10 @@ export interface BuildDoctorReportOptions {
    * singleton is read.
    */
   providerCallMetrics?: ProviderCallMetrics;
+  /** Issue #604 — test seam for daemon-served search latency telemetry. */
+  searchMetrics?: SearchLatencyMetrics;
+  /** Issue #604 — test seam for daemon stats telemetry captured out of process. */
+  daemonStatsPayload?: () => Promise<DoctorDaemonStatsPayload | null>;
   /**
    * Issue #388 — test seam for the local LLM endpoint readiness check.
    * Production callers leave this undefined so the doctor performs a
@@ -1495,6 +1514,26 @@ export async function buildDoctorReport(
     }
   }
 
+  const searchMetricsSource = options.searchMetrics ?? searchLatencyMetrics;
+  const daemonStats = await (options.daemonStatsPayload ?? (() => tryReadDaemonStatsPayload()))();
+  const denseSearchLatency = daemonStats?.dense_search_latency
+    ?? (
+      index.type === null
+        ? null
+        : summarizeDenseSearchLatency(
+            searchMetricsSource.snapshot(),
+            index.type,
+            resolveFlatSearchP95AdvisoryMs(),
+          )
+    );
+  if (denseSearchLatency?.advisory !== null && denseSearchLatency?.advisory !== undefined) {
+    checks.push({
+      name: 'flat_search_latency',
+      status: 'warn',
+      detail: denseSearchLatency.advisory.message,
+    });
+  }
+
   const packageRoot = options.packageRoot ?? resolvePackageRoot();
   const invokedPath = options.invokedPath ?? process.argv[1] ?? null;
   const cli = {
@@ -1556,6 +1595,7 @@ export async function buildDoctorReport(
     last_index_update: lastIndexUpdate,
     reindex_trigger: reindexTrigger,
     provider_calls: providerCalls,
+    dense_search_latency: denseSearchLatency,
     integrity,
   };
 }
@@ -1655,8 +1695,18 @@ async function readIndexHealth(activeModelId: string | null): Promise<DoctorRepo
     retention_previous_versions: 0,
   };
   if (activeModelId === null) {
-    return { path: FAISS_INDEX_PATH, binary_path: null, version: null, mtime: null, storage: emptyStorage };
+    return {
+      path: FAISS_INDEX_PATH,
+      binary_path: null,
+      version: null,
+      mtime: null,
+      type: null,
+      factory: null,
+      storage: emptyStorage,
+    };
   }
+  const indexType = await readStoredIndexType(activeModelId);
+  const indexFactory = indexFactoryForType(indexType);
   const storage = await readModelIndexStorage(activeModelId);
   const storageSummary: DoctorReport['index']['storage'] = {
     active_version_bytes: storage.active_version_bytes,
@@ -1667,7 +1717,15 @@ async function readIndexHealth(activeModelId: string | null): Promise<DoctorRepo
   };
   const binaryPath = await resolveFaissIndexBinaryPath(activeModelId);
   if (binaryPath === null) {
-    return { path: FAISS_INDEX_PATH, binary_path: null, version: null, mtime: null, storage: storageSummary };
+    return {
+      path: FAISS_INDEX_PATH,
+      binary_path: null,
+      version: null,
+      mtime: null,
+      type: indexType,
+      factory: indexFactory,
+      storage: storageSummary,
+    };
   }
   try {
     const st = await fsp.stat(binaryPath);
@@ -1676,10 +1734,20 @@ async function readIndexHealth(activeModelId: string | null): Promise<DoctorRepo
       binary_path: binaryPath,
       version: indexVersionFromPath(binaryPath),
       mtime: new Date(st.mtimeMs).toISOString(),
+      type: indexType,
+      factory: indexFactory,
       storage: storageSummary,
     };
   } catch {
-    return { path: FAISS_INDEX_PATH, binary_path: null, version: null, mtime: null, storage: storageSummary };
+    return {
+      path: FAISS_INDEX_PATH,
+      binary_path: null,
+      version: null,
+      mtime: null,
+      type: indexType,
+      factory: indexFactory,
+      storage: storageSummary,
+    };
   }
 }
 
@@ -2316,6 +2384,8 @@ export function formatDoctorMarkdown(report: DoctorReport): string {
   }
   lines.push(`Index: ${report.index.binary_path ?? '<not built>'}`);
   lines.push(`Index version: ${report.index.version ?? '<unknown>'}`);
+  lines.push(`Index type: ${report.index.type ?? '<unknown>'}`);
+  lines.push(`Index factory: ${report.index.factory ?? '<unknown>'}`);
   lines.push(`Index mtime: ${report.index.mtime ?? '<none>'}`);
   lines.push(
     `Index storage: ${formatBytes(report.index.storage.total_version_bytes)} total ` +
@@ -2514,6 +2584,22 @@ export function formatDoctorMarkdown(report: DoctorReport): string {
         ` p50=${row.latency_ms.p50}ms p95=${row.latency_ms.p95}ms` +
         ` p99=${row.latency_ms.p99}ms ${tokens}${errorMarker}`,
       );
+    }
+  }
+  lines.push('');
+  lines.push('Dense search latency:');
+  if (report.dense_search_latency === null) {
+    lines.push('  (no dense faiss_search latency observed)');
+  } else {
+    const row = report.dense_search_latency;
+    lines.push(
+      `  active_index=${row.active_index.type} factory=${row.active_index.factory} ` +
+      `samples=${row.sample_count} p50=${row.p50_ms}ms p95=${row.p95_ms}ms ` +
+      `threshold=${row.threshold_ms}ms`,
+    );
+    if (row.advisory !== null) {
+      lines.push(`  HINT ${row.advisory.message}`);
+      lines.push(`  docs: ${row.advisory.docs.join(', ')}`);
     }
   }
   lines.push('');

--- a/src/cli-serve.ts
+++ b/src/cli-serve.ts
@@ -357,7 +357,7 @@ export function createDaemonCommandHandlers(options: DaemonCommandHandlerOptions
       return result;
     },
     list: async (args) => captureProcessOutput(() => runListImpl(args)),
-    stats: async (args) => captureProcessOutput(() => runStatsImpl(args)),
+    stats: async (args) => captureProcessOutput(() => runStatsImpl(args, undefined, { preferDaemon: false })),
   };
 }
 

--- a/src/cli-stats.test.ts
+++ b/src/cli-stats.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, jest } from '@jest/globals';
 import {
   formatDenseCoverageSection,
+  formatDenseSearchLatencySection,
   formatContextualSection,
   formatFilesystemSection,
   formatRemoteTransportSection,
@@ -38,6 +39,8 @@ function payload(): KbStatsPayload {
       provider: 'ollama',
       model: 'nomic-embed-text:latest',
       dim: 768,
+      index_type: 'flat',
+      index_factory: 'Flat',
     },
     index_path: '/tmp/kb-index',
     last_index_update: {
@@ -188,6 +191,45 @@ describe('kb stats CLI', () => {
     );
   });
 
+  it('uses a reachable daemon stats payload before loading local index state', async () => {
+    const daemonPayload = payload();
+    daemonPayload.dense_search_latency = {
+      mode: 'dense',
+      stage: 'faiss_search',
+      status: 'success',
+      active_index: { type: 'flat', factory: 'Flat' },
+      sample_count: 3,
+      p50_ms: 20,
+      p95_ms: 45,
+      threshold_ms: 50,
+      since_started_at: '2026-06-12T10:00:00.000Z',
+      advisory: null,
+    };
+    const { deps, stdout } = makeDeps();
+    deps.tryReadDaemonStatsPayload = jest.fn(async () => daemonPayload);
+
+    const code = await runStats(['--format=json'], deps);
+
+    expect(code).toBe(0);
+    expect(JSON.parse(stdout.join(''))).toEqual(daemonPayload);
+    expect(deps.bootstrapLayout).not.toHaveBeenCalled();
+    expect(deps.computeKbStats).not.toHaveBeenCalled();
+  });
+
+  it('can disable daemon stats lookup for the resident daemon handler', async () => {
+    const { deps, stdout } = makeDeps();
+    deps.tryReadDaemonStatsPayload = jest.fn(async () => {
+      throw new Error('daemon lookup should be skipped');
+    });
+
+    const code = await runStats(['--format=json'], deps, { preferDaemon: false });
+
+    expect(code).toBe(0);
+    expect(JSON.parse(stdout.join(''))).toEqual(payload());
+    expect(deps.tryReadDaemonStatsPayload).not.toHaveBeenCalled();
+    expect(deps.computeKbStats).toHaveBeenCalledTimes(1);
+  });
+
   it('formats markdown as a compact table plus index metadata', async () => {
     const { deps, stdout } = makeDeps();
 
@@ -201,9 +243,45 @@ describe('kb stats CLI', () => {
     expect(out).toContain('- Provider: ollama');
     expect(out).toContain('- Model: nomic-embed-text:latest');
     expect(out).toContain('- Index type: flat');
+    expect(out).toContain('- Index factory: Flat');
     expect(out).toContain('- Index path: `/tmp/kb-index`');
     expect(out).toContain('## Relevance Gate');
     expect(out).toContain('- Gated queries: 0');
+  });
+
+  it('renders dense faiss_search latency and a suggest-only ANN hint when p95 is high', () => {
+    const p = payload();
+    p.dense_search_latency = {
+      mode: 'dense',
+      stage: 'faiss_search',
+      status: 'success',
+      active_index: { type: 'flat', factory: 'Flat' },
+      sample_count: 12,
+      p50_ms: 18.2,
+      p95_ms: 76.5,
+      threshold_ms: 50,
+      since_started_at: '2026-06-12T10:00:00.000Z',
+      advisory: {
+        code: 'FLAT_SCAN_P95_ABOVE_THRESHOLD',
+        message: 'Dense flat-search p95 is 76.5ms, above the 50ms advisory threshold. Approximate/ANN indexing is not auto-enabled and is not currently a supported switch; issue #596 is blocked until a viable tunable backend lands.',
+        docs: [
+          'docs/operations/index-quantization.md#hnsw--ann-status',
+          'docs/architecture/adr/0010-hnsw-binding-evaluation.md',
+          'https://github.com/jeanibarz/knowledge-base-mcp-server/issues/596',
+        ],
+      },
+    };
+
+    const lines = formatDenseSearchLatencySection(p);
+
+    expect(lines.join('\n')).toContain('## Dense Search Latency');
+    expect(lines.join('\n')).toContain('p50=18.2 ms, p95=76.5 ms, threshold=50 ms');
+    expect(lines.join('\n')).toContain('Hint: Dense flat-search p95 is 76.5ms');
+    expect(lines.join('\n')).toContain('issue #596 is blocked');
+  });
+
+  it('omits the dense search latency section when no search timing has been observed', () => {
+    expect(formatDenseSearchLatencySection(payload())).toEqual([]);
   });
 
   it('diagnoses shelves with files but zero dense chunks in markdown stats', async () => {

--- a/src/cli-stats.ts
+++ b/src/cli-stats.ts
@@ -1,6 +1,7 @@
 import { readFileSync, realpathSync } from 'fs';
 import * as path from 'path';
 import { resolveActiveModel } from './active-model.js';
+import { tryRunDaemonCommand } from './daemon-client.js';
 import {
   classifyKbSearchError,
   exitCodeForFailure,
@@ -57,9 +58,14 @@ export interface RunStatsDeps {
     manager: FaissIndexManager,
     options: ComputeKbStatsOptions,
   ) => Promise<KbStatsPayload>;
+  tryReadDaemonStatsPayload?: () => Promise<KbStatsPayload | null>;
   readPackageVersion: () => string;
   stdout: (text: string) => void;
   stderr: (text: string) => void;
+}
+
+export interface RunStatsOptions {
+  preferDaemon?: boolean;
 }
 
 const DEFAULT_DEPS: RunStatsDeps = {
@@ -73,7 +79,11 @@ const DEFAULT_DEPS: RunStatsDeps = {
   stderr: (text) => process.stderr.write(text),
 };
 
-export async function runStats(rest: string[], deps: RunStatsDeps = DEFAULT_DEPS): Promise<number> {
+export async function runStats(
+  rest: string[],
+  deps: RunStatsDeps = DEFAULT_DEPS,
+  options: RunStatsOptions = {},
+): Promise<number> {
   let parsed: StatsArgs;
   try {
     parsed = parseStatsArgs(rest);
@@ -83,6 +93,22 @@ export async function runStats(rest: string[], deps: RunStatsDeps = DEFAULT_DEPS
   }
 
   try {
+    if (options.preferDaemon !== false) {
+      // Keep daemon probing after argument validation so invalid local CLI
+      // input still fails locally instead of being hidden by a daemon fallback.
+      const readDaemonStats = deps.tryReadDaemonStatsPayload
+        ?? (deps === DEFAULT_DEPS ? tryReadDaemonStatsPayload : async () => null);
+      const daemonStats = await readDaemonStats();
+      if (daemonStats !== null) {
+        if (parsed.format === 'json') {
+          deps.stdout(`${JSON.stringify(daemonStats, null, 2)}\n`);
+        } else {
+          deps.stdout(formatStatsMarkdown(daemonStats));
+        }
+        return 0;
+      }
+    }
+
     await deps.bootstrapLayout();
     const activeModelId = await deps.resolveActiveModel();
     const manager = await deps.loadManagerForModel(activeModelId);
@@ -107,6 +133,20 @@ export async function runStats(rest: string[], deps: RunStatsDeps = DEFAULT_DEPS
       deps.stderr(formatKbSearchFailureStderr(failure).replace(/^kb search:/, 'kb stats:'));
     }
     return exitCodeForFailure(failure);
+  }
+}
+
+export async function tryReadDaemonStatsPayload(
+  options: { timeoutMs?: number } = {},
+): Promise<KbStatsPayload | null> {
+  try {
+    const result = await tryRunDaemonCommand('stats', ['--format=json'], {
+      timeoutMs: options.timeoutMs ?? 150,
+    });
+    if (result === null || result.exitCode !== 0) return null;
+    return JSON.parse(result.stdout) as KbStatsPayload;
+  } catch {
+    return null;
   }
 }
 
@@ -160,10 +200,12 @@ export function formatStatsMarkdown(payload: KbStatsPayload): string {
     `- Model: ${payload.embedding.model}`,
     `- Dimensions: ${dim}`,
     `- Index type: ${payload.embedding.index_type ?? 'flat'}`,
+    `- Index factory: ${payload.embedding.index_factory ?? 'Flat'}`,
     `- Index path: \`${payload.index_path}\``,
     `- Server version: ${payload.server.version}`,
     `- Uptime: ${formatInteger(uptimeMs)} ms`,
     '',
+    ...formatDenseSearchLatencySection(payload),
     ...formatFilesystemSection(payload),
     ...formatDenseCoverageSection(payload),
     '## Relevance Gate',
@@ -183,6 +225,24 @@ export function formatStatsMarkdown(payload: KbStatsPayload): string {
     ...formatRemoteTransportSection(payload),
     ...formatContextualSection(payload),
   ].join('\n');
+}
+
+export function formatDenseSearchLatencySection(payload: KbStatsPayload): string[] {
+  const row = payload.dense_search_latency;
+  if (row === undefined) return [];
+  const lines = [
+    '## Dense Search Latency',
+    '',
+    `- Active index: ${row.active_index.type} (factory ${row.active_index.factory})`,
+    `- Dense faiss_search: samples=${formatInteger(row.sample_count)}, ` +
+      `p50=${row.p50_ms} ms, p95=${row.p95_ms} ms, threshold=${row.threshold_ms} ms`,
+  ];
+  if (row.advisory !== null) {
+    lines.push(`- Hint: ${row.advisory.message}`);
+    lines.push(`- Docs: ${row.advisory.docs.join(', ')}`);
+  }
+  lines.push('');
+  return lines;
 }
 
 export function formatFilesystemSection(payload: KbStatsPayload): string[] {

--- a/src/config/indexing.ts
+++ b/src/config/indexing.ts
@@ -9,6 +9,8 @@ export const DEFAULT_OLLAMA_INDEXING_BATCH_SIZE = 16;
 const MAX_INDEXING_BATCH_SIZE = 512;
 export const KB_INDEX_TYPE_ENV = 'KB_INDEX_TYPE';
 export type FaissIndexType = 'flat' | 'sq8';
+export const KB_FLAT_SEARCH_P95_ADVISORY_MS_ENV = 'KB_FLAT_SEARCH_P95_ADVISORY_MS';
+export const DEFAULT_FLAT_SEARCH_P95_ADVISORY_MS = 50;
 
 export function resolveIndexingBatchSize(
   provider: string = EMBEDDING_PROVIDER,
@@ -40,6 +42,15 @@ export function resolveFaissIndexType(
   if (normalized === undefined || normalized === '') return 'flat';
   if (normalized === 'flat' || normalized === 'sq8') return normalized;
   return 'flat';
+}
+
+export function resolveFlatSearchP95AdvisoryMs(
+  raw: string | undefined = process.env[KB_FLAT_SEARCH_P95_ADVISORY_MS_ENV],
+): number {
+  if (raw === undefined || raw.trim() === '') return DEFAULT_FLAT_SEARCH_P95_ADVISORY_MS;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_FLAT_SEARCH_P95_ADVISORY_MS;
+  return Math.floor(parsed);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -13,6 +13,7 @@ describe('config schema validation (FR-OBS-470)', () => {
       KB_RELEVANCE_GATE: 'on',
       KB_GATE_LLM_ENDPOINT: 'http://127.0.0.1:8080/v1/chat/completions',
       KB_GATE_SCORE_FLOOR: '0.75',
+      KB_FLAT_SEARCH_P95_ADVISORY_MS: '75',
       KB_AGE_BUDGET_HOURS_ALPHA: '24',
       MCP_TRANSPORT: 'http',
       MCP_AUTH_TOKEN: 'x'.repeat(32),
@@ -25,6 +26,7 @@ describe('config schema validation (FR-OBS-470)', () => {
     expect(report.findings).toEqual(expect.arrayContaining([
       expect.objectContaining({ name: 'EMBEDDING_PROVIDER', status: 'ok', value: 'fake' }),
       expect.objectContaining({ name: 'KB_AGE_BUDGET_HOURS_ALPHA', status: 'ok', value: '24' }),
+      expect.objectContaining({ name: 'KB_FLAT_SEARCH_P95_ADVISORY_MS', status: 'ok', value: '75' }),
       expect.objectContaining({ name: 'KB_RERANK_TOP_N', status: 'ok', value: '12' }),
       expect.objectContaining({ name: 'MCP_AUTH_TOKEN', status: 'ok', value: '<redacted>' }),
     ]));
@@ -36,6 +38,7 @@ describe('config schema validation (FR-OBS-470)', () => {
       KB_RERANK: 'maybe',
       KB_RERANK_TOP_N: '1001',
       KB_GATE_SCORE_FLOOR: '0.95.0',
+      KB_FLAT_SEARCH_P95_ADVISORY_MS: '0',
       KB_GATE_LLM_ENDPOINT: 'not a url',
       MCP_PORT: '70000',
     }, { source: '/tmp/bad.env' });
@@ -47,6 +50,7 @@ describe('config schema validation (FR-OBS-470)', () => {
       expect.objectContaining({ name: 'KB_RERANK', status: 'error', message: expect.stringContaining('expected boolean') }),
       expect.objectContaining({ name: 'KB_RERANK_TOP_N', status: 'error', message: expect.stringContaining('<= 1000') }),
       expect.objectContaining({ name: 'KB_GATE_SCORE_FLOOR', status: 'error', message: expect.stringContaining('number') }),
+      expect.objectContaining({ name: 'KB_FLAT_SEARCH_P95_ADVISORY_MS', status: 'error', message: expect.stringContaining('>= 1') }),
       expect.objectContaining({ name: 'KB_GATE_LLM_ENDPOINT', status: 'error', message: expect.stringContaining('URL') }),
       expect.objectContaining({ name: 'MCP_PORT', status: 'error', message: expect.stringContaining('<= 65535') }),
     ]));
@@ -174,6 +178,12 @@ describe('config schema validation (FR-OBS-470)', () => {
       expect.objectContaining({
         name: 'KB_INGEST_SECRET_SCAN',
         value: 'off',
+        source: 'default',
+        redacted: false,
+      }),
+      expect.objectContaining({
+        name: 'KB_FLAT_SEARCH_P95_ADVISORY_MS',
+        value: '50',
         source: 'default',
         redacted: false,
       }),

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -13,6 +13,7 @@ import {
   resolveKnowledgeBasesRootDir,
 } from './paths.js';
 import {
+  DEFAULT_FLAT_SEARCH_P95_ADVISORY_MS,
   defaultIndexingBatchSize,
 } from './indexing.js';
 import {
@@ -217,6 +218,7 @@ export const CONFIG_SCHEMA: readonly ConfigSpec[] = [
   { name: 'KB_LOG_VERBOSE', kind: 'boolean', default: 'off' },
   { name: 'KB_SLOW_QUERY_MS', kind: 'duration', min: 1 },
   { name: 'KB_METRICS_EXPORT', kind: 'boolean', default: 'off', booleanValues: YES_NO_BOOL_VALUES, truthyValues: YES_NO_TRUTHY_VALUES },
+  { name: 'KB_FLAT_SEARCH_P95_ADVISORY_MS', kind: 'duration', default: String(DEFAULT_FLAT_SEARCH_P95_ADVISORY_MS), min: 1 },
   { name: 'KB_MUTATION_AUDIT_LOG', kind: 'path' },
   { name: 'KB_AGE_BUDGET_HOURS', kind: 'integer', min: 1 },
 

--- a/src/kb-stats.test.ts
+++ b/src/kb-stats.test.ts
@@ -16,6 +16,7 @@ interface FakeManager {
     totalChunks: number;
     chunkCountsByKb: Record<string, number>;
     dim: number | null;
+    indexType: 'flat' | 'sq8';
   };
   getLastIndexUpdateSummary(): unknown;
 }
@@ -26,6 +27,7 @@ function makeManager(opts: {
   modelId?: string;
   chunkCountsByKb?: Record<string, number>;
   dim?: number | null;
+  indexType?: 'flat' | 'sq8';
   lastIndexUpdateSummary?: unknown;
 }): FakeManager {
   const modelId = opts.modelId ?? 'huggingface__BAAI-bge-small-en-v1.5';
@@ -37,6 +39,7 @@ function makeManager(opts: {
       totalChunks: Object.values(opts.chunkCountsByKb ?? {}).reduce((s, n) => s + n, 0),
       chunkCountsByKb: opts.chunkCountsByKb ?? {},
       dim: opts.dim ?? null,
+      indexType: opts.indexType ?? 'flat',
     }),
     getLastIndexUpdateSummary: () => opts.lastIndexUpdateSummary ?? ({
       status: 'never_run',
@@ -92,6 +95,7 @@ describe('computeKbStats', () => {
   const originalEnv = {
     KNOWLEDGE_BASES_ROOT_DIR: process.env.KNOWLEDGE_BASES_ROOT_DIR,
     FAISS_INDEX_PATH: process.env.FAISS_INDEX_PATH,
+    KB_FLAT_SEARCH_P95_ADVISORY_MS: process.env.KB_FLAT_SEARCH_P95_ADVISORY_MS,
     INGEST_EXCLUDE_PATHS: process.env.INGEST_EXCLUDE_PATHS,
     INGEST_EXTRA_EXTENSIONS: process.env.INGEST_EXTRA_EXTENSIONS,
   };
@@ -147,6 +151,8 @@ describe('computeKbStats', () => {
       provider: 'huggingface',
       model: 'BAAI/bge-small-en-v1.5',
       dim: 384,
+      index_type: 'flat',
+      index_factory: 'Flat',
     });
     expect(payload.index_path).toBe(path.join(tempDir, '.faiss'));
     expect(payload.last_index_update).toMatchObject({
@@ -417,6 +423,106 @@ describe('computeKbStats', () => {
       expect(row.tokens_in).toBe(12);
       expect(row.latency_ms.p95).toBeGreaterThanOrEqual(row.latency_ms.p50);
       expect(row.since_started_at).toBe(new Date(1_700_000_000_000).toISOString());
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('summarizes dense flat-search latency and emits an advisory above the p95 threshold (#604)', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-stats-search-latency-'));
+    try {
+      await fsp.mkdir(path.join(tempDir, 'alpha'));
+      await fsp.writeFile(path.join(tempDir, 'alpha', 'a.md'), 'a');
+
+      const { computeKbStats } = await freshKbStats({
+        KNOWLEDGE_BASES_ROOT_DIR: tempDir,
+        FAISS_INDEX_PATH: path.join(tempDir, '.faiss'),
+        KB_FLAT_SEARCH_P95_ADVISORY_MS: '50',
+      });
+      const { SearchLatencyMetrics } = await import('./metrics.js');
+      const searchMetrics = new SearchLatencyMetrics({ now: () => 1_700_000_000_000 });
+      searchMetrics.record({
+        mode: 'dense',
+        status: 'success',
+        totalMs: 125,
+        stageDurationsMs: { faiss_search: 75 },
+      });
+      searchMetrics.record({
+        mode: 'dense',
+        status: 'success',
+        totalMs: 160,
+        stageDurationsMs: { faiss_search: 125 },
+      });
+
+      const payload = await computeKbStats(makeManager({ indexType: 'flat' }) as any, {
+        serverVersion: '0.0.0',
+        startedAt: Date.now(),
+        searchMetrics,
+      });
+
+      expect(payload.embedding).toMatchObject({
+        index_type: 'flat',
+        index_factory: 'Flat',
+      });
+      expect(payload.dense_search_latency).toMatchObject({
+        mode: 'dense',
+        stage: 'faiss_search',
+        status: 'success',
+        active_index: { type: 'flat', factory: 'Flat' },
+        sample_count: 2,
+        p50_ms: 100,
+        p95_ms: 280,
+        threshold_ms: 50,
+        since_started_at: new Date(1_700_000_000_000).toISOString(),
+        advisory: {
+          code: 'FLAT_SCAN_P95_ABOVE_THRESHOLD',
+          docs: expect.arrayContaining([
+            'docs/architecture/adr/0010-hnsw-binding-evaluation.md',
+            'https://github.com/jeanibarz/knowledge-base-mcp-server/issues/596',
+          ]),
+        },
+      });
+      expect(payload.dense_search_latency?.advisory?.message).toContain('not auto-enabled');
+      expect(payload.dense_search_latency?.advisory?.message).toContain('issue #596 is blocked');
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps dense latency advisory quiet when search timing is missing or below threshold (#604)', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-stats-search-latency-quiet-'));
+    try {
+      await fsp.mkdir(path.join(tempDir, 'alpha'));
+      await fsp.writeFile(path.join(tempDir, 'alpha', 'a.md'), 'a');
+
+      const { computeKbStats } = await freshKbStats({
+        KNOWLEDGE_BASES_ROOT_DIR: tempDir,
+        FAISS_INDEX_PATH: path.join(tempDir, '.faiss'),
+        KB_FLAT_SEARCH_P95_ADVISORY_MS: '50',
+      });
+      const { SearchLatencyMetrics } = await import('./metrics.js');
+      const emptyMetrics = new SearchLatencyMetrics({ now: () => 1 });
+
+      const missing = await computeKbStats(makeManager({}) as any, {
+        serverVersion: '0.0.0',
+        startedAt: Date.now(),
+        searchMetrics: emptyMetrics,
+      });
+      expect(missing.dense_search_latency).toBeUndefined();
+
+      const lowMetrics = new SearchLatencyMetrics({ now: () => 1_700_000_000_000 });
+      lowMetrics.record({
+        mode: 'dense',
+        status: 'success',
+        totalMs: 15,
+        stageDurationsMs: { faiss_search: 12 },
+      });
+      const belowThreshold = await computeKbStats(makeManager({}) as any, {
+        serverVersion: '0.0.0',
+        startedAt: Date.now(),
+        searchMetrics: lowMetrics,
+      });
+      expect(belowThreshold.dense_search_latency?.advisory).toBeNull();
     } finally {
       await fsp.rm(tempDir, { recursive: true, force: true });
     }

--- a/src/kb-stats.ts
+++ b/src/kb-stats.ts
@@ -37,11 +37,12 @@ import {
 import { logger } from './logger.js';
 import {
   providerCallMetrics,
+  quantileFromBuckets,
   searchLatencyMetrics,
   type ProviderCallMetrics,
   type ProviderCallSnapshot,
-  type SearchLatencyMetrics,
   type SearchLatencyMetricsSnapshot,
+  type SearchLatencyMetrics,
 } from './metrics.js';
 import { countIngestQuarantine } from './ingest-quarantine.js';
 import { queryEmbeddingCache, type QueryCacheStats } from './query-cache.js';
@@ -50,7 +51,10 @@ import {
   type RelevanceGateMetricsSnapshot,
 } from './relevance-gate-metrics.js';
 import type { TransportRuntimeStatsSnapshot } from './transport-runtime-stats.js';
-import type { FaissIndexType } from './config/indexing.js';
+import {
+  resolveFlatSearchP95AdvisoryMs,
+  type FaissIndexType,
+} from './config/indexing.js';
 
 export interface KbStatsRow {
   file_count: number;
@@ -99,8 +103,15 @@ export interface KbStatsPayload {
   filesystem: {
     enumeration_failures: KbFilesystemEnumerationDiagnostics;
   };
-  embedding: { provider: string; model: string; dim: number | null; index_type?: FaissIndexType };
+  embedding: {
+    provider: string;
+    model: string;
+    dim: number | null;
+    index_type?: FaissIndexType;
+    index_factory?: string;
+  };
   index_path: string;
+  dense_search_latency?: KbStatsDenseSearchLatencySummary;
   last_index_update: IndexUpdateSummary;
   server: { version: string; uptime_ms: number };
   /**
@@ -125,6 +136,28 @@ export interface KbStatsPayload {
    * that are not serving a remote transport.
    */
   remote_transport?: TransportRuntimeStatsSnapshot;
+}
+
+export interface KbStatsDenseSearchLatencySummary {
+  mode: 'dense';
+  stage: 'faiss_search';
+  status: 'success';
+  active_index: {
+    type: FaissIndexType;
+    factory: string;
+  };
+  sample_count: number;
+  p50_ms: number;
+  p95_ms: number;
+  threshold_ms: number;
+  since_started_at: string;
+  advisory: KbStatsDenseSearchLatencyAdvisory | null;
+}
+
+export interface KbStatsDenseSearchLatencyAdvisory {
+  code: 'FLAT_SCAN_P95_ABOVE_THRESHOLD';
+  message: string;
+  docs: string[];
 }
 
 export interface ComputeKbStatsOptions {
@@ -223,6 +256,14 @@ export async function computeKbStats(
 
   const metricsSource = options.metrics ?? providerCallMetrics;
   const searchMetricsSource = options.searchMetrics ?? searchLatencyMetrics;
+  const searchMetricsSnapshot = searchMetricsSource.snapshot();
+  const activeIndexType = indexStats.indexType ?? 'flat';
+  const activeIndexFactory = indexFactoryForType(activeIndexType);
+  const denseSearchLatency = summarizeDenseSearchLatency(
+    searchMetricsSnapshot,
+    activeIndexType,
+    resolveFlatSearchP95AdvisoryMs(),
+  );
   const managerSummary = manager.getLastIndexUpdateSummary();
   const readPersistedSummary = FaissIndexManager.readPersistedIndexUpdateSummary;
   const lastIndexUpdate = managerSummary.status === 'never_run'
@@ -242,22 +283,79 @@ export async function computeKbStats(
       provider: manager.embeddingProvider,
       model: manager.modelName,
       dim: indexStats.dim,
-      index_type: indexStats.indexType,
+      index_type: activeIndexType,
+      index_factory: activeIndexFactory,
     },
     index_path: FAISS_INDEX_PATH,
+    ...(denseSearchLatency === null ? {} : { dense_search_latency: denseSearchLatency }),
     last_index_update: lastIndexUpdate,
     server: {
       version: options.serverVersion,
       uptime_ms: Date.now() - options.startedAt,
     },
     provider_calls: metricsSource.snapshot(),
-    search_latency: searchMetricsSource.snapshot(),
+    search_latency: searchMetricsSnapshot,
     query_cache: await queryEmbeddingCache.stats(),
     relevance_gate: relevanceGateMetrics.snapshot(),
     ...(options.remoteTransportStats !== undefined
       ? { remote_transport: options.remoteTransportStats }
       : {}),
   };
+}
+
+export function indexFactoryForType(indexType: FaissIndexType): string {
+  return indexType === 'sq8' ? 'SQ8' : 'Flat';
+}
+
+export function summarizeDenseSearchLatency(
+  snapshot: SearchLatencyMetricsSnapshot,
+  indexType: FaissIndexType,
+  thresholdMs: number = resolveFlatSearchP95AdvisoryMs(),
+): KbStatsDenseSearchLatencySummary | null {
+  const histogram = snapshot.stages.dense?.faiss_search?.success;
+  if (histogram === undefined || histogram.count === 0) return null;
+  const p50 = roundLatency(quantileFromBuckets(histogram.buckets, histogram.count, 0.5));
+  const p95 = roundLatency(quantileFromBuckets(histogram.buckets, histogram.count, 0.95));
+  const activeIndexFactory = indexFactoryForType(indexType);
+  return {
+    mode: 'dense',
+    stage: 'faiss_search',
+    status: 'success',
+    active_index: {
+      type: indexType,
+      factory: activeIndexFactory,
+    },
+    sample_count: histogram.count,
+    p50_ms: p50,
+    p95_ms: p95,
+    threshold_ms: thresholdMs,
+    since_started_at: histogram.since_started_at,
+    advisory: indexType === 'flat' && p95 > thresholdMs
+      ? buildFlatSearchLatencyAdvisory(p95, thresholdMs)
+      : null,
+  };
+}
+
+function buildFlatSearchLatencyAdvisory(
+  p95Ms: number,
+  thresholdMs: number,
+): KbStatsDenseSearchLatencyAdvisory {
+  return {
+    code: 'FLAT_SCAN_P95_ABOVE_THRESHOLD',
+    message:
+      `Dense flat-search p95 is ${p95Ms}ms, above the ${thresholdMs}ms advisory threshold. ` +
+      'Approximate/ANN indexing is not auto-enabled and is not currently a supported switch; ' +
+      'issue #596 is blocked until a viable tunable backend lands.',
+    docs: [
+      'docs/operations/index-quantization.md#hnsw--ann-status',
+      'docs/architecture/adr/0010-hnsw-binding-evaluation.md',
+      'https://github.com/jeanibarz/knowledge-base-mcp-server/issues/596',
+    ],
+  };
+}
+
+function roundLatency(latencyMs: number): number {
+  return Math.round(latencyMs * 10) / 10;
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes #604.

- Surface active dense index type/factory in `kb doctor` and `kb stats`.
- Add measurable dense `faiss_search` p50/p95 latency summaries for doctor/stats, including daemon-backed stats so local CLI output can see latency recorded by `kb serve`.
- Add a configurable `KB_FLAT_SEARCH_P95_ADVISORY_MS` threshold, defaulting to 50ms, that only emits a hint when flat-search p95 crosses the threshold.

## Implementation choice

This is the smallest suggest-only version after #596 was blocked. It reuses the existing search latency histograms from #597 and existing persisted `index-type.txt` metadata. The advisory never mutates configuration, never auto-enables approximate search, and never changes retrieval behavior.

When p95 crosses the threshold, the hint explicitly says ANN indexing is not currently a supported switch and points at `docs/operations/index-quantization.md#hnsw--ann-status`, ADR 0010, and issue #596.

`kb stats` first tries the resident daemon `stats --format=json` command so CLI stats can surface latency measured in the daemon process. The daemon's own stats handler disables that proxy to avoid recursion. Missing daemon, missing latency, missing index, and below-threshold latency remain quiet/non-failing.

## Alternatives considered

- Adding a real HNSW/ANN factory: rejected for this PR because #596 is blocked on the current `faiss-node` binding lacking tunable HNSW parameters.
- Auto-enabling approximate search when p95 is high: rejected because #604 asks for suggest-only behavior and current ANN backend work is not viable.
- Reporting a noisy “no latency available” warning: rejected so fresh processes and missing telemetry stay quiet.

## #596 blocker context

#596/#602/#619 found that the current `faiss-node` path cannot expose the HNSW tuning needed for a safe ANN factory (`efConstruction`/`efSearch`). This PR deliberately does not add dependencies, does not imply a working HNSW switch, and does not change the search backend.

## Verification

- `npm test -- --runTestsByPath /home/jean/git/knowledge-base-mcp-server-issue-604-doctor-stats-latency-d050ef6/src/cli-doctor.test.ts /home/jean/git/knowledge-base-mcp-server-issue-604-doctor-stats-latency-d050ef6/src/cli-stats.test.ts /home/jean/git/knowledge-base-mcp-server-issue-604-doctor-stats-latency-d050ef6/src/kb-stats.test.ts /home/jean/git/knowledge-base-mcp-server-issue-604-doctor-stats-latency-d050ef6/src/config/schema.test.ts --runInBand`
- `npm run build`
- `npm run docs:check-anchors`

## Pre-PR review

Ran Kookr reviewer specialists before opening the PR. Findings addressed:

- Added `KB_FLAT_SEARCH_P95_ADVISORY_MS` to config schema with tests.
- Added daemon-backed stats flow so doctor/stats can surface latency recorded outside the fresh CLI process.
- Added below-threshold doctor coverage and exact p50/p95 stats assertions.
