### PR TITLE
Classify kb ask JSON failures

### DIFF
--- a/docs/cli-json-contracts.md
+++ b/docs/cli-json-contracts.md
@@ -360,6 +360,94 @@ Source and test anchors: `src/cli-search.ts:262-320`,
 `src/formatter.ts:136-213`, `src/cli-search-errors.ts:181-215`,
 `src/formatter.test.ts:133-185`, `src/cli-search-errors.test.ts:121-159`.
 
+## `kb ask`
+
+Invocation:
+
+```bash
+kb ask "<question>" --format=json [--kb=<name>] [--model=<id>] [--k=<int>]
+kb ask --stdin --format=json [--save-transcript --kb=<name> --yes]
+```
+
+Success envelope:
+
+```json
+{
+  "answer": "The release lead approves rollback.",
+  "citations": [
+    {
+      "knowledge_base": "ops",
+      "path": "runbooks/rollback.md",
+      "score": 0.12,
+      "chunk_id": "ops/runbooks/rollback.md#L12-L18"
+    }
+  ],
+  "llm": {
+    "endpoint": "http://127.0.0.1:8080/v1/chat/completions",
+    "profile": "env",
+    "mode": "external",
+    "source": "env",
+    "model": "qwen3"
+  },
+  "retrieval": {
+    "embedding_model": "ollama__nomic-embed-text-latest",
+    "k": 8,
+    "context_budget_tokens": 6000,
+    "refreshed": false,
+    "knowledge_base": "ops"
+  },
+  "context_packing": {
+    "budget_tokens": 6000,
+    "estimated_tokens": 42,
+    "included_chunks": 1,
+    "excluded_chunks": 0,
+    "truncated_chunks": 0,
+    "policy_filtered_chunks": 0,
+    "chunks": []
+  },
+  "abstention_reason": null
+}
+```
+
+Stable error envelope:
+
+```json
+{
+  "error": {
+    "code": "ASK_LLM_ENDPOINT_UNREACHABLE",
+    "category": "external",
+    "message": "local LLM request failed: connect ECONNREFUSED 127.0.0.1:8080",
+    "next_action": "Start or fix the configured LLM endpoint, then run `kb llm probe --endpoint=<url>` from the same shell."
+  },
+  "error_text": "kb ask: local LLM request failed: connect ECONNREFUSED 127.0.0.1:8080"
+}
+```
+
+Stable success fields are `answer`, `citations[]`, `llm`, `retrieval`,
+`context_packing`, and `abstention_reason`. When `--save-transcript` succeeds,
+the payload also includes `transcript.saved`, `transcript.knowledge_base`,
+`transcript.path`, and `transcript.title`.
+
+Stable error fields are `error.code`, `error.category`, `error.message`, and
+`error.next_action`. `error_text` is a compatibility display alias for the
+former `{"error": "kb ask: ..."}` JSON string; machine clients should branch on
+the object under `error`.
+
+Stdout/stderr and exit codes:
+
+- Success JSON is stdout with exit `0`.
+- JSON-mode classified failures are stdout with exit `1` or `2`.
+- Human-mode classified failures are stderr.
+- Exit `2` covers argument, active-model, LLM profile, and duplicate transcript
+  title errors. Exit `1` covers index, provider, LLM endpoint/response,
+  permission, lock, and unknown runtime errors.
+- The ask-first stable JSON error envelope is intentionally limited to `kb ask`;
+  remember, capture, and import-url retain their documented error behavior.
+
+Source and test anchors: `src/cli-ask.ts:122-237`,
+`src/ask-core.ts:255-324`, `src/search-errors-core.ts:82-142`,
+`src/cli-ask.test.ts:358-537`, `src/cli-json-contracts.test.ts:179-198`.
+
 ## `kb research`
 
 Invocation:

--- a/docs/reference/error-codes.md
+++ b/docs/reference/error-codes.md
@@ -1,14 +1,15 @@
 # KB Error Codes
 
 This reference documents the stable `KBErrorCode` values emitted by the server
