### PR TITLE
feat(retrieval): degrade dense provider outages to lexical

### DIFF
--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -14,6 +14,7 @@ verify the active behavior.
 | Advanced retrieval exploration | `kb search --diverse`, `--anti-query=<text>`, `--plus=<text>`, `--minus=<text>` | off | CLI search | Implemented, opt-in | per-call flags only | `kb search "agent evidence" --diverse --format=json` |
 | Query decomposition | `kb search --mode=hybrid --decompose`, `--decompose-provider=rule\|llm`, `--decompose-max-subqueries=<n>`, `--decompose-max-iterations=<n>`, `--decompose-max-candidates=<n>`, `--decompose-timeout-ms=<n>` | off | CLI hybrid search, BEIR `hybrid+decompose` benchmark mode | Implemented, opt-in | per-call flags only; `llm` provider uses `KB_DECOMPOSE_LLM_ENDPOINT` or `KB_LLM_ENDPOINT` and falls back to `rule` | `kb search "multi hop query" --mode=hybrid --decompose --format=json` |
 | Refresh before search | `kb search --refresh` | off | CLI search | Implemented | `--refresh` | `kb search "query" --refresh --timing` |
+| Dense-provider lexical degradation | `KB_DENSE_DEGRADE_ON_PROVIDER_ERROR=on` | off | MCP `retrieve_knowledge` dense/hybrid retrieval | Implemented, opt-in | none | Stop the embedding provider, call MCP `retrieve_knowledge` with `search_mode: "hybrid"`, and confirm `structuredContent.degraded: true` plus `degrade_reason` |
 | Active embedding model | `KB_ACTIVE_MODEL` | unset, then `${FAISS_INDEX_PATH}/active.txt`, then legacy provider env | CLI and MCP retrieval | Implemented | `--model=<id>` on CLI, `model_name` on MCP `retrieve_knowledge` | `kb models list` |
 | Query embedding cache | `KB_QUERY_CACHE` | on | CLI and MCP retrieval | Implemented | `kb search --no-cache` | `kb doctor --format=json` |
 | Query cache memory limit | `KB_QUERY_CACHE_LRU_MAX` | `256` | CLI and MCP retrieval | Implemented | none | `kb doctor --format=json` |
@@ -29,6 +30,16 @@ Neighbor context windows are dense-only. They expand the returned context after
 ranking and do not make neighboring chunks influence the dense score. See
 [Neighbor Context Search Windows](search-neighbor-context.md) for examples,
 markdown/JSON output shape, and when wider windows dilute results.
+
+`KB_DENSE_DEGRADE_ON_PROVIDER_ERROR=on` is fail-open only for classified
+transient embedding-provider failures (`PROVIDER_UNAVAILABLE` and
+`PROVIDER_TIMEOUT`). It does not hide `PROVIDER_AUTH`, validation, active-model,
+or index configuration errors. A degraded MCP response is lexical-only, sets
+`structuredContent.degraded: true` with a bounded `degrade_reason`, emits the
+same fields in the canonical search event, and increments
+`kb_search_degraded_total{mode,reason}` when metrics export is enabled. Query
+embedding cache hits still return through the normal dense/hybrid path because
+no provider call failed.
 
 ## Relevance Gate
 

