### PR TITLE
feat(mcp): bound query/array/glob inputs on MCP tools (#660)

### DIFF
--- a/src/KnowledgeBaseServer.test.ts
+++ b/src/KnowledgeBaseServer.test.ts
@@ -2554,4 +2554,96 @@ describe('KnowledgeBaseServer handlers', () => {
     expect((result as any).frontmatter.extras).toBeUndefined();
     expect((result as any).frontmatter.arxiv_id).toBe('2604.1');
   });
+
+  // --- #660: bounded MCP tool inputs ----------------------------------------
+  // The zod input schemas registered on the MCP tools must reject oversized
+  // free-form inputs (query text, extensions[]/tags[] arrays, path_glob length
+  // and wildcard complexity) so a hostile client cannot drive unbounded work.
+  // These assert against the ACTUAL schema wired into each tool, not a copy.
+
+  function toolInputSchema(server: any, toolName: string): any {
+    const tool = server['mcp']['_registeredTools'][toolName];
+    if (!tool) throw new Error(`tool ${toolName} not registered`);
+    return tool.inputSchema;
+  }
+
+  // Read the bounds from the same (freshly reset) module instance the server
+  // was built from, so the test sizes track the real wired defaults.
+  async function inputBounds(): Promise<{
+    KB_MAX_QUERY_CHARS: number;
+    KB_MAX_FILTER_ITEMS: number;
+    KB_MAX_GLOB_CHARS: number;
+    KB_MAX_GLOB_WILDCARDS: number;
+  }> {
+    return import('./KnowledgeBaseServer.js');
+  }
+
+  it('retrieve_knowledge rejects a query longer than KB_MAX_QUERY_CHARS', async () => {
+    await setRetrieveEnv();
+    const server = await freshServer();
+    const { KB_MAX_QUERY_CHARS } = await inputBounds();
+    const schema = toolInputSchema(server, 'retrieve_knowledge');
+    // At the cap: accepted.
+    expect(schema.safeParse({ query: 'a'.repeat(KB_MAX_QUERY_CHARS) }).success).toBe(true);
+    // One over the cap: rejected.
+    const over = schema.safeParse({ query: 'a'.repeat(KB_MAX_QUERY_CHARS + 1) });
+    expect(over.success).toBe(false);
+    expect(JSON.stringify(over.error)).toContain('at most');
+  });
+
+  it('retrieve_knowledge rejects extensions[] and tags[] longer than KB_MAX_FILTER_ITEMS', async () => {
+    await setRetrieveEnv();
+    const server = await freshServer();
+    const { KB_MAX_FILTER_ITEMS } = await inputBounds();
+    const schema = toolInputSchema(server, 'retrieve_knowledge');
+    const okItems = Array.from({ length: KB_MAX_FILTER_ITEMS }, () => '.md');
+    const tooMany = Array.from({ length: KB_MAX_FILTER_ITEMS + 1 }, () => '.md');
+    expect(schema.safeParse({ query: 'q', extensions: okItems }).success).toBe(true);
+    expect(schema.safeParse({ query: 'q', extensions: tooMany }).success).toBe(false);
+    expect(schema.safeParse({ query: 'q', tags: okItems }).success).toBe(true);
+    expect(schema.safeParse({ query: 'q', tags: tooMany }).success).toBe(false);
+  });
+
+  it('retrieve_knowledge rejects an over-long or over-complex path_glob', async () => {
+    await setRetrieveEnv();
+    const server = await freshServer();
+    const { KB_MAX_GLOB_CHARS, KB_MAX_GLOB_WILDCARDS } = await inputBounds();
+    const schema = toolInputSchema(server, 'retrieve_knowledge');
+    // Within bounds: accepted.
+    expect(schema.safeParse({ query: 'q', path_glob: 'runbooks/**' }).success).toBe(true);
+    // Over the length cap (non-wildcard chars, so only length triggers).
+    const longGlob = 'a'.repeat(KB_MAX_GLOB_CHARS + 1);
+    expect(schema.safeParse({ query: 'q', path_glob: longGlob }).success).toBe(false);
+    // Over the wildcard-complexity cap (short string, only wildcards trigger).
+    const complexGlob = '*'.repeat(KB_MAX_GLOB_WILDCARDS + 1);
+    expect(complexGlob.length).toBeLessThanOrEqual(KB_MAX_GLOB_CHARS);
+    const complex = schema.safeParse({ query: 'q', path_glob: complexGlob });
+    expect(complex.success).toBe(false);
+    expect(JSON.stringify(complex.error)).toContain('wildcard');
+  });
+
+  it('ask_knowledge rejects a query longer than KB_MAX_QUERY_CHARS', async () => {
+    await setRetrieveEnv();
+    const server = await freshServer();
+    const { KB_MAX_QUERY_CHARS } = await inputBounds();
+    const schema = toolInputSchema(server, 'ask_knowledge');
+    expect(schema.safeParse({ query: 'a'.repeat(KB_MAX_QUERY_CHARS) }).success).toBe(true);
+    expect(schema.safeParse({ query: 'a'.repeat(KB_MAX_QUERY_CHARS + 1) }).success).toBe(false);
+  });
+
+  it('diff_index bounds per-query length and the queries[] array size', async () => {
+    await setRetrieveEnv();
+    const server = await freshServer();
+    const { KB_MAX_QUERY_CHARS, KB_MAX_FILTER_ITEMS } = await inputBounds();
+    const schema = toolInputSchema(server, 'diff_index');
+    const base = { before: '1', after: '2' };
+    expect(schema.safeParse({ ...base, queries: ['ok'] }).success).toBe(true);
+    // A single over-long query is rejected.
+    expect(
+      schema.safeParse({ ...base, queries: ['a'.repeat(KB_MAX_QUERY_CHARS + 1)] }).success,
+    ).toBe(false);
+    // Too many queries is rejected.
+    const tooMany = Array.from({ length: KB_MAX_FILTER_ITEMS + 1 }, () => 'q');
+    expect(schema.safeParse({ ...base, queries: tooMany }).success).toBe(false);
+  });
 });

