### PR TITLE
feat(loaders): add structure-aware .ipynb ingest loader (#652)

### DIFF
--- a/src/file-ingest.ts
+++ b/src/file-ingest.ts
@@ -193,8 +193,10 @@ export function countStableChunkPrefix(
 /**
  * RFC 011 §5.4.2-aware chunk builder. Markdown files use the markdown
  * splitter (heading-aware); everything else (PDF text via pdf-parse,
- * HTML via html-to-text, operator-supplied extensions like `.json` /
- * `.csv`) goes through the recursive character splitter.
+ * HTML via html-to-text, structure-aware loaders like `.csv` / `.tsv` /
+ * `.ipynb`, operator-supplied extensions like `.json`) goes through the
+ * recursive character splitter — the per-cell blocks a `.ipynb` notebook
+ * emits are blank-line separated so cell boundaries are preferred splits.
  *
  * Each emitted `Document` carries the wire-shape metadata
  * `retrieve_knowledge` projects: `source`, `relativePath` (POSIX-form,

--- a/src/loaders-ipynb.test.ts
+++ b/src/loaders-ipynb.test.ts
@@ -1,0 +1,201 @@
+// Issue #652 — structure-aware Jupyter notebook (`.ipynb`) loader tests.
+//
+// Two layers:
+//   - `formatNotebook` directly: per-cell blocks, preserved cell-type/position
+//     context, selected-output folding, image/binary dropping, and nbformat v3
+//     back-compat.
+//   - `loadFile` dispatch: a `.ipynb` extension routes through the notebook
+//     loader (not the default UTF-8 text loader), and malformed JSON degrades
+//     to verbatim text rather than aborting ingest.
+
+import * as fsp from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { formatNotebook } from './loaders-ipynb.js';
+import { getLoader, LOADERS, loadFile, SUPPORTED_LOADER_EXTENSIONS } from './loaders.js';
+
+// A small nbformat v4 notebook: one markdown cell, one code cell with a
+// stream + text/plain + image output, and one code cell raising an error.
+function sampleNotebookV4(): string {
+  return JSON.stringify({
+    nbformat: 4,
+    nbformat_minor: 5,
+    metadata: {},
+    cells: [
+      {
+        cell_type: 'markdown',
+        metadata: {},
+        source: ['# Sales analysis\n', '\n', 'Load the data and compute totals.'],
+      },
+      {
+        cell_type: 'code',
+        execution_count: 1,
+        metadata: {},
+        source: ['import pandas as pd\n', "df = pd.read_csv('sales.csv')\n", 'df.head()'],
+        outputs: [
+          { output_type: 'stream', name: 'stdout', text: ['loaded 1000 rows\n'] },
+          {
+            output_type: 'execute_result',
+            execution_count: 1,
+            data: {
+              'text/plain': ['   id  amount\n', '0   1     100'],
+              'image/png': 'iVBORw0KGgoAAAANSUhEUgAA…',
+            },
+            metadata: {},
+          },
+        ],
+      },
+      {
+        cell_type: 'code',
+        execution_count: 2,
+        metadata: {},
+        source: ['1 / 0'],
+        outputs: [
+          {
+            output_type: 'error',
+            ename: 'ZeroDivisionError',
+            evalue: 'division by zero',
+            traceback: ['[0;31m---[0m', 'ZeroDivisionError: division by zero'],
+          },
+        ],
+      },
+    ],
+  });
+}
+
+describe('formatNotebook — per-cell structure-aware blocks', () => {
+  it('emits one labelled block per cell with type and 1-based position context', () => {
+    const text = formatNotebook(sampleNotebookV4(), '/kb/sales.ipynb');
+
+    expect(text).toContain('source_path: sales.ipynb');
+    expect(text).toContain('cell 1/3 (markdown):');
+    expect(text).toContain('cell 2/3 (code):');
+    expect(text).toContain('cell 3/3 (code):');
+  });
+
+  it('preserves the markdown narrative and code source verbatim', () => {
+    const text = formatNotebook(sampleNotebookV4(), '/kb/sales.ipynb');
+
+    expect(text).toContain('# Sales analysis');
+    expect(text).toContain('Load the data and compute totals.');
+    expect(text).toContain("df = pd.read_csv('sales.csv')");
+  });
+
+  it('folds textual outputs (stream, text/plain) into the code cell block', () => {
+    const text = formatNotebook(sampleNotebookV4(), '/kb/sales.ipynb');
+
+    expect(text).toContain('output:');
+    expect(text).toContain('loaded 1000 rows');
+    expect(text).toContain('id  amount');
+  });
+
+  it('drops binary/image outputs from the embeddable text', () => {
+    const text = formatNotebook(sampleNotebookV4(), '/kb/sales.ipynb');
+
+    expect(text).not.toContain('image/png');
+    expect(text).not.toContain('iVBORw0KGgo');
+  });
+
+  it('summarises an error output as `ename: evalue` and drops the ANSI traceback', () => {
+    const text = formatNotebook(sampleNotebookV4(), '/kb/sales.ipynb');
+
+    expect(text).toContain('ZeroDivisionError: division by zero');
+    expect(text).not.toContain('[0;31m');
+  });
+
+  it('keeps cells separated by a blank line so the splitter prefers cell boundaries', () => {
+    const text = formatNotebook(sampleNotebookV4(), '/kb/sales.ipynb');
+    // Each cell header sits at the start of a line; consecutive cells are
+    // separated by an empty line.
+    expect(text).toMatch(/\n\ncell 2\/3 \(code\):/);
+    expect(text).toMatch(/\n\ncell 3\/3 \(code\):/);
+  });
+
+  it('truncates runaway cell output instead of dumping it whole', () => {
+    const huge = 'x'.repeat(5000);
+    const notebook = JSON.stringify({
+      nbformat: 4,
+      cells: [
+        {
+          cell_type: 'code',
+          source: ['print("noise")'],
+          outputs: [{ output_type: 'stream', name: 'stdout', text: [huge] }],
+        },
+      ],
+    });
+
+    const text = formatNotebook(notebook, '/kb/noisy.ipynb');
+
+    expect(text).toContain('… [output truncated]');
+    expect(text.length).toBeLessThan(huge.length);
+  });
+
+  it('handles nbformat v3 worksheets and code cells that use `input`', () => {
+    const v3 = JSON.stringify({
+      nbformat: 3,
+      worksheets: [
+        {
+          cells: [
+            { cell_type: 'markdown', source: ['## Legacy notebook'] },
+            { cell_type: 'code', input: ['print("hi")'], outputs: [] },
+          ],
+        },
+      ],
+    });
+
+    const text = formatNotebook(v3, '/kb/legacy.ipynb');
+
+    expect(text).toContain('cell 1/2 (markdown):');
+    expect(text).toContain('## Legacy notebook');
+    expect(text).toContain('cell 2/2 (code):');
+    expect(text).toContain('print("hi")');
+  });
+
+  it('yields just the header for a well-formed but non-notebook JSON document', () => {
+    const text = formatNotebook('{"hello": "world"}', '/kb/config.ipynb');
+    expect(text).toBe('source_path: config.ipynb');
+  });
+});
+
+describe('loadFile dispatch — `.ipynb` routing', () => {
+  let tempDir = '';
+  let priorCacheDir: string | undefined;
+
+  beforeEach(async () => {
+    tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-loaders-ipynb-'));
+    priorCacheDir = process.env.EXTRACTION_TEXT_CACHE_DIR;
+    process.env.EXTRACTION_TEXT_CACHE_DIR = path.join(tempDir, 'extraction-cache');
+  });
+
+  afterEach(async () => {
+    if (priorCacheDir === undefined) delete process.env.EXTRACTION_TEXT_CACHE_DIR;
+    else process.env.EXTRACTION_TEXT_CACHE_DIR = priorCacheDir;
+    await fsp.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('registers `.ipynb` in the loader registry', () => {
+    expect(SUPPORTED_LOADER_EXTENSIONS).toContain('.ipynb');
+    expect(getLoader('/kb/x.ipynb')).toBe(LOADERS['.ipynb']);
+  });
+
+  it('routes a `.ipynb` file through the notebook loader, not the text loader', async () => {
+    const filePath = path.join(tempDir, 'analysis.ipynb');
+    await fsp.writeFile(filePath, sampleNotebookV4());
+
+    const text = await loadFile(filePath);
+
+    expect(getLoader(filePath)).toBe(LOADERS['.ipynb']);
+    expect(text).toContain('source_path: analysis.ipynb');
+    expect(text).toContain('cell 1/3 (markdown):');
+    expect(text).toContain('# Sales analysis');
+    // Not the raw JSON blob the default text loader would have returned.
+    expect(text).not.toContain('"cell_type"');
+  });
+
+  it('degrades malformed notebook JSON to verbatim text instead of throwing', async () => {
+    const filePath = path.join(tempDir, 'broken.ipynb');
+    await fsp.writeFile(filePath, '{ this is not valid json');
+
+    await expect(loadFile(filePath)).resolves.toBe('{ this is not valid json');
+  });
+});

--- a/src/loaders-ipynb.ts
+++ b/src/loaders-ipynb.ts
@@ -1,0 +1,176 @@
+// Issue #652 — structure-aware Jupyter notebook (`.ipynb`) ingest loader.
+//
+// A notebook is JSON, so without a dedicated loader it would either be skipped
+// (no extension match) or — if opted in via `INGEST_EXTRA_EXTENSIONS=.ipynb`
+// against the default text loader — ingested as one opaque JSON blob. That
+// flattens the notebook's natural structure: markdown narrative, code, and
+// outputs all dissolve into a single string of escaped JSON, so a chunk could
+// straddle the boundary between two unrelated cells and retrieval loses the
+// "this code does X, the prose above explains why" adjacency.
+//
+// This module mirrors the CSV/TSV structure-aware precedent (#592 / PR #605):
+// it parses the notebook and re-emits one labelled block per cell, preserving
+// cell position (`cell N/total`) and type (`markdown` / `code` / `raw`) as a
+// short context preface. Code cells additionally fold in selected textual
+// outputs (stdout/stderr streams, `text/plain` results, error name+value).
+// Blocks are separated by a blank line so the downstream recursive splitter
+// prefers cell boundaries when a notebook exceeds one chunk.
+//
+// Output handling (smallest sensible default; see PR description for the
+// alternatives weighed):
+//   - Included: stream text, `execute_result` / `display_data` `text/plain`,
+//     and `error` `ename: evalue`. These are the textual, embeddable outputs.
+//   - Dropped: images and any other binary/rich MIME bundle (`image/png`,
+//     `application/*`, …) — they carry no embeddable text.
+//   - Error tracebacks are summarised to `ename: evalue` rather than dumping
+//     the full ANSI-coded stack, which is mostly noise for retrieval.
+//   - Per-cell output text is truncated to keep a single noisy cell from
+//     dominating its block.
+//
+// Format support: nbformat v4 (`cells[]`) is the primary target. v3 notebooks
+// (`worksheets[].cells[]`, code cells using `input` instead of `source`) are
+// flattened best-effort so older exports still ingest rather than throwing.
+
+import * as path from 'path';
+
+/** Max characters of textual output folded into a single code cell's block. */
+const MAX_CELL_OUTPUT_CHARS = 1200;
+
+interface NotebookOutput {
+  output_type?: string;
+  name?: string;
+  text?: string | string[];
+  data?: Record<string, unknown>;
+  ename?: string;
+  evalue?: string;
+  traceback?: string[];
+}
+
+interface NotebookCell {
+  cell_type?: string;
+  source?: string | string[];
+  /** nbformat v3 code cells store their source under `input`. */
+  input?: string | string[];
+  outputs?: NotebookOutput[];
+}
+
+interface NotebookWorksheet {
+  cells?: NotebookCell[];
+}
+
+interface Notebook {
+  cells?: NotebookCell[];
+  worksheets?: NotebookWorksheet[];
+  nbformat?: number;
+}
+
+/** Notebook `source`/`text` fields are either a string or a string[] of lines. */
+function joinMultiline(value: string | string[] | undefined): string {
+  if (value === undefined) return '';
+  return Array.isArray(value) ? value.join('') : value;
+}
+
+/** Collapse a value to a printable string for `text/plain` MIME bundles. */
+function stringifyTextPlain(value: unknown): string {
+  if (typeof value === 'string') return value;
+  if (Array.isArray(value)) return value.map((v) => (typeof v === 'string' ? v : '')).join('');
+  return '';
+}
+
+/**
+ * Extract the embeddable text from a single output, dropping binary/rich MIME
+ * bundles. Returns an empty string when the output carries no textual payload
+ * (e.g. an image-only `display_data`).
+ */
+function formatOutput(output: NotebookOutput): string {
+  switch (output.output_type) {
+    case 'stream':
+      return joinMultiline(output.text);
+    case 'execute_result':
+    case 'display_data': {
+      const data = output.data ?? {};
+      return stringifyTextPlain(data['text/plain']);
+    }
+    case 'error': {
+      const ename = output.ename ?? 'Error';
+      const evalue = output.evalue ?? '';
+      return evalue ? `${ename}: ${evalue}` : ename;
+    }
+    default:
+      return '';
+  }
+}
+
+/** Join the textual outputs of a code cell, truncating runaway output. */
+function formatCellOutputs(outputs: NotebookOutput[] | undefined): string {
+  if (!outputs || outputs.length === 0) return '';
+  const parts = outputs
+    .map(formatOutput)
+    .map((part) => part.trimEnd())
+    .filter((part) => part.length > 0);
+  if (parts.length === 0) return '';
+  const joined = parts.join('\n');
+  if (joined.length <= MAX_CELL_OUTPUT_CHARS) return joined;
+  return `${joined.slice(0, MAX_CELL_OUTPUT_CHARS)}\n… [output truncated]`;
+}
+
+/** Flatten a notebook's cells across nbformat v4 (`cells`) and v3 (`worksheets`). */
+function collectCells(notebook: Notebook): NotebookCell[] {
+  if (Array.isArray(notebook.cells)) return notebook.cells;
+  if (Array.isArray(notebook.worksheets)) {
+    return notebook.worksheets.flatMap((sheet) => sheet.cells ?? []);
+  }
+  return [];
+}
+
+function formatCell(
+  cell: NotebookCell,
+  cellNumber: number,
+  totalCells: number,
+): string {
+  const cellType = typeof cell.cell_type === 'string' && cell.cell_type.length > 0
+    ? cell.cell_type
+    : 'unknown';
+  // v4 markdown/raw use `source`; v3 code cells use `input`.
+  const body = joinMultiline(cell.source ?? cell.input).trimEnd();
+  const header = `cell ${cellNumber}/${totalCells} (${cellType}):`;
+  const lines = [header];
+  if (body.length > 0) lines.push(body);
+  if (cellType === 'code') {
+    const outputs = formatCellOutputs(cell.outputs);
+    if (outputs.length > 0) {
+      lines.push('output:');
+      lines.push(outputs);
+    }
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Parse a notebook's raw JSON and re-emit it as structure-aware plain text:
+ * a `source_path` header followed by one blank-line-separated block per cell,
+ * each prefaced with its 1-based position, total count, and cell type.
+ *
+ * Throws `SyntaxError` on malformed JSON (the caller surfaces it as a parse
+ * failure, consistent with the {@link Loader} contract). A well-formed JSON
+ * document that is not notebook-shaped (no `cells`/`worksheets`) yields just
+ * the header, which is harmless and keeps the file ingestable.
+ */
+export function formatNotebook(raw: string, filePath: string): string {
+  const notebook = JSON.parse(raw) as Notebook;
+  const cells = collectCells(notebook);
+  const header = `source_path: ${path.basename(filePath)}`;
+  if (cells.length === 0) return header;
+  const blocks = cells.map((cell, index) => formatCell(cell, index + 1, cells.length));
+  return [header, '', ...interleaveBlankLines(blocks)].join('\n').trimEnd();
+}
+
+/** Join blocks with a single blank line between them. */
+function interleaveBlankLines(blocks: readonly string[]): string[] {
+  const out: string[] = [];
+  blocks.forEach((block, index) => {
+    if (index > 0) out.push('');
+    out.push(block);
+  });
+  return out;
+}

--- a/src/loaders.ts
+++ b/src/loaders.ts
@@ -27,6 +27,7 @@ import * as path from 'path';
 import { resolveLargeFileLimits, type KBLargeFilePolicy } from './config/ingest.js';
 import { resolveChunkSize } from './config/indexing.js';
 import { loadWithExtractionCache } from './extraction-cache.js';
+import { formatNotebook } from './loaders-ipynb.js';
 
 /** Loader contract: filePath in, plain text out. Throws on parse failure. */
 export type Loader = (filePath: string) => Promise<string>;
@@ -43,6 +44,8 @@ const HTML_LOADER_NAME = 'html-to-text';
 const HTML_LOADER_VERSION = 1;
 const DELIMITED_TABLE_LOADER_NAME = 'delimited-table';
 const DELIMITED_TABLE_LOADER_VERSION = 1;
+const IPYNB_LOADER_NAME = 'ipynb';
+const IPYNB_LOADER_VERSION = 1;
 
 export type LargeFileLimitKind = 'file_bytes' | 'extracted_text_bytes';
 
@@ -406,6 +409,48 @@ function loadTsv(filePath: string): Promise<string> {
   return loadDelimitedTable(filePath, '\t');
 }
 
+// Issue #652 — structure-aware Jupyter notebook loader. Parses the notebook
+// JSON and re-emits one labelled block per cell (see `loaders-ipynb.ts`)
+// rather than letting the file ride the default text loader as one opaque JSON
+// blob. Mirrors the delimited-table loader's large-file handling and gates the
+// parse behind the content-addressed extraction cache (#279).
+async function loadIpynb(filePath: string): Promise<string> {
+  const limits = resolveLargeFileLimits();
+  const size = await statSize(filePath);
+
+  if (limits.policy === 'truncate') {
+    // A truncated notebook is no longer valid JSON, so parsing the prefix
+    // would throw. Read the whole file (still bounded by the byte limits) and
+    // bound the formatted text afterwards, matching the delimited-table path.
+    const raw = await readUtf8Prefix(
+      filePath,
+      Math.min(size, limits.maxFileBytes, limits.maxExtractedTextBytes),
+    );
+    return applyExtractedTextLimit(filePath, safeFormatNotebook(raw, filePath));
+  }
+
+  enforceFileSizeLimit(filePath, size, limits);
+  const text = await loadWithExtractionCache({
+    filePath,
+    loaderName: IPYNB_LOADER_NAME,
+    loaderVersion: IPYNB_LOADER_VERSION,
+    parse: async (buffer) => safeFormatNotebook(buffer.toString('utf-8'), filePath),
+  });
+  return applyExtractedTextLimit(filePath, text);
+}
+
+// A `.ipynb` whose JSON is malformed (truncated export, hand-edited) should
+// not abort the whole ingest run. Fall back to the raw text so the file is
+// still ingested verbatim — the same outcome the default text loader would
+// have produced before this loader existed.
+function safeFormatNotebook(raw: string, filePath: string): string {
+  try {
+    return formatNotebook(raw, filePath);
+  } catch {
+    return raw;
+  }
+}
+
 // Reentrancy depth for `silencePdfjsConsole` — pdf-parse calls can interleave
 // (the hybrid-search dense and lexical legs both load PDFs in parallel under
 // `--refresh`). Depth-counting ensures the first concurrent caller installs
@@ -552,7 +597,8 @@ async function loadHtml(filePath: string): Promise<string> {
  * fall back to {@link loadText} (read-as-UTF-8); the loader registry only
  * needs an entry when the file format is binary or structured enough that
  * a naive UTF-8 read would be wrong (PDF bytes → U+FFFD noise; HTML →
- * embedded markup tags; CSV/TSV rows → chunks without column context).
+ * embedded markup tags; CSV/TSV rows → chunks without column context;
+ * `.ipynb` → one opaque JSON blob instead of per-cell context).
  * Plain-text formats (`.md`, `.txt`, `.json`, `.yaml`, any extension the
  * operator opts into via `INGEST_EXTRA_EXTENSIONS`) ride the default text
  * loader without needing to be enumerated here.
@@ -563,6 +609,7 @@ export const LOADERS: Readonly<Record<string, Loader>> = Object.freeze({
   '.htm': loadHtml,
   '.csv': loadCsv,
   '.tsv': loadTsv,
+  '.ipynb': loadIpynb,
 });
 
 /** Lowercased dot-prefixed extensions with a non-text loader registered. */


### PR DESCRIPTION
Closes #652

## What

Adds a first-class `.ipynb` loader so Jupyter notebooks are ingested **cell-by-cell** with cell position and type preserved, instead of being dumped as one opaque JSON blob (or silently skipped).

The new module `src/loaders-ipynb.ts` parses the notebook JSON and re-emits structure-aware plain text: a `source_path` header followed by one blank-line-separated block per cell, each prefaced with `cell N/total (cell_type):`. This mirrors the CSV/TSV structure-aware precedent (#592 / PR #605).

## How it routes

- `src/loaders.ts`: registers `.ipynb` → `loadIpynb` in the `LOADERS` registry. `loadIpynb` honours the large-file policy and gates the parse behind the content-addressed extraction cache (#279), exactly like the delimited-table loader.
- `src/file-ingest.ts`: doc comment updated — notebook blocks are blank-line separated so the recursive splitter prefers cell boundaries.
- Like `.csv`/`.tsv`, `.ipynb` is **not** added to the base ingest allowlist; operators opt in via `INGEST_EXTRA_EXTENSIONS=.ipynb`. (Keeps scope narrow and matches the existing structured-loader convention.)

## Output handling (smallest sensible default)

The issue left "which outputs to include" open. Chosen default:

- **Included:** `stream` text (stdout/stderr), `execute_result` / `display_data` `text/plain`, and `error` summarised as `ename: evalue`.
- **Dropped:** images and other binary/rich MIME bundles (`image/png`, `application/*`, …) — no embeddable text.
- **Truncated:** per-cell output capped (1200 chars) so one noisy cell can't dominate its block.
- Error ANSI tracebacks are summarised rather than dumped.

**Alternatives considered:** (a) include full tracebacks — rejected as mostly ANSI noise for retrieval; (b) markdown+code cell *pairing* into one block — deferred, per-cell is simpler and the blank-line separation already keeps adjacent narrative/code retrievable; (c) base-allowlisting `.ipynb` — rejected to match the opt-in CSV/TSV convention.

## Format support

nbformat v4 (`cells[]`) is the primary target. v3 notebooks (`worksheets[].cells[]`, code cells using `input` instead of `source`) are flattened best-effort. Malformed notebook JSON degrades to verbatim text rather than aborting the ingest run.

## Tests

`src/loaders-ipynb.test.ts` (new) covers per-cell blocks, preserved cell-type/position context, output folding, image/binary dropping, error summarisation, blank-line cell separation, output truncation, nbformat v3 back-compat, non-notebook JSON, `.ipynb` registry routing, and malformed-JSON fallback.

```
npx jest src/loaders.test.ts src/loaders-ipynb.test.ts
Test Suites: 2 passed, 2 total
Tests:       43 passed, 43 total
```

`npm run build` passes (clean `tsc`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)