### PR TITLE
Add shared test corpus builder

### DIFF
--- a/docs/testing/INDEX.md
+++ b/docs/testing/INDEX.md
@@ -35,6 +35,25 @@ The serial project is the explicit escape hatch for suites with shared process, 
 
 New tests should stay in the parallel project unless they require one of those shared resources. Add a test to the serial project by listing its path in `jest.config.js` and documenting the reason in this section.
 
+## Test Corpus Builder
+
+Use `createTestCorpus` from `src/test-support/corpus.ts` for tests that need a temporary knowledge-base root with Markdown files. Pass a relative-path-to-content map and call `cleanup()` in `finally`:
+
+```ts
+const corpus = await createTestCorpus({
+  files: {
+    'ops/note.md': '# Note\n',
+  },
+});
+try {
+  // Use corpus.rootDir or corpus.pathFor('ops/note.md').
+} finally {
+  await corpus.cleanup();
+}
+```
+
+Keep this helper limited to temp directory scaffolding, file writes, path lookup, and cleanup. Test-specific fakes for embeddings, indexes, process env, or CLI wiring should remain local to the tests that need them.
+
 ## Indexing
 
 ### TS-INDEX-358: Default Text-First Ingest Filter

--- a/src/cli-stale-check.test.ts
+++ b/src/cli-stale-check.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from '@jest/globals';
 import * as fsp from 'fs/promises';
 import * as os from 'os';
 import * as path from 'path';
