### PR TITLE
feat(reindex): disk-space preflight guard (#645)

### DIFF
--- a/docs/reference/error-codes.md
+++ b/docs/reference/error-codes.md
@@ -30,6 +30,7 @@ can change between releases.
 | `PREFACE_SIDECAR_CORRUPT` | A contextual-preface sidecar is unreadable or inconsistent. | Corrupt sidecar JSON, partial sidecar writes, or sidecar content that no longer matches expected contextual-retrieval schema. | Delete the offending sidecar under `$FAISS_INDEX_PATH/.contextual-prefaces/` so the next ingest can regenerate it. | No |
 | `REINDEX_LOCK_HELD` | A contextual reindex cannot start because another reindex owns the model lock. | A live `kb reindex --with-context` run is active, or a previous run left a state file that still appears live. | Check `kb reindex status --format=json`; wait for the active run or follow the incident runbook before removing any lock/state file. | Yes |
 | `REINDEX_BUDGET_EXCEEDED` | The contextual reindex estimate exceeds the configured quiet-window budget. | The estimated runtime would cross the LRA cron window or configured reindex budget guard. | Schedule the run inside the quiet window, reduce scope where supported, or pass `--force` only when the operator accepts the risk. | No |
+| `INSUFFICIENT_DISK_SPACE` | A write-heavy reindex/ingest preflight estimated more bytes than the volume can hold. | Estimated index/sidecar bytes plus the `KB_MIN_FREE_DISK_BYTES` margin exceed the `statfs`-reported free space under `$FAISS_INDEX_PATH`; the run refused before writing. | Free disk space under `$FAISS_INDEX_PATH` (prune old index versions, clear caches) or lower `KB_MIN_FREE_DISK_BYTES`, then retry. | No |
 
 ## Response Guidance
 

--- a/src/canonical-log.ts
+++ b/src/canonical-log.ts
@@ -241,6 +241,11 @@ function categoryForKBError(code: KBErrorCode): CanonicalErrorCategory {
       return 'lock';
     case 'REINDEX_BUDGET_EXCEEDED':
       return 'input';
+    // #645 — disk-space preflight refusal. Like the budget guard above it is
+    // a preflight precondition failure detected before any write, so it
+    // shares the `input` category.
+    case 'INSUFFICIENT_DISK_SPACE':
+      return 'input';
   }
 }
 
@@ -259,6 +264,7 @@ function isKBErrorCode(code: string): code is KBErrorCode {
     'PREFACE_SIDECAR_CORRUPT',
     'REINDEX_LOCK_HELD',
     'REINDEX_BUDGET_EXCEEDED',
+    'INSUFFICIENT_DISK_SPACE',
   ].includes(code);
 }
 

--- a/src/cli-reindex.test.ts
+++ b/src/cli-reindex.test.ts
@@ -4,7 +4,10 @@
 // index. These tests pin the help text so it cannot drift back to the
 // earlier wording that implied `--kb` limits which vectors are rebuilt.
 
