### PR TITLE
feat(indexing): pipeline embedding batches

### DIFF
--- a/benchmarks/indexing-concurrency.mjs
+++ b/benchmarks/indexing-concurrency.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+import { performance } from 'node:perf_hooks';
+
+const batches = positiveInteger(process.env.KB_INDEXING_BENCH_BATCHES, 12);
+const batchSize = positiveInteger(process.env.KB_INDEXING_BENCH_BATCH_SIZE, 64);
+const concurrency = Math.min(
+  4,
+  positiveInteger(process.env.KB_INDEXING_CONCURRENCY, 4),
+);
+const embedLatencyMs = positiveInteger(process.env.KB_INDEXING_BENCH_EMBED_MS, 80);
+const insertLatencyMs = positiveInteger(process.env.KB_INDEXING_BENCH_INSERT_MS, 12);
+
+function positiveInteger(raw, fallback) {
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : fallback;
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function embedBatch(index) {
+  await sleep(embedLatencyMs);
+  return {
+    index,
+    vectors: Array.from({ length: batchSize }, (_unused, i) => [index, i]),
+  };
+}
+
+async function insertBatch(_embedded) {
+  await sleep(insertLatencyMs);
+}
+
+async function runSequential() {
+  const startedAt = performance.now();
+  for (let i = 0; i < batches; i += 1) {
+    const embedded = await embedBatch(i);
+    await insertBatch(embedded);
+  }
+  return performance.now() - startedAt;
+}
+
+async function runPipelined() {
+  const startedAt = performance.now();
+  const inFlight = new Map();
+  let nextToLaunch = 0;
+
+  const launchMore = () => {
+    while (nextToLaunch < batches && inFlight.size < concurrency) {
+      const index = nextToLaunch;
+      inFlight.set(index, embedBatch(index));
+      nextToLaunch += 1;
+    }
+  };
+
+  launchMore();
+  for (let i = 0; i < batches; i += 1) {
+    const embedded = await inFlight.get(i);
+    inFlight.delete(i);
+    launchMore();
+    await insertBatch(embedded);
+  }
+
+  return performance.now() - startedAt;
+}
+
+const sequentialMs = await runSequential();
+const pipelinedMs = await runPipelined();
+const speedup = sequentialMs / pipelinedMs;
+
+const result = {
+  schema_version: 'kb.indexing-concurrency-bench.v1',
+  batches,
+  batch_size: batchSize,
+  concurrency,
+  embed_latency_ms: embedLatencyMs,
+  serialized_insert_latency_ms: insertLatencyMs,
+  sequential_ms: Math.round(sequentialMs),
+  pipelined_ms: Math.round(pipelinedMs),
+  speedup: Number(speedup.toFixed(2)),
+};
+
+console.log(JSON.stringify(result, null, 2));

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -10,6 +10,7 @@ rollback commands over design background.
 | [Eval gate harness](eval-gate-harness.md) | Measuring relevance-gate behavior before or after rollout. |
 | [Feedback workflow](feedback-workflow.md) | Recording retrieval judgements and promoting them into eval fixtures. |
 | [Incident response](incident-response.md) | Triage starts from a user-visible failure symptom. |
+| [Indexing](indexing.md) | Tuning indexing batch concurrency and measuring local throughput. |
 | [Index quantization](index-quantization.md) | Registering or evaluating an SQ8 FAISS index. |
 | [Local services](local-services.md) | Checking Ollama, llama-server, n8n, and local service health. |
 | [Logs reader](logs-reader.md) | Inspecting canonical logs and request ids. |

--- a/docs/operations/indexing.md
+++ b/docs/operations/indexing.md
@@ -1,0 +1,40 @@
+# Indexing Operations
+
+## Embedding Batch Concurrency
+
+`KB_INDEXING_CONCURRENCY` controls how many indexing embedding batches may be
+in flight at once. It defaults to `1`, which preserves the historical serial
+behavior.
+
+When set above `1`, indexing overlaps provider calls for later batches while
+FAISS insertion remains serialized in batch order. Progress events are emitted
+only after each in-order insert, so `batchIndex` and `processedChunks` remain
+monotonic even if a later embedding request completes first.
+
+The value is capped at `4` to bound memory to a small number of vector batches.
+Remote providers such as `huggingface` and `openai` may use the requested value.
+For `ollama`, values above `1` are ignored unless `OLLAMA_NUM_PARALLEL` is also
+set above `1`; the effective concurrency is then capped by `OLLAMA_NUM_PARALLEL`.
+
+Example:
+
+```bash
+KB_INDEXING_CONCURRENCY=4 kb reindex
+```
+
+Cross-batch duplicate chunks may be embedded more than once when their batches
+are in flight at the same time. Duplicate compaction still works within each
+embedding call and for already-completed batches. This tradeoff keeps the
+pipeline bounded and avoids retaining unbounded pending duplicate state during
+large reindexes.
+
+Use the local measurement harness before changing production defaults:
+
+```bash
+node benchmarks/indexing-concurrency.mjs
+KB_INDEXING_CONCURRENCY=2 node benchmarks/indexing-concurrency.mjs
+```
+
+The harness simulates provider latency and serialized insertion. Real-provider
+throughput still depends on provider rate limits, local Ollama parallelism, and
+network latency.

--- a/src/FaissIndexManager.test.ts
+++ b/src/FaissIndexManager.test.ts
@@ -385,6 +385,8 @@ describe('FaissIndexManager permission handling', () => {
     HUGGINGFACE_ENDPOINT_URL: process.env.HUGGINGFACE_ENDPOINT_URL,
     HUGGINGFACE_PROVIDER: process.env.HUGGINGFACE_PROVIDER,
     INDEXING_BATCH_SIZE: process.env.INDEXING_BATCH_SIZE,
+    KB_INDEXING_CONCURRENCY: process.env.KB_INDEXING_CONCURRENCY,
+    OLLAMA_NUM_PARALLEL: process.env.OLLAMA_NUM_PARALLEL,
     LOG_FILE: process.env.LOG_FILE,
     KB_MAX_FILE_BYTES: process.env.KB_MAX_FILE_BYTES,
     KB_MAX_EXTRACTED_TEXT_BYTES: process.env.KB_MAX_EXTRACTED_TEXT_BYTES,
@@ -405,6 +407,10 @@ describe('FaissIndexManager permission handling', () => {
     fromTextsMock.mockReset();
     loadMock.mockReset();
     similaritySearchMock.mockReset();
+    embedDocumentsMock.mockReset();
+    embedDocumentsMock.mockImplementation(async (texts: string[]) => texts.map(mockVectorForText));
+    embedQueryMock.mockReset();
+    embedQueryMock.mockImplementation(async (text: string) => mockVectorForText(text));
     embeddingConstructorMock.mockReset();
   });
 
@@ -964,6 +970,127 @@ describe('FaissIndexManager permission handling', () => {
       const sidecarPath = path.join(defaultKb, '.index', path.basename(docPath));
       await expect(fsp.readFile(sidecarPath, 'utf-8')).resolves.toMatch(/^[0-9a-f]{64}$/);
     }
+  });
+
+  it('pipelines embedding batches while inserting and reporting progress in order', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-faiss-pipelined-embeddings-'));
+    const kbDir = path.join(tempDir, 'kb');
+    const defaultKb = path.join(kbDir, 'default');
+    await fsp.mkdir(defaultKb, { recursive: true });
+    const docPaths: string[] = [];
+    for (let i = 0; i < 3; i += 1) {
+      const docPath = path.join(defaultKb, `doc-${i}.md`);
+      await fsp.writeFile(docPath, `# Doc ${i}\n\nPipelined content for document ${i}.`);
+      docPaths.push(docPath);
+    }
+
+    process.env.KNOWLEDGE_BASES_ROOT_DIR = kbDir;
+    process.env.FAISS_INDEX_PATH = path.join(tempDir, '.faiss');
+    process.env.EMBEDDING_PROVIDER = 'huggingface';
+    process.env.HUGGINGFACE_API_KEY = 'test-key';
+    process.env.INDEXING_BATCH_SIZE = '1';
+    process.env.KB_INDEXING_CONCURRENCY = '2';
+
+    let activeEmbeddings = 0;
+    let maxActiveEmbeddings = 0;
+    const completedProviderTexts: string[] = [];
+    embedDocumentsMock.mockImplementation(async (texts: string[]) => {
+      activeEmbeddings += 1;
+      maxActiveEmbeddings = Math.max(maxActiveEmbeddings, activeEmbeddings);
+      const firstText = texts[0] ?? '';
+      if (firstText.includes('Doc 0')) {
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+      completedProviderTexts.push(firstText);
+      activeEmbeddings -= 1;
+      return texts.map(mockVectorForText);
+    });
+
+    jest.resetModules();
+    const { FaissIndexManager } = await import('./FaissIndexManager.js');
+    const { EMBEDDING_CANARY_TEXT } = await import('./faiss-store-layout.js');
+    const manager = new FaissIndexManager();
+    await manager.initialize();
+    const progressEvents: Array<{
+      phase?: string;
+      batchIndex?: number;
+      processedChunks?: number;
+    }> = [];
+
+    await manager.updateIndex(undefined, {
+      onProgress: (progress) => {
+        progressEvents.push(progress);
+      },
+    });
+
+    expect(maxActiveEmbeddings).toBe(2);
+    expect(completedProviderTexts.filter((text) => text !== EMBEDDING_CANARY_TEXT)[0])
+      .toContain('Doc 1');
+
+    const [seedTexts, seedMetadatas] = fromTextsMock.mock.calls[0] as [
+      string[],
+      Array<{ source: string }>,
+    ];
+    expect(seedTexts).toHaveLength(1);
+    expect(seedMetadatas.map((metadata) => metadata.source)).toEqual(docPaths.slice(0, 1));
+
+    const appendedSources = addDocumentsMock.mock.calls.map((call) => {
+      const [docs] = call as [Array<{ metadata: { source: string } }>];
+      return docs.map((doc) => doc.metadata.source);
+    });
+    expect(appendedSources).toEqual([
+      docPaths.slice(1, 2),
+      docPaths.slice(2, 3),
+    ]);
+
+    const embedEvents = progressEvents.filter((event) => event.phase === 'embed');
+    expect(embedEvents.map((event) => ({
+      batchIndex: event.batchIndex,
+      processedChunks: event.processedChunks,
+    }))).toEqual([
+      { batchIndex: 1, processedChunks: 1 },
+      { batchIndex: 2, processedChunks: 2 },
+      { batchIndex: 3, processedChunks: 3 },
+    ]);
+  });
+
+  it('keeps ollama embedding batches serial unless OLLAMA_NUM_PARALLEL opts in', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-faiss-ollama-serial-'));
+    const kbDir = path.join(tempDir, 'kb');
+    const defaultKb = path.join(kbDir, 'default');
+    await fsp.mkdir(defaultKb, { recursive: true });
+    for (let i = 0; i < 3; i += 1) {
+      const docPath = path.join(defaultKb, `doc-${i}.md`);
+      await fsp.writeFile(docPath, `# Doc ${i}\n\nOllama serial content for document ${i}.`);
+    }
+
+    process.env.KNOWLEDGE_BASES_ROOT_DIR = kbDir;
+    process.env.FAISS_INDEX_PATH = path.join(tempDir, '.faiss');
+    process.env.EMBEDDING_PROVIDER = 'ollama';
+    process.env.OLLAMA_MODEL = 'nomic-embed-text';
+    process.env.INDEXING_BATCH_SIZE = '1';
+    process.env.KB_INDEXING_CONCURRENCY = '3';
+    delete process.env.OLLAMA_NUM_PARALLEL;
+
+    let activeEmbeddings = 0;
+    let maxActiveEmbeddings = 0;
+    embedDocumentsMock.mockImplementation(async (texts: string[]) => {
+      activeEmbeddings += 1;
+      maxActiveEmbeddings = Math.max(maxActiveEmbeddings, activeEmbeddings);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      activeEmbeddings -= 1;
+      return texts.map(mockVectorForText);
+    });
+
+    jest.resetModules();
+    const { FaissIndexManager } = await import('./FaissIndexManager.js');
+    const manager = new FaissIndexManager();
+    await manager.initialize();
+    await manager.updateIndex();
+
+    expect(maxActiveEmbeddings).toBe(1);
+    expect(fromTextsMock).toHaveBeenCalledTimes(1);
+    expect(addDocumentsMock).toHaveBeenCalledTimes(2);
   });
 
   it('embeds duplicate normalized chunk text once per indexing operation while preserving every source', async () => {

--- a/src/FaissIndexManager.ts
+++ b/src/FaissIndexManager.ts
@@ -30,6 +30,7 @@ import {
 import {
   resolveFaissIndexType,
   resolveIndexingBatchSize,
+  resolveIndexingConcurrency,
   type FaissIndexType,
 } from './config/indexing.js';
 import { casRootForIndexPath } from './docstore-cas.js';
@@ -90,7 +91,7 @@ import {
 } from './metadata-sidecar.js';
 import { queryEmbeddingCache, type QueryCacheLookupStatus, type QueryCacheTelemetry } from './query-cache.js';
 import { withSidecarLock } from './write-lock.js';
-import { FaissStoreAdapter } from './faiss-store-adapter.js';
+import { FaissStoreAdapter, type EmbeddedDocumentsBatch } from './faiss-store-adapter.js';
 import {
   recordIngestFailure,
   recordIngestSuccess,
@@ -570,6 +571,7 @@ export class FaissIndexManager {
   readonly modelDir: string;
   readonly modelNameFile: string;
   private readonly indexingBatchSize: number;
+  private readonly indexingConcurrency: number;
   private readonly indexType: FaissIndexType;
   private lastIndexUpdateSummary: IndexUpdateSummary;
   // Issue #283 — cached metadata sidecar so we don't re-parse the JSONL
@@ -605,6 +607,7 @@ export class FaissIndexManager {
     this.modelDir = modelDir(this.modelId);
     this.modelNameFile = modelNameFilePath(this.modelId);
     this.indexingBatchSize = resolveIndexingBatchSize(this.embeddingProvider);
+    this.indexingConcurrency = resolveIndexingConcurrency(this.embeddingProvider);
     this.indexType = opts?.indexType ?? resolveFaissIndexType();
     this.lastIndexUpdateSummary = createNeverRunIndexUpdateSummary(this.modelId);
 
@@ -1232,52 +1235,110 @@ export class FaissIndexManager {
     const batchCount = Math.ceil(documentsToAdd.length / this.indexingBatchSize);
     const embedStartedAtMs = Date.now();
     let processedChunks = 0;
-    let batchIndex = 0;
     // Scope duplicate-compaction to this indexing operation. FAISS still
     // receives every document; only provider embedDocuments calls are deduped.
+    // With opt-in cross-batch pipelining, identical text in two concurrently
+    // embedding batches may still race and call the provider twice. Keeping the
+    // cache local preserves bounded memory and deterministic FAISS insertion.
     const indexingEmbeddings = new IndexingEmbeddingDeduper(this.embeddings);
+    const batches: Document[][] = [];
     for (let offset = 0; offset < documentsToAdd.length; offset += this.indexingBatchSize) {
-      const batch = documentsToAdd.slice(offset, offset + this.indexingBatchSize);
-      batchIndex += 1;
+      batches.push(documentsToAdd.slice(offset, offset + this.indexingBatchSize));
+    }
+
+    const emitEmbeddingProgress = async (
+      batch: readonly Document[],
+      batchIndex: number,
+    ): Promise<void> => {
+      processedChunks += batch.length;
+      if (!opts?.onProgress) return;
+
+      const phaseElapsedMs = Date.now() - embedStartedAtMs;
+      const throughputChunksPerSecond = phaseElapsedMs > 0
+        ? processedChunks / (phaseElapsedMs / 1000)
+        : null;
+      const lastSource = batch[batch.length - 1]?.metadata?.source;
+      await opts.onProgress({
+        processedFiles: opts.processedFiles(),
+        totalFiles: opts.totalFiles,
+        currentFile: typeof lastSource === 'string' ? lastSource : '',
+        modelId: this.modelId,
+        phase: 'embed',
+        phaseStatus: 'progress',
+        processedChunks,
+        totalChunks: documentsToAdd.length,
+        batchIndex,
+        batchCount,
+        batchSize: batch.length,
+        provider: this.embeddingProvider,
+        modelName: this.modelName,
+        elapsedMs: Date.now() - opts.updateStartedAtMs,
+        phaseElapsedMs,
+        throughputChunksPerSecond: throughputChunksPerSecond ?? undefined,
+      });
+    };
+
+    const insertEmbeddedBatch = async (
+      embedded: EmbeddedDocumentsBatch,
+      batchIndex: number,
+    ): Promise<void> => {
       if (this.faissIndex === null) {
-        logger.info(`Creating new FAISS index from ${batch.length} text(s)...`);
-        this.faissIndex = await FaissStoreAdapter.fromDocuments(
-          batch,
-          indexingEmbeddings,
+        logger.info(`Creating new FAISS index from ${embedded.documents.length} text(s)...`);
+        this.faissIndex = await FaissStoreAdapter.fromEmbeddedDocuments(
+          embedded,
+          this.embeddings,
           { indexType: this.indexType },
         );
-        // The store must keep the real client for query embeddings and later
-        // operations; the deduper is only an insertion-time wrapper.
-        this.faissIndex.restoreEmbeddings(this.embeddings);
       } else {
-        await this.faissIndex.addDocumentsWithEmbeddings(batch, indexingEmbeddings);
+        await this.faissIndex.addEmbeddedDocuments(embedded);
       }
-      processedChunks += batch.length;
-      if (opts?.onProgress) {
-        const phaseElapsedMs = Date.now() - embedStartedAtMs;
-        const throughputChunksPerSecond = phaseElapsedMs > 0
-          ? processedChunks / (phaseElapsedMs / 1000)
-          : null;
-        const lastSource = batch[batch.length - 1]?.metadata?.source;
-        await opts.onProgress({
-          processedFiles: opts.processedFiles(),
-          totalFiles: opts.totalFiles,
-          currentFile: typeof lastSource === 'string' ? lastSource : '',
-          modelId: this.modelId,
-          phase: 'embed',
-          phaseStatus: 'progress',
-          processedChunks,
-          totalChunks: documentsToAdd.length,
-          batchIndex,
-          batchCount,
-          batchSize: batch.length,
-          provider: this.embeddingProvider,
-          modelName: this.modelName,
-          elapsedMs: Date.now() - opts.updateStartedAtMs,
-          phaseElapsedMs,
-          throughputChunksPerSecond: throughputChunksPerSecond ?? undefined,
-        });
+      await emitEmbeddingProgress(embedded.documents, batchIndex);
+    };
+
+    if (this.indexingConcurrency <= 1) {
+      for (let i = 0; i < batches.length; i += 1) {
+        const batch = batches[i];
+        const embedded = await FaissStoreAdapter.embedDocumentsForIndexing(batch, indexingEmbeddings);
+        await insertEmbeddedBatch(embedded, i + 1);
       }
+      return true;
+    }
+
+    type EmbeddedBatchResult =
+      | { ok: true; embedded: EmbeddedDocumentsBatch }
+      | { ok: false; error: unknown };
+    const inFlight = new Map<number, Promise<EmbeddedBatchResult>>();
+    let nextBatchToLaunch = 0;
+    const launchMoreEmbeddingBatches = (): void => {
+      while (
+        nextBatchToLaunch < batches.length &&
+        inFlight.size < this.indexingConcurrency
+      ) {
+        const launchIndex = nextBatchToLaunch;
+        const batch = batches[launchIndex];
+        inFlight.set(
+          launchIndex,
+          FaissStoreAdapter.embedDocumentsForIndexing(batch, indexingEmbeddings)
+            .then((embedded) => ({ ok: true, embedded }) as const)
+            .catch((error: unknown) => ({ ok: false, error }) as const),
+        );
+        nextBatchToLaunch += 1;
+      }
+    };
+
+    launchMoreEmbeddingBatches();
+    for (let i = 0; i < batches.length; i += 1) {
+      const resultPromise = inFlight.get(i);
+      if (resultPromise === undefined) {
+        throw new Error(`Missing in-flight embedding batch ${i + 1}`);
+      }
+      const result = await resultPromise;
+      inFlight.delete(i);
+      if (!result.ok) {
+        throw result.error;
+      }
+      launchMoreEmbeddingBatches();
+      await insertEmbeddedBatch(result.embedded, i + 1);
     }
     return true;
   }

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -7,6 +7,7 @@ import {
   resolveFaissIndexType,
   resolveChunkSize,
   resolveIndexingBatchSize,
+  resolveIndexingConcurrency,
 } from './config/indexing.js';
 import {
   parseKBLogFormat,
@@ -89,6 +90,37 @@ describe('resolveIndexingBatchSize (issue #236 — INDEXING_BATCH_SIZE)', () => 
 
     process.env.INDEXING_BATCH_SIZE = '0';
     expect(resolveIndexingBatchSize('ollama')).toBe(16);
+  });
+});
+
+describe('resolveIndexingConcurrency (issue #613 — KB_INDEXING_CONCURRENCY)', () => {
+  it('defaults to serial indexing for every provider', () => {
+    expect(resolveIndexingConcurrency('huggingface', {})).toBe(1);
+    expect(resolveIndexingConcurrency('openai', {})).toBe(1);
+    expect(resolveIndexingConcurrency('ollama', {})).toBe(1);
+  });
+
+  it('allows bounded remote-provider concurrency when explicitly enabled', () => {
+    expect(resolveIndexingConcurrency('huggingface', { KB_INDEXING_CONCURRENCY: '3' })).toBe(3);
+    expect(resolveIndexingConcurrency('openai', { KB_INDEXING_CONCURRENCY: '9' })).toBe(4);
+    expect(resolveIndexingConcurrency('openai', { KB_INDEXING_CONCURRENCY: '2.9' })).toBe(2);
+  });
+
+  it('falls back to serial indexing for invalid values', () => {
+    expect(resolveIndexingConcurrency('huggingface', { KB_INDEXING_CONCURRENCY: 'nope' })).toBe(1);
+    expect(resolveIndexingConcurrency('huggingface', { KB_INDEXING_CONCURRENCY: '0' })).toBe(1);
+  });
+
+  it('keeps ollama serial unless OLLAMA_NUM_PARALLEL opts in', () => {
+    expect(resolveIndexingConcurrency('ollama', { KB_INDEXING_CONCURRENCY: '3' })).toBe(1);
+    expect(resolveIndexingConcurrency('ollama', {
+      KB_INDEXING_CONCURRENCY: '3',
+      OLLAMA_NUM_PARALLEL: '1',
+    })).toBe(1);
+    expect(resolveIndexingConcurrency('ollama', {
+      KB_INDEXING_CONCURRENCY: '3',
+      OLLAMA_NUM_PARALLEL: '2',
+    })).toBe(2);
   });
 });
 

--- a/src/config/indexing.ts
+++ b/src/config/indexing.ts
@@ -6,8 +6,11 @@ import { EMBEDDING_PROVIDER } from './provider.js';
 
 export const DEFAULT_INDEXING_BATCH_SIZE = 64;
 export const DEFAULT_OLLAMA_INDEXING_BATCH_SIZE = 16;
+export const DEFAULT_INDEXING_CONCURRENCY = 1;
 const MAX_INDEXING_BATCH_SIZE = 512;
+const MAX_INDEXING_CONCURRENCY = 4;
 export const KB_INDEX_TYPE_ENV = 'KB_INDEX_TYPE';
+export const KB_INDEXING_CONCURRENCY_ENV = 'KB_INDEXING_CONCURRENCY';
 export type FaissIndexType = 'flat' | 'sq8';
 export const KB_FLAT_SEARCH_P95_ADVISORY_MS_ENV = 'KB_FLAT_SEARCH_P95_ADVISORY_MS';
 export const DEFAULT_FLAT_SEARCH_P95_ADVISORY_MS = 50;
@@ -28,6 +31,32 @@ export function resolveIndexingBatchSize(
 }
 
 export const INDEXING_BATCH_SIZE: number = resolveIndexingBatchSize();
+
+export function resolveIndexingConcurrency(
+  provider: string = EMBEDDING_PROVIDER,
+  env: NodeJS.ProcessEnv | Record<string, string | undefined> = process.env,
+): number {
+  const raw = env[KB_INDEXING_CONCURRENCY_ENV];
+  if (raw === undefined || raw.trim() === '') {
+    return DEFAULT_INDEXING_CONCURRENCY;
+  }
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return DEFAULT_INDEXING_CONCURRENCY;
+  }
+
+  const requested = Math.min(MAX_INDEXING_CONCURRENCY, Math.max(1, Math.floor(parsed)));
+  if (provider !== 'ollama' || requested === 1) {
+    return requested;
+  }
+
+  const ollamaParallelRaw = env.OLLAMA_NUM_PARALLEL;
+  const ollamaParallel = ollamaParallelRaw === undefined ? NaN : Number(ollamaParallelRaw);
+  if (!Number.isFinite(ollamaParallel) || ollamaParallel <= 1) {
+    return DEFAULT_INDEXING_CONCURRENCY;
+  }
+  return Math.min(requested, Math.floor(ollamaParallel));
+}
 
 export function defaultIndexingBatchSize(provider: string): number {
   return provider === 'ollama'

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -164,6 +164,12 @@ describe('config schema validation (FR-OBS-470)', () => {
         redacted: false,
       }),
       expect.objectContaining({
+        name: 'KB_INDEXING_CONCURRENCY',
+        value: '1',
+        source: 'default',
+        redacted: false,
+      }),
+      expect.objectContaining({
         name: 'HUGGINGFACE_API_KEY',
         value: '<redacted>',
         source: 'env',

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -156,6 +156,7 @@ export const CONFIG_SCHEMA: readonly ConfigSpec[] = [
   { name: 'OPENAI_MODEL_NAME', kind: 'string', default: DEFAULT_OPENAI_MODEL_NAME, emptyUsesDefault: true },
 
   { name: 'INDEXING_BATCH_SIZE', kind: 'integer', defaultValue: (env) => String(defaultIndexingBatchSize(effectiveStringValue(env, 'EMBEDDING_PROVIDER', 'huggingface'))), min: 1, max: 512 },
+  { name: 'KB_INDEXING_CONCURRENCY', kind: 'integer', default: '1', min: 1, max: 4 },
   { name: 'KB_CHUNK_SIZE', kind: 'integer', default: '1000', min: 1 },
   { name: 'KB_CHUNK_OVERLAP', kind: 'integer', defaultValue: (env) => defaultChunkOverlap(env), min: 0 },
   { name: 'INGEST_EXTRA_EXTENSIONS', kind: 'csv', default: '' },

--- a/src/faiss-store-adapter.test.ts
+++ b/src/faiss-store-adapter.test.ts
@@ -87,6 +87,45 @@ describe('FaissStoreAdapter', () => {
     expect(addVectors).toHaveBeenCalledWith([[1, 1, 1, 1], [2, 2, 2, 2]], docs);
   });
 
+  it('can embed a batch before serialized insertion', async () => {
+    const indexingEmbeddings = {
+      embedDocuments: jest.fn(async (texts: string[]) =>
+        texts.map((_t, i) => [i + 1, i + 2]),
+      ),
+      embedQuery: jest.fn(),
+    };
+    const docs = [
+      { pageContent: 'a', metadata: {} },
+      { pageContent: 'b', metadata: {} },
+    ];
+
+    const embedded = await FaissStoreAdapter.embedDocumentsForIndexing(
+      docs as never,
+      indexingEmbeddings as never,
+    );
+
+    expect(embedded.documents).toBe(docs);
+    expect(embedded.vectors).toEqual([[1, 2], [2, 3]]);
+
+    const addVectors = jest.fn(async () => {});
+    const store = {
+      embeddings: { embedDocuments: jest.fn(), embedQuery: jest.fn() },
+      addVectors,
+      index: { ntotal: () => 2, getDimension: () => 2 },
+      docstore: {
+        _docs: new Map<string, unknown>([
+          ['id-0', { pageContent: 'a', metadata: {} }],
+          ['id-1', { pageContent: 'b', metadata: {} }],
+        ]),
+      },
+    };
+
+    await adapterFor(store).addEmbeddedDocuments(embedded);
+
+    expect(addVectors).toHaveBeenCalledWith([[1, 2], [2, 3]], docs);
+    expect(indexingEmbeddings.embedDocuments).toHaveBeenCalledTimes(1);
+  });
+
   it('uses the preface-prepended form for embedding when metadata.contextual_preface is set', async () => {
     const indexingEmbeddings = {
       embedDocuments: jest.fn(async (texts: string[]) =>

--- a/src/faiss-store-adapter.ts
+++ b/src/faiss-store-adapter.ts
@@ -148,6 +148,11 @@ export interface QueryEmbeddingLookup {
   telemetry: QueryCacheTelemetry;
 }
 
+export interface EmbeddedDocumentsBatch {
+  documents: readonly Document[];
+  vectors: number[][];
+}
+
 /**
  * Small boundary around @langchain/community's FaissStore.
  *
@@ -174,6 +179,14 @@ export class FaissStoreAdapter {
     // We pre-compute embeddings against `embeddingText(doc)` and then store
     // the documents verbatim via `addVectors` — preserving caller-visible
     // pageContent byte-identical to today while enriching the vector.
+    const embedded = await FaissStoreAdapter.embedDocumentsForIndexing(documents, embeddings);
+    return FaissStoreAdapter.fromEmbeddedDocuments(embedded, embeddings, options);
+  }
+
+  static async embedDocumentsForIndexing(
+    documents: readonly Document[],
+    embeddings: EmbeddingsInterface,
+  ): Promise<EmbeddedDocumentsBatch> {
     const texts = documents.map(embeddingText);
     const vectors = await embeddings.embedDocuments(texts);
     if (vectors.length !== documents.length) {
@@ -181,15 +194,23 @@ export class FaissStoreAdapter {
         `Embedding provider returned ${vectors.length} vector(s) for ${documents.length} document(s)`,
       );
     }
+    return { documents, vectors };
+  }
+
+  static async fromEmbeddedDocuments(
+    embedded: EmbeddedDocumentsBatch,
+    embeddings: EmbeddingsInterface,
+    options: { indexType?: FaissIndexType } = {},
+  ): Promise<FaissStoreAdapter> {
     const indexType = options.indexType ?? resolveFaissIndexType();
-    const index = await createIndexForVectors(vectors, indexType);
+    const index = await createIndexForVectors(embedded.vectors, indexType);
     const store = new FaissStore(embeddings, { ...(index ? { index } : {}) } as FaissLibArgs);
-    await store.addVectors(vectors, [...documents]);
+    await store.addVectors(embedded.vectors, [...embedded.documents]);
     // Post-batch invariant: the FaissStore.addVectors call must produce a
     // 1:1 docstore-to-vector ratio. RFC 017 §3 mandates this check to catch
     // a partial-failure where `index.add()` succeeded but `docstore.add()`
     // threw mid-batch.
-    assertIndexDocstoreParity(store, 'FaissStoreAdapter.fromDocuments');
+    assertIndexDocstoreParity(store, 'FaissStoreAdapter.fromEmbeddedDocuments');
     return new FaissStoreAdapter(store);
   }
 
@@ -210,22 +231,20 @@ export class FaissStoreAdapter {
     documents: readonly Document[],
     embeddings: EmbeddingsInterface,
   ): Promise<void> {
-    assertEmbeddingsSlot(this.store);
     // RFC 017 §3 — embed against `embeddingText(doc)` (preface-prepended
     // when present), then call `addVectors` with the original documents.
     // The `embeddings` argument here may be an `IndexingEmbeddingDeduper`
     // (see FaissIndexManager:1062); it normalizes strings before
     // delegating, so two chunks with identical text but different prefaces
     // are now correctly different inputs and produce different vectors.
-    const texts = documents.map(embeddingText);
-    const vectors = await embeddings.embedDocuments(texts);
-    if (vectors.length !== documents.length) {
-      throw new Error(
-        `Embedding provider returned ${vectors.length} vector(s) for ${documents.length} document(s)`,
-      );
-    }
-    await this.store.addVectors(vectors, [...documents]);
-    assertIndexDocstoreParity(this.store, 'FaissStoreAdapter.addDocumentsWithEmbeddings');
+    const embedded = await FaissStoreAdapter.embedDocumentsForIndexing(documents, embeddings);
+    await this.addEmbeddedDocuments(embedded);
+  }
+
+  async addEmbeddedDocuments(embedded: EmbeddedDocumentsBatch): Promise<void> {
+    assertEmbeddingsSlot(this.store);
+    await this.store.addVectors(embedded.vectors, [...embedded.documents]);
+    assertIndexDocstoreParity(this.store, 'FaissStoreAdapter.addEmbeddedDocuments');
   }
 
   async similaritySearchUsingBestPath(options: {


### PR DESCRIPTION
## Summary

Closes #613.

Adds default-off, provider-aware pipelining for indexing embedding batches. `KB_INDEXING_CONCURRENCY` defaults to `1`, so existing serial behavior is preserved. When set above `1`, embedding calls for later batches can run concurrently, while FAISS creation/insertion and progress events are still consumed in original batch order.

## Implementation Choice

- Split `FaissStoreAdapter` into an embedding seam (`embedDocumentsForIndexing`) and serialized insertion seams (`fromEmbeddedDocuments`, `addEmbeddedDocuments`).
- Keep first-batch index creation semantics intact by constructing the store from the first embedded batch before appending later batches.
- Resolve `KB_INDEXING_CONCURRENCY` with a small cap of `4` to bound memory.
- Keep Ollama serial unless `OLLAMA_NUM_PARALLEL > 1`; the effective value is capped by Ollama parallelism.
- Preserve deterministic progress by emitting progress only after each in-order insert.
- On embedding failure, stop launching additional batches before rethrowing; already in-flight provider calls are not cancellable through the current embedding interface.

## Benchmark Evidence

Local harness: `node benchmarks/indexing-concurrency.mjs` simulates provider-bound embedding latency with serialized insertion.

- `node benchmarks/indexing-concurrency.mjs`: sequential 1112 ms, pipelined 290 ms, speedup 3.83x at concurrency 4.
- `KB_INDEXING_CONCURRENCY=2 node benchmarks/indexing-concurrency.mjs`: sequential 1112 ms, pipelined 507 ms, speedup 2.20x at concurrency 2.

This is a local measurement harness, not a claim about every real provider. Real gains still depend on provider rate limits, network latency, and `OLLAMA_NUM_PARALLEL` for Ollama.

## Alternatives Considered

- Leave embedding and insertion coupled: simplest, but prevents overlapping provider latency with serialized insertion.
- Make FAISS insertion concurrent: rejected because FAISS/docstore mutation must remain ordered and parity-checked.
- Hoist cross-batch duplicate promise tracking: deferred to keep memory bounded and avoid widening the change. Duplicate compaction remains within each embedding call and for already completed batches; concurrently in-flight duplicate batches may pay duplicate provider calls.

## Pre-PR Review

- detected project type: npm
- type/build checks: passed
- tests: passed
- bug reproduction: skipped, feature PR rather than `fix:` PR
- diff review: done
- portability scan: done manually; no added machine-local absolute paths
- reviewer specialists: conventions, correctness, dead-code, and test reviews completed; findings addressed

## Verification

- `npm test -- --runTestsByPath src/FaissIndexManager.test.ts src/faiss-store-adapter.test.ts src/config.test.ts src/config/schema.test.ts --runInBand` (passes; wrapper also ran full parallel suite)
- `npx jest --selectProjects serial --runTestsByPath /home/jean/git/knowledge-base-mcp-server-issue-613-indexing-pipeline-48972958/src/FaissIndexManager.test.ts --runInBand`
- `npx jest --selectProjects parallel --runTestsByPath /home/jean/git/knowledge-base-mcp-server-issue-613-indexing-pipeline-48972958/src/faiss-store-adapter.test.ts /home/jean/git/knowledge-base-mcp-server-issue-613-indexing-pipeline-48972958/src/config.test.ts /home/jean/git/knowledge-base-mcp-server-issue-613-indexing-pipeline-48972958/src/config/schema.test.ts --runInBand`
- `npm run build`
- `git diff --check`
- `node benchmarks/indexing-concurrency.mjs`
- `KB_INDEXING_CONCURRENCY=2 node benchmarks/indexing-concurrency.mjs`
