### PR TITLE
feat(logger): size-based LOG_FILE rotation via KB_LOG_MAX_BYTES (#658)

### DIFF
--- a/src/config/logging.ts
+++ b/src/config/logging.ts
@@ -27,3 +27,32 @@ export function readKBSlowQueryMs(env: NodeJS.ProcessEnv = process.env): number 
 }
 
 export const KB_SLOW_QUERY_MS: number | undefined = parseKBSlowQueryMs(process.env.KB_SLOW_QUERY_MS);
+
+// ---------------------------------------------------------------------------
+// Size-based LOG_FILE rotation/retention (#658).
+//
+// Opt-in: rotation is disabled unless KB_LOG_MAX_BYTES is a positive integer.
+// When enabled, the canonical LOG_FILE is rolled (LOG_FILE.1, .2, …) once it
+// reaches the byte cap, keeping at most KB_LOG_MAX_FILES generations.
+// ---------------------------------------------------------------------------
+
+export const DEFAULT_KB_LOG_MAX_FILES = 5;
+
+/** Parse the rotation byte cap; returns undefined (rotation off) when unset or invalid. */
+export function parseKBLogMaxBytes(raw: string | undefined): number | undefined {
+  if (raw === undefined || raw.trim() === '') return undefined;
+  const value = Number(raw.trim());
+  if (!Number.isFinite(value) || value <= 0) return undefined;
+  return Math.floor(value);
+}
+
+/** Parse the retained-generations bound; defaults to DEFAULT_KB_LOG_MAX_FILES, minimum 1. */
+export function parseKBLogMaxFiles(raw: string | undefined): number {
+  if (raw === undefined || raw.trim() === '') return DEFAULT_KB_LOG_MAX_FILES;
+  const value = Number(raw.trim());
+  if (!Number.isFinite(value) || value < 1) return DEFAULT_KB_LOG_MAX_FILES;
+  return Math.floor(value);
+}
+
+export const KB_LOG_MAX_BYTES: number | undefined = parseKBLogMaxBytes(process.env.KB_LOG_MAX_BYTES);
+export const KB_LOG_MAX_FILES: number = parseKBLogMaxFiles(process.env.KB_LOG_MAX_FILES);