-import { describe, expect, it } from '@jest/globals';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import * as fsp from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
 import { REINDEX_HELP } from './cli-reindex.js';
 
 describe('REINDEX_HELP — --kb scope accuracy (issue #406)', () => {
@@ -24,5 +27,61 @@ describe('REINDEX_HELP — --kb scope accuracy (issue #406)', () => {
   it('states the rebuild is always global regardless of --kb', () => {
     expect(REINDEX_HELP).toMatch(/always\s+global/i);
     expect(REINDEX_HELP).toMatch(/entire FAISS index/i);
+  });
+});
+
+// Issue #645 — disk-space preflight guard. The CLI must document and honor
+// exit code 5 (preflight refused before any write).
+describe('REINDEX_HELP — disk-space preflight exit code (issue #645)', () => {
+  it('documents exit code 5 for the disk-space preflight', () => {
+    expect(REINDEX_HELP).toMatch(/^\s*5\s+disk-space preflight/m);
+    expect(REINDEX_HELP).toMatch(/KB_MIN_FREE_DISK_BYTES/);
+  });
+});
+
+describe('runReindexCli — disk-space preflight (issue #645)', () => {
+  const savedEnv = {
+    FAISS_INDEX_PATH: process.env.FAISS_INDEX_PATH,
+    KB_MIN_FREE_DISK_BYTES: process.env.KB_MIN_FREE_DISK_BYTES,
+    KB_CONTEXTUAL_RETRIEVAL: process.env.KB_CONTEXTUAL_RETRIEVAL,
+  };
+  let dir: string;
+  let stderr: string;
+  let originalStderrWrite: typeof process.stderr.write;
+
+  beforeEach(async () => {
+    dir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-reindex-preflight-'));
+    stderr = '';
+    originalStderrWrite = process.stderr.write.bind(process.stderr);
+    process.stderr.write = ((chunk: string | Uint8Array) => {
+      stderr += typeof chunk === 'string' ? chunk : chunk.toString();
+      return true;
+    }) as typeof process.stderr.write;
+  });
+
+  afterEach(async () => {
+    process.stderr.write = originalStderrWrite;
+    for (const [key, value] of Object.entries(savedEnv)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    jest.resetModules();
+    await fsp.rm(dir, { recursive: true, force: true });
+  });
+
+  it('returns exit code 5 and writes a "need ~X, have Y" message when space is short', async () => {
+    // Point the index at a real (existing) dir so statfs succeeds, and set
+    // an impossible margin so the preflight always refuses. No write occurs.
+    process.env.FAISS_INDEX_PATH = dir;
+    process.env.KB_MIN_FREE_DISK_BYTES = String(Number.MAX_SAFE_INTEGER);
+    process.env.KB_CONTEXTUAL_RETRIEVAL = 'on';
+    jest.resetModules();
+    const { runReindexCli } = await import('./cli-reindex.js');
+
+    const code = await runReindexCli(['--with-context']);
+    expect(code).toBe(5);
+    expect(stderr).toMatch(/kb reindex: Insufficient disk space/);
+    expect(stderr).toMatch(/need ~/);
+    expect(stderr).toMatch(/have .* free/);
   });
 });

--- a/src/cli-reindex.ts
+++ b/src/cli-reindex.ts
@@ -15,6 +15,9 @@ import {
   type ReindexProgress,
 } from './reindex-progress.js';
 import { isContextualRetrievalEnabled } from './config/contextual-preface.js';
+import { FAISS_INDEX_PATH } from './config/paths.js';
+import { assertSufficientDiskSpace } from './disk-preflight.js';
+import { KBError } from './errors.js';
 import { logger } from './logger.js';
 
 export const REINDEX_HELP = `kb reindex — rebuild FAISS indexes (RFC 017)
@@ -94,6 +97,8 @@ Exit codes:
   2   argv / env error (e.g. --kb=<missing>, missing --with-context)
   3   guard blocked the run (inside or crossing the LRA window)
   4   another reindex is already running on the same model
+  5   disk-space preflight failed (estimated write exceeds free space
+      minus the KB_MIN_FREE_DISK_BYTES margin); nothing was written (#645)
 `;
 
 interface ReindexArgs {
@@ -159,6 +164,21 @@ export async function runReindexCli(rest: string[]): Promise<number> {
         'The reindex will run, but newly-embedded chunks will not carry contextual prefaces — ' +
         'i.e. it would behave like a force-rebuild without the feature. Set the env var first if that is unintended.\n',
     );
+  }
+
+  // #645 — disk-space preflight. A reindex writes a fresh FAISS index
+  // version, docstore, sidecars, and lexical indexes under
+  // $FAISS_INDEX_PATH before the atomic swap; refuse up front when the
+  // volume cannot hold the estimate (+ margin) instead of failing with a
+  // raw ENOSPC partway through an expensive run.
+  try {
+    await assertSufficientDiskSpace(FAISS_INDEX_PATH);
+  } catch (err) {
+    if (err instanceof KBError && err.code === 'INSUFFICIENT_DISK_SPACE') {
+      process.stderr.write(`kb reindex: ${err.message}\n`);
+      return 5;
+    }
+    throw err;
   }
 
   let result: ReindexResult;

--- a/src/disk-preflight.test.ts
+++ b/src/disk-preflight.test.ts
@@ -1,0 +1,186 @@
+// Issue #645 — unit tests for the disk-space preflight guard.
+//
+// Coverage:
+//  - resolveMinFreeDiskBytes: env parsing + fallback to the default margin.
+//  - evaluateDiskSpace: the pure sufficient/insufficient compare + clamping.
+//  - formatBytes: human-readable message formatting.
+//  - directorySizeBytes: recursive sizing of a real temp tree (+ ENOENT → 0).
+//  - assertSufficientDiskSpace: throws the typed KBError with a "need ~X,
+//    have Y" message when space is short (mocked statfs / current bytes),
+//    passes when ample, and degrades gracefully when statfs fails.
+
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+import * as fsp from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+
+import {
+  DEFAULT_MIN_FREE_DISK_BYTES,
+  DEFAULT_REINDEX_ESTIMATE_FACTOR,
+  assertSufficientDiskSpace,
+  availableDiskBytes,
+  directorySizeBytes,
+  evaluateDiskSpace,
+  formatBytes,
+  resolveMinFreeDiskBytes,
+} from './disk-preflight.js';
+import { KBError } from './errors.js';
+
+const MiB = 1024 * 1024;
+
+describe('resolveMinFreeDiskBytes (issue #645)', () => {
+  it('returns the default margin when unset or empty', () => {
+    expect(resolveMinFreeDiskBytes(undefined)).toBe(DEFAULT_MIN_FREE_DISK_BYTES);
+    expect(resolveMinFreeDiskBytes('')).toBe(DEFAULT_MIN_FREE_DISK_BYTES);
+    expect(resolveMinFreeDiskBytes('   ')).toBe(DEFAULT_MIN_FREE_DISK_BYTES);
+  });
+
+  it('parses a valid non-negative integer', () => {
+    expect(resolveMinFreeDiskBytes('0')).toBe(0);
+    expect(resolveMinFreeDiskBytes('1048576')).toBe(MiB);
+    expect(resolveMinFreeDiskBytes('123.9')).toBe(123); // floored
+  });
+
+  it('falls back to the default on garbage or negative input', () => {
+    expect(resolveMinFreeDiskBytes('abc')).toBe(DEFAULT_MIN_FREE_DISK_BYTES);
+    expect(resolveMinFreeDiskBytes('-5')).toBe(DEFAULT_MIN_FREE_DISK_BYTES);
+    expect(resolveMinFreeDiskBytes('NaN')).toBe(DEFAULT_MIN_FREE_DISK_BYTES);
+  });
+});
+
+describe('evaluateDiskSpace (issue #645)', () => {
+  it('is sufficient when available >= estimate + margin', () => {
+    const e = evaluateDiskSpace({ estimatedBytes: 100, availableBytes: 250, marginBytes: 150 });
+    expect(e.required_bytes).toBe(250);
+    expect(e.sufficient).toBe(true);
+  });
+
+  it('is insufficient when available < estimate + margin', () => {
+    const e = evaluateDiskSpace({ estimatedBytes: 100, availableBytes: 249, marginBytes: 150 });
+    expect(e.required_bytes).toBe(250);
+    expect(e.sufficient).toBe(false);
+  });
+
+  it('treats exact equality as sufficient', () => {
+    const e = evaluateDiskSpace({ estimatedBytes: 100, availableBytes: 100, marginBytes: 0 });
+    expect(e.sufficient).toBe(true);
+  });
+
+  it('clamps negative / non-finite inputs to zero', () => {
+    const e = evaluateDiskSpace({
+      estimatedBytes: -10,
+      availableBytes: Number.NaN,
+      marginBytes: -1,
+    });
+    expect(e.estimated_bytes).toBe(0);
+    expect(e.available_bytes).toBe(0);
+    expect(e.margin_bytes).toBe(0);
+    expect(e.required_bytes).toBe(0);
+    expect(e.sufficient).toBe(true);
+  });
+});
+
+describe('formatBytes (issue #645)', () => {
+  it('renders 1024-based units', () => {
+    expect(formatBytes(0)).toBe('0 B');
+    expect(formatBytes(512)).toBe('512 B');
+    expect(formatBytes(1024)).toBe('1 KiB');
+    expect(formatBytes(1536)).toBe('1.5 KiB');
+    expect(formatBytes(512 * MiB)).toBe('512 MiB');
+    expect(formatBytes(2 * 1024 * MiB)).toBe('2 GiB');
+  });
+
+  it('handles non-positive / non-finite input', () => {
+    expect(formatBytes(-1)).toBe('0 B');
+    expect(formatBytes(Number.NaN)).toBe('0 B');
+  });
+});
+
+describe('availableDiskBytes (issue #645)', () => {
+  it('multiplies bavail by bsize from the injected statfs', async () => {
+    const bytes = await availableDiskBytes('/whatever', async () => ({ bavail: 10, bsize: 4096 }));
+    expect(bytes).toBe(40960);
+  });
+});
+
+describe('directorySizeBytes (issue #645)', () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-disk-preflight-'));
+  });
+
+  afterEach(async () => {
+    await fsp.rm(dir, { recursive: true, force: true });
+  });
+
+  it('returns 0 for a non-existent directory (never indexed)', async () => {
+    expect(await directorySizeBytes(path.join(dir, 'missing'))).toBe(0);
+  });
+
+  it('sums file sizes recursively across nested directories', async () => {
+    await fsp.writeFile(path.join(dir, 'a.bin'), Buffer.alloc(100));
+    const sub = path.join(dir, 'nested', 'deep');
+    await fsp.mkdir(sub, { recursive: true });
+    await fsp.writeFile(path.join(sub, 'b.bin'), Buffer.alloc(250));
+    expect(await directorySizeBytes(dir)).toBe(350);
+  });
+});
+
+describe('assertSufficientDiskSpace (issue #645)', () => {
+  const okStatfs = (availableBytes: number) => async () => ({ bavail: availableBytes, bsize: 1 });
+
+  it('returns the estimate when space is ample', async () => {
+    const estimate = await assertSufficientDiskSpace('/index', {
+      currentBytes: 1000,
+      estimateFactor: 2,
+      minFreeBytes: 500,
+      statfs: okStatfs(10_000),
+    });
+    expect(estimate.estimated_bytes).toBe(2000); // 1000 * factor 2
+    expect(estimate.required_bytes).toBe(2500); // + 500 margin
+    expect(estimate.available_bytes).toBe(10_000);
+    expect(estimate.sufficient).toBe(true);
+  });
+
+  it('throws a typed INSUFFICIENT_DISK_SPACE KBError when space is short', async () => {
+    expect.assertions(4);
+    try {
+      await assertSufficientDiskSpace('/index', {
+        currentBytes: 4 * MiB,
+        estimateFactor: 1.5,
+        minFreeBytes: 2 * MiB,
+        statfs: okStatfs(5 * MiB),
+      });
+    } catch (err) {
+      expect(err).toBeInstanceOf(KBError);
+      expect((err as KBError).code).toBe('INSUFFICIENT_DISK_SPACE');
+      // need = 6 MiB estimate + 2 MiB margin = 8 MiB; have 5 MiB.
+      expect((err as KBError).message).toMatch(/need ~8 MiB/);
+      expect((err as KBError).message).toMatch(/have 5 MiB free/);
+    }
+  });
+
+  it('applies the default estimate factor when not overridden', async () => {
+    // current 1000 * 1.5 = 1500 estimate; margin 0; available 1500 → exact fit.
+    const estimate = await assertSufficientDiskSpace('/index', {
+      currentBytes: 1000,
+      minFreeBytes: 0,
+      statfs: okStatfs(1500),
+    });
+    expect(estimate.estimated_bytes).toBe(Math.ceil(1000 * DEFAULT_REINDEX_ESTIMATE_FACTOR));
+    expect(estimate.sufficient).toBe(true);
+  });
+
+  it('degrades gracefully (no throw) when statfs is unavailable', async () => {
+    const estimate = await assertSufficientDiskSpace('/index', {
+      currentBytes: 9_999_999,
+      minFreeBytes: Number.MAX_SAFE_INTEGER,
+      statfs: async () => {
+        throw new Error('statfs not supported');
+      },
+    });
+    expect(estimate.sufficient).toBe(true);
+    expect(estimate.available_bytes).toBe(Number.POSITIVE_INFINITY);
+  });
+});

