### PR TITLE
feat(serve): daemon concurrency cap + 429 admission control (#648)

### DIFF
--- a/src/cli-serve.test.ts
+++ b/src/cli-serve.test.ts
@@ -1,12 +1,19 @@
 import { afterEach, describe, expect, it, jest } from '@jest/globals';
 import * as http from 'node:http';
 import {
+  appendDaemonAdmissionMetrics,
   createDaemonCommandHandlers,
   formatStatsRunResultAsOpenMetrics,
   parseServeArgs,
   runServeStatus,
   startDaemonServer,
 } from './cli-serve.js';
+import {
+  DaemonAdmissionGate,
+  resolveDaemonAdmissionConfig,
+  DEFAULT_DAEMON_MAX_CONCURRENCY,
+  DEFAULT_DAEMON_QUEUE_MAX,
+} from './daemon-admission.js';
 import type { DaemonRunResult } from './daemon-client.js';
 import type { KbStatsPayload } from './kb-stats.js';
 import type { RunSearchDeps } from './cli-search.js';
@@ -15,6 +22,7 @@ import type { LexicalIndex } from './lexical-index.js';
 interface RawResponse {
   statusCode: number;
   body: string;
+  headers: http.IncomingHttpHeaders;
 }
 
 function request(
@@ -36,6 +44,7 @@ function request(
         res.on('end', () => resolve({
           statusCode: res.statusCode ?? 0,
           body: Buffer.concat(chunks).toString('utf-8'),
+          headers: res.headers,
         }));
       },
     );
@@ -155,6 +164,223 @@ describe('kb serve daemon', () => {
 
   it('keeps serve binding loopback-only', () => {
     expect(() => parseServeArgs(['--host=0.0.0.0'])).toThrow(/non-loopback/);
+  });
+});
+
+describe('daemon admission gate', () => {
+  it('resolves bounds from the environment, falling back to defaults', () => {
+    expect(resolveDaemonAdmissionConfig({})).toEqual({
+      maxConcurrency: DEFAULT_DAEMON_MAX_CONCURRENCY,
+      queueMax: DEFAULT_DAEMON_QUEUE_MAX,
+    });
+    expect(
+      resolveDaemonAdmissionConfig({
+        KB_DAEMON_MAX_CONCURRENCY: '3',
+        KB_DAEMON_QUEUE_MAX: '0',
+      }),
+    ).toEqual({ maxConcurrency: 3, queueMax: 0 });
+    // Invalid values fall back rather than throwing.
+    expect(
+      resolveDaemonAdmissionConfig({
+        KB_DAEMON_MAX_CONCURRENCY: 'nope',
+        KB_DAEMON_QUEUE_MAX: '-5',
+      }),
+    ).toEqual({
+      maxConcurrency: DEFAULT_DAEMON_MAX_CONCURRENCY,
+      queueMax: DEFAULT_DAEMON_QUEUE_MAX,
+    });
+  });
+
+  it('never runs more than maxConcurrency jobs at once', async () => {
+    const gate = new DaemonAdmissionGate({ maxConcurrency: 2, queueMax: 10 });
+    let active = 0;
+    let maxActive = 0;
+    let release!: () => void;
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const job = async (): Promise<void> => {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      await held;
+      active -= 1;
+    };
+
+    const accepted = Array.from({ length: 6 }, () => gate.run(job));
+    expect(accepted.every((p) => p !== null)).toBe(true);
+    // All six admitted (2 running + 4 queued), none rejected.
+    expect(gate.inFlight).toBe(6);
+    expect(gate.rejectedTotal).toBe(0);
+
+    await Promise.resolve();
+    expect(maxActive).toBe(2);
+
+    release();
+    await Promise.all(accepted);
+    expect(maxActive).toBe(2);
+    expect(gate.inFlight).toBe(0);
+  });
+
+  it('rejects with null once the cap and queue are both full', async () => {
+    const gate = new DaemonAdmissionGate({ maxConcurrency: 1, queueMax: 1 });
+    let release!: () => void;
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const job = (): Promise<void> => held;
+
+    const running = gate.run(job); // takes the single slot
+    const queued = gate.run(job); // fills the single queue position
+    const rejected = gate.run(job); // no room -> rejected
+
+    expect(running).not.toBeNull();
+    expect(queued).not.toBeNull();
+    expect(rejected).toBeNull();
+    expect(gate.rejectedTotal).toBe(1);
+    expect(gate.inFlight).toBe(2);
+
+    release();
+    await Promise.all([running, queued]);
+    expect(gate.inFlight).toBe(0);
+  });
+});
+
+describe('kb serve daemon admission control', () => {
+  const originalMetricsExport = process.env.KB_METRICS_EXPORT;
+
+  afterEach(() => {
+    if (originalMetricsExport === undefined) delete process.env.KB_METRICS_EXPORT;
+    else process.env.KB_METRICS_EXPORT = originalMetricsExport;
+  });
+
+  function blockingHandlers(onEnter: () => void, held: Promise<void>) {
+    const make = () => async (): Promise<DaemonRunResult> => {
+      onEnter();
+      await held;
+      return { exitCode: 0, stdout: 'ok\n', stderr: '' };
+    };
+    return { search: make(), list: make(), stats: make() };
+  }
+
+  it('caps concurrent in-flight requests at maxConcurrency', async () => {
+    let active = 0;
+    let maxActive = 0;
+    let release!: () => void;
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let resolveTwo!: () => void;
+    const twoStarted = new Promise<void>((resolve) => {
+      resolveTwo = resolve;
+    });
+    const handler = async (): Promise<DaemonRunResult> => {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      if (active === 2) resolveTwo();
+      await held;
+      active -= 1;
+      return { exitCode: 0, stdout: 'ok\n', stderr: '' };
+    };
+    const handlers = { search: handler, list: handler, stats: handler };
+
+    const daemon = await startDaemonServer({
+      port: 0,
+      idleTimeoutMs: 0,
+      admission: { maxConcurrency: 2, queueMax: 10 },
+      handlers,
+    });
+    try {
+      const inFlight = Array.from({ length: 5 }, () =>
+        request(daemon.url, {
+          method: 'POST',
+          path: '/v1/run',
+          body: { command: 'search', args: ['q'] },
+        }),
+      );
+      await twoStarted;
+      expect(maxActive).toBe(2);
+      release();
+      const results = await Promise.all(inFlight);
+      expect(results.every((r) => r.statusCode === 200)).toBe(true);
+      expect(maxActive).toBe(2);
+    } finally {
+      release();
+      await daemon.stop();
+    }
+  });
+
+  it('replies 429 + Retry-After once the queue is full', async () => {
+    let release!: () => void;
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let resolveStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      resolveStarted = resolve;
+    });
+    const handlers = blockingHandlers(() => resolveStarted(), held);
+
+    // queueMax 0 -> any request arriving while the single slot is busy is
+    // rejected immediately, making the 429 path deterministic.
+    const daemon = await startDaemonServer({
+      port: 0,
+      idleTimeoutMs: 0,
+      admission: { maxConcurrency: 1, queueMax: 0 },
+      handlers,
+      // Keep /metrics hermetic and fast — the daemon admission gauges are
+      // spliced into whatever body the handler returns.
+      metricsHandler: async () => '# EOF\n',
+    });
+    try {
+      const first = request(daemon.url, {
+        method: 'POST',
+        path: '/v1/run',
+        body: { command: 'search', args: ['q'] },
+      });
+      await started; // the slot is now occupied
+
+      const rejected = await request(daemon.url, {
+        method: 'POST',
+        path: '/v1/run',
+        body: { command: 'search', args: ['q'] },
+      });
+      expect(rejected.statusCode).toBe(429);
+      expect(rejected.headers['retry-after']).toBe('1');
+      expect(JSON.parse(rejected.body)).toMatchObject({ error: 'too_many_requests' });
+
+      process.env.KB_METRICS_EXPORT = 'on';
+      const metrics = await request(daemon.url, { path: '/metrics' });
+      expect(metrics.statusCode).toBe(200);
+      expect(metrics.body).toContain('# TYPE kb_daemon_rejected counter');
+      expect(metrics.body).toContain('kb_daemon_rejected_total 1');
+      expect(metrics.body).toContain('# TYPE kb_daemon_inflight gauge');
+
+      release();
+      const accepted = await first;
+      expect(accepted.statusCode).toBe(200);
+    } finally {
+      release();
+      await daemon.stop();
+    }
+  });
+});
+
+describe('appendDaemonAdmissionMetrics', () => {
+  it('splices admission metrics ahead of the OpenMetrics EOF terminator', () => {
+    const body = '# TYPE kb_server_uptime_ms gauge\nkb_server_uptime_ms 1\n# EOF\n';
+    const out = appendDaemonAdmissionMetrics(body, { inFlight: 3, rejectedTotal: 7 });
+    expect(out).toContain('kb_server_uptime_ms 1');
+    expect(out).toContain('kb_daemon_inflight 3');
+    expect(out).toContain('kb_daemon_rejected_total 7');
+    expect(out.endsWith('# EOF\n')).toBe(true);
+    // The EOF terminator stays last.
+    expect(out.indexOf('kb_daemon_inflight')).toBeLessThan(out.indexOf('# EOF'));
+  });
+
+  it('appends a terminator when the body has none', () => {
+    const out = appendDaemonAdmissionMetrics('custom 1\n', { inFlight: 0, rejectedTotal: 0 });
+    expect(out).toContain('custom 1');
+    expect(out).toContain('kb_daemon_inflight 0');
   });
 });
 

