### PR TITLE
Fix contextual reindex incremental refresh

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -38,7 +38,7 @@ The `kb` CLI exposes 35 commands.
 | [`kb open`](#kb-open) | Resolve a chunk id / kb:// URI / result path to its source file. |
 | [`kb promote`](#kb-promote) | Review and update lifecycle frontmatter on a KB note. |
 | [`kb quarantine`](#kb-quarantine) | Inspect and manage per-file ingest quarantine entries. |
-| [`kb reindex`](#kb-reindex) | Rebuild FAISS indexes (RFC 017 — requires --with-context). |
+| [`kb reindex`](#kb-reindex) | Refresh FAISS indexes (RFC 017 — requires --with-context). |
 | [`kb related`](#kb-related) | Find chunks related to an existing chunk id or kb:// URI. |
 | [`kb remember`](#kb-remember) | Suggest, create, or append knowledge-base notes (write path). |
 | [`kb research`](#kb-research) | Plan and collect read-only KB evidence packets. |
@@ -1028,27 +1028,28 @@ Examples:
 
 ## `kb reindex`
 
-Rebuild FAISS indexes (RFC 017 — requires --with-context).
+Refresh FAISS indexes (RFC 017 — requires --with-context).
 
 ```text
-kb reindex — rebuild FAISS indexes (RFC 017)
+kb reindex — refresh FAISS indexes (RFC 017)
 
 Usage:
   kb reindex --with-context [--kb=<name>...] [--force]
   kb reindex status [--kb=<name>...] [--format=md|json]
 
 The `--with-context` flag is REQUIRED in this milestone (M0b). It
-triggers a full rebuild of the ENTIRE FAISS index — every KB, every
-chunk — through the contextual-retrieval ingest path: per-chunk
-LLM-generated prefaces are prepended for embedding while the docstore
-content stays byte-identical. The `KB_CONTEXTUAL_RETRIEVAL=on`
-environment variable must also be set; the CLI emits a warning
-otherwise.
+refreshes the global FAISS index through the contextual-retrieval ingest
+path: per-chunk LLM-generated prefaces are prepended for embedding while
+the docstore content stays byte-identical. By default the refresh is
+incremental and embeds only changed/new files; pass `--force` for an
+explicit full rebuild of every KB and every chunk. The
+`KB_CONTEXTUAL_RETRIEVAL=on` environment variable must also be set; the
+CLI emits a warning otherwise.
 
 Behavior:
   - Refuses to start inside the LRA cron window (06:00-10:30 UTC) or
     when the estimated runtime would cross it; pass --force to bypass
-    both guards.
+    both guards and request a full rebuild.
   - The runtime estimate is cache-aware: only chunks without a valid
     contextual-preface sidecar are priced at the 8s cold-LLM ceiling, so
     a reindex resumed after a partial run is not blocked for work it
@@ -1057,12 +1058,14 @@ Behavior:
     so the trigger watcher (RFC 014) defers its own updates until the
     reindex finishes. The file is deleted on exit (and zombie-cleaned
     by any later observer that finds its PID dead).
-  - Delegates the actual rebuild to
-    `FaissIndexManager.updateIndex(undefined, { force: true })` —
-    same machinery the existing `kb search --refresh` path uses, so
-    sidecar invalidation, error handling, and atomic FAISS swaps come
-    for free. The `undefined` scope argument is deliberate: the
-    rebuild is ALWAYS global and `--kb` never narrows it (see below).
+  - Delegates the actual refresh to
+    `FaissIndexManager.updateIndex(undefined)` by default, or
+    `FaissIndexManager.updateIndex(undefined, { force: true })` with
+    `--force` — same machinery the existing `kb search --refresh`
+    path uses, so sidecar invalidation, error handling, and atomic FAISS
+    swaps come for free. The `undefined` scope argument is deliberate:
+    the refresh is ALWAYS global and `--kb` never narrows it (see
+    below).
   - When `KB_CONTEXTUAL_RETRIEVAL=on`, prints a `contextual:` line
     summarising preface coverage and failures (covered / failed /
     retry-pending chunks, with an error-code breakdown) read back from
@@ -1084,11 +1087,11 @@ Options:
   --with-context        Required in M0b. Required for the CLI to do
                         anything except the `status` subcommand;
                         without it, exit code 2.
-  --kb=<name>           Rebuild: guard/estimator hint only — NOT a scoped
-                        rebuild. The FAISS index is single-index-per-
+  --kb=<name>           Refresh: guard/estimator hint only — NOT a scoped
+                        refresh. The FAISS index is single-index-per-
                         model with every KB co-located, so a partial
-                        rebuild would orphan the other shelves' vectors;
-                        the rebuild is therefore always global regardless
+                        refresh would orphan the other shelves' vectors;
+                        the refresh is therefore always global regardless
                         of this flag. --kb only narrows the chunk-count
                         estimate and the cron-window guard arithmetic,
                         and is validated against registered KBs (unknown
@@ -1096,9 +1099,11 @@ Options:
                         Default: every registered KB. Status: limit the
                         report to this KB.
   --force               Bypass the LRA cron window guard AND the
-                        self-runtime-budget guard. Required to start
-                        a reindex inside 06:00-10:30 UTC or when the
-                        run is estimated to cross that window.
+                        self-runtime-budget guard, and request a full
+                        rebuild instead of the default incremental
+                        refresh. Required to start a reindex inside
+                        06:00-10:30 UTC or when the run is estimated to
+                        cross that window.
   --format=md|json      Output format for `status` (default: md).
   --help, -h            Show this help.
 

--- a/src/cli-reindex.test.ts
+++ b/src/cli-reindex.test.ts
@@ -1,8 +1,9 @@
 // Issue #406 — `kb reindex --kb` is a guard/estimator hint, not a scoped
-// rebuild. The M0b runner delegates to `updateIndex(undefined, { force:
-// true })`, which always rebuilds the whole single-index-per-model FAISS
-// index. These tests pin the help text so it cannot drift back to the
-// earlier wording that implied `--kb` limits which vectors are rebuilt.
+// refresh. The M0b runner delegates to `updateIndex(undefined)`, or the
+// forced rebuild variant with `--force`, so the operation is always global
+// across the single-index-per-model FAISS layout. These tests pin the help
+// text so it cannot drift back to the earlier wording that implied `--kb`
+// limits which vectors are rebuilt.
 
 import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import * as fsp from 'fs/promises';
@@ -18,15 +19,15 @@ describe('REINDEX_HELP — --kb scope accuracy (issue #406)', () => {
     expect(REINDEX_HELP).not.toMatch(/Reindex only this KB/i);
   });
 
-  it('describes --kb as a guard/estimator hint, not a scoped rebuild', () => {
+  it('describes --kb as a guard/estimator hint, not a scoped refresh', () => {
     expect(REINDEX_HELP).toMatch(/--kb/);
     expect(REINDEX_HELP).toMatch(/guard\/estimator hint/i);
-    expect(REINDEX_HELP).toMatch(/NOT a scoped\s+rebuild/i);
+    expect(REINDEX_HELP).toMatch(/NOT a scoped\s+refresh/i);
   });
 
-  it('states the rebuild is always global regardless of --kb', () => {
+  it('states the refresh is always global regardless of --kb', () => {
     expect(REINDEX_HELP).toMatch(/always\s+global/i);
-    expect(REINDEX_HELP).toMatch(/entire FAISS index/i);
+    expect(REINDEX_HELP).toMatch(/`--kb` never narrows it/i);
   });
 });
 

--- a/src/cli-reindex.ts
+++ b/src/cli-reindex.ts
@@ -20,24 +20,25 @@ import { assertSufficientDiskSpace } from './disk-preflight.js';
 import { KBError } from './errors.js';
 import { logger } from './logger.js';
 
-export const REINDEX_HELP = `kb reindex — rebuild FAISS indexes (RFC 017)
+export const REINDEX_HELP = `kb reindex — refresh FAISS indexes (RFC 017)
 
 Usage:
   kb reindex --with-context [--kb=<name>...] [--force]
   kb reindex status [--kb=<name>...] [--format=md|json]
 
 The \`--with-context\` flag is REQUIRED in this milestone (M0b). It
-triggers a full rebuild of the ENTIRE FAISS index — every KB, every
-chunk — through the contextual-retrieval ingest path: per-chunk
-LLM-generated prefaces are prepended for embedding while the docstore
-content stays byte-identical. The \`KB_CONTEXTUAL_RETRIEVAL=on\`
-environment variable must also be set; the CLI emits a warning
-otherwise.
+refreshes the global FAISS index through the contextual-retrieval ingest
+path: per-chunk LLM-generated prefaces are prepended for embedding while
+the docstore content stays byte-identical. By default the refresh is
+incremental and embeds only changed/new files; pass \`--force\` for an
+explicit full rebuild of every KB and every chunk. The
+\`KB_CONTEXTUAL_RETRIEVAL=on\` environment variable must also be set; the
+CLI emits a warning otherwise.
 
 Behavior:
   - Refuses to start inside the LRA cron window (06:00-10:30 UTC) or
     when the estimated runtime would cross it; pass --force to bypass
-    both guards.
+    both guards and request a full rebuild.
   - The runtime estimate is cache-aware: only chunks without a valid
     contextual-preface sidecar are priced at the 8s cold-LLM ceiling, so
     a reindex resumed after a partial run is not blocked for work it
@@ -46,12 +47,14 @@ Behavior:
     so the trigger watcher (RFC 014) defers its own updates until the
     reindex finishes. The file is deleted on exit (and zombie-cleaned
     by any later observer that finds its PID dead).
-  - Delegates the actual rebuild to
-    \`FaissIndexManager.updateIndex(undefined, { force: true })\` —
-    same machinery the existing \`kb search --refresh\` path uses, so
-    sidecar invalidation, error handling, and atomic FAISS swaps come
-    for free. The \`undefined\` scope argument is deliberate: the
-    rebuild is ALWAYS global and \`--kb\` never narrows it (see below).
+  - Delegates the actual refresh to
+    \`FaissIndexManager.updateIndex(undefined)\` by default, or
+    \`FaissIndexManager.updateIndex(undefined, { force: true })\` with
+    \`--force\` — same machinery the existing \`kb search --refresh\`
+    path uses, so sidecar invalidation, error handling, and atomic FAISS
+    swaps come for free. The \`undefined\` scope argument is deliberate:
+    the refresh is ALWAYS global and \`--kb\` never narrows it (see
+    below).
   - When \`KB_CONTEXTUAL_RETRIEVAL=on\`, prints a \`contextual:\` line
     summarising preface coverage and failures (covered / failed /
     retry-pending chunks, with an error-code breakdown) read back from
@@ -73,11 +76,11 @@ Options:
   --with-context        Required in M0b. Required for the CLI to do
                         anything except the \`status\` subcommand;
                         without it, exit code 2.
-  --kb=<name>           Rebuild: guard/estimator hint only — NOT a scoped
-                        rebuild. The FAISS index is single-index-per-
+  --kb=<name>           Refresh: guard/estimator hint only — NOT a scoped
+                        refresh. The FAISS index is single-index-per-
                         model with every KB co-located, so a partial
-                        rebuild would orphan the other shelves' vectors;
-                        the rebuild is therefore always global regardless
+                        refresh would orphan the other shelves' vectors;
+                        the refresh is therefore always global regardless
                         of this flag. --kb only narrows the chunk-count
                         estimate and the cron-window guard arithmetic,
                         and is validated against registered KBs (unknown
@@ -85,9 +88,11 @@ Options:
                         Default: every registered KB. Status: limit the
                         report to this KB.
   --force               Bypass the LRA cron window guard AND the
-                        self-runtime-budget guard. Required to start
-                        a reindex inside 06:00-10:30 UTC or when the
-                        run is estimated to cross that window.
+                        self-runtime-budget guard, and request a full
+                        rebuild instead of the default incremental
+                        refresh. Required to start a reindex inside
+                        06:00-10:30 UTC or when the run is estimated to
+                        cross that window.
   --format=md|json      Output format for \`status\` (default: md).
   --help, -h            Show this help.
 
@@ -221,7 +226,8 @@ function formatHumanResult(result: ReindexResult): string {
   lines.push(`  total_chunks_estimate: ${result.total_chunks_estimate}`);
   lines.push(
     `  contextual_estimate:   cold=${est.cold_chunks} ` +
-      `cache_hits=${est.cache_hits} retry_skips=${est.retry_skips}`,
+      `cache_hits=${est.cache_hits} retry_skips=${est.retry_skips} ` +
+      `unchanged=${est.unchanged_chunks}`,
   );
   lines.push(`  estimated_seconds:     ${result.estimated_seconds}`);
   lines.push(`  took_ms:               ${result.took_ms}`);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -134,7 +134,7 @@ const SUBCOMMANDS: readonly Subcommand[] = [
   { name: 'where',        summary: 'Recommend the best KB and file for a given topic.',                      help: WHERE_HELP,        handler: runWhere },
   { name: 'models',       summary: 'Manage embedding models (list, add, set-active, remove).',               help: MODELS_HELP,       handler: runModels },
   { name: 'llm',          summary: 'Configure local LLM endpoints and managed warm model services.',          help: LLM_HELP,          handler: runLlm },
-  { name: 'reindex',      summary: 'Rebuild FAISS indexes (RFC 017 — requires --with-context).',              help: REINDEX_HELP,      handler: runReindexCli },
+  { name: 'reindex',      summary: 'Refresh FAISS indexes (RFC 017 — requires --with-context).',              help: REINDEX_HELP,      handler: runReindexCli },
   { name: 'completion',   summary: 'Generate shell completions for bash, zsh, or fish.',                      help: COMPLETION_HELP,   handler: runCompletionWithCurrentManifest },
 ];
 

--- a/src/reindex-runner.test.ts
+++ b/src/reindex-runner.test.ts
@@ -185,10 +185,11 @@ describe('self-runtime estimator', () => {
 describe('cache-aware reindex estimate (#408)', () => {
   type ContextualPrefaceModule = typeof import('./contextual-preface.js');
 
-  async function writeManifest(kb: string, relPath: string, chunkCount: number): Promise<void> {
+  async function writeManifest(kb: string, relPath: string, chunkCount: number): Promise<string> {
     const manifestPath = path.join(tempDir, 'kbs', kb, '.index', `${relPath}.chunks.json`);
     await fsp.mkdir(path.dirname(manifestPath), { recursive: true });
     await fsp.writeFile(manifestPath, JSON.stringify({ chunks: new Array(chunkCount).fill({}) }));
+    return manifestPath;
   }
 
   async function writeSidecar(
@@ -221,7 +222,13 @@ describe('cache-aware reindex estimate (#408)', () => {
     await writeManifest('alpha', path.join('sub', 'nested'), 5);
     const est = await runner.estimateContextualReindexWork(['alpha']);
     // No sidecars yet — every chunk is cold, identical to the pre-#408 estimate.
-    expect(est).toEqual({ total_chunks: 8, cache_hits: 0, retry_skips: 0, cold_chunks: 8 });
+    expect(est).toEqual({
+      total_chunks: 8,
+      unchanged_chunks: 0,
+      cache_hits: 0,
+      retry_skips: 0,
+      cold_chunks: 8,
+    });
   });
 
   it('estimateContextualReindexWork counts sidecar hits as non-cold', async () => {
@@ -232,7 +239,13 @@ describe('cache-aware reindex estimate (#408)', () => {
       { chunk_index: 1, chunk_hash: 'b', preface: 'ctx 1' },
     ]);
     const est = await runner.estimateContextualReindexWork(['alpha']);
-    expect(est).toEqual({ total_chunks: 4, cache_hits: 2, retry_skips: 0, cold_chunks: 2 });
+    expect(est).toEqual({
+      total_chunks: 4,
+      unchanged_chunks: 0,
+      cache_hits: 2,
+      retry_skips: 0,
+      cold_chunks: 2,
+    });
   });
 
   it('prices only cold chunks for the LRA-window guard', async () => {
@@ -257,6 +270,7 @@ describe('cache-aware reindex estimate (#408)', () => {
     expect(result.estimated_seconds).toBe(80);
     expect(result.contextual_estimate).toEqual({
       total_chunks: 1000,
+      unchanged_chunks: 0,
       cache_hits: 990,
       retry_skips: 0,
       cold_chunks: 10,
@@ -275,9 +289,41 @@ describe('cache-aware reindex estimate (#408)', () => {
     expect(result.outcome).toBe('guard_blocked');
     expect(result.contextual_estimate).toEqual({
       total_chunks: 1000,
+      unchanged_chunks: 0,
       cache_hits: 0,
       retry_skips: 0,
       cold_chunks: 1000,
+    });
+  });
+
+  it('does not guard-block unchanged files missing contextual sidecars on incremental runs', async () => {
+    const relPath = 'note';
+    const sourcePath = path.join(tempDir, 'kbs', 'alpha', relPath);
+    await fsp.writeFile(sourcePath, 'unchanged source\n');
+    const manifestPath = await writeManifest('alpha', relPath, 1000);
+    const { calculateSHA256 } = await import('./file-utils.js');
+    await fsp.writeFile(
+      manifestPath.replace(/\.chunks\.json$/, ''),
+      await calculateSHA256(sourcePath),
+      'utf-8',
+    );
+
+    const result = await runner.runReindex({
+      knowledgeBases: [],
+      force: false,
+      now: new Date(Date.UTC(2026, 4, 15, 4, 0, 0)),
+      resolveKbs: async () => ['alpha'],
+      runUpdateIndex: async () => makeNeverRunSummary(),
+    });
+
+    expect(result.outcome).toBe('completed');
+    expect(result.estimated_seconds).toBe(0);
+    expect(result.contextual_estimate).toEqual({
+      total_chunks: 1000,
+      unchanged_chunks: 1000,
+      cache_hits: 0,
+      retry_skips: 0,
+      cold_chunks: 0,
     });
   });
 });
@@ -375,6 +421,56 @@ describe('.reindex.run.json + PID liveness', () => {
     expect(check.alive).toBe(false);
     // File should have been deleted by the zombie cleanup.
     await expect(fsp.access(runner.runStateFilePath())).rejects.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Manager dispatch (#695) — daily contextual reindex is incremental by
+// default; `--force` is the explicit full rebuild path.
+// ---------------------------------------------------------------------------
+
+describe('manager dispatch (#695)', () => {
+  function makeManager(summary = makeNeverRunSummary()): {
+    manager: import('./FaissIndexManager.js').FaissIndexManager;
+    updateIndex: jest.Mock;
+  } {
+    const updateIndex = jest.fn(async () => undefined);
+    const manager = {
+      updateIndex,
+      getLastIndexUpdateSummary: jest.fn(() => summary),
+    } as unknown as import('./FaissIndexManager.js').FaissIndexManager;
+    return { manager, updateIndex };
+  }
+
+  it('uses the incremental updateIndex path by default', async () => {
+    const { manager, updateIndex } = makeManager();
+
+    const result = await runner.runReindex({
+      knowledgeBases: [],
+      force: false,
+      now: new Date(Date.UTC(2026, 4, 15, 0, 0, 0)),
+      resolveKbs: async () => ['alpha', 'beta'],
+      manager,
+    });
+
+    expect(result.outcome).toBe('completed');
+    expect(updateIndex).toHaveBeenCalledTimes(1);
+    expect(updateIndex).toHaveBeenCalledWith(undefined);
+  });
+
+  it('uses the full rebuild path only when force is true', async () => {
+    const { manager, updateIndex } = makeManager();
+
+    const result = await runner.runReindex({
+      knowledgeBases: [],
+      force: true,
+      resolveKbs: async () => ['alpha', 'beta'],
+      manager,
+    });
+
+    expect(result.outcome).toBe('completed');
+    expect(updateIndex).toHaveBeenCalledTimes(1);
+    expect(updateIndex).toHaveBeenCalledWith(undefined, { force: true });
   });
 });
 

--- a/src/reindex-runner.ts
+++ b/src/reindex-runner.ts
@@ -1,11 +1,12 @@
 // RFC 017 M0b — orchestration for `kb reindex --with-context`.
 //
-// The actual rebuild is delegated to the existing
-// `FaissIndexManager.updateIndex(undefined, { force: true })` path —
-// that already walks every KB, re-embeds every chunk through the
+// The actual refresh is delegated to the existing
+// `FaissIndexManager.updateIndex(undefined)` path by default — that
+// already walks every KB, embeds only changed/new chunks through the
 // adapter (patched by M0a to apply contextual prefaces upstream of the
-// embedder), and atomically swaps the FAISS index per RFC 014. M0b's
-// job is the orchestration around it:
+// embedder), and atomically swaps the FAISS index per RFC 014 when
+// needed. Passing `--force` upgrades this to the explicit global rebuild
+// path. M0b's job is the orchestration around it:
 //
 //  1. Resolve in-scope KBs (default: every registered KB). Count total
 //     chunks from existing chunk manifests and estimate runtime as
@@ -17,7 +18,8 @@
 //  4. Write `.reindex.run.json` with this process's PID + scope. The
 //     trigger watcher consults this file before grabbing the per-model
 //     write lock, deferring its update until we finish (M0b §5 step 5).
-//  5. Run `updateIndex(undefined, { force: true })`.
+//  5. Run `updateIndex(undefined)` or, with `--force`,
+//     `updateIndex(undefined, { force: true })`.
 //  6. Delete `.reindex.run.json` on success or failure.
 //
 // What this file does NOT do:
@@ -35,6 +37,7 @@ import {
   KNOWLEDGE_BASES_ROOT_DIR,
 } from './config/paths.js';
 import { emitCanonicalLog } from './canonical-log.js';
+import { calculateSHA256 } from './file-utils.js';
 import {
   isContextualRetrievalEnabled,
   type ContextualErrorCode,
@@ -68,16 +71,18 @@ export const REINDEX_RUN_SCHEMA_VERSION = 'reindex-run.v1';
 export interface ReindexOptions {
   /**
    * KB names used for the chunk-count estimate and the cron-window guard
-   * arithmetic — NOT a scoped rebuild. `updateIndex` is always invoked
+   * arithmetic — NOT a scoped refresh. `updateIndex` is always invoked
    * with an `undefined` (whole-corpus) scope; see `runManagerUpdateIndex`.
-   * A partial rebuild would orphan the other shelves' vectors in the
+   * A partial refresh would orphan the other shelves' vectors in the
    * single-index-per-model FAISS layout. Empty array means "every
    * registered KB".
    */
   knowledgeBases: readonly string[];
   /**
-   * Skip the LRA-cron guard AND the self-runtime-budget guard. Operators
-   * pass `--force` from the CLI; tests pass `force: true` directly.
+   * Skip the LRA-cron guard and self-runtime-budget guard, and request an
+   * explicit global rebuild instead of the default incremental refresh.
+   * Operators pass `--force` from the CLI; tests pass `force: true`
+   * directly.
    */
   force: boolean;
   /**
@@ -97,7 +102,7 @@ export interface ReindexOptions {
    * Test seam: bypass the actual updateIndex call (which requires a
    * working embedding provider). Returns a synthetic IndexUpdateSummary.
    */
-  runUpdateIndex?: () => Promise<IndexUpdateSummary>;
+  runUpdateIndex?: (options: { force: boolean }) => Promise<IndexUpdateSummary>;
 }
 
 /**
@@ -109,6 +114,8 @@ export interface ReindexOptions {
 export interface ContextualReindexEstimate {
   /** Total chunks across all in-scope KBs, summed from chunk manifests. */
   total_chunks: number;
+  /** Chunks whose source hash is unchanged and are skipped by incremental refresh. */
+  unchanged_chunks: number;
   /** Chunks with a valid cached preface — no LLM call. */
   cache_hits: number;
   /** Chunks with a recorded failure whose retry-after has not elapsed. */
@@ -383,19 +390,27 @@ async function readManifestChunkCount(manifestPath: string): Promise<number> {
  *     not-yet-due retry skip, or a cold LLM call (see
  *     `classifyContextualSidecarChunks`).
  *
+ * For the default incremental refresh (#695), unchanged files are skipped by
+ * `updateIndex(undefined)`, so missing contextual sidecars on unchanged
+ * sources are counted as `unchanged_chunks`, not `cold_chunks`. Passing
+ * `changedOnly: false` estimates the full force-rebuild path instead.
+ *
  * `cold_chunks * REINDEX_PER_CHUNK_ESTIMATE_MS` is then the cache-aware
- * runtime upper bound. A first-ever reindex (no sidecars) yields
+ * runtime upper bound. A first-ever force reindex (no sidecars) yields
  * `cold_chunks === total_chunks`, identical to the pre-#408 estimate.
  */
 export async function estimateContextualReindexWork(
   kbs: readonly string[],
   now: Date = new Date(),
+  options: { changedOnly?: boolean } = {},
 ): Promise<ContextualReindexEstimate> {
   const nowMs = now.getTime();
   let totalChunks = 0;
+  let unchangedChunks = 0;
   let cacheHits = 0;
   let retrySkips = 0;
   let coldChunks = 0;
+  const changedOnly = options.changedOnly === true;
 
   for (const kb of kbs) {
     const indexDir = path.join(KNOWLEDGE_BASES_ROOT_DIR, kb, '.index');
@@ -407,6 +422,10 @@ export async function estimateContextualReindexWork(
       // `<kb>/.index/<rel>.chunks.json` → source `<kb>/<rel>`.
       const rel = path.relative(indexDir, manifestPath).replace(/\.chunks\.json$/, '');
       const source = path.join(KNOWLEDGE_BASES_ROOT_DIR, kb, rel);
+      if (changedOnly && !(await sourceHashDiffersFromStoredHash(source, manifestPath))) {
+        unchangedChunks += chunkCount;
+        continue;
+      }
       const tally = await classifyContextualSidecarChunks(source, kb, chunkCount, nowMs);
       cacheHits += tally.cache_hits;
       retrySkips += tally.retry_skips;
@@ -416,10 +435,27 @@ export async function estimateContextualReindexWork(
 
   return {
     total_chunks: totalChunks,
+    unchanged_chunks: unchangedChunks,
     cache_hits: cacheHits,
     retry_skips: retrySkips,
     cold_chunks: coldChunks,
   };
+}
+
+async function sourceHashDiffersFromStoredHash(
+  sourcePath: string,
+  manifestPath: string,
+): Promise<boolean> {
+  try {
+    const storedHashPath = manifestPath.replace(/\.chunks\.json$/, '');
+    const [sourceHash, storedHash] = await Promise.all([
+      calculateSHA256(sourcePath),
+      fsp.readFile(storedHashPath, 'utf-8'),
+    ]);
+    return sourceHash !== storedHash;
+  } catch {
+    return true;
+  }
 }
 
 /**
@@ -467,7 +503,9 @@ export async function runReindex(options: ReindexOptions): Promise<ReindexResult
   //    priced at the 8s cold-LLM ceiling, so a reindex following a partial
   //    run is not needlessly guard-blocked for work it would skip.
   const kbs = await resolveKbsInScope(options);
-  const estimate = await estimateContextualReindexWork(kbs, now);
+  const estimate = await estimateContextualReindexWork(kbs, now, {
+    changedOnly: !options.force,
+  });
   const totalChunks = estimate.total_chunks;
   const estimatedSeconds = Math.ceil((estimate.cold_chunks * REINDEX_PER_CHUNK_ESTIMATE_MS) / 1_000);
 
@@ -540,11 +578,12 @@ export async function runReindex(options: ReindexOptions): Promise<ReindexResult
   };
   await writeRunState(state);
 
-  // 5. Run the actual rebuild via `updateIndex(undefined, { force: true })`.
-  //    The force flag triggers a global rebuild that walks every KB and
-  //    re-embeds every chunk — including the new contextual-preface
-  //    metadata stamped by M0a's patched `buildChunkDocuments`. The
-  //    per-model write lock is acquired internally by updateIndex.
+  // 5. Run the actual refresh. By default this uses the existing
+  //    incremental path: every KB is scanned, but only changed/new files
+  //    are loaded and embedded. `--force` remains the explicit global
+  //    rebuild path that drops the in-memory FAISS store and re-embeds the
+  //    whole corpus. The per-model write lock is acquired internally by
+  //    updateIndex.
   let summary: IndexUpdateSummary;
   try {
     if (options.runUpdateIndex) {
@@ -554,10 +593,10 @@ export async function runReindex(options: ReindexOptions): Promise<ReindexResult
       // is configured (e.g. in CI) — even though the real `updateIndex`
       // is being mocked here. The manager is only consumed by the
       // non-seam path below, so construct it lazily there.
-      summary = await options.runUpdateIndex();
+      summary = await options.runUpdateIndex({ force: options.force });
     } else {
       const manager = options.manager ?? (await createManagerForReindex());
-      summary = await runManagerUpdateIndex(manager);
+      summary = await runManagerUpdateIndex(manager, options.force);
     }
   } catch (err) {
     await deleteRunState();
@@ -621,12 +660,18 @@ async function createManagerForReindex(): Promise<FaissIndexManager> {
   return manager;
 }
 
-async function runManagerUpdateIndex(manager: FaissIndexManager): Promise<IndexUpdateSummary> {
-  // `force: true` triggers a global rebuild: drops the in-memory FAISS
-  // store, walks every KB, re-embeds every chunk. M0a's patched adapter
-  // applies contextual prefaces to the embedding input when
-  // KB_CONTEXTUAL_RETRIEVAL=on, leaving the docstore byte-identical.
-  await manager.updateIndex(undefined, { force: true });
+async function runManagerUpdateIndex(
+  manager: FaissIndexManager,
+  force: boolean,
+): Promise<IndexUpdateSummary> {
+  // The default daily path is incremental: scan every KB but only embed
+  // changed/new files. `--force` is the operator escape hatch for an
+  // explicit full rebuild, including the first contextual-preface rollout.
+  if (force) {
+    await manager.updateIndex(undefined, { force: true });
+  } else {
+    await manager.updateIndex(undefined);
+  }
   return manager.getLastIndexUpdateSummary();
 }
 


### PR DESCRIPTION
## Summary

- make `kb reindex --with-context` use the existing incremental `updateIndex(undefined)` path by default
- keep `--force` as the explicit full-corpus rebuild path
- make the non-force guard estimate only changed/new source files, counting unchanged chunks separately
- update help text and regression tests for the new default

Closes #695

## Verification

- `env -u KB_LOG_FORMAT -u KB_LOG_FILE -u LOG_FILE npx jest --runInBand --runTestsByPath src/reindex-runner.test.ts src/cli-reindex.test.ts`
- `env -u KB_LOG_FORMAT -u KB_LOG_FILE -u LOG_FILE npx jest --runInBand --runTestsByPath src/reindex-runner.test.ts src/cli-reindex.test.ts src/cli-json-contracts.test.ts`
- `node scripts/gen-cli-reference.mjs --check`
- Bug reproduction: added a regression with 1000 unchanged chunks and no contextual sidecars; the old guard would price all 1000 as cold and block near the LRA window, while the new incremental estimate completes with `cold_chunks=0` and `unchanged_chunks=1000`.
- Full build/type-check: left to CI per repo instruction for worktrees. A local post-merge rebuild hook attempted `npm run build` and failed in pre-existing `src/cli-stale-check.ts` Node `Dirent` type errors, outside this PR's changed files.

## Pre-PR review

- conventions specialist: copy/readability findings fixed
- correctness specialist: guard-estimate blocker fixed with regression coverage
- dead-code specialist: no dead code introduced
- test specialist: no test quality issues

## KB lookup

KB miss: `kb search "contextual reindex incremental embedding force updateIndex"` returned no repo-specific guidance.