--- a/src/disk-preflight.ts
+++ b/src/disk-preflight.ts
@@ -1,0 +1,212 @@
+// Issue #645 — disk-space preflight guard for write-heavy reindex/ingest.
+//
+// A `kb reindex --with-context` triggers a full rebuild that writes a new
+// FAISS index version, docstore JSON, contextual-preface sidecars, and
+// lexical indexes under `$FAISS_INDEX_PATH` — all *before* the atomic swap
+// (RFC 014). If the volume runs out of space mid-write the operation
+// surfaces as a raw `ENOSPC` after an expensive partial run, leaving an
+// abandoned half-written version on disk.
+//
+// This module is the *preventive* complement to the `disk-full` chaos test
+// (#473): it estimates how many bytes the rebuild will need, compares that
+// (plus a safety margin) against the `statfs`-reported available bytes, and
+// throws a typed `KBError('INSUFFICIENT_DISK_SPACE', …)` with an actionable
+// "need ~X, have Y" message before any write starts.
+//
+// Design notes (see PR for alternatives):
+//  - Estimate = current on-disk footprint under `$FAISS_INDEX_PATH` × an
+//    empirical factor. A full reindex writes a fresh version roughly the
+//    size of the committed one; the factor covers the temporary overlap of
+//    old + new version during the atomic swap and sidecar growth. A
+//    first-ever reindex (empty dir) estimates 0, so only the margin gates it.
+//  - Margin is `KB_MIN_FREE_DISK_BYTES` (default 512 MiB), kept conservative
+//    and tunable so this is not a hard surprise.
+//  - `fs.promises.statfs` is on all supported Node versions; if it is
+//    unavailable or fails, the guard degrades gracefully (skips, logs a
+//    warning) rather than blocking a reindex on a portability gap.
+
+import * as fsp from 'fs/promises';
+import * as path from 'path';
+
+import { KBError } from './errors.js';
+import { logger } from './logger.js';
+
+/** Default safety margin: free bytes that must remain after the estimate. */
+export const DEFAULT_MIN_FREE_DISK_BYTES = 512 * 1024 * 1024; // 512 MiB
+
+/**
+ * Multiplier applied to the current on-disk index footprint to approximate
+ * the bytes a full rebuild will write. >1 because the atomic swap keeps the
+ * old version on disk while the new one is built (RFC 014) and sidecars can
+ * grow between runs. Conservative by design; tune via the PR if observed
+ * rebuilds need more headroom.
+ */
+export const DEFAULT_REINDEX_ESTIMATE_FACTOR = 1.5;
+
+/**
+ * Resolve the operator-tunable safety margin from `KB_MIN_FREE_DISK_BYTES`.
+ * Falls back to {@link DEFAULT_MIN_FREE_DISK_BYTES} when unset, empty, or
+ * not a finite non-negative number.
+ */
+export function resolveMinFreeDiskBytes(
+  raw: string | undefined = process.env.KB_MIN_FREE_DISK_BYTES,
+): number {
+  if (raw === undefined || raw.trim() === '') return DEFAULT_MIN_FREE_DISK_BYTES;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < 0) return DEFAULT_MIN_FREE_DISK_BYTES;
+  return Math.floor(n);
+}
+
+/** Test seam: returns available bytes for the filesystem backing `dir`. */
+export type StatfsFn = (dir: string) => Promise<{ bavail: number; bsize: number }>;
+
+const defaultStatfs: StatfsFn = async (dir) => {
+  const s = await fsp.statfs(dir);
+  return { bavail: Number(s.bavail), bsize: Number(s.bsize) };
+};
+
+/**
+ * Recursively sum the byte size of every regular file under `dir`.
+ * Best-effort: a missing directory (never indexed) yields 0, and unreadable
+ * entries are skipped rather than aborting the estimate.
+ */
+export async function directorySizeBytes(dir: string): Promise<number> {
+  let entries: Array<import('fs').Dirent>;
+  try {
+    entries = await fsp.readdir(dir, { withFileTypes: true });
+  } catch {
+    return 0;
+  }
+  let total = 0;
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      total += await directorySizeBytes(full);
+    } else if (entry.isFile()) {
+      try {
+        const st = await fsp.stat(full);
+        total += st.size;
+      } catch {
+        // best-effort
+      }
+    }
+  }
+  return total;
+}
+
+/** Available bytes on the filesystem backing `dir` (bavail × bsize). */
+export async function availableDiskBytes(dir: string, statfs: StatfsFn = defaultStatfs): Promise<number> {
+  const { bavail, bsize } = await statfs(dir);
+  return bavail * bsize;
+}
+
+export interface DiskSpaceEstimate {
+  /** Approximate bytes the write will produce. */
+  estimated_bytes: number;
+  /** Bytes currently free on the target filesystem. */
+  available_bytes: number;
+  /** Safety-margin bytes that must remain free after the write. */
+  margin_bytes: number;
+  /** estimated_bytes + margin_bytes — the minimum free space to proceed. */
+  required_bytes: number;
+  /** Whether available_bytes >= required_bytes. */
+  sufficient: boolean;
+}
+
+/**
+ * Pure compare logic — kept separate from any IO so it is trivially
+ * unit-testable. Negative or non-finite inputs are clamped to 0.
+ */
+export function evaluateDiskSpace(params: {
+  estimatedBytes: number;
+  availableBytes: number;
+  marginBytes: number;
+}): DiskSpaceEstimate {
+  const estimated = Math.max(0, Number.isFinite(params.estimatedBytes) ? params.estimatedBytes : 0);
+  const available = Math.max(0, Number.isFinite(params.availableBytes) ? params.availableBytes : 0);
+  const margin = Math.max(0, Number.isFinite(params.marginBytes) ? params.marginBytes : 0);
+  const required = estimated + margin;
+  return {
+    estimated_bytes: estimated,
+    available_bytes: available,
+    margin_bytes: margin,
+    required_bytes: required,
+    sufficient: available >= required,
+  };
+}
+
+/** Human-readable byte size for error messages (1024-based). */
+export function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return '0 B';
+  const units = ['B', 'KiB', 'MiB', 'GiB', 'TiB'];
+  let value = bytes;
+  let unit = 0;
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit += 1;
+  }
+  const rounded = unit === 0 ? Math.round(value) : Math.round(value * 10) / 10;
+  return `${rounded} ${units[unit]}`;
+}
+
+export interface DiskPreflightOptions {
+  /** Override the safety margin; defaults to {@link resolveMinFreeDiskBytes}. */
+  minFreeBytes?: number;
+  /** Override the estimate multiplier; defaults to {@link DEFAULT_REINDEX_ESTIMATE_FACTOR}. */
+  estimateFactor?: number;
+  /** Test seam: statfs implementation. */
+  statfs?: StatfsFn;
+  /** Test seam: precomputed current on-disk footprint of `dir`. */
+  currentBytes?: number;
+}
+
+/**
+ * Preflight guard: estimate the bytes a write-heavy reindex/ingest against
+ * `dir` will need and refuse up front when the filesystem cannot hold it.
+ *
+ * Throws `KBError('INSUFFICIENT_DISK_SPACE', …)` with a "need ~X, have Y"
+ * message when available space is below estimate + margin. Returns the
+ * computed {@link DiskSpaceEstimate} on success.
+ *
+ * If `statfs` is unavailable or fails (older runtimes, exotic filesystems),
+ * the guard degrades gracefully: it logs a warning and returns a permissive
+ * estimate rather than blocking the operation on a portability gap.
+ */
+export async function assertSufficientDiskSpace(
+  dir: string,
+  options: DiskPreflightOptions = {},
+): Promise<DiskSpaceEstimate> {
+  const margin = options.minFreeBytes ?? resolveMinFreeDiskBytes();
+  const factor = options.estimateFactor ?? DEFAULT_REINDEX_ESTIMATE_FACTOR;
+
+  const currentBytes = options.currentBytes ?? (await directorySizeBytes(dir));
+  const estimatedBytes = Math.ceil(currentBytes * factor);
+
+  let availableBytes: number;
+  try {
+    availableBytes = await availableDiskBytes(dir, options.statfs ?? defaultStatfs);
+  } catch (err) {
+    logger.warn(
+      `#645: disk-space preflight skipped — statfs("${dir}") failed: ${(err as Error).message}`,
+    );
+    return {
+      estimated_bytes: estimatedBytes,
+      available_bytes: Number.POSITIVE_INFINITY,
+      margin_bytes: margin,
+      required_bytes: estimatedBytes + margin,
+      sufficient: true,
+    };
+  }
+
+  const estimate = evaluateDiskSpace({ estimatedBytes, availableBytes, marginBytes: margin });
+  if (!estimate.sufficient) {
+    throw new KBError(
+      'INSUFFICIENT_DISK_SPACE',
+      `Insufficient disk space for reindex at "${dir}": need ~${formatBytes(estimate.required_bytes)} ` +
+        `(estimate ${formatBytes(estimate.estimated_bytes)} + ${formatBytes(estimate.margin_bytes)} margin), ` +
+        `have ${formatBytes(estimate.available_bytes)} free. ` +
+        `Free up space or lower KB_MIN_FREE_DISK_BYTES (current margin ${estimate.margin_bytes} bytes).`,
+    );
+  }
+  return estimate;
+}

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -17,7 +17,13 @@ export type KBErrorCode =
   | 'PREFACE_LLM_FAILURE'
   | 'PREFACE_SIDECAR_CORRUPT'
   | 'REINDEX_LOCK_HELD'
