### PR TITLE
feat(cli-logs): add `kb logs --summary` aggregate diagnostics (#657)

### DIFF
--- a/src/cli-logs.test.ts
+++ b/src/cli-logs.test.ts
@@ -87,6 +87,24 @@ describe('parseLogsArgs', () => {
     expect(() => parseLogsArgs(['recent', '--limit=0'])).toThrow(/between 1 and 500/);
     expect(() => parseLogsArgs(['recent', '--slow', '--min-ms=0'])).toThrow(/at least 1/);
   });
+
+  it('parses the summary action in both forms and rejects show-only filters', () => {
+    expect(parseLogsArgs(['--summary'])).toEqual({
+      action: 'summary',
+      format: 'md',
+      limit: 20,
+      slow: false,
+      degraded: false,
+    });
+    expect(parseLogsArgs(['summary', '--limit=5', '--format=json'])).toEqual({
+      action: 'summary',
+      format: 'json',
+      limit: 5,
+      slow: false,
+      degraded: false,
+    });
+    expect(() => parseLogsArgs(['--summary', '--request-id=a'])).toThrow(/summary does not accept/);
+  });
 });
 
 describe('parseCanonicalLogLines', () => {
@@ -333,5 +351,137 @@ describe('runLogs', () => {
         message: 'no log file found; pass --file=<path> or set LOG_FILE',
       },
     });
+  });
+});
+
+describe('runLogs --summary', () => {
+  // took_ms 10..100 across 10 requests; 3 carry errors. Used to assert exact
+  // percentile math and the outcome/error-code breakdown.
+  const summaryLog = [
+    canonical({ request_id: 'r1', query_sha256: 'q1', took_ms: 10 }),
+    canonical({ request_id: 'r2', query_sha256: 'q2', took_ms: 20 }),
+    canonical({ request_id: 'r3', query_sha256: 'q3', took_ms: 30, error: { code: 'VALIDATION', category: 'input' } }),
+    canonical({ request_id: 'r4', query_sha256: 'q4', took_ms: 40 }),
+    canonical({ request_id: 'r5', query_sha256: 'q5', took_ms: 50 }),
+    canonical({ request_id: 'r6', query_sha256: 'q6', took_ms: 60 }),
+    canonical({ request_id: 'r7', query_sha256: 'q7', took_ms: 70, error: { code: 'PROVIDER_TIMEOUT', category: 'provider' } }),
+    canonical({ request_id: 'r8', query_sha256: 'q8', took_ms: 80 }),
+    canonical({ request_id: 'r9', query_sha256: 'q9', took_ms: 90 }),
+    canonical({ request_id: 'r10', query_sha256: 'q10', took_ms: 100, error: { code: 'PROVIDER_TIMEOUT', category: 'provider' } }),
+  ].join('\n');
+
+  it('aggregates percentiles, outcomes, and error-code breakdown as JSON', async () => {
+    const { deps, stdout, stderr } = depsFor(
+      { '/repo/kb.log': summaryLog },
+      { LOG_FILE: './kb.log' },
+    );
+
+    const code = await runLogs(['--summary', '--limit=3', '--format=json'], deps);
+
+    expect(code).toBe(0);
+    expect(stderr).toEqual([]);
+    const payload = JSON.parse(stdout.join('')) as {
+      action: string;
+      summary: {
+        total_requests: number;
+        outcomes: { success: number; error: number };
+        by_error_code: Record<string, number>;
+        by_error_category: Record<string, number>;
+        latency_ms: { count: number; min: number; max: number; p50: number; p95: number; p99: number } | null;
+        slowest: Array<{ request_id: string; took_ms: number; error_code?: string }>;
+      };
+    };
+
+    expect(payload.action).toBe('summary');
+    expect(payload.summary.total_requests).toBe(10);
+    expect(payload.summary.outcomes).toEqual({ success: 7, error: 3 });
+    expect(payload.summary.by_error_code).toEqual({ PROVIDER_TIMEOUT: 2, VALIDATION: 1 });
+    expect(payload.summary.by_error_category).toEqual({ provider: 2, input: 1 });
+    expect(payload.summary.latency_ms).toEqual({
+      count: 10,
+      min: 10,
+      max: 100,
+      p50: 50,
+      p95: 100,
+      p99: 100,
+    });
+    // top-N slowest, descending, honouring --limit
+    expect(payload.summary.slowest.map((entry) => entry.request_id)).toEqual(['r10', 'r9', 'r8']);
+    expect(payload.summary.slowest[0]).toMatchObject({ took_ms: 100, error_code: 'PROVIDER_TIMEOUT' });
+  });
+
+  it('computes nearest-rank percentiles for an odd-sized sample', async () => {
+    // took_ms = [100, 200, 300]; p50 -> rank 2 -> 200, p95/p99 -> rank 3 -> 300.
+    const { deps, stdout } = depsFor(
+      {
+        '/repo/kb.log': [
+          canonical({ request_id: 'a', took_ms: 300 }),
+          canonical({ request_id: 'b', took_ms: 100 }),
+          canonical({ request_id: 'c', took_ms: 200 }),
+        ].join('\n'),
+      },
+      { LOG_FILE: './kb.log' },
+    );
+
+    const code = await runLogs(['--summary', '--format=json'], deps);
+
+    expect(code).toBe(0);
+    const payload = JSON.parse(stdout.join('')) as {
+      summary: { latency_ms: { p50: number; p95: number; p99: number; min: number; max: number } };
+    };
+    expect(payload.summary.latency_ms).toMatchObject({ min: 100, p50: 200, p95: 300, p99: 300, max: 300 });
+  });
+
+  it('renders the summary as markdown', async () => {
+    const { deps, stdout } = depsFor(
+      { '/repo/kb.log': summaryLog },
+      { LOG_FILE: './kb.log' },
+    );
+
+    const code = await runLogs(['--summary'], deps);
+
+    expect(code).toBe(0);
+    const md = stdout.join('');
+    expect(md).toContain('## Summary');
+    expect(md).toContain('- Total requests: 10');
+    expect(md).toContain('- Success: 7');
+    expect(md).toContain('- Error: 3');
+    expect(md).toContain('p95: 100 ms');
+    expect(md).toContain('`PROVIDER_TIMEOUT`: 2');
+    expect(md).toContain('### Slowest queries');
+    expect(md).toContain('`r10`');
+  });
+
+  it('reports null latency and empty breakdown for a log with no timed requests', async () => {
+    // Canonical lines whose took_ms is non-numeric are ignored for latency.
+    const { deps, stdout } = depsFor(
+      {
+        '/repo/kb.log': JSON.stringify({
+          schema_version: 'kb-canonical.v1',
+          ts: '2026-05-18T20:00:00.000Z',
+          request_id: 'no-timing',
+          process: 'cli',
+          cmd: 'kb search',
+          took_ms: 'not-a-number',
+        }),
+      },
+      { LOG_FILE: './kb.log' },
+    );
+
+    const code = await runLogs(['--summary', '--format=json'], deps);
+
+    expect(code).toBe(0);
+    const payload = JSON.parse(stdout.join('')) as {
+      summary: {
+        total_requests: number;
+        outcomes: { success: number; error: number };
+        latency_ms: null | object;
+        slowest: unknown[];
+      };
+    };
+    expect(payload.summary.total_requests).toBe(1);
+    expect(payload.summary.outcomes).toEqual({ success: 1, error: 0 });
+    expect(payload.summary.latency_ms).toBeNull();
+    expect(payload.summary.slowest).toEqual([]);
   });
 });

