### PR TITLE
feat(ask): interactive `kb ask -i` REPL with multi-turn follow-ups (#649)

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -78,6 +78,10 @@ Options:
   --endpoint=<url>      OpenAI-compatible chat endpoint for this call only.
   --llm-profile=<name>  Use a saved `kb llm` profile.
   --format=md|json      Output format (default: md).
+  --interactive, -i     Start a multi-turn REPL: the first question retrieves
+                        evidence and follow-ups reuse it (/refresh to re-retrieve).
+                        Requires a TTY; otherwise falls back to one-shot. In-session
+                        commands: /sources, /kb <name>, /save, /refresh, /reset, /exit.
   --no-stream           Wait for the full answer before printing markdown output.
   --timing              Include elapsed milliseconds for retrieval and LLM stages.
   --stdin               Read question from stdin.

--- a/src/ask-core.ts
+++ b/src/ask-core.ts
@@ -217,14 +217,26 @@ export async function askKnowledge(
   }, deps, nowMs());
 }
 
-export async function executeAsk(
+export interface AskEvidence {
+  /** Embedding model id used for retrieval (folds into the answer-cache key). */
+  activeModelId: string;
+  /** Retrieved + sensitivity-hydrated + gated documents, reusable across turns. */
+  results: SearchResultDocument[];
+}
+
+/**
+ * Retrieval half of {@link executeAsk}: resolves the active embedding model and
+ * returns the retrieved evidence. Split out so the interactive REPL (#649) can
+ * retrieve once and reuse the same evidence across follow-up turns instead of
+ * paying retrieval latency on every question.
+ */
+export async function retrieveAskEvidence(
   args: AskExecutionArgs,
   deps: RunAskCoreDeps,
-  totalStartedAt: number,
-): Promise<AskKnowledgeResult> {
+  timing: TimingPayload | null = null,
+): Promise<AskEvidence> {
   let activeModelId: string;
   let results;
-  const timing: TimingPayload | null = args.timing ? {} : null;
   try {
     let startedAt = nowMs();
     await deps.bootstrapLayout();
@@ -295,6 +307,24 @@ export async function executeAsk(
     const failure = classifyKbSearchError(err);
     throw new AskExecutionError(failure.message, exitCodeForFailure(failure), failure);
   }
+
+  return { activeModelId, results };
+}
+
+/**
+ * Answering half of {@link executeAsk}: packs the supplied evidence, resolves
+ * the LLM target, and produces the cited answer (with optional streaming). The
+ * REPL calls this directly with cached evidence on follow-up turns (#649), so
+ * the one-shot CLI and the interactive session share one answering path.
+ */
+export async function answerWithEvidence(
+  args: AskExecutionArgs,
+  evidence: AskEvidence,
+  deps: RunAskCoreDeps,
+  totalStartedAt: number,
+  timing: TimingPayload | null = null,
+): Promise<AskKnowledgeResult> {
+  const { activeModelId, results } = evidence;
 
   let target: LlmTarget;
   try {
@@ -438,6 +468,16 @@ export async function executeAsk(
     abstention_reason: inferAskAbstentionReason(answer, packedContext.payload),
     ...(compactTiming ? { timing: compactTiming } : {}),
   };
+}
+
+export async function executeAsk(
+  args: AskExecutionArgs,
+  deps: RunAskCoreDeps,
+  totalStartedAt: number,
+): Promise<AskKnowledgeResult> {
+  const timing: TimingPayload | null = args.timing ? {} : null;
+  const evidence = await retrieveAskEvidence(args, deps, timing);
+  return answerWithEvidence(args, evidence, deps, totalStartedAt, timing);
 }
 
 const ASK_REDACT_OUTBOUND_ENV = 'KB_ASK_REDACT_OUTBOUND';

--- a/src/ask-repl.test.ts
+++ b/src/ask-repl.test.ts
@@ -1,0 +1,273 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { Readable, Writable } from 'stream';
+import {
+  buildHistoryContext,
+  createReplSession,
+  formatSourcesBlock,
+  parseReplLine,
+  runAskRepl,
+  type SaveTranscriptInput,
+  type SaveTranscriptResult,
+} from './ask-repl.js';
+import { AnswerCache } from './ask-answer-cache.js';
+import type { AskExecutionArgs, AskKnowledgeResult, RunAskCoreDeps } from './ask-core.js';
+import type { ChatCompletionOptions, ChatCompletionResult } from './llm-client.js';
+
+// --- fixtures (mirrors the manager/deps shape in ask-core.test.ts) ----------
+
+function makeManager(): { similaritySearch: jest.Mock } & Record<string, unknown> {
+  return {
+    modelDir: '/tmp/kb-ask-repl-model',
+    initialize: jest.fn(async () => {}),
+    updateIndex: jest.fn(async () => {}),
+    similaritySearch: jest.fn(async () => [
+      {
+        pageContent: 'The deploy switched the embedding model.',
+        metadata: {
+          knowledgeBase: 'ops',
+          relativePath: 'deploys.md',
+          loc: { lines: { from: 10, to: 18 } },
+        },
+        score: 0.1234,
+      },
+    ]),
+  };
+}
+
+type ChatMock = jest.MockedFunction<(options: ChatCompletionOptions) => Promise<ChatCompletionResult>>;
+
+function staticAnswer(content = 'A grounded answer.'): ChatMock {
+  return jest.fn(async () => ({ content, model: 'qwen3', raw: {} })) as unknown as ChatMock;
+}
+
+function makeCoreDeps(manager: ReturnType<typeof makeManager>, call: ChatMock): RunAskCoreDeps {
+  return {
+    bootstrapLayout: jest.fn(async () => {}),
+    resolveActiveModel: jest.fn(async () => 'ollama__nomic-embed-text-latest') as RunAskCoreDeps['resolveActiveModel'],
+    loadManagerForModel: jest.fn(async () => manager as never),
+    loadReadOnlyIndex: jest.fn(async () => {}),
+    withWriteLock: (jest.fn(async <T>(_resource: string, action: () => Promise<T>) => action())) as RunAskCoreDeps['withWriteLock'],
+    callChatCompletion: call as unknown as RunAskCoreDeps['callChatCompletion'],
+    answerCache: new AnswerCache({ enabled: false }),
+  };
+}
+
+function baseArgs(kb?: string): AskExecutionArgs {
+  return {
+    question: '',
+    ...(kb !== undefined ? { kb } : {}),
+    endpoint: 'http://127.0.0.1:9/v1/chat/completions',
+    k: 8,
+    contextBudgetTokens: 6000,
+    refresh: false,
+    timing: false,
+  };
+}
+
+function scripted(lines: string[]): Readable {
+  return Readable.from(lines.map((line) => `${line}\n`));
+}
+
+function sink(): { stream: Writable; text: () => string } {
+  const chunks: string[] = [];
+  const stream = new Writable({
+    write(chunk, _enc, cb) {
+      chunks.push(chunk.toString());
+      cb();
+    },
+  });
+  return { stream, text: () => chunks.join('') };
+}
+
+interface ReplHarness {
+  manager: ReturnType<typeof makeManager>;
+  call: ChatMock;
+  out: ReturnType<typeof sink>;
+  err: ReturnType<typeof sink>;
+}
+
+async function runScript(
+  lines: string[],
+  options: {
+    kb?: string;
+    call?: ChatMock;
+    saveTranscript?: (input: SaveTranscriptInput) => Promise<SaveTranscriptResult>;
+    env?: NodeJS.ProcessEnv;
+  } = {},
+): Promise<ReplHarness & { code: number }> {
+  const manager = makeManager();
+  const call = options.call ?? staticAnswer();
+  const out = sink();
+  const err = sink();
+  const code = await runAskRepl({
+    baseArgs: baseArgs(options.kb),
+    coreDeps: makeCoreDeps(manager, call),
+    input: scripted(lines),
+    output: out.stream,
+    errOutput: err.stream,
+    env: options.env ?? { NO_COLOR: '1' },
+    ...(options.saveTranscript !== undefined ? { saveTranscript: options.saveTranscript } : {}),
+  });
+  return { manager, call, out, err, code };
+}
+
+// --- pure helpers -----------------------------------------------------------
+
+describe('parseReplLine', () => {
+  it('treats non-slash lines as questions and blanks as empty', () => {
+    expect(parseReplLine('what changed?')).toEqual({ type: 'question', text: 'what changed?' });
+    expect(parseReplLine('   ')).toEqual({ type: 'empty' });
+  });
+
+  it('parses meta-commands with and without arguments', () => {
+    expect(parseReplLine('/sources')).toEqual({ type: 'sources' });
+    expect(parseReplLine('/kb ops')).toEqual({ type: 'kb', name: 'ops' });
+    expect(parseReplLine('/kb')).toEqual({ type: 'kb', name: null });
+    expect(parseReplLine('/save My Title')).toEqual({ type: 'save', title: 'My Title' });
+    expect(parseReplLine('/save')).toEqual({ type: 'save' });
+    expect(parseReplLine('/refresh')).toEqual({ type: 'refresh' });
+    expect(parseReplLine('/reset')).toEqual({ type: 'reset' });
+    expect(parseReplLine('/help')).toEqual({ type: 'help' });
+    expect(parseReplLine('/exit')).toEqual({ type: 'exit' });
+    expect(parseReplLine('/quit')).toEqual({ type: 'exit' });
+  });
+
+  it('flags unknown commands without confusing them for questions', () => {
+    expect(parseReplLine('/bogus now')).toEqual({ type: 'unknown', command: 'bogus' });
+  });
+});
+
+describe('buildHistoryContext', () => {
+  it('returns empty for no history and bounds to the most recent turns', () => {
+    expect(buildHistoryContext([], 6)).toBe('');
+    const turns = Array.from({ length: 5 }, (_, i) => ({ question: `q${i}`, answer: `a${i}` }));
+    const ctx = buildHistoryContext(turns, 2);
+    expect(ctx).toContain('q3');
+    expect(ctx).toContain('q4');
+    expect(ctx).not.toContain('q0');
+  });
+});
+
+describe('formatSourcesBlock', () => {
+  it('lists citations, and reports none when empty', () => {
+    const withCites = { citations: [{ knowledge_base: 'ops', path: 'deploys.md', score: 0.12, chunk_id: 'c1' }] } as AskKnowledgeResult;
+    expect(formatSourcesBlock(withCites)).toContain('ops:deploys.md');
+    const empty = { citations: [] } as unknown as AskKnowledgeResult;
+    expect(formatSourcesBlock(empty)).toMatch(/none/);
+  });
+});
+
+describe('createReplSession', () => {
+  it('normalizes a blank KB to undefined', () => {
+    expect(createReplSession('  ').kb).toBeUndefined();
+    expect(createReplSession('ops').kb).toBe('ops');
+  });
+});
+
+// --- loop behavior ----------------------------------------------------------
+
+describe('runAskRepl loop', () => {
+  it('retrieves once and reuses evidence for follow-up turns', async () => {
+    const h = await runScript(['first question', 'a follow up', '/exit'], { kb: 'ops' });
+    expect(h.code).toBe(0);
+    // Retrieval ran once; both turns answered (evidence reused on the follow-up).
+    expect(h.manager.similaritySearch).toHaveBeenCalledTimes(1);
+    expect(h.call).toHaveBeenCalledTimes(2);
+    expect(h.out.text()).toContain('A grounded answer.');
+  });
+
+  it('re-retrieves after /refresh', async () => {
+    const h = await runScript(['q1', '/refresh', 'q2', '/exit'], { kb: 'ops' });
+    expect(h.manager.similaritySearch).toHaveBeenCalledTimes(2);
+    expect(h.err.text()).toMatch(/re-retrieves/);
+  });
+
+  it('re-retrieves after switching the KB with /kb', async () => {
+    const h = await runScript(['q1', '/kb other', 'q2', '/exit'], { kb: 'ops' });
+    expect(h.manager.similaritySearch).toHaveBeenCalledTimes(2);
+    expect(h.err.text()).toContain('Switched to knowledge base: other');
+  });
+
+  it('serves /sources from the last answer and handles unknown commands', async () => {
+    const h = await runScript(['q1', '/sources', '/bogus', '/exit'], { kb: 'ops' });
+    expect(h.err.text()).toContain('Sources:');
+    expect(h.err.text()).toContain('ops:deploys.md');
+    expect(h.err.text()).toContain('Unknown command: /bogus');
+  });
+
+  it('reports no sources before any question', async () => {
+    const h = await runScript(['/sources', '/exit'], { kb: 'ops' });
+    expect(h.err.text()).toContain('No sources yet');
+    expect(h.manager.similaritySearch).not.toHaveBeenCalled();
+  });
+
+  it('/reset clears evidence and history so the next question re-retrieves', async () => {
+    const h = await runScript(['q1', '/reset', 'q2', '/exit'], { kb: 'ops' });
+    expect(h.err.text()).toContain('Session reset.');
+    expect(h.manager.similaritySearch).toHaveBeenCalledTimes(2);
+  });
+
+  it('streams answer tokens to stdout when the endpoint streams', async () => {
+    const streaming = jest.fn(async (options: ChatCompletionOptions) => {
+      if (options.stream) {
+        options.stream.onFirstToken?.();
+        await options.stream.onToken('AN');
+        await options.stream.onToken('SWER');
+      }
+      return { content: 'ANSWER', model: 'qwen3', raw: {} };
+    }) as unknown as ChatMock;
+    const h = await runScript(['q1', '/exit'], { kb: 'ops', call: streaming });
+    // Streamed once (not double-written from the final content).
+    expect(h.out.text()).toBe('ANSWER\n');
+  });
+
+  it('keeps the session alive when a turn fails', async () => {
+    const flaky = jest.fn<(options: ChatCompletionOptions) => Promise<ChatCompletionResult>>()
+      .mockRejectedValueOnce(new Error('llm offline'))
+      .mockResolvedValueOnce({ content: 'recovered', model: 'qwen3', raw: {} }) as unknown as ChatMock;
+    const h = await runScript(['q1', 'q2', '/exit'], { kb: 'ops', call: flaky });
+    expect(h.code).toBe(0);
+    expect(h.err.text()).toContain('ask failed: llm offline');
+    expect(h.out.text()).toContain('recovered');
+  });
+
+  it('honors NO_COLOR by emitting no ANSI escapes in the chrome', async () => {
+    const h = await runScript(['q1', '/exit'], { kb: 'ops', env: { NO_COLOR: '1' } });
+    // eslint-disable-next-line no-control-regex
+    expect(h.err.text()).not.toMatch(/\x1b\[/);
+  });
+
+  it('emits an ANSI prompt when color is enabled', async () => {
+    const h = await runScript(['/exit'], { kb: 'ops', env: {} });
+    // eslint-disable-next-line no-control-regex
+    expect(h.err.text()).toMatch(/\x1b\[1m/);
+  });
+});
+
+describe('runAskRepl /save', () => {
+  it('persists the last exchange through the save callback', async () => {
+    const saveTranscript = jest.fn(async (input: SaveTranscriptInput): Promise<SaveTranscriptResult> => ({
+      kb: input.kb,
+      path: 'ask-transcript.md',
+    }));
+    const h = await runScript(['q1', '/save', '/exit'], { kb: 'ops', saveTranscript });
+    expect(saveTranscript).toHaveBeenCalledTimes(1);
+    expect(saveTranscript.mock.calls[0]![0]).toMatchObject({ kb: 'ops', question: 'q1' });
+    expect(h.err.text()).toContain('Saved transcript: ops:ask-transcript.md');
+  });
+
+  it('refuses /save without a knowledge base', async () => {
+    const saveTranscript = jest.fn(async (input: SaveTranscriptInput): Promise<SaveTranscriptResult> => ({
+      kb: input.kb,
+      path: 'x.md',
+    }));
+    const h = await runScript(['q1', '/save', '/exit'], { saveTranscript });
+    expect(saveTranscript).not.toHaveBeenCalled();
+    expect(h.err.text()).toContain('needs a knowledge base');
+  });
+
+  it('refuses /save before any answer', async () => {
+    const h = await runScript(['/save', '/exit'], { kb: 'ops' });
+    expect(h.err.text()).toContain('Nothing to save yet');
+  });
+});

--- a/src/ask-repl.ts
+++ b/src/ask-repl.ts
@@ -1,0 +1,353 @@
+// Interactive `kb ask -i` REPL (#649). A readline loop that reuses the existing
+// answering core (src/ask-core.ts): the first question retrieves evidence, and
+// follow-up turns reuse the cached evidence (re-retrieving only on `/refresh`,
+// `/reset`, or a `/kb` switch). The REPL chrome — prompt, sources, notices — is
+// written to stderr so the answer text on stdout stays pipe-clean, mirroring the
+// `kb search -i` picker (src/cli-search-picker.ts). Honors NO_COLOR; the non-TTY
+// fall-back to one-shot lives in the caller (src/cli-ask.ts).
+
+import * as readline from 'readline';
+import {
+  answerWithEvidence,
+  retrieveAskEvidence,
+  type AskEvidence,
+  type AskExecutionArgs,
+  type AskKnowledgeResult,
+  type RunAskCoreDeps,
+} from './ask-core.js';
+import { nowMs } from './timing-core.js';
+
+/** Default number of prior Q/A exchanges folded into follow-up context. */
+export const DEFAULT_REPL_HISTORY_LIMIT = 6;
+/** Per-answer character cap when an exchange is replayed as follow-up context. */
+const HISTORY_ANSWER_CHAR_CAP = 600;
+
+export const REPL_HELP = `Interactive ask — commands:
+  <question>      Ask a question. The first question retrieves evidence;
+                  follow-ups reuse it until you /refresh, /reset, or /kb.
+  /sources        List the citations behind the most recent answer.
+  /kb <name>      Scope retrieval to a knowledge base (refreshes evidence).
+  /kb             Show the current knowledge-base scope.
+  /refresh        Drop cached evidence; the next question re-retrieves (rescan).
+  /save [title]   Save the last exchange as a transcript note (needs a KB).
+  /reset          Clear cached evidence and conversation history.
+  /help, /?       Show this help.
+  /exit, /quit    Leave the interactive session.`;
+
+export type ReplCommand =
+  | { type: 'question'; text: string }
+  | { type: 'sources' }
+  | { type: 'kb'; name: string | null }
+  | { type: 'save'; title?: string }
+  | { type: 'reset' }
+  | { type: 'refresh' }
+  | { type: 'help' }
+  | { type: 'exit' }
+  | { type: 'empty' }
+  | { type: 'unknown'; command: string };
+
+export interface ReplHistoryTurn {
+  question: string;
+  answer: string;
+}
+
+export interface AskReplSession {
+  kb: string | undefined;
+  /** Cached retrieval evidence reused across follow-ups (null forces a retrieve). */
+  evidence: AskEvidence | null;
+  /** When true, the next retrieval rescans KB files (set by /refresh). */
+  forceRescan: boolean;
+  lastResult: AskKnowledgeResult | null;
+  lastQuestion: string | null;
+  history: ReplHistoryTurn[];
+}
+
+export interface SaveTranscriptInput {
+  result: AskKnowledgeResult;
+  question: string;
+  kb: string;
+  title?: string;
+}
+
+export interface SaveTranscriptResult {
+  kb: string;
+  path: string;
+}
+
+export interface RunAskReplOptions {
+  /** Retrieval/answer parameters shared by every turn (question is per-turn). */
+  baseArgs: AskExecutionArgs;
+  coreDeps: RunAskCoreDeps;
+  input?: NodeJS.ReadableStream;
+  /** Answer text sink (defaults to stdout); kept clean for piping. */
+  output?: NodeJS.WritableStream;
+  /** REPL chrome sink — prompt, sources, notices (defaults to stderr). */
+  errOutput?: NodeJS.WritableStream;
+  env?: NodeJS.ProcessEnv;
+  /** Optional initial question (e.g. `kb ask -i "first question"`). */
+  seedQuestion?: string;
+  /** Persists the last exchange for /save; omitted when saving is unavailable. */
+  saveTranscript?: (input: SaveTranscriptInput) => Promise<SaveTranscriptResult>;
+  historyLimit?: number;
+  now?: () => number;
+}
+
+export function createReplSession(kb?: string): AskReplSession {
+  return {
+    kb: kb !== undefined && kb.trim() !== '' ? kb : undefined,
+    evidence: null,
+    forceRescan: false,
+    lastResult: null,
+    lastQuestion: null,
+    history: [],
+  };
+}
+
+export function parseReplLine(line: string): ReplCommand {
+  const trimmed = line.trim();
+  if (trimmed === '') return { type: 'empty' };
+  if (!trimmed.startsWith('/')) return { type: 'question', text: trimmed };
+
+  const body = trimmed.slice(1);
+  const spaceIndex = body.search(/\s/);
+  const command = (spaceIndex === -1 ? body : body.slice(0, spaceIndex)).toLowerCase();
+  const arg = spaceIndex === -1 ? '' : body.slice(spaceIndex + 1).trim();
+
+  switch (command) {
+    case 'sources':
+      return { type: 'sources' };
+    case 'kb':
+      return { type: 'kb', name: arg === '' ? null : arg };
+    case 'save':
+      return arg === '' ? { type: 'save' } : { type: 'save', title: arg };
+    case 'reset':
+      return { type: 'reset' };
+    case 'refresh':
+      return { type: 'refresh' };
+    case 'help':
+    case '?':
+      return { type: 'help' };
+    case 'exit':
+    case 'quit':
+    case 'q':
+      return { type: 'exit' };
+    default:
+      return { type: 'unknown', command };
+  }
+}
+
+export function replColorEnabled(env: NodeJS.ProcessEnv): boolean {
+  if (env.NO_COLOR !== undefined && env.NO_COLOR !== '') return false;
+  return true;
+}
+
+/** Render the citations behind a result as a stderr-friendly block. */
+export function formatSourcesBlock(result: AskKnowledgeResult): string {
+  if (result.citations.length === 0) {
+    return 'Sources: none (the answer cited no retrieved chunks).\n';
+  }
+  const lines = ['Sources:'];
+  for (const c of result.citations) {
+    const kb = c.knowledge_base ? `${c.knowledge_base}:` : '';
+    const score = typeof c.score === 'number' ? ` (score ${c.score.toFixed(2)})` : '';
+    const chunk = c.chunk_id ? ` - chunk ${c.chunk_id}` : '';
+    lines.push(`  - ${kb}${c.path}${score}${chunk}`);
+  }
+  return `${lines.join('\n')}\n`;
+}
+
+/**
+ * Fold recent exchanges into a compact, bounded task-context block so follow-up
+ * turns carry conversational memory without re-retrieving. Only passed to the
+ * answer phase (never the retrieval phase), so it never perturbs the relevance
+ * gate.
+ */
+export function buildHistoryContext(history: ReplHistoryTurn[], limit: number): string {
+  if (history.length === 0) return '';
+  const recent = history.slice(-limit);
+  const lines = ['Earlier conversation in this session (most recent last):'];
+  for (const turn of recent) {
+    lines.push(`Q: ${turn.question}`);
+    lines.push(`A: ${truncate(turn.answer, HISTORY_ANSWER_CHAR_CAP)}`);
+  }
+  return lines.join('\n');
+}
+
+function truncate(value: string, cap: number): string {
+  const compact = value.replace(/\s+/g, ' ').trim();
+  return compact.length > cap ? `${compact.slice(0, cap - 1)}…` : compact;
+}
+
+export async function runAskRepl(opts: RunAskReplOptions): Promise<number> {
+  const input = opts.input ?? process.stdin;
+  const output = opts.output ?? process.stdout;
+  const errOutput = opts.errOutput ?? process.stderr;
+  const env = opts.env ?? process.env;
+  const color = replColorEnabled(env);
+  const historyLimit = opts.historyLimit ?? DEFAULT_REPL_HISTORY_LIMIT;
+  const now = opts.now ?? nowMs;
+
+  const session = createReplSession(opts.baseArgs.kb);
+  const promptText = color ? '\x1b[1mkb›\x1b[0m ' : 'kb> ';
+  const promptOut = (): void => { errOutput.write(promptText); };
+
+  errOutput.write('Interactive ask — type a question, /help for commands, /exit to quit.\n');
+  if (session.kb !== undefined) errOutput.write(`Knowledge base: ${session.kb}\n`);
+
+  const buildTurnArgs = (question: string, refresh: boolean, withHistory: boolean): AskExecutionArgs => {
+    const taskContext = withHistory ? buildHistoryContext(session.history, historyLimit) : '';
+    return {
+      ...opts.baseArgs,
+      ...(session.kb !== undefined ? { kb: session.kb } : { kb: undefined }),
+      question,
+      refresh,
+      timing: false,
+      ...(taskContext !== '' ? { taskContext } : {}),
+    };
+  };
+
+  const handleQuestion = async (text: string): Promise<void> => {
+    try {
+      if (session.evidence === null) {
+        const retrievalArgs = buildTurnArgs(text, session.forceRescan, false);
+        session.evidence = await retrieveAskEvidence(retrievalArgs, opts.coreDeps);
+        session.forceRescan = false;
+      }
+      let streamed = false;
+      const answerArgs: AskExecutionArgs = {
+        ...buildTurnArgs(text, false, true),
+        onAnswerToken: (token: string) => {
+          streamed = true;
+          output.write(token);
+        },
+      };
+      const result = await answerWithEvidence(answerArgs, session.evidence, opts.coreDeps, now());
+      if (!streamed) output.write(result.answer);
+      output.write('\n');
+
+      session.lastResult = result;
+      session.lastQuestion = text;
+      session.history.push({ question: text, answer: result.answer });
+      if (session.history.length > historyLimit) {
+        session.history.splice(0, session.history.length - historyLimit);
+      }
+      errOutput.write(formatSourcesBlock(result));
+    } catch (err) {
+      // A failed turn (LLM down, retrieval error) must not kill the session. A
+      // retrieval failure leaves evidence null so the next question retries; an
+      // answer failure keeps the cached evidence for reuse.
+      errOutput.write(`ask failed: ${(err as Error).message}\n`);
+    }
+  };
+
+  const handleSave = async (title: string | undefined): Promise<void> => {
+    if (session.lastResult === null || session.lastQuestion === null) {
+      errOutput.write('Nothing to save yet — ask a question first.\n');
+      return;
+    }
+    if (opts.saveTranscript === undefined) {
+      errOutput.write('Saving transcripts is not available in this session.\n');
+      return;
+    }
+    if (session.kb === undefined) {
+      errOutput.write('/save needs a knowledge base — start with --kb=<name> or use /kb <name>.\n');
+      return;
+    }
+    try {
+      const saved = await opts.saveTranscript({
+        result: session.lastResult,
+        question: session.lastQuestion,
+        kb: session.kb,
+        ...(title !== undefined ? { title } : {}),
+      });
+      errOutput.write(`Saved transcript: ${saved.kb}:${saved.path}\n`);
+    } catch (err) {
+      errOutput.write(`save failed: ${(err as Error).message}\n`);
+    }
+  };
+
+  const handle = async (command: ReplCommand): Promise<void> => {
+    switch (command.type) {
+      case 'question':
+        await handleQuestion(command.text);
+        return;
+      case 'sources':
+        if (session.lastResult === null) errOutput.write('No sources yet — ask a question first.\n');
+        else errOutput.write(formatSourcesBlock(session.lastResult));
+        return;
+      case 'kb':
+        if (command.name === null) {
+          errOutput.write(`Knowledge base: ${session.kb ?? 'all (unscoped)'}\n`);
+        } else {
+          session.kb = command.name;
+          session.evidence = null;
+          errOutput.write(`Switched to knowledge base: ${command.name} (evidence refreshes on next question).\n`);
+        }
+        return;
+      case 'refresh':
+        session.evidence = null;
+        session.forceRescan = true;
+        errOutput.write('Evidence cleared; the next question re-retrieves (with a KB rescan).\n');
+        return;
+      case 'reset':
+        session.evidence = null;
+        session.forceRescan = false;
+        session.lastResult = null;
+        session.lastQuestion = null;
+        session.history = [];
+        errOutput.write('Session reset.\n');
+        return;
+      case 'save':
+        await handleSave(command.title);
+        return;
+      case 'help':
+        errOutput.write(`${REPL_HELP}\n`);
+        return;
+      case 'unknown':
+        errOutput.write(`Unknown command: /${command.command} — type /help for commands.\n`);
+        return;
+      case 'empty':
+      case 'exit':
+        return;
+    }
+  };
+
+  return new Promise<number>((resolve) => {
+    const rl = readline.createInterface({ input, terminal: false });
+    let queue: Promise<void> = Promise.resolve();
+    let closed = false;
+
+    const enqueue = (fn: () => Promise<void>): void => {
+      queue = queue.then(fn).catch((err) => {
+        errOutput.write(`repl error: ${(err as Error).message}\n`);
+      });
+    };
+
+    if (opts.seedQuestion !== undefined && opts.seedQuestion.trim() !== '') {
+      enqueue(async () => {
+        await handle({ type: 'question', text: opts.seedQuestion!.trim() });
+        if (!closed) promptOut();
+      });
+    } else {
+      promptOut();
+    }
+
+    rl.on('line', (line) => {
+      const command = parseReplLine(line);
+      if (command.type === 'exit') {
+        closed = true;
+        rl.close();
+        return;
+      }
+      enqueue(async () => {
+        await handle(command);
+        if (!closed) promptOut();
+      });
+    });
+
+    rl.on('close', () => {
+      closed = true;
+      queue.then(() => resolve(0)).catch(() => resolve(0));
+    });
+  });
+}

--- a/src/cli-ask.test.ts
+++ b/src/cli-ask.test.ts
@@ -43,6 +43,7 @@ describe('parseAskArgs', () => {
       refresh: true,
       stdin: false,
       format: 'json',
+      interactive: false,
       noStream: false,
       timing: true,
       saveTranscript: true,
@@ -64,6 +65,14 @@ describe('parseAskArgs', () => {
       question: 'what changed?',
       format: 'md',
       noStream: true,
+    });
+  });
+
+  it('parses -i / --interactive without consuming the question', () => {
+    expect(parseAskArgs(['-i'])).toMatchObject({ question: null, interactive: true });
+    expect(parseAskArgs(['--interactive', 'why?'])).toMatchObject({
+      question: 'why?',
+      interactive: true,
     });
   });
 
@@ -1367,3 +1376,74 @@ function createAskFixtureHarness(options: AskFixtureHarnessOptions) {
     },
   };
 }
+
+describe('kb ask --interactive routing', () => {
+  function makeInteractiveDeps(overrides: Partial<RunAskDeps> = {}): {
+    deps: RunAskDeps;
+    runRepl: jest.Mock;
+    callChatCompletion: jest.Mock;
+  } {
+    const manager = {
+      modelDir: '/tmp/kb-ask-repl-route',
+      initialize: jest.fn(async () => {}),
+      updateIndex: jest.fn(async () => {}),
+      similaritySearch: jest.fn(async () => [
+        {
+          pageContent: 'Rollback needs the release lead.',
+          metadata: { knowledgeBase: 'ops', relativePath: 'rollback.md' },
+          score: 0.1,
+        },
+      ]),
+    };
+    const callChatCompletion = jest.fn(async () => ({ content: 'one-shot answer', model: 'qwen3', raw: {} }));
+    const runRepl = jest.fn(async () => 0);
+    const deps: RunAskDeps = {
+      bootstrapLayout: jest.fn(async () => {}),
+      resolveActiveModel: jest.fn(async () => 'ollama__nomic-embed-text-latest'),
+      loadManagerForModel: jest.fn(async () => manager as never),
+      loadWithJsonRetry: jest.fn(async () => {}),
+      withWriteLock: jest.fn(async <T>(_resource: string, action: () => Promise<T>) => action()) as RunAskDeps['withWriteLock'],
+      callChatCompletion: callChatCompletion as unknown as RunAskDeps['callChatCompletion'],
+      createTranscriptNote: createAskTranscriptNote,
+      knowledgeBasesRootDir: '/tmp/kb-ask-root',
+      runRepl: runRepl as unknown as RunAskDeps['runRepl'],
+      ...overrides,
+    };
+    return { deps, runRepl: runRepl as unknown as jest.Mock, callChatCompletion: callChatCompletion as unknown as jest.Mock };
+  }
+
+  it('routes to the REPL with a seed question when stdin is a TTY', async () => {
+    const { deps, runRepl, callChatCompletion } = makeInteractiveDeps({ stdinIsTty: () => true });
+    const code = await runAsk(['-i', 'first question', '--kb=ops'], deps);
+    expect(code).toBe(0);
+    expect(runRepl).toHaveBeenCalledTimes(1);
+    expect(callChatCompletion).not.toHaveBeenCalled();
+    const opts = runRepl.mock.calls[0]![0] as { baseArgs: { kb?: string }; seedQuestion?: string };
+    expect(opts.baseArgs.kb).toBe('ops');
+    expect(opts.seedQuestion).toBe('first question');
+  });
+
+  it('falls back to one-shot when stdin is not a TTY', async () => {
+    const previousEndpoint = process.env.KB_LLM_ENDPOINT;
+    process.env.KB_LLM_ENDPOINT = 'http://127.0.0.1:8080/v1/chat/completions';
+    const stdoutSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    const stderr: string[] = [];
+    const stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation((chunk) => {
+      stderr.push(String(chunk));
+      return true;
+    });
+    try {
+      const { deps, runRepl, callChatCompletion } = makeInteractiveDeps({ stdinIsTty: () => false });
+      const code = await runAsk(['-i', 'a question', '--kb=ops'], deps);
+      expect(code).toBe(0);
+      expect(runRepl).not.toHaveBeenCalled();
+      expect(callChatCompletion).toHaveBeenCalledTimes(1);
+      expect(stderr.join('')).toContain('falling back to one-shot');
+    } finally {
+      stdoutSpy.mockRestore();
+      stderrSpy.mockRestore();
+      if (previousEndpoint === undefined) delete process.env.KB_LLM_ENDPOINT;
+      else process.env.KB_LLM_ENDPOINT = previousEndpoint;
+    }
+  });
+});

--- a/src/cli-ask.ts
+++ b/src/cli-ask.ts
@@ -37,11 +37,17 @@ import {
   executeAsk,
   packAskContext,
   type AskCitation,
+  type AskExecutionArgs,
   type AskKnowledgeResult,
   type AskLlmPayload,
   type AskRetrievalPayload,
   type RunAskCoreDeps,
 } from './ask-core.js';
+import {
+  runAskRepl,
+  type SaveTranscriptInput,
+  type SaveTranscriptResult,
+} from './ask-repl.js';
 
 export {
   DEFAULT_ASK_CONTEXT_BUDGET_TOKENS,
@@ -71,6 +77,10 @@ Options:
   --endpoint=<url>      OpenAI-compatible chat endpoint for this call only.
   --llm-profile=<name>  Use a saved \`kb llm\` profile.
   --format=md|json      Output format (default: md).
+  --interactive, -i     Start a multi-turn REPL: the first question retrieves
+                        evidence and follow-ups reuse it (/refresh to re-retrieve).
+                        Requires a TTY; otherwise falls back to one-shot. In-session
+                        commands: /sources, /kb <name>, /save, /refresh, /reset, /exit.
   --no-stream           Wait for the full answer before printing markdown output.
   --timing              Include elapsed milliseconds for retrieval and LLM stages.
   --stdin               Read question from stdin.
@@ -92,6 +102,7 @@ export interface AskArgs {
   refresh: boolean;
   stdin: boolean;
   format: 'md' | 'json';
+  interactive: boolean;
   noStream: boolean;
   timing: boolean;
   saveTranscript: boolean;
@@ -123,6 +134,10 @@ export interface RunAskDeps extends Omit<RunAskCoreDeps, 'loadReadOnlyIndex'> {
   loadWithJsonRetry: typeof loadWithJsonRetry;
   createTranscriptNote: typeof createAskTranscriptNote;
   knowledgeBasesRootDir: string;
+  /** Interactive REPL runner (injectable for tests; defaults to {@link runAskRepl}). */
+  runRepl?: typeof runAskRepl;
+  /** Whether stdin is a TTY — gates the REPL vs. the one-shot fall-back. */
+  stdinIsTty?: () => boolean;
 }
 
 const defaultRunAskDeps: RunAskDeps = {
@@ -134,6 +149,8 @@ const defaultRunAskDeps: RunAskDeps = {
   callChatCompletion,
   createTranscriptNote: createAskTranscriptNote,
   knowledgeBasesRootDir: KNOWLEDGE_BASES_ROOT_DIR,
+  runRepl: runAskRepl,
+  stdinIsTty: () => Boolean(process.stdin.isTTY),
 };
 
 export async function runAsk(rest: string[], deps: RunAskDeps = defaultRunAskDeps): Promise<number> {
@@ -148,6 +165,27 @@ export async function runAsk(rest: string[], deps: RunAskDeps = defaultRunAskDep
   if (args.stdin && args.question === null) {
     args.question = await readAllStdin();
   }
+
+  if (args.interactive) {
+    const stdinIsTty = deps.stdinIsTty ?? (() => Boolean(process.stdin.isTTY));
+    if (stdinIsTty()) {
+      const runRepl = deps.runRepl ?? runAskRepl;
+      const seedQuestion = args.question !== null && args.question.trim() !== ''
+        ? args.question.trim()
+        : undefined;
+      return runRepl({
+        baseArgs: toAskBaseArgs(args),
+        coreDeps: toRunAskCoreDeps(deps),
+        env: process.env,
+        ...(seedQuestion !== undefined ? { seedQuestion } : {}),
+        saveTranscript: (input) => persistAskTranscript(deps, input),
+      });
+    }
+    // Non-TTY (piped/redirected) input cannot drive a REPL — fall back to a
+    // single one-shot answer over the supplied question (#649).
+    process.stderr.write('kb ask: interactive mode requires a TTY; falling back to one-shot.\n');
+  }
+
   if (args.question === null || args.question.trim() === '') {
     const failure = classifyKbAskError(new Error('missing <question> (or use --stdin)'), 'argument');
     return reportAskFailure(args.format, failure);
@@ -295,6 +333,52 @@ function toRunAskCoreDeps(deps: RunAskDeps): RunAskCoreDeps {
   };
 }
 
+/** Project parsed CLI args onto the per-turn retrieval/answer shape the REPL drives. */
+function toAskBaseArgs(args: AskArgs): AskExecutionArgs {
+  return {
+    question: '',
+    ...(args.kb !== undefined ? { kb: args.kb } : {}),
+    ...(args.model !== undefined ? { model: args.model } : {}),
+    ...(args.llmProfile !== undefined ? { llmProfile: args.llmProfile } : {}),
+    ...(args.endpoint !== undefined ? { endpoint: args.endpoint } : {}),
+    k: args.k,
+    contextBudgetTokens: args.contextBudgetTokens,
+    refresh: args.refresh,
+    timing: false,
+    ...(args.taskContext !== undefined ? { taskContext: args.taskContext } : {}),
+    ...(args.gate !== undefined ? { gate: args.gate } : {}),
+  };
+}
+
+/**
+ * Persist a REPL exchange as a transcript note, reusing the one-shot transcript
+ * markdown + atomic-write plumbing so interactive and one-shot saves never
+ * diverge. (#649)
+ */
+async function persistAskTranscript(
+  deps: RunAskDeps,
+  input: SaveTranscriptInput,
+): Promise<SaveTranscriptResult> {
+  const title = input.title ?? defaultAskTranscriptTitle(input.question);
+  const content = buildAskTranscriptMarkdown({
+    title,
+    createdAt: new Date().toISOString(),
+    question: input.question,
+    answer: input.result.answer,
+    citations: input.result.citations,
+    llm: input.result.llm,
+    retrieval: input.result.retrieval,
+    ...(input.result.timing ? { timing: input.result.timing } : {}),
+  });
+  const path = await deps.createTranscriptNote(
+    deps.knowledgeBasesRootDir,
+    input.kb,
+    title,
+    content,
+  );
+  return { kb: input.kb, path };
+}
+
 export function parseAskArgs(rest: string[]): AskArgs {
   const out: AskArgs = {
     question: null,
@@ -303,6 +387,7 @@ export function parseAskArgs(rest: string[]): AskArgs {
     refresh: false,
     stdin: false,
     format: 'md',
+    interactive: false,
     noStream: false,
     timing: false,
     saveTranscript: false,
@@ -312,6 +397,7 @@ export function parseAskArgs(rest: string[]): AskArgs {
     const raw = rest[i];
     if (raw === '--refresh') { out.refresh = true; continue; }
     if (raw === '--stdin') { out.stdin = true; continue; }
+    if (raw === '--interactive' || raw === '-i') { out.interactive = true; continue; }
     if (raw === '--no-stream') { out.noStream = true; continue; }
     if (raw === '--timing') { out.timing = true; continue; }
     if (raw === '--save-transcript') { out.saveTranscript = true; continue; }


### PR DESCRIPTION
Closes #649.

## What

Adds an interactive mode to `kb ask` (`-i` / `--interactive`): a readline REPL that keeps a session so users can ask follow-ups without re-running the whole command and paying retrieval + model-warmup latency again.

- **Evidence reuse**: the first question retrieves evidence; follow-up turns reuse the cached evidence. Retrieval re-runs only on `/refresh`, `/reset`, or a `/kb` switch.
- **Bounded conversation memory**: the last few Q/A exchanges are folded into a compact task-context block on follow-ups (passed only to the answer phase, never retrieval, so the relevance gate is untouched).
- **Meta-commands**: `/sources`, `/kb <name>` (or bare `/kb` to show scope), `/refresh`, `/save [title]`, `/reset`, `/help`, `/exit` (aliases `/quit`, `/q`).
- **Streaming**: composes with the existing token streaming; answer text goes to stdout, REPL chrome (prompt, sources, notices) to stderr so piping stays clean (mirrors the `kb search -i` picker).
- **Honors `NO_COLOR`** and **non-TTY**: when stdin is not a TTY, `-i` prints a notice and falls back to a one-shot answer.

## How it stays DRY

`src/ask-core.ts`'s `executeAsk` is split into `retrieveAskEvidence` + `answerWithEvidence`; `executeAsk` now composes them and is behavior-identical (existing ask-core/cli-ask suites pass unchanged). The one-shot CLI and the REPL share the same answering path. `/save` reuses the existing transcript-markdown builder and atomic-write plumbing.

## Design choices (issue left open)

- `/refresh` clears cached evidence so the **next** question re-retrieves (with a KB rescan), rather than re-querying the previous question immediately — simplest behavior matching "re-retrieve on /refresh".
- Follow-up history is bounded (default 6 exchanges, each answer truncated to ~600 chars) to keep context size bounded per the issue's note.
- REPL `/save` writes the transcript note but does not emit a mutation audit record (the one-shot `--save-transcript` path still does); kept out to hold scope narrow.

## Tests

`src/ask-repl.test.ts` drives the loop with scripted stdin (Readable) and asserts: follow-ups reuse evidence (`similaritySearch` called once across turns), `/refresh` and `/kb` re-retrieve, meta-commands work, streaming renders once, a failed turn doesn't kill the session, `NO_COLOR` emits no ANSI, and `/save` plumbing. `src/cli-ask.test.ts` covers the `-i` parse and the TTY-routes-to-REPL / non-TTY-falls-back-to-one-shot branch.

Verified with `npx jest src/cli-ask src/ask-repl src/ask-core` (64 passed). Per repo guidance a full `npm run build` was skipped (OOM risk); ts-jest type-checks the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)