### PR TITLE
fix(feedback-ledger): tolerate torn JSONL lines (#655)

### DIFF
--- a/src/feedback-ledger.test.ts
+++ b/src/feedback-ledger.test.ts
@@ -11,6 +11,7 @@ import {
   feedbackLedgerPath,
   parseFeedbackJsonl,
   readFeedbackLedger,
+  readFeedbackLedgerWithStats,
 } from './feedback-ledger.js';
 import { normalizeRetrievalEvalFixture } from './retrieval-eval.js';
 
@@ -60,9 +61,77 @@ describe('feedback ledger entries', () => {
     ]);
   });
 
-  it('rejects invalid JSONL rows with line numbers', () => {
+  it('rejects well-formed JSON rows with an invalid schema, citing line numbers', () => {
     expect(() => parseFeedbackJsonl('{"schema_version":"wrong"}\n'))
       .toThrow('feedback ledger line 1');
+  });
+});
+
+describe('corruption-tolerant feedback ledger reads', () => {
+  const validLine = (id: string): string => JSON.stringify(buildFeedbackEntry({
+    id,
+    now: new Date('2026-05-19T10:00:00.000Z'),
+    kb: 'ops',
+    query: 'rollback procedure',
+    source: `runbooks/${id}.md`,
+  }));
+
+  it('parses a clean ledger with no malformed lines', () => {
+    const raw = `${validLine('entry-1')}\n${validLine('entry-2')}\n`;
+    const result = parseFeedbackJsonl(raw);
+    expect(result.malformedLineCount).toBe(0);
+    expect(result.entries.map((entry) => entry.id)).toEqual(['entry-1', 'entry-2']);
+  });
+
+  it('skips and counts a torn final line instead of throwing', () => {
+    // A crash mid-append leaves a truncated last line with no trailing newline.
+    const raw = `${validLine('entry-1')}\n${validLine('entry-2')}\n{"schema_version":"kb-feed`;
+    const result = parseFeedbackJsonl(raw);
+    expect(result.malformedLineCount).toBe(1);
+    expect(result.entries.map((entry) => entry.id)).toEqual(['entry-1', 'entry-2']);
+  });
+
+  it('skips and counts multiple interior malformed lines, keeping good entries', () => {
+    const raw = [
+      validLine('entry-1'),
+      'this is not json at all',
+      validLine('entry-2'),
+      '{"truncated": ',
+      validLine('entry-3'),
+      '', // blank lines are ignored, not counted as malformed
+    ].join('\n');
+    const result = parseFeedbackJsonl(raw);
+    expect(result.malformedLineCount).toBe(2);
+    expect(result.entries.map((entry) => entry.id)).toEqual(['entry-1', 'entry-2', 'entry-3']);
+  });
+
+  it('surfaces good entries and the malformed count from readFeedbackLedgerWithStats', async () => {
+    const dir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-feedback-torn-'));
+    const kbDir = path.join(dir, 'ops');
+    await fsp.mkdir(kbDir, { recursive: true });
+
+    await appendFeedbackEntry(kbDir, {
+      id: 'entry-1',
+      now: new Date('2026-05-19T10:00:00.000Z'),
+      kb: 'ops',
+      query: 'rollback procedure',
+      source: 'runbooks/deploy.md',
+    });
+    // Simulate a torn write appended after the valid entry.
+    await fsp.appendFile(feedbackLedgerPath(kbDir), '{"schema_version":"kb-feed', 'utf-8');
+
+    const stats = await readFeedbackLedgerWithStats(kbDir);
+    expect(stats.malformedLineCount).toBe(1);
+    expect(stats.entries.map((entry) => entry.id)).toEqual(['entry-1']);
+
+    // The array-returning reader stays corruption-tolerant for existing callers.
+    await expect(readFeedbackLedger(kbDir)).resolves.toMatchObject([{ id: 'entry-1' }]);
+  });
+
+  it('reports zero malformed lines for a missing ledger', async () => {
+    const dir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-feedback-missing-'));
+    const stats = await readFeedbackLedgerWithStats(path.join(dir, 'ops'));
+    expect(stats).toEqual({ entries: [], malformedLineCount: 0 });
   });
 });
 

--- a/src/feedback-ledger.ts
+++ b/src/feedback-ledger.ts
@@ -54,6 +54,16 @@ export interface PromotedFixture {
   cases: Array<Record<string, unknown>>;
 }
 
