### PR TITLE
[codex] Add opt-in kb serve daemon autostart

### DIFF
--- a/docs/operations/daemon-lifecycle.md
+++ b/docs/operations/daemon-lifecycle.md
@@ -7,7 +7,8 @@ loaded in memory so each CLI invocation skips the cold-start cost.
 
 CLI clients use the daemon when they pass `--daemon`. If the daemon is not
 reachable, they print a one-line notice on stderr and fall back to direct
-in-process execution.
+in-process execution. Autostart is default-off; set `KB_DAEMON_AUTOSTART=on`
+only when daemon-capable reads should try to start `kb serve` automatically.
 
 ## When to run it
 
@@ -84,6 +85,7 @@ Exit codes are deliberately distinct:
     "pid": 41234,
     "uptime_ms": 124500,
     "idle_timeout_ms": 300000,
+    "ownership": "manual",
     "commands": ["search", "list", "stats"]
   }
 }
@@ -121,9 +123,38 @@ Any CLI subcommand that supports `--daemon` will use the daemon when set:
 kb search "your query" --daemon --format=json
 ```
 
-Without `--daemon` the CLI runs in-process. If you want daemon-first by
-default, alias it: `alias kb-d='kb --daemon'` — there is no global switch (the
-fallback is intentionally explicit).
+Without `--daemon` the CLI runs in-process.
+
+## Autostart on daemon-capable reads
+
+`KB_DAEMON_AUTOSTART=on` is an opt-in companion to daemon-capable CLI reads.
+When a read path asks for the daemon and no listener is present at the
+configured daemon URL, the client starts a detached `kb serve`, polls
+`GET /health` with a bounded readiness deadline, then retries the command
+through the daemon. If readiness does not complete in time, the CLI prints a
+clear autostart notice and runs the command directly.
+
+```bash
+export KB_DAEMON_AUTOSTART=on
+kb search "your query" --daemon
+```
+
+Race handling is intentionally conservative:
+
+- If several callers start at the same time, each caller re-polls `/health`.
+  A process that loses the bind race can still use the daemon started by
+  another caller.
+- If something answers at the configured URL but does not return the kb
+  `/health` contract, the client treats that as a protocol mismatch and does
+  not start another daemon blindly.
+- Autostarted daemons report `"ownership": "autostart"` in `/health` and
+  `kb serve status`; foreground and systemd-launched daemons report
+  `"ownership": "manual"`.
+
+For long-lived supervised daemons, prefer a systemd user unit with
+`--idle-timeout-ms=0` and leave `KB_DAEMON_AUTOSTART` off in that service
+environment. Autostart is for opportunistic warm reads, not for replacing a
+deliberately managed daemon.
 
 ## Limits
 
@@ -137,7 +168,9 @@ fallback is intentionally explicit).
 ## Diagnose
 
 - **`kb search --daemon` falls back silently**: run `kb serve status`. If exit
-  `3`, start the daemon. If exit `1`, the daemon is misconfigured.
+  `3`, start the daemon or set `KB_DAEMON_AUTOSTART=on` for opportunistic
+  starts. If exit `1`, the daemon URL is occupied by an incompatible or stale
+  process and autostart will not override it.
 - **Daemon exits after 5 minutes**: that's the default idle timeout. Set
   `--idle-timeout-ms=0` to disable, or wrap in systemd with `Restart=`.
 - **`Address already in use`**: another daemon (or other process) holds the

--- a/docs/operations/local-services.md
+++ b/docs/operations/local-services.md
@@ -18,7 +18,7 @@ defaults, see [`docs/feature-flags.md`](../feature-flags.md).
 | `kb` CLI | shell command | this package | `kb doctor` |
 | MCP stdio server | client child process | MCP client | restart the MCP client |
 | MCP HTTP/SSE server | `127.0.0.1:8765` when enabled | this package process supervisor | `curl http://127.0.0.1:8765/health` |
