### PR TITLE
feat(reranker): disk-tiered persistent rerank-score cache (#646)

### DIFF
--- a/src/config/reranker.ts
+++ b/src/config/reranker.ts
@@ -2,6 +2,50 @@ export const DEFAULT_RERANK_MODEL = 'Xenova/ms-marco-MiniLM-L-6-v2';
 export const DEFAULT_RERANK_TOP_N = 40;
 export const MAX_RERANK_TOP_N = 1000;
 
+// ---------------------------------------------------------------------------
+// Disk-tiered rerank-score cache configuration (#646).
+//
+// The cross-encoder is the most expensive query-time stage and its score cache
+// has been in-process only (InMemoryRerankScoreCache). KB_RERANK_CACHE opts in
+// to the persistent L1-memory + disk cache (DiskTieredRerankScoreCache), so
+// rerank scores survive process exit and are reused across cold `kb` CLI
+// invocations — mirroring the query embedding cache (ADR 0009).
+//
+// Opt-in (default off): unlike KB_QUERY_CACHE, the rerank cache is disabled by
+// default so existing behavior — an in-memory cache that leaves no on-disk
+// artifacts — is preserved unless an operator explicitly enables it.
+// ---------------------------------------------------------------------------
+
+export const DEFAULT_RERANK_CACHE_DISK_MAX_BYTES = 64 * 1024 * 1024;
+
+/**
+ * Whether the disk-tiered rerank-score cache is enabled. Opt-in: only the
+ * affirmative aliases (`on`/`true`/`1`/`enabled`) turn it on; anything else —
+ * including unset — leaves it off.
+ */
+export function isRerankCacheEnabled(raw: string | undefined = process.env.KB_RERANK_CACHE): boolean {
+  const value = (raw ?? '').trim().toLowerCase();
+  return value === 'on' || value === 'true' || value === '1' || value === 'enabled';
+}
+
+/**
+ * Resolve the disk-tier size bound in bytes. KB_RERANK_CACHE_DISK_MAX_BYTES is
+ * interpreted directly as a byte count (it is the bound the issue specifies).
+ * A missing, blank, non-numeric, or non-positive value falls back to the 64 MiB
+ * default, so the disk tier can never be left silently unbounded by a malformed
+ * setting.
+ */
+export function resolveRerankCacheDiskMaxBytes(
+  raw: string | undefined = process.env.KB_RERANK_CACHE_DISK_MAX_BYTES,
+): number {
+  const parsed = raw === undefined || raw.trim() === '' ? NaN : Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_RERANK_CACHE_DISK_MAX_BYTES;
+  return Math.floor(parsed);
+}
+
+export const KB_RERANK_CACHE_ENABLED = isRerankCacheEnabled();
+export const KB_RERANK_CACHE_DISK_MAX_BYTES = resolveRerankCacheDiskMaxBytes();
+
 export type RerankOverride = 'on' | 'off' | undefined;
 
 export interface RerankerConfig {

--- a/src/rerank-cache-disk.test.ts
+++ b/src/rerank-cache-disk.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from '@jest/globals';
+import * as fs from 'fs';
+import * as fsp from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  DiskTieredRerankScoreCache,
+  normalizeRerankQuery,
+  rerankScoreCacheKey,
+  rerankScoreCacheRoot,
+} from './rerank-cache-disk.js';
+import { isRerankCacheEnabled, resolveRerankCacheDiskMaxBytes } from './config/reranker.js';
+
+async function tempIndexPath(prefix: string): Promise<string> {
+  const dir = await fsp.mkdtemp(path.join(os.tmpdir(), prefix));
+  return path.join(dir, '.faiss');
+}
+
+const MODEL = 'Xenova/ms-marco-MiniLM-L-6-v2';
+
+describe('DiskTieredRerankScoreCache (#646)', () => {
+  it('persists scores across cache instances via the disk tier', async () => {
+    const indexPath = await tempIndexPath('kb-rerank-cache-roundtrip-');
+    try {
+      const first = new DiskTieredRerankScoreCache({ indexPath, enabled: true });
+      expect(first.get(MODEL, 'how do rollbacks work', 'candidate body')).toBeNull();
+      first.set(MODEL, 'how do rollbacks work', 'candidate body', 0.875);
+
+      // A fresh instance has a cold L1 but must recover the score from disk.
+      const second = new DiskTieredRerankScoreCache({ indexPath, enabled: true });
+      const hit = second.get(MODEL, 'how do rollbacks work', 'candidate body');
+      expect(hit).toBe(0.875);
+      const stats = second.stats();
+      expect(stats.disk_hits).toBe(1);
+      expect(stats.l1_hits).toBe(0);
+
+      // Promotes into L1 on the disk hit — a second read is a memory hit.
+      expect(second.get(MODEL, 'how do rollbacks work', 'candidate body')).toBe(0.875);
+      expect(second.stats().l1_hits).toBe(1);
+    } finally {
+      await fsp.rm(path.dirname(indexPath), { recursive: true, force: true });
+    }
+  });
+
+  it('derives a stable, normalized key and isolates by model and candidate', () => {
+    // Query normalization (trim, whitespace-collapse, lower-case, NFKC) makes
+    // these the same key; model id and candidate text are part of the key.
+    expect(rerankScoreCacheKey(MODEL, '  Query   Text ', 'body')).toBe(
+      rerankScoreCacheKey(MODEL, 'query text', 'body'),
+    );
+    expect(rerankScoreCacheKey(MODEL, 'q', 'body-a')).not.toBe(
+      rerankScoreCacheKey(MODEL, 'q', 'body-b'),
+    );
+    expect(rerankScoreCacheKey('model-a', 'q', 'body')).not.toBe(
+      rerankScoreCacheKey('model-b', 'q', 'body'),
+    );
+    expect(normalizeRerankQuery('  A B\nC  ')).toBe('a b c');
+  });
+
+  it('serves a normalized-query variant from cache without re-scoring', async () => {
+    const indexPath = await tempIndexPath('kb-rerank-cache-normalize-');
+    try {
+      const cache = new DiskTieredRerankScoreCache({ indexPath, enabled: true });
+      cache.set(MODEL, '  Query   Text ', 'body', 0.5);
+      expect(cache.get(MODEL, 'query text', 'body')).toBe(0.5);
+
+      // Different model id is a distinct entry — a miss, not a stale hit.
+      expect(cache.get('other-model', 'query text', 'body')).toBeNull();
+    } finally {
+      await fsp.rm(path.dirname(indexPath), { recursive: true, force: true });
+    }
+  });
+
+  it('enforces the disk size bound by evicting oldest entries', async () => {
+    const indexPath = await tempIndexPath('kb-rerank-cache-evict-');
+    try {
+      // Probe one entry's on-disk footprint, then bound the disk tier to ~2.5
+      // entries so writing a 3rd forces eviction of the oldest.
+      const probe = new DiskTieredRerankScoreCache({ indexPath, enabled: true });
+      probe.set(MODEL, 'probe', 'probe-body', 0.1);
+      const entryBytes = probe.diskSizeBytes();
+      expect(entryBytes).toBeGreaterThan(0);
+      await fsp.rm(path.join(rerankScoreCacheRoot(indexPath)), { recursive: true, force: true });
+
+      const cache = new DiskTieredRerankScoreCache({
+        indexPath,
+        enabled: true,
+        l1Max: 0, // force every read to go to disk
+        diskMaxBytes: Math.floor(entryBytes * 2.5),
+      });
+
+      cache.set(MODEL, 'q1', 'first', 0.11);
+      cache.set(MODEL, 'q2', 'second', 0.22);
+      cache.set(MODEL, 'q3', 'third', 0.33);
+
+      // Three entries exceed the ~2.5-entry bound, so the oldest (q1) is gone.
+      expect(cache.diskSizeBytes()).toBeLessThanOrEqual(Math.floor(entryBytes * 2.5));
+      expect(cache.get(MODEL, 'q1', 'first')).toBeNull();
+      expect(cache.get(MODEL, 'q3', 'third')).toBe(0.33);
+    } finally {
+      await fsp.rm(path.dirname(indexPath), { recursive: true, force: true });
+    }
+  });
+
+  it('treats a corrupt disk entry as a miss and removes it', async () => {
+    const indexPath = await tempIndexPath('kb-rerank-cache-corrupt-');
+    try {
+      const cache = new DiskTieredRerankScoreCache({ indexPath, enabled: true, l1Max: 0 });
+      const key = rerankScoreCacheKey(MODEL, 'broken', 'body');
+      const file = path.join(rerankScoreCacheRoot(indexPath), key.slice(0, 2), `${key}.json`);
+      fs.mkdirSync(path.dirname(file), { recursive: true });
+      fs.writeFileSync(file, 'not json', 'utf-8');
+
+      expect(cache.get(MODEL, 'broken', 'body')).toBeNull();
+      expect(cache.stats().corruptions).toBe(1);
+      expect(fs.existsSync(file)).toBe(false);
+    } finally {
+      await fsp.rm(path.dirname(indexPath), { recursive: true, force: true });
+    }
+  });
+
+  it('is a no-op (no disk artifacts) when disabled', async () => {
+    const indexPath = await tempIndexPath('kb-rerank-cache-disabled-');
+    try {
+      const cache = new DiskTieredRerankScoreCache({ indexPath, enabled: false });
+      cache.set(MODEL, 'q', 'body', 0.9);
+      expect(cache.get(MODEL, 'q', 'body')).toBeNull();
+      expect(cache.diskSizeBytes()).toBe(0);
+      expect(fs.existsSync(rerankScoreCacheRoot(indexPath))).toBe(false);
+    } finally {
+      await fsp.rm(path.dirname(indexPath), { recursive: true, force: true });
+    }
+  });
+
+  it('parses KB_RERANK_CACHE as opt-in and the byte bound with a safe default', () => {
+    expect(isRerankCacheEnabled('')).toBe(false);
+    expect(isRerankCacheEnabled(undefined)).toBe(false);
+    expect(isRerankCacheEnabled('off')).toBe(false);
+    expect(isRerankCacheEnabled('on')).toBe(true);
+    expect(isRerankCacheEnabled(' TRUE ')).toBe(true);
+    expect(isRerankCacheEnabled('1')).toBe(true);
+
+    expect(resolveRerankCacheDiskMaxBytes('1048576')).toBe(1048576);
+    expect(resolveRerankCacheDiskMaxBytes('')).toBe(64 * 1024 * 1024);
+    expect(resolveRerankCacheDiskMaxBytes('-5')).toBe(64 * 1024 * 1024);
+    expect(resolveRerankCacheDiskMaxBytes('nonsense')).toBe(64 * 1024 * 1024);
+  });
+});

--- a/src/rerank-cache-disk.ts
+++ b/src/rerank-cache-disk.ts
@@ -1,0 +1,277 @@
+import { createHash } from 'crypto';
+import * as fs from 'fs';
+import * as path from 'path';
+import { FAISS_INDEX_PATH } from './config/paths.js';
+import {
+  KB_RERANK_CACHE_DISK_MAX_BYTES,
+  KB_RERANK_CACHE_ENABLED,
+} from './config/reranker.js';
+import { logger } from './logger.js';
+import type { RerankScoreCache } from './reranker.js';
+
+// Disk-tiered persistent rerank-score cache (#646). Mirrors the two-tier
+// query embedding cache (src/query-cache.ts, ADR 0009): an in-memory LRU L1
+// in front of a content-addressed disk tier so cross-encoder scores survive
+// process exit and are reused across cold `kb` CLI invocations.
+//
+// The RerankScoreCache interface (src/reranker.ts) is SYNCHRONOUS — it is
+// consulted on the hot path of rerankFusedResults without awaiting — so the
+// disk tier uses synchronous fs calls (atomic write-then-rename). Scores are
+// tiny scalars, so a per-entry JSON file keeps each write/read cheap and makes
+// size-bound eviction a simple oldest-file sweep.
+
+export const RERANK_SCORE_CACHE_SCHEMA_VERSION = 'kb-rerank-score-cache.v1';
+
+export const DEFAULT_RERANK_CACHE_L1_MAX = 4096;
+
+export interface DiskTieredRerankScoreCacheOptions {
+  indexPath?: string;
+  enabled?: boolean;
+  l1Max?: number;
+  diskMaxBytes?: number;
+}
+
+export interface RerankScoreCacheStats {
+  enabled: boolean;
+  l1_hits: number;
+  disk_hits: number;
+  misses: number;
+  writes: number;
+  corruptions: number;
+  l1_size: number;
+  disk_size_bytes: number;
+}
+
+interface RerankScoreRecord {
+  schema_version: typeof RERANK_SCORE_CACHE_SCHEMA_VERSION;
+  score: number;
+}
+
+/**
+ * Normalize a query for cache-key derivation. Matches the in-memory cache's
+ * normalization (trim, collapse whitespace, lower-case) plus NFKC so that
+ * unicode-equivalent queries share a key, consistent with the query cache.
+ */
+export function normalizeRerankQuery(query: string): string {
+  return query.normalize('NFKC').trim().replace(/\s+/g, ' ').toLowerCase();
+}
+
+/**
+ * Content-addressed key: sha256(schema | model | normalizedQuery |
+ * sha256(candidateText)). The candidate text is pre-hashed so arbitrarily long
+ * passages do not bloat the digest input, and the model id is included so a
+ * reranker model change never serves stale scores.
+ */
+export function rerankScoreCacheKey(modelId: string, query: string, candidateText: string): string {
+  return createHash('sha256')
+    .update(RERANK_SCORE_CACHE_SCHEMA_VERSION)
+    .update('\x1f')
+    .update(modelId)
+    .update('\x1f')
+    .update(normalizeRerankQuery(query))
+    .update('\x1f')
+    .update(createHash('sha256').update(candidateText, 'utf-8').digest('hex'))
+    .digest('hex');
+}
+
+export function rerankScoreCacheRoot(indexPath: string = FAISS_INDEX_PATH): string {
+  return path.join(indexPath, 'cache', 'rerank-scores');
+}
+
+export class DiskTieredRerankScoreCache implements RerankScoreCache {
+  private readonly enabled: boolean;
+  private readonly cacheRoot: string;
+  private readonly diskMaxBytes: number;
+  private readonly l1Max: number;
+  private readonly l1 = new Map<string, number>();
+  private l1Hits = 0;
+  private diskHits = 0;
+  private misses = 0;
+  private writes = 0;
+  private corruptions = 0;
+
+  constructor(options: DiskTieredRerankScoreCacheOptions = {}) {
+    this.enabled = options.enabled ?? KB_RERANK_CACHE_ENABLED;
+    this.cacheRoot = rerankScoreCacheRoot(options.indexPath ?? FAISS_INDEX_PATH);
+    this.diskMaxBytes = options.diskMaxBytes ?? KB_RERANK_CACHE_DISK_MAX_BYTES;
+    this.l1Max = options.l1Max ?? DEFAULT_RERANK_CACHE_L1_MAX;
+  }
+
+  get(modelId: string, query: string, candidateText: string): number | null {
+    if (!this.enabled) return null;
+    const key = rerankScoreCacheKey(modelId, query, candidateText);
+    const memoryHit = this.l1.get(key);
+    if (memoryHit !== undefined) {
+      // LRU bump.
+      this.l1.delete(key);
+      this.l1.set(key, memoryHit);
+      this.l1Hits += 1;
+      return memoryHit;
+    }
+    const diskHit = this.readDisk(key);
+    if (diskHit !== null) {
+      this.diskHits += 1;
+      this.l1Set(key, diskHit);
+      return diskHit;
+    }
+    this.misses += 1;
+    return null;
+  }
+
+  set(modelId: string, query: string, candidateText: string, score: number): void {
+    if (!this.enabled) return;
+    if (!Number.isFinite(score)) return;
+    const key = rerankScoreCacheKey(modelId, query, candidateText);
+    this.l1Set(key, score);
+    try {
+      this.writeDisk(key, score);
+      this.writes += 1;
+      this.enforceDiskLimit();
+    } catch (err) {
+      logger.warn(`rerank score cache write skipped: ${(err as Error).message}`);
+    }
+  }
+
+  clearMemory(): void {
+    this.l1.clear();
+  }
+
+  stats(): RerankScoreCacheStats {
+    return {
+      enabled: this.enabled,
+      l1_hits: this.l1Hits,
+      disk_hits: this.diskHits,
+      misses: this.misses,
+      writes: this.writes,
+      corruptions: this.corruptions,
+      l1_size: this.l1.size,
+      disk_size_bytes: this.diskSizeBytes(),
+    };
+  }
+
+  diskSizeBytes(): number {
+    return listEntryFiles(this.cacheRoot).reduce((sum, file) => sum + file.size, 0);
+  }
+
+  private l1Set(key: string, value: number): void {
+    if (this.l1Max <= 0) return;
+    if (this.l1.has(key)) this.l1.delete(key);
+    this.l1.set(key, value);
+    while (this.l1.size > this.l1Max) {
+      const oldest = this.l1.keys().next().value as string | undefined;
+      if (oldest === undefined) break;
+      this.l1.delete(oldest);
+    }
+  }
+
+  private entryPath(key: string): string {
+    // Shard by the first two hex chars (256-way fan-out) so a single directory
+    // never accumulates millions of entries — the same content-addressing
+    // discipline git uses for loose objects.
+    return path.join(this.cacheRoot, key.slice(0, 2), `${key}.json`);
+  }
+
+  private readDisk(key: string): number | null {
+    const file = this.entryPath(key);
+    let raw: string;
+    try {
+      raw = fs.readFileSync(file, 'utf-8');
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null;
+      this.recordCorrupt(file);
+      return null;
+    }
+    let record: RerankScoreRecord;
+    try {
+      record = JSON.parse(raw) as RerankScoreRecord;
+    } catch {
+      this.recordCorrupt(file);
+      return null;
+    }
+    if (
+      record === null ||
+      typeof record !== 'object' ||
+      record.schema_version !== RERANK_SCORE_CACHE_SCHEMA_VERSION ||
+      typeof record.score !== 'number' ||
+      !Number.isFinite(record.score)
+    ) {
+      this.recordCorrupt(file);
+      return null;
+    }
+    return record.score;
+  }
+
+  private writeDisk(key: string, score: number): void {
+    const file = this.entryPath(key);
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    const record: RerankScoreRecord = { schema_version: RERANK_SCORE_CACHE_SCHEMA_VERSION, score };
+    const tmp = `${file}.${process.pid}.tmp`;
+    try {
+      fs.writeFileSync(tmp, `${JSON.stringify(record)}\n`, 'utf-8');
+      fs.renameSync(tmp, file);
+    } catch (err) {
+      try {
+        fs.unlinkSync(tmp);
+      } catch {
+        // best-effort cleanup of the temp file
+      }
+      throw err;
+    }
+  }
+
+  private recordCorrupt(file: string): void {
+    this.corruptions += 1;
+    try {
+      fs.unlinkSync(file);
+    } catch {
+      // best-effort: a missing/locked corrupt file is fine to ignore
+    }
+  }
+
+  private enforceDiskLimit(): void {
+    if (this.diskMaxBytes <= 0) return;
+    const files = listEntryFiles(this.cacheRoot);
+    let total = files.reduce((sum, file) => sum + file.size, 0);
+    if (total <= this.diskMaxBytes) return;
+    // Evict oldest-first by mtime until back under the bound.
+    files.sort((a, b) => a.mtimeMs - b.mtimeMs);
+    for (const file of files) {
+      if (total <= this.diskMaxBytes) break;
+      try {
+        fs.unlinkSync(file.path);
+        total -= file.size;
+      } catch {
+        // already gone or locked by another process — skip it
+      }
+    }
+  }
+}
+
+function listEntryFiles(root: string): Array<{ path: string; size: number; mtimeMs: number }> {
+  const out: Array<{ path: string; size: number; mtimeMs: number }> = [];
+  const walk = (dir: string): void => {
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return;
+      throw err;
+    }
+    for (const entry of entries) {
+      const child = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(child);
+        continue;
+      }
+      if (!entry.isFile() || !entry.name.endsWith('.json')) continue;
+      try {
+        const st = fs.statSync(child);
+        out.push({ path: child, size: st.size, mtimeMs: st.mtimeMs });
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+      }
+    }
+  };
+  walk(root);
+  return out;
+}

