### PR TITLE
Detect embedding canary drift

### DIFF
--- a/docs/operations/switching-embedding-models.md
+++ b/docs/operations/switching-embedding-models.md
@@ -33,6 +33,18 @@ kb stats --format=json
 kb reindex status --format=json
 ```
 
+In the doctor JSON, check `embedding_canary.status` for the active model:
+
+- `ok` means the active provider re-embedded the persisted canary close enough
+  to the vector captured when the index was built.
+- `not_recorded` means the index was built before canary fingerprints were
+  recorded. Rebuild that model once with the current CLI before relying on the
+  canary for drift detection.
+- `warn` means the canary changed or its dimensions no longer match. Treat that
+  as possible silent embedding-model drift: either rebuild the index for the
+  intended provider/model or restore the original embedding backend before
+  serving queries from that index.
+
 Capture the current active model id:
 
 ```bash

--- a/src/FaissIndexManager.test.ts
+++ b/src/FaissIndexManager.test.ts
@@ -651,6 +651,51 @@ describe('FaissIndexManager permission handling', () => {
       .rejects.toMatchObject({ code: 'ENOENT' });
   });
 
+  it('persists an embedding canary fingerprint in the index integrity manifest', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-faiss-canary-'));
+    const kbDir = path.join(tempDir, 'kb');
+    const defaultKb = path.join(kbDir, 'default');
+    await fsp.mkdir(defaultKb, { recursive: true });
+    await fsp.writeFile(path.join(defaultKb, 'doc.md'), '# Doc\n\nCanary content.');
+
+    process.env.KNOWLEDGE_BASES_ROOT_DIR = kbDir;
+    process.env.FAISS_INDEX_PATH = path.join(tempDir, '.faiss');
+    process.env.EMBEDDING_PROVIDER = 'huggingface';
+    process.env.HUGGINGFACE_API_KEY = 'test-key';
+
+    jest.resetModules();
+    const { FaissIndexManager } = await import('./FaissIndexManager.js');
+    const {
+      EMBEDDING_CANARY_ID,
+      EMBEDDING_CANARY_TEXT_SHA256,
+    } = await import('./faiss-store-layout.js');
+    const manager = new FaissIndexManager();
+    await manager.initialize();
+    await manager.updateIndex();
+
+    const manifest = JSON.parse(
+      await fsp.readFile(
+        path.join(versionedIndexPathIn(process.env.FAISS_INDEX_PATH!), 'integrity.json'),
+        'utf-8',
+      ),
+    ) as {
+      embedding_canary?: {
+        canary_id: string;
+        text_sha256: string;
+        embedding_role: string;
+        dimensions: number;
+        vector: number[];
+      };
+    };
+    expect(manifest.embedding_canary).toMatchObject({
+      canary_id: EMBEDDING_CANARY_ID,
+      text_sha256: EMBEDDING_CANARY_TEXT_SHA256,
+      embedding_role: 'document',
+      dimensions: 2,
+    });
+    expect(manifest.embedding_canary?.vector).toHaveLength(2);
+  });
+
   it('recovers a save-complete pending manifest by finishing hash and chunk sidecars', async () => {
     const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-faiss-pending-complete-'));
     const kbDir = path.join(tempDir, 'kb');
@@ -945,6 +990,7 @@ describe('FaissIndexManager permission handling', () => {
     jest.resetModules();
     const { FaissIndexManager } = await import('./FaissIndexManager.js');
     const { normalizeChunkTextForEmbedding } = await import('./file-ingest.js');
+    const { EMBEDDING_CANARY_TEXT } = await import('./faiss-store-layout.js');
     const manager = new FaissIndexManager();
     await manager.initialize();
     embedDocumentsMock.mockClear();
@@ -978,7 +1024,7 @@ describe('FaissIndexManager permission handling', () => {
     const providerTexts = embedDocumentsMock.mock.calls.flatMap((call) => {
       const [texts] = call as [string[]];
       return texts;
-    });
+    }).filter((text) => text !== EMBEDDING_CANARY_TEXT);
     expect(providerTexts).toEqual([...new Set(indexedTexts.map(normalizeChunkTextForEmbedding))]);
     expect(providerTexts).toHaveLength(2);
     expect(providerTexts).toContain(normalizeChunkTextForEmbedding(seedTexts[0]));
@@ -1010,6 +1056,7 @@ describe('FaissIndexManager permission handling', () => {
 
     jest.resetModules();
     const { FaissIndexManager } = await import('./FaissIndexManager.js');
+    const { EMBEDDING_CANARY_TEXT } = await import('./faiss-store-layout.js');
     const manager = new FaissIndexManager();
     await manager.initialize();
     await manager.updateIndex();
@@ -1052,7 +1099,7 @@ describe('FaissIndexManager permission handling', () => {
     const providerTexts = embedDocumentsMock.mock.calls.flatMap((call) => {
       const [texts] = call as [string[]];
       return texts;
-    });
+    }).filter((text) => text !== EMBEDDING_CANARY_TEXT);
     expect(providerTexts).toHaveLength(appendedChunkCount);
     expect(saveMock).toHaveBeenCalledTimes(1);
     expect(manager.getLastIndexUpdateSummary()).toMatchObject({

--- a/src/FaissIndexManager.ts
+++ b/src/FaissIndexManager.ts
@@ -50,6 +50,7 @@ import {
 } from './layout-bootstrap.js';
 import { mapBounded, resolveFsConcurrency } from './bounded-concurrency.js';
 import {
+  createEmbeddingCanaryFingerprint,
   loadFaissStoreAtomic,
   loadFaissStoreFromVersionDir,
   resolveActiveIndexFilePath as resolveActiveIndexFilePathFromLayout,
@@ -1188,6 +1189,10 @@ export class FaissIndexManager {
     // safer enforcement; future violations are caught by reviewers, not by
     // runtime assertion that itself misfires.
 
+    const embeddingsForCanary = this.embeddings as Partial<Pick<EmbeddingsClient, 'embedDocuments'>> | undefined;
+    const embeddingCanary = typeof embeddingsForCanary?.embedDocuments === 'function'
+      ? await createEmbeddingCanaryFingerprint({ embedDocuments: embeddingsForCanary.embedDocuments })
+      : null;
     this.swapCounter += 1;
     await saveFaissStoreAtomic({
       store: this.faissStoreForPersistence(),
@@ -1195,6 +1200,7 @@ export class FaissIndexManager {
       modelId: this.modelId,
       swapCounter: this.swapCounter,
       indexType: this.indexType,
+      embeddingCanary,
       casRoot: casRootForIndexPath(FAISS_INDEX_PATH),
       onCommitted: opts.onCommitted,
     });

--- a/src/cli-bug-report.test.ts
+++ b/src/cli-bug-report.test.ts
@@ -30,6 +30,16 @@ function minimalDoctorReport(): DoctorReport {
       ownership_check: 'checked',
       entries: [],
     },
+    embedding_canary: {
+      status: 'skipped',
+      canary_id: null,
+      recorded_at: null,
+      dimensions: null,
+      similarity: null,
+      threshold: 0.999,
+      detail: 'embedding canary skipped because the active model index is not built',
+      next_action: null,
+    },
     extraction_cache: {
       cache_dir: '/tmp/faiss/extracted-text',
       exists: false,

--- a/src/cli-doctor.test.ts
+++ b/src/cli-doctor.test.ts
@@ -421,6 +421,114 @@ describe('kb doctor', () => {
     }
   });
 
+  it('reports legacy indexes without an embedding canary as not recorded', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-doctor-canary-missing-'));
+    try {
+      const { rootDir, faissDir } = await seedDoctorBase(tempDir);
+
+      const { buildDoctorReport, formatDoctorMarkdown } = await freshDoctor({
+        KNOWLEDGE_BASES_ROOT_DIR: rootDir,
+        FAISS_INDEX_PATH: faissDir,
+        EMBEDDING_PROVIDER: 'huggingface',
+        HUGGINGFACE_MODEL_NAME: MODEL_NAME,
+        HUGGINGFACE_API_KEY: 'test-key',
+      });
+
+      const report = await buildDoctorReport({
+        backendHealthCheck: async () => ({ healthy: true, detail: 'backend ok' }),
+        packageRoot: tempDir,
+        invokedPath: null,
+        packageVersion: '9.9.9',
+        llmEndpointProbe: healthyLlmProbe,
+      });
+
+      expect(report.embedding_canary).toMatchObject({
+        status: 'not_recorded',
+        similarity: null,
+      });
+      expect(report.checks).toContainEqual({
+        name: 'embedding_canary',
+        status: 'ok',
+        detail: expect.stringContaining('not recorded'),
+      });
+      const markdown = formatDoctorMarkdown(report);
+      expect(markdown).toContain('Embedding canary:');
+      expect(markdown).toContain('status: not_recorded');
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('warns when the persisted embedding canary no longer matches the active provider', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-doctor-canary-drift-'));
+    try {
+      const rootDir = path.join(tempDir, 'kbs');
+      const faissDir = path.join(tempDir, '.faiss');
+      const fakeModelId = 'fake__bag-256d';
+      const modelDir = path.join(faissDir, 'models', fakeModelId);
+      const versionDir = path.join(modelDir, 'index.v1');
+      await fsp.mkdir(rootDir, { recursive: true });
+      await fsp.mkdir(versionDir, { recursive: true });
+      await fsp.writeFile(path.join(modelDir, 'model_name.txt'), 'bag-256d');
+      await fsp.writeFile(path.join(faissDir, 'active.txt'), fakeModelId);
+      await fsp.writeFile(path.join(versionDir, 'faiss.index'), 'fake-index');
+      await fsp.writeFile(path.join(versionDir, 'docstore.json'), '{}');
+      await fsp.symlink('index.v1', path.join(modelDir, 'index'), 'dir');
+
+      const {
+        EMBEDDING_CANARY_ID,
+        EMBEDDING_CANARY_TEXT_SHA256,
+      } = await import('./faiss-store-layout.js');
+      await fsp.writeFile(path.join(versionDir, 'integrity.json'), JSON.stringify({
+        schema_version: 'kb.index-integrity.v1',
+        written_at: '2026-06-13T00:00:00.000Z',
+        model_id: fakeModelId,
+        index_type: 'flat',
+        embedding_canary: {
+          canary_id: EMBEDDING_CANARY_ID,
+          text_sha256: EMBEDDING_CANARY_TEXT_SHA256,
+          embedding_role: 'document',
+          captured_at: '2026-06-13T00:00:00.000Z',
+          dimensions: 2,
+          vector: [1, 0],
+        },
+        files: {
+          'faiss.index': { sha256: '0'.repeat(64) },
+          'docstore.json': { sha256: '1'.repeat(64) },
+        },
+      }), 'utf-8');
+
+      const { buildDoctorReport, formatDoctorMarkdown } = await freshDoctor({
+        KNOWLEDGE_BASES_ROOT_DIR: rootDir,
+        FAISS_INDEX_PATH: faissDir,
+        EMBEDDING_PROVIDER: 'fake',
+      });
+
+      const report = await buildDoctorReport({
+        packageRoot: tempDir,
+        invokedPath: null,
+        packageVersion: '9.9.9',
+        llmEndpointProbe: healthyLlmProbe,
+      });
+
+      expect(report.embedding_canary).toMatchObject({
+        status: 'warn',
+        canary_id: EMBEDDING_CANARY_ID,
+        next_action: expect.stringContaining('docs/operations/switching-embedding-models.md'),
+      });
+      expect(report.checks).toContainEqual({
+        name: 'embedding_canary',
+        status: 'warn',
+        detail: expect.stringContaining('incompatible'),
+      });
+      const markdown = formatDoctorMarkdown(report);
+      expect(markdown).toContain('status: warn');
+      expect(markdown).toContain('next_action: Review docs/operations/switching-embedding-models.md');
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it('marks Ollama backend unhealthy when the active embedding model is missing', async () => {
     const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-doctor-ollama-missing-model-'));
     const oldFetch = global.fetch;

--- a/src/cli-doctor.ts
+++ b/src/cli-doctor.ts
@@ -52,6 +52,8 @@ import {
   FaissIndexManager,
   type IndexUpdateSummary,
 } from './FaissIndexManager.js';
+import { createEmbeddingsClient } from './embedding-provider.js';
+import type { EmbeddingProvider } from './model-id.js';
 import {
   AgeBudgetConfigError,
   computeAgeBudgetStatus,
@@ -104,6 +106,13 @@ import {
   verifyIntegrity,
   type IntegrityReport,
 } from './cli-verify.js';
+import {
+  EMBEDDING_CANARY_COSINE_WARN_THRESHOLD,
+  EMBEDDING_CANARY_ID,
+  createEmbeddingCanaryFingerprint,
+  cosineSimilarity,
+  readIndexIntegrityManifest,
+} from './faiss-store-layout.js';
 import { createDoctorBugReportBundle } from './cli-bug-report.js';
 import {
   WRITE_LOCK_OWNER_SCHEMA_VERSION,
@@ -190,6 +199,7 @@ export interface DoctorArgs {
 
 export type HealthStatus = 'ok' | 'warn' | 'error';
 export type EndpointHealthStatus = HealthStatus | 'skipped';
+export type EmbeddingCanaryHealthStatus = HealthStatus | 'not_recorded' | 'skipped';
 type DoctorDaemonStatsPayload = Pick<KbStatsPayload, 'dense_search_latency'>;
 
 export interface EndpointReadinessEntry {
@@ -273,6 +283,17 @@ export interface DoctorIndexSecurityEntry {
   warnings: string[];
 }
 
+export interface DoctorEmbeddingCanaryReport {
+  status: EmbeddingCanaryHealthStatus;
+  canary_id: string | null;
+  recorded_at: string | null;
+  dimensions: number | null;
+  similarity: number | null;
+  threshold: number;
+  detail: string;
+  next_action: string | null;
+}
+
 export interface DoctorReport {
   status: HealthStatus;
   checks: Array<{ name: string; status: HealthStatus; detail: string }>;
@@ -306,6 +327,7 @@ export interface DoctorReport {
     ownership_check: 'checked' | 'skipped';
     entries: DoctorIndexSecurityEntry[];
   };
+  embedding_canary: DoctorEmbeddingCanaryReport;
   extraction_cache: {
     cache_dir: string;
     exists: boolean;
@@ -471,6 +493,13 @@ export interface BuildDoctorReportOptions {
   llmEndpointProbe?: LlmEndpointProbe;
   /** Run the slow `kb verify --integrity` audit and fold it into status. */
   integrity?: boolean;
+  /** Test seam for the embedding canary drift check. */
+  embeddingCanaryCheck?: (
+    modelId: string | null,
+    provider: string | null,
+    modelName: string | null,
+    binaryPath: string | null,
+  ) => Promise<DoctorEmbeddingCanaryReport>;
 }
 
 export interface BuildEndpointReadinessReportOptions {
@@ -1359,6 +1388,16 @@ export async function buildDoctorReport(
       ? 'FAISS index boundary permissions look safe'
       : `${indexSecurityWarningCount} FAISS index boundary permission warning(s)`,
   });
+  const embeddingCanary = await (
+    options.embeddingCanaryCheck ?? readEmbeddingCanaryHealth
+  )(activeModelId, activeProvider, activeModelName, index.binary_path);
+  checks.push({
+    name: 'embedding_canary',
+    status: embeddingCanary.status === 'warn' || embeddingCanary.status === 'error'
+      ? embeddingCanary.status
+      : 'ok',
+    detail: embeddingCanary.detail,
+  });
   const extractionCache = await readExtractionCacheHealth();
   checks.push({
     name: 'extraction_cache',
@@ -1580,6 +1619,7 @@ export async function buildDoctorReport(
     },
     index,
     index_security: indexSecurity,
+    embedding_canary: embeddingCanary,
     extraction_cache: extractionCache,
     stale_counts_by_kb: staleCounts,
     filesystem: staleResult.filesystem,
@@ -1749,6 +1789,139 @@ async function readIndexHealth(activeModelId: string | null): Promise<DoctorRepo
       storage: storageSummary,
     };
   }
+}
+
+async function readEmbeddingCanaryHealth(
+  activeModelId: string | null,
+  provider: string | null,
+  modelName: string | null,
+  binaryPath: string | null,
+): Promise<DoctorEmbeddingCanaryReport> {
+  const base = (): Omit<DoctorEmbeddingCanaryReport, 'status' | 'detail'> => ({
+    canary_id: null,
+    recorded_at: null,
+    dimensions: null,
+    similarity: null,
+    threshold: EMBEDDING_CANARY_COSINE_WARN_THRESHOLD,
+    next_action: null,
+  });
+
+  if (activeModelId === null || binaryPath === null) {
+    return {
+      ...base(),
+      status: 'skipped',
+      detail: 'embedding canary skipped because the active model index is not built',
+    };
+  }
+
+  let manifest: Awaited<ReturnType<typeof readIndexIntegrityManifest>>;
+  try {
+    manifest = await readIndexIntegrityManifest(path.dirname(binaryPath));
+  } catch (err) {
+    return {
+      ...base(),
+      status: 'error',
+      detail: `could not read embedding canary manifest: ${(err as Error).message}`,
+      next_action: 'Run kb verify --integrity, then rebuild the affected index if the manifest is corrupt.',
+    };
+  }
+  const canary = manifest?.embedding_canary;
+  if (canary === undefined) {
+    return {
+      ...base(),
+      status: 'not_recorded',
+      detail: 'embedding canary not recorded for this index; rebuild the index to capture a canary fingerprint',
+      next_action: 'Run a forced reindex with this version before relying on drift detection for this model.',
+    };
+  }
+
+  if (
+    canary.canary_id !== EMBEDDING_CANARY_ID ||
+    !Array.isArray(canary.vector) ||
+    canary.vector.length === 0 ||
+    canary.dimensions !== canary.vector.length
+  ) {
+    return {
+      ...base(),
+      status: 'warn',
+      canary_id: typeof canary.canary_id === 'string' ? canary.canary_id : null,
+      recorded_at: typeof canary.captured_at === 'string' ? canary.captured_at : null,
+      dimensions: typeof canary.dimensions === 'number' ? canary.dimensions : null,
+      detail: 'embedding canary metadata is invalid or was written with an unsupported canary id',
+      next_action: 'Rebuild the index with the current CLI; see docs/operations/switching-embedding-models.md for model-switch validation steps.',
+    };
+  }
+
+  if (provider === null || modelName === null || !isEmbeddingsProvider(provider)) {
+    return {
+      ...base(),
+      status: 'error',
+      canary_id: canary.canary_id,
+      recorded_at: canary.captured_at,
+      dimensions: canary.dimensions,
+      detail: 'embedding canary could not run because the active embedding provider is unresolved',
+      next_action: 'Fix the active model metadata, then rerun kb doctor.',
+    };
+  }
+
+  try {
+    const embeddings = await createEmbeddingsClient({ provider, modelName });
+    const current = await createEmbeddingCanaryFingerprint(embeddings);
+    const similarity = cosineSimilarity(canary.vector, current.vector);
+    if (similarity === null) {
+      return {
+        ...base(),
+        status: 'warn',
+        canary_id: canary.canary_id,
+        recorded_at: canary.captured_at,
+        dimensions: canary.dimensions,
+        detail: `embedding canary dimensions are incompatible: recorded=${canary.vector.length}, current=${current.vector.length}`,
+        next_action: 'Review docs/operations/switching-embedding-models.md, then rebuild or switch back to a matching embedding model.',
+      };
+    }
+    const common = {
+      canary_id: canary.canary_id,
+      recorded_at: canary.captured_at,
+      dimensions: canary.dimensions,
+      similarity,
+      threshold: EMBEDDING_CANARY_COSINE_WARN_THRESHOLD,
+    };
+    if (similarity < EMBEDDING_CANARY_COSINE_WARN_THRESHOLD) {
+      return {
+        ...common,
+        status: 'warn',
+        detail: `embedding canary drift detected: cosine=${formatSimilarity(similarity)} below threshold=${EMBEDDING_CANARY_COSINE_WARN_THRESHOLD}`,
+        next_action: 'Review docs/operations/switching-embedding-models.md, then rebuild the index for the intended model or restore the original embedding backend.',
+      };
+    }
+    return {
+      ...common,
+      status: 'ok',
+      detail: `embedding canary matches persisted fingerprint: cosine=${formatSimilarity(similarity)}`,
+      next_action: null,
+    };
+  } catch (err) {
+    return {
+      ...base(),
+      status: 'error',
+      canary_id: canary.canary_id,
+      recorded_at: canary.captured_at,
+      dimensions: canary.dimensions,
+      detail: `embedding canary re-embed failed: ${(err as Error).message}`,
+      next_action: 'Fix embedding provider credentials/connectivity, then rerun kb doctor.',
+    };
+  }
+}
+
+function isEmbeddingsProvider(value: string): value is EmbeddingProvider | 'fake' {
+  return value === 'huggingface' ||
+    value === 'ollama' ||
+    value === 'openai' ||
+    value === 'fake';
+}
+
+function formatSimilarity(value: number): string {
+  return value.toFixed(6);
 }
 
 async function readIndexSecurity(
@@ -2394,6 +2567,20 @@ export function formatDoctorMarkdown(report: DoctorReport): string {
       `${report.index.storage.inactive_version_count} retained inactive version(s); ` +
       `retention=${report.index.storage.retention_previous_versions})`,
   );
+  lines.push('Embedding canary:');
+  lines.push(`  status: ${report.embedding_canary.status}`);
+  lines.push(`  canary_id: ${report.embedding_canary.canary_id ?? '<not recorded>'}`);
+  lines.push(`  recorded_at: ${report.embedding_canary.recorded_at ?? '<not recorded>'}`);
+  lines.push(
+    `  cosine: ${report.embedding_canary.similarity === null
+      ? 'n/a'
+      : formatSimilarity(report.embedding_canary.similarity)} ` +
+      `(threshold=${report.embedding_canary.threshold})`,
+  );
+  lines.push(`  detail: ${report.embedding_canary.detail}`);
+  if (report.embedding_canary.next_action !== null) {
+    lines.push(`  next_action: ${report.embedding_canary.next_action}`);
+  }
   lines.push('Extracted-text cache:');
   lines.push(`  path: ${report.extraction_cache.cache_dir}`);
   lines.push(

--- a/src/faiss-store-layout.test.ts
+++ b/src/faiss-store-layout.test.ts
@@ -1,0 +1,59 @@
+import {
+  EMBEDDING_CANARY_ID,
+  EMBEDDING_CANARY_TEXT_SHA256,
+  cosineSimilarity,
+  createEmbeddingCanaryFingerprint,
+} from './faiss-store-layout.js';
+
+describe('embedding canary fingerprint', () => {
+  it('captures the fixed document canary vector with a stable identity', async () => {
+    const embeddings = {
+      embedDocuments: jest.fn(async (texts: string[]) => texts.map(() => [0.6, 0.8])),
+    };
+
+    const fingerprint = await createEmbeddingCanaryFingerprint(
+      embeddings,
+      new Date('2026-06-13T00:00:00.000Z'),
+    );
+
+    expect(embeddings.embedDocuments).toHaveBeenCalledWith([
+      expect.stringContaining('kb embedding canary v1'),
+    ]);
+    expect(fingerprint).toEqual({
+      canary_id: EMBEDDING_CANARY_ID,
+      text_sha256: EMBEDDING_CANARY_TEXT_SHA256,
+      embedding_role: 'document',
+      captured_at: '2026-06-13T00:00:00.000Z',
+      dimensions: 2,
+      vector: [0.6, 0.8],
+    });
+  });
+
+  it('rejects missing and non-finite canary vectors', async () => {
+    await expect(
+      createEmbeddingCanaryFingerprint({
+        embedDocuments: async () => [],
+      }),
+    ).rejects.toThrow(/no vector/);
+
+    await expect(
+      createEmbeddingCanaryFingerprint({
+        embedDocuments: async () => [[1, Number.NaN]],
+      }),
+    ).rejects.toThrow(/non-finite/);
+  });
+});
+
+describe('cosineSimilarity', () => {
+  it('returns cosine similarity for equal-length finite vectors', () => {
+    expect(cosineSimilarity([1, 0], [1, 0])).toBeCloseTo(1);
+    expect(cosineSimilarity([1, 0], [0, 1])).toBeCloseTo(0);
+  });
+
+  it('returns null for incompatible vectors', () => {
+    expect(cosineSimilarity([], [])).toBeNull();
+    expect(cosineSimilarity([1], [1, 2])).toBeNull();
+    expect(cosineSimilarity([0, 0], [1, 2])).toBeNull();
+    expect(cosineSimilarity([1, Infinity], [1, 2])).toBeNull();
+  });
+});

--- a/src/faiss-store-layout.ts
+++ b/src/faiss-store-layout.ts
@@ -1,4 +1,5 @@
 import * as fsp from 'fs/promises';
+import * as crypto from 'crypto';
 import * as path from 'path';
 import type { EmbeddingsInterface } from '@langchain/core/embeddings';
 import { FaissStore } from '@langchain/community/vectorstores/faiss';
@@ -18,12 +19,30 @@ const SYMLINK_NAME = 'index';
 const LEGACY_INDEX_NAME = 'faiss.index';
 export const INDEX_INTEGRITY_MANIFEST_FILENAME = 'integrity.json';
 export const INDEX_INTEGRITY_MANIFEST_SCHEMA_VERSION = 'kb.index-integrity.v1';
+export const EMBEDDING_CANARY_TEXT =
+  'kb embedding canary v1: stable fingerprint for detecting silent embedding model drift.';
+export const EMBEDDING_CANARY_TEXT_SHA256 = crypto
+  .createHash('sha256')
+  .update(EMBEDDING_CANARY_TEXT, 'utf-8')
+  .digest('hex');
+export const EMBEDDING_CANARY_ID = `sha256:${EMBEDDING_CANARY_TEXT_SHA256}`;
+export const EMBEDDING_CANARY_COSINE_WARN_THRESHOLD = 0.999;
+
+export interface EmbeddingCanaryFingerprint {
+  canary_id: typeof EMBEDDING_CANARY_ID;
+  text_sha256: typeof EMBEDDING_CANARY_TEXT_SHA256;
+  embedding_role: 'document';
+  captured_at: string;
+  dimensions: number;
+  vector: number[];
+}
 
 export interface IndexIntegrityManifest {
   schema_version: typeof INDEX_INTEGRITY_MANIFEST_SCHEMA_VERSION;
   written_at: string;
   model_id: string;
   index_type: FaissIndexType;
+  embedding_canary?: EmbeddingCanaryFingerprint;
   files: {
     'faiss.index': { sha256: string };
     'docstore.json': { sha256: string };
@@ -294,6 +313,7 @@ export async function saveFaissStoreAtomic(options: {
   modelId: string;
   swapCounter: number;
   indexType?: FaissIndexType;
+  embeddingCanary?: EmbeddingCanaryFingerprint | null;
   /**
    * RFC 016 — when provided, the per-model `docstore.json` written by
    * `FaissStore.save` is canonicalized and hardlinked to a shared payload
@@ -315,6 +335,7 @@ export async function saveFaissStoreAtomic(options: {
     modelId,
     swapCounter,
     indexType = resolveFaissIndexType(),
+    embeddingCanary = null,
     casRoot = null,
     onCommitted,
   } = options;
@@ -337,7 +358,9 @@ export async function saveFaissStoreAtomic(options: {
   if (casRoot !== null) {
     dedup = await dedupeDocstoreOnSave({ stagingDir, casRoot, swapCounter });
   }
-  await writeIndexIntegrityManifest(stagingDir, modelId, indexType);
+  await writeIndexIntegrityManifest(stagingDir, modelId, indexType, {
+    embeddingCanary,
+  });
 
   const tmpLink = path.join(
     modelDir,
@@ -373,12 +396,14 @@ export async function writeIndexIntegrityManifest(
   versionDir: string,
   modelId: string,
   indexType: FaissIndexType = resolveFaissIndexType(),
+  opts: { embeddingCanary?: EmbeddingCanaryFingerprint | null } = {},
 ): Promise<IndexIntegrityManifest> {
   const manifest: IndexIntegrityManifest = {
     schema_version: INDEX_INTEGRITY_MANIFEST_SCHEMA_VERSION,
     written_at: new Date().toISOString(),
     model_id: modelId,
     index_type: indexType,
+    ...(opts.embeddingCanary ? { embedding_canary: opts.embeddingCanary } : {}),
     files: {
       'faiss.index': {
         sha256: await calculateSHA256(path.join(versionDir, 'faiss.index')),
@@ -394,6 +419,63 @@ export async function writeIndexIntegrityManifest(
     { encoding: 'utf-8', mode: 0o600 },
   );
   return manifest;
+}
+
+export async function createEmbeddingCanaryFingerprint(
+  embeddings: Pick<EmbeddingsInterface, 'embedDocuments'>,
+  capturedAt: Date = new Date(),
+): Promise<EmbeddingCanaryFingerprint> {
+  const vectors = await embeddings.embedDocuments([EMBEDDING_CANARY_TEXT]);
+  const vector = vectors[0];
+  if (!Array.isArray(vector) || vector.length === 0) {
+    throw new Error('Embedding canary provider returned no vector');
+  }
+  if (!vector.every((value) => Number.isFinite(value))) {
+    throw new Error('Embedding canary provider returned a non-finite vector value');
+  }
+  return {
+    canary_id: EMBEDDING_CANARY_ID,
+    text_sha256: EMBEDDING_CANARY_TEXT_SHA256,
+    embedding_role: 'document',
+    captured_at: capturedAt.toISOString(),
+    dimensions: vector.length,
+    vector,
+  };
+}
+
+export function cosineSimilarity(a: readonly number[], b: readonly number[]): number | null {
+  if (a.length === 0 || a.length !== b.length) return null;
+  let dot = 0;
+  let aNorm = 0;
+  let bNorm = 0;
+  for (let i = 0; i < a.length; i += 1) {
+    const av = a[i];
+    const bv = b[i];
+    if (!Number.isFinite(av) || !Number.isFinite(bv)) return null;
+    dot += av * bv;
+    aNorm += av * av;
+    bNorm += bv * bv;
+  }
+  if (aNorm === 0 || bNorm === 0) return null;
+  return dot / (Math.sqrt(aNorm) * Math.sqrt(bNorm));
+}
+
+export async function readIndexIntegrityManifest(
+  versionDir: string,
+): Promise<IndexIntegrityManifest | null> {
+  let raw: string;
+  try {
+    raw = await fsp.readFile(
+      path.join(versionDir, INDEX_INTEGRITY_MANIFEST_FILENAME),
+      'utf-8',
+    );
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT' || code === 'ENOTDIR') return null;
+    throw err;
+  }
+  const parsed = JSON.parse(raw) as IndexIntegrityManifest;
+  return parsed;
 }
 
 export async function resolveActiveIndexFilePath(modelDir: string): Promise<string | null> {


### PR DESCRIPTION
Closes #612

## Summary
- Persist an optional fixed-text embedding canary fingerprint in index integrity manifests during index saves.
- Add a `kb doctor` embedding_canary report/check that re-embeds the canary, compares cosine similarity, and reports drift or incompatible dimensions with next-action guidance.
- Document canary statuses in the embedding-model switching runbook.

## Implementation choice
The canary is a fixed string identified by `sha256:<hash>` and embedded with the document embedding path, so task-prefix wrappers and provider behavior match index-time document vectors. The doctor check is the only path that re-embeds it; normal index load and query paths only read existing data as before. The warning threshold is intentionally conservative and fixed at cosine 0.999 to avoid adding another config surface.

## Compatibility
Old indexes and manifests without `embedding_canary` report `not_recorded` and keep the doctor check row OK. Rebuilding with this version records the canary. Fake embeddings use the deterministic provider and can be checked without network access.

## Alternatives considered
- Query-time drift checks: rejected because this would add provider calls to normal load/search paths.
- A mutable corpus document canary: rejected because source edits would make the fingerprint ambiguous.
- A configurable threshold: deferred because there is no narrow established config need yet.

## Verification
- Attempted requested command: `npm test -- --runTestsByPath src/faiss-store-layout.test.ts /home/jean/git/knowledge-base-mcp-server/src/FaissIndexManager.test.ts /home/jean/git/knowledge-base-mcp-server/src/cli-doctor.test.ts --runInBand` (failed after the full parallel suite because the absolute paths target the main checkout and `faiss-store-layout.test.ts` is not in the serial Jest project selection).
- `npx jest --selectProjects parallel --runTestsByPath src/faiss-store-layout.test.ts --runInBand`
- `npx jest --selectProjects serial --runTestsByPath src/FaissIndexManager.test.ts src/cli-doctor.test.ts --runInBand`
- `npm run build`
- `git diff --check`