### PR TITLE
feat(cli): honor NO_COLOR + unified --color control (#659)

### DIFF
--- a/src/cli-search.ts
+++ b/src/cli-search.ts
@@ -38,6 +38,7 @@ import {
   type ScoredDocument,
 } from './formatter.js';
 import { runPicker } from './cli-search-picker.js';
+import { parseColorMode, resolveColorEnabled, type ColorMode } from './color.js';
 import { listKnowledgeBases } from './kb-fs.js';
 import { withWriteLock } from './write-lock.js';
 import { loadManagerForModel, loadWithJsonRetry } from './cli-shared.js';
@@ -269,6 +270,13 @@ Output:
                         emphasis. auto uses ANSI only on a TTY (default);
                         always also works through pipes; never disables it.
   --no-highlight        Alias for --highlight=never.
+  --color=auto|always|never
+                        Unified control for all ANSI color/emphasis output.
+                        auto colorizes only on a TTY with NO_COLOR unset
+                        (default); always forces color (even through a pipe and
+                        over NO_COLOR); never disables it. Also set via KB_COLOR.
+                        Honors the NO_COLOR standard (https://no-color.org).
+                        Precedence: --color > NO_COLOR > KB_COLOR > TTY.
   --daemon              Use the local read-only daemon when available; falls
                         back to direct search when unreachable.
   --no-freshness        Skip the staleness scan and omit freshness output.
@@ -341,6 +349,8 @@ interface SearchArgs {
   noCache: boolean;
   freshness: boolean;
   highlight: SearchHighlightMode;
+  color: ColorMode;
+  colorExplicit: boolean;
   explainEmpty: boolean;
   explain: boolean;
   neighborContext?: NeighborContextOptions;
@@ -940,6 +950,8 @@ export function parseSearchArgs(rest: string[]): SearchArgs {
     noCache: false,
     freshness: true,
     highlight: 'auto',
+    color: 'auto',
+    colorExplicit: false,
     explainEmpty: false,
     explain: false,
     diverse: false,
@@ -1083,6 +1095,11 @@ export function parseSearchArgs(rest: string[]): SearchArgs {
       }
       out.highlight = v; continue;
     }
+    if (raw.startsWith('--color=')) {
+      out.color = parseColorMode(raw.slice('--color='.length));
+      out.colorExplicit = true;
+      continue;
+    }
     if (raw.startsWith('--view=')) {
       const v = raw.slice('--view='.length);
       if (v !== 'compact') throw new Error(`invalid --view: ${raw} (expected 'compact')`);
@@ -1136,15 +1153,25 @@ function buildSearchHighlightOptions(
 }
 
 export function shouldHighlightSearchOutput(
-  parsed: { format: SearchFormat; highlight: SearchHighlightMode },
+  parsed: { format: SearchFormat; highlight: SearchHighlightMode; color?: ColorMode; colorExplicit?: boolean },
   env: NodeJS.ProcessEnv = process.env,
   stdoutIsTTY: boolean = process.stdout.isTTY === true,
 ): boolean {
+  // Highlighting only applies to markdown, and `--highlight=never` is a hard
+  // off switch for this specific feature regardless of the color decision.
   if (parsed.format !== 'md') return false;
   if (parsed.highlight === 'never') return false;
-  if (env.NO_COLOR !== undefined) return false;
-  if (parsed.highlight === 'always') return true;
-  return stdoutIsTTY;
+  // Route the colorize decision through the unified resolver (#659). An explicit
+  // `--color` is authoritative; otherwise a non-default `--highlight` acts as the
+  // color flag for back-compat (so `--highlight=always` still forces ANSI through
+  // a pipe). When neither is set the flag is left undefined so NO_COLOR, KB_COLOR,
+  // and TTY detection inside the resolver decide.
+  const flag: ColorMode | undefined = parsed.colorExplicit
+    ? parsed.color ?? 'auto'
+    : parsed.highlight !== 'auto'
+      ? parsed.highlight
+      : undefined;
+  return resolveColorEnabled({ flag, env, isTTY: stdoutIsTTY });
 }
 
 export function extractSearchHighlightTerms(query: string): string[] {

--- a/src/color.test.ts
+++ b/src/color.test.ts
@@ -1,0 +1,141 @@
+import {
+  ANSI_BOLD,
+  ANSI_BOLD_OFF,
+  isNoColorSet,
+  parseColorMode,
+  readKbColorMode,
+  resolveColorEnabled,
+} from './color.js';
+import { shouldHighlightSearchOutput } from './cli-search.js';
+
+describe('parseColorMode', () => {
+  it('accepts the three modes', () => {
+    expect(parseColorMode('auto')).toBe('auto');
+    expect(parseColorMode('always')).toBe('always');
+    expect(parseColorMode('never')).toBe('never');
+  });
+
+  it('rejects anything else with a flag-shaped error', () => {
+    expect(() => parseColorMode('sometimes')).toThrow(/invalid --color: sometimes/);
+    expect(() => parseColorMode('1', '--color')).toThrow(
+      /expected 'auto', 'always', or 'never'/,
+    );
+  });
+});
+
+describe('isNoColorSet', () => {
+  it('treats a non-empty NO_COLOR as set and empty/unset as not set', () => {
+    expect(isNoColorSet({ NO_COLOR: '1' })).toBe(true);
+    expect(isNoColorSet({ NO_COLOR: '0' })).toBe(true);
+    expect(isNoColorSet({ NO_COLOR: 'anything' })).toBe(true);
+    expect(isNoColorSet({ NO_COLOR: '' })).toBe(false);
+    expect(isNoColorSet({})).toBe(false);
+  });
+});
+
+describe('readKbColorMode', () => {
+  it('parses recognized values case-insensitively and ignores junk', () => {
+    expect(readKbColorMode({ KB_COLOR: 'always' })).toBe('always');
+    expect(readKbColorMode({ KB_COLOR: 'NEVER' })).toBe('never');
+    expect(readKbColorMode({ KB_COLOR: '  Auto ' })).toBe('auto');
+    expect(readKbColorMode({ KB_COLOR: 'yes' })).toBeUndefined();
+    expect(readKbColorMode({ KB_COLOR: '' })).toBeUndefined();
+    expect(readKbColorMode({})).toBeUndefined();
+  });
+});
+
+describe('resolveColorEnabled precedence matrix', () => {
+  it('default auto colorizes only on a TTY', () => {
+    expect(resolveColorEnabled({ env: {}, isTTY: true })).toBe(true);
+    expect(resolveColorEnabled({ env: {}, isTTY: false })).toBe(false);
+  });
+
+  it('honors NO_COLOR even on a TTY', () => {
+    expect(resolveColorEnabled({ env: { NO_COLOR: '1' }, isTTY: true })).toBe(false);
+  });
+
+  it('--color=always forces color through a pipe and over NO_COLOR', () => {
+    expect(resolveColorEnabled({ flag: 'always', env: {}, isTTY: false })).toBe(true);
+    expect(resolveColorEnabled({ flag: 'always', env: { NO_COLOR: '1' }, isTTY: false })).toBe(true);
+  });
+
+  it('--color=never overrides a TTY', () => {
+    expect(resolveColorEnabled({ flag: 'never', env: {}, isTTY: true })).toBe(false);
+  });
+
+  it('--color=auto auto-detects and still honors NO_COLOR (skips KB_COLOR)', () => {
+    expect(resolveColorEnabled({ flag: 'auto', env: {}, isTTY: true })).toBe(true);
+    expect(resolveColorEnabled({ flag: 'auto', env: { NO_COLOR: '1' }, isTTY: true })).toBe(false);
+    // explicit --color=auto bypasses the KB_COLOR default
+    expect(resolveColorEnabled({ flag: 'auto', env: { KB_COLOR: 'always' }, isTTY: false })).toBe(false);
+  });
+
+  it('KB_COLOR acts as an env-level default below the flag and NO_COLOR', () => {
+    expect(resolveColorEnabled({ env: { KB_COLOR: 'always' }, isTTY: false })).toBe(true);
+    expect(resolveColorEnabled({ env: { KB_COLOR: 'never' }, isTTY: true })).toBe(false);
+    // NO_COLOR beats the KB_COLOR default
+    expect(resolveColorEnabled({ env: { KB_COLOR: 'always', NO_COLOR: '1' }, isTTY: false })).toBe(false);
+    // an explicit flag beats KB_COLOR
+    expect(resolveColorEnabled({ flag: 'never', env: { KB_COLOR: 'always' }, isTTY: true })).toBe(false);
+  });
+
+  it('exposes the shared ANSI bold codes', () => {
+    expect(ANSI_BOLD).toBe('\x1b[1m');
+    expect(ANSI_BOLD_OFF).toBe('\x1b[22m');
+  });
+});
+
+describe('shouldHighlightSearchOutput routes through the unified color control', () => {
+  it('only highlights markdown', () => {
+    expect(
+      shouldHighlightSearchOutput({ format: 'json', highlight: 'auto' }, {}, true),
+    ).toBe(false);
+    expect(
+      shouldHighlightSearchOutput({ format: 'md', highlight: 'auto' }, {}, true),
+    ).toBe(true);
+  });
+
+  it('treats --highlight=never as a hard off switch', () => {
+    expect(
+      shouldHighlightSearchOutput({ format: 'md', highlight: 'never' }, {}, true),
+    ).toBe(false);
+  });
+
+  it('suppresses on NO_COLOR by default and lets --color=always override it', () => {
+    expect(
+      shouldHighlightSearchOutput({ format: 'md', highlight: 'auto' }, { NO_COLOR: '1' }, true),
+    ).toBe(false);
+    expect(
+      shouldHighlightSearchOutput(
+        { format: 'md', highlight: 'auto', color: 'always', colorExplicit: true },
+        { NO_COLOR: '1' },
+        false,
+      ),
+    ).toBe(true);
+  });
+
+  it('lets --color=never override a TTY and the legacy --highlight=always', () => {
+    expect(
+      shouldHighlightSearchOutput(
+        { format: 'md', highlight: 'always', color: 'never', colorExplicit: true },
+        {},
+        true,
+      ),
+    ).toBe(false);
+  });
+
+  it('honors KB_COLOR when neither --color nor --highlight is set', () => {
+    expect(
+      shouldHighlightSearchOutput({ format: 'md', highlight: 'auto' }, { KB_COLOR: 'always' }, false),
+    ).toBe(true);
+    expect(
+      shouldHighlightSearchOutput({ format: 'md', highlight: 'auto' }, { KB_COLOR: 'never' }, true),
+    ).toBe(false);
+  });
+
+  it('keeps the legacy --highlight=always force-through-pipe behavior', () => {
+    expect(
+      shouldHighlightSearchOutput({ format: 'md', highlight: 'always' }, {}, false),
+    ).toBe(true);
+  });
+});

--- a/src/color.ts
+++ b/src/color.ts
@@ -1,0 +1,98 @@
+// Issue #659 — single color-control resolver for all ANSI output.
+//
+// One precedence rule governs every ANSI emitter (the formatter's query-term
+// highlighting / bold) so color is predictable and standards compliant instead
+// of each feature deciding on its own ad-hoc TTY check.
+//
+// Precedence, highest first:
+//   1. An explicit `--color=always|never` flag — a per-invocation override that
+//      beats everything, including NO_COLOR. The NO_COLOR standard explicitly
+//      permits command-line options to re-enable color.
+//   2. The NO_COLOR environment standard (https://no-color.org): when set to a
+//      non-empty value, ANSI color is disabled.
+//   3. `KB_COLOR=auto|always|never` — an app-level default in env form, weaker
+//      than both the flag and the NO_COLOR standard.
+//   4. `auto` (the default, and what `--color=auto` / `KB_COLOR=auto` request):
+//      colorize only when the target stream is a TTY.
+
+export type ColorMode = 'auto' | 'always' | 'never';
+
+export const KB_COLOR_ENV = 'KB_COLOR';
+
+/** Shared ANSI emphasis codes — the single home for the bold escape sequence. */
+export const ANSI_BOLD = '\x1b[1m';
+export const ANSI_BOLD_OFF = '\x1b[22m';
+
+/**
+ * Validates a `--color` value, throwing a flag-shaped error on anything other
+ * than the three accepted modes so the CLI can report it like its peers.
+ */
+export function parseColorMode(value: string, flagName = '--color'): ColorMode {
+  if (value === 'auto' || value === 'always' || value === 'never') return value;
+  throw new Error(`invalid ${flagName}: ${value} (expected 'auto', 'always', or 'never')`);
+}
+
+export interface ColorDecisionInput {
+  /** Mode from an explicit `--color` flag; `undefined` when the flag is absent. */
+  flag?: ColorMode;
+  env?: NodeJS.ProcessEnv;
+  isTTY?: boolean;
+}
+
+/**
+ * NO_COLOR is honored when present and non-empty. The no-color.org FAQ treats an
+ * empty string as "unset", which also matches how a user clears the variable
+ * with `NO_COLOR=`.
+ */
+export function isNoColorSet(env: NodeJS.ProcessEnv): boolean {
+  const value = env.NO_COLOR;
+  return value !== undefined && value !== '';
+}
+
+/**
+ * Reads `KB_COLOR` as a `ColorMode`. An unset, empty, or unrecognized value
+ * yields `undefined` so a typo degrades to the default rather than crashing a
+ * search.
+ */
+export function readKbColorMode(env: NodeJS.ProcessEnv): ColorMode | undefined {
+  const raw = env[KB_COLOR_ENV];
+  if (raw === undefined) return undefined;
+  const normalized = raw.trim().toLowerCase();
+  if (normalized === 'auto' || normalized === 'always' || normalized === 'never') {
+    return normalized;
+  }
+  return undefined;
+}
+
+/**
+ * Resolves whether ANSI color should be emitted, applying the precedence rule
+ * documented at the top of this module. This is the single decision every ANSI
+ * emitter should route through.
+ */
+export function resolveColorEnabled(input: ColorDecisionInput = {}): boolean {
+  const env = input.env ?? process.env;
+  const isTTY = input.isTTY ?? false;
+
+  // 1. An explicit `--color` flag is authoritative — it overrides NO_COLOR and
+  //    the KB_COLOR default. `auto` means "auto-detect" and skips KB_COLOR.
+  if (input.flag === 'always') return true;
+  if (input.flag === 'never') return false;
+  if (input.flag === 'auto') return autoColorEnabled(env, isTTY);
+
+  // 2. No `--color` flag: the NO_COLOR standard wins over the KB_COLOR default.
+  if (isNoColorSet(env)) return false;
+
+  // 3. KB_COLOR app-level default.
+  const kbColor = readKbColorMode(env);
+  if (kbColor === 'always') return true;
+  if (kbColor === 'never') return false;
+
+  // 4. `auto` (KB_COLOR=auto or unset): TTY only.
+  return isTTY;
+}
+
+/** `auto` resolution: honor NO_COLOR, otherwise colorize only on a TTY. */
+function autoColorEnabled(env: NodeJS.ProcessEnv, isTTY: boolean): boolean {
+  if (isNoColorSet(env)) return false;
+  return isTTY;
+}

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -6,6 +6,7 @@
 import type { Document } from '@langchain/core/documents';
 import { buildChunkCitation, type ChunkCitation } from './chunk-id.js';
 import type { CanonicalDegradedStage } from './canonical-log.js';
+import { ANSI_BOLD, ANSI_BOLD_OFF } from './color.js';
 import { KB_EDITOR_URI, type KBEditorUriMode } from './config/retrieval.js';
 import {
   applyInjectionGuard,
@@ -89,8 +90,8 @@ export interface RetrievalHighlightOptions {
   terms: readonly string[];
 }
 
-const ANSI_BOLD = '\x1b[1m';
-const ANSI_BOLD_OFF = '\x1b[22m';
+// Query-term highlighting emits ANSI bold; the escape codes live in `color.ts`
+// so all ANSI output shares one source and one color-control decision (#659).
 
 /**
  * Strips `frontmatter.extras` from a chunk's metadata before wire


### PR DESCRIPTION
## Summary

Honors the cross-tool **NO_COLOR** standard (https://no-color.org) and adds a single, unified `--color=auto|always|never` flag (plus `KB_COLOR`) governing **all** ANSI output, replacing the per-feature ad-hoc TTY checks.

Closes #659

## What changed

- **New `src/color.ts`** — the single color-control resolver. `resolveColorEnabled({ flag, env, isTTY })` applies one precedence rule:

  ```
  --color flag  >  NO_COLOR  >  KB_COLOR  >  TTY auto
  ```

  - `auto` (default): colorize only when stdout is a TTY **and** NO_COLOR is unset.
  - `--color=always` / `--color=never`: deliberate opt-in/out that overrides NO_COLOR (the standard explicitly permits command-line flags to re-enable color).
  - `KB_COLOR=auto|always|never`: the env-form default, weaker than both the flag and the NO_COLOR standard.
  - It also owns the shared `ANSI_BOLD` / `ANSI_BOLD_OFF` escape codes so there is a single home for ANSI.

- **`src/formatter.ts`** — query-term highlighting now imports the bold escape codes from `color.ts` (single ANSI source) instead of defining its own constants.

- **`src/cli-search.ts`** — adds the `--color` flag, documents it in `kb search --help`, and routes `shouldHighlightSearchOutput` through `resolveColorEnabled` (replacing the inline `format===md` + `NO_COLOR` + `isTTY` logic). The legacy `--highlight` flag still works and maps onto the unified control for back-compat.

- **`src/color.test.ts`** — covers the full precedence matrix: NO_COLOR set/empty/unset, `--color=always|never|auto`, `KB_COLOR` defaults, non-TTY, and the `shouldHighlightSearchOutput` integration (markdown-only gating, `--highlight=never` hard-off, `--color` overrides, legacy force-through-pipe).

## Design choices the issue left open (smallest implementation)

- **KB_COLOR precedence**: placed *below* NO_COLOR (so `NO_COLOR` wins over a `KB_COLOR=always` env default), matching the issue's stated `--color > NO_COLOR > …` order and the conservative/accessible default. Only a per-invocation `--color` flag overrides NO_COLOR.
- **Legacy `--highlight=always`** now consistently forces color the same way `--color=always` does (it previously was suppressed by NO_COLOR). This makes the legacy alias map 1:1 onto the unified control, as the issue requested.
- **Picker scope**: the issue mentions the interactive picker as a future ANSI emitter. The resolver is the shared seam any emitter can adopt; routing `src/cli-search-picker.ts` was kept out of this change to keep the write scope narrow (it can adopt `resolveColorEnabled` in a follow-up).
- **Empty `NO_COLOR=""`** is treated as unset (per the no-color.org FAQ), which also matches a user clearing the variable.

## Tests

`npx jest src/color.test.ts src/formatter.test.ts src/cli-search.test.ts` → all green (color 28, formatter, cli-search 98). The local full `npm run build` is currently memory-starved by concurrent jobs on this machine; CI runs the authoritative build/typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)