--- a/src/logger.test.ts
+++ b/src/logger.test.ts
@@ -7,27 +7,33 @@ describe('logger', () => {
     LOG_FILE: process.env.LOG_FILE,
     LOG_LEVEL: process.env.LOG_LEVEL,
     KB_LOG_FORMAT: process.env.KB_LOG_FORMAT,
+    KB_LOG_MAX_BYTES: process.env.KB_LOG_MAX_BYTES,
+    KB_LOG_MAX_FILES: process.env.KB_LOG_MAX_FILES,
+  };
+
+  const restoreEnv = (key: keyof typeof originalEnv) => {
+    if (originalEnv[key] === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = originalEnv[key];
+    }
   };
 
   afterEach(() => {
-    if (originalEnv.LOG_FILE === undefined) {
-      delete process.env.LOG_FILE;
-    } else {
-      process.env.LOG_FILE = originalEnv.LOG_FILE;
-    }
-    if (originalEnv.LOG_LEVEL === undefined) {
-      delete process.env.LOG_LEVEL;
-    } else {
-      process.env.LOG_LEVEL = originalEnv.LOG_LEVEL;
-    }
-    if (originalEnv.KB_LOG_FORMAT === undefined) {
-      delete process.env.KB_LOG_FORMAT;
-    } else {
-      process.env.KB_LOG_FORMAT = originalEnv.KB_LOG_FORMAT;
-    }
+    restoreEnv('LOG_FILE');
+    restoreEnv('LOG_LEVEL');
+    restoreEnv('KB_LOG_FORMAT');
+    restoreEnv('KB_LOG_MAX_BYTES');
+    restoreEnv('KB_LOG_MAX_FILES');
     jest.restoreAllMocks();
     jest.resetModules();
   });
+
+  // Build a canonical payload whose written line (payload + '\n') is exactly `bytes` long.
+  const canonicalLineOfBytes = (tag: string, bytes: number): string => {
+    const padding = Math.max(0, bytes - 1 - tag.length); // -1 for the '\n' the logger appends
+    return `${tag}${'x'.repeat(padding)}`;
+  };
 
   it('writes log messages to the configured file', async () => {
     const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-logger-file-'));
@@ -105,5 +111,90 @@ describe('logger', () => {
     const fileContents = await fsp.readFile(logFile, 'utf-8');
     expect(fileContents).toContain('text remains');
     expect(fileContents).not.toContain('kb-canonical.v1');
+  });
+
+  it('does not rotate when KB_LOG_MAX_BYTES is unset (disabled by default)', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-logger-norotate-'));
+    const logFile = path.join(tempDir, 'app.log');
+    process.env.LOG_FILE = logFile;
+    delete process.env.KB_LOG_MAX_BYTES;
+
+    await jest.isolateModulesAsync(async () => {
+      const { logger } = await import('./logger.js');
+      for (let i = 0; i < 20; i += 1) {
+        logger.canonical(canonicalLineOfBytes(`L${i}`, 50));
+      }
+    });
+
+    await expect(fsp.stat(`${logFile}.1`)).rejects.toThrow();
+    const contents = await fsp.readFile(logFile, 'utf-8');
+    expect(contents).toContain('L0');
+    expect(contents).toContain('L19');
+  });
+
+  it('rotates LOG_FILE to LOG_FILE.1 once it reaches KB_LOG_MAX_BYTES', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-logger-rotate-'));
+    const logFile = path.join(tempDir, 'app.log');
+    process.env.LOG_FILE = logFile;
+    process.env.KB_LOG_FORMAT = 'canonical';
+    process.env.KB_LOG_MAX_BYTES = '100';
+
+    await jest.isolateModulesAsync(async () => {
+      const { logger } = await import('./logger.js');
+      // Each line is 61 bytes. After A (61) and B (122) the file is over the
+      // 100-byte cap, so writing C rolls A+B into .1 and starts a fresh file.
+      logger.canonical(canonicalLineOfBytes('A', 61));
+      logger.canonical(canonicalLineOfBytes('B', 61));
+      logger.canonical(canonicalLineOfBytes('C', 61));
+    });
+
+    const rolled = await fsp.readFile(`${logFile}.1`, 'utf-8');
+    expect(rolled).toContain('A');
+    expect(rolled).toContain('B');
+    expect(rolled).not.toContain('C');
+
+    const current = await fsp.readFile(logFile, 'utf-8');
+    expect(current).toContain('C');
+    expect(current).not.toContain('A');
+  });
+
+  it('honors the KB_LOG_MAX_FILES retention bound', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-logger-retention-'));
+    const logFile = path.join(tempDir, 'app.log');
+    process.env.LOG_FILE = logFile;
+    process.env.KB_LOG_FORMAT = 'canonical';
+    process.env.KB_LOG_MAX_BYTES = '50';
+    process.env.KB_LOG_MAX_FILES = '2';
+
+    await jest.isolateModulesAsync(async () => {
+      const { logger } = await import('./logger.js');
+      // 31-byte lines past a 50-byte cap force repeated rotations.
+      for (let i = 0; i < 12; i += 1) {
+        logger.canonical(canonicalLineOfBytes(`L${i}`, 31));
+      }
+    });
+
+    await expect(fsp.stat(`${logFile}.1`)).resolves.toBeDefined();
+    await expect(fsp.stat(`${logFile}.2`)).resolves.toBeDefined();
+    // Retention is 2: a third generation must never be created.
+    await expect(fsp.stat(`${logFile}.3`)).rejects.toThrow();
+  });
+
+  it('rolls an oversized pre-existing log on startup', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-logger-startup-'));
+    const logFile = path.join(tempDir, 'app.log');
+    await fsp.writeFile(logFile, `${'x'.repeat(500)}\n`, 'utf-8');
+    process.env.LOG_FILE = logFile;
+    process.env.KB_LOG_MAX_BYTES = '100';
+
+    await jest.isolateModulesAsync(async () => {
+      await import('./logger.js');
+      await new Promise((resolve) => setImmediate(resolve));
+    });
+
+    const rolled = await fsp.readFile(`${logFile}.1`, 'utf-8');
+    expect(rolled.length).toBeGreaterThanOrEqual(500);
+    const current = await fsp.readFile(logFile, 'utf-8');
+    expect(current.length).toBeLessThan(100);
   });
 });

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,6 +1,15 @@
-import { appendFileSync, createWriteStream, existsSync, mkdirSync } from 'fs';
+import {
+  appendFileSync,
+  createWriteStream,
+  existsSync,
+  mkdirSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+} from 'fs';
 import { dirname } from 'path';
 import { format } from 'util';
