### PR TITLE
Surface aggregate degraded stages

### DIFF
--- a/docs/cli-json-contracts.md
+++ b/docs/cli-json-contracts.md
@@ -420,7 +420,7 @@ Stable lexical fields are `mode`, `results`, and `knowledge_bases[]` with
 per-KB warnings to stderr and can return exit code `1` when one or more KBs
 failed while still printing this JSON payload.
 
-Hybrid success envelope:
+Hybrid success envelope with a degraded rerank stage:
 
 ```json
 {
@@ -432,13 +432,17 @@ Hybrid success envelope:
   },
   "rrf": { "c": 60, "fetch_k": 40 },
   "rerank": {
-    "enabled": false,
+    "enabled": true,
     "model": "Xenova/ms-marco-MiniLM-L-6-v2",
-    "candidates": 0,
+    "candidates": 10,
     "cache_hits": 0,
-    "degraded": false,
-    "degrade_reason": null
-  }
+    "degraded": true,
+    "degrade_reason": "model unavailable"
+  },
+  "degraded": true,
+  "degraded_stages": [
+    { "stage": "rerank", "reason": "model unavailable" }
+  ]
 }
 ```
 
@@ -448,6 +452,12 @@ Stable hybrid fields are `mode`, `results`, `retrievers.dense.fetched`,
 `rrf.fetch_k`. `rerank.enabled`, `rerank.model`, `rerank.candidates`,
 `rerank.cache_hits`, `rerank.degraded`, and `rerank.degrade_reason` are stable
 when the `rerank` object is present.
+
+Search envelopes MAY include top-level `degraded: true` and
+`degraded_stages[]` when a known, classified fallback affected the returned
+results. `degraded_stages[].stage` is machine-readable (`dense`, `rerank`, or
+`gate`); `reason` is present when the originating stage supplied one. Disabled
+stages, skipped stages, and successful stages are not counted as degraded.
 
 When `kb search --mode=hybrid --candidate-pool-k=<n> --format=json` is used,
 the payload also includes `high_recall` with schema version
@@ -1302,6 +1312,7 @@ Invocation:
 
 ```bash
 kb logs recent --format=json [--limit=<n>] [--file=<path>]
+kb logs recent --degraded --format=json [--limit=<n>] [--file=<path>]
 kb logs show --request-id=<id> --format=json [--file=<path>]
 kb logs show --query-sha=<hash> --format=json [--file=<path>]
 ```
@@ -1318,6 +1329,8 @@ Report envelope:
   "canonical_event_count": 3,
   "ignored_line_count": 6,
   "malformed_canonical_line_count": 1,
