### PR TITLE
feat(search): add mtime recency filters

### DIFF
--- a/docs/cli-json-contracts.md
+++ b/docs/cli-json-contracts.md
@@ -245,6 +245,7 @@ Invocation:
 
 ```bash
 kb search "<query>" --format=json [--kb=<name>] [--model=<id>] [--k=<int>]
+kb search "<query>" --format=json [--since=30d] [--until=2026-06-01]
 kb search "<query>" --format=json --refresh [--kb=<name>]
 kb search --stdin --format=json
 kb search "<query>" --format=json --mode=dense|lexical|hybrid|auto
@@ -344,6 +345,12 @@ Optional stable fields:
   `--anti-query` is not raw farthest-neighbor search.
 - `auto_threshold`: present with `--threshold=auto`. Shape:
   `{"threshold": number, "knee_index": number|null, "kept": number}`.
+- `--since` / `--until`: dense-only input filters. They do not add response
+  fields; they narrow `results` to chunks whose current source-file mtime is
+  within the requested range. Bounds accept durations such as `30d` or `24h`
+  and ISO dates/timestamps. The comparison uses the file mtime at query time,
+  so a stale index can produce matches whose indexed text predates or postdates
+  the current file mtime.
 - `timing`: present with `--timing`; keys are elapsed millisecond counters and
   mode labels. Dense query-cache diagnostics use the flat keys
   `query_cache`, `query_cache_enabled`, `query_cache_model_id`, and

--- a/src/KnowledgeBaseServer.test.ts
+++ b/src/KnowledgeBaseServer.test.ts
@@ -2043,6 +2043,51 @@ describe('KnowledgeBaseServer handlers', () => {
     );
   });
 
+  it('handleRetrieveKnowledge forwards since / until mtime filters (#609)', async () => {
+    await setRetrieveEnv();
+    updateIndexMock.mockResolvedValue(undefined);
+    similaritySearchMock.mockResolvedValue([]);
+
+    const server = await freshServer();
+
+    await server['handleRetrieveKnowledge']({
+      query: 'q',
+      since: '30d',
+      until: '24h',
+    });
+
+    expect(similaritySearchMock).toHaveBeenLastCalledWith(
+      'q',
+      10,
+      undefined,
+      undefined,
+      { extensions: undefined, pathGlob: undefined, tags: undefined, since: '30d', until: '24h' },
+      expect.any(Object),
+    );
+  });
+
+  it('handleRetrieveKnowledge rejects invalid recency ranges before retrieval (#609)', async () => {
+    await setRetrieveEnv();
+    updateIndexMock.mockResolvedValue(undefined);
+    similaritySearchMock.mockResolvedValue([]);
+
+    const server = await freshServer();
+
+    const result = await server['handleRetrieveKnowledge']({
+      query: 'q',
+      since: '24h',
+      until: '30d',
+    });
+
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content[0].text).error).toMatchObject({
+      code: 'VALIDATION',
+      message: expect.stringContaining('invalid recency range'),
+    });
+    expect(updateIndexMock).not.toHaveBeenCalled();
+    expect(similaritySearchMock).not.toHaveBeenCalled();
+  });
+
   it('handleRetrieveKnowledge scopes returned sources to knowledge_base_name (#71)', async () => {
     const tempDir = await setRetrieveEnv();
     const alphaSource = path.join(tempDir, 'alpha', 'one.md');

--- a/src/KnowledgeBaseServer.ts
+++ b/src/KnowledgeBaseServer.ts
@@ -115,6 +115,7 @@ import {
   classifyDenseDegradationReason,
   type DenseDegradationReason,
 } from './search-core.js';
+import { parseRecencyFilterRange } from './search-filters.js';
 import {
   applyRelevanceGate,
   emitRelevanceGateDecision,
@@ -203,12 +204,14 @@ function hasNeighborContext(options: NeighborContextOptions | undefined): boolea
 }
 
 function hasRetrievalFilters(
-  filters: { extensions?: string[]; pathGlob?: string; tags?: string[] } | undefined,
+  filters: { extensions?: string[]; pathGlob?: string; tags?: string[]; since?: string; until?: string } | undefined,
 ): boolean {
   return filters !== undefined && (
     (filters.extensions?.length ?? 0) > 0 ||
     filters.pathGlob !== undefined ||
-    (filters.tags?.length ?? 0) > 0
+    (filters.tags?.length ?? 0) > 0 ||
+    filters.since !== undefined ||
+    filters.until !== undefined
   );
 }
 
@@ -291,6 +294,8 @@ export class KnowledgeBaseServer {
         extensions: z.array(z.string()).optional().describe('Limit results to chunks whose source file has one of these extensions (e.g. [".md", ".pdf"]). Case-insensitive; leading dot optional.'),
         path_glob: z.string().optional().describe('Limit results to chunks whose KB-internal relative path matches this glob (e.g. "runbooks/**"). The KB-name segment is stripped before matching.'),
         tags: z.array(z.string()).optional().describe('Limit results to chunks whose source file has ALL of these tags in its YAML frontmatter.'),
+        since: z.string().optional().describe('Limit dense results to chunks whose current source-file mtime is at or after this bound. Accepts durations like "30d"/"24h" or ISO dates/timestamps; mtime can differ from indexed-content time on stale indexes.'),
+        until: z.string().optional().describe('Limit dense results to chunks whose current source-file mtime is at or before this bound. Accepts durations like "30d"/"24h" or ISO dates/timestamps; mtime can differ from indexed-content time on stale indexes.'),
         context_before: z.number().int().min(0).max(5).optional().describe('Opt-in neighbor context: include up to this many preceding chunks from the same source around each dense semantic match. Defaults to 0.'),
         context_after: z.number().int().min(0).max(5).optional().describe('Opt-in neighbor context: include up to this many following chunks from the same source around each dense semantic match. Defaults to 0.'),
         context_window: z.number().int().min(0).max(5).optional().describe('Shorthand for setting context_before and context_after to the same value. Defaults to 0.'),
@@ -710,6 +715,8 @@ export class KnowledgeBaseServer {
     extensions?: string[];
     path_glob?: string;
     tags?: string[];
+    since?: string;
+    until?: string;
     context_before?: number;
     context_after?: number;
     context_window?: number;
@@ -724,8 +731,8 @@ export class KnowledgeBaseServer {
     const knowledgeBaseName: string | undefined = args.knowledge_base_name;
     const threshold: number | undefined = args.threshold;
     const modelNameOverride: string | undefined = args.model_name;
-    const filters = (args.extensions || args.path_glob || args.tags)
-      ? { extensions: args.extensions, pathGlob: args.path_glob, tags: args.tags }
+    const filters = (args.extensions || args.path_glob || args.tags || args.since || args.until)
+      ? { extensions: args.extensions, pathGlob: args.path_glob, tags: args.tags, since: args.since, until: args.until }
       : undefined;
     const searchMode: 'dense' | 'hybrid' = args.search_mode ?? 'dense';
     const taskContext = args.task_context;
@@ -741,6 +748,27 @@ export class KnowledgeBaseServer {
       threshold: threshold ?? 2,
       search_mode: searchMode,
     }, async () => {
+      try {
+        parseRecencyFilterRange({ since: args.since, until: args.until });
+      } catch (err) {
+        searchLatencyMetrics.record({
+          mode: searchMode,
+          status: 'error',
+          totalMs: Date.now() - requestStartedAt,
+        });
+        return {
+          content: [{
+            type: 'text',
+            text: JSON.stringify({
+              error: {
+                code: 'VALIDATION',
+                message: (err as Error).message,
+              },
+            }),
+          }],
+          isError: true,
+        };
+      }
       if (searchMode === 'hybrid') {
         if (hasNeighborContext(neighborContext)) {
           searchLatencyMetrics.record({
@@ -1042,7 +1070,7 @@ export class KnowledgeBaseServer {
     query: string;
     knowledgeBaseName?: string;
     modelNameOverride?: string;
-    filters?: { extensions?: string[]; pathGlob?: string; tags?: string[] };
+    filters?: { extensions?: string[]; pathGlob?: string; tags?: string[]; since?: string; until?: string };
     canonical?: Partial<CanonicalLogInput>;
     taskContext?: string;
     gateOverride?: RelevanceGateOverride;

--- a/src/cli-search.test.ts
+++ b/src/cli-search.test.ts
@@ -151,6 +151,27 @@ describe('parseSearchArgs freshness', () => {
   });
 });
 
+describe('parseSearchArgs recency filters (#609)', () => {
+  it('accepts --since and --until duration or ISO bounds', () => {
+    expect(parseSearchArgs([
+      'query',
+      '--since=2026-06-01',
+      '--until=2026-06-02T00:00:00Z',
+    ])).toMatchObject({
+      since: '2026-06-01',
+      until: '2026-06-02T00:00:00Z',
+    });
+    expect(parseSearchArgs(['query', '--since=30d'])).toMatchObject({ since: '30d' });
+  });
+
+  it('rejects malformed and inverted recency ranges', () => {
+    expect(() => parseSearchArgs(['query', '--since=soon'])).toThrow(/invalid since/);
+    expect(() => parseSearchArgs(['query', '--since=24h', '--until=30d'])).toThrow(
+      /invalid recency range/,
+    );
+  });
+});
+
 describe('parseSearchArgs pager (#471)', () => {
   it('defaults to env-driven pager resolution', () => {
     expect(parseSearchArgs(['query'])).toMatchObject({ pager: null });
@@ -831,6 +852,46 @@ describe('runSearch timing guard (#331)', () => {
       sidecar_fast_path: 'hit',
       post_filter_kept: 6,
       post_filter_ms: 3,
+    });
+  });
+
+  it('forwards --since/--until as dense recency filters and surfaces timing diagnostics', async () => {
+    const { deps, manager } = makeDeps();
+    manager.similaritySearch.mockImplementationOnce(async (...args: unknown[]) => {
+      const denseTiming = args[5] as SimilaritySearchTiming;
+      denseTiming.fetch_k = 20;
+      denseTiming.post_filter_ms = 4;
+      denseTiming.post_filter_kept = 1;
+      return [{
+        pageContent: 'recent runbook',
+        metadata: { source: '/kb/ops/recent.md', relativePath: 'ops/recent.md', chunkIndex: 0 },
+        score: 0.12,
+      }] as never;
+    });
+
+    const out = await captureSearchOutput([
+      'runbook',
+      '--since=2026-06-01',
+      '--until=2026-06-02',
+      '--format=json',
+      '--timing',
+      '--no-freshness',
+    ], deps);
+
+    expect(out.code).toBe(0);
+    expect(manager.similaritySearch).toHaveBeenCalledWith(
+      'runbook',
+      10,
+      undefined,
+      undefined,
+      { since: '2026-06-01', until: '2026-06-02' },
+      expect.any(Object),
+      { noCache: false, retrievalViews: undefined },
+    );
+    expect(JSON.parse(out.stdout).filter_diagnostics).toMatchObject({
+      fetch_k: 20,
+      post_filter_kept: 1,
+      post_filter_ms: 4,
     });
   });
 

--- a/src/cli-search.ts
+++ b/src/cli-search.ts
@@ -141,6 +141,10 @@ import {
   type QueryDecompositionProvider,
   type QueryDecompositionTrace,
 } from './query-decomposition.js';
+import {
+  parseRecencyFilterRange,
+  type SimilaritySearchFilters,
+} from './search-filters.js';
 
 export const SEARCH_HELP = `kb search — semantic search across knowledge bases
 