--- a/src/KnowledgeBaseServer.ts
+++ b/src/KnowledgeBaseServer.ts
@@ -144,6 +144,57 @@ import { callChatCompletion } from './llm-client.js';
 const SERVER_NAME = 'knowledge-base-server';
 const SERVER_VERSION = '0.1.0';
 
+// ---------------------------------------------------------------------------
+// MCP tool input bounds (#660).
+// Bound the most attacker-influenced free-form tool inputs — query text,
+// extensions[]/tags[] filter arrays, and path_glob — so a malformed or hostile
+// client cannot drive unbounded work (huge embeddings, pathological minimatch
+// evaluation) through retrieve_knowledge and friends, especially over the
+// remote HTTP/SSE transport. Mirrors the existing task_context truncation
+// (2000 chars, relevance-gate.ts) and the numeric caps (context_window max 5).
+// Defaults are generous so legitimate large-but-reasonable inputs are
+// unaffected; each is overridable via an env var without touching
+// config/schema.ts. Violations surface as zod VALIDATION errors at the MCP
+// tool boundary.
+// ---------------------------------------------------------------------------
+
+function parsePositiveIntEnv(raw: string | undefined, fallback: number): number {
+  if (raw === undefined || raw.trim() === '') return fallback;
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed <= 0) return fallback;
+  return parsed;
+}
+
+export const KB_MAX_QUERY_CHARS = parsePositiveIntEnv(process.env.KB_MAX_QUERY_CHARS, 8192);
+export const KB_MAX_FILTER_ITEMS = parsePositiveIntEnv(process.env.KB_MAX_FILTER_ITEMS, 64);
+export const KB_MAX_GLOB_CHARS = parsePositiveIntEnv(process.env.KB_MAX_GLOB_CHARS, 1024);
+export const KB_MAX_GLOB_WILDCARDS = parsePositiveIntEnv(process.env.KB_MAX_GLOB_WILDCARDS, 64);
+
+const boundedQueryString = () =>
+  z.string().max(
+    KB_MAX_QUERY_CHARS,
+    `query must be at most ${KB_MAX_QUERY_CHARS} characters`,
+  );
+
+const boundedFilterArray = () =>
+  z.array(z.string()).max(
+    KB_MAX_FILTER_ITEMS,
+    `at most ${KB_MAX_FILTER_ITEMS} items are allowed`,
+  );
+
+// path_glob: cap raw length AND wildcard count. minimatch translates each
+// wildcard into regex alternation; an unbounded wildcard count is the
+// complexity lever a hostile glob would pull, so a length cap alone is
+// insufficient.
+const boundedGlobString = () =>
+  z
+    .string()
+    .max(KB_MAX_GLOB_CHARS, `path_glob must be at most ${KB_MAX_GLOB_CHARS} characters`)
+    .refine(
+      (value) => (value.match(/[*?]/g)?.length ?? 0) <= KB_MAX_GLOB_WILDCARDS,
+      `path_glob must contain at most ${KB_MAX_GLOB_WILDCARDS} wildcard characters`,
+    );
+
 function mcpErrorContent(error: Error): TextContent {
   const code = error instanceof KBError
     ? error.code
@@ -304,7 +355,7 @@ export class KnowledgeBaseServer {
       'retrieve_knowledge',
       RETRIEVE_KNOWLEDGE_DESCRIPTION,
       {
-        query: z.string().describe('The search query to use for retrieving similar chunks from the knowledge base.'),
+        query: boundedQueryString().describe('The search query to use for retrieving similar chunks from the knowledge base.'),
         knowledge_base_name: z.string().optional().describe('The name of the knowledge base to search. If omitted, all available knowledge bases are considered.'),
         threshold: z.number().optional().describe('The maximum similarity score threshold for returned documents. Defaults to 2 if not specified.'),
         // RFC 013 M3 §4.5 — optional override of the active embedding model.
@@ -313,9 +364,9 @@ export class KnowledgeBaseServer {
         model_name: z.string().optional().describe('The model_id of an alternate embedding model to query (e.g. "openai__text-embedding-3-small"). If omitted, the active model is used. Run list_models for available ids.'),
         // Issue #53 — metadata POST-filters. Applied after FAISS returns,
         // ANDed with each other and with knowledge_base_name + threshold.
-        extensions: z.array(z.string()).optional().describe('Limit results to chunks whose source file has one of these extensions (e.g. [".md", ".pdf"]). Case-insensitive; leading dot optional.'),
-        path_glob: z.string().optional().describe('Limit results to chunks whose KB-internal relative path matches this glob (e.g. "runbooks/**"). The KB-name segment is stripped before matching.'),
-        tags: z.array(z.string()).optional().describe('Limit results to chunks whose source file has ALL of these tags in its YAML frontmatter.'),
+        extensions: boundedFilterArray().optional().describe('Limit results to chunks whose source file has one of these extensions (e.g. [".md", ".pdf"]). Case-insensitive; leading dot optional.'),
+        path_glob: boundedGlobString().optional().describe('Limit results to chunks whose KB-internal relative path matches this glob (e.g. "runbooks/**"). The KB-name segment is stripped before matching.'),
+        tags: boundedFilterArray().optional().describe('Limit results to chunks whose source file has ALL of these tags in its YAML frontmatter.'),
         since: z.string().optional().describe('Limit dense results to chunks whose current source-file mtime is at or after this bound. Accepts durations like "30d"/"24h" or ISO dates/timestamps; mtime can differ from indexed-content time on stale indexes.'),
         until: z.string().optional().describe('Limit dense results to chunks whose current source-file mtime is at or before this bound. Accepts durations like "30d"/"24h" or ISO dates/timestamps; mtime can differ from indexed-content time on stale indexes.'),
         context_before: z.number().int().min(0).max(5).optional().describe('Opt-in neighbor context: include up to this many preceding chunks from the same source around each dense semantic match. Defaults to 0.'),
@@ -338,7 +389,7 @@ export class KnowledgeBaseServer {
       'ask_knowledge',
       ASK_KNOWLEDGE_DESCRIPTION,
       {
-        query: z.string().describe('Question to answer from retrieved knowledge-base snippets.'),
+        query: boundedQueryString().describe('Question to answer from retrieved knowledge-base snippets.'),
         knowledge_base_name: z.string().optional().describe('Name of a single knowledge base to search. If omitted, all available knowledge bases are considered.'),
         model_name: z.string().optional().describe('Registered embedding model_id to use for retrieval. If omitted, the active model is used.'),
         llm_profile: z.string().optional().describe('Saved kb llm profile name to use for answer generation.'),
@@ -379,7 +430,7 @@ export class KnowledgeBaseServer {
       {
         before: z.string().describe('BEFORE index version number, relative directory, or absolute version directory.'),
         after: z.string().describe('AFTER index version number, relative directory, or absolute version directory.'),
-        queries: z.array(z.string()).min(1).describe('Plaintext queries to run against both index versions.'),
+        queries: z.array(boundedQueryString()).min(1).max(KB_MAX_FILTER_ITEMS).describe('Plaintext queries to run against both index versions.'),
         model_name: z.string().optional().describe('Optional registered embedding model id. If omitted, the active model is used.'),
         knowledge_base_name: z.string().optional().describe('Optional KB scope applied to every query.'),
         top_k: z.number().int().min(1).max(100).optional().describe('Top-K results per query. Default 10.'),


### PR DESCRIPTION
## Summary

Adds explicit, configurable upper bounds to the most attacker-influenced free-form MCP tool inputs in `src/KnowledgeBaseServer.ts`, so a malformed or hostile client cannot drive unbounded work (huge embeddings, pathological `minimatch` evaluation) through `retrieve_knowledge` and friends — especially over the remote HTTP/SSE transport.

Bounds applied to the zod input schemas:

| Field | Tool(s) | Bound | Default | Env override |
| --- | --- | --- | --- | --- |
| `query` | `retrieve_knowledge`, `ask_knowledge`, `diff_index` (per item) | max chars | 8192 | `KB_MAX_QUERY_CHARS` |
| `extensions[]`, `tags[]` | `retrieve_knowledge` | max item count | 64 | `KB_MAX_FILTER_ITEMS` |
| `path_glob` | `retrieve_knowledge` | max length | 1024 | `KB_MAX_GLOB_CHARS` |
| `path_glob` | `retrieve_knowledge` | max `*`/`?` wildcard count | 64 | `KB_MAX_GLOB_WILDCARDS` |
| `queries[]` | `diff_index` | max array size | 64 | `KB_MAX_FILTER_ITEMS` |

These mirror the existing accepted precedents: the `task_context` truncation (2000 chars) and the existing numeric caps (`context_window` max 5).

## Design choices (issue left these open)

- **Reject vs clamp:** chose **reject** via zod `.max()` / `.refine()`. It's the smallest implementation, surfaces as a clear zod `VALIDATION` error at the tool boundary, is consistent with the existing numeric `.max()` bounds, and makes the limits visible in each tool's published `inputSchema`.
- **Exact limits:** generous defaults so legitimate large-but-reasonable inputs are unaffected.
- **Configurability:** inline constants parsed from env vars (mirroring the `KB_INGEST_ENABLED` style) — **no edit to `config/schema.ts`**, per the existing config conventions.
- **`path_glob` complexity:** a length cap alone is insufficient since `minimatch` expands each wildcard, so the wildcard count is also capped.

## Tests

Added focused tests in `src/KnowledgeBaseServer.test.ts` asserting oversized query / `extensions[]` / `tags[]` / `path_glob` (length **and** wildcard count) / `diff_index` queries are rejected, while at-the-cap inputs pass. Tests assert against the **actual** zod schema wired into each registered MCP tool, not a copy.

`npx jest KnowledgeBaseServer` → 85/85 pass; `npm run build` clean.

Closes #660

🤖 Generated with [Claude Code](https://claude.com/claude-code)