--- a/src/reranker.ts
+++ b/src/reranker.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_RERANK_MODEL,
   DEFAULT_RERANK_TOP_N,
   isRerankSkippedForDomain,
+  KB_RERANK_CACHE_ENABLED,
   normalizeRerankDomain,
   parseRerankFlag,
   parseRerankTopN,
@@ -14,6 +15,7 @@ import {
   type RerankOverride,
   type RerankerConfig,
 } from './config/reranker.js';
+import { DiskTieredRerankScoreCache } from './rerank-cache-disk.js';
 import { logger } from './logger.js';
 
 export {
@@ -102,7 +104,14 @@ export class InMemoryRerankScoreCache implements RerankScoreCache {
   }
 }
 
-export const globalRerankScoreCache = new InMemoryRerankScoreCache();
+// #646: when KB_RERANK_CACHE is enabled, the global cache gains a persistent
+// disk tier (L1 memory + disk) so cross-encoder scores survive process exit and
+// warm cold `kb` CLI invocations. Otherwise it stays the in-process LRU, which
+// leaves no on-disk artifacts. Both implement the synchronous RerankScoreCache
+// interface, so rerankFusedResults is unaffected by the choice.
+export const globalRerankScoreCache: RerankScoreCache = KB_RERANK_CACHE_ENABLED
+  ? new DiskTieredRerankScoreCache()
+  : new InMemoryRerankScoreCache();
 
 const providerCache = new Map<string, Promise<Reranker>>();
 const warnedDegradeReasons = new Set<string>();