--- a/src/cli-logs.ts
+++ b/src/cli-logs.ts
@@ -8,6 +8,7 @@ export const LOGS_HELP = `kb logs — inspect historical canonical request logs
 Usage:
   kb logs --slow [--min-ms=<n>] [--limit=<n>] [--file=<path>] [--format=md|json]
   kb logs --degraded [--limit=<n>] [--file=<path>] [--format=md|json]
+  kb logs --summary [--limit=<n>] [--file=<path>] [--format=md|json]
   kb logs recent [--slow] [--degraded] [--min-ms=<n>] [--limit=<n>] [--file=<path>] [--format=md|json]
   kb logs show --request-id=<id> [--file=<path>] [--format=md|json]
   kb logs show --query-sha=<hash> [--file=<path>] [--format=md|json]
@@ -16,15 +17,21 @@ Reads mixed text/canonical log files, keeps only \`kb-canonical.v1\` JSON lines,
 and summarizes request ids, query hashes, timings, errors, cache state, gate
 fields, rerank fields, top sources, and recovery hints.
 
+The --summary view aggregates the whole log into a post-hoc report: request
+counts by outcome and error code/category, latency percentiles (p50/p95/p99)
+over took_ms, and the top-N slowest queries.
+
 Options:
   --file=<path>         Log file to read. Defaults to LOG_FILE, then known
                         local log paths if they exist.
   --format=md|json      Output format (default: md).
-  --limit=<n>           Number of recent canonical events to show (default: 20).
+  --limit=<n>           Number of recent canonical events to show, or top-N
+                        slowest queries for --summary (default: 20).
   --slow                Show only events marked slow, or events matching
                         --min-ms when that filter is supplied.
   --degraded            Show only events with aggregate degraded=true.
   --min-ms=<n>          Minimum took_ms for the slow view; implies --slow.
+  --summary             Aggregate the whole log into a diagnostics report.
   --request-id=<id>     Show canonical events for one request id.
   --query-sha=<hash>    Show canonical events for one query_sha256 value.
   --help, -h            Show this help.
@@ -33,6 +40,8 @@ Examples:
   kb logs recent
   kb logs --slow
   kb logs --degraded
+  kb logs --summary
+  kb logs --summary --limit=5 --format=json
   kb logs recent --slow --min-ms=1000
   kb logs recent --limit=5 --format=json
   kb logs show --request-id=maw6d3qfabcd1234
@@ -43,7 +52,7 @@ const LOGS_SCHEMA_VERSION = 'kb.logs.v1';
 const DEFAULT_LIMIT = 20;
 const MAX_LIMIT = 500;
 
-type LogsAction = 'recent' | 'show';
+type LogsAction = 'recent' | 'show' | 'summary';
 type LogsFormat = 'md' | 'json';
 
 export interface LogsArgs {
@@ -86,6 +95,37 @@ interface LogsPayload {
   degraded_event_count: number;
   result_count: number;
   events: CanonicalLogSummary[];
+  summary?: LogsAggregate;
+}
+
+interface LogsAggregate {
+  total_requests: number;
+  outcomes: {
+    success: number;
+    error: number;
+  };
+  by_error_code: Record<string, number>;
+  by_error_category: Record<string, number>;
+  latency_ms: LatencyStats | null;
+  slowest: SlowestQuery[];
+}
+
+interface LatencyStats {
+  count: number;
+  min: number;
+  max: number;
+  p50: number;
+  p95: number;
+  p99: number;
+}
+
+interface SlowestQuery {
+  request_id?: string;
+  query_sha256?: string;
+  took_ms: number;
+  ts?: string;
+  cmd?: string;
+  error_code?: string;
 }
 
 interface CanonicalLogSummary {
@@ -199,8 +239,11 @@ export function parseLogsArgs(rest: string[]): LogsArgs {
   }
   let action: LogsAction;
   let optionStart = 1;
-  if (rest[0] === 'recent' || rest[0] === 'show') {
+  if (rest[0] === 'recent' || rest[0] === 'show' || rest[0] === 'summary') {
     action = rest[0];
+  } else if (rest[0] === '--summary') {
+    action = 'summary';
+    optionStart = 0;
   } else if (
     rest[0] === '--slow' ||
     rest[0] === '--degraded' ||
@@ -232,6 +275,10 @@ export function parseLogsArgs(rest: string[]): LogsArgs {
     }
     if (raw.startsWith('--limit=')) {
       out.limit = parseLimit(raw.slice('--limit='.length));
+      continue;
+    }
+    if (raw === '--summary') {
+      out.action = 'summary';
       continue;
     }
     if (raw === '--slow') {
@@ -277,9 +324,9 @@ export function parseLogsArgs(rest: string[]): LogsArgs {
     throw new Error(`unexpected argument: ${JSON.stringify(raw)}`);
   }
 
-  if (out.action === 'recent') {
+  if (out.action !== 'show') {
     if (out.requestId !== undefined || out.querySha !== undefined) {
-      throw new Error('recent does not accept --request-id or --query-sha; use `kb logs show`');
+      throw new Error(`${out.action} does not accept --request-id or --query-sha; use \`kb logs show\``);
     }
   } else if ((out.requestId === undefined) === (out.querySha === undefined)) {
     throw new Error('show requires exactly one of --request-id or --query-sha');
@@ -375,6 +422,7 @@ function expandPath(filePath: string, deps: RunLogsDeps): string {
 }
 
 function selectEvents(events: CanonicalLogRecord[], args: LogsArgs): CanonicalLogRecord[] {
+  if (args.action === 'summary') return [];
   const base = args.action === 'recent'
     ? events
     : args.requestId !== undefined
@@ -420,7 +468,103 @@ function buildLogsPayload(
     degraded_event_count: parsed.events.filter((event) => event.degraded === true).length,
     result_count: events.length,
     events: events.map(summarizeEvent),
+    ...(args.action === 'summary'
+      ? { summary: aggregateEvents(parsed.events, args.limit) }
+      : {}),
   };
+}
+
+function aggregateEvents(events: CanonicalLogRecord[], topN: number): LogsAggregate {
+  const byErrorCode: Record<string, number> = {};
+  const byErrorCategory: Record<string, number> = {};
+  let success = 0;
+  let error = 0;
+  const latencies: number[] = [];
+  const timed: SlowestQuery[] = [];
+
+  for (const event of events) {
+    const errInfo = errorInfo(event.error);
+    if (errInfo !== undefined) {
+      error++;
+      byErrorCode[errInfo.code] = (byErrorCode[errInfo.code] ?? 0) + 1;
+      byErrorCategory[errInfo.category] = (byErrorCategory[errInfo.category] ?? 0) + 1;
+    } else {
+      success++;
+    }
+
+    const tookMs = numberField(event.took_ms);
+    if (tookMs !== undefined) {
+      latencies.push(tookMs);
+      timed.push({
+        ...(stringField(event.request_id) !== undefined ? { request_id: stringField(event.request_id) } : {}),
+        ...(stringField(event.query_sha256) !== undefined ? { query_sha256: stringField(event.query_sha256) } : {}),
+        took_ms: tookMs,
+        ...(stringField(event.ts) !== undefined ? { ts: stringField(event.ts) } : {}),
+        ...(stringField(event.cmd ?? event.tool) !== undefined ? { cmd: stringField(event.cmd ?? event.tool) } : {}),
+        ...(errInfo !== undefined ? { error_code: errInfo.code } : {}),
+      });
+    }
+  }
+
+  const slowest = timed
+    .slice()
+    .sort((a, b) => (b.took_ms - a.took_ms) || compareStrings(a.request_id, b.request_id))
+    .slice(0, topN);
+
+  return {
+    total_requests: events.length,
+    outcomes: { success, error },
+    by_error_code: sortRecordByCountDesc(byErrorCode),
+    by_error_category: sortRecordByCountDesc(byErrorCategory),
+    latency_ms: latencyStats(latencies),
+    slowest,
+  };
+}
+
+function latencyStats(values: number[]): LatencyStats | null {
+  if (values.length === 0) return null;
+  const sorted = values.slice().sort((a, b) => a - b);
+  return {
+    count: sorted.length,
+    min: sorted[0],
+    max: sorted[sorted.length - 1],
+    p50: percentile(sorted, 50),
+    p95: percentile(sorted, 95),
+    p99: percentile(sorted, 99),
+  };
+}
+
+// Exact nearest-rank percentile over an ascending-sorted array. Suitable for
+// the typical on-disk log sizes this command targets; for very large logs an
+// approximate streaming digest would be needed, but exact sort keeps the math
+// auditable in tests.
+function percentile(sortedAsc: number[], p: number): number {
+  const rank = Math.ceil((p / 100) * sortedAsc.length);
+  const index = Math.min(sortedAsc.length - 1, Math.max(0, rank - 1));
+  return sortedAsc[index];
+}
+
+function errorInfo(error: unknown): { code: string; category: string } | undefined {
+  if (error === undefined || error === null) return undefined;
+  if (typeof error === 'object') {
+    const record = error as { code?: unknown; category?: unknown };
+    const code = typeof record.code === 'string' ? record.code : 'ERROR';
+    const category = typeof record.category === 'string' ? record.category : 'unknown';
+    return { code, category };
+  }
+  return { code: String(error), category: 'unknown' };
+}
+
+function sortRecordByCountDesc(record: Record<string, number>): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const [key] of Object.entries(record).sort((a, b) => (b[1] - a[1]) || compareStrings(a[0], b[0]))) {
+    out[key] = record[key];
+  }
+  return out;
+}
+
+function compareStrings(a: string | undefined, b: string | undefined): number {
+  return (a ?? '').localeCompare(b ?? '');
 }
 
 function summarizeEvent(event: CanonicalLogRecord): CanonicalLogSummary {
@@ -485,6 +629,11 @@ function formatLogsMarkdown(payload: LogsPayload): string {
     '',
   ];
 
+  if (payload.summary !== undefined) {
+    lines.push(...formatSummaryMarkdown(payload.summary));
+    return lines.join('\n');
+  }
+
   if (payload.events.length === 0) {
     lines.push('No matching canonical log events.', '');
     return lines.join('\n');
@@ -514,6 +663,77 @@ function formatLogsMarkdown(payload: LogsPayload): string {
     lines.push(...formatEventDetails(event));
   }
   return lines.join('\n');
+}
+
+function formatSummaryMarkdown(summary: LogsAggregate): string[] {
+  const lines = [
+    '## Summary',
+    '',
+    `- Total requests: ${summary.total_requests}`,
+    `- Success: ${summary.outcomes.success}`,
+    `- Error: ${summary.outcomes.error}`,
+    '',
+  ];
+
+  const latency = summary.latency_ms;
+  lines.push('### Latency (took_ms)', '');
+  if (latency === null) {
+    lines.push('No timed requests.', '');
+  } else {
+    lines.push(
+      `- Count: ${latency.count}`,
+      `- Min: ${latency.min} ms`,
+      `- p50: ${latency.p50} ms`,
+      `- p95: ${latency.p95} ms`,
+      `- p99: ${latency.p99} ms`,
+      `- Max: ${latency.max} ms`,
+      '',
+    );
+  }
+
+  lines.push('### By error code', '');
+  const errorCodes = Object.entries(summary.by_error_code);
+  if (errorCodes.length === 0) {
+    lines.push('No errors.', '');
+  } else {
+    for (const [code_, count] of errorCodes) {
+      lines.push(`- ${code(code_)}: ${count}`);
+    }
+    lines.push('');
+  }
+
+  lines.push('### By error category', '');
+  const errorCategories = Object.entries(summary.by_error_category);
+  if (errorCategories.length === 0) {
+    lines.push('No errors.', '');
+  } else {
+    for (const [category, count] of errorCategories) {
+      lines.push(`- ${code(category)}: ${count}`);
+    }
+    lines.push('');
+  }
+
+  lines.push('### Slowest queries', '');
+  if (summary.slowest.length === 0) {
+    lines.push('No timed requests.', '');
+    return lines;
+  }
+  lines.push(
+    '| Took | Request | Query SHA | Command/tool | Error | Time |',
+    '| ---: | --- | --- | --- | --- | --- |',
+  );
+  for (const entry of summary.slowest) {
+    lines.push([
+      `${entry.took_ms} ms`,
+      code(entry.request_id),
+      code(entry.query_sha256),
+      code(entry.cmd),
+      code(entry.error_code),
+      entry.ts ?? '',
+    ].map(escapeTableCell).join(' | ').replace(/^/, '| ').replace(/$/, ' |'));
+  }
+  lines.push('');
+  return lines;
 }
 
 function formatEventDetails(event: CanonicalLogSummary): string[] {


### PR DESCRIPTION
## Summary

Adds a `kb logs --summary` mode that aggregates the historical canonical `LOG_FILE` into a post-hoc diagnostics report — offline triage without standing up a Prometheus scraper. Reuses the existing malformed-line-tolerant canonical-log parser in `src/cli-logs.ts`.

The summary reports:
- **Request counts by outcome** — `success` vs `error`, plus breakdowns by error `code` and `category`.
- **Latency percentiles** — p50/p95/p99 (plus count/min/max) over `took_ms`.
- **Top-N slowest queries** — honouring `--limit` (default 20), descending by `took_ms`.

Both `--format=md` (default) and `--format=json` are supported, e.g.:

```
kb logs --summary
kb logs --summary --limit=5 --format=json
```

## Implementation notes / design choices

The issue left a few details open; per the "smallest implementation" guidance:

- **Percentiles** use the exact nearest-rank method over a sorted sample (`rank = ceil(p/100 * N)`). Exact sort is fine for the typical on-disk log sizes this command targets; a streaming digest would only be needed for very large logs. This keeps the math auditable in tests. Noted in a code comment.
- **Outcome / error grouping** uses the canonical `error.code` / `error.category` fields already emitted by `classifyCanonicalError` (KBError taxonomy). An event is an `error` outcome iff it carries an `error` object; otherwise `success`.
- **Top-N** reuses the existing `--limit` flag rather than adding a new `--top` flag.
- Events whose `took_ms` is missing/non-numeric are excluded from latency stats and the slowest list but still counted in totals/outcomes; `latency_ms` is `null` when there are no timed requests.
- `--summary` is accepted both as a leading token (`kb logs --summary`) and as `kb logs summary`. Like `recent`, it rejects `--request-id`/`--query-sha`.

The `summary` object is added to the existing `kb.logs.v1` payload (only present for the summary action), so the JSON schema version is unchanged.

## Tests

Extended `src/cli-logs.test.ts` with focused cases over a small synthetic log:
- exact percentile math (p50/p95/p99) for both even- and odd-sized samples,
- outcome and error-code/category breakdown,
- top-N slowest ordering honouring `--limit`,
- markdown rendering,
- null-latency/empty-breakdown for a log with no timed requests,
- arg parsing for both `--summary` forms.

`npx jest cli-logs` → 15 passed. `npm run build` → clean. Manual smoke test of the built CLI confirmed md + json output.

Closes #657

🤖 Generated with [Claude Code](https://claude.com/claude-code)