### PR TITLE
chore(build): enable TypeScript incremental builds (#643)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 build/
 coverage/
+*.tsbuildinfo
 __pycache__/
 *.py[cod]
 .DS_Store

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,17 @@ For focused local work:
 
 Treat watch mode as local-only. It expects an interactive terminal and should not be used in automation.
 
+## Incremental Builds
+
+`tsc` runs with `incremental: true`, persisting compile state to `build/.tsbuildinfo` (and `build/benchmarks/.tsbuildinfo` for the bench config). Unchanged files are skipped, so the second `npm run build` after a small edit is much faster than the cold build. The `.tsbuildinfo` files live under the git-ignored `build/` directory and are never committed; CI always runs from a clean checkout, so it gets a correct cold build.
+
+If a branch switch or other change leaves stale build state, reset it with the clean escape hatch:
+
+- `npm run build:clean` — removes the `build/` directory (including `.tsbuildinfo`).
+- Equivalently, `rm -rf build` or `tsc --build --clean`.
+
+The next `npm run build` then rebuilds from scratch.
+
 ## Spinning Off Follow-Up Issues
 
 If you notice an obvious-but-out-of-scope bug or improvement while working, do not silently absorb it into the current PR. Open a tracking issue with the **What / Where (file:line) / Why / Suggested fix** format and link it in the PR's **Follow-ups** section.

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json && chmod +x build/index.js build/cli.js",
+    "build:clean": "rm -rf build",
     "check": "npm run build && npm run test:coverage && npm run docs:check-anchors && npm run docs:check-config-reference",
     "bench": "npm run build && tsc -p tsconfig.bench.json && node build/benchmarks/run.js",
     "bench:beir": "npm run build && tsc -p tsconfig.bench.json && node build/benchmarks/beir/run.js",

--- a/tsconfig.bench.json
+++ b/tsconfig.bench.json
@@ -2,7 +2,8 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "build/benchmarks",
-    "rootDir": "benchmarks"
+    "rootDir": "benchmarks",
+    "tsBuildInfoFile": "build/benchmarks/.tsbuildinfo"
   },
   "include": ["benchmarks/**/*.ts"],
   "exclude": ["node_modules", "benchmarks/**/*.test.ts"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,9 @@
     "outDir": "build",
     "rootDir": "src",
     "sourceMap": true,
-    "useDefineForClassFields": true
+    "useDefineForClassFields": true,
+    "incremental": true,
+    "tsBuildInfoFile": "build/.tsbuildinfo"
   },
   "include": ["src/**/*.ts", "src/**/*.mjs"],
   "exclude": ["node_modules", "src/**/*.test.ts", "src/test-support"]


### PR DESCRIPTION
## Summary
Enables TypeScript **incremental** compilation so the warm local `build→test` loop is faster, while keeping CI's clean cold build correct.

- `tsconfig.json`: `incremental: true` + `tsBuildInfoFile: build/.tsbuildinfo`.
- `tsconfig.bench.json`: inherits `incremental` via `extends`, with its own `build/benchmarks/.tsbuildinfo`.
- `.gitignore`: ignore `*.tsbuildinfo` (the state lives under the already-ignored `build/`, so it is never committed; CI runs from a clean checkout → correct cold build).
- `CONTRIBUTING.md`: documents the behavior and the clean escape hatch.
- `package.json`: appends a single `build:clean` script (`rm -rf build`) — `build`/`check`/`test` lines untouched.

## Scope / risk
Low-risk **incremental-only** change. Did **not** migrate to `composite`/project references (that needs `declaration: true` and can surface latent type issues) — left as a deferred follow-up.

## Verification
- `tsc -p tsconfig.json --showConfig` resolves `incremental: true` and `tsBuildInfoFile: ./build/.tsbuildinfo`.
- Configs and `package.json` parse as valid JSON.
- CI runs the full clean build/test.

Closes #643