--- a/docs/operations/incident-response.md
+++ b/docs/operations/incident-response.md
@@ -18,7 +18,7 @@ symptom-first and links deeper procedures for the same failure modes.
 | --- | --- | --- | --- |
 | Search returns 0 results for known content | `kb logs recent --format=json` and `kb stats` | Refresh the affected KB or bypass gate/rerank to bisect | [`docs/troubleshooting-local-kb.md`](../troubleshooting-local-kb.md) |
 | FAISS write lock is busy | Search error category `lock` or code `REFRESH_LOCK_BUSY` | Wait for the writer; keep using read-only search | [`local-services.md`](local-services.md#refresh-and-reindex-discipline) |
-| Embedding provider is degraded | `kb doctor --format=json` backend row or provider error codes | Start/fix the backend, then retry | [`local-services.md`](local-services.md#daily-health-check) |
+| Embedding provider is degraded | `kb doctor --format=json` backend row, provider error codes, or `degraded: true` retrieval events | Start/fix the backend; optionally enable MCP lexical degradation during the incident | [`local-services.md`](local-services.md#daily-health-check) |
 | LLM judge is unreachable | Gate canonical event has `gate.degraded: true` | Let fail-soft retrieval continue; fix judge endpoint before changing gate defaults | [`eval-gate-harness.md`](eval-gate-harness.md) |
 | `kb serve` refuses connections | `kb serve status --json` | Start or restart only the warm CLI daemon | [`daemon-lifecycle.md`](daemon-lifecycle.md) |
 | Quarantine count is growing | `kb quarantine list --format=json` | Fix or acknowledge specific files, then retry ingest | [`ADR 0008`](../architecture/adr/0008-ingest-quarantine-jsonl-vs-sqlite.md) |
@@ -229,7 +229,21 @@ kb logs recent --limit=50 --format=json \
 ```
 
 Look for `backend.healthy: false`, `PROVIDER_UNAVAILABLE`,
-`PROVIDER_TIMEOUT`, or `PROVIDER_AUTH`.
+`PROVIDER_TIMEOUT`, or `PROVIDER_AUTH`. If
+`KB_DENSE_DEGRADE_ON_PROVIDER_ERROR=on` is enabled for the MCP server, also
+check whether searches succeeded with `degraded: true` and bounded
+`degrade_reason` values:
+
+```bash
+kb logs recent --limit=50 --format=json \
+  | jq '.events[]
+        | select(.tool == "retrieve_knowledge" and .degraded == true)
+        | {ts, request_id, process, tool, search_mode, degraded, degrade_reason, result_count}'
+```
+
+The opt-in degradation path is lexical-only and only applies to
+`PROVIDER_UNAVAILABLE` / `PROVIDER_TIMEOUT`. `PROVIDER_AUTH`, active-model,
+validation, and index errors should still fail closed.
 
 **Mitigate**
 
@@ -248,7 +262,19 @@ Look for `backend.healthy: false`, `PROVIDER_UNAVAILABLE`,
    kb search "known phrase" --k=5
    ```
 
-4. If a refresh failed mid-run, inspect `kb doctor` and `kb stats` before
+4. For MCP agents that must continue read-only retrieval while a local
+   embedding daemon is down, temporarily start the MCP server with lexical
+   degradation enabled:
+
+   ```bash
+   export KB_DENSE_DEGRADE_ON_PROVIDER_ERROR=on
+   ```
+
+   Confirm degraded responses through canonical logs or `/metrics`
+   (`kb_search_degraded_total{mode,reason}`), and remove the flag after the
+   provider is healthy.
+
+5. If a refresh failed mid-run, inspect `kb doctor` and `kb stats` before
    starting a broad refresh.
 
 **Escalate**

--- a/src/KnowledgeBaseServer.test.ts
+++ b/src/KnowledgeBaseServer.test.ts
@@ -1608,6 +1608,32 @@ describe('KnowledgeBaseServer handlers', () => {
     expect((result as any).structuredContent?.degraded).toBeUndefined();
   });
 
+  it('handleRetrieveKnowledge does not degrade hybrid retrieval when request filters are present', async () => {
+    const tempDir = await setRetrieveEnv();
+    process.env.KB_DENSE_DEGRADE_ON_PROVIDER_ERROR = 'on';
+    await fsp.mkdir(path.join(tempDir, 'alpha'), { recursive: true });
+    await fsp.writeFile(path.join(tempDir, 'alpha', 'doc.md'), 'Hybrid lexical fallback content');
+    updateIndexMock.mockResolvedValue(undefined);
+
+    const server = await freshServer();
+    const { searchLatencyMetrics } = await import('./metrics.js');
+    searchLatencyMetrics.reset();
+    const { KBError } = await import('./errors.js');
+    similaritySearchMock.mockRejectedValue(new KBError('PROVIDER_TIMEOUT', 'embedding provider timed out'));
+
+    const result = await server['handleRetrieveKnowledge']({
+      query: 'hybrid fallback',
+      knowledge_base_name: 'alpha',
+      search_mode: 'hybrid',
+      tags: ['ops'],
+    });
+
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content[0].text).error.code).toBe('PROVIDER_TIMEOUT');
+    expect((result as any).structuredContent?.degraded).toBeUndefined();
+    expect(searchLatencyMetrics.snapshot().degraded).toEqual({});
+  });
+
   it('handleRetrieveKnowledge degrades hybrid retrieval to lexical-only when opted in', async () => {
     const tempDir = await setRetrieveEnv();
     const logFile = path.join(tempDir, 'canonical.log');

--- a/src/KnowledgeBaseServer.test.ts
+++ b/src/KnowledgeBaseServer.test.ts
@@ -92,6 +92,7 @@ describe('KnowledgeBaseServer handlers', () => {
     KB_INGEST_ENABLED: process.env.KB_INGEST_ENABLED,
     INGEST_EXTRA_EXTENSIONS: process.env.INGEST_EXTRA_EXTENSIONS,
     INGEST_EXCLUDE_PATHS: process.env.INGEST_EXCLUDE_PATHS,
+    KB_DENSE_DEGRADE_ON_PROVIDER_ERROR: process.env.KB_DENSE_DEGRADE_ON_PROVIDER_ERROR,
   };
 
   beforeEach(() => {
@@ -1432,6 +1433,229 @@ describe('KnowledgeBaseServer handlers', () => {
       state: 'injected',
       input_count: 2,
       output_count: 2,
+    });
+  });
+
+  it('handleRetrieveKnowledge fails closed on provider errors by default', async () => {
+    const tempDir = await setRetrieveEnv();
+    await fsp.mkdir(path.join(tempDir, 'alpha'), { recursive: true });
+    await fsp.writeFile(path.join(tempDir, 'alpha', 'doc.md'), 'Alpha fallback content');
+    updateIndexMock.mockResolvedValue(undefined);
+
+    const server = await freshServer();
+    const { KBError } = await import('./errors.js');
+    similaritySearchMock.mockRejectedValue(new KBError('PROVIDER_UNAVAILABLE', 'embedding provider unavailable'));
+
+    const result = await server['handleRetrieveKnowledge']({
+      query: 'alpha',
+      knowledge_base_name: 'alpha',
+    });
+
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content[0].text).error.code).toBe('PROVIDER_UNAVAILABLE');
+    expect((result as any).structuredContent?.degraded).toBeUndefined();
+  });
+
+  it('handleRetrieveKnowledge degrades dense retrieval to lexical-only when opted in', async () => {
+    const tempDir = await setRetrieveEnv();
+    const logFile = path.join(tempDir, 'canonical.log');
+    process.env.KB_DENSE_DEGRADE_ON_PROVIDER_ERROR = 'on';
+    process.env.LOG_FILE = logFile;
+    process.env.KB_LOG_FORMAT = 'canonical';
+    await fsp.mkdir(path.join(tempDir, 'alpha'), { recursive: true });
+    await fsp.writeFile(path.join(tempDir, 'alpha', 'doc.md'), 'Alpha lexical fallback content');
+    await fsp.writeFile(path.join(tempDir, 'alpha', 'second.md'), 'Second alpha fallback content');
+    updateIndexMock.mockResolvedValue(undefined);
+
+    const server = await freshServer();
+    const { KBError } = await import('./errors.js');
+    similaritySearchMock.mockRejectedValue(new KBError('PROVIDER_TIMEOUT', 'embedding provider timed out'));
+
+    const result = await server['handleRetrieveKnowledge']({
+      query: 'alpha fallback',
+      knowledge_base_name: 'alpha',
+      gate: 'on',
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0].text).toContain('> _Mode: degraded lexical-only (reason: provider_timeout; original mode dense)._');
+    expect(result.content[0].text).toContain('Alpha lexical fallback content');
+    expect(result.content[0].text).toContain('Second alpha fallback content');
+    expect((result as any).structuredContent).toMatchObject({
+      degraded: true,
+      degrade_reason: 'provider_timeout',
+      gate_verdict: {
+        state: 'injected',
+        input_count: 2,
+        output_count: 2,
+      },
+    });
+    const events = (await readCanonicalEvents(logFile))
+      .filter((event) => event.tool === 'retrieve_knowledge');
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      search_mode: 'dense',
+      degraded: true,
+      degrade_reason: 'provider_timeout',
+      result_count: 2,
+    });
+    expect(events[0].error).toBeUndefined();
+  });
+
+  it('handleRetrieveKnowledge does not degrade dense retrieval when metadata filters are present', async () => {
+    const tempDir = await setRetrieveEnv();
+    process.env.KB_DENSE_DEGRADE_ON_PROVIDER_ERROR = 'on';
+    await fsp.mkdir(path.join(tempDir, 'alpha'), { recursive: true });
+    await fsp.writeFile(path.join(tempDir, 'alpha', 'doc.md'), 'Alpha fallback content');
+    updateIndexMock.mockResolvedValue(undefined);
+
+    const server = await freshServer();
+    const { KBError } = await import('./errors.js');
+    similaritySearchMock.mockRejectedValue(new KBError('PROVIDER_TIMEOUT', 'embedding provider timed out'));
+
+    const result = await server['handleRetrieveKnowledge']({
+      query: 'alpha',
+      knowledge_base_name: 'alpha',
+      extensions: ['.md'],
+    });
+
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content[0].text).error.code).toBe('PROVIDER_TIMEOUT');
+    expect((result as any).structuredContent?.degraded).toBeUndefined();
+  });
+
+  it('handleRetrieveKnowledge does not degrade provider auth errors', async () => {
+    const tempDir = await setRetrieveEnv();
+    process.env.KB_DENSE_DEGRADE_ON_PROVIDER_ERROR = 'on';
+    await fsp.mkdir(path.join(tempDir, 'alpha'), { recursive: true });
+    await fsp.writeFile(path.join(tempDir, 'alpha', 'doc.md'), 'Alpha fallback content');
+    updateIndexMock.mockResolvedValue(undefined);
+
+    const server = await freshServer();
+    const { KBError } = await import('./errors.js');
+    similaritySearchMock.mockRejectedValue(new KBError('PROVIDER_AUTH', 'missing provider credentials'));
+
+    const result = await server['handleRetrieveKnowledge']({
+      query: 'alpha',
+      knowledge_base_name: 'alpha',
+    });
+
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content[0].text).error.code).toBe('PROVIDER_AUTH');
+    expect((result as any).structuredContent?.degraded).toBeUndefined();
+  });
+
+  it('handleRetrieveKnowledge returns the provider error when no lexical leg is available', async () => {
+    await setRetrieveEnv();
+    process.env.KB_DENSE_DEGRADE_ON_PROVIDER_ERROR = 'on';
+    updateIndexMock.mockResolvedValue(undefined);
+
+    const server = await freshServer();
+    const { KBError } = await import('./errors.js');
+    similaritySearchMock.mockRejectedValue(new KBError('PROVIDER_UNAVAILABLE', 'embedding provider unavailable'));
+
+    const result = await server['handleRetrieveKnowledge']({
+      query: 'alpha',
+      knowledge_base_name: 'missing-kb',
+    });
+
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content[0].text).error.code).toBe('PROVIDER_UNAVAILABLE');
+    expect((result as any).structuredContent?.degraded).toBeUndefined();
+  });
+
+  it('handleRetrieveKnowledge returns the provider error when every lexical leg fails', async () => {
+    const tempDir = await setRetrieveEnv();
+    process.env.KB_DENSE_DEGRADE_ON_PROVIDER_ERROR = 'on';
+    await fsp.mkdir(path.join(tempDir, 'alpha'), { recursive: true });
+    await fsp.writeFile(path.join(tempDir, 'alpha', 'doc.md'), 'Alpha fallback content');
+    updateIndexMock.mockResolvedValue(undefined);
+
+    const server = await freshServer();
+    const { LexicalIndex } = await import('./lexical-index.js');
+    jest.spyOn(LexicalIndex, 'load').mockRejectedValueOnce(new Error('broken lexical index'));
+    const { KBError } = await import('./errors.js');
+    similaritySearchMock.mockRejectedValue(new KBError('PROVIDER_UNAVAILABLE', 'embedding provider unavailable'));
+
+    const result = await server['handleRetrieveKnowledge']({
+      query: 'alpha',
+      knowledge_base_name: 'alpha',
+    });
+
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content[0].text).error.code).toBe('PROVIDER_UNAVAILABLE');
+    expect((result as any).structuredContent?.degraded).toBeUndefined();
+  });
+
+  it('handleRetrieveKnowledge fails closed for hybrid provider errors by default', async () => {
+    const tempDir = await setRetrieveEnv();
+    await fsp.mkdir(path.join(tempDir, 'alpha'), { recursive: true });
+    await fsp.writeFile(path.join(tempDir, 'alpha', 'doc.md'), 'Hybrid lexical fallback content');
+    updateIndexMock.mockResolvedValue(undefined);
+
+    const server = await freshServer();
+    const { KBError } = await import('./errors.js');
+    similaritySearchMock.mockRejectedValue(new KBError('PROVIDER_UNAVAILABLE', 'embedding provider unavailable'));
+
+    const result = await server['handleRetrieveKnowledge']({
+      query: 'hybrid fallback',
+      knowledge_base_name: 'alpha',
+      search_mode: 'hybrid',
+    });
+
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content[0].text).error.code).toBe('PROVIDER_UNAVAILABLE');
+    expect((result as any).structuredContent?.degraded).toBeUndefined();
+  });
+
+  it('handleRetrieveKnowledge degrades hybrid retrieval to lexical-only when opted in', async () => {
+    const tempDir = await setRetrieveEnv();
+    const logFile = path.join(tempDir, 'canonical.log');
+    process.env.KB_DENSE_DEGRADE_ON_PROVIDER_ERROR = 'on';
+    process.env.LOG_FILE = logFile;
+    process.env.KB_LOG_FORMAT = 'canonical';
+    await fsp.mkdir(path.join(tempDir, 'alpha'), { recursive: true });
+    await fsp.writeFile(path.join(tempDir, 'alpha', 'doc.md'), 'Hybrid lexical fallback content');
+    updateIndexMock.mockResolvedValue(undefined);
+
+    const server = await freshServer();
+    const { searchLatencyMetrics } = await import('./metrics.js');
+    searchLatencyMetrics.reset();
+    const { KBError } = await import('./errors.js');
+    similaritySearchMock.mockRejectedValue(new KBError('PROVIDER_UNAVAILABLE', 'embedding provider unavailable'));
+
+    const result = await server['handleRetrieveKnowledge']({
+      query: 'hybrid fallback',
+      knowledge_base_name: 'alpha',
+      search_mode: 'hybrid',
+      gate: 'on',
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0].text).toContain(
+      '> _Mode: degraded lexical-only (reason: provider_unavailable; original mode hybrid); dense fetched 0, lexical fetched 1',
+    );
+    expect(result.content[0].text).toContain('Hybrid lexical fallback content');
+    expect((result as any).structuredContent).toMatchObject({
+      degraded: true,
+      degrade_reason: 'provider_unavailable',
+      gate_verdict: {
+        state: 'injected',
+        input_count: 1,
+        output_count: 1,
+      },
+    });
+    const events = (await readCanonicalEvents(logFile))
+      .filter((event) => event.tool === 'retrieve_knowledge');
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      search_mode: 'hybrid',
+      degraded: true,
+      degrade_reason: 'provider_unavailable',
+      result_count: 1,
+    });
+    expect(searchLatencyMetrics.snapshot().degraded).toEqual({
+      hybrid: { provider_unavailable: 1 },
     });
   });
 