--- a/src/cli-serve.ts
+++ b/src/cli-serve.ts
@@ -15,6 +15,12 @@ import {
   type DaemonHealth,
   type DaemonRunResult,
 } from './daemon-client.js';
+import {
+  DaemonAdmissionGate,
+  DAEMON_RETRY_AFTER_SECONDS,
+  resolveDaemonAdmissionConfig,
+  type DaemonAdmissionConfig,
+} from './daemon-admission.js';
 import { formatKbStatsOpenMetrics } from './prometheus-export.js';
 import type { KbStatsPayload } from './kb-stats.js';
 import { LexicalIndexCache } from './lexical-index-cache.js';
@@ -48,6 +54,11 @@ Environment:
                             http://127.0.0.1:17799).
   KB_METRICS_EXPORT         Set to \`on\` to expose OpenMetrics text at
                             \`GET /metrics\` on the loopback daemon.
+  KB_DAEMON_MAX_CONCURRENCY Max requests the daemon runs at once before
+                            queueing (default 8).
+  KB_DAEMON_QUEUE_MAX       Max requests queued beyond the concurrency cap
+                            before the daemon replies 429 + Retry-After
+                            (default 128; 0 rejects immediately when full).
 
 Exit codes:
   0   daemon started, or \`kb serve status\` found a reachable daemon
@@ -74,6 +85,12 @@ export interface DaemonCommandHandlers {
 export interface StartDaemonServerOptions extends Partial<ServeArgs> {
   handlers?: DaemonCommandHandlers;
   metricsHandler?: () => Promise<string>;
+  /**
+   * Admission-control bounds (issue #648). Defaults are resolved from
+   * `KB_DAEMON_MAX_CONCURRENCY` / `KB_DAEMON_QUEUE_MAX`; tests pass an
+   * explicit config so the cap/queue/429 behaviour is deterministic.
+   */
+  admission?: DaemonAdmissionConfig;
 }
 
 export interface DaemonCommandHandlerOptions {
@@ -217,9 +234,16 @@ export async function startDaemonServer(
   };
   assertLoopbackHost(parsed.host);
   const handlers = options.handlers ?? createDaemonCommandHandlers();
-  const metricsHandler = options.metricsHandler ?? defaultMetricsHandler;
+  const baseMetricsHandler = options.metricsHandler ?? defaultMetricsHandler;
+  const admission = new DaemonAdmissionGate(
+    options.admission ?? resolveDaemonAdmissionConfig(),
+  );
+  // Always surface the daemon's admission gauge/counter on /metrics, even
+  // when a custom metrics body is supplied, by splicing the lines in ahead
+  // of the OpenMetrics `# EOF` terminator.
+  const metricsHandler = async (): Promise<string> =>
+    appendDaemonAdmissionMetrics(await baseMetricsHandler(), admission);
   let idleTimer: NodeJS.Timeout | undefined;