### PR DESCRIPTION
## Summary

Closes #646.

The cross-encoder reranker is the most expensive query-time stage, and its score cache (`InMemoryRerankScoreCache`) was in-process only: every cold `kb` CLI invocation and every daemon restart started with an empty rerank cache and re-ran the cross-encoder for queries it had already scored.

This adds **`DiskTieredRerankScoreCache`** (`src/rerank-cache-disk.ts`) — an L1 in-memory LRU in front of a content-addressed disk tier, keyed by `sha256(model | normalizedQuery | sha256(candidateText))`. It mirrors the two-tier query embedding cache (`src/query-cache.ts`, ADR 0009), so rerank scores now survive process exit and warm cold invocations.

## Design notes & decisions

The issue left storage format open; I picked the **smallest implementation** that satisfies persistence + key derivation + size-bound eviction:

- **Synchronous fs (not async like the query cache).** `RerankScoreCache` (`src/reranker.ts`) is a synchronous interface — `get`/`set` are consulted on the hot path of `rerankFusedResults` without `await`. So the disk tier uses sync `fs` calls with atomic write-then-rename. Scores are tiny scalars, so per-entry JSON files keep each read/write cheap and make size-bound eviction a simple oldest-by-mtime sweep.
- **Storage format: one JSON file per entry**, sharded by the first two hex chars of the key (256-way fan-out, git loose-object style). *Alternatives considered:* a single sharded JSON blob or SQLite — both add either rewrite-amplification or a dependency for no benefit at this entry size.
- **Key includes the model id and full candidate text** (pre-hashed) so a reranker model change never serves stale scores.
- **Corruption handling** matches the query cache: a parse failure or schema mismatch is treated as a miss and the entry is unlinked.
- **`KB_RERANK_CACHE` defaults to OFF (opt-in).** *Alternative considered:* default-on for parity with `KB_QUERY_CACHE`. I chose opt-in to preserve existing behavior exactly — the global cache stays the in-process LRU and leaves no on-disk artifacts unless an operator enables it. When enabled, it becomes the default `globalRerankScoreCache`. `KB_RERANK_CACHE_DISK_MAX_BYTES` bounds the disk tier (default 64 MiB; interpreted directly as bytes per the issue).

## Config (`src/config/reranker.ts`)

| Env var | Default | Meaning |
| --- | --- | --- |
| `KB_RERANK_CACHE` | off | `on`/`true`/`1`/`enabled` selects the disk-tiered cache as `globalRerankScoreCache` |
| `KB_RERANK_CACHE_DISK_MAX_BYTES` | `67108864` (64 MiB) | disk-tier size bound; malformed/non-positive → default |

## Tests (`src/rerank-cache-disk.test.ts`)

- cross-instance disk persistence (cold L1 recovers from disk, then promotes to L1)
- key derivation: query normalization stability + isolation by model and candidate text
- size-bound eviction (oldest-first)
- corrupt-entry recovery (treated as miss, removed)
- disabled no-op (no on-disk artifacts)
- config parsing (`KB_RERANK_CACHE` aliases, byte-bound default)

## Verification

`npx jest --runTestsByPath src/rerank-cache-disk.test.ts src/reranker.test.ts src/config/reranker.test.ts` → **25 passed**.

> Note: the local full `npm run build` (`tsc`) was skipped — it repeatedly OOM-killed on this host under load, unrelated to this change. The change was validated via the targeted jest suite above (ts-jest type-checks the touched files), and CI runs the full build/typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)