--- a/src/KnowledgeBaseServer.ts
+++ b/src/KnowledgeBaseServer.ts
@@ -1119,6 +1119,7 @@ export class KnowledgeBaseServer {
         if (
           !KB_DENSE_DEGRADE_ON_PROVIDER_ERROR ||
           reason === null ||
+          hasRetrievalFilters(filters) ||
           kbs.length === 0 ||
           lexicalLegResult.failed >= kbs.length
         ) {

--- a/src/KnowledgeBaseServer.ts
+++ b/src/KnowledgeBaseServer.ts
@@ -39,6 +39,7 @@ import {
 } from './config/mcp-descriptions.js';
 import {
   FRONTMATTER_EXTRAS_WIRE_VISIBLE,
+  KB_DENSE_DEGRADE_ON_PROVIDER_ERROR,
 } from './config/retrieval.js';
 import {
   INGEST_EXCLUDE_PATHS,
@@ -111,6 +112,10 @@ import {
   type DiffIndexQuery,
 } from './diff-index-core.js';
 import {
+  classifyDenseDegradationReason,
+  type DenseDegradationReason,
+} from './search-core.js';
+import {
   applyRelevanceGate,
   emitRelevanceGateDecision,
   formatGateVerdictFooter,
@@ -168,6 +173,20 @@ function withGateVerdict<T extends CallToolResult>(
   } as T;
 }
 
+function withDegradationMetadata<T extends CallToolResult>(
+  result: T,
+  reason: DenseDegradationReason,
+): T {
+  return {
+    ...result,
+    structuredContent: {
+      ...((result as { structuredContent?: Record<string, unknown> }).structuredContent ?? {}),
+      degraded: true,
+      degrade_reason: reason,
+    },
+  } as T;
+}
+
 function resolveNeighborContextOptions(args: {
   context_before?: number;
   context_after?: number;
@@ -181,6 +200,16 @@ function resolveNeighborContextOptions(args: {
 
 function hasNeighborContext(options: NeighborContextOptions | undefined): boolean {
   return (options?.before ?? 0) > 0 || (options?.after ?? 0) > 0;
+}
+
+function hasRetrievalFilters(
+  filters: { extensions?: string[]; pathGlob?: string; tags?: string[] } | undefined,
+): boolean {
+  return filters !== undefined && (
+    (filters.extensions?.length ?? 0) > 0 ||
+    filters.pathGlob !== undefined ||
+    (filters.tags?.length ?? 0) > 0
+  );
 }
 
 function topSourcesForCanonicalLog(
@@ -782,23 +811,57 @@ export class KnowledgeBaseServer {
 
       // Perform similarity search using the provided query.
       const timing: SimilaritySearchTiming = {};
-      let similaritySearchResults = await manager.similaritySearch(
-        query,
-        10,
-        threshold,
-        knowledgeBaseName,
-        filters,
-        timing,
-      );
-      if (neighborContext) {
+      let degradedReason: DenseDegradationReason | null = null;
+      let similaritySearchResults;
+      try {
+        similaritySearchResults = await manager.similaritySearch(
+          query,
+          10,
+          threshold,
+          knowledgeBaseName,
+          filters,
+          timing,
+        );
+      } catch (error: unknown) {
+        const reason = classifyDenseDegradationReason(error);
+        if (
+          !KB_DENSE_DEGRADE_ON_PROVIDER_ERROR ||
+          reason === null ||
+          hasRetrievalFilters(filters) ||
+          hasNeighborContext(neighborContext)
+        ) {
+          throw error;
+        }
+        const degraded = await this.runDegradedLexicalOnly({
+          query,
+          knowledgeBaseName,
+          fetchK: 10,
+        });
+        if (degraded === null) throw error;
+        degradedReason = reason;
+        similaritySearchResults = degraded.results;
+        searchLatencyMetrics.recordDegraded('dense', reason);
+        if (canonical) {
+          canonical.degraded = true;
+          canonical.degrade_reason = reason;
+        }
+        logger.warn(`retrieve_knowledge dense degraded to lexical-only: ${reason}`);
+      }
+      if (neighborContext && degradedReason === null) {
         similaritySearchResults = manager.expandWithNeighborContext(
           similaritySearchResults,
           neighborContext,
         );
       }
       const denseDistanceById = new Map<string, number>();
+      const lexicalHitIds = degradedReason === null ? undefined : new Set<string>();
       for (const result of similaritySearchResults) {
-        denseDistanceById.set(chunkIdFromMetadata(result.metadata as Record<string, unknown>), result.score);
+        const id = chunkIdFromMetadata(result.metadata as Record<string, unknown>);
+        if (degradedReason === null) {
+          denseDistanceById.set(id, result.score);
+        } else {
+          lexicalHitIds?.add(id);
+        }
       }
       const gateStartedAt = Date.now();
       const gate = await applyRelevanceGate({
@@ -806,6 +869,7 @@ export class KnowledgeBaseServer {
         taskContext,
         candidates: similaritySearchResults,
         denseDistanceById,
+        lexicalHitIds,
         gateOverride,
         process: 'mcp',
       });
@@ -840,6 +904,10 @@ export class KnowledgeBaseServer {
       if (gate.verdict.state !== 'bypassed') {
         responseText = `${responseText}\n\n${formatGateVerdictFooter(gate.verdict)}`;
       }
+      if (degradedReason !== null) {
+        responseText = `> _Mode: degraded lexical-only (reason: ${degradedReason}; original mode dense)._` +
+          `\n\n${responseText}`;
+      }
       canonical.format_ms = Date.now() - formatStartedAt;
       const stageTiming: TimingPayload = {
         embed_query_ms: timing.embed_query_ms,
@@ -871,7 +939,10 @@ export class KnowledgeBaseServer {
       }
 
       const content: TextContent = { type: 'text', text: responseText };
-      return withGateVerdict({ content: [content] }, gate.verdict);
+      const response = withGateVerdict({ content: [content] }, gate.verdict);
+      return degradedReason === null
+        ? response
+        : withDegradationMetadata(response, degradedReason);
     } catch (error: unknown) {
       const err = toError(error);
       searchLatencyMetrics.record({
@@ -1003,17 +1074,23 @@ export class KnowledgeBaseServer {
 
       // Dense leg — over-fetch to give RRF room.
       const denseTiming: SimilaritySearchTiming = {};
+      let denseError: unknown = null;
       const densePromise = manager
         .similaritySearch(query, fetchK, Number.POSITIVE_INFINITY, knowledgeBaseName, filters, denseTiming)
-        .then((rs) => rs.map((r) => ({ pageContent: r.pageContent, metadata: r.metadata, score: r.score })));
+        .then((rs) => rs.map((r) => ({ pageContent: r.pageContent, metadata: r.metadata, score: r.score })))
+        .catch((err) => {
+          denseError = err;
+          return [];
+        });
 
       // Lexical leg — BM25 over the same chunks the FAISS path embeds, but
       // managed independently (the lexical index is model-agnostic and lives
       // under `${FAISS_INDEX_PATH}/lexical/<kb>/`). Auto-refresh on first use
       // per KB; explicit refresh is the CLI's job (`kb search --refresh`).
+      const allKbNames = await listKnowledgeBases(KNOWLEDGE_BASES_ROOT_DIR);
       const kbNames = knowledgeBaseName
-        ? [knowledgeBaseName]
-        : await listKnowledgeBases(KNOWLEDGE_BASES_ROOT_DIR);
+        ? allKbNames.filter((name) => name === knowledgeBaseName)
+        : allKbNames;
       const kbs = kbNames.map((kbName) => ({ kbName, kbPath: path.join(KNOWLEDGE_BASES_ROOT_DIR, kbName) }));
       let lexicalSearchMs = 0;
       const lexicalStartedAt = Date.now();
@@ -1027,22 +1104,48 @@ export class KnowledgeBaseServer {
         },
       }).then((res) => {
         lexicalSearchMs = Date.now() - lexicalStartedAt;
-        return res.hits;
+        return res;
       });
 
-      const [denseResults, lexicalResults] = await Promise.all([densePromise, lexicalPromise]);
+      const [denseResults, lexicalLegResult] = await Promise.all([densePromise, lexicalPromise]);
+      const lexicalResults = lexicalLegResult.hits;
       if (canonical) {
         canonical.embed_ms = denseTiming.embed_query_ms;
         canonical.faiss_ms = denseTiming.faiss_search_ms ?? denseTiming.query_search_ms;
       }
+      let degradedReason: DenseDegradationReason | null = null;
+      if (denseError !== null) {
+        const reason = classifyDenseDegradationReason(denseError);
+        if (
+          !KB_DENSE_DEGRADE_ON_PROVIDER_ERROR ||
+          reason === null ||
+          kbs.length === 0 ||
+          lexicalLegResult.failed >= kbs.length
+        ) {
+          throw denseError;
+        }
+        degradedReason = reason;
+        searchLatencyMetrics.recordDegraded('hybrid', reason);
+        if (canonical) {
+          canonical.degraded = true;
+          canonical.degrade_reason = reason;
+        }
+        logger.warn(`retrieve_knowledge hybrid degraded to lexical-only: ${reason}`);
+      }
 
       const rerankConfig = resolveRerankerConfig(process.env, rerankOverride, knowledgeBaseName ?? null);
       const fusionStartedAt = Date.now();
-      const fusion = fuseHybridResultsWithDiagnostics({
-        denseResults,
-        lexicalResults,
-        k: rerankConfig.enabled ? Math.max(HYBRID_TOP_K, rerankConfig.topN) : HYBRID_TOP_K,
-      });
+      const fusion = degradedReason === null
+        ? fuseHybridResultsWithDiagnostics({
+            denseResults,
+            lexicalResults,
+            k: rerankConfig.enabled ? Math.max(HYBRID_TOP_K, rerankConfig.topN) : HYBRID_TOP_K,
+          })
+        : {
+            results: lexicalResults.slice(0, rerankConfig.enabled ? Math.max(HYBRID_TOP_K, rerankConfig.topN) : HYBRID_TOP_K),
+            denseDistanceById: new Map<string, number>(),
+            lexicalHitIds: new Set(lexicalResults.map((r) => chunkIdFromMetadata(r.metadata))),
+          };
       const fusionMs = Date.now() - fusionStartedAt;
       let ranked = fusion.results;
       const rerankStartedAt = Date.now();
@@ -1112,13 +1215,19 @@ export class KnowledgeBaseServer {
       const rerankHeader = rerankResult.candidatesIn > 0
         ? `; rerank ${rerankResult.model}${rerankResult.degraded ? ' degraded' : ''}`
         : '';
-      const header = `> _Mode: hybrid (RRF c=${HYBRID_RRF_C}); dense fetched ${denseResults.length}, lexical fetched ${lexicalResults.length}${rerankHeader} (#206 stage 2)._`;
+      const modeHeader = degradedReason === null
+        ? `hybrid (RRF c=${HYBRID_RRF_C})`
+        : `degraded lexical-only (reason: ${degradedReason}; original mode hybrid)`;
+      const header = `> _Mode: ${modeHeader}; dense fetched ${denseResults.length}, lexical fetched ${lexicalResults.length}${rerankHeader} (#206 stage 2)._`;
       responseText = modelNameOverride !== undefined
         ? `> _Model: ${activeModelId}_\n${header}\n\n${responseText}`
         : `${header}\n\n${responseText}`;
 
       const content: TextContent = { type: 'text', text: responseText };
-      return withGateVerdict({ content: [content] }, gate.verdict);
+      const response = withGateVerdict({ content: [content] }, gate.verdict);
+      return degradedReason === null
+        ? response
+        : withDegradationMetadata(response, degradedReason);
     } catch (error: unknown) {
       const err = toError(error);
       searchLatencyMetrics.record({
@@ -1130,6 +1239,33 @@ export class KnowledgeBaseServer {
       if (err.stack) logger.error(err.stack);
       return { content: [mcpErrorContent(err)], isError: true };
     }
+  }
+
+  private async runDegradedLexicalOnly(input: {
+    query: string;
+    knowledgeBaseName?: string;
+    fetchK: number;
+  }): Promise<{ results: Array<{ pageContent: string; metadata: Record<string, unknown>; score: number }> } | null> {
+    const allKbNames = await listKnowledgeBases(KNOWLEDGE_BASES_ROOT_DIR);
+    const kbNames = input.knowledgeBaseName
+      ? allKbNames.filter((name) => name === input.knowledgeBaseName)
+      : allKbNames;
+    if (kbNames.length === 0) return null;
+    const kbs = kbNames.map((kbName) => ({
+      kbName,
+      kbPath: path.join(KNOWLEDGE_BASES_ROOT_DIR, kbName),
+    }));
+    const row = await runLexicalLeg({
+      kbs,
+      query: input.query,
+      fetchK: input.fetchK,
+      refresh: 'when-empty',
+      onError: (kbName, err) => {
+        logger.warn(`degraded lexical-only: lexical leg failed for KB "${kbName}": ${err.message}`);
+      },
+    });
+    if (row.failed >= kbs.length) return null;
+    return { results: row.hits };
   }
 
   async run() {

--- a/src/canonical-log.test.ts
+++ b/src/canonical-log.test.ts
@@ -48,6 +48,9 @@ describe('canonical log line schema (#216)', () => {
         model_id: 'fake__model',
         elapsed_ms: 1,
       },
+      error: { code: 'PROVIDER_TIMEOUT', category: 'provider' },
+      degraded: true,
+      degrade_reason: 'provider_timeout',
     });
 
     const json = stableCanonicalJson(event);
@@ -66,10 +69,15 @@ describe('canonical log line schema (#216)', () => {
         model_id: 'fake__model',
         elapsed_ms: 1,
       },
+      error: { code: 'PROVIDER_TIMEOUT', category: 'provider' },
+      degraded: true,
+      degrade_reason: 'provider_timeout',
     });
     expect(json.indexOf('"schema_version"')).toBeLessThan(json.indexOf('"request_id"'));
     expect(json.indexOf('"top_sources"')).toBeLessThan(json.indexOf('"took_ms"'));
     expect(json.indexOf('"cache"')).toBeLessThan(json.indexOf('"query_cache"'));
+    expect(json.indexOf('"error"')).toBeLessThan(json.indexOf('"degraded"'));
+    expect(json.indexOf('"degraded"')).toBeLessThan(json.indexOf('"degrade_reason"'));
   });
 
   it('extracts error code and category from MCP tool error payloads', () => {

--- a/src/canonical-log.ts
+++ b/src/canonical-log.ts
@@ -4,6 +4,7 @@ import { KBError, type KBErrorCode } from './errors.js';
 import { ActiveModelResolutionError } from './active-model.js';
 import type { QueryCacheOutcome, QueryCacheTelemetry } from './query-cache.js';
 import { readKBSlowQueryMs } from './config/logging.js';
+import type { DenseDegradationReason } from './search-core.js';
 
 export const CANONICAL_SCHEMA_VERSION = 'kb-canonical.v1';
 
@@ -57,6 +58,8 @@ export interface CanonicalLogEvent {
   cache?: CanonicalCacheStatus;
   query_cache?: QueryCacheTelemetry;
   error?: CanonicalError;
+  degraded?: true;
+  degrade_reason?: DenseDegradationReason;
   recovery_hint?: string;
   rerank?: Record<string, unknown>;
   gate?: Record<string, unknown>;
@@ -101,6 +104,8 @@ const CANONICAL_FIELD_ORDER: readonly (keyof CanonicalLogEvent)[] = [
   'cache',
   'query_cache',
   'error',
+  'degraded',
+  'degrade_reason',
   'recovery_hint',
   'rerank',
   'gate',
@@ -155,6 +160,8 @@ export function normalizeCanonicalEvent(input: CanonicalLogInput): CanonicalLogE
   assignIfDefined(event, 'cache', input.cache);
   assignIfDefined(event, 'query_cache', input.query_cache);
   assignIfDefined(event, 'error', input.error);
+  assignIfDefined(event, 'degraded', input.degraded);
+  assignIfDefined(event, 'degrade_reason', input.degrade_reason);
   assignIfDefined(event, 'recovery_hint', input.recovery_hint);
   assignIfDefined(event, 'rerank', input.rerank);
   assignIfDefined(event, 'gate', input.gate);

--- a/src/cli-research.test.ts
+++ b/src/cli-research.test.ts
@@ -85,6 +85,7 @@ function statsPayload(overrides: Partial<KbStatsPayload> = {}): KbStatsPayload {
     search_latency: {
       requests: {},
       stages: {},
+      degraded: {},
     },
     query_cache: {
       hits: 0,

--- a/src/cli-serve.test.ts
+++ b/src/cli-serve.test.ts
@@ -248,6 +248,7 @@ describe('kb serve metrics formatting', () => {
       search_latency: {
         requests: {},
         stages: {},
+        degraded: {},
       },
       query_cache: {
         hits: 0,

--- a/src/cli-stats.test.ts
+++ b/src/cli-stats.test.ts
@@ -75,6 +75,7 @@ function payload(): KbStatsPayload {
     search_latency: {
       requests: {},
       stages: {},
+      degraded: {},
     },
     query_cache: {
       hits: 0,

--- a/src/config/retrieval.ts
+++ b/src/config/retrieval.ts
@@ -25,3 +25,19 @@ export function parseKBEditorUri(raw: string | undefined): KBEditorUriMode {
 }
 
 export const KB_EDITOR_URI: KBEditorUriMode = parseKBEditorUri(process.env.KB_EDITOR_URI);
+
+// ---------------------------------------------------------------------------
+// Dense-provider degradation (#595).
+// ---------------------------------------------------------------------------
+
+export function parseDenseDegradeOnProviderError(raw: string | undefined): boolean {
+  return raw?.trim().toLowerCase() === 'on';
+}
+
+/**
+ * Off by default: dense and hybrid retrieval fail closed unless the operator
+ * explicitly accepts lexical-only degradation during transient provider
+ * outages.
+ */
+export const KB_DENSE_DEGRADE_ON_PROVIDER_ERROR: boolean =
+  parseDenseDegradeOnProviderError(process.env.KB_DENSE_DEGRADE_ON_PROVIDER_ERROR);

--- a/src/metrics.test.ts
+++ b/src/metrics.test.ts
@@ -175,14 +175,28 @@ describe('SearchLatencyMetrics', () => {
     expect(snap.stages.hybrid?.lexical_search?.success).toMatchObject({ count: 1, sum_ms: 40 });
     expect(snap.stages.hybrid?.fusion?.success).toMatchObject({ count: 1, sum_ms: 3 });
     expect(snap.stages.hybrid?.fusion?.error).toBeUndefined();
+    expect(snap.degraded).toEqual({});
+  });
+
+  it('records degraded search counters by bounded mode and reason labels', () => {
+    const metrics = new SearchLatencyMetrics({ now: () => 1 });
+    metrics.recordDegraded('dense', 'provider_timeout');
+    metrics.recordDegraded('dense', 'provider_timeout');
+    metrics.recordDegraded('hybrid', 'provider_unavailable');
+
+    expect(metrics.snapshot().degraded).toEqual({
+      dense: { provider_timeout: 2 },
+      hybrid: { provider_unavailable: 1 },
+    });
   });
 
   it('reset() clears search latency state', () => {
     const metrics = new SearchLatencyMetrics({ now: () => 1 });
     metrics.record({ mode: 'dense', status: 'success', totalMs: 1 });
+    metrics.recordDegraded('dense', 'provider_timeout');
     expect(metrics.snapshot().requests.dense?.success?.count).toBe(1);
     metrics.reset();
-    expect(metrics.snapshot()).toEqual({ requests: {}, stages: {} });
+    expect(metrics.snapshot()).toEqual({ requests: {}, stages: {}, degraded: {} });
   });
 });
 

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -9,6 +9,7 @@
 // runtime histograms live on the existing `kb_stats` MCP tool surface.
 
 import type { SearchLatencyStage } from './timing-core.js';
+import type { DenseDegradationReason } from './search-core.js';
 
 /**
  * Fixed log-spaced latency bucket upper bounds, in milliseconds. 10 bucket
@@ -86,6 +87,7 @@ export interface SearchLatencyMetricsSnapshot {
     SearchLatencyMode,
     Partial<Record<SearchLatencyStage, Partial<Record<SearchLatencyStatus, LatencyHistogramSnapshot>>>>
   >>;
+  degraded: Partial<Record<SearchLatencyMode, Partial<Record<DenseDegradationReason, number>>>>;
 }
 
 function emptyState(now: number): MetricsState {
@@ -265,6 +267,7 @@ export class ProviderCallMetrics {
 export class SearchLatencyMetrics {
   private readonly requestStates = new Map<string, HistogramState>();
   private readonly stageStates = new Map<string, HistogramState>();
+  private readonly degradedCounts = new Map<string, number>();
   private readonly now: () => number;
 
   constructor(options: { now?: () => number } = {}) {
@@ -280,6 +283,11 @@ export class SearchLatencyMetrics {
       const stageState = this.getStageState(sample.mode, stage, sample.status);
       recordHistogramSample(stageState, value);
     }
+  }
+
+  recordDegraded(mode: SearchLatencyMode, reason: DenseDegradationReason): void {
+    const key = `${mode}|${reason}`;
+    this.degradedCounts.set(key, (this.degradedCounts.get(key) ?? 0) + 1);
   }
 
   snapshot(): SearchLatencyMetricsSnapshot {
@@ -298,12 +306,20 @@ export class SearchLatencyMetrics {
       stages[mode]![stage]![status] = snapshotHistogram(state);
     }
 
-    return { requests, stages };
+    const degraded: SearchLatencyMetricsSnapshot['degraded'] = {};
+    for (const [key, count] of this.degradedCounts.entries()) {
+      const [mode, reason] = key.split('|') as [SearchLatencyMode, DenseDegradationReason];
+      degraded[mode] ??= {};
+      degraded[mode]![reason] = count;
+    }
+
+    return { requests, stages, degraded };
   }
 
   reset(): void {
     this.requestStates.clear();
     this.stageStates.clear();
+    this.degradedCounts.clear();
   }
 
   private getRequestState(mode: SearchLatencyMode, status: SearchLatencyStatus): HistogramState {

--- a/src/prometheus-export.test.ts
+++ b/src/prometheus-export.test.ts
@@ -24,6 +24,7 @@ describe('formatKbStatsOpenMetrics', () => {
     expect(text).toContain('kb_search_request_duration_ms_bucket{le="+Inf",mode="dense",status="success"} 1');
     expect(text).toContain('kb_search_request_duration_ms_sum{mode="dense",status="success"} 80');
     expect(text).toContain('kb_search_request_duration_ms_count{mode="dense",status="success"} 1');
+    expect(text).toContain('kb_search_degraded_total{mode="hybrid",reason="provider_timeout"} 2');
     expect(text).toContain('# TYPE kb_search_stage_duration_ms histogram');
     expect(text).toContain('kb_search_stage_duration_ms_bucket{le="30",mode="dense",stage="embed_query",status="success"} 1');
     expect(text).toContain('kb_search_stage_duration_ms_sum{mode="dense",stage="embed_query",status="success"} 12');
@@ -115,6 +116,11 @@ function samplePayload(): KbStatsPayload {
           embed_query: {
             success: histogramSnapshot(12),
           },
+        },
+      },
+      degraded: {
+        hybrid: {
+          provider_timeout: 2,
         },
       },
     },

--- a/src/prometheus-export.ts
+++ b/src/prometheus-export.ts
@@ -111,6 +111,7 @@ export function formatKbStatsOpenMetrics(payload: KbStatsPayload): string {
     },
     ...providerLatencyMetrics(payload),
     ...searchLatencyCounterMetrics(payload.search_latency),
+    ...searchDegradedCounterMetrics(payload.search_latency),
     {
       name: 'kb_query_cache_hits_total',
       help: 'Query embedding cache hits.',
@@ -300,6 +301,25 @@ function searchLatencyCounterMetrics(snapshot: SearchLatencyMetricsSnapshot): Me
   return [{
     name: 'kb_search_requests_total',
     help: 'Daemon-served search requests by effective mode and status.',
+    type: 'counter',
+    samples,
+  }];
+}
+
+function searchDegradedCounterMetrics(snapshot: SearchLatencyMetricsSnapshot): MetricDefinition[] {
+  const samples: MetricSample[] = [];
+  for (const [mode, byReason] of Object.entries(snapshot.degraded)) {
+    for (const [reason, count] of Object.entries(byReason ?? {})) {
+      samples.push({
+        name: 'kb_search_degraded_total',
+        labels: { mode, reason },
+        value: count,
+      });
+    }
+  }
+  return [{
+    name: 'kb_search_degraded_total',
+    help: 'Search requests degraded from dense-provider retrieval to lexical-only output by bounded reason.',
     type: 'counter',
     samples,
   }];

--- a/src/search-core.test.ts
+++ b/src/search-core.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from '@jest/globals';
 import {
   buildExplainEmptyDiagnostics,
+  classifyDenseDegradationReason,
   computeAutoThreshold,
   formatAutoModeHeader,
   formatAutoThresholdHeader,
@@ -11,6 +12,8 @@ import {
   type ExplainEmptyDiagnostics,
   type Staleness,
 } from './search-core.js';
+import { parseDenseDegradeOnProviderError } from './config/retrieval.js';
+import { KBError } from './errors.js';
 
 const MTIME = '2026-05-03T15:33:56.964Z';
 
@@ -240,6 +243,26 @@ describe('formatAutoModeHeader', () => {
     expect(formatAutoModeHeader({ mode: 'hybrid', reason: 'file-like token' })).toBe(
       '> _Mode: auto -> hybrid (file-like token)._',
     );
+  });
+});
+
+describe('dense provider degradation policy (#595)', () => {
+  it('keeps the feature flag opt-in', () => {
+    expect(parseDenseDegradeOnProviderError(undefined)).toBe(false);
+    expect(parseDenseDegradeOnProviderError('')).toBe(false);
+    expect(parseDenseDegradeOnProviderError('true')).toBe(false);
+    expect(parseDenseDegradeOnProviderError(' on ')).toBe(true);
+    expect(parseDenseDegradeOnProviderError('ON')).toBe(true);
+  });
+
+  it('classifies only transient provider errors as degradable', () => {
+    expect(classifyDenseDegradationReason(new KBError('PROVIDER_UNAVAILABLE', 'provider down')))
+      .toBe('provider_unavailable');
+    expect(classifyDenseDegradationReason(new KBError('PROVIDER_TIMEOUT', 'provider timed out')))
+      .toBe('provider_timeout');
+    expect(classifyDenseDegradationReason(new KBError('PROVIDER_AUTH', 'missing key')))
+      .toBeNull();
+    expect(classifyDenseDegradationReason(new Error('ECONNREFUSED'))).toBeNull();
   });
 });
 

--- a/src/search-core.ts
+++ b/src/search-core.ts
@@ -24,6 +24,7 @@ import {
   listKnowledgeBases,
   type KbFilesystemEnumerationFailure,
 } from './kb-fs.js';
+import { KBError } from './errors.js';
 
 // -- Search mode -------------------------------------------------------------
 
@@ -56,6 +57,22 @@ export function resolveAutoSearchMode(query: string): AutoSearchModeDecision {
 
 export function formatAutoModeHeader(decision: AutoSearchModeDecision): string {
   return `> _Mode: auto -> ${decision.mode} (${decision.reason})._`;
+}
+
+// -- Dense-provider degradation ---------------------------------------------
+
+export type DenseDegradationReason = 'provider_unavailable' | 'provider_timeout';
+
+export function classifyDenseDegradationReason(error: unknown): DenseDegradationReason | null {
+  if (!(error instanceof KBError)) return null;
+  switch (error.code) {
+    case 'PROVIDER_UNAVAILABLE':
+      return 'provider_unavailable';
+    case 'PROVIDER_TIMEOUT':
+      return 'provider_timeout';
+    default:
+      return null;
+  }
 }
 
 // -- Auto-threshold (knee detection) -----------------------------------------


### PR DESCRIPTION
## Summary

Closes #595.

Adds opt-in MCP retrieval degradation for `KB_DENSE_DEGRADE_ON_PROVIDER_ERROR=on`. When `retrieve_knowledge` dense or hybrid search hits a classified transient embedding-provider failure, the handler retries lexical-only if a registered lexical KB can be searched and marks the response as degraded.

## Implementation Choice

- Added a bounded degradation classifier for `PROVIDER_UNAVAILABLE` and `PROVIDER_TIMEOUT` only.
- Kept the flag off by default through `KB_DENSE_DEGRADE_ON_PROVIDER_ERROR=on` parsing in retrieval config.
- Wired MCP `retrieve_knowledge` dense and hybrid paths because they are the primary agent-facing surfaces for this issue.
- Degraded responses include `structuredContent.degraded: true` and `degrade_reason`, canonical log `degraded` / `degrade_reason`, and `kb_search_degraded_total{mode,reason}` metrics.
- During degraded lexical-only output, relevance gate input uses no dense-distance map and passes lexical hit ids, so gate/rerank code does not treat BM25 scores as dense distances.

## Alternatives Considered

- Broadly refactoring CLI, eval, and MCP dense-leg invocation into one shared fallback pipeline. I avoided that because `hybrid-retrieval.ts` deliberately keeps dense calls adapter-owned, and the issue asked for the smallest implementation across primary tested surfaces.
- Degrading filtered dense or hybrid requests. I kept those fail-closed because the current lexical leg does not apply `extensions`, `path_glob`, or `tags` filters, so fallback could otherwise return content the caller excluded.
- Treating raw network errors like `ECONNREFUSED` as degradable. I kept degradation limited to existing classified `KBError` provider codes so auth/config errors and unknown failures stay visible.

## Limitations

- This PR implements degradation for MCP `retrieve_knowledge` dense and hybrid retrieval. CLI search remains fail-closed and should use explicit `--mode=lexical` as the manual workaround.
- Configuration/auth errors such as `PROVIDER_AUTH`, active-model resolution failures, validation errors, index errors, neighbor-context dense requests, and filtered dense or hybrid requests do not degrade.
- Query embedding cache hits may avoid provider access; degradation only triggers when the dense provider call actually fails.
- If no registered lexical KB is available or every lexical leg fails, the original classified provider error is returned.

## Verification

- `npm test -- --runTestsByPath /home/jean/git/knowledge-base-mcp-server-issue-595-dense-lexical-degrade-d050ef6/src/search-core.test.ts /home/jean/git/knowledge-base-mcp-server-issue-595-dense-lexical-degrade-d050ef6/src/canonical-log.test.ts /home/jean/git/knowledge-base-mcp-server-issue-595-dense-lexical-degrade-d050ef6/src/prometheus-export.test.ts /home/jean/git/knowledge-base-mcp-server-issue-595-dense-lexical-degrade-d050ef6/src/KnowledgeBaseServer.test.ts /home/jean/git/knowledge-base-mcp-server-issue-595-dense-lexical-degrade-d050ef6/src/metrics.test.ts --runInBand`
- `npm run build`
- `npm run docs:check-anchors`

## Review Notes

Pre-PR specialist review ran for conventions, correctness/design, dead-code, and test-quality. Blocking findings around dense filtered fallback and BM25 scores being misused as dense distances were fixed before opening this PR. Supervisor follow-up for filtered hybrid fallback is fixed in `39ffa85`; hybrid degradation now fails closed when request filters are present.