+export interface ParsedFeedbackLedger {
+  entries: FeedbackLedgerEntry[];
+  /**
+   * Number of non-empty lines that could not be parsed as JSON and were
+   * skipped (e.g. a torn final line from a crash mid-append). Mirrors the
+   * canonical-log reader's `malformed_canonical_line_count`.
+   */
+  malformedLineCount: number;
+}
+
 export function feedbackLedgerPath(kbDir: string): string {
   return path.join(kbDir, '.index', FEEDBACK_LEDGER_FILENAME);
 }
@@ -67,31 +77,41 @@ export async function appendFeedbackEntry(kbDir: string, input: FeedbackAddInput
 }
 
 export async function readFeedbackLedger(kbDir: string): Promise<FeedbackLedgerEntry[]> {
+  return (await readFeedbackLedgerWithStats(kbDir)).entries;
+}
+
+export async function readFeedbackLedgerWithStats(kbDir: string): Promise<ParsedFeedbackLedger> {
   const ledgerPath = feedbackLedgerPath(kbDir);
   let raw: string;
   try {
     raw = await fsp.readFile(ledgerPath, 'utf-8');
   } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return [];
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return { entries: [], malformedLineCount: 0 };
     throw err;
   }
   return parseFeedbackJsonl(raw);
 }
 
-export function parseFeedbackJsonl(raw: string): FeedbackLedgerEntry[] {
+export function parseFeedbackJsonl(raw: string): ParsedFeedbackLedger {
   const entries: FeedbackLedgerEntry[] = [];
+  let malformedLineCount = 0;
   const lines = raw.split(/\r?\n/);
   lines.forEach((line, idx) => {
     if (line.trim().length === 0) return;
     let parsed: unknown;
     try {
       parsed = JSON.parse(line);
-    } catch (err) {
-      throw new Error(`feedback ledger line ${idx + 1} is not valid JSON: ${(err as Error).message}`);
+    } catch {
+      // A non-parseable line is almost always a torn write (crash mid-append)
+      // or other byte-level corruption. Skip and count it rather than bricking
+      // the whole read; well-formed-but-schema-invalid lines still throw below
+      // so genuine format/version mismatches stay loud.
+      malformedLineCount++;
+      return;
     }
     entries.push(normalizeFeedbackEntry(parsed, idx + 1));
   });
-  return entries;
+  return { entries, malformedLineCount };
 }
 
 export function buildFeedbackEntry(input: FeedbackAddInput): FeedbackLedgerEntry {


### PR DESCRIPTION
## Summary

Closes #655.

`parseFeedbackJsonl` / `readFeedbackLedger` threw on the **first** non-parseable JSONL line, so a single torn append (crash/OOM/`kill -9` mid-write leaving a truncated final line) permanently bricked `kb feedback` reads and any eval-fixture promotion built on them.

This makes the read corruption-tolerant by skipping and **counting** non-parseable lines, mirroring the canonical-log reader's `malformed_canonical_line_count` (`src/cli-logs.ts`).

## Changes

- `parseFeedbackJsonl(raw)` now returns `{ entries, malformedLineCount }`. A line that fails `JSON.parse` is skipped and counted instead of throwing.
- New `readFeedbackLedgerWithStats(kbDir)` surfaces `{ entries, malformedLineCount }` from disk (and `{ entries: [], malformedLineCount: 0 }` for a missing ledger).
- `readFeedbackLedger(kbDir)` keeps its `FeedbackLedgerEntry[]` return (delegates to the stats variant), so existing callers in `src/cli-feedback.ts` are unchanged — scope stays within the ledger module.
- Tests cover a clean ledger, a torn final line, multiple interior malformed lines, the on-disk stats path, and a missing ledger.

## Design choice (issue left open)

The issue noted two open questions: whether to silently skip, and whether mid-file corruption should warn loudly.

- **Count is always surfaced** (never swallowed) via `malformedLineCount`, so corruption is observable rather than hidden.
- **Failure-type-aware** handling: only byte-level corruption (`JSON.parse` failure — the torn-write case) is tolerated. A line that is *valid JSON but has an invalid schema* still throws loudly, because that signals a genuine format/version mismatch worth failing on rather than silently dropping every entry. This is the smallest change that fixes the torn-write case and keeps the existing "reject invalid schema with line numbers" contract.

**Alternatives considered:** (a) also skip+count schema-invalid rows — rejected as it could silently drop an entire newer-format ledger; (b) change `readFeedbackLedger`'s return type to the stats struct and update `cli-feedback.ts` — rejected to keep write scope within the ledger module.

## Verification

- `npx jest src/feedback-ledger` — 10 passed.
- `npm run build` — typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)