+import { KB_LOG_MAX_BYTES, KB_LOG_MAX_FILES } from './config/logging.js';
 
 type LogLevel = 'debug' | 'info' | 'warn' | 'error';
 type LogFormat = 'text' | 'canonical' | 'both';
@@ -16,9 +25,84 @@ const envLevel = (process.env.LOG_LEVEL || 'info').toLowerCase() as LogLevel;
 const activeLevel = LEVEL_PRIORITY[envLevel] ? envLevel : 'info';
 const envFormat = (process.env.KB_LOG_FORMAT || 'both').toLowerCase() as LogFormat;
 const activeFormat: LogFormat = ['text', 'canonical', 'both'].includes(envFormat) ? envFormat : 'both';
-const destinations: NodeJS.WritableStream[] = [process.stderr];
 
 const logFilePath = process.env.LOG_FILE;
+// Rotation is opt-in: undefined byte cap means the log appends forever (legacy behavior).
+const maxBytes = KB_LOG_MAX_BYTES;
+const maxFiles = KB_LOG_MAX_FILES;
+
+// The active append stream for text logs; reopened after each rotation so that
+// subsequent writes target the fresh LOG_FILE inode rather than a rolled file.
+let fileStream: NodeJS.WritableStream | undefined;
+
+function openFileStream(): void {
+  if (!logFilePath) return;
+  const stream = createWriteStream(logFilePath, { flags: 'a' });
+  stream.on('error', (error) => {
+    const message = `${new Date().toISOString()} [ERROR] Log file stream error for ${logFilePath}: ${format(error)}`;
+    process.stderr.write(`${message}\n`);
+  });
+  fileStream = stream;
+  try {
+    stream.write('');
+  } catch (error) {
+    const message = `${new Date().toISOString()} [ERROR] Failed to prime log file ${logFilePath}: ${format(error)}`;
+    process.stderr.write(`${message}\n`);
+  }
+}
+
+// Roll LOG_FILE → LOG_FILE.1, shifting existing generations and dropping any
+// beyond the retention bound. Closes the active stream first so the rename
+// targets a quiescent file, then reopens it on the fresh path.
+function rotate(): void {
+  if (!logFilePath) return;
+  const wasOpen = fileStream !== undefined;
+  if (fileStream) {
+    try {
+      fileStream.end();
+    } catch {
+      // best effort – continue with the rotation regardless
+    }
+    fileStream = undefined;
+  }
+  try {
+    const oldest = `${logFilePath}.${maxFiles}`;
+    if (existsSync(oldest)) {
+      unlinkSync(oldest);
+    }
+    for (let i = maxFiles - 1; i >= 1; i -= 1) {
+      const src = `${logFilePath}.${i}`;
+      if (existsSync(src)) {
+        renameSync(src, `${logFilePath}.${i + 1}`);
+      }
+    }
+    renameSync(logFilePath, `${logFilePath}.1`);
+  } catch (error) {
+    process.stderr.write(
+      `${new Date().toISOString()} [ERROR] Failed to rotate log file ${logFilePath}: ${format(error)}\n`,
+    );
+  } finally {
+    if (wasOpen) {
+      openFileStream();
+    }
+  }
+}
+
+// Rotate before writing when the existing file has reached the byte cap. The
+// stat is skipped entirely when rotation is disabled, so the default path pays
+// no per-write overhead.
+function maybeRotate(): void {
+  if (!logFilePath || maxBytes === undefined) return;
+  let currentSize: number;
+  try {
+    currentSize = statSync(logFilePath).size;
+  } catch {
+    return; // file is absent or unreadable – nothing to roll
+  }
+  if (currentSize < maxBytes) return;
+  rotate();
+}
+
 if (logFilePath) {
   try {
     const parentDir = dirname(logFilePath);
@@ -26,22 +110,13 @@ if (logFilePath) {
       mkdirSync(parentDir, { recursive: true });
     }
     appendFileSync(logFilePath, '');
-    const stream = createWriteStream(logFilePath, { flags: 'a' });
-    stream.on('error', (error) => {
-      const message = `${new Date().toISOString()} [ERROR] Log file stream error for ${logFilePath}: ${format(error)}`;
-      process.stderr.write(`${message}\n`);
-    });
-    destinations.push(stream);
-    try {
-      stream.write('');
-    } catch (error) {
-      const message = `${new Date().toISOString()} [ERROR] Failed to prime log file ${logFilePath}: ${format(error)}`;
-      process.stderr.write(`${message}\n`);
-    }
+    // Roll an oversized pre-existing log on startup before opening the stream.
+    maybeRotate();
+    openFileStream();
     process.on('exit', () => {
       try {
-        stream.end();
-      } catch (error) {
+        fileStream?.end();
+      } catch {
         // noop – logging best effort on shutdown
       }
     });
@@ -60,14 +135,17 @@ function write(level: LogLevel, args: unknown[]): void {
   }
   const message = format(...args);
   const line = `${new Date().toISOString()} [${level.toUpperCase()}] ${message}\n`;
-  for (const destination of destinations) {
+  try {
+    process.stderr.write(line);
+  } catch {
+    // stderr failures are unrecoverable here; swallow to protect the caller.
+  }
+  if (fileStream) {
+    maybeRotate();
     try {
-      destination.write(line);
+      fileStream?.write(line);
     } catch (error) {
-      // If writing to a destination fails, fall back to stderr without recursion.
-      if (destination !== process.stderr) {
-        process.stderr.write(`${new Date().toISOString()} [ERROR] Failed to write log: ${format(error)}\n`);
-      }
+      process.stderr.write(`${new Date().toISOString()} [ERROR] Failed to write log: ${format(error)}\n`);
     }
   }
 }
@@ -78,6 +156,7 @@ function writeCanonical(jsonLine: string): void {
   }
   const line = `${jsonLine}\n`;
   if (logFilePath) {
+    maybeRotate();
     try {
       appendFileSync(logFilePath, line);
     } catch (error) {


### PR DESCRIPTION
## Summary

Adds opt-in **size-based rotation/retention** for the canonical `LOG_FILE`, so a long-lived `kb serve` daemon or busy CLI host doesn't grow the log unbounded and fill the disk (issue #658).

- New config in `src/config/logging.ts`:
  - `KB_LOG_MAX_BYTES` — byte cap that enables rotation (positive integer; unset/invalid = **disabled**).
  - `KB_LOG_MAX_FILES` — number of rolled generations to keep (default **5**, minimum 1).
- `src/logger.ts`: when the file reaches `KB_LOG_MAX_BYTES`, it rolls `LOG_FILE → LOG_FILE.1`, shifting `.1 → .2 …` and dropping anything beyond the retention bound. The active append stream is closed before the rename and reopened on the fresh path; canonical (`appendFileSync`) writes land in the new file too. An oversized pre-existing log is rolled once on startup.

### Behavior / design notes (smallest viable choices)
- **Disabled by default.** With no `KB_LOG_MAX_BYTES`, the size check — and its per-write `statSync` — is skipped entirely, so the default pure-append path is unchanged and pays no overhead. This addresses the issue's "avoid per-write stat overhead" concern by gating the stat behind opt-in.
- **Trigger = size-check-on-write (and on-open).** Rotation fires when the *existing* file has reached the cap, before the next write, so a file may exceed the cap by at most one line. Chosen over periodic timers for simplicity and determinism.
- **Retention default 5**, the value suggested in the issue.
- Per the issue's concurrency caveat, this targets the single-process daemon/CLI case (size-check + rename in one process); cross-process coordination for multiple appenders sharing one `LOG_FILE` is left as follow-up.

### Tests (`src/logger.test.ts`)
- rotation does **not** occur when `KB_LOG_MAX_BYTES` is unset;
- rotates `LOG_FILE → LOG_FILE.1` once the cap is reached, fresh file continues;
- honors the `KB_LOG_MAX_FILES` retention bound (no `.3` when max is 2);
- rolls an oversized pre-existing log on startup.

`npx jest logger` → 8/8 pass. `npm run build` → clean.

Closes #658

🤖 Generated with [Claude Code](https://claude.com/claude-code)