-| Warm CLI daemon | `http://127.0.0.1:17799` | `kb serve` process | `kb serve status` |
+| Warm CLI daemon | `http://127.0.0.1:17799` | foreground/systemd `kb serve`, or opt-in `KB_DAEMON_AUTOSTART=on` | `kb serve status` |
 | Ollama embeddings | `http://localhost:11434` | Ollama | `curl http://localhost:11434/api/tags` |
 | n8n workflows | `http://127.0.0.1:5678` by n8n default | n8n or local-research-agent | n8n/systemd status |
 | External local LLM | `http://127.0.0.1:8080/v1/chat/completions` by convention | usually local-research-agent | `kb llm probe --endpoint=http://127.0.0.1:8080/v1/chat/completions` |
@@ -47,7 +47,7 @@ Interpret the checks in order:
 | --- | --- | --- |
 | `kb doctor` reports provider unavailable | Query embeddings cannot run | Start Ollama or fix provider credentials/env, then retry `kb doctor`. |
 | `kb doctor` reports a stale index | Source files changed after the active index | Run a scoped refresh: `kb search "known phrase" --kb=<name> --refresh`. |
-| `kb serve status` exits `3` | No warm CLI daemon answered | Start one with `kb serve` only if you need repeated low-latency CLI reads. |
+| `kb serve status` exits `3` | No warm CLI daemon answered | Start one with `kb serve`, or set `KB_DAEMON_AUTOSTART=on` for opportunistic daemon-capable reads. |
 | `kb llm status` shows no profiles | `kb ask` may still use `KB_LLM_ENDPOINT`, but no profile is stored | Add an external profile with `kb llm use-endpoint <url>` or install a managed one. |
 | MCP client works differently than the shell | The client inherited different env or package version | Restart the client after updating its env block or package spec. |
 
