### PR TITLE
test: update stats report fixtures

### DIFF
--- a/src/KnowledgeBaseServer.test.ts
+++ b/src/KnowledgeBaseServer.test.ts
@@ -423,6 +423,8 @@ describe('KnowledgeBaseServer handlers', () => {
       provider: 'huggingface',
       model: 'BAAI/bge-small-en-v1.5',
       dim: 384,
+      index_type: 'flat',
+      index_factory: 'Flat',
     });
     expect(payload.index_path).toBe(process.env.FAISS_INDEX_PATH);
     expect(payload.last_index_update.status).toBe('never_run');

--- a/src/cli-bug-report.test.ts
+++ b/src/cli-bug-report.test.ts
@@ -15,6 +15,8 @@ function minimalDoctorReport(): DoctorReport {
       binary_path: null,
       version: null,
       mtime: null,
+      type: null,
+      factory: null,
       storage: {
         active_version_bytes: null,
         inactive_version_count: 0,
@@ -131,6 +133,7 @@ function minimalDoctorReport(): DoctorReport {
       limitation: 'test',
     },
     provider_calls: {},
+    dense_search_latency: null,
     integrity: null,
   };
 }


### PR DESCRIPTION
## Summary

Follow-up for post-merge CI drift from #627 / #604.

- Update the server stats test expectation for the new `index_type` and `index_factory` fields.
- Update the bug-report doctor fixture for the new nullable `index.type`, `index.factory`, and `dense_search_latency` fields.

## Root Cause

PR #627 merged before the Node 24 matrix test finished. The full suite then failed because two non-focused fixtures still described the pre-#604 report shape.

## Verification

- `npm run build`
- `npm test -- --runTestsByPath src/cli-bug-report.test.ts --runInBand`
- `npm test -- --runTestsByPath src/KnowledgeBaseServer.test.ts --runInBand`
- `npm test -- --runTestsByPath src/KnowledgeBaseServer.test.ts src/cli-bug-report.test.ts --runInBand`
- `git diff --check`
