### PR TITLE
Add dedicated hnswlib-node ANN backend

### DIFF
--- a/benchmarks/hnsw-ann.mjs
+++ b/benchmarks/hnsw-ann.mjs
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+import { performance } from 'node:perf_hooks';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const faiss = require('faiss-node');
+const { HierarchicalNSW } = require('hnswlib-node');
+
+const dims = intEnv('KB_HNSW_BENCH_DIMS', 64);
+const vectors = intEnv('KB_HNSW_BENCH_VECTORS', 3000);
+const queries = intEnv('KB_HNSW_BENCH_QUERIES', 120);
+const k = intEnv('KB_HNSW_BENCH_K', 10);
+const clusters = intEnv('KB_HNSW_BENCH_CLUSTERS', 48);
+const m = intEnv('KB_HNSW_M', 32);
+const efConstruction = intEnv('KB_HNSW_EF_CONSTRUCTION', 200);
+const efSearch = intEnv('KB_HNSW_EF_SEARCH', 100);
+const seed = intEnv('KB_HNSW_RANDOM_SEED', 100);
+const bootstrapIterations = intEnv('KB_HNSW_BENCH_BOOTSTRAP', 500);
+
+const corpus = makeClusteredVectors({ count: vectors, dims, clusters });
+const queryVectors = corpus.slice(0, queries).map((vector, i) =>
+  perturb(vector, 0.01 + (i % 7) * 0.002),
+);
+
+const flat = new faiss.IndexFlatL2(dims);
+flat.add(flatten(corpus));
+const exact = measureQueries('flat', (query) => flat.search(query, k).labels);
+
+const sq8 = faiss.Index.fromFactory(dims, 'SQ8', faiss.MetricType.METRIC_L2);
+if (sq8.isTrained?.() === false) sq8.train(flatten(corpus));
+sq8.add(flatten(corpus));
+const sq8Result = measureQueries('sq8', (query) => sq8.search(query, k).labels);
+
+const beforeHnswMemory = process.memoryUsage().rss;
+const hnsw = new HierarchicalNSW('l2', dims);
+hnsw.initIndex({ maxElements: corpus.length, m, efConstruction, randomSeed: seed });
+hnsw.setEf(efSearch);
+for (let i = 0; i < corpus.length; i += 1) hnsw.addPoint(corpus[i], i);
+const afterHnswMemory = process.memoryUsage().rss;
+const hnswResult = measureQueries('hnsw', (query) => hnsw.searchKnn(query, k).neighbors);
+
+const report = {
+  schema_version: 'kb.hnsw-ann-benchmark.v1',
+  config: {
+    vectors,
+    queries,
+    dims,
+    k,
+    clusters,
+    hnsw: { m, efConstruction, efSearch, metric: 'l2', randomSeed: seed },
+    bootstrap_iterations: bootstrapIterations,
+  },
+  baselines: {
+    flat: summarize('flat', exact.labels, exact.labels, exact.latencies, 0),
+    sq8: summarize('sq8', exact.labels, sq8Result.labels, sq8Result.latencies, 0),
+  },
+  hnsw: summarize(
+    'hnsw',
+    exact.labels,
+    hnswResult.labels,
+    hnswResult.latencies,
+    afterHnswMemory - beforeHnswMemory,
+  ),
+};
+
+console.log(JSON.stringify(report, null, 2));
+
+function intEnv(name, fallback) {
+  const raw = process.env[name];
+  if (raw === undefined || raw.trim() === '') return fallback;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : fallback;
+}
+
+function makeClusteredVectors({ count, dims: vectorDims, clusters: clusterCount }) {
+  const out = [];
+  for (let i = 0; i < count; i += 1) {
+    const cluster = i % clusterCount;
+    const vector = [];
+    for (let d = 0; d < vectorDims; d += 1) {
+      const base = Math.sin((cluster + 1) * (d + 3) * 0.017);
+      const local = Math.cos((i + 11) * (d + 5) * 0.013) * 0.05;
+      vector.push(base + local);
+    }
+    out.push(vector);
+  }
+  return out;
+}
+
+function perturb(vector, amount) {
+  return vector.map((value, i) => value + Math.sin((i + 1) * 0.37) * amount);
+}
+
+function flatten(matrix) {
+  return matrix.flatMap((row) => row);
+}
+
+function measureQueries(name, search) {
+  const labels = [];
+  const latencies = [];
+  for (const query of queryVectors) {
+    const started = performance.now();
+    labels.push(search(query));
+    latencies.push(performance.now() - started);
+  }
+  return { name, labels, latencies };
+}
+
+function summarize(name, exactLabels, candidateLabels, latencies, memoryBytes) {
+  const recalls = candidateLabels.map((labels, i) => recallAtK(exactLabels[i], labels));
+  const ndcgs = candidateLabels.map((labels, i) => ndcgAtK(exactLabels[i], labels));
+  return {
+    name,
+    recall_at_k: mean(recalls),
+    recall_at_k_ci95: bootstrapCi(recalls),
+    ndcg_at_k: mean(ndcgs),
+    ndcg_at_k_ci95: bootstrapCi(ndcgs),
+    latency_ms: {
+      p50: percentile(latencies, 0.5),
+      p95: percentile(latencies, 0.95),
+    },
+    memory_delta_bytes: memoryBytes,
+  };
+}
+
+function recallAtK(exactLabels, candidateLabels) {
+  const exactSet = new Set(exactLabels);
+  let hits = 0;
+  for (const label of candidateLabels) if (exactSet.has(label)) hits += 1;
+  return hits / exactLabels.length;
+}
+
+function ndcgAtK(exactLabels, candidateLabels) {
+  const exactRank = new Map(exactLabels.map((label, i) => [label, i]));
+  let dcg = 0;
+  for (let i = 0; i < candidateLabels.length; i += 1) {
+    if (exactRank.has(candidateLabels[i])) dcg += 1 / Math.log2(i + 2);
+  }
+  let idcg = 0;
+  for (let i = 0; i < exactLabels.length; i += 1) idcg += 1 / Math.log2(i + 2);
+  return idcg === 0 ? 0 : dcg / idcg;
+}
+
+function mean(values) {
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+function percentile(values, q) {
+  const sorted = [...values].sort((a, b) => a - b);
+  const index = Math.min(sorted.length - 1, Math.max(0, Math.ceil(sorted.length * q) - 1));
+  return sorted[index];
+}
+
+function bootstrapCi(values) {
+  const means = [];
+  let state = 0x9e3779b9;
+  for (let i = 0; i < bootstrapIterations; i += 1) {
+    let sum = 0;
+    for (let j = 0; j < values.length; j += 1) {
+      state = (Math.imul(state, 1664525) + 1013904223) >>> 0;
+      sum += values[state % values.length];
+    }
+    means.push(sum / values.length);
+  }
+  return [percentile(means, 0.025), percentile(means, 0.975)];
+}

--- a/docs/operations/indexing.md
+++ b/docs/operations/indexing.md
@@ -38,3 +38,72 @@ KB_INDEXING_CONCURRENCY=2 node benchmarks/indexing-concurrency.mjs
 The harness simulates provider latency and serialized insertion. Real-provider
 throughput still depends on provider rate limits, local Ollama parallelism, and
 network latency.
+
+## HNSW ANN Indexing
+
+`KB_INDEX_TYPE=hnsw` enables the dedicated `hnswlib-node` backend. It is
+opt-in only; `flat` remains the default, and the server does not auto-enable
+approximate search based on corpus size or latency.
+
+Use HNSW when a large local corpus has measured dense-search latency that is
+too high for the workflow and a recall trade-off is acceptable. HNSW changes
+retrieval semantics: it is approximate nearest-neighbor search, so top-k
+results can differ from exact flat search. Raise `KB_HNSW_EF_SEARCH` to recover
+recall at query time, and raise `KB_HNSW_EF_CONSTRUCTION` when rebuild time and
+graph memory are acceptable.
+
+```bash
+KB_INDEX_TYPE=hnsw \
+KB_HNSW_M=32 \
+KB_HNSW_EF_CONSTRUCTION=200 \
+KB_HNSW_EF_SEARCH=100 \
+kb reindex --force
+```
+
+Parameter mapping:
+
+- `KB_HNSW_M` maps to `HierarchicalNSW.initIndex(..., m, ...)`.
+- `KB_HNSW_EF_CONSTRUCTION` maps to `initIndex(..., efConstruction, ...)`.
+- `KB_HNSW_EF_SEARCH` maps to `setEf(ef)` and is reapplied after every load and
+  before query execution.
+
+HNSW indexes use the same versioned swap model as FAISS but persist a distinct
+binary:
+
+```text
+$FAISS_INDEX_PATH/models/<model_id>/
+  index -> index.vN
+  index.vN/
+    hnsw.index
+    docstore.json
+    integrity.json
+```
+
+The integrity manifest records `backend: "hnsw"`, `index_type: "hnsw"`, `m`,
+`efConstruction`, `efSearch`, metric, capacity policy, random seed, dimensions,
+and file hashes. A backend or build-parameter mismatch removes the active
+symlink for rebuild, or fails in strict read-only mode; it is not loaded as the
+wrong binary format. Existing `flat` and `sq8` FAISS indexes continue to use
+`faiss.index` and the legacy FAISS load path.
+
+Benchmark before recommending HNSW for an installation:
+
+```bash
+node benchmarks/hnsw-ann.mjs
+```
+
+The harness reports recall@k and nDCG@k deltas against exact flat search,
+p50/p95 query latency, HNSW memory delta, and bootstrap confidence intervals
+for flat, SQ8, and HNSW. A local smoke run on 2026-06-13 used:
+
+```bash
+KB_HNSW_BENCH_VECTORS=500 \
+KB_HNSW_BENCH_QUERIES=30 \
+KB_HNSW_BENCH_BOOTSTRAP=50 \
+node benchmarks/hnsw-ann.mjs
+```
+
+Smoke result summary: HNSW recall@10 `1.0` with CI `[1.0, 1.0]`, nDCG@10
+`1.0` with CI `[1.0, 1.0]`, p50 `0.0349ms`, p95 `0.0519ms`, and about `3.0MiB`
+RSS delta. This is a synthetic smoke check only; use the BEIR/evaluation
+fixtures for corpus-specific promotion decisions.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -9,7 +9,11 @@ Run `npm run docs:generate-config-reference` after changing the schema.
 |---|---|---|---|---|---|---|
 | <code>KNOWLEDGE_BASES_ROOT_DIR</code> | <code>path</code> | <code>$HOME/knowledge_bases</code> |  |  | uses default | Root directory containing knowledge base shelves. |
 | <code>FAISS_INDEX_PATH</code> | <code>path</code> | <code>$KNOWLEDGE_BASES_ROOT_DIR/.faiss</code> |  |  | uses default | Directory where FAISS index data is stored. |
-| <code>KB_INDEX_TYPE</code> | <code>enum</code> | <code>flat</code> | <code>flat</code>, <code>sq8</code> |  | uses default |  |
+| <code>KB_INDEX_TYPE</code> | <code>enum</code> | <code>flat</code> | <code>flat</code>, <code>sq8</code>, <code>hnsw</code> |  | uses default |  |
+| <code>KB_HNSW_M</code> | <code>integer</code> | <code>32</code> |  | >= <code>2</code>; <= <code>128</code>; digits only | uses default | HNSW graph connectivity when KB_INDEX_TYPE=hnsw. |
+| <code>KB_HNSW_EF_CONSTRUCTION</code> | <code>integer</code> | <code>200</code> |  | >= <code>1</code>; <= <code>10000</code>; digits only | uses default | HNSW build-time candidate list size when KB_INDEX_TYPE=hnsw. |
+| <code>KB_HNSW_EF_SEARCH</code> | <code>integer</code> | <code>100</code> |  | >= <code>1</code>; <= <code>10000</code>; digits only | uses default | HNSW query-time candidate list size when KB_INDEX_TYPE=hnsw. |
+| <code>KB_HNSW_RANDOM_SEED</code> | <code>integer</code> | <code>100</code> |  | >= <code>1</code>; <= <code>2147483647</code>; digits only | uses default | HNSW random seed recorded in the index manifest. |
 | <code>EMBEDDING_PROVIDER</code> | <code>enum</code> | <code>huggingface</code> | <code>huggingface</code>, <code>ollama</code>, <code>openai</code>, <code>fake</code> |  | uses default | Default embedding provider for retrieval and ingest. |
 | <code>KB_ACTIVE_MODEL</code> | <code>string</code> | _unset_ |  |  | kept as set | Active model override; otherwise the active model sidecar or legacy provider env is used. |
 | <code>KB_FAKE_DIM</code> | <code>integer</code> | <code>256</code> |  | >= <code>8</code>; <= <code>4096</code> | uses default |  |

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@modelcontextprotocol/sdk": "^1.17.2",
         "axios": "^1.6.7",
         "faiss-node": "latest",
+        "hnswlib-node": "^3.0.0",
         "html-to-text": "^9.0.5",
         "js-yaml": "^4.1.1",
         "langchain": "^0.3.15",
@@ -5967,6 +5968,27 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hnswlib-node": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hnswlib-node/-/hnswlib-node-3.0.0.tgz",
+      "integrity": "sha512-fypn21qvVORassppC8/qNfZ5KAOspZpm/IbUkAtlqvbtDNnF5VVk5RWF7O5V6qwr7z+T3s1ePej6wQt5wRQ4Cg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "node-addon-api": "^8.0.0"
+      }
+    },
+    "node_modules/hnswlib-node/node_modules/node-addon-api": {
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.8.0.tgz",
+      "integrity": "sha512-c5Ko1fZJIJmzhFIkhRN76WTq+fC6tWnGy9CXA0fA+XygsWZmEwG8vmbkNqxMyoaa0Tin4djul49NzdVcJJcjeA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
       }
     },
     "node_modules/html-escaper": {

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "@modelcontextprotocol/sdk": "^1.17.2",
     "axios": "^1.6.7",
     "faiss-node": "latest",
+    "hnswlib-node": "^3.0.0",
     "html-to-text": "^9.0.5",
     "js-yaml": "^4.1.1",
     "langchain": "^0.3.15",

--- a/src/FaissIndexManager.test.ts
+++ b/src/FaissIndexManager.test.ts
@@ -397,6 +397,11 @@ describe('FaissIndexManager permission handling', () => {
     KB_INGEST_SECRET_SCAN: process.env.KB_INGEST_SECRET_SCAN,
     KB_SECRET_SCAN_BYPASS_KBS: process.env.KB_SECRET_SCAN_BYPASS_KBS,
     KB_LOG_FORMAT: process.env.KB_LOG_FORMAT,
+    KB_INDEX_TYPE: process.env.KB_INDEX_TYPE,
+    KB_HNSW_M: process.env.KB_HNSW_M,
+    KB_HNSW_EF_CONSTRUCTION: process.env.KB_HNSW_EF_CONSTRUCTION,
+    KB_HNSW_EF_SEARCH: process.env.KB_HNSW_EF_SEARCH,
+    KB_HNSW_RANDOM_SEED: process.env.KB_HNSW_RANDOM_SEED,
   };
 
 
@@ -700,6 +705,55 @@ describe('FaissIndexManager permission handling', () => {
       dimensions: 2,
     });
     expect(manifest.embedding_canary?.vector).toHaveLength(2);
+  });
+
+  it('builds, persists, reloads, and queries an HNSW index when explicitly configured', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-hnsw-manager-'));
+    const kbDir = path.join(tempDir, 'kb');
+    const defaultKb = path.join(kbDir, 'default');
+    await fsp.mkdir(defaultKb, { recursive: true });
+    await fsp.writeFile(path.join(defaultKb, 'doc.md'), '# Alpha\n\nAlpha HNSW content.');
+
+    process.env.KNOWLEDGE_BASES_ROOT_DIR = kbDir;
+    process.env.FAISS_INDEX_PATH = path.join(tempDir, '.faiss');
+    process.env.EMBEDDING_PROVIDER = 'huggingface';
+    process.env.HUGGINGFACE_API_KEY = 'test-key';
+    process.env.KB_INDEX_TYPE = 'hnsw';
+    process.env.KB_HNSW_M = '8';
+    process.env.KB_HNSW_EF_CONSTRUCTION = '40';
+    process.env.KB_HNSW_EF_SEARCH = '20';
+
+    jest.resetModules();
+    const { FaissIndexManager } = await import('./FaissIndexManager.js');
+    const manager = new FaissIndexManager();
+    await manager.initialize();
+    await manager.updateIndex();
+
+    const versionDir = versionedIndexPathIn(process.env.FAISS_INDEX_PATH!);
+    await expect(fsp.stat(path.join(versionDir, 'hnsw.index'))).resolves.toBeTruthy();
+    await expect(fsp.stat(path.join(versionDir, 'faiss.index'))).rejects.toMatchObject({ code: 'ENOENT' });
+    const manifest = JSON.parse(
+      await fsp.readFile(path.join(versionDir, 'integrity.json'), 'utf-8'),
+    );
+    expect(manifest).toMatchObject({
+      backend: 'hnsw',
+      index_type: 'hnsw',
+      hnsw: {
+        m: 8,
+        efConstruction: 40,
+        efSearch: 20,
+        metric: 'l2',
+      },
+    });
+
+    const reloaded = new FaissIndexManager();
+    await reloaded.initialize({ readOnly: true });
+    const results = await reloaded.similaritySearch('Alpha HNSW content', 1, Number.POSITIVE_INFINITY);
+    expect(results[0]?.pageContent).toContain('Alpha HNSW content');
+    expect(reloaded.getStats()).toMatchObject({
+      totalChunks: 1,
+      indexType: 'hnsw',
+    });
   });
 
   it('recovers a save-complete pending manifest by finishing hash and chunk sidecars', async () => {

--- a/src/FaissIndexManager.ts
+++ b/src/FaissIndexManager.ts
@@ -28,10 +28,14 @@ import {
   resolveRefreshQuiesceMs,
 } from './config/ingest.js';
 import {
-  resolveFaissIndexType,
+  backendForIndexType,
+  resolveHnswIndexConfig,
+  resolveIndexType,
   resolveIndexingBatchSize,
   resolveIndexingConcurrency,
-  type FaissIndexType,
+  type HnswIndexConfig,
+  type IndexBackend,
+  type SearchIndexType,
 } from './config/indexing.js';
 import { casRootForIndexPath } from './docstore-cas.js';
 import {
@@ -52,9 +56,12 @@ import {
 import { mapBounded, resolveFsConcurrency } from './bounded-concurrency.js';
 import {
   createEmbeddingCanaryFingerprint,
+  loadHnswIndexAtomic,
   loadFaissStoreAtomic,
   loadFaissStoreFromVersionDir,
+  readIndexIntegrityManifest,
   resolveActiveIndexFilePath as resolveActiveIndexFilePathFromLayout,
+  saveHnswIndexAtomic,
   saveFaissStoreAtomic,
 } from './faiss-store-layout.js';
 import {
@@ -92,6 +99,8 @@ import {
 import { queryEmbeddingCache, type QueryCacheLookupStatus, type QueryCacheTelemetry } from './query-cache.js';
 import { withSidecarLock } from './write-lock.js';
 import { FaissStoreAdapter, type EmbeddedDocumentsBatch } from './faiss-store-adapter.js';
+import { HnswIndexAdapter } from './hnsw-index-adapter.js';
+import type { SearchIndexAdapter } from './search-index-adapter.js';
 import {
   recordIngestFailure,
   recordIngestSuccess,
@@ -237,7 +246,7 @@ function totalFileCount(
 export interface FaissIndexManagerOptions {
   provider: EmbeddingProvider;
   modelName: string;
-  indexType?: FaissIndexType;
+  indexType?: SearchIndexType;
 }
 
 export interface IndexUpdateProgress {
@@ -553,7 +562,7 @@ function parsePersistedIndexUpdateSummary(value: unknown): IndexUpdateSummary | 
 }
 
 export class FaissIndexManager {
-  private faissIndex: FaissStoreAdapter | null = null;
+  private faissIndex: SearchIndexAdapter | null = null;
   // Issue #59 — populated by initialize() via dynamic import of the active
   // provider's @langchain module. Definite-assignment-asserted because the
   // class invariant is "every method that touches embeddings runs after
@@ -572,7 +581,9 @@ export class FaissIndexManager {
   readonly modelNameFile: string;
   private readonly indexingBatchSize: number;
   private readonly indexingConcurrency: number;
-  private readonly indexType: FaissIndexType;
+  private readonly indexType: SearchIndexType;
+  private readonly indexBackend: IndexBackend;
+  private readonly hnswConfig: HnswIndexConfig | null;
   private lastIndexUpdateSummary: IndexUpdateSummary;
   // Issue #283 — cached metadata sidecar so we don't re-parse the JSONL
   // file on every query. Invalidated whenever updateIndex rewrites it,
@@ -608,14 +619,19 @@ export class FaissIndexManager {
     this.modelNameFile = modelNameFilePath(this.modelId);
     this.indexingBatchSize = resolveIndexingBatchSize(this.embeddingProvider);
     this.indexingConcurrency = resolveIndexingConcurrency(this.embeddingProvider);
-    this.indexType = opts?.indexType ?? resolveFaissIndexType();
+    this.indexType = opts?.indexType ?? resolveIndexType();
+    this.indexBackend = backendForIndexType(this.indexType);
+    this.hnswConfig = this.indexType === 'hnsw' ? resolveHnswIndexConfig() : null;
     this.lastIndexUpdateSummary = createNeverRunIndexUpdateSummary(this.modelId);
 
     // Issue #59 — embeddings are constructed lazily inside initialize() so
     // the unused providers' @langchain modules never load. API-key validation
     // moves with them; the throw still fires before any disk work.
 
-    logger.info(`FaissIndexManager bound to ${this.modelDir} (provider=${this.embeddingProvider}, model=${this.modelName}, id=${this.modelId})`);
+    logger.info(
+      `FaissIndexManager bound to ${this.modelDir} (provider=${this.embeddingProvider}, ` +
+        `model=${this.modelName}, id=${this.modelId}, index=${this.indexType})`,
+    );
   }
 
   get hasLoadedIndex(): boolean {
@@ -1117,12 +1133,25 @@ export class FaissIndexManager {
    * `list_models` (active-model.ts:detectDowngradeHazard), so no marker
    * file is required — the filesystem is the single source of truth.
    */
-  private async loadAtomic(opts: { repairCorrupt?: boolean } = {}): Promise<FaissStoreAdapter | null> {
+  private async loadAtomic(opts: { repairCorrupt?: boolean } = {}): Promise<SearchIndexAdapter | null> {
+    if (this.indexBackend === 'hnsw') {
+      if (this.hnswConfig === null) {
+        throw new Error('HNSW index configuration was not initialized');
+      }
+      return await loadHnswIndexAtomic({
+        modelDir: this.modelDir,
+        modelId: this.modelId,
+        config: this.hnswConfig,
+        handleFsOperationError,
+        repairCorrupt: opts.repairCorrupt,
+      });
+    }
     const store = await loadFaissStoreAtomic({
       modelDir: this.modelDir,
       modelId: this.modelId,
       embeddings: this.embeddings,
       handleFsOperationError,
+      expectedIndexType: this.indexType === 'sq8' ? 'sq8' : 'flat',
       repairCorrupt: opts.repairCorrupt,
     });
     return store === null ? null : FaissStoreAdapter.fromStore(store);
@@ -1156,6 +1185,21 @@ export class FaissIndexManager {
   async loadFromVersionDir(versionDir: string): Promise<void> {
     if (!this.embeddings) {
       throw new Error('FaissIndexManager.loadFromVersionDir requires initialize() first');
+    }
+    const manifest = await readIndexIntegrityManifest(versionDir);
+    if ((manifest?.backend ?? 'faiss') === 'hnsw') {
+      if (manifest?.hnsw === undefined) {
+        throw new Error(`HNSW version directory ${versionDir} is missing manifest metadata`);
+      }
+      this.faissIndex = await HnswIndexAdapter.load(
+        versionDir,
+        this.hnswConfig ?? resolveHnswIndexConfig(),
+        manifest.hnsw.dimensions,
+      );
+      this.metadataSidecarAllowedForLoadedStore = false;
+      this.metadataSidecarCache = null;
+      this.metadataSidecarMissingLogged = false;
+      return;
     }
     const store = await loadFaissStoreFromVersionDir({
       versionDir,
@@ -1197,12 +1241,27 @@ export class FaissIndexManager {
       ? await createEmbeddingCanaryFingerprint({ embedDocuments: embeddingsForCanary.embedDocuments })
       : null;
     this.swapCounter += 1;
+    if (this.indexBackend === 'hnsw') {
+      if (!(this.faissIndex instanceof HnswIndexAdapter) || this.hnswConfig === null) {
+        throw new Error('atomicSave called with a non-HNSW adapter for HNSW index type');
+      }
+      await saveHnswIndexAtomic({
+        adapter: this.faissIndex,
+        modelDir: this.modelDir,
+        modelId: this.modelId,
+        swapCounter: this.swapCounter,
+        config: this.hnswConfig,
+        embeddingCanary,
+        onCommitted: opts.onCommitted,
+      });
+      return;
+    }
     await saveFaissStoreAtomic({
       store: this.faissStoreForPersistence(),
       modelDir: this.modelDir,
       modelId: this.modelId,
       swapCounter: this.swapCounter,
-      indexType: this.indexType,
+      indexType: this.indexType === 'sq8' ? 'sq8' : 'flat',
       embeddingCanary,
       casRoot: casRootForIndexPath(FAISS_INDEX_PATH),
       onCommitted: opts.onCommitted,
@@ -1212,11 +1271,23 @@ export class FaissIndexManager {
   private faissStoreForPersistence(): ReturnType<FaissStoreAdapter['getStoreForPersistence']> {
     const candidate = this.faissIndex as
       | FaissStoreAdapter
-      | ReturnType<FaissStoreAdapter['getStoreForPersistence']>;
+      | HnswIndexAdapter
+      | ReturnType<FaissStoreAdapter['getStoreForPersistence']>
+      | null;
+    if (candidate instanceof HnswIndexAdapter) {
+      throw new Error('atomicSave called with a HNSW adapter for FAISS index type');
+    }
     if (candidate instanceof FaissStoreAdapter) {
       return candidate.getStoreForPersistence();
     }
-    return candidate;
+    if (
+      candidate !== null &&
+      typeof candidate === 'object' &&
+      typeof (candidate as { save?: unknown }).save === 'function'
+    ) {
+      return candidate as ReturnType<FaissStoreAdapter['getStoreForPersistence']>;
+    }
+    throw new Error('atomicSave called with a non-FAISS adapter for FAISS index type');
   }
 
   private async addDocumentsToIndex(
@@ -1283,12 +1354,17 @@ export class FaissIndexManager {
       batchIndex: number,
     ): Promise<void> => {
       if (this.faissIndex === null) {
-        logger.info(`Creating new FAISS index from ${embedded.documents.length} text(s)...`);
-        this.faissIndex = await FaissStoreAdapter.fromEmbeddedDocuments(
-          embedded,
-          this.embeddings,
-          { indexType: this.indexType },
-        );
+        logger.info(`Creating new ${this.indexBackend.toUpperCase()} index from ${embedded.documents.length} text(s)...`);
+        this.faissIndex = this.indexBackend === 'hnsw'
+          ? await HnswIndexAdapter.fromEmbeddedDocuments(
+              embedded,
+              this.hnswConfig ?? resolveHnswIndexConfig(),
+            )
+          : await FaissStoreAdapter.fromEmbeddedDocuments(
+              embedded,
+              this.embeddings,
+              { indexType: this.indexType === 'sq8' ? 'sq8' : 'flat' },
+            );
       } else {
         await this.faissIndex.addEmbeddedDocuments(embedded);
       }
@@ -2820,7 +2896,7 @@ export class FaissIndexManager {
     totalChunks: number;
     chunkCountsByKb: Record<string, number>;
     dim: number | null;
-    indexType: FaissIndexType;
+    indexType: SearchIndexType;
   } {
     if (!this.faissIndex) {
       return { totalChunks: 0, chunkCountsByKb: {}, dim: null, indexType: this.indexType };
@@ -2843,7 +2919,7 @@ export class FaissIndexManager {
    * if no index has been persisted yet for this model.
    */
   async resolveActiveIndexFilePath(): Promise<string | null> {
-    return resolveActiveIndexFilePathFromLayout(this.modelDir);
+    return resolveActiveIndexFilePathFromLayout(this.modelDir, this.indexBackend);
   }
 }
 

--- a/src/active-model.ts
+++ b/src/active-model.ts
@@ -28,7 +28,7 @@ import {
   parseIndexVersionDirName,
   resolveIndexVersionRetention,
 } from './faiss-store-layout.js';
-import { resolveFaissIndexType, type FaissIndexType } from './config/indexing.js';
+import { resolveIndexType, type SearchIndexType } from './config/indexing.js';
 
 const ACTIVE_FILE = path.join(FAISS_INDEX_PATH, 'active.txt');
 const MODELS_DIR = path.join(FAISS_INDEX_PATH, 'models');
@@ -422,16 +422,16 @@ export async function readStoredModelName(modelId: string): Promise<string | nul
   }
 }
 
-export async function readStoredIndexType(modelId: string): Promise<FaissIndexType> {
+export async function readStoredIndexType(modelId: string): Promise<SearchIndexType> {
   try {
-    return resolveFaissIndexType(await fsp.readFile(indexTypeFilePath(modelId), 'utf-8'));
+    return resolveIndexType(await fsp.readFile(indexTypeFilePath(modelId), 'utf-8'));
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === 'ENOENT') return 'flat';
     throw err;
   }
 }
 
-export async function writeIndexTypeAtomic(modelId: string, indexType: FaissIndexType): Promise<void> {
+export async function writeIndexTypeAtomic(modelId: string, indexType: SearchIndexType): Promise<void> {
   const target = indexTypeFilePath(modelId);
   const tmp = `${target}.${process.pid}.tmp`;
   await fsp.writeFile(tmp, `${indexType}\n`, 'utf-8');

--- a/src/cli-doctor.ts
+++ b/src/cli-doctor.ts
@@ -18,7 +18,7 @@ import {
   readModelIndexStorage,
   readStoredIndexType,
   resolveActiveModel,
-  resolveFaissIndexBinaryPath,
+  modelDir,
 } from './active-model.js';
 import {
   FAISS_INDEX_PATH,
@@ -90,7 +90,11 @@ import {
   type LlmProfile,
 } from './llm-profiles.js';
 import { resolveRerankerConfig } from './config/reranker.js';
-import { resolveFlatSearchP95AdvisoryMs, type FaissIndexType } from './config/indexing.js';
+import {
+  backendForIndexType,
+  resolveFlatSearchP95AdvisoryMs,
+  type SearchIndexType,
+} from './config/indexing.js';
 import { tryReadDaemonStatsPayload } from './cli-stats.js';
 import {
   daemonUrlFromEnv,
@@ -112,6 +116,7 @@ import {
   createEmbeddingCanaryFingerprint,
   cosineSimilarity,
   readIndexIntegrityManifest,
+  resolveActiveIndexFilePath,
 } from './faiss-store-layout.js';
 import { createDoctorBugReportBundle } from './cli-bug-report.js';
 import {
@@ -307,7 +312,7 @@ export interface DoctorReport {
     binary_path: string | null;
     version: string | null;
     mtime: string | null;
-    type: FaissIndexType | null;
+    type: SearchIndexType | null;
     factory: string | null;
     storage: {
       active_version_bytes: number | null;
@@ -1755,7 +1760,10 @@ async function readIndexHealth(activeModelId: string | null): Promise<DoctorRepo
     total_version_bytes: storage.total_version_bytes,
     retention_previous_versions: storage.retention_previous_versions,
   };
-  const binaryPath = await resolveFaissIndexBinaryPath(activeModelId);
+  const binaryPath = await resolveActiveIndexFilePath(
+    modelDir(activeModelId),
+    backendForIndexType(indexType),
+  );
   if (binaryPath === null) {
     return {
       path: FAISS_INDEX_PATH,

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -4,7 +4,9 @@ import {
   parseKbMaxFileBytes,
 } from './config/ingest.js';
 import {
+  resolveHnswIndexConfig,
   resolveFaissIndexType,
+  resolveIndexType,
   resolveChunkSize,
   resolveIndexingBatchSize,
   resolveIndexingConcurrency,
@@ -134,6 +136,45 @@ describe('resolveFaissIndexType (#468 — KB_INDEX_TYPE)', () => {
   it('accepts flat and sq8 case-insensitively', () => {
     expect(resolveFaissIndexType('flat')).toBe('flat');
     expect(resolveFaissIndexType(' SQ8 ')).toBe('sq8');
+  });
+
+  it('keeps hnsw opt-in on the generic parser without sending it to FAISS', () => {
+    expect(resolveIndexType(' HNSW ')).toBe('hnsw');
+    expect(resolveFaissIndexType('hnsw')).toBe('flat');
+  });
+});
+
+describe('resolveHnswIndexConfig (#623)', () => {
+  it('uses explicit non-binding defaults for HNSW tuning', () => {
+    expect(resolveHnswIndexConfig({})).toEqual({
+      m: 32,
+      efConstruction: 200,
+      efSearch: 100,
+      metric: 'l2',
+      capacityPolicy: 'resize_to_fit',
+      randomSeed: 100,
+    });
+  });
+
+  it('parses valid HNSW parameters and rejects invalid values', () => {
+    expect(resolveHnswIndexConfig({
+      KB_HNSW_M: '16',
+      KB_HNSW_EF_CONSTRUCTION: '80',
+      KB_HNSW_EF_SEARCH: '40',
+      KB_HNSW_RANDOM_SEED: '1234',
+    })).toMatchObject({
+      m: 16,
+      efConstruction: 80,
+      efSearch: 40,
+      randomSeed: 1234,
+    });
+
+    expect(() => resolveHnswIndexConfig({ KB_HNSW_M: '1' })).toThrow(/KB_HNSW_M/);
+    expect(() => resolveHnswIndexConfig({
+      KB_HNSW_M: '64',
+      KB_HNSW_EF_CONSTRUCTION: '32',
+    })).toThrow(/KB_HNSW_EF_CONSTRUCTION.*KB_HNSW_M/);
+    expect(() => resolveHnswIndexConfig({ KB_HNSW_EF_SEARCH: '1.5' })).toThrow(/KB_HNSW_EF_SEARCH/);
   });
 });
 

--- a/src/config/indexing.ts
+++ b/src/config/indexing.ts
@@ -11,9 +11,36 @@ const MAX_INDEXING_BATCH_SIZE = 512;
 const MAX_INDEXING_CONCURRENCY = 4;
 export const KB_INDEX_TYPE_ENV = 'KB_INDEX_TYPE';
 export const KB_INDEXING_CONCURRENCY_ENV = 'KB_INDEXING_CONCURRENCY';
+export const KB_HNSW_M_ENV = 'KB_HNSW_M';
+export const KB_HNSW_EF_CONSTRUCTION_ENV = 'KB_HNSW_EF_CONSTRUCTION';
+export const KB_HNSW_EF_SEARCH_ENV = 'KB_HNSW_EF_SEARCH';
+export const KB_HNSW_RANDOM_SEED_ENV = 'KB_HNSW_RANDOM_SEED';
 export type FaissIndexType = 'flat' | 'sq8';
+export type SearchIndexType = FaissIndexType | 'hnsw';
+export type IndexBackend = 'faiss' | 'hnsw';
 export const KB_FLAT_SEARCH_P95_ADVISORY_MS_ENV = 'KB_FLAT_SEARCH_P95_ADVISORY_MS';
 export const DEFAULT_FLAT_SEARCH_P95_ADVISORY_MS = 50;
+export const DEFAULT_HNSW_M = 32;
+export const DEFAULT_HNSW_EF_CONSTRUCTION = 200;
+export const DEFAULT_HNSW_EF_SEARCH = 100;
+export const DEFAULT_HNSW_RANDOM_SEED = 100;
+export const HNSW_METRIC = 'l2';
+export const HNSW_CAPACITY_POLICY = 'resize_to_fit';
+const MIN_HNSW_M = 2;
+const MAX_HNSW_M = 128;
+const MIN_HNSW_EF = 1;
+const MAX_HNSW_EF = 10000;
+const MIN_HNSW_RANDOM_SEED = 1;
+const MAX_HNSW_RANDOM_SEED = 2_147_483_647;
+
+export interface HnswIndexConfig {
+  m: number;
+  efConstruction: number;
+  efSearch: number;
+  metric: typeof HNSW_METRIC;
+  capacityPolicy: typeof HNSW_CAPACITY_POLICY;
+  randomSeed: number;
+}
 
 export function resolveIndexingBatchSize(
   provider: string = EMBEDDING_PROVIDER,
@@ -64,13 +91,87 @@ export function defaultIndexingBatchSize(provider: string): number {
     : DEFAULT_INDEXING_BATCH_SIZE;
 }
 
+export function resolveIndexType(
+  raw: string | undefined = process.env[KB_INDEX_TYPE_ENV],
+): SearchIndexType {
+  const normalized = raw?.trim().toLowerCase();
+  if (normalized === undefined || normalized === '') return 'flat';
+  if (normalized === 'flat' || normalized === 'sq8' || normalized === 'hnsw') return normalized;
+  return 'flat';
+}
+
 export function resolveFaissIndexType(
   raw: string | undefined = process.env[KB_INDEX_TYPE_ENV],
 ): FaissIndexType {
-  const normalized = raw?.trim().toLowerCase();
-  if (normalized === undefined || normalized === '') return 'flat';
-  if (normalized === 'flat' || normalized === 'sq8') return normalized;
-  return 'flat';
+  const resolved = resolveIndexType(raw);
+  return resolved === 'hnsw' ? 'flat' : resolved;
+}
+
+export function backendForIndexType(indexType: SearchIndexType): IndexBackend {
+  return indexType === 'hnsw' ? 'hnsw' : 'faiss';
+}
+
+function parseStrictInteger(
+  name: string,
+  raw: string | undefined,
+  fallback: number,
+  min: number,
+  max: number,
+): number {
+  const trimmed = raw?.trim();
+  if (trimmed === undefined || trimmed === '') return fallback;
+  if (!/^\d+$/.test(trimmed)) {
+    throw new Error(`${name} must be an integer between ${min} and ${max}`);
+  }
+  const parsed = Number(trimmed);
+  if (!Number.isSafeInteger(parsed) || parsed < min || parsed > max) {
+    throw new Error(`${name} must be an integer between ${min} and ${max}`);
+  }
+  return parsed;
+}
+
+export function resolveHnswIndexConfig(
+  env: NodeJS.ProcessEnv | Record<string, string | undefined> = process.env,
+): HnswIndexConfig {
+  const m = parseStrictInteger(
+    KB_HNSW_M_ENV,
+    env[KB_HNSW_M_ENV],
+    DEFAULT_HNSW_M,
+    MIN_HNSW_M,
+    MAX_HNSW_M,
+  );
+  const efConstruction = parseStrictInteger(
+    KB_HNSW_EF_CONSTRUCTION_ENV,
+    env[KB_HNSW_EF_CONSTRUCTION_ENV],
+    DEFAULT_HNSW_EF_CONSTRUCTION,
+    MIN_HNSW_EF,
+    MAX_HNSW_EF,
+  );
+  if (efConstruction < m) {
+    throw new Error(`${KB_HNSW_EF_CONSTRUCTION_ENV} must be >= ${KB_HNSW_M_ENV}`);
+  }
+  const efSearch = parseStrictInteger(
+    KB_HNSW_EF_SEARCH_ENV,
+    env[KB_HNSW_EF_SEARCH_ENV],
+    DEFAULT_HNSW_EF_SEARCH,
+    MIN_HNSW_EF,
+    MAX_HNSW_EF,
+  );
+  const randomSeed = parseStrictInteger(
+    KB_HNSW_RANDOM_SEED_ENV,
+    env[KB_HNSW_RANDOM_SEED_ENV],
+    DEFAULT_HNSW_RANDOM_SEED,
+    MIN_HNSW_RANDOM_SEED,
+    MAX_HNSW_RANDOM_SEED,
+  );
+  return {
+    m,
+    efConstruction,
+    efSearch,
+    metric: HNSW_METRIC,
+    capacityPolicy: HNSW_CAPACITY_POLICY,
+    randomSeed,
+  };
 }
 
 export function resolveFlatSearchP95AdvisoryMs(

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -73,17 +73,24 @@ describe('config schema validation (FR-OBS-470)', () => {
 
   it('matches the runtime KB_INDEX_TYPE parser for case-insensitive values', () => {
     const validation = validateConfigEnv({
-      KB_INDEX_TYPE: ' SQ8 ',
+      KB_INDEX_TYPE: ' HNSW ',
+      KB_HNSW_M: '32',
+      KB_HNSW_EF_CONSTRUCTION: '200',
+      KB_HNSW_EF_SEARCH: '100',
     });
     const show = showConfigEnv({
-      KB_INDEX_TYPE: ' SQ8 ',
+      KB_INDEX_TYPE: ' HNSW ',
     });
 
     expect(validation.findings).toEqual(expect.arrayContaining([
-      expect.objectContaining({ name: 'KB_INDEX_TYPE', status: 'ok', value: 'sq8' }),
+      expect.objectContaining({ name: 'KB_INDEX_TYPE', status: 'ok', value: 'hnsw' }),
+      expect.objectContaining({ name: 'KB_HNSW_M', status: 'ok', value: '32' }),
+      expect.objectContaining({ name: 'KB_HNSW_EF_CONSTRUCTION', status: 'ok', value: '200' }),
+      expect.objectContaining({ name: 'KB_HNSW_EF_SEARCH', status: 'ok', value: '100' }),
     ]));
     expect(show.entries).toEqual(expect.arrayContaining([
-      expect.objectContaining({ name: 'KB_INDEX_TYPE', value: 'sq8', source: 'env' }),
+      expect.objectContaining({ name: 'KB_INDEX_TYPE', value: 'hnsw', source: 'env' }),
+      expect.objectContaining({ name: 'KB_HNSW_M', value: '32', source: 'default' }),
     ]));
   });
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -14,6 +14,10 @@ import {
 } from './paths.js';
 import {
   DEFAULT_FLAT_SEARCH_P95_ADVISORY_MS,
+  DEFAULT_HNSW_EF_CONSTRUCTION,
+  DEFAULT_HNSW_EF_SEARCH,
+  DEFAULT_HNSW_M,
+  DEFAULT_HNSW_RANDOM_SEED,
   defaultIndexingBatchSize,
 } from './indexing.js';
 import {
@@ -143,7 +147,11 @@ const CONTROLLED_PREFIXES = [
 export const CONFIG_SCHEMA: readonly ConfigSpec[] = [
   { name: 'KNOWLEDGE_BASES_ROOT_DIR', kind: 'path', docDefault: '$HOME/knowledge_bases', description: 'Root directory containing knowledge base shelves.', defaultValue: (env) => resolveKnowledgeBasesRootDir(env.KNOWLEDGE_BASES_ROOT_DIR) },
   { name: 'FAISS_INDEX_PATH', kind: 'path', docDefault: '$KNOWLEDGE_BASES_ROOT_DIR/.faiss', description: 'Directory where FAISS index data is stored.', defaultValue: (env) => defaultFaissIndexPath(effectiveStringValue(env, 'KNOWLEDGE_BASES_ROOT_DIR', resolveKnowledgeBasesRootDir(undefined))) },
-  { name: 'KB_INDEX_TYPE', kind: 'enum', values: ['flat', 'sq8'], default: 'flat', normalize: lowercase },
+  { name: 'KB_INDEX_TYPE', kind: 'enum', values: ['flat', 'sq8', 'hnsw'], default: 'flat', normalize: lowercase },
+  { name: 'KB_HNSW_M', kind: 'integer', default: String(DEFAULT_HNSW_M), min: 2, max: 128, integerSyntax: 'digits', description: 'HNSW graph connectivity when KB_INDEX_TYPE=hnsw.' },
+  { name: 'KB_HNSW_EF_CONSTRUCTION', kind: 'integer', default: String(DEFAULT_HNSW_EF_CONSTRUCTION), min: 1, max: 10000, integerSyntax: 'digits', description: 'HNSW build-time candidate list size when KB_INDEX_TYPE=hnsw.' },
+  { name: 'KB_HNSW_EF_SEARCH', kind: 'integer', default: String(DEFAULT_HNSW_EF_SEARCH), min: 1, max: 10000, integerSyntax: 'digits', description: 'HNSW query-time candidate list size when KB_INDEX_TYPE=hnsw.' },
+  { name: 'KB_HNSW_RANDOM_SEED', kind: 'integer', default: String(DEFAULT_HNSW_RANDOM_SEED), min: 1, max: 2147483647, integerSyntax: 'digits', description: 'HNSW random seed recorded in the index manifest.' },
   { name: 'EMBEDDING_PROVIDER', kind: 'enum', values: [...KNOWN_EMBEDDING_PROVIDERS], default: 'huggingface', description: 'Default embedding provider for retrieval and ingest.' },
   { name: 'KB_ACTIVE_MODEL', kind: 'string', description: 'Active model override; otherwise the active model sidecar or legacy provider env is used.' },
   { name: 'KB_FAKE_DIM', kind: 'integer', default: '256', min: 8, max: 4096 },

--- a/src/faiss-store-adapter.ts
+++ b/src/faiss-store-adapter.ts
@@ -4,6 +4,7 @@ import type { Document } from '@langchain/core/documents';
 import { embeddingText } from './contextual-preface.js';
 import { resolveFaissIndexType, type FaissIndexType } from './config/indexing.js';
 import type { QueryCacheLookupStatus, QueryCacheTelemetry } from './query-cache.js';
+import type { SearchIndexAdapter } from './search-index-adapter.js';
 
 type ScoredFaissDocument = [Document, number];
 
@@ -161,7 +162,7 @@ export interface EmbeddedDocumentsBatch {
  * and the optional vector-first search method. Keep those assumptions here so
  * FaissIndexManager remains the public orchestration facade.
  */
-export class FaissStoreAdapter {
+export class FaissStoreAdapter implements SearchIndexAdapter {
   private constructor(private readonly store: FaissStore) {}
 
   static fromStore(store: FaissStore): FaissStoreAdapter {

--- a/src/faiss-store-layout.test.ts
+++ b/src/faiss-store-layout.test.ts
@@ -3,7 +3,15 @@ import {
   EMBEDDING_CANARY_TEXT_SHA256,
   cosineSimilarity,
   createEmbeddingCanaryFingerprint,
+  loadFaissStoreAtomic,
+  readIndexIntegrityManifest,
+  saveHnswIndexAtomic,
 } from './faiss-store-layout.js';
+import { HnswIndexAdapter } from './hnsw-index-adapter.js';
+import type { HnswIndexConfig } from './config/indexing.js';
+import * as fsp from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
 
 describe('embedding canary fingerprint', () => {
   it('captures the fixed document canary vector with a stable identity', async () => {
@@ -55,5 +63,87 @@ describe('cosineSimilarity', () => {
     expect(cosineSimilarity([1], [1, 2])).toBeNull();
     expect(cosineSimilarity([0, 0], [1, 2])).toBeNull();
     expect(cosineSimilarity([1, Infinity], [1, 2])).toBeNull();
+  });
+});
+
+describe('HNSW versioned layout', () => {
+  const hnswConfig: HnswIndexConfig = {
+    m: 8,
+    efConstruction: 40,
+    efSearch: 20,
+    metric: 'l2',
+    capacityPolicy: 'resize_to_fit',
+    randomSeed: 100,
+  };
+
+  it('persists HNSW indexes with explicit backend metadata', async () => {
+    const modelDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-hnsw-layout-'));
+    const adapter = await HnswIndexAdapter.fromEmbeddedDocuments({
+      documents: [
+        { pageContent: 'alpha', metadata: { knowledgeBase: 'kb' } } as never,
+        { pageContent: 'beta', metadata: { knowledgeBase: 'kb' } } as never,
+      ],
+      vectors: [[0, 0], [1, 0]],
+    }, hnswConfig);
+
+    await saveHnswIndexAtomic({
+      adapter,
+      modelDir,
+      modelId: 'model',
+      swapCounter: 1,
+      config: hnswConfig,
+    });
+
+    const active = await fsp.readlink(path.join(modelDir, 'index'));
+    expect(active).toBe('index.v0');
+    await expect(fsp.stat(path.join(modelDir, 'index.v0', 'hnsw.index'))).resolves.toBeTruthy();
+    const manifest = await readIndexIntegrityManifest(path.join(modelDir, 'index.v0'));
+    expect(manifest).toMatchObject({
+      backend: 'hnsw',
+      index_type: 'hnsw',
+      hnsw: {
+        m: 8,
+        efConstruction: 40,
+        efSearch: 20,
+        metric: 'l2',
+        capacity_policy: 'resize_to_fit',
+        random_seed: 100,
+        dimensions: 2,
+        max_elements: 2,
+      },
+      files: {
+        'hnsw.index': { sha256: expect.any(String) },
+        'docstore.json': { sha256: expect.any(String) },
+      },
+    });
+  });
+
+  it('does not load an HNSW binary through the FAISS loader', async () => {
+    const modelDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-hnsw-mismatch-'));
+    const adapter = await HnswIndexAdapter.fromEmbeddedDocuments({
+      documents: [
+        { pageContent: 'alpha', metadata: {} } as never,
+      ],
+      vectors: [[0, 0]],
+    }, hnswConfig);
+    await saveHnswIndexAtomic({
+      adapter,
+      modelDir,
+      modelId: 'model',
+      swapCounter: 1,
+      config: hnswConfig,
+    });
+
+    const loaded = await loadFaissStoreAtomic({
+      modelDir,
+      modelId: 'model',
+      embeddings: { embedDocuments: async () => [], embedQuery: async () => [] },
+      handleFsOperationError: ((action: string, targetPath: string, error: unknown) => {
+        throw new Error(`${action} ${targetPath}: ${(error as Error).message}`);
+      }),
+    });
+
+    expect(loaded).toBeNull();
+    await expect(fsp.lstat(path.join(modelDir, 'index'))).rejects.toMatchObject({ code: 'ENOENT' });
   });
 });

--- a/src/faiss-store-layout.ts
+++ b/src/faiss-store-layout.ts
@@ -9,7 +9,21 @@ import {
   type DedupOutcome,
 } from './docstore-cas.js';
 import { calculateSHA256, pathExists } from './file-utils.js';
-import { resolveFaissIndexType, type FaissIndexType } from './config/indexing.js';
+import {
+  backendForIndexType,
+  HNSW_CAPACITY_POLICY,
+  HNSW_METRIC,
+  resolveFaissIndexType,
+  type FaissIndexType,
+  type HnswIndexConfig,
+  type IndexBackend,
+  type SearchIndexType,
+} from './config/indexing.js';
+import {
+  HNSW_DOCSTORE_FILENAME,
+  HNSW_INDEX_FILENAME,
+  HnswIndexAdapter,
+} from './hnsw-index-adapter.js';
 import { logger } from './logger.js';
 
 export const INDEX_VERSION_RETENTION_ENV = 'KB_INDEX_VERSION_RETENTION';
@@ -17,6 +31,7 @@ export const DEFAULT_PREVIOUS_INDEX_VERSION_RETENTION = 2;
 const VERSION_DIR_PATTERN = /^index\.v(\d+)$/;
 const SYMLINK_NAME = 'index';
 const LEGACY_INDEX_NAME = 'faiss.index';
+export const FAISS_INDEX_FILENAME = LEGACY_INDEX_NAME;
 export const INDEX_INTEGRITY_MANIFEST_FILENAME = 'integrity.json';
 export const INDEX_INTEGRITY_MANIFEST_SCHEMA_VERSION = 'kb.index-integrity.v1';
 export const EMBEDDING_CANARY_TEXT =
@@ -41,12 +56,20 @@ export interface IndexIntegrityManifest {
   schema_version: typeof INDEX_INTEGRITY_MANIFEST_SCHEMA_VERSION;
   written_at: string;
   model_id: string;
-  index_type: FaissIndexType;
-  embedding_canary?: EmbeddingCanaryFingerprint;
-  files: {
-    'faiss.index': { sha256: string };
-    'docstore.json': { sha256: string };
+  backend?: IndexBackend;
+  index_type: SearchIndexType;
+  hnsw?: {
+    m: number;
+    efConstruction: number;
+    efSearch: number;
+    metric: typeof HNSW_METRIC;
+    capacity_policy: typeof HNSW_CAPACITY_POLICY;
+    random_seed: number;
+    dimensions: number;
+    max_elements: number;
   };
+  embedding_canary?: EmbeddingCanaryFingerprint;
+  files: Record<string, { sha256: string }>;
 }
 
 export interface IndexVersionPruneResult {
@@ -177,6 +200,29 @@ export async function pruneInactiveIndexVersions(
 
 type FsOperationErrorHandler = (action: string, targetPath: string, error: unknown) => never;
 
+function manifestBackend(manifest: IndexIntegrityManifest | null): IndexBackend {
+  return manifest?.backend ?? 'faiss';
+}
+
+function mismatchMessage(
+  versionDir: string,
+  expectedBackend: IndexBackend,
+  actualBackend: IndexBackend,
+): string {
+  return `Versioned index ${versionDir} was written for backend ${actualBackend}, ` +
+    `but the current configuration expects ${expectedBackend}`;
+}
+
+async function readManifestForLoad(versionDir: string): Promise<IndexIntegrityManifest | null> {
+  try {
+    return await readIndexIntegrityManifest(versionDir);
+  } catch (err) {
+    throw new Error(
+      `Versioned index ${versionDir} has a malformed integrity manifest: ${(err as Error).message}`,
+    );
+  }
+}
+
 /**
  * RFC 017 M0c — load a specific `index.vN/` directory directly,
  * bypassing the `index` symlink. Used by `kb eval --compare-index` to
@@ -201,6 +247,7 @@ export async function loadFaissStoreAtomic(options: {
   modelId: string;
   embeddings: EmbeddingsInterface;
   handleFsOperationError: FsOperationErrorHandler;
+  expectedIndexType?: FaissIndexType;
   repairCorrupt?: boolean;
 }): Promise<FaissStore | null> {
   const {
@@ -208,6 +255,7 @@ export async function loadFaissStoreAtomic(options: {
     modelId,
     embeddings,
     handleFsOperationError,
+    expectedIndexType = resolveFaissIndexType(),
     repairCorrupt = true,
   } = options;
   const symlinkPath = path.join(modelDir, SYMLINK_NAME);
@@ -231,6 +279,40 @@ export async function loadFaissStoreAtomic(options: {
         );
       }
       throw err;
+    }
+
+    const manifest = await readManifestForLoad(resolved);
+    const actualBackend = manifestBackend(manifest);
+    if (actualBackend !== 'faiss') {
+      const message = mismatchMessage(resolved, 'faiss', actualBackend);
+      if (!repairCorrupt) {
+        throw new Error(`${message}; read-only load will not rebuild it.`);
+      }
+      logger.warn(`${message}; removing active symlink so the next update rebuilds.`);
+      try {
+        await fsp.rm(symlinkPath, { force: true });
+      } catch (unlinkErr) {
+        handleFsOperationError('delete mismatched index symlink', symlinkPath, unlinkErr);
+      }
+      return null;
+    }
+    if (
+      manifest !== null &&
+      manifest.index_type !== undefined &&
+      manifest.index_type !== expectedIndexType
+    ) {
+      const message = `Versioned FAISS index ${resolved} was written as ` +
+        `${manifest.index_type}, but the current configuration expects ${expectedIndexType}`;
+      if (!repairCorrupt) {
+        throw new Error(`${message}; read-only load will not rebuild it.`);
+      }
+      logger.warn(`${message}; removing active symlink so the next update rebuilds.`);
+      try {
+        await fsp.rm(symlinkPath, { force: true });
+      } catch (unlinkErr) {
+        handleFsOperationError('delete mismatched index symlink', symlinkPath, unlinkErr);
+      }
+      return null;
     }
 
     let store: FaissStore;
@@ -274,6 +356,19 @@ export async function loadFaissStoreAtomic(options: {
   }
 
   if (await pathExists(legacyPath)) {
+    if (backendForIndexType(expectedIndexType) !== 'faiss') {
+      if (!repairCorrupt) {
+        throw new Error(
+          `Legacy FAISS index at ${legacyPath} cannot satisfy backend hnsw; ` +
+            `read-only load will not rebuild it.`,
+        );
+      }
+      logger.warn(
+        `Legacy FAISS index at ${legacyPath} ignored because current backend is hnsw. ` +
+          `The next updateIndex will rebuild into the versioned HNSW layout.`,
+      );
+      return null;
+    }
     try {
       logger.info(
         `Loading legacy FAISS index for model ${modelId} from faiss.index/. ` +
@@ -304,6 +399,141 @@ export async function loadFaissStoreAtomic(options: {
   logger.info(
     `FAISS index not found for model ${modelId}. It will be created on the next updateIndex.`,
   );
+  return null;
+}
+
+export async function loadHnswIndexAtomic(options: {
+  modelDir: string;
+  modelId: string;
+  config: HnswIndexConfig;
+  handleFsOperationError: FsOperationErrorHandler;
+  repairCorrupt?: boolean;
+}): Promise<HnswIndexAdapter | null> {
+  const {
+    modelDir,
+    modelId,
+    config,
+    handleFsOperationError,
+    repairCorrupt = true,
+  } = options;
+  const symlinkPath = path.join(modelDir, SYMLINK_NAME);
+  const legacyPath = path.join(modelDir, LEGACY_INDEX_NAME);
+
+  const symStat = await fsp.lstat(symlinkPath).catch((err) => {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null;
+    throw err;
+  });
+
+  if (symStat?.isSymbolicLink()) {
+    let resolved: string;
+    try {
+      resolved = await fsp.realpath(symlinkPath);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+        throw new Error(
+          `loadAtomic: symlink ${symlinkPath} target vanished between lstat and realpath - ` +
+            `N=3 retention contract violated. Check for concurrent gc, manual filesystem ` +
+            `surgery, or unexpected rmrf.`,
+        );
+      }
+      throw err;
+    }
+
+    const manifest = await readManifestForLoad(resolved);
+    const actualBackend = manifestBackend(manifest);
+    if (actualBackend !== 'hnsw') {
+      const message = mismatchMessage(resolved, 'hnsw', actualBackend);
+      if (!repairCorrupt) {
+        throw new Error(`${message}; read-only load will not rebuild it.`);
+      }
+      logger.warn(`${message}; removing active symlink so the next update rebuilds.`);
+      try {
+        await fsp.rm(symlinkPath, { force: true });
+      } catch (unlinkErr) {
+        handleFsOperationError('delete mismatched index symlink', symlinkPath, unlinkErr);
+      }
+      return null;
+    }
+    if (manifest?.index_type !== 'hnsw' || manifest.hnsw === undefined) {
+      const message = `Versioned HNSW index ${resolved} is missing HNSW manifest metadata`;
+      if (!repairCorrupt) {
+        throw new Error(`${message}; read-only load will not rebuild it.`);
+      }
+      logger.warn(`${message}; removing active symlink so the next update rebuilds.`);
+      try {
+        await fsp.rm(symlinkPath, { force: true });
+      } catch (unlinkErr) {
+        handleFsOperationError('delete incomplete HNSW index symlink', symlinkPath, unlinkErr);
+      }
+      return null;
+    }
+    if (
+      manifest.hnsw.m !== config.m ||
+      manifest.hnsw.efConstruction !== config.efConstruction ||
+      manifest.hnsw.metric !== config.metric ||
+      manifest.hnsw.random_seed !== config.randomSeed
+    ) {
+      const message = `Versioned HNSW index ${resolved} was built with ` +
+        `m=${manifest.hnsw.m}, efConstruction=${manifest.hnsw.efConstruction}, ` +
+        `metric=${manifest.hnsw.metric}, randomSeed=${manifest.hnsw.random_seed}; ` +
+        `current configuration expects m=${config.m}, ` +
+        `efConstruction=${config.efConstruction}, metric=${config.metric}, ` +
+        `randomSeed=${config.randomSeed}`;
+      if (!repairCorrupt) {
+        throw new Error(`${message}; read-only load will not rebuild it.`);
+      }
+      logger.warn(`${message}; removing active symlink so the next update rebuilds.`);
+      try {
+        await fsp.rm(symlinkPath, { force: true });
+      } catch (unlinkErr) {
+        handleFsOperationError('delete retuned HNSW index symlink', symlinkPath, unlinkErr);
+      }
+      return null;
+    }
+
+    try {
+      logger.info(
+        `Loading HNSW index for model ${modelId} from ${path.basename(resolved)} ` +
+          `(m=${config.m}, efConstruction=${config.efConstruction}, efSearch=${config.efSearch})`,
+      );
+      return await HnswIndexAdapter.load(resolved, config, manifest.hnsw.dimensions);
+    } catch (err) {
+      if (!repairCorrupt) {
+        throw new Error(
+          `Versioned HNSW index ${resolved} is corrupt or unreadable; ` +
+            `read-only load will not repair it. Underlying error: ${(err as Error).message}`,
+        );
+      }
+      logger.warn(
+        `Versioned HNSW index ${resolved} is corrupt or unreadable - ` +
+          `removing symlink and falling back to rebuild. Error:`,
+        err,
+      );
+      try {
+        await fsp.rm(symlinkPath, { force: true });
+      } catch (unlinkErr) {
+        handleFsOperationError('delete corrupt HNSW index symlink', symlinkPath, unlinkErr);
+      }
+      return null;
+    }
+  }
+
+  if (await pathExists(legacyPath)) {
+    if (!repairCorrupt) {
+      throw new Error(
+        `Legacy FAISS index at ${legacyPath} cannot satisfy backend hnsw; ` +
+          `read-only load will not rebuild it.`,
+      );
+    }
+    logger.warn(
+      `Legacy FAISS index at ${legacyPath} ignored because current backend is hnsw. ` +
+        `The next updateIndex will rebuild into the versioned HNSW layout.`,
+    );
+  } else {
+    logger.info(
+      `HNSW index not found for model ${modelId}. It will be created on the next updateIndex.`,
+    );
+  }
   return null;
 }
 
@@ -359,6 +589,7 @@ export async function saveFaissStoreAtomic(options: {
     dedup = await dedupeDocstoreOnSave({ stagingDir, casRoot, swapCounter });
   }
   await writeIndexIntegrityManifest(stagingDir, modelId, indexType, {
+    backend: 'faiss',
     embeddingCanary,
   });
 
@@ -392,26 +623,115 @@ export async function saveFaissStoreAtomic(options: {
   }
 }
 
+export async function saveHnswIndexAtomic(options: {
+  adapter: HnswIndexAdapter;
+  modelDir: string;
+  modelId: string;
+  swapCounter: number;
+  config: HnswIndexConfig;
+  embeddingCanary?: EmbeddingCanaryFingerprint | null;
+  onCommitted?: () => Promise<void>;
+}): Promise<void> {
+  const {
+    adapter,
+    modelDir,
+    modelId,
+    swapCounter,
+    config,
+    embeddingCanary = null,
+    onCommitted,
+  } = options;
+  const symlinkPath = path.join(modelDir, SYMLINK_NAME);
+  const currentTarget = await readSymlinkOrNull(symlinkPath);
+  const nextVersion = nextVersionAfter(currentTarget);
+  const stagingDir = path.join(modelDir, nextVersion);
+
+  if (await pathExists(stagingDir)) {
+    logger.warn(`atomicSave: clearing orphan staging dir ${stagingDir} from prior crash`);
+    await fsp.rm(stagingDir, { recursive: true, force: true });
+  }
+  await adapter.save(stagingDir);
+  await writeIndexIntegrityManifest(stagingDir, modelId, 'hnsw', {
+    backend: 'hnsw',
+    hnsw: {
+      ...config,
+      dimensions: adapter.vectorDimension(),
+      maxElements: adapter.totalVectors(),
+    },
+    embeddingCanary,
+  });
+
+  const tmpLink = path.join(
+    modelDir,
+    `.${SYMLINK_NAME}.tmp.${process.pid}.${swapCounter}`,
+  );
+  await fsp.symlink(nextVersion, tmpLink);
+  await fsp.rename(tmpLink, symlinkPath);
+  await onCommitted?.();
+  logger.info(
+    `atomicSave: ${modelId} ${currentTarget ?? '(none)'} -> ${nextVersion} ` +
+      `(hnsw m=${config.m}, efConstruction=${config.efConstruction}, efSearch=${config.efSearch})`,
+  );
+
+  await pruneInactiveIndexVersions(modelDir, {
+    retention: resolveIndexVersionRetention(),
+  });
+}
+
 export async function writeIndexIntegrityManifest(
   versionDir: string,
   modelId: string,
-  indexType: FaissIndexType = resolveFaissIndexType(),
-  opts: { embeddingCanary?: EmbeddingCanaryFingerprint | null } = {},
+  indexType: SearchIndexType = resolveFaissIndexType(),
+  opts: {
+    backend?: IndexBackend;
+    hnsw?: HnswIndexConfig & {
+      dimensions: number;
+      maxElements: number;
+    };
+    embeddingCanary?: EmbeddingCanaryFingerprint | null;
+  } = {},
 ): Promise<IndexIntegrityManifest> {
+  const backend = opts.backend ?? backendForIndexType(indexType);
+  let files: Record<string, { sha256: string }>;
+  if (backend === 'hnsw') {
+    files = {
+        [HNSW_INDEX_FILENAME]: {
+          sha256: await calculateSHA256(path.join(versionDir, HNSW_INDEX_FILENAME)),
+        },
+        [HNSW_DOCSTORE_FILENAME]: {
+          sha256: await calculateSHA256(path.join(versionDir, HNSW_DOCSTORE_FILENAME)),
+        },
+      };
+  } else {
+    files = {
+        [FAISS_INDEX_FILENAME]: {
+          sha256: await calculateSHA256(path.join(versionDir, FAISS_INDEX_FILENAME)),
+        },
+        'docstore.json': {
+          sha256: await calculateSHA256(path.join(versionDir, 'docstore.json')),
+        },
+      };
+  }
   const manifest: IndexIntegrityManifest = {
     schema_version: INDEX_INTEGRITY_MANIFEST_SCHEMA_VERSION,
     written_at: new Date().toISOString(),
     model_id: modelId,
+    backend,
     index_type: indexType,
+    ...(opts.hnsw ? {
+      hnsw: {
+        m: opts.hnsw.m,
+        efConstruction: opts.hnsw.efConstruction,
+        efSearch: opts.hnsw.efSearch,
+        metric: opts.hnsw.metric,
+        capacity_policy: opts.hnsw.capacityPolicy,
+        random_seed: opts.hnsw.randomSeed,
+        dimensions: opts.hnsw.dimensions,
+        max_elements: opts.hnsw.maxElements,
+      },
+    } : {}),
     ...(opts.embeddingCanary ? { embedding_canary: opts.embeddingCanary } : {}),
-    files: {
-      'faiss.index': {
-        sha256: await calculateSHA256(path.join(versionDir, 'faiss.index')),
-      },
-      'docstore.json': {
-        sha256: await calculateSHA256(path.join(versionDir, 'docstore.json')),
-      },
-    },
+    files,
   };
   await fsp.writeFile(
     path.join(versionDir, INDEX_INTEGRITY_MANIFEST_FILENAME),
@@ -478,19 +798,24 @@ export async function readIndexIntegrityManifest(
   return parsed;
 }
 
-export async function resolveActiveIndexFilePath(modelDir: string): Promise<string | null> {
+export async function resolveActiveIndexFilePath(
+  modelDir: string,
+  backend: IndexBackend = 'faiss',
+): Promise<string | null> {
   const symlinkPath = path.join(modelDir, SYMLINK_NAME);
+  const indexFilename = backend === 'hnsw' ? HNSW_INDEX_FILENAME : FAISS_INDEX_FILENAME;
   try {
     const symStat = await fsp.lstat(symlinkPath);
     if (symStat.isSymbolicLink()) {
       const resolved = await fsp.realpath(symlinkPath);
-      const candidate = path.join(resolved, LEGACY_INDEX_NAME);
+      const candidate = path.join(resolved, indexFilename);
       if (await pathExists(candidate)) return candidate;
     }
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
   }
 
+  if (backend === 'hnsw') return null;
   const legacyFile = path.join(modelDir, LEGACY_INDEX_NAME, LEGACY_INDEX_NAME);
   if (await pathExists(legacyFile)) return legacyFile;
   return null;

--- a/src/hnsw-index-adapter.test.ts
+++ b/src/hnsw-index-adapter.test.ts
@@ -1,0 +1,88 @@
+import * as fsp from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import type { Document } from '@langchain/core/documents';
+import {
+  HNSW_DOCSTORE_FILENAME,
+  HNSW_INDEX_FILENAME,
+  HnswIndexAdapter,
+} from './hnsw-index-adapter.js';
+import type { HnswIndexConfig } from './config/indexing.js';
+
+const config: HnswIndexConfig = {
+  m: 8,
+  efConstruction: 40,
+  efSearch: 20,
+  metric: 'l2',
+  capacityPolicy: 'resize_to_fit',
+  randomSeed: 100,
+};
+
+function docs(): Document[] {
+  return [
+    { pageContent: 'alpha', metadata: { knowledgeBase: 'kb-a' } } as Document,
+    { pageContent: 'beta', metadata: { knowledgeBase: 'kb-a' } } as Document,
+    { pageContent: 'gamma', metadata: { knowledgeBase: 'kb-b' } } as Document,
+  ];
+}
+
+describe('HnswIndexAdapter', () => {
+  it('builds, queries, persists, and reloads a tuned HNSW index', async () => {
+    const documents = docs();
+    const adapter = await HnswIndexAdapter.fromEmbeddedDocuments({
+      documents,
+      vectors: [
+        [0, 0],
+        [10, 0],
+        [0, 10],
+      ],
+    }, config);
+
+    expect(adapter.totalVectors()).toBe(3);
+    expect(adapter.vectorDimension()).toBe(2);
+    expect(adapter.chunkCountsByKnowledgeBase()).toEqual({ 'kb-a': 2, 'kb-b': 1 });
+
+    const beforeSave = await adapter.similaritySearchUsingBestPath({
+      query: 'ignored',
+      k: 2,
+      getQueryEmbedding: async () => ({
+        embedding: [0, 0],
+        status: 'miss',
+        telemetry: { enabled: true, outcome: 'miss', model_id: 'm', elapsed_ms: 0 },
+      }),
+    });
+    expect(beforeSave.map(([doc]) => doc.pageContent)).toContain('alpha');
+
+    const dir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-hnsw-adapter-'));
+    await adapter.save(dir);
+    await expect(fsp.stat(path.join(dir, HNSW_INDEX_FILENAME))).resolves.toBeTruthy();
+    await expect(fsp.stat(path.join(dir, HNSW_DOCSTORE_FILENAME))).resolves.toBeTruthy();
+
+    const loaded = await HnswIndexAdapter.load(dir, { ...config, efSearch: 30 }, 2);
+    const afterLoad = await loaded.similaritySearchUsingBestPath({
+      query: 'ignored',
+      k: 1,
+      getQueryEmbedding: async () => ({
+        embedding: [10, 0],
+        status: 'miss',
+        telemetry: { enabled: true, outcome: 'miss', model_id: 'm', elapsed_ms: 0 },
+      }),
+    });
+
+    expect(afterLoad).toHaveLength(1);
+    expect(afterLoad[0][0].pageContent).toBe('beta');
+  });
+
+  it('rejects dimension mismatches before mutating the index', async () => {
+    const adapter = await HnswIndexAdapter.fromEmbeddedDocuments({
+      documents: [docs()[0]],
+      vectors: [[0, 0]],
+    }, config);
+
+    await expect(adapter.addEmbeddedDocuments({
+      documents: [docs()[1]],
+      vectors: [[1, 2, 3]],
+    })).rejects.toThrow(/dimension mismatch/);
+    expect(adapter.totalVectors()).toBe(1);
+  });
+});

--- a/src/hnsw-index-adapter.ts
+++ b/src/hnsw-index-adapter.ts
@@ -1,0 +1,230 @@
+import * as fsp from 'fs/promises';
+import * as path from 'path';
+import type { Document } from '@langchain/core/documents';
+import type { HierarchicalNSW as HierarchicalNSWHandle, SpaceName } from 'hnswlib-node';
+import type { HnswIndexConfig } from './config/indexing.js';
+import type {
+  EmbeddedDocumentsBatch,
+  FaissSearchTimingSink,
+  QueryEmbeddingLookup,
+} from './faiss-store-adapter.js';
+import type {
+  ScoredIndexDocument,
+  SearchIndexAdapter,
+} from './search-index-adapter.js';
+
+export const HNSW_INDEX_FILENAME = 'hnsw.index';
+export const HNSW_DOCSTORE_FILENAME = 'docstore.json';
+export const HNSW_DOCSTORE_SCHEMA_VERSION = 'kb.hnsw-docstore.v1';
+
+interface HnswDocstorePayload {
+  schema_version: typeof HNSW_DOCSTORE_SCHEMA_VERSION;
+  documents: Array<{
+    id: string;
+    pageContent: string;
+    metadata: Record<string, unknown>;
+  }>;
+}
+
+type HnswlibModule = {
+  HierarchicalNSW: new (spaceName: SpaceName, numDimensions: number) => HierarchicalNSWHandle;
+};
+
+async function importHnswlib(): Promise<HnswlibModule> {
+  return await import('hnswlib-node') as HnswlibModule;
+}
+
+function assertVectorShape(vectors: readonly number[][]): number {
+  const dimension = vectors[0]?.length;
+  if (dimension === undefined || dimension <= 0) {
+    throw new Error('HNSW index requires at least one non-empty vector');
+  }
+  for (const vector of vectors) {
+    if (vector.length !== dimension) {
+      throw new Error('HNSW index requires equal-length vectors');
+    }
+    if (!vector.every((value) => Number.isFinite(value))) {
+      throw new Error('HNSW index received a non-finite vector value');
+    }
+  }
+  return dimension;
+}
+
+function toDocument(entry: HnswDocstorePayload['documents'][number]): Document {
+  return {
+    pageContent: entry.pageContent,
+    metadata: entry.metadata ?? {},
+  } as Document;
+}
+
+function asDocstorePayload(documents: readonly Document[]): HnswDocstorePayload {
+  return {
+    schema_version: HNSW_DOCSTORE_SCHEMA_VERSION,
+    documents: documents.map((document, index) => ({
+      id: `doc-${index}`,
+      pageContent: document.pageContent,
+      metadata: { ...(document.metadata as Record<string, unknown> | undefined) },
+    })),
+  };
+}
+
+export class HnswIndexAdapter implements SearchIndexAdapter {
+  private constructor(
+    private readonly index: HierarchicalNSWHandle,
+    private readonly documents: Document[],
+    private readonly config: HnswIndexConfig,
+  ) {}
+
+  static async fromEmbeddedDocuments(
+    embedded: EmbeddedDocumentsBatch,
+    config: HnswIndexConfig,
+  ): Promise<HnswIndexAdapter> {
+    const dimension = assertVectorShape(embedded.vectors);
+    const { HierarchicalNSW } = await importHnswlib();
+    const index = new HierarchicalNSW(config.metric, dimension);
+    index.initIndex({
+      maxElements: Math.max(1, embedded.vectors.length),
+      m: config.m,
+      efConstruction: config.efConstruction,
+      randomSeed: config.randomSeed,
+      allowReplaceDeleted: false,
+    });
+    index.setEf(config.efSearch);
+    const adapter = new HnswIndexAdapter(index, [], config);
+    await adapter.addEmbeddedDocuments(embedded);
+    return adapter;
+  }
+
+  static async load(
+    directory: string,
+    config: HnswIndexConfig,
+    dimensions: number,
+  ): Promise<HnswIndexAdapter> {
+    const rawDocstore = await fsp.readFile(
+      path.join(directory, HNSW_DOCSTORE_FILENAME),
+      'utf-8',
+    );
+    const parsed = JSON.parse(rawDocstore) as HnswDocstorePayload;
+    if (parsed.schema_version !== HNSW_DOCSTORE_SCHEMA_VERSION || !Array.isArray(parsed.documents)) {
+      throw new Error('HNSW docstore has an unsupported schema');
+    }
+    const documents = parsed.documents.map(toDocument);
+    const { HierarchicalNSW } = await importHnswlib();
+    const index = new HierarchicalNSW(config.metric, dimensions);
+    await index.readIndex(path.join(directory, HNSW_INDEX_FILENAME), false);
+    index.setEf(config.efSearch);
+    if (index.getCurrentCount() !== documents.length) {
+      throw new Error(
+        `HNSW index/docstore divergence after load: count=${index.getCurrentCount()}, ` +
+          `docstore.size=${documents.length}`,
+      );
+    }
+    return new HnswIndexAdapter(index, documents, config);
+  }
+
+  async save(directory: string): Promise<void> {
+    await fsp.mkdir(directory, { recursive: true });
+    await this.index.writeIndex(path.join(directory, HNSW_INDEX_FILENAME));
+    await fsp.writeFile(
+      path.join(directory, HNSW_DOCSTORE_FILENAME),
+      `${JSON.stringify(asDocstorePayload(this.documents), null, 2)}\n`,
+      { encoding: 'utf-8', mode: 0o600 },
+    );
+  }
+
+  async addEmbeddedDocuments(embedded: EmbeddedDocumentsBatch): Promise<void> {
+    if (embedded.documents.length === 0) return;
+    const dimension = assertVectorShape(embedded.vectors);
+    if (dimension !== this.index.getNumDimensions()) {
+      throw new Error(
+        `HNSW vector dimension mismatch: index=${this.index.getNumDimensions()}, vectors=${dimension}`,
+      );
+    }
+    const nextTotal = this.documents.length + embedded.documents.length;
+    if (nextTotal > this.index.getMaxElements()) {
+      this.index.resizeIndex(nextTotal);
+    }
+    for (let i = 0; i < embedded.documents.length; i += 1) {
+      const label = this.documents.length;
+      this.index.addPoint(embedded.vectors[i], label, false);
+      this.documents.push(embedded.documents[i]);
+    }
+    if (this.index.getCurrentCount() !== this.documents.length) {
+      throw new Error(
+        `HNSW index/docstore divergence after batch: count=${this.index.getCurrentCount()}, ` +
+          `docstore.size=${this.documents.length}`,
+      );
+    }
+  }
+
+  async similaritySearchUsingBestPath(options: {
+    query: string;
+    k: number;
+    timing?: FaissSearchTimingSink;
+    getQueryEmbedding: () => Promise<QueryEmbeddingLookup>;
+  }): Promise<ScoredIndexDocument[]> {
+    if (this.documents.length === 0 || options.k <= 0) return [];
+
+    const embedStartedAt = Date.now();
+    const cached = await options.getQueryEmbedding();
+    if (options.timing) {
+      if (options.timing.embed_query_ms === undefined) {
+        options.timing.embed_query_ms = Date.now() - embedStartedAt;
+      }
+      if (options.timing.query_cache === undefined) {
+        options.timing.query_cache = cached.status;
+      }
+      if (options.timing.query_cache_telemetry === undefined) {
+        options.timing.query_cache_telemetry = cached.telemetry;
+      }
+    }
+
+    const searchStartedAt = Date.now();
+    if (cached.embedding.length !== this.index.getNumDimensions()) {
+      throw new Error(
+        `HNSW query dimension mismatch: index=${this.index.getNumDimensions()}, ` +
+          `query=${cached.embedding.length}`,
+      );
+    }
+    this.index.setEf(this.config.efSearch);
+    const result = this.index.searchKnn(cached.embedding, Math.min(options.k, this.documents.length));
+    if (options.timing) {
+      options.timing.faiss_search_ms =
+        (options.timing.faiss_search_ms ?? 0) + (Date.now() - searchStartedAt);
+    }
+    return result.neighbors.map((label, i) => {
+      const document = this.documents[label];
+      if (document === undefined) {
+        throw new Error(`HNSW search returned missing docstore label ${label}`);
+      }
+      return [document, result.distances[i]] as ScoredIndexDocument;
+    });
+  }
+
+  totalVectors(): number {
+    return this.index.getCurrentCount();
+  }
+
+  vectorDimension(): number {
+    return this.index.getNumDimensions();
+  }
+
+  docstoreDocuments(): Document[] {
+    return [...this.documents];
+  }
+
+  docstoreEntries(): Array<[string, Document]> {
+    return this.documents.map((document, index) => [`doc-${index}`, document]);
+  }
+
+  chunkCountsByKnowledgeBase(): Record<string, number> {
+    const counts: Record<string, number> = {};
+    for (const doc of this.documents) {
+      const kb = doc.metadata?.knowledgeBase;
+      if (typeof kb === 'string') {
+        counts[kb] = (counts[kb] ?? 0) + 1;
+      }
+    }
+    return counts;
+  }
+}

--- a/src/kb-stats.ts
+++ b/src/kb-stats.ts
@@ -53,7 +53,7 @@ import {
 import type { TransportRuntimeStatsSnapshot } from './transport-runtime-stats.js';
 import {
   resolveFlatSearchP95AdvisoryMs,
-  type FaissIndexType,
+  type SearchIndexType,
 } from './config/indexing.js';
 
 export interface KbStatsRow {
@@ -107,7 +107,7 @@ export interface KbStatsPayload {
     provider: string;
     model: string;
     dim: number | null;
-    index_type?: FaissIndexType;
+    index_type?: SearchIndexType;
     index_factory?: string;
   };
   index_path: string;
@@ -143,7 +143,7 @@ export interface KbStatsDenseSearchLatencySummary {
   stage: 'faiss_search';
   status: 'success';
   active_index: {
-    type: FaissIndexType;
+    type: SearchIndexType;
     factory: string;
   };
   sample_count: number;
@@ -303,13 +303,14 @@ export async function computeKbStats(
   };
 }
 
-export function indexFactoryForType(indexType: FaissIndexType): string {
+export function indexFactoryForType(indexType: SearchIndexType): string {
+  if (indexType === 'hnsw') return 'HNSW';
   return indexType === 'sq8' ? 'SQ8' : 'Flat';
 }
 
 export function summarizeDenseSearchLatency(
   snapshot: SearchLatencyMetricsSnapshot,
-  indexType: FaissIndexType,
+  indexType: SearchIndexType,
   thresholdMs: number = resolveFlatSearchP95AdvisoryMs(),
 ): KbStatsDenseSearchLatencySummary | null {
   const histogram = snapshot.stages.dense?.faiss_search?.success;

--- a/src/search-index-adapter.ts
+++ b/src/search-index-adapter.ts
@@ -1,0 +1,23 @@
+import type { Document } from '@langchain/core/documents';
+import type {
+  EmbeddedDocumentsBatch,
+  FaissSearchTimingSink,
+  QueryEmbeddingLookup,
+} from './faiss-store-adapter.js';
+
+export type ScoredIndexDocument = [Document, number];
+
+export interface SearchIndexAdapter {
+  addEmbeddedDocuments(embedded: EmbeddedDocumentsBatch): Promise<void>;
+  similaritySearchUsingBestPath(options: {
+    query: string;
+    k: number;
+    timing?: FaissSearchTimingSink;
+    getQueryEmbedding: () => Promise<QueryEmbeddingLookup>;
+  }): Promise<ScoredIndexDocument[]>;
+  totalVectors(): number;
+  vectorDimension(): number;
+  docstoreDocuments(): Document[];
+  docstoreEntries(): Array<[string, Document]>;
+  chunkCountsByKnowledgeBase(): Record<string, number>;
+}


### PR DESCRIPTION
Closes #623

## Design
- Adds opt-in `KB_INDEX_TYPE=hnsw`; the default remains `flat`, and there is no corpus-size or latency-based auto-enable path.
- Introduces a narrow `SearchIndexAdapter` boundary so existing FAISS `flat`/`sq8` behavior stays on the FAISS adapter while HNSW uses a dedicated `hnswlib-node` adapter.
- Persists HNSW under `index.vN/hnsw.index` with `docstore.json`; the integrity manifest records `backend: hnsw` plus `m`, `efConstruction`, `efSearch`, metric, capacity policy, random seed, dimensions, and max elements.
- HNSW loads reapply the configured `efSearch` after `readIndex`, and queries set it again before search. Build-time parameter mismatches rebuild/fail safely instead of silently loading the wrong binary.
- The FAISS loader treats legacy manifests without `backend` as FAISS-compatible, rejects HNSW manifests, and validates FAISS `flat`/`sq8` manifest mismatches.
- This does not add an arbitrary raw FAISS factory knob.

## Alternatives considered
- Rejected raw FAISS HNSW factory descriptors because the current `faiss-node` path can encode descriptors but cannot expose/tune `efConstruction` and `efSearch`.
- Rejected making ANN the default or auto-enabling it from corpus size/latency, because HNSW changes recall semantics and should stay explicit.

## Dependency and native binding notes
- Adds `hnswlib-node@3.0.0` as a direct dependency.
- Local install/build/load verification passed. The first install attempt hit host `ENOSPC`; after clearing the local npm cache, `npm install hnswlib-node --save` succeeded and the native module loaded.
- Binding mapping is explicit: `m` and `efConstruction` are passed to `HierarchicalNSW.initIndex(...)`; `efSearch` maps to `HierarchicalNSW.setEf(...)` after load and before query.

## Verification
- Native smoke: imported `hnswlib-node`, created `HierarchicalNSW`, ran `initIndex`, `setEf`, `addPoint`, and `searchKnn`.
- `npm run build` passed.
- `npm run docs:generate-config-reference` passed.
- `npm run docs:check-config-reference` passed.
- `npm run docs:check-anchors` passed with 0 stale anchors.
- `npm run test:file -- src/config.test.ts src/config/schema.test.ts src/hnsw-index-adapter.test.ts src/faiss-store-layout.test.ts src/FaissIndexManager.test.ts` passed: 5 suites, 199 tests.
- `npm run test:file -- src/atomic-save.test.ts` passed: 14 tests.
- `npm test -- --runInBand` passed. The parallel Jest project emitted the existing worker forced-exit warning after all tests passed.
- `git diff --check` passed.

## Benchmark evidence and limits
- Added `benchmarks/hnsw-ann.mjs`, which reports recall@k, nDCG@k, bootstrap confidence intervals, p50/p95 latency, and memory deltas for HNSW versus exact flat and SQ8.
- Local smoke command: `KB_HNSW_BENCH_VECTORS=500 KB_HNSW_BENCH_QUERIES=30 KB_HNSW_BENCH_BOOTSTRAP=50 node benchmarks/hnsw-ann.mjs`.
- Smoke result: HNSW recall@10 `1.0` CI `[1.0, 1.0]`, nDCG@10 `1.0` CI `[1.0, 1.0]`, p50 about `0.0349ms`, p95 about `0.0519ms`, memory delta about `3.0MiB`. SQ8 recall@10 was about `0.9867` CI `[0.9733, 0.9967]` with nDCG@10 about `0.9915` CI `[0.9830, 0.9979]`.
- A full BEIR or production-corpus run was not run locally due cost; the harness and docs now make that validation repeatable before promoting HNSW for a real corpus.

## FAISS compatibility
Existing FAISS `flat` and `sq8` indexes continue to use the FAISS adapter, `faiss.index`, and legacy-compatible manifests. The full test suite and focused persistence tests passed with those paths unchanged.

## Docs
`docs/reference/configuration.md` changed because it is generated from the updated config schema. Operational HNSW guidance was added to `docs/operations/indexing.md`.