### PR TITLE
feat: add search snippet output

### DIFF
--- a/src/cli-search.test.ts
+++ b/src/cli-search.test.ts
@@ -139,6 +139,66 @@ describe('parseSearchArgs output format', () => {
     expect(parseSearchArgs(['query', '--no-highlight'])).toMatchObject({ highlight: 'never' });
     expect(() => parseSearchArgs(['query', '--highlight=sometimes'])).toThrow(/invalid --highlight/);
   });
+
+  it('accepts search snippet controls', () => {
+    const previous = process.env.KB_SEARCH_SNIPPET;
+    delete process.env.KB_SEARCH_SNIPPET;
+    try {
+      expect(parseSearchArgs(['query']).snippetLines).toBeUndefined();
+      expect(parseSearchArgs(['query', '--snippet'])).toMatchObject({ snippetLines: 5 });
+      expect(parseSearchArgs(['query', '--snippet=3'])).toMatchObject({ snippetLines: 3 });
+      expect(parseSearchArgs(['query', '--snippet=3', '--full']).snippetLines).toBeUndefined();
+      expect(() => parseSearchArgs(['query', '--snippet=0'])).toThrow(/invalid --snippet/);
+    } finally {
+      if (previous === undefined) delete process.env.KB_SEARCH_SNIPPET;
+      else process.env.KB_SEARCH_SNIPPET = previous;
+    }
+  });
+
+  it('uses KB_SEARCH_SNIPPET as an opt-in default with --full as an escape hatch', () => {
+    const previous = process.env.KB_SEARCH_SNIPPET;
+    process.env.KB_SEARCH_SNIPPET = '2';
+    try {
+      expect(parseSearchArgs(['query'])).toMatchObject({ snippetLines: 2 });
+      expect(parseSearchArgs(['query', '--full']).snippetLines).toBeUndefined();
+    } finally {
+      if (previous === undefined) delete process.env.KB_SEARCH_SNIPPET;
+      else process.env.KB_SEARCH_SNIPPET = previous;
+    }
+  });
+
+  it.each([
+    ['true', 5],
+    ['on', 5],
+    ['yes', 5],
+    ['false', undefined],
+    ['off', undefined],
+    ['no', undefined],
+    ['0', undefined],
+    ['', undefined],
+  ])('parses KB_SEARCH_SNIPPET=%p', (value, expected) => {
+    const previous = process.env.KB_SEARCH_SNIPPET;
+    process.env.KB_SEARCH_SNIPPET = value;
+    try {
+      expect(parseSearchArgs(['query']).snippetLines).toBe(expected);
+    } finally {
+      if (previous === undefined) delete process.env.KB_SEARCH_SNIPPET;
+      else process.env.KB_SEARCH_SNIPPET = previous;
+    }
+  });
+
+  it('lets explicit snippet flags override an invalid KB_SEARCH_SNIPPET', () => {
+    const previous = process.env.KB_SEARCH_SNIPPET;
+    process.env.KB_SEARCH_SNIPPET = 'bogus';
+    try {
+      expect(parseSearchArgs(['query', '--full']).snippetLines).toBeUndefined();
+      expect(parseSearchArgs(['query', '--snippet=2'])).toMatchObject({ snippetLines: 2 });
+      expect(() => parseSearchArgs(['query'])).toThrow(/invalid KB_SEARCH_SNIPPET/);
+    } finally {
+      if (previous === undefined) delete process.env.KB_SEARCH_SNIPPET;
+      else process.env.KB_SEARCH_SNIPPET = previous;
+    }
+  });
 });
 
 describe('parseSearchArgs freshness', () => {
@@ -448,7 +508,7 @@ describe('runSearch timing guard (#331)', () => {
         };
         return [
           {
-            pageContent: 'first result',
+            pageContent: 'intro\nrollback detail\nappendix',
             metadata: { source: '/kb/ops/first.md', chunkIndex: 0 },
             score: 0.11,
           },
@@ -467,7 +527,7 @@ describe('runSearch timing guard (#331)', () => {
       '',
     ].join('\n');
 
-    const out = await captureSearchOutput(['--batch-jsonl', '--timing', '--no-freshness'], deps, stdin);
+    const out = await captureSearchOutput(['--batch-jsonl', '--snippet=1', '--timing', '--no-freshness'], deps, stdin);
 
     expect(out.code).toBe(0);
     expect(out.stderr).toBe('');
@@ -520,7 +580,10 @@ describe('runSearch timing guard (#331)', () => {
           query_cache_model_id: 'ollama__nomic-embed-text-latest',
           query_cache_elapsed_ms: 3,
         },
-        results: [{ content: 'first result' }],
+        results: [{
+          content: 'intro\nrollback detail\nappendix',
+          snippet: '…\nrollback detail\n…',
+        }],
       },
     });
     expect(envelopes[1]).toMatchObject({
@@ -765,6 +828,65 @@ describe('runSearch timing guard (#331)', () => {
     expect(out.code).toBe(0);
     expect(out.stdout).not.toContain('\x1b[');
     expect(JSON.parse(out.stdout).results[0].content).toBe('Rollback plan');
+  });
+
+  it('renders a focused markdown snippet when requested', async () => {
+    const { deps, manager } = makeDeps();
+    manager.similaritySearch.mockResolvedValueOnce([{
+      pageContent: 'intro\nsetup\nRollback plan\nverify\nappendix',
+      metadata: { source: '/kb/ops/rollback.md', chunkIndex: 0 },
+      score: 0.12,
+    }] as never);
+
+    const out = await captureSearchOutput(['rollback', '--snippet=1', '--no-freshness'], deps);
+
+    expect(out.code).toBe(0);
+    expect(out.stdout).toContain('…\nRollback plan\n…');
+    expect(out.stdout).not.toContain('intro');
+    expect(out.stdout).not.toContain('appendix');
+  });
+
+  it('adds snippets to JSON output without replacing content', async () => {
+    const { deps, manager } = makeDeps();
+    manager.similaritySearch.mockResolvedValueOnce([{
+      pageContent: 'intro\nsetup\nRollback plan\nverify\nappendix',
+      metadata: { source: '/kb/ops/rollback.md', chunkIndex: 0 },
+      score: 0.12,
+    }] as never);
+
+    const out = await captureSearchOutput([
+      'rollback',
+      '--snippet=1',
+      '--format=json',
+      '--no-freshness',
+    ], deps);
+
+    expect(out.code).toBe(0);
+    const result = JSON.parse(out.stdout).results[0];
+    expect(result.content).toBe('intro\nsetup\nRollback plan\nverify\nappendix');
+    expect(result.snippet).toBe('…\nRollback plan\n…');
+  });
+
+  it('lets --full disable KB_SEARCH_SNIPPET for output', async () => {
+    const previous = process.env.KB_SEARCH_SNIPPET;
+    process.env.KB_SEARCH_SNIPPET = '1';
+    const { deps, manager } = makeDeps();
+    manager.similaritySearch.mockResolvedValueOnce([{
+      pageContent: 'intro\nRollback plan\nappendix',
+      metadata: { source: '/kb/ops/rollback.md', chunkIndex: 0 },
+      score: 0.12,
+    }] as never);
+
+    try {
+      const out = await captureSearchOutput(['rollback', '--full', '--no-freshness'], deps);
+
+      expect(out.code).toBe(0);
+      expect(out.stdout).toContain('intro\nRollback plan\nappendix');
+      expect(out.stdout).not.toContain('…');
+    } finally {
+      if (previous === undefined) delete process.env.KB_SEARCH_SNIPPET;
+      else process.env.KB_SEARCH_SNIPPET = previous;
+    }
   });
 
   it('exposes query-cache telemetry in dense JSON, timing, and canonical metadata', async () => {

--- a/src/cli-search.ts
+++ b/src/cli-search.ts
@@ -35,6 +35,7 @@ import {
   formatRetrievalGroupedBySourceAsMarkdown,
   groupRetrievalBySource,
   type RetrievalHighlightOptions,
+  type RetrievalSnippetOptions,
   type ScoredDocument,
 } from './formatter.js';
 import { runPicker } from './cli-search-picker.js';
@@ -270,6 +271,10 @@ Output:
                         emphasis. auto uses ANSI only on a TTY (default);
                         always also works through pipes; never disables it.
   --no-highlight        Alias for --highlight=never.
+  --snippet[=N]         Markdown/JSON: show an N-line focused excerpt centered
+                        on the densest query-term match. Default N is 5.
+                        Also set via KB_SEARCH_SNIPPET=true|N.
+  --full                Disable snippet mode and render full result bodies.
   --color=auto|always|never
                         Unified control for all ANSI color/emphasis output.
                         auto colorizes only on a TTY with NO_COLOR unset
@@ -316,6 +321,7 @@ Examples:
 
 export type SearchFormat = 'md' | 'json' | 'vimgrep' | 'compact';
 export type SearchHighlightMode = 'auto' | 'always' | 'never';
+const DEFAULT_SEARCH_SNIPPET_LINES = 5;
 
 let lastSearchCanonicalTelemetry: Partial<CanonicalLogInput> | null = null;
 
@@ -349,6 +355,7 @@ interface SearchArgs {
   noCache: boolean;
   freshness: boolean;
   highlight: SearchHighlightMode;
+  snippetLines?: number;
   color: ColorMode;
   colorExplicit: boolean;
   explainEmpty: boolean;
@@ -751,6 +758,7 @@ export async function runSearch(
       advancedRetrieval,
       queryCache: denseTiming.query_cache_telemetry,
       retrievalViews: parsed.retrievalViews,
+      snippet: buildSearchSnippetOptions(parsed, query),
     });
     process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
   } else if (parsed.format === 'vimgrep') {
@@ -783,6 +791,7 @@ export async function runSearch(
       explain: parsed.explain,
       advancedRetrieval,
       highlight: buildSearchHighlightOptions(parsed, query),
+      snippet: buildSearchSnippetOptions(parsed, query),
     }));
   }
 
@@ -934,6 +943,7 @@ async function runAdvancedDenseSearch(input: {
 }
 
 export function parseSearchArgs(rest: string[]): SearchArgs {
+  let snippetExplicit = false;
   const out: SearchArgs = {
     query: null,
     k: 10,
@@ -973,6 +983,16 @@ export function parseSearchArgs(rest: string[]): SearchArgs {
     if (raw === '--no-cache') { out.noCache = true; continue; }
     if (raw === '--highlight') { out.highlight = 'always'; continue; }
     if (raw === '--no-highlight') { out.highlight = 'never'; continue; }
+    if (raw === '--snippet') {
+      snippetExplicit = true;
+      out.snippetLines = DEFAULT_SEARCH_SNIPPET_LINES;
+      continue;
+    }
+    if (raw === '--full') {
+      snippetExplicit = true;
+      out.snippetLines = undefined;
+      continue;
+    }
     if (raw === '--gate') { out.gateOverride = 'on'; continue; }
     if (raw === '--no-gate') { out.gateOverride = 'off'; continue; }
     if (raw === '--rerank') { out.rerankOverride = 'on'; continue; }
@@ -1095,6 +1115,11 @@ export function parseSearchArgs(rest: string[]): SearchArgs {
       }
       out.highlight = v; continue;
     }
+    if (raw.startsWith('--snippet=')) {
+      snippetExplicit = true;
+      out.snippetLines = parseSearchSnippetCount(raw.slice('--snippet='.length), '--snippet');
+      continue;
+    }
     if (raw.startsWith('--color=')) {
       out.color = parseColorMode(raw.slice('--color='.length));
       out.colorExplicit = true;
@@ -1111,6 +1136,9 @@ export function parseSearchArgs(rest: string[]): SearchArgs {
   }
   if (hasRecencyFilter(out)) {
     parseRecencyFilterRange({ since: out.since, until: out.until });
+  }
+  if (!snippetExplicit) {
+    out.snippetLines = parseSearchSnippetEnv(process.env.KB_SEARCH_SNIPPET);
   }
   return out;
 }
@@ -1141,6 +1169,28 @@ function parsePositiveFlag(raw: string, prefix: string): number {
   return n;
 }
 
+function parseSearchSnippetEnv(raw: string | undefined): number | undefined {
+  if (raw === undefined) return undefined;
+  const value = raw.trim();
+  if (value === '') return undefined;
+  const normalized = value.toLocaleLowerCase();
+  if (normalized === 'false' || normalized === 'off' || normalized === 'no' || normalized === '0') {
+    return undefined;
+  }
+  if (normalized === 'true' || normalized === 'on' || normalized === 'yes') {
+    return DEFAULT_SEARCH_SNIPPET_LINES;
+  }
+  return parseSearchSnippetCount(value, 'KB_SEARCH_SNIPPET');
+}
+
+function parseSearchSnippetCount(value: string, source: string): number {
+  const n = Number(value);
+  if (!Number.isSafeInteger(n) || n <= 0) {
+    throw new Error(`invalid ${source}: ${value} (expected positive integer)`);
+  }
+  return n;
+}
+
 function buildSearchHighlightOptions(
   parsed: SearchArgs,
   query: string,
@@ -1150,6 +1200,15 @@ function buildSearchHighlightOptions(
   }
   const terms = extractSearchHighlightTerms(query);
   return terms.length === 0 ? undefined : { terms };
+}
+
+function buildSearchSnippetOptions(
+  parsed: Pick<SearchArgs, 'snippetLines'>,
+  query: string,
+): RetrievalSnippetOptions | undefined {
+  return parsed.snippetLines === undefined
+    ? undefined
+    : { lines: parsed.snippetLines, terms: extractSearchHighlightTerms(query) };
 }
 
 export function shouldHighlightSearchOutput(
@@ -1456,11 +1515,17 @@ export interface DenseSearchJsonPayloadInput {
   advancedRetrieval?: AdvancedRetrievalMetadata | null;
   queryCache?: QueryCacheTelemetry;
   retrievalViews?: RetrievalViewKind[];
+  snippet?: RetrievalSnippetOptions;
 }
 
 export function buildDenseSearchJsonPayload(input: DenseSearchJsonPayloadInput): Record<string, unknown> {
   const payload: Record<string, unknown> = {
-    results: formatRetrievalAsJson(input.results, FRONTMATTER_EXTRAS_WIRE_VISIBLE, KB_EDITOR_URI),
+    results: formatRetrievalAsJson(
+      input.results,
+      FRONTMATTER_EXTRAS_WIRE_VISIBLE,
+      KB_EDITOR_URI,
+      input.snippet,
+    ),
   };
   if (input.requestedMode === 'auto') {
     payload.mode = input.effectiveMode;
@@ -1472,6 +1537,7 @@ export function buildDenseSearchJsonPayload(input: DenseSearchJsonPayloadInput):
       input.results,
       FRONTMATTER_EXTRAS_WIRE_VISIBLE,
       KB_EDITOR_URI,
+      input.snippet,
     );
   }
   Object.assign(payload, buildFreshnessJsonFields(input));
@@ -1598,6 +1664,7 @@ export interface DenseSearchMarkdownOutputInput {
   explain?: boolean;
   advancedRetrieval?: AdvancedRetrievalMetadata | null;
   highlight?: RetrievalHighlightOptions;
+  snippet?: RetrievalSnippetOptions;
 }
 
 export function formatDenseSearchMarkdownOutput(input: DenseSearchMarkdownOutputInput): string {
@@ -1625,6 +1692,7 @@ export function formatDenseSearchMarkdownOutput(input: DenseSearchMarkdownOutput
       FRONTMATTER_EXTRAS_WIRE_VISIBLE,
       KB_EDITOR_URI,
       input.highlight,
+      input.snippet,
     );
   } else {
     md = formatRetrievalAsMarkdown(
@@ -1632,6 +1700,7 @@ export function formatDenseSearchMarkdownOutput(input: DenseSearchMarkdownOutput
       FRONTMATTER_EXTRAS_WIRE_VISIBLE,
       KB_EDITOR_URI,
       input.highlight,
+      input.snippet,
     );
   }
   output += `${md}\n\n`;
@@ -2037,6 +2106,7 @@ async function runBatchJsonlSearch(
           explainEmptyDiagnostics,
           gateVerdict: gate.verdict,
           queryCache: denseTiming.query_cache_telemetry,
+          snippet: buildSearchSnippetOptions(row, query),
         }),
       });
     } catch (err) {
@@ -2494,7 +2564,12 @@ async function runLexicalSearch(
       ...(autoModeDecision
         ? { requested_mode: 'auto' as const, auto_mode: autoModeDecision }
         : {}),
-      results: formatRetrievalAsJson(formatted as never, FRONTMATTER_EXTRAS_WIRE_VISIBLE, KB_EDITOR_URI),
+      results: formatRetrievalAsJson(
+        formatted as never,
+        FRONTMATTER_EXTRAS_WIRE_VISIBLE,
+        KB_EDITOR_URI,
+        buildSearchSnippetOptions(parsed, query),
+      ),
       knowledge_bases: perKb.map((r) => ({
         kb: r.kbName,
         files: r.refreshSummary?.totalFiles ?? null,
@@ -2549,6 +2624,7 @@ async function runLexicalSearch(
         FRONTMATTER_EXTRAS_WIRE_VISIBLE,
         KB_EDITOR_URI,
         buildSearchHighlightOptions(parsed, query),
+        buildSearchSnippetOptions(parsed, query),
       )}\n\n`;
     }
     const summaryLines = perKb.map((r) => {
@@ -2892,7 +2968,12 @@ async function runHybridSearch(
       ...(autoModeDecision
         ? { requested_mode: 'auto' as const, auto_mode: autoModeDecision }
         : {}),
-      results: formatRetrievalAsJson(ranked as never, FRONTMATTER_EXTRAS_WIRE_VISIBLE, KB_EDITOR_URI),
+      results: formatRetrievalAsJson(
+        ranked as never,
+        FRONTMATTER_EXTRAS_WIRE_VISIBLE,
+        KB_EDITOR_URI,
+        buildSearchSnippetOptions(parsed, query),
+      ),
       retrievers: {
         dense: { fetched: denseResults.length, model: activeModelId },
         lexical: {
@@ -2977,6 +3058,7 @@ async function runHybridSearch(
         FRONTMATTER_EXTRAS_WIRE_VISIBLE,
         KB_EDITOR_URI,
         buildSearchHighlightOptions(parsed, query),
+        buildSearchSnippetOptions(parsed, query),
       )}\n\n`;
     }
     output += `> _Hybrid status: dense fetched ${denseResults.length}, lexical fetched ${lexicalResults.length} with unit=${parsed.lexicalUnit} (refreshed ${lexicalResultsRow.refreshed}, ${lexicalResultsRow.failed} failed); fused via RRF (c=${HYBRID_RRF_C}, fetch_k=${fetchK})._\n`;

--- a/src/formatter.test.ts
+++ b/src/formatter.test.ts
@@ -8,6 +8,7 @@ import {
   formatRetrievalAsMarkdown,
   groupRetrievalBySource,
   highlightQueryTerms,
+  renderSearchSnippet,
   sanitizeMetadataForWire,
   ScoredDocument,
 } from './formatter.js';
@@ -216,6 +217,50 @@ describe('formatRetrievalAsMarkdown', () => {
     expect(out).toContain('"source": "rollback.md"');
     expect(out).not.toContain('"source": "\\u001b');
   });
+
+  it('renders a focused snippet window around the densest query-term match', () => {
+    const doc: ScoredDocument = {
+      pageContent: [
+        'intro line',
+        'setup line',
+        'rollback first mention',
+        'rollback second mention',
+        'cleanup line',
+        'appendix line',
+      ].join('\n'),
+      metadata: { source: 'rollback.md' },
+      score: 0.42,
+    } as unknown as ScoredDocument;
+
+    const out = formatRetrievalAsMarkdown([doc], false, 'none', undefined, {
+      terms: ['rollback'],
+      lines: 2,
+    });
+
+    expect(out).toContain('…\nrollback first mention\nrollback second mention\n…');
+    expect(out).not.toContain('intro line');
+    expect(out).not.toContain('appendix line');
+  });
+
+  it('preserves highlighting inside a focused snippet window', () => {
+    const doc: ScoredDocument = {
+      pageContent: 'before\nDeploy rollback procedure\nafter',
+      metadata: { source: 'rollback.md' },
+      score: 0.42,
+    } as unknown as ScoredDocument;
+
+    const out = formatRetrievalAsMarkdown(
+      [doc],
+      false,
+      'none',
+      { terms: ['rollback'] },
+      { terms: ['rollback'], lines: 1 },
+    );
+
+    expect(out).toContain(`…\nDeploy \x1b[1mrollback\x1b[22m procedure\n…`);
+    expect(out).not.toContain('before');
+    expect(out).not.toContain('after');
+  });
 });
 
 describe('highlightQueryTerms', () => {
@@ -228,6 +273,18 @@ describe('highlightQueryTerms', () => {
   it('handles overlapping terms without nested ANSI escapes', () => {
     expect(highlightQueryTerms('rollback roll', ['roll', 'rollback'])).toBe(
       '\x1b[1mrollback\x1b[22m \x1b[1mroll\x1b[22m',
+    );
+  });
+});
+
+describe('renderSearchSnippet', () => {
+  it('leaves short content unchanged', () => {
+    expect(renderSearchSnippet('one\ntwo', { terms: ['missing'], lines: 5 })).toBe('one\ntwo');
+  });
+
+  it('falls back to the first window when there is no term match', () => {
+    expect(renderSearchSnippet('one\ntwo\nthree', { terms: ['missing'], lines: 2 })).toBe(
+      'one\ntwo\n…',
     );
   });
 });
@@ -545,6 +602,19 @@ describe('formatRetrievalAsJson', () => {
       chunkIndex: 3,
     });
   });
+
+  it('adds an optional snippet field while preserving full JSON content', () => {
+    const doc: ScoredDocument = {
+      pageContent: 'alpha\nbeta\nneedle here\ngamma\ndelta',
+      metadata: { source: 'doc.md' },
+      score: 1.5,
+    } as unknown as ScoredDocument;
+
+    const out = formatRetrievalAsJson([doc], false, 'none', { terms: ['needle'], lines: 1 });
+
+    expect(out[0].content).toBe('alpha\nbeta\nneedle here\ngamma\ndelta');
+    expect(out[0].snippet).toBe('…\nneedle here\n…');
+  });
 });
 
 describe('formatRetrievalAsVimgrep', () => {
@@ -779,5 +849,29 @@ describe('formatRetrievalGroupedBySourceAsMarkdown', () => {
     expect(out).toContain('"from":20');
     expect(out).toContain('first chunk');
     expect(out).toContain('second chunk');
+  });
+
+  it('renders focused snippets while preserving grouped source metadata', () => {
+    const docs: ScoredDocument[] = [
+      {
+        pageContent: 'intro\nsetup\nrollback detail\nverify\nappendix',
+        metadata: { source: 'kb/repeated.md', loc: { lines: { from: 1, to: 5 } } },
+        score: 0.7,
+      } as unknown as ScoredDocument,
+    ];
+
+    const out = formatRetrievalGroupedBySourceAsMarkdown(
+      docs,
+      false,
+      'none',
+      undefined,
+      { terms: ['rollback'], lines: 1 },
+    );
+
+    expect(out).toContain('**Source 1:** `kb/repeated.md`');
+    expect(out).toContain('**Location:** `{"lines":{"from":1,"to":5}}`');
+    expect(out).toContain('…\n   rollback detail\n   …');
+    expect(out).not.toContain('intro');
+    expect(out).not.toContain('appendix');
   });
 });

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -40,6 +40,7 @@ export interface RetrievalJsonResult {
   score: number | null;
   rerank_score?: number;
   content: string;
+  snippet?: string;
   metadata: Record<string, unknown>;
   chunk_id?: string;
   editor_uri?: string;
@@ -88,6 +89,11 @@ export interface CompactRetrievalOptions {
 
 export interface RetrievalHighlightOptions {
   terms: readonly string[];
+}
+
+export interface RetrievalSnippetOptions {
+  terms: readonly string[];
+  lines: number;
 }
 
 // Query-term highlighting emits ANSI bold; the escape codes live in `color.ts`
@@ -150,6 +156,7 @@ export function formatRetrievalAsMarkdown(
   extrasVisible: boolean,
   editorUriMode: KBEditorUriMode = KB_EDITOR_URI,
   highlight?: RetrievalHighlightOptions,
+  snippet?: RetrievalSnippetOptions,
 ): string {
   if (!results || results.length === 0) {
     return formatRetrievalEmptyAsMarkdown();
@@ -166,7 +173,10 @@ export function formatRetrievalAsMarkdown(
         extrasVisible,
       );
       const guarded = guardRetrievalChunk(doc.pageContent, sanitizedMetadata, guardOptions);
-      const content = applyRetrievalHighlight(guarded.content.trim(), highlight);
+      const content = applyRetrievalHighlight(
+        applyRetrievalSnippet(guarded.content.trim(), snippet),
+        highlight,
+      );
       const citation = buildChunkCitation(guarded.metadata, editorUriMode);
       const metadata = JSON.stringify(guarded.metadata, null, 2);
       const scoreText = doc.score !== undefined ? `**Score:** ${doc.score.toFixed(2)}\n\n` : '';
@@ -184,8 +194,9 @@ export function formatRetrievalGroupedBySourceAsMarkdown(
   extrasVisible: boolean,
   editorUriMode: KBEditorUriMode = KB_EDITOR_URI,
   highlight?: RetrievalHighlightOptions,
+  snippet?: RetrievalSnippetOptions,
 ): string {
-  const grouped = groupRetrievalBySource(results, extrasVisible, editorUriMode);
+  const grouped = groupRetrievalBySource(results, extrasVisible, editorUriMode, snippet);
   if (grouped.length === 0) {
     return formatRetrievalEmptyAsMarkdown();
   }
@@ -198,7 +209,7 @@ export function formatRetrievalGroupedBySourceAsMarkdown(
           const openText = chunk.editor_uri ? `\n   **Open:** ${chunk.editor_uri}` : '';
           const shieldText = formatInjectionGrouped(chunk.injection_signals);
           const typeText = chunk.match_type ? `\n   **Type:** ${chunk.match_type}` : '';
-          const content = applyRetrievalHighlight(chunk.content.trim(), highlight);
+          const content = applyRetrievalHighlight((chunk.snippet ?? chunk.content).trim(), highlight);
           const contextText = formatJsonContextChunksForGroupedMarkdown(chunk.context_chunks, highlight);
           return `${chunkIdx + 1}. **Score:** ${scoreText}${typeText}\n   **Location:** ${locationText}${openText}\n\n   ${indentChunkContent(content)}${shieldText}${contextText}`;
         })
@@ -221,6 +232,19 @@ export function highlightQueryTerms(text: string, terms: readonly string[]): str
   return text.replace(new RegExp(pattern, 'giu'), (match) => `${ANSI_BOLD}${match}${ANSI_BOLD_OFF}`);
 }
 
+export function renderSearchSnippet(content: string, options: RetrievalSnippetOptions): string {
+  const lines = content.split(/\r?\n/);
+  const windowSize = Math.max(1, Math.floor(options.lines));
+  if (lines.length <= windowSize) return content;
+
+  const start = bestSnippetStart(lines, normalizeHighlightTerms(options.terms), windowSize);
+  const end = Math.min(lines.length, start + windowSize);
+  const out = lines.slice(start, end);
+  if (start > 0) out.unshift('…');
+  if (end < lines.length) out.push('…');
+  return out.join('\n');
+}
+
 export function formatDegradedStagesFooter(stages: readonly CanonicalDegradedStage[] | undefined): string {
   if (stages === undefined || stages.length === 0) return '';
   const stageText = stages
@@ -231,6 +255,52 @@ export function formatDegradedStagesFooter(stages: readonly CanonicalDegradedSta
 
 function applyRetrievalHighlight(text: string, highlight: RetrievalHighlightOptions | undefined): string {
   return highlight ? highlightQueryTerms(text, highlight.terms) : text;
+}
+
+function applyRetrievalSnippet(text: string, snippet: RetrievalSnippetOptions | undefined): string {
+  return snippet ? renderSearchSnippet(text, snippet) : text;
+}
+
+function bestSnippetStart(lines: readonly string[], terms: readonly string[], windowSize: number): number {
+  const lastStart = Math.max(0, lines.length - windowSize);
+  if (terms.length === 0) return 0;
+  const pattern = new RegExp(terms.map(escapeRegex).join('|'), 'giu');
+  const lineScores = lines.map((line) => (line.match(pattern) ?? []).length);
+  // Prefer the densest matching window; when windows tie, choose the one whose
+  // center is closest to the weighted center of all matched lines.
+  const targetLine = weightedMatchLine(lineScores);
+  let bestStart = 0;
+  let bestScore = 0;
+  for (let start = 0; start <= lastStart; start += 1) {
+    let score = 0;
+    for (let idx = start; idx < start + windowSize; idx += 1) {
+      score += lineScores[idx] ?? 0;
+    }
+    if (
+      score > bestScore ||
+      (score === bestScore &&
+        score > 0 &&
+        windowDistance(start, windowSize, targetLine) < windowDistance(bestStart, windowSize, targetLine))
+    ) {
+      bestScore = score;
+      bestStart = start;
+    }
+  }
+  return bestScore === 0 ? 0 : bestStart;
+}
+
+function weightedMatchLine(lineScores: readonly number[]): number {
+  let total = 0;
+  let weighted = 0;
+  lineScores.forEach((score, idx) => {
+    total += score;
+    weighted += score * idx;
+  });
+  return total === 0 ? 0 : weighted / total;
+}
+
+function windowDistance(start: number, windowSize: number, targetLine: number): number {
+  return Math.abs(start + (windowSize - 1) / 2 - targetLine);
 }
 
 function normalizeHighlightTerms(terms: readonly string[]): string[] {
@@ -261,6 +331,7 @@ export function formatRetrievalAsJson(
   results: ScoredDocument[] | null | undefined,
   extrasVisible: boolean,
   editorUriMode: KBEditorUriMode = KB_EDITOR_URI,
+  snippet?: RetrievalSnippetOptions,
 ): RetrievalJsonResult[] {
   if (!results || results.length === 0) return [];
   const guardOptions = resolveInjectionGuardOptions();
@@ -276,6 +347,7 @@ export function formatRetrievalAsJson(
       score: doc.score ?? null,
       ...(doc.rerankScore !== undefined ? { rerank_score: doc.rerankScore } : {}),
       content: guarded.content,
+      ...(snippet ? { snippet: applyRetrievalSnippet(guarded.content, snippet) } : {}),
       metadata: guarded.metadata,
       ...(citation ? { chunk_id: citation.chunk_id } : {}),
       ...(citation?.editor_uri ? { editor_uri: citation.editor_uri } : {}),
@@ -298,6 +370,7 @@ export function groupRetrievalBySource(
   results: ScoredDocument[] | null | undefined,
   extrasVisible: boolean,
   editorUriMode: KBEditorUriMode = KB_EDITOR_URI,
+  snippet?: RetrievalSnippetOptions,
 ): GroupedRetrievalSource[] {
   if (!results || results.length === 0) return [];
 
@@ -329,6 +402,7 @@ export function groupRetrievalBySource(
     group.chunks.push({
       score,
       content: guarded.content,
+      ...(snippet ? { snippet: applyRetrievalSnippet(guarded.content, snippet) } : {}),
       metadata: guarded.metadata,
       location,
       ...(citation ? { chunk_id: citation.chunk_id } : {}),


### PR DESCRIPTION
## Summary
- add `--snippet[=N]`, `KB_SEARCH_SNIPPET`, and `--full` for focused `kb search` excerpts
- render snippets in markdown and add an optional JSON `snippet` field while preserving full `content`
- apply snippet support across dense, lexical, hybrid, grouped JSON, and batch JSONL search payloads

Closes #691

## Verification
- KB hits: attempted `kb search "kb search snippet excerpt window long chunks highlight formatter"`; local FAISS index was not initialized, so this was a KB miss due unavailable index
- `unset KB_LOG_FORMAT KB_LOG_FILE LOG_FILE; npx jest --runInBand --runTestsByPath src/formatter.test.ts src/cli-search.test.ts` (171 passed)
- `git diff --check`
- manual added-line portability/secret/debug scan: clean
- pre-PR reviewers: conventions/correctness/test findings addressed; dead-code clean

## Local limitations
- Full build/type-check left to CI per chain convention for this repo. A local auto-rebuild hook attempted `npm run build` and failed in unrelated `src/cli-stale-check.ts` Node `Dirent` type errors.
- Touched-file ESLint could not start because linked `node_modules` is missing `typescript-eslint`, imported by `eslint.config.js`.