-  let queue: Promise<void> = Promise.resolve();
   const startedAt = Date.now();
   let boundUrl = '';
 
@@ -239,10 +263,7 @@ export async function startDaemonServer(
 
   const server = http.createServer((req, res) => {
     resetIdleTimer();
-    void handleRequest(req, res, handlers, metricsHandler, buildHealth, (job) => {
-      queue = queue.then(job, job);
-      return queue;
-    });
+    void handleRequest(req, res, handlers, metricsHandler, buildHealth, admission);
   });
 
   server.on('close', () => {
@@ -344,7 +365,7 @@ async function handleRequest(
   handlers: DaemonCommandHandlers,
   metricsHandler: () => Promise<string>,
   buildHealth: () => DaemonHealth,
-  enqueue: (job: () => Promise<void>) => Promise<void>,
+  admission: DaemonAdmissionGate,
 ): Promise<void> {
   const url = new URL(req.url ?? '/', 'http://placeholder');
   if (req.method === 'GET' && url.pathname === '/health') {
@@ -352,7 +373,10 @@ async function handleRequest(
     return;
   }
   if (url.pathname === '/metrics') {
-    await handleMetricsRequest(req, res, metricsHandler, enqueue);
+    // /metrics stays outside admission control: scraping must keep working
+    // under load, which is exactly when the daemon_inflight / rejected
+    // gauges matter most.
+    await handleMetricsRequest(req, res, metricsHandler);
     return;
   }
   if (req.method !== 'POST' || url.pathname !== '/v1/run') {
@@ -379,7 +403,7 @@ async function handleRequest(
     return;
   }
 
-  await enqueue(async () => {
+  const accepted = admission.run(async () => {
     try {
       writeJson(res, 200, await handlers[command](args));
     } catch (err) {
@@ -389,6 +413,24 @@ async function handleRequest(
         stderr: `kb serve: ${(err as Error).message}\n`,
       });
     }
+  });
+  if (accepted === null) {
+    rejectOverloaded(res);
+    return;
+  }
+  await accepted;
+}
+
+/**
+ * Admission-control rejection (issue #648): the concurrency slots and the
+ * bounded queue are both full, so shed load with a fast `429` and a
+ * `Retry-After` hint rather than letting the backlog grow without limit.
+ */
+function rejectOverloaded(res: http.ServerResponse): void {
+  res.setHeader('Retry-After', String(DAEMON_RETRY_AFTER_SECONDS));
+  writeJson(res, 429, {
+    error: 'too_many_requests',
+    message: 'kb serve: daemon at capacity; retry after backoff',
   });
 }
 
@@ -413,7 +455,6 @@ async function handleMetricsRequest(
   req: http.IncomingMessage,
   res: http.ServerResponse,
   metricsHandler: () => Promise<string>,
-  enqueue: (job: () => Promise<void>) => Promise<void>,
 ): Promise<void> {
   if (!isMetricsExportEnabled()) {
     writeJson(res, 404, { error: 'not_found' });
@@ -426,22 +467,45 @@ async function handleMetricsRequest(
     return;
   }
 
-  await enqueue(async () => {
-    try {
-      const body = await metricsHandler();
-      res.writeHead(200, {
-        'Content-Type': OPENMETRICS_CONTENT_TYPE,
-        'Cache-Control': 'no-store',
-      });
-      if (method === 'GET') res.end(body);
-      else res.end();
-    } catch (err) {
-      writeJson(res, 500, {
-        error: 'metrics_unavailable',
-        message: (err as Error).message,
-      });
-    }
-  });
+  try {
+    const body = await metricsHandler();
+    res.writeHead(200, {
+      'Content-Type': OPENMETRICS_CONTENT_TYPE,
+      'Cache-Control': 'no-store',
+    });
+    if (method === 'GET') res.end(body);
+    else res.end();
+  } catch (err) {
+    writeJson(res, 500, {
+      error: 'metrics_unavailable',
+      message: (err as Error).message,
+    });
+  }
+}
+
+/**
+ * Splice the daemon admission-control metrics (issue #648) into an
+ * OpenMetrics body ahead of its `# EOF` terminator. The counter family
+ * name omits the `_total` suffix to match the convention in
+ * prometheus-export.ts (`metricFamilyName`).
+ */
+export function appendDaemonAdmissionMetrics(
+  body: string,
+  gate: { inFlight: number; rejectedTotal: number },
+): string {
+  const lines = [
+    '# HELP kb_daemon_inflight Admitted-but-incomplete kb serve daemon requests (running + queued).',
+    '# TYPE kb_daemon_inflight gauge',
+    `kb_daemon_inflight ${gate.inFlight}`,
+    '# HELP kb_daemon_rejected Total kb serve daemon requests rejected by admission control.',
+    '# TYPE kb_daemon_rejected counter',
+    `kb_daemon_rejected_total ${gate.rejectedTotal}`,
+  ];
+  const eofMarker = '# EOF\n';
+  if (body.endsWith(eofMarker)) {
+    return `${body.slice(0, -eofMarker.length)}${lines.join('\n')}\n${eofMarker}`;
+  }
+  return `${body}${lines.join('\n')}\n`;
 }
 
 async function defaultMetricsHandler(): Promise<string> {

--- a/src/daemon-admission.ts
+++ b/src/daemon-admission.ts
@@ -1,0 +1,154 @@
+// src/daemon-admission.ts
+//
+// Issue #648 — admission control for the `kb serve` daemon.
+//
+// The daemon (`startDaemonServer` in cli-serve.ts) amortizes index/model
+// load across bursty, concurrent agent CLI calls (RFC 015 / #615). Each
+// in-flight read can drive an embedding call, a FAISS scan, and a
+// cross-encoder rerank; without a bound, a burst of parallel reads
+// oversubscribes CPU/memory and lets the request backlog grow without
+// limit.
+//
+// This gate caps how many requests run at once
+// (KB_DAEMON_MAX_CONCURRENCY), queues a bounded backlog
+// (KB_DAEMON_QUEUE_MAX), and rejects the rest so callers get a fast
+// `429 Too Many Requests` + `Retry-After` instead of unbounded latency. It
+// mirrors the worker-pool admission shape of `bounded-concurrency.ts`
+// (mapBounded) but for inbound requests, where the work-list is open-ended
+// rather than a fixed array.
+
+export const DAEMON_MAX_CONCURRENCY_ENV = 'KB_DAEMON_MAX_CONCURRENCY';
+export const DAEMON_QUEUE_MAX_ENV = 'KB_DAEMON_QUEUE_MAX';
+
+/**
+ * Default concurrent-request cap. Matches DEFAULT_FS_CONCURRENCY (8) so the
+ * daemon's inbound admission and its internal fan-out share one mental
+ * model; tune with KB_DAEMON_MAX_CONCURRENCY on smaller boxes.
+ */
+export const DEFAULT_DAEMON_MAX_CONCURRENCY = 8;
+
+/**
+ * Default bounded backlog beyond the concurrency cap. Generous enough to
+ * absorb an agent firing a parallel batch of `kb search` calls while still
+ * shedding load once the daemon is genuinely saturated.
+ */
+export const DEFAULT_DAEMON_QUEUE_MAX = 128;
+
+/** Advisory `Retry-After` (seconds) returned with a rejection. */
+export const DAEMON_RETRY_AFTER_SECONDS = 1;
+
+export interface DaemonAdmissionConfig {
+  maxConcurrency: number;
+  queueMax: number;
+}
+
+function parseBoundedInt(
+  raw: string | undefined,
+  fallback: number,
+  min: number,
+): number {
+  if (raw === undefined || raw.trim() === '') {
+    return fallback;
+  }
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || !Number.isInteger(parsed) || parsed < min) {
+    return fallback;
+  }
+  return parsed;
+}
+
+export function resolveDaemonAdmissionConfig(
+  env: NodeJS.ProcessEnv = process.env,
+): DaemonAdmissionConfig {
+  return {
+    maxConcurrency: parseBoundedInt(
+      env[DAEMON_MAX_CONCURRENCY_ENV],
+      DEFAULT_DAEMON_MAX_CONCURRENCY,
+      1,
+    ),
+    // queueMax of 0 is valid — it makes the daemon reject immediately once
+    // the concurrency slots are full (immediate-429 mode).
+    queueMax: parseBoundedInt(
+      env[DAEMON_QUEUE_MAX_ENV],
+      DEFAULT_DAEMON_QUEUE_MAX,
+      0,
+    ),
+  };
+}
+
+/**
+ * Bounded admission gate for inbound daemon requests.
+ *
+ * `running` counts the slots currently held (≤ maxConcurrency); `waiters`
+ * is the bounded queue. A freed slot is handed directly to the next waiter
+ * — `running` is not decremented and re-incremented across the handoff — so
+ * the concurrency cap can never be transiently exceeded by an interleaving
+ * `run()` call racing a queued waiter for the slot.
+ */
+export class DaemonAdmissionGate {
+  private readonly maxConcurrency: number;
+  private readonly queueMax: number;
+  private running = 0;
+  private readonly waiters: Array<() => void> = [];
+  private rejectedTotalCount = 0;
+
+  constructor(config: DaemonAdmissionConfig) {
+    this.maxConcurrency = Math.max(1, Math.floor(config.maxConcurrency));
+    this.queueMax = Math.max(0, Math.floor(config.queueMax));
+  }
+
+  /** Admitted-but-incomplete requests (running + queued). */
+  get inFlight(): number {
+    return this.running + this.waiters.length;
+  }
+
+  /** Total requests rejected because both the cap and the queue were full. */
+  get rejectedTotal(): number {
+    return this.rejectedTotalCount;
+  }
+
+  /**
+   * Run `job` under the admission bound. Returns the job's settle promise
+   * when admitted (immediately or after queueing), or `null` when both the
+   * concurrency slots and the queue are full — the caller should then reply
+   * `429` + `Retry-After`. Rejection is decided synchronously, so the
+   * counter and the returned value never disagree.
+   */
+  run<T>(job: () => Promise<T>): Promise<T> | null {
+    if (this.running >= this.maxConcurrency && this.waiters.length >= this.queueMax) {
+      this.rejectedTotalCount += 1;
+      return null;
+    }
+    return this.execute(job);
+  }
+
+  private async execute<T>(job: () => Promise<T>): Promise<T> {
+    await this.acquire();
+    try {
+      return await job();
+    } finally {
+      this.release();
+    }
+  }
+
+  private acquire(): Promise<void> {
+    if (this.running < this.maxConcurrency) {
+      this.running += 1;
+      return Promise.resolve();
+    }
+    return new Promise<void>((resolve) => {
+      this.waiters.push(resolve);
+    });
+  }
+
+  private release(): void {
+    const next = this.waiters.shift();
+    if (next !== undefined) {
+      // Hand the just-freed slot straight to the next waiter: `running`
+      // stays put (one job left, one starts), so the cap holds.
+      next();
+      return;
+    }
+    this.running -= 1;
+  }
+}


### PR DESCRIPTION
Closes #648

## Summary
The `kb serve` daemon (`startDaemonServer` in `src/cli-serve.ts`) accepted unbounded concurrent requests, serializing all work through a single promise chain with no backpressure. Under a burst — e.g. an agent firing many parallel `kb search` calls — the request backlog could grow without limit.

This adds a bounded **admission gate** for inbound daemon requests:

- **`KB_DAEMON_MAX_CONCURRENCY`** (default `8`) — max requests running at once. Matches `DEFAULT_FS_CONCURRENCY` for a consistent mental model.
- **`KB_DAEMON_QUEUE_MAX`** (default `128`; `0` = immediate-429) — bounded backlog beyond the cap.
- Beyond `cap + queue`, the daemon replies **`429 Too Many Requests` + `Retry-After`** instead of queueing forever.

## Implementation notes / design decisions
- **New helper `src/daemon-admission.ts`** mirrors the worker-pool shape of `bounded-concurrency.ts` (reused read-only, not edited) but for an open-ended inbound work-list. A freed concurrency slot is handed **directly** to the next waiter (`running` is not decremented/re-incremented across the handoff), so the cap can never be transiently exceeded by a `run()` call racing a queued waiter.
- **Where it lives:** the issue references both `cli-serve.ts` and `src/transport/base-http-host.ts`, but the actual `kb serve` daemon that `KB_DAEMON_*` governs is the standalone `http` server in `cli-serve.ts` — it does **not** use `BaseHttpHost`. `base-http-host.ts` is the separate MCP remote transport (SSE/streamable HTTP) with its own `inFlight` tracking and auth-backoff 429; grafting `KB_DAEMON_*` admission there would be semantically wrong. So this implements admission control only in the `kb serve` daemon and leaves `base-http-host.ts` untouched.
- **Queue-then-429** (not immediate-429) is the default, since agent clients that respect `Retry-After` benefit from a small bounded wait. `KB_DAEMON_QUEUE_MAX=0` opts into immediate-429.
- **`/health` and `/metrics` stay outside admission control** — observability must keep working precisely when the daemon is under load. `/metrics` exposes `kb_daemon_inflight` (gauge) and `kb_daemon_rejected_total` (counter), spliced ahead of the OpenMetrics `# EOF` terminator and named consistently with existing `kb_*` exports (counter family name drops the `_total` suffix, matching `prometheus-export.ts`).

## Tests (in `src/cli-serve.test.ts`)
- Gate unit tests: env-config resolution + fallbacks; never exceeds `maxConcurrency`; returns `null` and increments `rejectedTotal` once cap+queue are full.
- Daemon integration: caps concurrent in-flight requests at the cap; replies `429` + `Retry-After: 1` once the queue is full, and `/metrics` reports `kb_daemon_rejected_total 1`.
- `appendDaemonAdmissionMetrics` splices ahead of `# EOF` and handles a body with no terminator.

## Verification
- `npx jest cli-serve` → **18 passed**. (`base-http-host` has no test file; `base-http-host.ts` is unchanged.)
- Full `tsc -p tsconfig.json` OOMs in this constrained sandbox (unrelated to the change); the changed files type-check under the jest (ts-jest) transform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