-and CLI. Operators can see these codes in classified CLI JSON failures under
-`error.code`, MCP tool error payloads, and canonical logs from server-side and
-reindex paths that preserve `KBError` details. Some CLI wrappers log only their
-process exit class, such as `EXIT_1` or `EXIT_2`, so prefer the command's JSON
-error payload when available. Contextual-retrieval ingest can also surface
-related per-chunk sidecar `error_code` values; those are lower-level
-diagnostics, while the codes below are the operator-facing taxonomy from
-`src/errors.ts`.
+and CLI, plus command-local classified CLI codes where a command has a stable
+JSON error envelope. Operators can see these codes in classified CLI JSON
+failures under `error.code`, MCP tool error payloads, and canonical logs from
+server-side and reindex paths that preserve `KBError` details. Some CLI wrappers
+log only their process exit class, such as `EXIT_1` or `EXIT_2`, so prefer the
+command's JSON error payload when available. Contextual-retrieval ingest can
+also surface related per-chunk sidecar `error_code` values; those are
+lower-level diagnostics, while the first table below is the operator-facing
+taxonomy from `src/errors.ts`.
 
 Use the code to decide the first response. Message text is diagnostic prose and
 can change between releases.
@@ -43,3 +44,25 @@ For symptom-first triage, start with
 [`docs/operations/incident-response.md`](../operations/incident-response.md).
 For JSON output shapes, see
 [`docs/cli-json-contracts.md`](../cli-json-contracts.md).
+
+## `kb ask` CLI Codes
+
+`kb ask --format=json` uses the same classified envelope shape as dense
+`kb search`: `error.code`, `error.category`, `error.message`, and
+`error.next_action`. It can emit the shared `KBErrorCode` values above for
+retrieval/index/model failures and the ask-local codes below for argument, LLM,
+and transcript paths.
+
+| Code | Category | Meaning | Operator Remedy | Transient? |
+| --- | --- | --- | --- | --- |
+| <code>ASK_ARGUMENT_INVALID</code> | `input` | The ask command line is missing or rejects an argument. | Fix the argv shown in `error.message`; run `kb ask --help` for usage. | No |
+| <code>ASK_CONTEXT_BUDGET_INVALID</code> | `input` | `--context-budget-tokens` is not an integer at or above the minimum. | Pass `--context-budget-tokens=<int>` with a value of at least 64. | No |
+| <code>ASK_LLM_PROFILE_INVALID</code> | `configuration` | The selected or active `kb llm` profile is malformed or unreadable. | Run `kb llm status --format=json`, repair the profile, or choose a valid `--llm-profile`. | No |
+| <code>ASK_LLM_AUTH</code> | `configuration` | The LLM provider rejected credentials. | Fix provider credentials in the environment used to launch `kb`, then probe the endpoint. | No |
+| <code>ASK_LLM_RATE_LIMITED</code> | `external` | The LLM provider returned HTTP 429. | Wait for quota/rate limit recovery, then retry. | Yes |
+| <code>ASK_LLM_ENDPOINT_UNREACHABLE</code> | `external` | The answer LLM endpoint is unreachable, timed out, or returned a transient/server failure. | Start or fix the configured endpoint, then run `kb llm probe --endpoint=<url>`. | Yes |
+| <code>ASK_LLM_RESPONSE_INVALID</code> | `external` | The endpoint answered but not with a usable OpenAI-compatible chat completion. | Probe the endpoint and fix the service/model response shape. | No |
+| <code>ASK_LLM_REQUEST_FAILED</code> | `external` | The LLM call failed outside a recognized `LlmClientError` path. | Check `kb llm status --format=json` and probe the configured endpoint. | Unknown |
+| <code>ASK_TRANSCRIPT_EXISTS</code> | `input` | `--save-transcript` would overwrite an existing note. | Choose a different `--title` or remove the existing transcript note. | No |
+| <code>ASK_TRANSCRIPT_PERMISSION_DENIED</code> | `permissions` | Transcript write failed with a filesystem permission/read-only error. | Grant write access to the target KB directory, then retry. | No |
+| <code>ASK_TRANSCRIPT_WRITE_FAILED</code> | `unknown` | Transcript write failed without a more specific errno classification. | Check the target KB path and disk state, then retry. | Unknown |