@@ -92,6 +92,10 @@ When bringing the full stack up after reboot or a model change:
    kb serve
    ```
 
+   If you do not want a long-lived foreground or systemd daemon, leave the
+   daemon stopped and set `KB_DAEMON_AUTOSTART=on` only in shells where
+   daemon-capable reads should start an opportunistic `kb serve`.
+
 5. Restart MCP clients last. Stdio MCP servers inherit env once, at client
    launch, so client restart is what picks up a new package, model, token, or
    `KNOWLEDGE_BASES_ROOT_DIR`.
@@ -103,7 +107,7 @@ Prefer the narrowest restart that matches the symptom:
 | Symptom | Restart |
 | --- | --- |
 | Shell `kb` is fixed but MCP client still fails | Restart the MCP client. |
-| `kb search --daemon` is stale or slow | Stop the `kb serve` process and start a new one. |
+| `kb search --daemon` is stale or slow | Check `kb serve status` ownership. Stop/restart the manual daemon or let the autostarted daemon idle out, then retry. |
 | `kb ask` uses the wrong external LLM | Update `KB_LLM_ENDPOINT` or `kb llm use-endpoint <url>`, then retry. |
 | Managed `kb` LLM changed model | `kb llm set-model --profile=<name> --model=<file.gguf> --start`. |
 | Ollama model or endpoint changed | Restart Ollama, then run `kb doctor`. |
@@ -204,6 +208,12 @@ Keep these defaults distinct:
 One process should own each port. If a port is already in use, either point
 `kb` at that existing owner with an endpoint/profile setting or choose a
 different port for the new managed service.
+
+`kb serve status` reports daemon ownership. `manual` means a foreground or
+supervised `kb serve` process owns the URL; `autostart` means a CLI read
+started it because `KB_DAEMON_AUTOSTART=on` was set. Do not enable autostart
+inside a systemd unit that already manages `kb serve`; keep one ownership mode
+per daemon URL.
 
 ## Shutdown Checklist
 

--- a/src/cli-serve.test.ts
+++ b/src/cli-serve.test.ts
@@ -85,6 +85,7 @@ describe('kb serve daemon', () => {
         pid: process.pid,
         url: daemon.url.href,
         idle_timeout_ms: 0,
+        ownership: 'manual',
         commands: ['search', 'list', 'stats'],
       });
       expect(typeof healthBody.uptime_ms).toBe('number');
@@ -195,6 +196,21 @@ describe('kb serve daemon', () => {
 
   it('keeps serve binding loopback-only', () => {
     expect(() => parseServeArgs(['--host=0.0.0.0'])).toThrow(/non-loopback/);
+  });
+
+  it('advertises autostart ownership from the hidden owner flag', async () => {
+    const parsed = parseServeArgs(['--port=0', '--idle-timeout-ms=0', '--owner=autostart']);
+    const daemon = await startDaemonServer(parsed);
+    try {
+      const health = await request(daemon.url, { path: '/health' });
+      expect(health.statusCode).toBe(200);
+      expect(JSON.parse(health.body)).toMatchObject({
+        status: 'ok',
+        ownership: 'autostart',
+      });
+    } finally {
+      await daemon.stop();
+    }
   });
 });
 
@@ -335,6 +351,7 @@ describe('kb serve status', () => {
       expect(result.code).toBe(0);
       expect(result.stdout).toContain('daemon running');
       expect(result.stdout).toContain(`pid:          ${process.pid}`);
+      expect(result.stdout).toContain('ownership:    manual');
       expect(result.stdout).toContain('commands:     search, list, stats');
     } finally {
       await daemon.stop();

--- a/src/cli-serve.ts
+++ b/src/cli-serve.ts
@@ -13,6 +13,7 @@ import {
   tryFetchDaemonHealth,
   type DaemonCommand,
   type DaemonHealth,
+  type DaemonOwnership,
   type DaemonRunResult,
 } from './daemon-client.js';
 import { formatKbStatsOpenMetrics } from './prometheus-export.js';
@@ -65,6 +66,7 @@ interface ServeArgs {
   host: string;
   port: number;
   idleTimeoutMs: number;
+  ownership: DaemonOwnership;
 }
 
 export interface DaemonCommandHandlers {
@@ -96,6 +98,7 @@ const DEFAULT_SERVE_ARGS: ServeArgs = {
   host: '127.0.0.1',
   port: 17799,
   idleTimeoutMs: 300_000,
+  ownership: 'manual',
 };
 
 export async function runServe(rest: string[]): Promise<number> {
@@ -196,6 +199,9 @@ function formatServeStatus(health: DaemonHealth, queriedUrl: URL): string {
       `  idle timeout: ${health.idle_timeout_ms === 0 ? 'disabled' : formatDuration(health.idle_timeout_ms)}`,
     );
   }
+  if (health.ownership !== undefined) {
+    lines.push(`  ownership:    ${health.ownership}`);
+  }
   if (health.commands !== undefined) {
     lines.push(`  commands:     ${health.commands.join(', ')}`);
   }
@@ -216,6 +222,7 @@ export async function startDaemonServer(
     host: options.host ?? DEFAULT_SERVE_ARGS.host,
     port: options.port ?? DEFAULT_SERVE_ARGS.port,
     idleTimeoutMs: options.idleTimeoutMs ?? DEFAULT_SERVE_ARGS.idleTimeoutMs,
+    ownership: options.ownership ?? DEFAULT_SERVE_ARGS.ownership,
   };
   assertLoopbackHost(parsed.host);
   const handlers = options.handlers ?? createDaemonCommandHandlers();
@@ -235,6 +242,7 @@ export async function startDaemonServer(
     pid: process.pid,
     url: boundUrl,
     idle_timeout_ms: parsed.idleTimeoutMs,
+    ownership: parsed.ownership,
     commands: [...DAEMON_COMMANDS],
     uptime_ms: Date.now() - startedAt,
   });
@@ -317,6 +325,14 @@ export function parseServeArgs(rest: string[]): ServeArgs {
         throw new Error(`invalid --idle-timeout-ms: ${raw}`);
       }
       out.idleTimeoutMs = idleTimeoutMs;
+      continue;
+    }
+    if (raw.startsWith('--owner=')) {
+      const ownership = raw.slice('--owner='.length);
+      if (ownership !== 'manual' && ownership !== 'autostart') {
+        throw new Error(`invalid --owner: ${raw}`);
+      }
+      out.ownership = ownership;
       continue;
     }
     if (raw.startsWith('--')) throw new Error(`unknown flag: ${raw}`);

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -225,6 +225,7 @@ export const CONFIG_SCHEMA: readonly ConfigSpec[] = [
   { name: 'KB_DAEMON_URL', kind: 'url', protocols: ['http:', 'https:'] },
   { name: 'KB_DAEMON_HOST', kind: 'string', default: '127.0.0.1', emptyUsesDefault: true },
   { name: 'KB_DAEMON_PORT', kind: 'integer', default: '17799', min: 1, max: 65535 },
+  { name: 'KB_DAEMON_AUTOSTART', kind: 'boolean', default: 'off', booleanValues: YES_NO_BOOL_VALUES, truthyValues: YES_NO_TRUTHY_VALUES },
   { name: 'MCP_TRANSPORT', kind: 'enum', values: ['stdio', 'sse', 'http'], default: 'stdio' },
   { name: 'MCP_PORT', kind: 'integer', default: '8765', min: 1, max: 65535 },
   { name: 'MCP_BIND_ADDR', kind: 'string', default: '127.0.0.1' },

--- a/src/daemon-client.test.ts
+++ b/src/daemon-client.test.ts
@@ -1,13 +1,15 @@
-import { describe, expect, it } from '@jest/globals';
+import { describe, expect, it, jest } from '@jest/globals';
 import * as http from 'node:http';
 import type { AddressInfo } from 'node:net';
 import {
   DaemonProtocolError,
+  DaemonUnavailableError,
   daemonUrlFromEnv,
   fetchDaemonHealth,
   runDaemonCommand,
   tryFetchDaemonHealth,
   tryRunDaemonCommand,
+  type SpawnDaemon,
 } from './daemon-client.js';
 
 async function withServer(
@@ -54,11 +56,14 @@ describe('daemon client', () => {
   });
 
   it('returns null from tryRunDaemonCommand when the daemon is unreachable', async () => {
+    const spawnImpl = jest.fn<SpawnDaemon>();
     const result = await tryRunDaemonCommand('search', ['q'], {
       env: { KB_DAEMON_URL: 'http://127.0.0.1:17798' },
       timeoutMs: 50,
+      spawnImpl,
     });
     expect(result).toBeNull();
+    expect(spawnImpl).not.toHaveBeenCalled();
   });
 
   it('treats malformed daemon payloads as protocol errors', async () => {
@@ -123,4 +128,133 @@ describe('daemon client', () => {
         .rejects.toBeInstanceOf(DaemonProtocolError);
     });
   });
+
+  it('autostarts a detached daemon and reruns the command after health is ready', async () => {
+    let call = 0;
+    const child = { once: jest.fn(() => child), unref: jest.fn() };
+    const spawnImpl = jest.fn<SpawnDaemon>(() => child);
+    const fetchImpl = jest.fn(async (url: URL | RequestInfo, init?: RequestInit) => {
+      call += 1;
+      const pathname = new URL(String(url)).pathname;
+      if (call === 1 && pathname === '/v1/run') {
+        throw Object.assign(new TypeError('fetch failed'), { cause: { code: 'ECONNREFUSED' } });
+      }
+      if (call === 2 && pathname === '/health') {
+        throw Object.assign(new TypeError('fetch failed'), { cause: { code: 'ECONNREFUSED' } });
+      }
+      if (call === 3 && pathname === '/health') {
+        return jsonResponse({ status: 'ok', commands: ['search', 'list', 'stats'] });
+      }
+      if (call === 4 && pathname === '/v1/run') {
+        expect(init?.method).toBe('POST');
+        return jsonResponse({ exitCode: 0, stdout: 'warm\n', stderr: '' });
+      }
+      throw new Error(`unexpected fetch call ${call} ${pathname}`);
+    });
+    const notices: string[] = [];
+
+    const result = await tryRunDaemonCommand('search', ['q'], {
+      env: { KB_DAEMON_AUTOSTART: 'on', KB_DAEMON_URL: 'http://127.0.0.1:17799/' },
+      fetchImpl,
+      spawnImpl,
+      sleep: async () => {},
+      notice: (message) => notices.push(message),
+      autostartDeadlineMs: 1000,
+    });
+
+    expect(result).toEqual({ exitCode: 0, stdout: 'warm\n', stderr: '' });
+    expect(spawnImpl).toHaveBeenCalledWith(
+      process.execPath,
+      expect.arrayContaining(['serve', '--owner=autostart']),
+      expect.objectContaining({ detached: true, stdio: 'ignore' }),
+    );
+    expect(child.once).toHaveBeenCalledWith('error', expect.any(Function));
+    expect(child.unref).toHaveBeenCalled();
+    expect(notices).toEqual([
+      'kb daemon autostart: started kb serve; daemon is ready at http://127.0.0.1:17799/\n',
+    ]);
+  });
+
+  it('does not autostart when an existing listener has a protocol mismatch', async () => {
+    const spawnImpl = jest.fn<SpawnDaemon>();
+    const fetchImpl = jest.fn(async (url: URL | RequestInfo) => {
+      const pathname = new URL(String(url)).pathname;
+      if (pathname === '/v1/run') {
+        throw Object.assign(new TypeError('fetch failed'), { cause: { code: 'ECONNREFUSED' } });
+      }
+      return jsonResponse({ service: 'not-kb' });
+    });
+
+    await expect(tryRunDaemonCommand('search', ['q'], {
+      env: { KB_DAEMON_AUTOSTART: 'on', KB_DAEMON_URL: 'http://127.0.0.1:17799/' },
+      fetchImpl,
+      spawnImpl,
+    })).rejects.toBeInstanceOf(DaemonProtocolError);
+    expect(spawnImpl).not.toHaveBeenCalled();
+  });
+
+  it('re-polls readiness when spawn itself loses a startup race', async () => {
+    let call = 0;
+    const spawnImpl = jest.fn<SpawnDaemon>(() => {
+      throw Object.assign(new Error('spawn EADDRINUSE'), { code: 'EADDRINUSE' });
+    });
+    const fetchImpl = jest.fn(async (url: URL | RequestInfo) => {
+      call += 1;
+      const pathname = new URL(String(url)).pathname;
+      if (call === 1 && pathname === '/v1/run') {
+        throw Object.assign(new TypeError('fetch failed'), { cause: { code: 'ECONNREFUSED' } });
+      }
+      if (call === 2 && pathname === '/health') {
+        throw Object.assign(new TypeError('fetch failed'), { cause: { code: 'ECONNREFUSED' } });
+      }
+      if (call === 3 && pathname === '/health') {
+        return jsonResponse({ status: 'ok', commands: ['search'] });
+      }
+      if (call === 4 && pathname === '/v1/run') {
+        return jsonResponse({ exitCode: 0, stdout: 'won\n', stderr: '' });
+      }
+      throw new Error(`unexpected fetch call ${call} ${pathname}`);
+    });
+
+    await expect(tryRunDaemonCommand('search', ['q'], {
+      env: { KB_DAEMON_AUTOSTART: 'on', KB_DAEMON_URL: 'http://127.0.0.1:17799/' },
+      fetchImpl,
+      spawnImpl,
+      sleep: async () => {},
+      notice: () => undefined,
+    })).resolves.toEqual({ exitCode: 0, stdout: 'won\n', stderr: '' });
+    expect(spawnImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back cold with a notice when autostart readiness times out', async () => {
+    const child = { once: jest.fn(() => child), unref: jest.fn() };
+    const fetchImpl = jest.fn(async () => {
+      throw new DaemonUnavailableError('kb daemon is not reachable', { cause: { code: 'ECONNREFUSED' } });
+    });
+    const notices: string[] = [];
+    let now = 0;
+
+    const result = await tryRunDaemonCommand('search', ['q'], {
+      env: { KB_DAEMON_AUTOSTART: 'on', KB_DAEMON_URL: 'http://127.0.0.1:17799/' },
+      fetchImpl,
+      spawnImpl: jest.fn<SpawnDaemon>(() => child),
+      sleep: async (ms) => { now += ms; },
+      now: () => now,
+      notice: (message) => notices.push(message),
+      autostartDeadlineMs: 250,
+      autostartPollIntervalMs: 100,
+    });
+
+    expect(result).toBeNull();
+    expect(notices).toEqual([
+      'kb daemon autostart: kb serve was not ready after 250ms; running command directly.\n',
+    ]);
+  });
 });
+
+function jsonResponse(payload: unknown, init: { status?: number } = {}): Response {
+  return new Response(JSON.stringify(payload), {
+    status: init.status ?? 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}

--- a/src/daemon-client.ts
+++ b/src/daemon-client.ts
@@ -1,3 +1,5 @@
+import { spawn } from 'node:child_process';
+
 export interface DaemonRunResult {
   exitCode: number;
   stdout: string;
@@ -5,6 +7,7 @@ export interface DaemonRunResult {
 }
 
 export type DaemonCommand = 'search' | 'list' | 'stats';
+export type DaemonOwnership = 'manual' | 'autostart';
 
 /**
  * Lifecycle snapshot returned by the daemon's `GET /health` endpoint and
@@ -17,15 +20,36 @@ export interface DaemonHealth {
   pid?: number;
   url?: string;
   idle_timeout_ms?: number;
+  ownership?: DaemonOwnership;
   commands?: string[];
   uptime_ms?: number;
 }
+
+interface SpawnedDaemonProcess {
+  once(event: 'error', listener: (err: Error) => void): SpawnedDaemonProcess;
+  unref(): void;
+}
+
+export type SpawnDaemon = (
+  command: string,
+  args: string[],
+  options: { detached: true; stdio: 'ignore'; env: NodeJS.ProcessEnv },
+) => SpawnedDaemonProcess;
 
 export interface DaemonClientOptions {
   env?: NodeJS.ProcessEnv;
   fetchImpl?: typeof fetch;
   timeoutMs?: number;
+  spawnImpl?: SpawnDaemon;
+  sleep?: (ms: number) => Promise<void>;
+  now?: () => number;
+  notice?: (message: string) => void;
+  autostartDeadlineMs?: number;
+  autostartPollIntervalMs?: number;
 }
+
+const DEFAULT_AUTOSTART_DEADLINE_MS = 3_000;
+const DEFAULT_AUTOSTART_POLL_INTERVAL_MS = 100;
 
 export class DaemonUnavailableError extends Error {
   constructor(message: string, options?: ErrorOptions) {
@@ -64,7 +88,10 @@ export async function tryRunDaemonCommand(
   try {
     return await runDaemonCommand(command, args, options);
   } catch (err) {
-    if (err instanceof DaemonUnavailableError) return null;
+    if (err instanceof DaemonUnavailableError) {
+      if (!daemonAutostartEnabled(options.env) || !isSafeNoListenerFailure(err)) return null;
+      return runDaemonCommandAfterAutostart(command, args, options);
+    }
     throw err;
   }
 }
@@ -148,7 +175,7 @@ export async function tryFetchDaemonHealth(
  */
 function rethrowDaemonFetchError(err: unknown, endpointHref: string): never {
   if (err instanceof DaemonProtocolError) throw err;
-  const code = (err as NodeJS.ErrnoException | undefined)?.code;
+  const code = errorCode(err);
   if (
     code === 'ECONNREFUSED' ||
     code === 'ECONNRESET' ||
@@ -193,9 +220,141 @@ function parseDaemonHealth(payload: unknown): DaemonHealth {
   if (typeof obj.pid === 'number') health.pid = obj.pid;
   if (typeof obj.url === 'string') health.url = obj.url;
   if (typeof obj.idle_timeout_ms === 'number') health.idle_timeout_ms = obj.idle_timeout_ms;
+  if (obj.ownership === 'manual' || obj.ownership === 'autostart') health.ownership = obj.ownership;
   if (Array.isArray(obj.commands) && obj.commands.every((item) => typeof item === 'string')) {
     health.commands = obj.commands as string[];
   }
   if (typeof obj.uptime_ms === 'number') health.uptime_ms = obj.uptime_ms;
   return health;
+}
+
+async function runDaemonCommandAfterAutostart(
+  command: DaemonCommand,
+  args: string[],
+  options: DaemonClientOptions,
+): Promise<DaemonRunResult | null> {
+  let preflight: DaemonHealth | null;
+  try {
+    preflight = await tryFetchDaemonHealth(options);
+  } catch (err) {
+    // Something is already answering at the URL, but not with the kb daemon
+    // health contract. Do not start another process into a foreign listener.
+    throw err;
+  }
+
+  if (preflight === null) {
+    const started = startDetachedDaemon(options);
+    const health = await pollDaemonReady(options);
+    if (health === null) {
+      writeNotice(options, autostartTimeoutNotice(options));
+      return null;
+    }
+    writeNotice(
+      options,
+      started
+        ? `kb daemon autostart: started kb serve; daemon is ready at ${health.url ?? daemonUrlFromEnv(options.env).href}\n`
+        : `kb daemon autostart: daemon is ready at ${health.url ?? daemonUrlFromEnv(options.env).href}\n`,
+    );
+  }
+
+  try {
+    return await runDaemonCommand(command, args, options);
+  } catch (err) {
+    if (err instanceof DaemonUnavailableError) {
+      writeNotice(options, 'kb daemon autostart: daemon became unavailable after readiness; running command directly.\n');
+      return null;
+    }
+    throw err;
+  }
+}
+
+function daemonAutostartEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const raw = env.KB_DAEMON_AUTOSTART?.trim().toLowerCase();
+  return raw === 'on' || raw === 'true' || raw === '1' || raw === 'yes';
+}
+
+function startDetachedDaemon(options: DaemonClientOptions): boolean {
+  try {
+    const spawnImpl = options.spawnImpl ?? spawnDetachedDaemon;
+    const command = daemonServeCommand();
+    const child = spawnImpl(command.bin, command.args, {
+      detached: true,
+      stdio: 'ignore',
+      env: { ...process.env, ...options.env },
+    });
+    ignoreSpawnError(child);
+    child.unref();
+    return true;
+  } catch {
+    // A concurrent caller may have won the bind/start race. Poll anyway.
+    return false;
+  }
+}
+
+function daemonServeCommand(): { bin: string; args: string[] } {
+  const entrypoint = process.argv[1];
+  if (entrypoint === undefined || entrypoint.trim() === '') {
+    return { bin: 'kb', args: ['serve', '--owner=autostart'] };
+  }
+  return { bin: process.execPath, args: [entrypoint, 'serve', '--owner=autostart'] };
+}
+
+function spawnDetachedDaemon(
+  command: string,
+  args: string[],
+  options: { detached: true; stdio: 'ignore'; env: NodeJS.ProcessEnv },
+): SpawnedDaemonProcess {
+  return spawn(command, args, options);
+}
+
+function ignoreSpawnError(child: SpawnedDaemonProcess): void {
+  child.once('error', () => undefined);
+}
+
+async function pollDaemonReady(options: DaemonClientOptions): Promise<DaemonHealth | null> {
+  const deadlineMs = options.autostartDeadlineMs ?? DEFAULT_AUTOSTART_DEADLINE_MS;
+  const pollIntervalMs = options.autostartPollIntervalMs ?? DEFAULT_AUTOSTART_POLL_INTERVAL_MS;
+  const now = options.now ?? Date.now;
+  const sleep = options.sleep ?? defaultSleep;
+  const deadlineAt = now() + deadlineMs;
+  while (now() <= deadlineAt) {
+    const health = await tryFetchDaemonHealth({
+      ...options,
+      timeoutMs: Math.min(options.timeoutMs ?? 500, Math.max(1, deadlineAt - now())),
+    });
+    if (health !== null) return health;
+    const remainingMs = deadlineAt - now();
+    if (remainingMs <= 0) break;
+    await sleep(Math.min(pollIntervalMs, remainingMs));
+  }
+  return null;
+}
+
+function autostartTimeoutNotice(options: DaemonClientOptions): string {
+  const deadlineMs = options.autostartDeadlineMs ?? DEFAULT_AUTOSTART_DEADLINE_MS;
+  return `kb daemon autostart: kb serve was not ready after ${deadlineMs}ms; running command directly.\n`;
+}
+
+function writeNotice(options: DaemonClientOptions, message: string): void {
+  if (options.notice !== undefined) {
+    options.notice(message);
+    return;
+  }
+  process.stderr.write(message);
+}
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isSafeNoListenerFailure(err: DaemonUnavailableError): boolean {
+  return errorCode(err.cause) === 'ECONNREFUSED';
+}
+
+function errorCode(err: unknown): string | undefined {
+  const direct = (err as NodeJS.ErrnoException | undefined)?.code;
+  if (typeof direct === 'string') return direct;
+  const cause = (err as { cause?: unknown } | undefined)?.cause;
+  const causeCode = (cause as NodeJS.ErrnoException | undefined)?.code;
+  return typeof causeCode === 'string' ? causeCode : undefined;
 }


### PR DESCRIPTION
Closes #615

## What changed
- Added default-off `KB_DAEMON_AUTOSTART=on` handling for daemon-capable CLI reads through the shared daemon client.
- When no daemon listener is present, the client starts a detached `kb serve`, polls `/health` with a bounded deadline, then retries through the daemon or falls back cold with an explicit notice.
- Added daemon ownership reporting (`manual` vs `autostart`) in `/health` and `kb serve status`, plus a hidden `--owner=autostart` serve flag used by autostarted processes.
- Documented autostart behavior, race handling, and ownership boundaries in the daemon lifecycle and local-services runbooks.

## Implementation choice
The autostart logic lives in `daemon-client.ts` rather than individual CLI commands so existing daemon-eligible reads get the same behavior without editing the top-level CLI routing. The spawned process reuses the current Node CLI entrypoint when available, preserving the active checkout/package, and falls back to `kb serve` only if no entrypoint is available.

## Race handling
- Autostart only proceeds after an unavailable daemon request with a safe no-listener signal (`ECONNREFUSED`).
- A `/health` protocol mismatch is treated as an existing foreign/stale listener and does not trigger blind autostart.
- Spawn/bind races are tolerated by polling `/health` after spawn attempts; callers that lose the race can use the daemon another caller started.
- If readiness misses the bounded deadline, the command falls back to direct execution with an autostart notice.

## Alternatives considered
- Editing each daemon-capable CLI command separately: rejected because the shared client already owns unavailable/protocol distinctions.
- Making autostart default-on: rejected to preserve existing fallback behavior and avoid surprising process ownership.
- Treating every fetch failure as startable: rejected because timeouts/resets can indicate a foreign or unhealthy listener, not an empty port.

## Verification
- `npm run build`
- `npx jest --selectProjects parallel --runTestsByPath src/daemon-client.test.ts src/cli-serve.test.ts --runInBand`
- `git diff --check`
- Attempted requested form: `npm test -- --runTestsByPath /home/jean/git/knowledge-base-mcp-server-issue-615-daemon-autostart-48972958/src/daemon-client.test.ts /home/jean/git/knowledge-base-mcp-server-issue-615-daemon-autostart-48972958/src/cli-serve.test.ts --runInBand`. The full parallel project passed (`158 passed`, `2047 passed`) but the command exited 1 because the repo script then forwarded the narrowed paths to the serial Jest project, where these two parallel-project tests are excluded and Jest reported `No tests found`.
