### PR TITLE
feat: pin faiss-node dependency

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,24 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    paths:
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/dependency-review.yml'
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Review dependency changes
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/sdk-trace-base": "^2.0.0",
         "axios": "^1.6.7",
-        "faiss-node": "latest",
+        "faiss-node": "0.5.1",
         "hnswlib-node": "^3.0.0",
         "html-to-text": "^9.0.5",
         "js-yaml": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/sdk-trace-base": "^2.0.0",
     "axios": "^1.6.7",
-    "faiss-node": "latest",
+    "faiss-node": "0.5.1",
     "hnswlib-node": "^3.0.0",
     "html-to-text": "^9.0.5",
     "js-yaml": "^4.1.1",


### PR DESCRIPTION
## Summary

- pin `faiss-node` to the lockfile-resolved `0.5.1` instead of floating on `latest`
- add a pull-request dependency-review workflow that blocks newly introduced high-severity dependency changes

## Notes

`npm audit --audit-level=high` currently fails on existing advisories in the dependency tree, so this PR uses GitHub's dependency-review gate for the smallest non-disruptive supply-chain CI coverage. That keeps unrelated PRs from going red on pre-existing advisories while still gating new high-severity dependency changes.

KB hits: none directly relevant from `kb search "pin faiss-node dependency audit supply chain gate"`.

## Verification

- `npm install --package-lock-only --ignore-scripts`
- `npm rebuild faiss-node hnswlib-node`
- `env -u KB_LOG_FORMAT -u KB_LOG_FILE -u LOG_FILE npm run build`
- `env -u KB_LOG_FORMAT -u KB_LOG_FILE -u LOG_FILE npm run lint`
- `env -u KB_LOG_FORMAT -u KB_LOG_FILE -u LOG_FILE npm test`
- `node --input-type=module -e "import fs from 'node:fs'; import yaml from 'yaml'; yaml.parse(fs.readFileSync('.github/workflows/dependency-review.yml', 'utf8'));"`
- manual portability scan of added lines for user-specific absolute paths

No targeted Jest suite applies because this only changes package metadata and a GitHub Actions workflow.

Closes #692