+import { createTestCorpus } from './test-support/corpus.js';
 import {
   extractReferences,
   formatReport,
@@ -80,24 +81,20 @@ describe('staleCheck (filesystem + injected url checker)', () => {
   }
 
   it('flags MISSING tilde paths, OK url, MISSING relative path', async () => {
-    const { rootDir, cleanup } = await makeKb('kb-stale-fs-');
-    try {
-      const kbDir = path.join(rootDir, 'ops');
-      await fsp.mkdir(kbDir, { recursive: true });
-      const notePath = path.join(kbDir, 'note.md');
-      await fsp.writeFile(
-        notePath,
-        [
+    const corpus = await createTestCorpus({
+      prefix: 'kb-stale-fs-',
+      files: {
+        'ops/note.md': [
           'Active: ~/this-path-should-not-exist-stale-check-test',
           'See https://example.com/ok',
           '[broken](missing.md)',
         ].join('\n') + '\n',
-        'utf-8',
-      );
-
+      },
+    });
+    try {
       const checker: UrlChecker = async () => ({ status: 'OK' });
       const report = await staleCheck({
-        rootDir,
+        rootDir: corpus.rootDir,
         cachePath: null,
         urlChecker: checker,
       });
@@ -109,7 +106,7 @@ describe('staleCheck (filesystem + injected url checker)', () => {
       const types = stale.map((r) => r.type).sort();
       expect(types).toEqual(['rel-path', 'tilde-path']);
     } finally {
-      await cleanup();
+      await corpus.cleanup();
     }
   });
 

--- a/src/cli-superseded.test.ts
+++ b/src/cli-superseded.test.ts
@@ -1,7 +1,5 @@
 import { describe, expect, it } from '@jest/globals';
-import * as fsp from 'fs/promises';
-import * as os from 'os';
-import * as path from 'path';
+import { createTestCorpus } from './test-support/corpus.js';
 import {
   formatSupersededJson,
   formatSupersededMarkdown,
@@ -41,63 +39,44 @@ describe('parseSupersededArgs', () => {
 
 describe('supersededCheck', () => {
   async function makeKb(): Promise<{ rootDir: string; cleanup: () => Promise<void> }> {
-    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-superseded-'));
-    const rootDir = path.join(tempDir, 'kbs');
-    const kbDir = path.join(rootDir, 'ops');
-    await fsp.mkdir(path.join(kbDir, 'patterns'), { recursive: true });
-    await fsp.writeFile(
-      path.join(kbDir, 'patterns', 'old-low.md'),
-      [
-        '---',
-        'status: active',
-        'confidence: 0.2',
-        'last_verified_at: 2025-01-01',
-        '---',
-        '# Old Low Confidence',
-        '',
-        'Old agent memory that may have been replaced.',
-      ].join('\n') + '\n',
-      'utf-8',
-    );
-    await fsp.writeFile(
-      path.join(kbDir, 'patterns', 'current.md'),
-      [
-        '---',
-        'status: active',
-        'confidence: 0.9',
-        'last_verified_at: 2026-05-01',
-        '---',
-        '# Current',
-        '',
-        'Newer replacement note.',
-      ].join('\n') + '\n',
-      'utf-8',
-    );
-    await fsp.writeFile(
-      path.join(kbDir, 'contradicted.md'),
-      [
-        '---',
-        'contradicted_by:',
-        '  - patterns/current.md',
-        '---',
-        '# Contradicted',
-      ].join('\n') + '\n',
-      'utf-8',
-    );
-    await fsp.writeFile(
-      path.join(kbDir, 'archived.md'),
-      [
-        '---',
-        'review_status: archived',
-        '---',
-        '# Archived',
-      ].join('\n') + '\n',
-      'utf-8',
-    );
-    return {
-      rootDir,
-      cleanup: async () => fsp.rm(tempDir, { recursive: true, force: true }),
-    };
+    return createTestCorpus({
+      prefix: 'kb-superseded-',
+      files: {
+        'ops/patterns/old-low.md': [
+          '---',
+          'status: active',
+          'confidence: 0.2',
+          'last_verified_at: 2025-01-01',
+          '---',
+          '# Old Low Confidence',
+          '',
+          'Old agent memory that may have been replaced.',
+        ].join('\n') + '\n',
+        'ops/patterns/current.md': [
+          '---',
+          'status: active',
+          'confidence: 0.9',
+          'last_verified_at: 2026-05-01',
+          '---',
+          '# Current',
+          '',
+          'Newer replacement note.',
+        ].join('\n') + '\n',
+        'ops/contradicted.md': [
+          '---',
+          'contradicted_by:',
+          '  - patterns/current.md',
+          '---',
+          '# Contradicted',
+        ].join('\n') + '\n',
+        'ops/archived.md': [
+          '---',
+          'review_status: archived',
+          '---',
+          '# Archived',
+        ].join('\n') + '\n',
+      },
+    });
   }
 
   it('flags lifecycle metadata and conservative same-KB semantic neighbors', async () => {

--- a/src/test-support/corpus.test.ts
+++ b/src/test-support/corpus.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from '@jest/globals';
+import * as fsp from 'fs/promises';
+import * as path from 'path';
+import { createTestCorpus } from './corpus.js';
+
+describe('createTestCorpus', () => {
+  it('writes nested files under an isolated KB root and cleans them up', async () => {
+    const corpus = await createTestCorpus({
+      prefix: 'kb-corpus-test-',
+      files: {
+        'ops/note.md': 'hello\n',
+        'ops/deep/second.md': 'world\n',
+      },
+    });
+
+    try {
+      await expect(fsp.readFile(corpus.pathFor('ops/note.md'), 'utf-8')).resolves.toBe('hello\n');
+      await expect(fsp.readFile(corpus.pathFor('ops/deep/second.md'), 'utf-8')).resolves.toBe('world\n');
+      expect(path.basename(corpus.rootDir)).toBe('kbs');
+      expect(path.dirname(corpus.rootDir)).toBe(corpus.tempDir);
+    } finally {
+      await corpus.cleanup();
+    }
+
+    await expect(fsp.stat(corpus.tempDir)).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('supports explicit writes after setup', async () => {
+    const corpus = await createTestCorpus({ prefix: 'kb-corpus-test-' });
+
+    try {
+      const filePath = await corpus.writeFile('ops/new.md', 'new note\n');
+      expect(filePath).toBe(corpus.pathFor('ops/new.md'));
+      await expect(fsp.readFile(filePath, 'utf-8')).resolves.toBe('new note\n');
+    } finally {
+      await corpus.cleanup();
+    }
+  });
+
+  it('rejects paths that escape the corpus root', async () => {
+    await expect(createTestCorpus({
+      prefix: 'kb-corpus-test-',
+      files: {
+        '../outside.md': 'nope\n',
+      },
+    })).rejects.toThrow('escapes the root');
+  });
+});

--- a/src/test-support/corpus.ts
+++ b/src/test-support/corpus.ts
@@ -1,0 +1,66 @@
+import * as fsp from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+
+export interface TestCorpusFileMap {
+  [relativePath: string]: string | Buffer;
+}
+
+export interface TestCorpus {
+  tempDir: string;
+  rootDir: string;
+  pathFor: (relativePath: string) => string;
+  writeFile: (relativePath: string, content: string | Buffer) => Promise<string>;
+  cleanup: () => Promise<void>;
+}
+
+export interface TestCorpusOptions {
+  prefix?: string;
+  files?: TestCorpusFileMap;
+}
+
+export async function createTestCorpus(options: TestCorpusOptions = {}): Promise<TestCorpus> {
+  const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), options.prefix ?? 'kb-corpus-'));
+  const rootDir = path.join(tempDir, 'kbs');
+  await fsp.mkdir(rootDir, { recursive: true });
+
+  const corpus: TestCorpus = {
+    tempDir,
+    rootDir,
+    pathFor: (relativePath: string) => corpusPath(rootDir, relativePath),
+    writeFile: async (relativePath: string, content: string | Buffer) => {
+      const filePath = corpusPath(rootDir, relativePath);
+      await fsp.mkdir(path.dirname(filePath), { recursive: true });
+      await fsp.writeFile(filePath, content);
+      return filePath;
+    },
+    cleanup: async () => {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    },
+  };
+
+  try {
+    for (const [relativePath, content] of Object.entries(options.files ?? {})) {
+      await corpus.writeFile(relativePath, content);
+    }
+  } catch (error) {
+    await corpus.cleanup();
+    throw error;
+  }
+
+  return corpus;
+}
+
+function corpusPath(rootDir: string, relativePath: string): string {
+  if (path.isAbsolute(relativePath)) {
+    throw new Error(`test corpus paths must be relative: ${relativePath}`);
+  }
+
+  const resolvedPath = path.resolve(rootDir, relativePath);
+  const relativeToRoot = path.relative(rootDir, resolvedPath);
+  if (relativeToRoot === '' || relativeToRoot.startsWith('..') || path.isAbsolute(relativeToRoot)) {
+    throw new Error(`test corpus path escapes the root: ${relativePath}`);
+  }
+
+  return resolvedPath;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,5 +16,5 @@
     "useDefineForClassFields": true
   },
   "include": ["src/**/*.ts", "src/**/*.mjs"],
-  "exclude": ["node_modules", "src/**/*.test.ts"]
+  "exclude": ["node_modules", "src/**/*.test.ts", "src/test-support"]
 }


### PR DESCRIPTION
## Summary

- Add `createTestCorpus` in `src/test-support/corpus.ts` for temporary KB roots, relative file maps, path lookup, explicit writes, and cleanup.
- Convert representative stale-check and superseded tests to use the shared corpus helper.
- Document the helper in `docs/testing/INDEX.md` and exclude `src/test-support` from production TypeScript output.

Closes #618

## Implementation Choice

The helper stays intentionally narrow: temp directory creation, `kbs` root creation, relative file writes, path lookup, path-escape validation, and idempotent cleanup via `fs.rm(..., { recursive: true, force: true })`. Setup failures also clean up the temp directory before rethrowing.

## Alternatives Considered

- A broader fixture system that also owns fake embeddings, index construction, process env, or CLI wiring. Deferred to keep this issue focused.
- A sweeping migration of every hand-rolled temp KB scaffold. Deferred; this PR converts only representative examples.

## Scope Deferred

- No fake embedding helpers.
- No index builders.
- No global environment mutation helpers.
- No broad test-suite migration.

## Verification

- `npm install`
- `npx jest --selectProjects parallel --runTestsByPath src/test-support/corpus.test.ts src/cli-stale-check.test.ts src/cli-superseded.test.ts --runInBand`
- `npm run build`
- `git diff --check`

Note: I also attempted the issue-specified `npm test -- --runTestsByPath ... --runInBand` form from the issue worktree. With the current package scripts it runs the full parallel project first, then forwards these parallel-project test paths to `test:serial`, where Jest reports `No tests found`. The focused parallel Jest command above is the equivalent passing slice for these files.