+  "slow_event_count": 0,
+  "degraded_event_count": 1,
   "result_count": 1,
   "events": [
     {
@@ -1330,6 +1343,10 @@ Report envelope:
       "timings": { "embed_ms": 10, "faiss_ms": 20, "format_ms": 3 },
       "cache": "miss",
       "result_count": 3,
+      "degraded": true,
+      "degraded_stages": [
+        { "stage": "gate", "reason": "judge failed" }
+      ],
       "top_sources": ["docs/a.md"],
       "error": { "code": "PROVIDER_TIMEOUT", "category": "provider" },
       "recovery_hint": "Run `kb doctor`."
@@ -1345,9 +1362,12 @@ Stable fields:
 - `source` is the resolved log file path. Resolution uses `--file`, then
   `LOG_FILE`, then existing local default paths.
 - Counts report the scan outcome before filtering.
+- `filters.degraded: true` is present for `--degraded`; the filter keeps only
+  canonical event summaries whose aggregate `degraded` field is true.
 - `events[]` contains summaries of `kb-canonical.v1` lines only. Text log
   lines are ignored. Each event includes `timings`; optional fields are
-  present only when the canonical log line carried them.
+  present only when the canonical log line carried them. Degraded summaries
+  preserve `degraded` and `degraded_stages[]` when present.
 
 Stdout/stderr and exit codes:
 

--- a/src/KnowledgeBaseServer.test.ts
+++ b/src/KnowledgeBaseServer.test.ts
@@ -1483,6 +1483,7 @@ describe('KnowledgeBaseServer handlers', () => {
     expect(result.content[0].text).toContain('Second alpha fallback content');
     expect((result as any).structuredContent).toMatchObject({
       degraded: true,
+      degraded_stages: [{ stage: 'dense', reason: 'provider_timeout' }],
       degrade_reason: 'provider_timeout',
       gate_verdict: {
         state: 'injected',
@@ -1496,6 +1497,7 @@ describe('KnowledgeBaseServer handlers', () => {
     expect(events[0]).toMatchObject({
       search_mode: 'dense',
       degraded: true,
+      degraded_stages: [{ stage: 'dense', reason: 'provider_timeout' }],
       degrade_reason: 'provider_timeout',
       result_count: 2,
     });
@@ -1664,6 +1666,7 @@ describe('KnowledgeBaseServer handlers', () => {
     expect(result.content[0].text).toContain('Hybrid lexical fallback content');
     expect((result as any).structuredContent).toMatchObject({
       degraded: true,
+      degraded_stages: [{ stage: 'dense', reason: 'provider_unavailable' }],
       degrade_reason: 'provider_unavailable',
       gate_verdict: {
         state: 'injected',
@@ -1677,6 +1680,7 @@ describe('KnowledgeBaseServer handlers', () => {
     expect(events[0]).toMatchObject({
       search_mode: 'hybrid',
       degraded: true,
+      degraded_stages: [{ stage: 'dense', reason: 'provider_unavailable' }],
       degrade_reason: 'provider_unavailable',
       result_count: 1,
     });
@@ -1715,6 +1719,59 @@ describe('KnowledgeBaseServer handlers', () => {
       expect(text).toContain('rerank stub-reranker');
       expect(text.indexOf('Lexical winner content')).toBeGreaterThanOrEqual(0);
       expect(text.indexOf('Lexical winner content')).toBeLessThan(text.indexOf('Dense loser content'));
+    } finally {
+      restoreFactory();
+    }
+  });
+
+  it('handleRetrieveKnowledge surfaces reranker degradation in structured content and canonical logs', async () => {
+    const tempDir = await setRetrieveEnv();
+    const logFile = path.join(tempDir, 'canonical.log');
+    process.env.LOG_FILE = logFile;
+    process.env.KB_LOG_FORMAT = 'canonical';
+    process.env.KB_RERANK = 'on';
+    process.env.KB_RERANK_TOP_N = '2';
+    await fsp.mkdir(path.join(tempDir, 'alpha'), { recursive: true });
+    await fsp.writeFile(path.join(tempDir, 'alpha', 'doc.md'), 'Alpha lexical content');
+    updateIndexMock.mockResolvedValue(undefined);
+    similaritySearchMock.mockResolvedValue([
+      { pageContent: 'Dense content', metadata: { source: '/kb/dense.md', chunkIndex: 0 }, score: 0.2 },
+    ]);
+
+    const server = await freshServer();
+    const { setRerankerFactoryForTests } = await import('./reranker.js');
+    const restoreFactory = setRerankerFactoryForTests(async () => {
+      throw new Error('reranker model unavailable');
+    });
+    try {
+      const result = await server['handleRetrieveKnowledge']({
+        query: 'alpha',
+        knowledge_base_name: 'alpha',
+        search_mode: 'hybrid',
+      });
+
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0].text).toContain('rerank Xenova/ms-marco-MiniLM-L-6-v2 degraded');
+      expect(result.content[0].text).toContain('> _Degraded stages: rerank (reranker model unavailable)._');
+      expect((result as any).structuredContent).toMatchObject({
+        degraded: true,
+        degraded_stages: [{ stage: 'rerank', reason: 'reranker model unavailable' }],
+      });
+      expect((result as any).structuredContent.degrade_reason).toBeUndefined();
+
+      const events = (await readCanonicalEvents(logFile))
+        .filter((event) => event.tool === 'retrieve_knowledge');
+      expect(events).toHaveLength(1);
+      expect(events[0]).toMatchObject({
+        search_mode: 'hybrid',
+        degraded: true,
+        degraded_stages: [{ stage: 'rerank', reason: 'reranker model unavailable' }],
+        rerank: {
+          degraded: true,
+          degrade_reason: 'reranker model unavailable',
+        },
+      });
+      expect(events[0].degrade_reason).toBeUndefined();
     } finally {
       restoreFactory();
     }

--- a/src/KnowledgeBaseServer.ts
+++ b/src/KnowledgeBaseServer.ts
@@ -61,7 +61,10 @@ import {
   TransportConfigError,
   type TransportConfig,
 } from './transport-config.js';
-import { formatRetrievalAsMarkdown } from './formatter.js';
+import {
+  formatDegradedStagesFooter,
+  formatRetrievalAsMarkdown,
+} from './formatter.js';
 import {
   listKnowledgeBases,
   resolveKnowledgeBaseDir,
@@ -96,7 +99,11 @@ import {
 import {
   canonicalErrorFromToolResult,
   classifyCanonicalError,
+  canonicalGateStageRecord,
+  canonicalRerankStageRecord,
+  degradationSummaryFields,
   emitCanonicalLog,
+  type CanonicalDegradedStage,
   type CanonicalLogInput,
 } from './canonical-log.js';
 import { formatKbStatsOpenMetrics } from './prometheus-export.js';
@@ -184,6 +191,21 @@ function withDegradationMetadata<T extends CallToolResult>(
       ...((result as { structuredContent?: Record<string, unknown> }).structuredContent ?? {}),
       degraded: true,
       degrade_reason: reason,
+    },
+  } as T;
+}
+
+function withDegradationSummary<T extends CallToolResult>(
+  result: T,
+  stages: readonly CanonicalDegradedStage[] | undefined,
+): T {
+  if (stages === undefined || stages.length === 0) return result;
+  return {
+    ...result,
+    structuredContent: {
+      ...((result as { structuredContent?: Record<string, unknown> }).structuredContent ?? {}),
+      degraded: true,
+      degraded_stages: stages,
     },
   } as T;
 }
@@ -912,6 +934,7 @@ export class KnowledgeBaseServer {
         taskContext,
         observability: gate.observability,
       });
+      canonical.gate = canonicalGateStageRecord(gate.verdict);
       if (process.env.KB_LOG_VERBOSE === '1') {
         logger.debug(`[${Date.now()}] Similarity search completed`);
       }
@@ -935,6 +958,15 @@ export class KnowledgeBaseServer {
       if (degradedReason !== null) {
         responseText = `> _Mode: degraded lexical-only (reason: ${degradedReason}; original mode dense)._` +
           `\n\n${responseText}`;
+      }
+      const degradation = degradationSummaryFields({
+        degraded: degradedReason === null ? undefined : true,
+        degrade_reason: degradedReason ?? undefined,
+        gate: canonical.gate,
+      });
+      const degradedFooter = formatDegradedStagesFooter(degradation.degraded_stages);
+      if (degradedFooter !== '') {
+        responseText = `${responseText}\n\n${degradedFooter}`;
       }
       canonical.format_ms = Date.now() - formatStartedAt;
       const stageTiming: TimingPayload = {
@@ -968,9 +1000,10 @@ export class KnowledgeBaseServer {
 
       const content: TextContent = { type: 'text', text: responseText };
       const response = withGateVerdict({ content: [content] }, gate.verdict);
+      const responseWithSummary = withDegradationSummary(response, degradation.degraded_stages);
       return degradedReason === null
-        ? response
-        : withDegradationMetadata(response, degradedReason);
+        ? responseWithSummary
+        : withDegradationMetadata(responseWithSummary, degradedReason);
     } catch (error: unknown) {
       const err = toError(error);
       searchLatencyMetrics.record({
@@ -1190,6 +1223,9 @@ export class KnowledgeBaseServer {
       });
       const rerankMs = rerankResult.tookMs ?? Date.now() - rerankStartedAt;
       ranked = rerankResult.results;
+      if (canonical) {
+        canonical.rerank = canonicalRerankStageRecord(rerankResult);
+      }
       const gateStartedAt = Date.now();
       const gate = await applyRelevanceGate({
         query,
@@ -1211,6 +1247,9 @@ export class KnowledgeBaseServer {
         taskContext,
         observability: gate.observability,
       });
+      if (canonical) {
+        canonical.gate = canonicalGateStageRecord(gate.verdict);
+      }
 
       const formatStartedAt = Date.now();
       let responseText = formatRetrievalAsMarkdown(ranked as never, FRONTMATTER_EXTRAS_WIRE_VISIBLE);
@@ -1251,12 +1290,23 @@ export class KnowledgeBaseServer {
       responseText = modelNameOverride !== undefined
         ? `> _Model: ${activeModelId}_\n${header}\n\n${responseText}`
         : `${header}\n\n${responseText}`;
+      const degradation = degradationSummaryFields({
+        degraded: degradedReason === null ? undefined : true,
+        degrade_reason: degradedReason ?? undefined,
+        rerank: canonical?.rerank,
+        gate: canonical?.gate,
+      });
+      const degradedFooter = formatDegradedStagesFooter(degradation.degraded_stages);
+      if (degradedFooter !== '') {
+        responseText = `${responseText}\n\n${degradedFooter}`;
+      }
 
       const content: TextContent = { type: 'text', text: responseText };
       const response = withGateVerdict({ content: [content] }, gate.verdict);
+      const responseWithSummary = withDegradationSummary(response, degradation.degraded_stages);
       return degradedReason === null
-        ? response
-        : withDegradationMetadata(response, degradedReason);
+        ? responseWithSummary
+        : withDegradationMetadata(responseWithSummary, degradedReason);
     } catch (error: unknown) {
       const err = toError(error);
       searchLatencyMetrics.record({

--- a/src/canonical-log.test.ts
+++ b/src/canonical-log.test.ts
@@ -1,6 +1,7 @@
 import {
   CANONICAL_SCHEMA_VERSION,
   canonicalErrorFromToolResult,
+  deriveDegradedStages,
   hashQuery,
   normalizeCanonicalEvent,
   stableCanonicalJson,
@@ -50,6 +51,7 @@ describe('canonical log line schema (#216)', () => {
       },
       error: { code: 'PROVIDER_TIMEOUT', category: 'provider' },
       degraded: true,
+      degraded_stages: [{ stage: 'dense', reason: 'provider_timeout' }],
       degrade_reason: 'provider_timeout',
     });
 
@@ -71,13 +73,49 @@ describe('canonical log line schema (#216)', () => {
       },
       error: { code: 'PROVIDER_TIMEOUT', category: 'provider' },
       degraded: true,
+      degraded_stages: [{ stage: 'dense', reason: 'provider_timeout' }],
       degrade_reason: 'provider_timeout',
     });
     expect(json.indexOf('"schema_version"')).toBeLessThan(json.indexOf('"request_id"'));
     expect(json.indexOf('"top_sources"')).toBeLessThan(json.indexOf('"took_ms"'));
     expect(json.indexOf('"cache"')).toBeLessThan(json.indexOf('"query_cache"'));
     expect(json.indexOf('"error"')).toBeLessThan(json.indexOf('"degraded"'));
-    expect(json.indexOf('"degraded"')).toBeLessThan(json.indexOf('"degrade_reason"'));
+    expect(json.indexOf('"degraded"')).toBeLessThan(json.indexOf('"degraded_stages"'));
+    expect(json.indexOf('"degraded_stages"')).toBeLessThan(json.indexOf('"degrade_reason"'));
+  });
+
+  it('derives aggregate degraded stages from known classified fallback sub-records', () => {
+    const event = normalizeCanonicalEvent({
+      request_id: 'req-degraded',
+      ts: '2026-05-12T00:00:00.000Z',
+      process: 'cli',
+      cmd: 'kb search',
+      took_ms: 25,
+      degraded: true,
+      degrade_reason: 'provider_unavailable',
+      rerank: {
+        degraded: true,
+        degrade_reason: 'reranker unavailable',
+      },
+      gate: {
+        degraded: true,
+        degrade_reason: 'judge failed',
+      },
+    });
+
+    expect(event.degraded).toBe(true);
+    expect(event.degraded_stages).toEqual([
+      { stage: 'dense', reason: 'provider_unavailable' },
+      { stage: 'rerank', reason: 'reranker unavailable' },
+      { stage: 'gate', reason: 'judge failed' },
+    ]);
+  });
+
+  it('does not count disabled or successful sub-stages as degraded', () => {
+    expect(deriveDegradedStages({
+      rerank: { enabled: false, degraded: false, degrade_reason: null },
+      gate: { state: 'bypassed', degraded: false, degrade_reason: null },
+    })).toEqual([]);
   });
 
   it('extracts error code and category from MCP tool error payloads', () => {

--- a/src/canonical-log.ts
+++ b/src/canonical-log.ts
@@ -31,6 +31,29 @@ export interface CanonicalError {
   category: CanonicalErrorCategory;
 }
 
+export interface CanonicalDegradedStage {
+  stage: 'dense' | 'rerank' | 'gate';
+  reason?: string;
+}
+
+export interface CanonicalGateStageInput {
+  state: string;
+  input_count: number;
+  output_count: number;
+  judge: {
+    status: string;
+    reason?: string;
+  };
+}
+
+export interface CanonicalRerankStageInput {
+  model: string;
+  candidatesIn: number;
+  cacheHits: number;
+  degraded: boolean;
+  degradeReason: string | null;
+}
+
 export interface CanonicalLogEvent {
   schema_version: typeof CANONICAL_SCHEMA_VERSION;
   ts: string;
@@ -59,6 +82,7 @@ export interface CanonicalLogEvent {
   query_cache?: QueryCacheTelemetry;
   error?: CanonicalError;
   degraded?: true;
+  degraded_stages?: CanonicalDegradedStage[];
   degrade_reason?: DenseDegradationReason;
   recovery_hint?: string;
   rerank?: Record<string, unknown>;
@@ -105,6 +129,7 @@ const CANONICAL_FIELD_ORDER: readonly (keyof CanonicalLogEvent)[] = [
   'query_cache',
   'error',
   'degraded',
+  'degraded_stages',
   'degrade_reason',
   'recovery_hint',
   'rerank',
@@ -160,7 +185,6 @@ export function normalizeCanonicalEvent(input: CanonicalLogInput): CanonicalLogE
   assignIfDefined(event, 'cache', input.cache);
   assignIfDefined(event, 'query_cache', input.query_cache);
   assignIfDefined(event, 'error', input.error);
-  assignIfDefined(event, 'degraded', input.degraded);
   assignIfDefined(event, 'degrade_reason', input.degrade_reason);
   assignIfDefined(event, 'recovery_hint', input.recovery_hint);
   assignIfDefined(event, 'rerank', input.rerank);
@@ -168,7 +192,66 @@ export function normalizeCanonicalEvent(input: CanonicalLogInput): CanonicalLogE
   assignIfDefined(event, 'secret_scan', input.secret_scan);
   assignIfDefined(event, 'llm_provider', input.llm_provider);
 
+  applyDegradationSummary(event, input.degraded);
+
   return event;
+}
+
+export function deriveDegradedStages(input: {
+  degraded?: true;
+  degrade_reason?: DenseDegradationReason;
+  rerank?: Record<string, unknown>;
+  gate?: Record<string, unknown>;
+}): CanonicalDegradedStage[] {
+  const stages: CanonicalDegradedStage[] = [];
+  if (input.degraded === true || input.degrade_reason !== undefined) {
+    stages.push({
+      stage: 'dense',
+      ...(input.degrade_reason !== undefined ? { reason: input.degrade_reason } : {}),
+    });
+  }
+  addSubrecordDegradation(stages, 'rerank', input.rerank);
+  addSubrecordDegradation(stages, 'gate', input.gate);
+  return stages;
+}
+
+export function degradationSummaryFields(input: {
+  degraded?: true;
+  degrade_reason?: DenseDegradationReason;
+  rerank?: Record<string, unknown>;
+  gate?: Record<string, unknown>;
+}): { degraded?: true; degraded_stages?: CanonicalDegradedStage[] } {
+  const degradedStages = deriveDegradedStages(input);
+  return degradedStages.length === 0
+    ? {}
+    : { degraded: true, degraded_stages: degradedStages };
+}
+
+export function canonicalGateStageRecord(
+  verdict: CanonicalGateStageInput,
+): Record<string, unknown> | undefined {
+  if (verdict.state === 'bypassed') return undefined;
+  const degraded = verdict.judge.status === 'failed';
+  return {
+    state: verdict.state,
+    input_count: verdict.input_count,
+    output_count: verdict.output_count,
+    degraded,
+    degrade_reason: degraded ? verdict.judge.reason ?? 'judge failed' : null,
+  };
+}
+
+export function canonicalRerankStageRecord(
+  result: CanonicalRerankStageInput,
+): Record<string, unknown> | undefined {
+  if (result.candidatesIn === 0) return undefined;
+  return {
+    model: result.model,
+    candidates_in: result.candidatesIn,
+    cache_hits: result.cacheHits,
+    degraded: result.degraded,
+    degrade_reason: result.degradeReason,
+  };
 }
 
 export function stableCanonicalJson(event: CanonicalLogEvent): string {
@@ -297,4 +380,35 @@ function assignIfDefined<K extends keyof CanonicalLogEvent>(
 
 function roundNonNegative(value: number | undefined): number | undefined {
   return value === undefined ? undefined : Math.max(0, Math.round(value));
+}
+
+function applyDegradationSummary(event: CanonicalLogEvent, explicitDegraded: true | undefined): void {
+  const summary = degradationSummaryFields({
+    degraded: explicitDegraded,
+    degrade_reason: event.degrade_reason,
+    rerank: event.rerank,
+    gate: event.gate,
+  });
+  assignIfDefined(event, 'degraded', summary.degraded);
+  assignIfDefined(event, 'degraded_stages', summary.degraded_stages);
+}
+
+function addSubrecordDegradation(
+  stages: CanonicalDegradedStage[],
+  stage: CanonicalDegradedStage['stage'],
+  record: Record<string, unknown> | undefined,
+): void {
+  if (record?.degraded !== true) return;
+  const reason = stringRecordField(record, 'degrade_reason')
+    ?? stringRecordField(record, 'degradeReason')
+    ?? stringRecordField(record, 'reason');
+  stages.push({
+    stage,
+    ...(reason !== undefined && reason !== '' ? { reason } : {}),
+  });
+}
+
+function stringRecordField(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key];
+  return typeof value === 'string' ? value : undefined;
 }

--- a/src/cli-json-contracts.test.ts
+++ b/src/cli-json-contracts.test.ts
@@ -4,6 +4,7 @@ import * as fsp from 'fs/promises';
 import * as os from 'os';
 import * as path from 'path';
 import { toJsonReport } from './cli-eval.js';
+import { buildDenseSearchJsonPayload } from './cli-search.js';
 import { runWhere, type RunWhereDeps } from './cli-where.js';
 import type { SearchResultDocument } from './FaissIndexManager.js';
 import type { Staleness } from './search-core.js';
@@ -511,6 +512,36 @@ describe('CLI JSON contract golden outputs', () => {
       source: logFile,
       result_count: 1,
       events: [expect.objectContaining({ request_id: 'req-1', result_count: 3 })],
+    });
+  });
+
+  it('kb search JSON envelope carries aggregate gate degradation fields', () => {
+    const payload = record(buildDenseSearchJsonPayload({
+      results: [doc('alpha', 'note.md', 0.1)],
+      requestedMode: 'dense',
+      effectiveMode: 'dense',
+      autoModeDecision: null,
+      groupBySource: false,
+      refreshed: false,
+      scopedKb: 'alpha',
+      staleness: FRESH,
+      autoThresholdDecision: null,
+      timing: null,
+      gateVerdict: {
+        schema_version: 'kb.relevance-gate.v1',
+        state: 'injected',
+        low_confidence: false,
+        input_count: 1,
+        output_count: 1,
+        dropped: [],
+        judge: { status: 'failed', reason: 'judge failed' },
+        empty_verdict_enabled: false,
+      },
+    }));
+
+    expect(payload).toMatchObject({
+      degraded: true,
+      degraded_stages: [{ stage: 'gate', reason: 'judge failed' }],
     });
   });
 

--- a/src/cli-logs.test.ts
+++ b/src/cli-logs.test.ts
@@ -49,12 +49,14 @@ describe('parseLogsArgs', () => {
       file: './kb.log',
       limit: 5,
       slow: false,
+      degraded: false,
     });
     expect(parseLogsArgs(['show', '--request-id=req-1'])).toEqual({
       action: 'show',
       format: 'md',
       limit: 20,
       slow: false,
+      degraded: false,
       requestId: 'req-1',
     });
     expect(parseLogsArgs(['show', '--query-sha=abc123'])).toMatchObject({
@@ -66,7 +68,15 @@ describe('parseLogsArgs', () => {
       format: 'md',
       limit: 20,
       slow: true,
+      degraded: false,
       minMs: 250,
+    });
+    expect(parseLogsArgs(['--degraded', '--format=json'])).toEqual({
+      action: 'recent',
+      format: 'json',
+      limit: 20,
+      slow: false,
+      degraded: true,
     });
   });
 
@@ -195,6 +205,47 @@ describe('runLogs', () => {
     expect(payload.events.map((event) => event.request_id)).toEqual(['req-250', 'req-400']);
   });
 
+  it('filters recent events to degraded canonical markers with kb logs --degraded', async () => {
+    const { deps, stdout, stderr } = depsFor({
+      '/repo/kb.log': [
+        canonical({ request_id: 'req-ok', query_sha256: 'ok' }),
+        canonical({
+          request_id: 'req-degraded',
+          query_sha256: 'degraded',
+          degraded: true,
+          degraded_stages: [
+            { stage: 'rerank', reason: 'model unavailable' },
+          ],
+        }),
+      ].join('\n'),
+    }, { LOG_FILE: './kb.log' });
+
+    const code = await runLogs(['--degraded', '--format=json'], deps);
+
+    expect(code).toBe(0);
+    expect(stderr).toEqual([]);
+    const payload = JSON.parse(stdout.join('')) as {
+      filters: { degraded?: true };
+      degraded_event_count: number;
+      result_count: number;
+      events: Array<{
+        request_id: string;
+        degraded?: true;
+        degraded_stages?: Array<{ stage: string; reason?: string }>;
+      }>;
+    };
+    expect(payload.filters).toEqual({ degraded: true });
+    expect(payload.degraded_event_count).toBe(1);
+    expect(payload.result_count).toBe(1);
+    expect(payload.events).toEqual([
+      expect.objectContaining({
+        request_id: 'req-degraded',
+        degraded: true,
+        degraded_stages: [{ stage: 'rerank', reason: 'model unavailable' }],
+      }),
+    ]);
+  });
+
   it('shows request details with timings, sources, gate, rerank, and recovery hints in markdown', async () => {
     const { deps, stdout } = depsFor({
       '/tmp/canonical.log': [
@@ -207,6 +258,8 @@ describe('runLogs', () => {
           format_ms: 5,
           top_sources: ['docs/a.md', 'docs/b.md'],
           gate: { verdict: 'injected', kept: 2 },
+          degraded: true,
+          degraded_stages: [{ stage: 'gate', reason: 'judge failed' }],
           rerank_ms: 11,
           error: { code: 'PROVIDER_TIMEOUT', category: 'provider' },
           recovery_hint: 'Run `kb doctor`.',
@@ -225,6 +278,7 @@ describe('runLogs', () => {
     expect(md).toContain('took=125ms, embed=20ms, faiss=40ms, format=5ms');
     expect(md).toContain('`docs/a.md`, `docs/b.md`');
     expect(md).toContain('Gate: `{"verdict":"injected","kept":2}`');
+    expect(md).toContain('Degraded: gate:judge failed');
     expect(md).toContain('Rerank: `{"rerank_ms":11}`');
     expect(md).toContain('Recovery hint: Run `kb doctor`.');
   });

--- a/src/cli-logs.ts
+++ b/src/cli-logs.ts
@@ -7,7 +7,8 @@ export const LOGS_HELP = `kb logs — inspect historical canonical request logs
 
 Usage:
   kb logs --slow [--min-ms=<n>] [--limit=<n>] [--file=<path>] [--format=md|json]
-  kb logs recent [--slow] [--min-ms=<n>] [--limit=<n>] [--file=<path>] [--format=md|json]
+  kb logs --degraded [--limit=<n>] [--file=<path>] [--format=md|json]
+  kb logs recent [--slow] [--degraded] [--min-ms=<n>] [--limit=<n>] [--file=<path>] [--format=md|json]
   kb logs show --request-id=<id> [--file=<path>] [--format=md|json]
   kb logs show --query-sha=<hash> [--file=<path>] [--format=md|json]
 
@@ -22,6 +23,7 @@ Options:
   --limit=<n>           Number of recent canonical events to show (default: 20).
   --slow                Show only events marked slow, or events matching
                         --min-ms when that filter is supplied.
+  --degraded            Show only events with aggregate degraded=true.
   --min-ms=<n>          Minimum took_ms for the slow view; implies --slow.
   --request-id=<id>     Show canonical events for one request id.
   --query-sha=<hash>    Show canonical events for one query_sha256 value.
@@ -30,6 +32,7 @@ Options:
 Examples:
   kb logs recent
   kb logs --slow
+  kb logs --degraded
   kb logs recent --slow --min-ms=1000
   kb logs recent --limit=5 --format=json
   kb logs show --request-id=maw6d3qfabcd1234
@@ -49,6 +52,7 @@ export interface LogsArgs {
   file?: string;
   limit: number;
   slow: boolean;
+  degraded: boolean;
   minMs?: number;
   requestId?: string;
   querySha?: string;
@@ -71,6 +75,7 @@ interface LogsPayload {
     request_id?: string;
     query_sha256?: string;
     slow?: true;
+    degraded?: true;
     min_ms?: number;
   };
   scanned_line_count: number;
@@ -78,6 +83,7 @@ interface LogsPayload {
   ignored_line_count: number;
   malformed_canonical_line_count: number;
   slow_event_count: number;
+  degraded_event_count: number;
   result_count: number;
   events: CanonicalLogSummary[];
 }
@@ -94,6 +100,8 @@ interface CanonicalLogSummary {
   query_sha256?: string;
   took_ms?: number;
   slow?: true;
+  degraded?: true;
+  degraded_stages?: CanonicalLogSummaryDegradedStage[];
   timings: {
     embed_ms?: number;
     faiss_ms?: number;
@@ -108,6 +116,11 @@ interface CanonicalLogSummary {
   recovery_hint?: string;
   gate?: unknown;
   rerank?: Record<string, unknown>;
+}
+
+interface CanonicalLogSummaryDegradedStage {
+  stage: string;
+  reason?: string;
 }
 
 export interface RunLogsDeps {
@@ -188,14 +201,19 @@ export function parseLogsArgs(rest: string[]): LogsArgs {
   let optionStart = 1;
   if (rest[0] === 'recent' || rest[0] === 'show') {
     action = rest[0];
-  } else if (rest[0] === '--slow' || rest[0] === '--min-ms' || rest[0].startsWith('--min-ms=')) {
+  } else if (
+    rest[0] === '--slow' ||
+    rest[0] === '--degraded' ||
+    rest[0] === '--min-ms' ||
+    rest[0].startsWith('--min-ms=')
+  ) {
     action = 'recent';
     optionStart = 0;
   } else {
     throw new Error(`unknown action: ${JSON.stringify(rest[0])}`);
   }
 
-  const out: LogsArgs = { action, format: 'md', limit: DEFAULT_LIMIT, slow: false };
+  const out: LogsArgs = { action, format: 'md', limit: DEFAULT_LIMIT, slow: false, degraded: false };
   for (let index = optionStart; index < rest.length; index++) {
     const raw = rest[index];
     if (raw.startsWith('--file=')) {
@@ -218,6 +236,10 @@ export function parseLogsArgs(rest: string[]): LogsArgs {
     }
     if (raw === '--slow') {
       out.slow = true;
+      continue;
+    }
+    if (raw === '--degraded') {
+      out.degraded = true;
       continue;
     }
     if (raw === '--min-ms') {
@@ -358,7 +380,10 @@ function selectEvents(events: CanonicalLogRecord[], args: LogsArgs): CanonicalLo
     : args.requestId !== undefined
       ? events.filter((event) => event.request_id === args.requestId)
       : events.filter((event) => event.query_sha256 === args.querySha);
-  const filtered = args.slow ? base.filter((event) => matchesSlowFilter(event, args)) : base;
+  let filtered = args.slow ? base.filter((event) => matchesSlowFilter(event, args)) : base;
+  if (args.degraded) {
+    filtered = filtered.filter((event) => event.degraded === true);
+  }
   return args.action === 'recent' ? filtered.slice(-args.limit) : filtered;
 }
 
@@ -384,6 +409,7 @@ function buildLogsPayload(
       ...(args.requestId !== undefined ? { request_id: args.requestId } : {}),
       ...(args.querySha !== undefined ? { query_sha256: args.querySha } : {}),
       ...(args.slow ? { slow: true as const } : {}),
+      ...(args.degraded ? { degraded: true as const } : {}),
       ...(args.minMs !== undefined ? { min_ms: args.minMs } : {}),
     },
     scanned_line_count: parsed.scannedLineCount,
@@ -391,6 +417,7 @@ function buildLogsPayload(
     ignored_line_count: parsed.ignoredLineCount,
     malformed_canonical_line_count: parsed.malformedCanonicalLineCount,
     slow_event_count: parsed.events.filter((event) => event.slow === true).length,
+    degraded_event_count: parsed.events.filter((event) => event.degraded === true).length,
     result_count: events.length,
     events: events.map(summarizeEvent),
   };
@@ -408,7 +435,9 @@ function summarizeEvent(event: CanonicalLogRecord): CanonicalLogSummary {
     kb_scope: kbScopeField(event.kb_scope),
     query_sha256: stringField(event.query_sha256),
     took_ms: numberField(event.took_ms),
-    slow: slowField(event.slow),
+    slow: trueMarkerField(event.slow),
+    degraded: trueMarkerField(event.degraded),
+    degraded_stages: degradedStagesField(event.degraded_stages),
     timings: {
       embed_ms: numberField(event.embed_ms),
       faiss_ms: numberField(event.faiss_ms),
@@ -452,6 +481,7 @@ function formatLogsMarkdown(payload: LogsPayload): string {
     `- Ignored lines: ${payload.ignored_line_count}`,
     `- Malformed canonical lines: ${payload.malformed_canonical_line_count}`,
     `- Slow events: ${payload.slow_event_count}`,
+    `- Degraded events: ${payload.degraded_event_count}`,
     '',
   ];
 
@@ -461,8 +491,8 @@ function formatLogsMarkdown(payload: LogsPayload): string {
   }
 
   lines.push(
-    '| Time | Request | Command/tool | Query SHA | Took | Slow | Results | Error | Cache |',
-    '| --- | --- | --- | --- | ---: | --- | ---: | --- | --- |',
+    '| Time | Request | Command/tool | Query SHA | Took | Slow | Degraded | Results | Error | Cache |',
+    '| --- | --- | --- | --- | ---: | --- | --- | ---: | --- | --- |',
   );
   for (const event of payload.events) {
     lines.push([
@@ -472,6 +502,7 @@ function formatLogsMarkdown(payload: LogsPayload): string {
       code(event.query_sha256 ?? ''),
       event.took_ms === undefined ? '' : `${event.took_ms} ms`,
       event.slow === true ? 'yes' : '',
+      event.degraded === true ? formatDegradedStages(event.degraded_stages) : '',
       event.result_count === undefined ? '' : String(event.result_count),
       code(formatError(event.error)),
       event.cache ?? '',
@@ -490,6 +521,7 @@ function formatEventDetails(event: CanonicalLogSummary): string[] {
   const lines = [`## ${title}`, ''];
   lines.push(`- Timings: ${formatTimings(event)}`);
   if (event.slow === true) lines.push('- Slow: yes');
+  if (event.degraded === true) lines.push(`- Degraded: ${formatDegradedStages(event.degraded_stages)}`);
   if (event.model_id !== undefined) lines.push(`- Model: \`${event.model_id}\``);
   if (event.kb_scope !== undefined) lines.push(`- KB scope: \`${event.kb_scope ?? 'all'}\``);
   if (event.top_sources !== undefined && event.top_sources.length > 0) {
@@ -537,7 +569,7 @@ function numberField(value: unknown): number | undefined {
   return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
 }
 
-function slowField(value: unknown): true | undefined {
+function trueMarkerField(value: unknown): true | undefined {
   return value === true ? true : undefined;
 }
 
@@ -548,6 +580,27 @@ function kbScopeField(value: unknown): string | null | undefined {
 function stringArrayField(value: unknown): string[] | undefined {
   if (!Array.isArray(value)) return undefined;
   return value.filter((item): item is string => typeof item === 'string');
+}
+
+function degradedStagesField(value: unknown): CanonicalLogSummaryDegradedStage[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const stages = value.flatMap((item): CanonicalLogSummaryDegradedStage[] => {
+    if (typeof item !== 'object' || item === null) return [];
+    const record = item as Record<string, unknown>;
+    if (typeof record.stage !== 'string') return [];
+    return [{
+      stage: record.stage,
+      ...(typeof record.reason === 'string' ? { reason: record.reason } : {}),
+    }];
+  });
+  return stages.length === 0 ? undefined : stages;
+}
+
+function formatDegradedStages(stages: CanonicalLogSummaryDegradedStage[] | undefined): string {
+  if (stages === undefined || stages.length === 0) return 'yes';
+  return stages
+    .map((stage) => stage.reason === undefined ? stage.stage : `${stage.stage}:${stage.reason}`)
+    .join(', ');
 }
 
 function compactJson(value: unknown): string {

--- a/src/cli-search.test.ts
+++ b/src/cli-search.test.ts
@@ -1813,6 +1813,45 @@ describe('runSearch timing guard (#331)', () => {
     });
   });
 
+  it('surfaces gate degradation in dense JSON output and canonical telemetry', async () => {
+    const { deps, manager } = makeDeps();
+    manager.similaritySearch.mockResolvedValueOnce([
+      {
+        pageContent: 'deployment rollback',
+        metadata: { source: '/kb/deploy.md', chunkIndex: 0 },
+        score: 0.2,
+      },
+    ] as never);
+
+    const out = await captureSearchOutput([
+      'query',
+      '--gate',
+      '--task-context=answer the deployment rollback question with current operational constraints',
+      '--format=json',
+      '--no-freshness',
+    ], deps);
+
+    expect(out.code).toBe(0);
+    const payload = JSON.parse(out.stdout);
+    expect(payload).toMatchObject({
+      degraded: true,
+      degraded_stages: [{ stage: 'gate', reason: 'KB_GATE_LLM_ENDPOINT unset; degraded to A2' }],
+      gate_verdict: {
+        state: 'injected',
+        judge: {
+          status: 'failed',
+          reason: 'KB_GATE_LLM_ENDPOINT unset; degraded to A2',
+        },
+      },
+    });
+    expect(takeLastSearchCanonicalTelemetry()).toMatchObject({
+      gate: {
+        degraded: true,
+        degrade_reason: 'KB_GATE_LLM_ENDPOINT unset; degraded to A2',
+      },
+    });
+  });
+
   it('ignores invalid reranker-only topN config when dense mode cannot rerank', async () => {
     const { deps } = makeDeps();
     const previousRerank = process.env.KB_RERANK;
@@ -1962,6 +2001,69 @@ describe('runSearch timing guard (#331)', () => {
       });
       expect(payload.timing).toMatchObject({
         rerank_candidates: 3,
+      });
+    } finally {
+      restoreFactory();
+      if (previousRerank === undefined) delete process.env.KB_RERANK;
+      else process.env.KB_RERANK = previousRerank;
+      if (previousTopN === undefined) delete process.env.KB_RERANK_TOP_N;
+      else process.env.KB_RERANK_TOP_N = previousTopN;
+    }
+  });
+
+  it('surfaces hybrid reranker degradation in markdown output and canonical telemetry', async () => {
+    const manager = {
+      modelDir: '/tmp/kb-test-model',
+      initialize: jest.fn(async () => {}),
+      updateIndex: jest.fn(async () => {}),
+      similaritySearch: jest.fn(async () => [
+        {
+          pageContent: 'dense candidate',
+          metadata: { source: '/kb/dense.md', chunkIndex: 0 },
+          score: 0.1,
+        },
+      ]),
+    } as unknown as FaissIndexManager & { similaritySearch: jest.Mock };
+    const deps: RunSearchDeps = {
+      bootstrapLayout: jest.fn(async () => {}),
+      resolveActiveModel: jest.fn(async () => 'ollama__nomic-embed-text-latest'),
+      loadManagerForModel: jest.fn(async () => manager),
+      loadWithJsonRetry: jest.fn(async () => {}),
+      listLexicalKbs: jest.fn(async () => [{ kbName: 'alpha', kbPath: '/kb/alpha' }]),
+      runLexicalLeg: jest.fn(async () => ({
+        refreshed: 0,
+        failed: 0,
+        hits: [
+          {
+            pageContent: 'lexical candidate',
+            metadata: { source: '/kb/lexical.md', chunkIndex: 0 },
+            score: 10,
+          },
+        ],
+      })),
+    };
+    const restoreFactory = setRerankerFactoryForTests(async () => {
+      throw new Error('reranker unavailable');
+    });
+    const previousRerank = process.env.KB_RERANK;
+    const previousTopN = process.env.KB_RERANK_TOP_N;
+    process.env.KB_RERANK = 'on';
+    process.env.KB_RERANK_TOP_N = '2';
+
+    try {
+      const out = await captureSearchOutput(
+        ['query', '--mode=hybrid', '--k=2', '--no-freshness'],
+        deps,
+      );
+
+      expect(out.code).toBe(0);
+      expect(out.stdout).toContain('> _Rerank: Xenova/ms-marco-MiniLM-L-6-v2; rescored 2 candidate(s), cache hits 0; degraded to fused order._');
+      expect(out.stdout).toContain('> _Degraded stages: rerank (reranker unavailable)._');
+      expect(takeLastSearchCanonicalTelemetry()).toMatchObject({
+        rerank: {
+          degraded: true,
+          degrade_reason: 'reranker unavailable',
+        },
       });
     } finally {
       restoreFactory();

--- a/src/cli-search.ts
+++ b/src/cli-search.ts
@@ -28,6 +28,7 @@ import {
 import {
   formatRetrievalAsJson,
   formatRetrievalAsCompactTable,
+  formatDegradedStagesFooter,
   formatRetrievalAsMarkdown,
   formatRetrievalAsVimgrep,
   formatRetrievalEmptyAsMarkdown,
@@ -123,7 +124,13 @@ import {
   type SearchMode,
   type Staleness,
 } from './search-core.js';
-import { hashQuery, type CanonicalLogInput } from './canonical-log.js';
+import {
+  canonicalGateStageRecord,
+  canonicalRerankStageRecord,
+  degradationSummaryFields,
+  hashQuery,
+  type CanonicalLogInput,
+} from './canonical-log.js';
 import type { QueryCacheTelemetry } from './query-cache.js';
 import {
   KB_RETRIEVAL_VIEWS_ENV,
@@ -706,6 +713,7 @@ export async function runSearch(
     searchMode: effectiveMode,
     results,
     denseTiming,
+    gateVerdict,
   });
 
   if (shouldUsePicker(parsed)) {
@@ -1344,6 +1352,7 @@ function recordDenseSearchCanonicalTelemetry(input: {
   searchMode: EffectiveSearchMode;
   results: ScoredDocument[];
   denseTiming: SimilaritySearchTiming;
+  gateVerdict?: RelevanceGateVerdict;
 }): void {
   const queryCache = input.denseTiming.query_cache_telemetry;
   lastSearchCanonicalTelemetry = {
@@ -1361,6 +1370,7 @@ function recordDenseSearchCanonicalTelemetry(input: {
     faiss_ms: input.denseTiming.faiss_search_ms ?? input.denseTiming.query_search_ms,
     cache: queryCache?.outcome,
     query_cache: queryCache,
+    gate: input.gateVerdict === undefined ? undefined : canonicalGateStageRecord(input.gateVerdict),
   };
 }
 
@@ -1455,7 +1465,9 @@ export function buildDenseSearchJsonPayload(input: DenseSearchJsonPayloadInput):
       kept: input.autoThresholdDecision.kept,
     };
   }
-  payload.gate_verdict = input.gateVerdict ?? defaultBypassedGateVerdict(input.results.length);
+  const gateVerdict = input.gateVerdict ?? defaultBypassedGateVerdict(input.results.length);
+  payload.gate_verdict = gateVerdict;
+  Object.assign(payload, degradationSummaryFields({ gate: canonicalGateStageRecord(gateVerdict) }));
   if (input.advancedRetrieval !== undefined && input.advancedRetrieval !== null) {
     payload.advanced_retrieval = input.advancedRetrieval;
   }
@@ -1615,6 +1627,12 @@ export function formatDenseSearchMarkdownOutput(input: DenseSearchMarkdownOutput
   if (gateVerdict.state !== 'bypassed') {
     output += `${formatGateVerdictFooter(gateVerdict)}\n`;
   }
+  const degradedFooter = formatDegradedStagesFooter(
+    degradationSummaryFields({ gate: canonicalGateStageRecord(gateVerdict) }).degraded_stages,
+  );
+  if (degradedFooter !== '') {
+    output += `${degradedFooter}\n`;
+  }
   if (input.explain) {
     output += `${formatGateDroppedList(gateVerdict)}\n`;
   }
@@ -1656,6 +1674,12 @@ export function formatDenseSearchCompactOutput(input: {
   const gateVerdict = input.gateVerdict ?? defaultBypassedGateVerdict(input.results.length);
   if (gateVerdict.state !== 'bypassed') {
     output += `${formatGateVerdictFooter(gateVerdict)}\n`;
+  }
+  const degradedFooter = formatDegradedStagesFooter(
+    degradationSummaryFields({ gate: canonicalGateStageRecord(gateVerdict) }).degraded_stages,
+  );
+  if (degradedFooter !== '') {
+    output += `${degradedFooter}\n`;
   }
   if (input.results.length > 0 && input.filterDiagnostics) {
     output += `${formatFilterSelectivityDiagnosticsFooter(input.filterDiagnostics)}\n`;
@@ -2805,6 +2829,22 @@ async function runHybridSearch(
     return reportFailure(classifyKbSearchError(err), parsed.format);
   }
   ranked = ranked.slice(0, parsed.k);
+  const rerankStage = canonicalRerankStageRecord(rerankResult);
+  const gateStage = canonicalGateStageRecord(gateVerdict);
+  const degradation = degradationSummaryFields({ rerank: rerankStage, gate: gateStage });
+  lastSearchCanonicalTelemetry = {
+    query_sha256: hashQuery(query),
+    query_len_chars: query.length,
+    model_id: activeModelId,
+    kb_scope: parsed.kb ?? null,
+    k: parsed.k,
+    search_mode: 'hybrid',
+    result_count: ranked.length,
+    top_score: ranked[0]?.score,
+    top_sources: topSourcesForCanonicalLog(ranked as never),
+    rerank: rerankStage,
+    gate: gateStage,
+  };
   if (timing) timing.total_ms = elapsedMs(totalStartedAt);
   if (timing && deps.onSearchTiming !== undefined) {
     deps.onSearchTiming({
@@ -2854,6 +2894,7 @@ async function runHybridSearch(
         degrade_reason: rerankResult.degradeReason,
       },
       gate_verdict: gateVerdict,
+      ...degradation,
       ...(parsed.timing && timing ? { timing: compactTimingPayload(timing) } : {}),
     };
     process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
@@ -2883,6 +2924,10 @@ async function runHybridSearch(
     }
     if (gateVerdict.state !== 'bypassed') {
       output += `${formatGateVerdictFooter(gateVerdict)}\n`;
+    }
+    const degradedFooter = formatDegradedStagesFooter(degradation.degraded_stages);
+    if (degradedFooter !== '') {
+      output += `${degradedFooter}\n`;
     }
     if (parsed.explain) {
       output += `${formatGateDroppedList(gateVerdict)}\n`;
@@ -2920,6 +2965,10 @@ async function runHybridSearch(
     }
     if (gateVerdict.state !== 'bypassed') {
       output += `${formatGateVerdictFooter(gateVerdict)}\n`;
+    }
+    const degradedFooter = formatDegradedStagesFooter(degradation.degraded_stages);
+    if (degradedFooter !== '') {
+      output += `${degradedFooter}\n`;
     }
     if (parsed.explain) {
       output += `${formatGateDroppedList(gateVerdict)}\n`;

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -5,6 +5,7 @@
 
 import type { Document } from '@langchain/core/documents';
 import { buildChunkCitation, type ChunkCitation } from './chunk-id.js';
+import type { CanonicalDegradedStage } from './canonical-log.js';
 import { KB_EDITOR_URI, type KBEditorUriMode } from './config/retrieval.js';
 import {
   applyInjectionGuard,
@@ -217,6 +218,14 @@ export function highlightQueryTerms(text: string, terms: readonly string[]): str
   if (normalizedTerms.length === 0 || text === '') return text;
   const pattern = normalizedTerms.map(escapeRegex).join('|');
   return text.replace(new RegExp(pattern, 'giu'), (match) => `${ANSI_BOLD}${match}${ANSI_BOLD_OFF}`);
+}
+
+export function formatDegradedStagesFooter(stages: readonly CanonicalDegradedStage[] | undefined): string {
+  if (stages === undefined || stages.length === 0) return '';
+  const stageText = stages
+    .map((stage) => stage.reason === undefined ? stage.stage : `${stage.stage} (${stage.reason})`)
+    .join(', ');
+  return `> _Degraded stages: ${stageText}._`;
 }
 
 function applyRetrievalHighlight(text: string, highlight: RetrievalHighlightOptions | undefined): string {


### PR DESCRIPTION
## Summary

Closes #614.

This adds one aggregate degradation surface over already-classified fallback markers:

- canonical log normalization now derives optional top-level `degraded: true` and stable `degraded_stages[]` entries from dense fallback, rerank, and relevance-gate sub-records
- MCP and CLI search responses surface the same aggregate fields in structured/JSON output, with concise markdown/compact footers for human output
- `kb logs --degraded` filters canonical event summaries with aggregate `degraded === true` and reports degraded counts/stages in JSON and markdown
- CLI JSON contract docs describe the additive fields and log filter behavior

## Fallback / Degradation Semantics

The aggregate helper only summarizes known fallback state that already exists on the event/result path. It does not add new fallback behavior.

- Dense provider lexical fallback is reported as stage `dense` and keeps the existing `degrade_reason` for compatibility.
- Reranker fallback is reported as stage `rerank` only when the reranker actually ran and degraded to fused order.
- Relevance-gate judge fallback is reported as stage `gate` when the gate sub-record marks `degraded: true`.
- Disabled, skipped, bypassed, and successful stages are not counted as degraded.

## Alternatives Considered

- Threading new booleans through each call site: rejected in favor of a pure derivation helper at the canonical/result-envelope layer.
- Treating intentionally disabled stages as degraded: rejected because the issue asks for visibility over classified fallbacks, not config choices.
- Adding ingest-time preface failure aggregation: intentionally out of scope per issue guidance.

## Verification

- `npm install`
- `npm test -- --runTestsByPath src/canonical-log.test.ts src/cli-logs.test.ts src/cli-json-contracts.test.ts src/KnowledgeBaseServer.test.ts --runInBand` (repo wrapper ran full parallel suite first, then targeted serial suite)
- `npm run test:serial -- --runTestsByPath src/canonical-log.test.ts src/cli-logs.test.ts src/cli-json-contracts.test.ts src/cli-search.test.ts src/KnowledgeBaseServer.test.ts --runInBand` (serial project picked up KnowledgeBaseServer)
- `LOG_FILE= npx jest --selectProjects parallel --runInBand --runTestsByPath src/canonical-log.test.ts src/cli-logs.test.ts src/cli-json-contracts.test.ts src/cli-search.test.ts`
- `npm run build`
- `git diff --check`

## Pre-PR Review

- conventions-specialist: findings addressed (shared canonical stage adapters, renamed true marker parser, clarified docs example label)
- correctness-specialist: no verified findings
- deadcode-specialist: no dead code introduced
- test-specialist: finding addressed with direct `runSearch` coverage for gate and rerank degradation surfaces