--- a/src/ask-core.ts
+++ b/src/ask-core.ts
@@ -21,6 +21,7 @@ import {
 } from './relevance-gate.js';
 import { chunkIdFromMetadata } from './rrf.js';
 import {
+  classifyKbAskError,
   classifyKbSearchError,
   exitCodeForFailure,
 } from './search-errors-core.js';
@@ -275,7 +276,8 @@ export async function executeAsk(
     target = await resolveLlmTarget(args);
     if (timing) timing.llm_profile_resolution_ms = elapsedMs(startedAt);
   } catch (err) {
-    throw new AskExecutionError((err as Error).message, 2);
+    const failure = classifyKbAskError(err, 'llm-profile');
+    throw new AskExecutionError(failure.message, exitCodeForFailure(failure), failure);
   }
 
   if (target.profile.mode === 'managed') {
@@ -321,7 +323,8 @@ export async function executeAsk(
     answer = response.content;
     llmModel = response.model;
   } catch (err) {
-    throw new AskExecutionError((err as Error).message, 1);
+    const failure = classifyKbAskError(err, 'llm-chat');
+    throw new AskExecutionError(failure.message, exitCodeForFailure(failure), failure);
   }
 
   if (timing) timing.total_ms = elapsedMs(totalStartedAt);

--- a/src/cli-ask.test.ts
+++ b/src/cli-ask.test.ts
@@ -14,7 +14,7 @@ import {
   askKnowledge,
   packAskContext,
 } from './ask-core.js';
-import { callChatCompletion } from './llm-client.js';
+import { callChatCompletion, LlmClientError } from './llm-client.js';
 
 describe('parseAskArgs', () => {
   it('parses retrieval and LLM options', () => {
@@ -352,6 +352,179 @@ describe('ask transcript records', () => {
       if (previousEndpoint === undefined) delete process.env.KB_LLM_ENDPOINT;
       else process.env.KB_LLM_ENDPOINT = previousEndpoint;
       await fsp.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('emits a classified JSON error for invalid ask context budget', async () => {
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const stdoutSpy = jest.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+      stdout.push(String(chunk));
+      return true;
+    });
+    const stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation((chunk) => {
+      stderr.push(String(chunk));
+      return true;
+    });
+
+    try {
+      const code = await runAsk([
+        'What changed?',
+        '--context-budget-tokens=63',
+        '--format=json',
+      ]);
+
+      expect(code).toBe(2);
+      expect(stderr.join('')).toBe('');
+      const payload = JSON.parse(stdout.join('')) as {
+        error: { code: string; category: string; message: string; next_action: string };
+        error_text: string;
+      };
+      expect(payload.error).toMatchObject({
+        code: 'ASK_CONTEXT_BUDGET_INVALID',
+        category: 'input',
+        message: expect.stringContaining('invalid --context-budget-tokens'),
+        next_action: 'Pass `--context-budget-tokens=<int>` with a value of at least 64, then retry.',
+      });
+      expect(payload.error_text).toContain('kb ask: invalid --context-budget-tokens');
+    } finally {
+      stdoutSpy.mockRestore();
+      stderrSpy.mockRestore();
+    }
+  });
+
+  it('emits a classified JSON error when the answer LLM endpoint is unreachable', async () => {
+    const previousEndpoint = process.env.KB_LLM_ENDPOINT;
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const stdoutSpy = jest.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+      stdout.push(String(chunk));
+      return true;
+    });
+    const stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation((chunk) => {
+      stderr.push(String(chunk));
+      return true;
+    });
+
+    try {
+      process.env.KB_LLM_ENDPOINT = 'http://127.0.0.1:8080/v1/chat/completions';
+      const manager = {
+        modelDir: '/tmp/kb-ask-model',
+        initialize: jest.fn(async () => {}),
+        updateIndex: jest.fn(async () => {}),
+        similaritySearch: jest.fn(async () => [
+          {
+            pageContent: 'Rollback approval requires the release lead.',
+            metadata: { knowledgeBase: 'ops', relativePath: 'runbooks/rollback.md' },
+            score: 0.1,
+          },
+        ]),
+      };
+      const deps: RunAskDeps = {
+        bootstrapLayout: jest.fn(async () => {}),
+        resolveActiveModel: jest.fn(async () => 'ollama__nomic-embed-text-latest'),
+        loadManagerForModel: jest.fn(async () => manager as never),
+        loadWithJsonRetry: jest.fn(async () => {}),
+        withWriteLock: jest.fn(async <T>(_resource: string, action: () => Promise<T>) => action()) as RunAskDeps['withWriteLock'],
+        callChatCompletion: jest.fn(async () => {
+          throw new LlmClientError('local LLM request failed: connect ECONNREFUSED 127.0.0.1:8080', { transient: true });
+        }),
+        createTranscriptNote: createAskTranscriptNote,
+        knowledgeBasesRootDir: '/tmp/kb-ask-root',
+      };
+
+      const code = await runAsk(['Who approves rollback?', '--kb=ops', '--format=json'], deps);
+
+      expect(code).toBe(1);
+      expect(stderr.join('')).toBe('');
+      const payload = JSON.parse(stdout.join('')) as {
+        error: { code: string; category: string; message: string; next_action: string };
+        error_text: string;
+      };
+      expect(payload.error).toMatchObject({
+        code: 'ASK_LLM_ENDPOINT_UNREACHABLE',
+        category: 'external',
+        message: 'local LLM request failed: connect ECONNREFUSED 127.0.0.1:8080',
+        next_action: 'Start or fix the configured LLM endpoint, then run `kb llm probe --endpoint=<url>` from the same shell.',
+      });
+      expect(payload.error_text).toBe('kb ask: local LLM request failed: connect ECONNREFUSED 127.0.0.1:8080');
+    } finally {
+      stdoutSpy.mockRestore();
+      stderrSpy.mockRestore();
+      if (previousEndpoint === undefined) delete process.env.KB_LLM_ENDPOINT;
+      else process.env.KB_LLM_ENDPOINT = previousEndpoint;
+    }
+  });
+
+  it('emits a classified JSON error when transcript writing fails', async () => {
+    const previousEndpoint = process.env.KB_LLM_ENDPOINT;
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const stdoutSpy = jest.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+      stdout.push(String(chunk));
+      return true;
+    });
+    const stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation((chunk) => {
+      stderr.push(String(chunk));
+      return true;
+    });
+
+    try {
+      process.env.KB_LLM_ENDPOINT = 'http://127.0.0.1:8080/v1/chat/completions';
+      const manager = {
+        modelDir: '/tmp/kb-ask-model',
+        initialize: jest.fn(async () => {}),
+        updateIndex: jest.fn(async () => {}),
+        similaritySearch: jest.fn(async () => [
+          {
+            pageContent: 'Rollback approval requires the release lead.',
+            metadata: { knowledgeBase: 'ops', relativePath: 'runbooks/rollback.md' },
+            score: 0.1,
+          },
+        ]),
+      };
+      const deps: RunAskDeps = {
+        bootstrapLayout: jest.fn(async () => {}),
+        resolveActiveModel: jest.fn(async () => 'ollama__nomic-embed-text-latest'),
+        loadManagerForModel: jest.fn(async () => manager as never),
+        loadWithJsonRetry: jest.fn(async () => {}),
+        withWriteLock: jest.fn(async <T>(_resource: string, action: () => Promise<T>) => action()) as RunAskDeps['withWriteLock'],
+        callChatCompletion: jest.fn(async () => ({
+          content: 'Rollback approval requires the release lead.',
+          model: 'qwen3',
+          raw: {},
+        })),
+        createTranscriptNote: jest.fn(async () => {
+          throw new Error('refusing to overwrite existing transcript: incident-answer.md');
+        }),
+        knowledgeBasesRootDir: '/tmp/kb-ask-root',
+      };
+
+      const code = await runAsk([
+        'Who approves rollback?',
+        '--kb=ops',
+        '--format=json',
+        '--save-transcript',
+        '--title=Incident answer',
+        '--yes',
+      ], deps);
+
+      expect(code).toBe(2);
+      expect(stderr.join('')).toBe('');
+      const payload = JSON.parse(stdout.join('')) as {
+        error: { code: string; category: string; message: string; next_action: string };
+      };
+      expect(payload.error).toMatchObject({
+        code: 'ASK_TRANSCRIPT_EXISTS',
+        category: 'input',
+        message: 'refusing to overwrite existing transcript: incident-answer.md',
+        next_action: 'Choose a different `--title` or remove the existing transcript note, then retry.',
+      });
+    } finally {
+      stdoutSpy.mockRestore();
+      stderrSpy.mockRestore();
+      if (previousEndpoint === undefined) delete process.env.KB_LLM_ENDPOINT;
+      else process.env.KB_LLM_ENDPOINT = previousEndpoint;
     }
   });
 

--- a/src/cli-ask.ts
+++ b/src/cli-ask.ts
@@ -10,8 +10,10 @@ import {
   type RefreshStatus,
 } from './audit-log.js';
 import {
-  formatKbSearchFailureJson,
-  formatKbSearchFailureStderr,
+  classifyKbAskError,
+  exitCodeForFailure,
+  formatKbAskFailureJson,
+  formatKbAskFailureStderr,
 } from './search-errors-core.js';
 import { loadManagerForModel, loadWithJsonRetry } from './cli-shared.js';
 import {
@@ -140,15 +142,15 @@ export async function runAsk(rest: string[], deps: RunAskDeps = defaultRunAskDep
   try {
     args = parseAskArgs(rest);
   } catch (err) {
-    process.stderr.write(`kb ask: ${(err as Error).message}\n`);
-    return 2;
+    const failure = classifyKbAskError(err, 'argument');
+    return reportAskFailure(requestedAskFormat(rest), failure);
   }
   if (args.stdin && args.question === null) {
     args.question = await readAllStdin();
   }
   if (args.question === null || args.question.trim() === '') {
-    process.stderr.write('kb ask: missing <question> (or use --stdin)\n');
-    return 2;
+    const failure = classifyKbAskError(new Error('missing <question> (or use --stdin)'), 'argument');
+    return reportAskFailure(args.format, failure);
   }
 
   let result: AskKnowledgeResult;
@@ -170,13 +172,13 @@ export async function runAsk(rest: string[], deps: RunAskDeps = defaultRunAskDep
   } catch (err) {
     if (err instanceof AskExecutionError) {
       if (err.failure !== undefined) {
-        if (args.format === 'json') process.stdout.write(formatKbSearchFailureJson(err.failure));
-        else process.stderr.write(formatKbSearchFailureStderr(err.failure));
-        return err.exitCode;
+        return reportAskFailure(args.format, err.failure, err.exitCode);
       }
-      return reportAskError(args.format, `kb ask: ${err.message}`, err.exitCode);
+      const failure = classifyKbAskError(err, 'runtime');
+      return reportAskFailure(args.format, failure, err.exitCode);
     }
-    return reportAskError(args.format, `kb ask: ${(err as Error).message}`, 1);
+    const failure = classifyKbAskError(err, 'runtime');
+    return reportAskFailure(args.format, failure);
   }
 
   let savedTranscript: SavedTranscriptInfo | null = null;
@@ -237,7 +239,8 @@ export async function runAsk(rest: string[], deps: RunAskDeps = defaultRunAskDep
       });
     }
     if (writeError !== undefined) {
-      return reportAskError(args.format, `kb ask: ${writeError.message}`, 1);
+      const failure = classifyKbAskError(writeError, 'transcript');
+      return reportAskFailure(args.format, failure);
     }
     savedTranscript = {
       saved: true,
@@ -489,13 +492,21 @@ function sha256(value: string): string {
   return crypto.createHash('sha256').update(value).digest('hex');
 }
 
-function reportAskError(format: 'md' | 'json', message: string, code: number): number {
+function reportAskFailure(
+  format: 'md' | 'json',
+  failure: ReturnType<typeof classifyKbAskError>,
+  code = exitCodeForFailure(failure),
+): number {
   if (format === 'json') {
-    process.stdout.write(`${JSON.stringify({ error: message }, null, 2)}\n`);
+    process.stdout.write(formatKbAskFailureJson(failure));
   } else {
-    process.stderr.write(`${message}\n`);
+    process.stderr.write(formatKbAskFailureStderr(failure));
   }
   return code;
+}
+
+function requestedAskFormat(rest: string[]): 'md' | 'json' {
+  return rest.includes('--format=json') ? 'json' : 'md';
 }
 
 async function readAllStdin(): Promise<string> {

--- a/src/cli-json-contracts.test.ts
+++ b/src/cli-json-contracts.test.ts
@@ -18,6 +18,7 @@ const docsPath = path.join(process.cwd(), 'docs', 'cli-json-contracts.md');
 const DOCUMENTED_COMMANDS = [
   'kb help',
   'kb search',
+  'kb ask',
   'kb remember',
   'kb capture',
   'kb where',
@@ -168,6 +169,25 @@ const docAssertions: Record<DocumentedCommand, (examples: unknown[]) => void> = 
       message: expect.any(String),
       next_action: expect.any(String),
     });
+  },
+  'kb ask': (examples) => {
+    expect(examples).toHaveLength(2);
+    expect(record(examples[0])).toMatchObject({
+      answer: expect.any(String),
+      citations: expect.any(Array),
+      llm: expect.any(Object),
+      retrieval: expect.any(Object),
+      context_packing: expect.any(Object),
+      abstention_reason: null,
+    });
+    const errorExample = record(examples[1]);
+    expect(record(errorExample.error)).toMatchObject({
+      code: expect.any(String),
+      category: expect.any(String),
+      message: expect.any(String),
+      next_action: expect.any(String),
+    });
+    expect(errorExample.error_text).toEqual(expect.any(String));
   },
   'kb remember': (examples) => {
     expect(examples).toHaveLength(3);
@@ -353,6 +373,21 @@ describe('CLI JSON contract golden outputs', () => {
       message: expect.any(String),
       next_action: expect.any(String),
     });
+  });
+
+  it('kb ask --format=json preserves the structured error envelope', () => {
+    const result = runCli(['ask', 'What changed?', '--format=json']);
+
+    expect(result.code).toBe(2);
+    expect(result.stderr).toBe('');
+    const payload = record(parseStdoutJson(result));
+    expect(record(payload.error)).toMatchObject({
+      code: 'ACTIVE_MODEL_UNRESOLVED',
+      category: 'configuration',
+      message: expect.any(String),
+      next_action: expect.any(String),
+    });
+    expect(payload.error_text).toEqual(expect.stringContaining('kb ask:'));
   });
 
   it('kb remember writes the documented success JSON fields', () => {

--- a/src/search-errors-core.ts
+++ b/src/search-errors-core.ts
@@ -15,6 +15,7 @@
 
 import { ActiveModelResolutionError } from './active-model.js';
 import { KBError, type KBErrorCode } from './errors.js';
+import { LlmClientError } from './llm-client.js';
 import { RerankerConfigError } from './config/reranker.js';
 import { WriteLockContentionError } from './write-lock.js';
 
@@ -43,6 +44,14 @@ export interface SearchFailure {
 }
 
 const RUN_DOCTOR = 'Run `kb doctor` to diagnose backend, configuration, and index health.';
+const ASK_HELP_NEXT_ACTION = 'Fix the command arguments and retry. Run `kb ask --help` for usage.';
+
+export type AskFailureKind =
+  | 'argument'
+  | 'llm-profile'
+  | 'llm-chat'
+  | 'transcript'
+  | 'runtime';
 
 export function classifyKbSearchError(err: unknown): SearchFailure {
   if (err instanceof WriteLockContentionError) {
@@ -91,6 +100,46 @@ export function classifyKbSearchError(err: unknown): SearchFailure {
     message,
     next_action: RUN_DOCTOR,
   };
+}
+
+export function classifyKbAskError(err: unknown, kind: AskFailureKind): SearchFailure {
+  if (kind === 'runtime') {
+    return classifyKbSearchError(err);
+  }
+
+  const message = errorMessage(err);
+  if (kind === 'argument') {
+    if (message.includes('--context-budget-tokens')) {
+      return {
+        code: 'ASK_CONTEXT_BUDGET_INVALID',
+        category: 'input',
+        message,
+        next_action: 'Pass `--context-budget-tokens=<int>` with a value of at least 64, then retry.',
+      };
+    }
+    return {
+      code: 'ASK_ARGUMENT_INVALID',
+      category: 'input',
+      message,
+      next_action: ASK_HELP_NEXT_ACTION,
+    };
+  }
+
+  if (kind === 'llm-profile') {
+    return {
+      code: 'ASK_LLM_PROFILE_INVALID',
+      category: 'configuration',
+      message,
+      next_action:
+        'Run `kb llm status --format=json` to inspect the active profile, then fix it with `kb llm use-endpoint <url> --profile=<name>` or choose a valid `--llm-profile=<name>`.',
+    };
+  }
+
+  if (kind === 'llm-chat') {
+    return classifyAskLlmError(err, message);
+  }
+
+  return classifyAskTranscriptError(err, message);
 }
 
 function classifyKBError(err: KBError): SearchFailure {
@@ -221,8 +270,34 @@ function classifyKBError(err: KBError): SearchFailure {
 
 /** Stderr (markdown / human-mode) renderer. Always ends with a trailing newline. */
 export function formatKbSearchFailureStderr(failure: SearchFailure): string {
+  return formatClassifiedFailureStderr('kb search', failure);
+}
+
+/** JSON renderer for `--format=json` so agents can branch on `error.category`/`error.code`. */
+export function formatKbSearchFailureJson(failure: SearchFailure): string {
+  return formatClassifiedFailureJson(failure);
+}
+
+/** Stderr renderer for `kb ask` classified failures. Always ends with a trailing newline. */
+export function formatKbAskFailureStderr(failure: SearchFailure): string {
+  return formatClassifiedFailureStderr('kb ask', failure);
+}
+
+/**
+ * JSON renderer for `kb ask --format=json` classified failures.
+ *
+ * `error_text` intentionally preserves the former one-line string shape for
+ * display-oriented callers while `error` becomes the stable classified object.
+ */
+export function formatKbAskFailureJson(failure: SearchFailure): string {
+  return formatClassifiedFailureJson(failure, {
+    legacyErrorText: `kb ask: ${failure.message}`,
+  });
+}
+
+function formatClassifiedFailureStderr(command: string, failure: SearchFailure): string {
   const lines = [
-    `kb search: ${failure.message}`,
+    `${command}: ${failure.message}`,
     `  category: ${failure.category} (code: ${failure.code})`,
     `  next: ${failure.next_action}`,
   ];
@@ -232,8 +307,10 @@ export function formatKbSearchFailureStderr(failure: SearchFailure): string {
   return `${lines.join('\n')}\n`;
 }
 
-/** JSON renderer for `--format=json` so agents can branch on `error.category`/`error.code`. */
-export function formatKbSearchFailureJson(failure: SearchFailure): string {
+function formatClassifiedFailureJson(
+  failure: SearchFailure,
+  options: { legacyErrorText?: string } = {},
+): string {
   const error: Record<string, unknown> = {
     code: failure.code,
     category: failure.category,
@@ -253,7 +330,10 @@ export function formatKbSearchFailureJson(failure: SearchFailure): string {
   if (failure.category === 'lock') {
     error.retry_hint = failure.next_action;
   }
-  return `${JSON.stringify({ error }, null, 2)}\n`;
+  return `${JSON.stringify({
+    error,
+    ...(options.legacyErrorText !== undefined ? { error_text: options.legacyErrorText } : {}),
+  }, null, 2)}\n`;
 }
 
 /**
@@ -267,4 +347,85 @@ export function exitCodeForFailure(failure: SearchFailure): number {
     return 2;
   }
   return 1;
+}
+
+function classifyAskLlmError(err: unknown, message: string): SearchFailure {
+  if (err instanceof LlmClientError) {
+    if (err.status === 401 || err.status === 403) {
+      return {
+        code: 'ASK_LLM_AUTH',
+        category: 'configuration',
+        message,
+        next_action:
+          'Fix the LLM provider credentials in the environment used to launch `kb`, then run `kb llm probe --endpoint=<url>`.',
+      };
+    }
+    if (err.status === 429) {
+      return {
+        code: 'ASK_LLM_RATE_LIMITED',
+        category: 'external',
+        message,
+        next_action:
+          'Wait for the LLM provider rate limit to clear, then retry `kb ask`; check provider quota if this repeats.',
+      };
+    }
+    if (err.transient === true || err.status === undefined || err.status >= 500) {
+      return {
+        code: 'ASK_LLM_ENDPOINT_UNREACHABLE',
+        category: 'external',
+        message,
+        next_action:
+          'Start or fix the configured LLM endpoint, then run `kb llm probe --endpoint=<url>` from the same shell.',
+      };
+    }
+    return {
+      code: 'ASK_LLM_RESPONSE_INVALID',
+      category: 'external',
+      message,
+      next_action:
+        'Probe the LLM endpoint with `kb llm probe --endpoint=<url>` and verify it returns OpenAI-compatible chat completions.',
+    };
+  }
+
+  return {
+    code: 'ASK_LLM_REQUEST_FAILED',
+    category: 'external',
+    message,
+    next_action:
+      'Check the configured LLM endpoint with `kb llm status --format=json` and `kb llm probe --endpoint=<url>`, then retry.',
+  };
+}
+
+function classifyAskTranscriptError(err: unknown, message: string): SearchFailure {
+  if (message.includes('refusing to overwrite existing transcript')) {
+    return {
+      code: 'ASK_TRANSCRIPT_EXISTS',
+      category: 'input',
+      message,
+      next_action: 'Choose a different `--title` or remove the existing transcript note, then retry.',
+    };
+  }
+
+  const code = (err as NodeJS.ErrnoException | undefined)?.code;
+  if (code === 'EACCES' || code === 'EPERM' || code === 'EROFS') {
+    return {
+      code: 'ASK_TRANSCRIPT_PERMISSION_DENIED',
+      category: 'permissions',
+      message,
+      next_action:
+        'Grant the running user write access to the target knowledge base directory, then retry `kb ask --save-transcript`.',
+    };
+  }
+
+  return {
+    code: 'ASK_TRANSCRIPT_WRITE_FAILED',
+    category: 'unknown',
+    message,
+    next_action:
+      'Check the target knowledge base path and disk state, then retry `kb ask --save-transcript`.',
+  };
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
 }


### PR DESCRIPTION
Closes #616

## What changed
- Routed `kb ask` argument, retrieval/index, LLM profile, LLM call, transcript-write, and fallback runtime failures through the classified failure contract: `category`, `code`, `message`, and `next_action`.
- Added ask-specific stable codes for context budget, LLM profile/auth/rate-limit/endpoint/response, and transcript write paths where the code can classify reliably.
- Added shared classified renderers so search behavior stays unchanged while ask renders `kb ask` stderr and JSON envelopes.
- Documented `kb ask` JSON contracts and ask-local error codes without extending remember/capture/import-url.

## Implementation choice
Kept the existing search classifier as the shared core and added a small ask-specific extension in `search-errors-core.ts`. `ask-core` now attaches classified failures to `AskExecutionError` for LLM profile and chat failures, and `cli-ask` classifies parser and transcript-write failures at the CLI boundary.

## Alternatives considered
- A separate ask-only error module: avoided because `kb ask` already shares retrieval/index failures with search and the renderer contract should stay consistent.
- A stable envelope for remember/capture/import-url: intentionally not included; this is the ask-first phase only.

## Compatibility decision for `error`
`kb ask --format=json` now uses `error` as the classified object, matching the search contract. To preserve a display-friendly alias for callers that previously expected the one-line string, the JSON payload also includes `error_text` with the old `kb ask: ...` text. Machine clients should branch on `error.code` and `error.category`.

## Verification
- `npm test -- --runTestsByPath /home/jean/git/knowledge-base-mcp-server-issue-616-classified-ask-errors-48972958/src/cli-ask.test.ts /home/jean/git/knowledge-base-mcp-server-issue-616-classified-ask-errors-48972958/src/cli-json-contracts.test.ts --runInBand`
  - This repo script ran all 158 parallel suites successfully, then exited 1 because the serial Jest project has no matching `cli-ask` or `cli-json-contracts` tests.
- `npx jest --selectProjects parallel --runTestsByPath /home/jean/git/knowledge-base-mcp-server-issue-616-classified-ask-errors-48972958/src/cli-ask.test.ts /home/jean/git/knowledge-base-mcp-server-issue-616-classified-ask-errors-48972958/src/cli-json-contracts.test.ts --runInBand`
- `npm run build`
- `git diff --check`