-  | 'REINDEX_BUDGET_EXCEEDED';
+  | 'REINDEX_BUDGET_EXCEEDED'
+  // Issue #645 — disk-space preflight guard. Thrown by the reindex/ingest
+  // entry path when estimated required bytes exceed available free space
+  // (minus the KB_MIN_FREE_DISK_BYTES margin), so a write-heavy run fails
+  // fast with an actionable "need ~X, have Y" message instead of an
+  // ENOSPC partway through.
+  | 'INSUFFICIENT_DISK_SPACE';
 
 export class KBError extends Error {
   readonly code: KBErrorCode;

--- a/src/search-errors-core.ts
+++ b/src/search-errors-core.ts
@@ -204,6 +204,17 @@ function classifyKBError(err: KBError): SearchFailure {
         next_action:
           'The estimated reindex runtime would cross the LRA cron window (06:00-10:30 UTC). Schedule the run for the quiet window or pass `--force`.',
       };
+    // #645 — disk-space preflight refusal. Not reachable from the search
+    // path (it originates in the reindex/ingest entry path), but wired in to
+    // keep the exhaustiveness check honest when the code is added.
+    case 'INSUFFICIENT_DISK_SPACE':
+      return {
+        code,
+        category: 'input',
+        message: err.message,
+        next_action:
+          'Free disk space under `$FAISS_INDEX_PATH` (or lower `KB_MIN_FREE_DISK_BYTES`) and retry; the reindex/ingest refused before writing.',
+      };
     default: {
       // Exhaustiveness — if a new KBErrorCode is added, the switch above must
       // be updated. The fallthrough here keeps the runtime behaviour safe.


### PR DESCRIPTION
## Summary

Adds a **disk-space preflight guard** for write-heavy reindex/ingest so the operation fails fast with an actionable, typed error instead of a raw `ENOSPC` partway through an expensive run (which can leave a half-written index version behind).

Closes #645

## What changed

- **`src/disk-preflight.ts`** (new): estimates required bytes and compares against free space.
  - `assertSufficientDiskSpace(dir, opts)` — estimate = current on-disk footprint under `dir` × an empirical factor; throws `KBError('INSUFFICIENT_DISK_SPACE', …)` when `available < estimate + margin`.
  - Pure, unit-testable helpers: `evaluateDiskSpace`, `directorySizeBytes`, `availableDiskBytes` (statfs seam), `resolveMinFreeDiskBytes`, `formatBytes`.
  - Margin is `KB_MIN_FREE_DISK_BYTES` (default **512 MiB**).
  - If `statfs` is unavailable/fails, the guard **degrades gracefully** (logs a warning, does not block) rather than failing on a portability gap.
- **`src/errors.ts`**: additive new `KBErrorCode` `INSUFFICIENT_DISK_SPACE`.
- **`src/cli-reindex.ts`**: calls the preflight against `FAISS_INDEX_PATH` in the reindex entry path before `runReindex`; insufficient space prints the message and **exits 5** (newly documented in `REINDEX_HELP`) without starting the rebuild.
- **`src/canonical-log.ts`, `src/search-errors-core.ts`**: wire the new code into the two existing **exhaustive** `KBErrorCode` switches (compile-required). Both map it to the `input` category, matching the sibling preflight guard `REINDEX_BUDGET_EXCEEDED`.
- Tests: `src/disk-preflight.test.ts` (estimate/compare logic + typed error with mocked statfs) and an exit-code-5 behavioral test added to `src/cli-reindex.test.ts`.

## Design choices (issue left these open — smallest implementation chosen)

- **Estimate factor `1.5`** (constant `DEFAULT_REINDEX_ESTIMATE_FACTOR`). A full rebuild writes a fresh version ≈ the committed one; >1 covers the old+new overlap during the atomic swap (RFC 014) plus sidecar growth. *Alternative:* corpus-size × per-chunk factor, or an env-tunable factor — deferred to keep the surface minimal.
- **Margin default `512 MiB`** via `KB_MIN_FREE_DISK_BYTES`. *Alternative:* a percentage-of-volume margin — deferred.
- **Scope:** per the task constraints, `KB_MIN_FREE_DISK_BYTES` is read directly from env in `disk-preflight.ts` rather than added to `config/schema.ts`, and the guard is invoked from `cli-reindex.ts` rather than editing `FaissIndexManager.ts`.
- **`--force` is orthogonal** to the disk guard (it only bypasses the LRA-cron guards); lower/disable via `KB_MIN_FREE_DISK_BYTES`.

## Testing

```
npx jest --runInBand --runTestsByPath src/disk-preflight.test.ts src/cli-reindex.test.ts
# Test Suites: 2 passed, 2 total
# Tests:       21 passed, 21 total
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