@@ -162,6 +166,12 @@ Output normally ends with a freshness footer (markdown) or staleness fields
 Scope:
   --kb=<name>           Scope to one knowledge base. Omit to search ALL KBs.
   --model=<id>          Override the active model for this call (RFC 013).
+  --since=<time>        Dense-only: keep chunks whose current source-file
+                        mtime is at or after this bound. Accepts durations
+                        like 30d/24h or ISO dates/timestamps.
+  --until=<time>        Dense-only: keep chunks whose current source-file
+                        mtime is at or before this bound. File mtime can
+                        differ from indexed-content time on stale indexes.
 
 Result tuning:
   --threshold=<float>   Max similarity score; lower = closer match (default 2).
@@ -236,8 +246,8 @@ Output:
                         result envelope per row. Each row accepts query plus
                         optional per-row search option fields such as kb, k,
                         mode, model, threshold, no_cache, freshness,
-                        group_by_source, task_context, gate, refresh, and
-                        context_window.
+                        group_by_source, task_context, gate, refresh, since,
+                        until, and context_window.
   --group-by-source     Collapse repeated chunks from the same source file
                         in markdown output. With \`--format=json\`, adds a
                         \`grouped_results\` field alongside raw results.
@@ -309,6 +319,8 @@ interface SearchArgs {
   model?: string;
   threshold?: number;
   thresholdAuto: boolean;
+  since?: string;
+  until?: string;
   k: number;
   format: SearchFormat;
   refresh: boolean;
@@ -472,6 +484,10 @@ export async function runSearch(
     process.stderr.write('kb search: neighbor context expansion is only supported with --mode=dense\n');
     return 2;
   }
+  if (hasRecencyFilter(parsed) && effectiveMode !== 'dense') {
+    process.stderr.write('kb search: --since/--until are only supported with --mode=dense\n');
+    return 2;
+  }
   if (parsed.candidatePoolK !== undefined && effectiveMode !== 'hybrid') {
     process.stderr.write('kb search: --candidate-pool-k is only supported with --mode=hybrid\n');
     return 2;
@@ -567,6 +583,7 @@ export async function runSearch(
   let autoThresholdDecision: AutoThresholdDecision | null = null;
   let advancedRetrieval: AdvancedRetrievalMetadata | null = null;
   const denseTiming: SimilaritySearchTiming = {};
+  const filters = searchFiltersFromArgs(parsed);
   try {
     const startedAt = nowMs();
     if (hasAdvancedRetrieval(parsed)) {
@@ -584,7 +601,7 @@ export async function runSearch(
         parsed.k,
         Number.POSITIVE_INFINITY,
         parsed.kb,
-        undefined,
+        filters,
         denseTiming,
         { noCache: parsed.noCache, retrievalViews: parsed.retrievalViews },
       );
@@ -596,7 +613,7 @@ export async function runSearch(
         parsed.k,
         parsed.threshold,
         parsed.kb,
-        undefined,
+        filters,
         denseTiming,
         { noCache: parsed.noCache, retrievalViews: parsed.retrievalViews },
       );
@@ -868,7 +885,7 @@ async function runAdvancedDenseSearch(input: {
       candidateK,
       input.parsed.threshold,
       input.parsed.kb,
-      undefined,
+      searchFiltersFromArgs(input.parsed),
       input.denseTiming,
       { noCache: input.parsed.noCache, retrievalViews: input.parsed.retrievalViews },
     );
@@ -1032,6 +1049,8 @@ export function parseSearchArgs(rest: string[]): SearchArgs {
       if (!Number.isFinite(n)) throw new Error(`invalid --threshold: ${raw}`);
       out.threshold = n; continue;
     }
+    if (raw.startsWith('--since=')) { out.since = raw.slice('--since='.length); continue; }
+    if (raw.startsWith('--until=')) { out.until = raw.slice('--until='.length); continue; }
     if (raw.startsWith('--k=')) {
       const n = Number(raw.slice('--k='.length));
       if (!Number.isInteger(n) || n <= 0) throw new Error(`invalid --k: ${raw}`);
@@ -1065,7 +1084,20 @@ export function parseSearchArgs(rest: string[]): SearchArgs {
     if (out.query === null) { out.query = raw; continue; }
     throw new Error(`unexpected argument: ${raw}`);
   }
+  if (hasRecencyFilter(out)) {
+    parseRecencyFilterRange({ since: out.since, until: out.until });
+  }
   return out;
+}
+
+function hasRecencyFilter(args: Pick<SearchArgs, 'since' | 'until'>): boolean {
+  return args.since !== undefined || args.until !== undefined;
+}
+
+function searchFiltersFromArgs(args: Pick<SearchArgs, 'since' | 'until'>): SimilaritySearchFilters | undefined {
+  return hasRecencyFilter(args)
+    ? { since: args.since, until: args.until }
+    : undefined;
 }
 
 function parseNonEmptyComponent(raw: string, prefix: string): string {
@@ -1297,7 +1329,8 @@ function hasFilterSelectivitySurface(
 ): boolean {
   return (
     typeof parsed.kb === 'string' && parsed.kb.length > 0
-  ) || denseTiming.sidecar_candidates !== undefined
+  ) || hasRecencyFilter(parsed)
+    || denseTiming.sidecar_candidates !== undefined
     || denseTiming.sidecar_fast_path !== undefined
     || denseTiming.post_filter_kept !== undefined;
 }
@@ -1867,7 +1900,7 @@ async function runBatchJsonlSearch(
           row.k,
           Number.POSITIVE_INFINITY,
           row.kb,
-          undefined,
+          searchFiltersFromArgs(row),
           denseTiming,
           { noCache: row.noCache },
         );
@@ -1879,7 +1912,7 @@ async function runBatchJsonlSearch(
           row.k,
           row.threshold,
           row.kb,
-          undefined,
+          searchFiltersFromArgs(row),
           denseTiming,
           { noCache: row.noCache },
         );
@@ -2119,6 +2152,17 @@ function parseBatchJsonlRow(line: string, lineNumber: number, defaults: SearchAr
   if (refresh !== undefined) row.refresh = refresh;
   const freshness = readBatchBoolean(raw, 'freshness', lineNumber);
   if (freshness !== undefined) row.freshness = freshness;
+  const since = readBatchString(raw, 'since', lineNumber, false);
+  if (since !== undefined) row.since = since;
+  const until = readBatchString(raw, 'until', lineNumber, false);
+  if (until !== undefined) row.until = until;
+  if (hasRecencyFilter(row)) {
+    try {
+      parseRecencyFilterRange({ since: row.since, until: row.until });
+    } catch (err) {
+      throw new Error(`line ${lineNumber}: ${(err as Error).message}`);
+    }
+  }
   const groupBySource = readBatchBoolean(raw, 'group_by_source', lineNumber);
   if (groupBySource !== undefined) row.groupBySource = groupBySource;
   const explainEmpty = readBatchBoolean(raw, 'explain_empty', lineNumber);

--- a/src/search-filters.test.ts
+++ b/src/search-filters.test.ts
@@ -1,0 +1,101 @@
+import * as fsp from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import type { Document } from '@langchain/core/documents';
+import { afterEach, describe, expect, it } from '@jest/globals';
+import {
+  createSimilaritySearchPostFilter,
+  parseRecencyFilterRange,
+  type ScoredDocument,
+} from './search-filters.js';
+
+describe('parseRecencyFilterRange (#609)', () => {
+  const nowMs = Date.parse('2026-06-13T12:00:00Z');
+
+  it('accepts duration and ISO date bounds deterministically', () => {
+    expect(parseRecencyFilterRange({ since: '30d', until: '24h', nowMs })).toEqual({
+      sinceMs: Date.parse('2026-05-14T12:00:00Z'),
+      untilMs: Date.parse('2026-06-12T12:00:00Z'),
+    });
+    expect(parseRecencyFilterRange({
+      since: '2026-06-01',
+      until: '2026-06-02T03:04:05Z',
+      nowMs,
+    })).toEqual({
+      sinceMs: Date.parse('2026-06-01T00:00:00Z'),
+      untilMs: Date.parse('2026-06-02T03:04:05Z'),
+    });
+  });
+
+  it('rejects invalid and inverted ranges', () => {
+    expect(() => parseRecencyFilterRange({ since: 'soon', nowMs })).toThrow(/invalid since/);
+    expect(() => parseRecencyFilterRange({ until: '0d', nowMs })).toThrow(/invalid until/);
+    expect(() => parseRecencyFilterRange({ since: '24h', until: '30d', nowMs })).toThrow(
+      /invalid recency range/,
+    );
+  });
+});
+
+describe('createSimilaritySearchPostFilter recency filters (#609)', () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(tempDirs.map((dir) => fsp.rm(dir, { recursive: true, force: true })));
+    tempDirs.length = 0;
+  });
+
+  async function makeFile(name: string, mtimeIso: string): Promise<string> {
+    const dir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-search-filter-recency-'));
+    tempDirs.push(dir);
+    const filePath = path.join(dir, name);
+    await fsp.writeFile(filePath, 'content', 'utf-8');
+    const mtime = new Date(mtimeIso);
+    await fsp.utimes(filePath, mtime, mtime);
+    return filePath;
+  }
+
+  function row(source: string | undefined, score = 0.1): ScoredDocument {
+    return [
+      {
+        pageContent: source ?? 'missing source',
+        metadata: source === undefined
+          ? { relativePath: 'kb/missing.md' }
+          : { source, relativePath: `kb/${path.basename(source)}`, extension: '.md' },
+      } as Document,
+      score,
+    ];
+  }
+
+  it('filters candidates by current source-file mtime after metadata filters', async () => {
+    const recent = await makeFile('recent.md', '2026-06-10T00:00:00Z');
+    const old = await makeFile('old.md', '2026-05-01T00:00:00Z');
+    const filter = createSimilaritySearchPostFilter({
+      threshold: 2,
+      knowledgeBasesRootDir: path.dirname(path.dirname(recent)),
+      filters: { extensions: ['md'], since: '2026-06-01', until: '2026-06-30' },
+    });
+
+    expect(filter.requiresOverfetch).toBe(true);
+    expect(filter.apply([row(recent), row(old), row(undefined)]).map(([doc]) => doc.pageContent))
+      .toEqual([recent]);
+  });
+
+  it('memoizes file stats by source path within one post-filter', async () => {
+    const dir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-search-filter-recency-'));
+    tempDirs.push(dir);
+    const source = path.join(dir, 'memo.md');
+    const filter = createSimilaritySearchPostFilter({
+      threshold: 2,
+      knowledgeBasesRootDir: dir,
+      filters: { since: '2026-06-01' },
+    });
+
+    expect(filter.apply([row(source)])).toHaveLength(0);
+
+    await fsp.writeFile(source, 'content', 'utf-8');
+    const mtime = new Date('2026-06-10T00:00:00Z');
+    await fsp.utimes(source, mtime, mtime);
+
+    expect(filter.apply([row(source, 0.2)])).toHaveLength(0);
+  });
+});

--- a/src/search-filters.ts
+++ b/src/search-filters.ts
@@ -1,3 +1,4 @@
+import * as fs from 'fs';
 import * as path from 'path';
 import type { Document } from '@langchain/core/documents';
 import { minimatch } from 'minimatch';
@@ -6,9 +7,16 @@ export interface SimilaritySearchFilters {
   extensions?: readonly string[];
   pathGlob?: string;
   tags?: readonly string[];
+  since?: string;
+  until?: string;
 }
 
 export type ScoredDocument = readonly [Document, number];
+
+export interface RecencyFilterRange {
+  sinceMs?: number;
+  untilMs?: number;
+}
 
 export interface SimilaritySearchPostFilter {
   requiresOverfetch: boolean;
@@ -20,20 +28,28 @@ export function createSimilaritySearchPostFilter(options: {
   knowledgeBasesRootDir: string;
   knowledgeBaseName?: string;
   filters?: SimilaritySearchFilters;
+  recencyNowMs?: number;
 }): SimilaritySearchPostFilter {
   const { threshold, knowledgeBasesRootDir, knowledgeBaseName, filters } = options;
   const scoped = typeof knowledgeBaseName === 'string' && knowledgeBaseName.length > 0;
   const normalizedExtensions = normalizeExtensionFilter(filters?.extensions);
   const pathGlob = filters?.pathGlob && filters.pathGlob.length > 0 ? filters.pathGlob : undefined;
   const requiredTags = filters?.tags?.filter((t): t is string => typeof t === 'string' && t.length > 0) ?? [];
+  const recencyRange = parseRecencyFilterRange({
+    since: filters?.since,
+    until: filters?.until,
+    nowMs: options.recencyNowMs,
+  });
   const hasMetadataFilter =
     normalizedExtensions !== undefined || pathGlob !== undefined || requiredTags.length > 0;
+  const hasRecencyFilter = recencyRange !== undefined;
+  const sourceMtimeMemo = new Map<string, number | null>();
   const kbPrefix = scoped
     ? path.join(knowledgeBasesRootDir, knowledgeBaseName as string) + path.sep
     : undefined;
 
   return {
-    requiresOverfetch: scoped || hasMetadataFilter,
+    requiresOverfetch: scoped || hasMetadataFilter || hasRecencyFilter,
     apply(resultsWithScore) {
       return resultsWithScore.filter(([doc, score]) => {
         if (score > threshold) {
@@ -66,10 +82,100 @@ export function createSimilaritySearchPostFilter(options: {
             if (!tagSet.has(required)) return false;
           }
         }
+        if (recencyRange !== undefined) {
+          const source = metadata?.source;
+          if (typeof source !== 'string' || source.length === 0) {
+            return false;
+          }
+          const mtimeMs = sourceMtimeMs(source, sourceMtimeMemo);
+          if (mtimeMs === null) return false;
+          if (recencyRange.sinceMs !== undefined && mtimeMs < recencyRange.sinceMs) {
+            return false;
+          }
+          if (recencyRange.untilMs !== undefined && mtimeMs > recencyRange.untilMs) {
+            return false;
+          }
+        }
         return true;
       });
     },
   };
+}
+
+export function parseRecencyFilterRange(input: {
+  since?: string;
+  until?: string;
+  nowMs?: number;
+}): RecencyFilterRange | undefined {
+  const nowMs = input.nowMs ?? Date.now();
+  const sinceMs = input.since === undefined
+    ? undefined
+    : parseRecencyBound(input.since, 'since', nowMs);
+  const untilMs = input.until === undefined
+    ? undefined
+    : parseRecencyBound(input.until, 'until', nowMs);
+  if (sinceMs === undefined && untilMs === undefined) return undefined;
+  if (sinceMs !== undefined && untilMs !== undefined && sinceMs > untilMs) {
+    throw new Error('invalid recency range: since must be earlier than or equal to until');
+  }
+  return { sinceMs, untilMs };
+}
+
+const DURATION_RE = /^([1-9]\d*)(ms|s|m|h|d|w)$/i;
+const ISO_DATE_OR_TIMESTAMP_RE =
+  /^\d{4}-\d{2}-\d{2}(?:[T ]\d{2}:\d{2}(?::\d{2}(?:\.\d{1,3})?)?(?:Z|[+-]\d{2}:?\d{2})?)?$/;
+
+function parseRecencyBound(raw: string, label: 'since' | 'until', nowMs: number): number {
+  const value = raw.trim();
+  if (value.length === 0) {
+    throw new Error(`invalid ${label}: expected duration like 30d/24h or ISO date`);
+  }
+  const durationMatch = DURATION_RE.exec(value);
+  if (durationMatch !== null) {
+    const amount = Number(durationMatch[1]);
+    const unit = durationMatch[2].toLowerCase();
+    return nowMs - amount * durationUnitMs(unit);
+  }
+  if (!ISO_DATE_OR_TIMESTAMP_RE.test(value)) {
+    throw new Error(`invalid ${label}: expected duration like 30d/24h or ISO date`);
+  }
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`invalid ${label}: expected duration like 30d/24h or ISO date`);
+  }
+  return parsed;
+}
+
+function durationUnitMs(unit: string): number {
+  switch (unit) {
+    case 'ms': return 1;
+    case 's': return 1000;
+    case 'm': return 60 * 1000;
+    case 'h': return 60 * 60 * 1000;
+    case 'd': return 24 * 60 * 60 * 1000;
+    case 'w': return 7 * 24 * 60 * 60 * 1000;
+    default: {
+      const exhaustive: never = unit as never;
+      return exhaustive;
+    }
+  }
+}
+
+function sourceMtimeMs(source: string, memo: Map<string, number | null>): number | null {
+  if (memo.has(source)) {
+    return memo.get(source) ?? null;
+  }
+  let mtimeMs: number | null = null;
+  try {
+    const stat = fs.statSync(source);
+    if (stat.isFile()) {
+      mtimeMs = stat.mtimeMs;
+    }
+  } catch {
+    mtimeMs = null;
+  }
+  memo.set(source, mtimeMs);
+  return mtimeMs;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Add dense `kb search --since/--until` recency filters accepting duration bounds like `30d`/`24h` and ISO dates/timestamps.
- Add matching `since`/`until` arguments to MCP `retrieve_knowledge`.
- Filter on current source-file mtime with a per-query/per-source stat memo, and make recency activate the existing post-filter overfetch path.
- Document that mtime can differ from indexed-content time when the index is stale.

## Implementation Notes

- Recency parsing is shared in `search-filters.ts` so CLI and MCP validate the same duration/ISO forms and reject inverted ranges.
- Recency remains a post-filter because phase 1 uses live filesystem mtime, not indexed metadata. It is intentionally not added to metadata-sidecar pushdown.
- CLI recency filters are dense-only in this phase to avoid mixing filtered dense candidates with unfiltered lexical candidates in hybrid/lexical modes.

## Alternatives Considered

- Frontmatter date filtering: deferred per issue scope to avoid new metadata schema/reindex requirements.
- Recency ranking: deferred per issue scope; this only filters candidates.
- Sidecar/index pushdown: rejected for phase 1 because source-file mtime is live filesystem state and can change independently of the index.

## Verification

- `npm test -- --runTestsByPath src/search-filters.test.ts src/cli-search.test.ts src/KnowledgeBaseServer.test.ts src/cli-json-contracts.test.ts --runInBand`
- `npm run build`
- `git diff --check`

Closes #609
