### PR TITLE
feat: add project config file loader

### DIFF
--- a/src/cli-config.test.ts
+++ b/src/cli-config.test.ts
@@ -10,9 +10,15 @@ import {
   parseConfigArgs,
   runConfig,
 } from './cli-config.js';
+import { resetProjectConfigForTests } from './config/project-config.js';
 
 const ORIGINAL_ENV = { ...process.env };
-const cliPath = path.join(process.cwd(), 'build', 'cli.js');
+const ORIGINAL_CWD = process.cwd();
+const tsxLoaderPath = path.join(ORIGINAL_CWD, 'node_modules', 'tsx', 'dist', 'loader.mjs');
+
+function cliArgs(...args: string[]): string[] {
+  return ['--enable-source-maps', '--import', tsxLoaderPath, path.join(ORIGINAL_CWD, 'src', 'cli.ts'), ...args];
+}
 
 let stdout = '';
 let stderr = '';
@@ -20,6 +26,7 @@ let tempDir = '';
 
 beforeEach(async () => {
   process.env = { ...ORIGINAL_ENV };
+  resetProjectConfigForTests();
   stdout = '';
   stderr = '';
   tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-config-validate-'));
@@ -35,7 +42,9 @@ beforeEach(async () => {
 
 afterEach(async () => {
   jest.restoreAllMocks();
+  process.chdir(ORIGINAL_CWD);
   process.env = { ...ORIGINAL_ENV };
+  resetProjectConfigForTests();
   await fsp.rm(tempDir, { recursive: true, force: true });
 });
 
@@ -87,7 +96,7 @@ describe('kb config validate (FR-OBS-470)', () => {
   });
 
   it('is reachable through the top-level kb dispatcher', async () => {
-    const help = spawnSync('node', [cliPath, 'config', '--help'], {
+    const help = spawnSync('node', cliArgs('config', '--help'), {
       env: { PATH: ORIGINAL_ENV.PATH ?? '', KB_LOG_FORMAT: 'text' },
       encoding: 'utf-8',
     });
@@ -95,7 +104,7 @@ describe('kb config validate (FR-OBS-470)', () => {
     expect(help.stdout).toContain('kb config validate');
     expect(help.stdout).toContain('kb config show');
 
-    const result = spawnSync('node', [cliPath, 'config', 'validate', '--format=json'], {
+    const result = spawnSync('node', cliArgs('config', 'validate', '--format=json'), {
       env: { PATH: ORIGINAL_ENV.PATH ?? '', KB_LOG_FORMAT: 'text', KB_RERANK: 'maybe' },
       encoding: 'utf-8',
     });
@@ -108,6 +117,35 @@ describe('kb config validate (FR-OBS-470)', () => {
     expect(parsed.findings).toEqual(expect.arrayContaining([
       expect.objectContaining({ name: 'KB_RERANK', status: 'error' }),
     ]));
+  });
+
+  it('does not let malformed project config break help or explicit dotenv validation', async () => {
+    await fsp.writeFile(path.join(tempDir, 'kb.config.yaml'), 'KB_RERANK: []\n');
+    const dotenv = path.join(tempDir, 'good.env');
+    await fsp.writeFile(dotenv, [
+      'EMBEDDING_PROVIDER=fake',
+      'KB_RERANK=off',
+    ].join('\n'));
+
+    const help = spawnSync('node', cliArgs('config', '--help'), {
+      cwd: tempDir,
+      env: { PATH: ORIGINAL_ENV.PATH ?? '', KB_LOG_FORMAT: 'text' },
+      encoding: 'utf-8',
+    });
+    expect(help.status).toBe(0);
+    expect(help.stdout).toContain('kb config validate');
+
+    const validate = spawnSync('node', cliArgs('config', 'validate', `--file=${dotenv}`, '--format=json'), {
+      cwd: tempDir,
+      env: { PATH: ORIGINAL_ENV.PATH ?? '', KB_LOG_FORMAT: 'text' },
+      encoding: 'utf-8',
+    });
+    expect(validate.status).toBe(0);
+    expect(JSON.parse(validate.stdout)).toMatchObject({
+      schema_version: 'kb.config-validate.v1',
+      status: 'ok',
+      source: dotenv,
+    });
   });
 
   it('renders markdown with per-variable verdicts', () => {
@@ -202,8 +240,82 @@ describe('kb config show (#545)', () => {
     expect(stderr).toBe('');
   });
 
+  it('layers project config files under explicit env and reports file provenance', async () => {
+    await fsp.writeFile(path.join(tempDir, 'kb.config.yaml'), [
+      'KNOWLEDGE_BASES_ROOT_DIR: /tmp/file-kbs',
+      'KB_RELEVANCE_GATE: on',
+      'KB_RERANK_TOP_N: 7',
+    ].join('\n'));
+    process.chdir(tempDir);
+    process.env = {
+      PATH: ORIGINAL_ENV.PATH ?? '',
+      KB_RERANK_TOP_N: '9',
+    };
+    resetProjectConfigForTests();
+
+    await expect(runConfig(['show', '--format=json', '--non-default-only'])).resolves.toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.config_file).toBe(path.join(tempDir, 'kb.config.yaml'));
+    expect(parsed.entries).toEqual(expect.arrayContaining([
+      {
+        name: 'KNOWLEDGE_BASES_ROOT_DIR',
+        kind: 'path',
+        value: '/tmp/file-kbs',
+        source: 'file',
+        redacted: false,
+      },
+      {
+        name: 'KB_RELEVANCE_GATE',
+        kind: 'boolean',
+        value: 'on',
+        source: 'file',
+        redacted: false,
+      },
+      {
+        name: 'KB_RERANK_TOP_N',
+        kind: 'integer',
+        value: '9',
+        source: 'env',
+        redacted: false,
+      },
+    ]));
+  });
+
+  it('validates the effective runtime config after project config layering', async () => {
+    await fsp.writeFile(path.join(tempDir, '.kbrc.json'), JSON.stringify({
+      KB_RERANK: 'on',
+      KB_RERANK_TOP_N: 2000,
+    }));
+    process.chdir(tempDir);
+    process.env = { PATH: ORIGINAL_ENV.PATH ?? '' };
+    resetProjectConfigForTests();
+
+    await expect(runConfig(['validate', '--format=json'])).resolves.toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.source).toContain(path.join(tempDir, '.kbrc.json'));
+    expect(parsed.findings).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        name: 'KB_RERANK_TOP_N',
+        status: 'error',
+        message: expect.stringContaining('<= 1000'),
+      }),
+    ]));
+  });
+
+  it('reports malformed project config with the offending key for runtime show', async () => {
+    await fsp.writeFile(path.join(tempDir, 'kb.config.yaml'), 'KB_RELEVANCE_GATE: []\n');
+    process.chdir(tempDir);
+    process.env = { PATH: ORIGINAL_ENV.PATH ?? '' };
+    resetProjectConfigForTests();
+
+    await expect(runConfig(['show', '--format=json'])).resolves.toBe(2);
+    expect(stdout).toBe('');
+    expect(stderr).toContain(`invalid project config ${path.join(tempDir, 'kb.config.yaml')} (KB_RELEVANCE_GATE)`);
+    expect(stderr).toContain('expected a string, number, or boolean value');
+  });
+
   it('is reachable through the top-level kb dispatcher', () => {
-    const result = spawnSync('node', [cliPath, 'config', 'show', '--format=json', '--non-default-only'], {
+    const result = spawnSync('node', cliArgs('config', 'show', '--format=json', '--non-default-only'), {
       env: { PATH: ORIGINAL_ENV.PATH ?? '', KB_LOG_FORMAT: 'text', KB_RELEVANCE_GATE: 'on' },
       encoding: 'utf-8',
     });
@@ -220,6 +332,35 @@ describe('kb config show (#545)', () => {
         value: 'on',
         source: 'env',
         redacted: false,
+      }),
+    ]));
+  });
+
+  it('loads project config through the top-level kb dispatcher', async () => {
+    await fsp.writeFile(path.join(tempDir, '.kbrc.json'), JSON.stringify({
+      KNOWLEDGE_BASES_ROOT_DIR: '/tmp/subprocess-kbs',
+      KB_RELEVANCE_GATE: 'on',
+    }));
+
+    const result = spawnSync('node', cliArgs('config', 'show', '--format=json', '--non-default-only'), {
+      cwd: tempDir,
+      env: { PATH: ORIGINAL_ENV.PATH ?? '', KB_LOG_FORMAT: 'text' },
+      encoding: 'utf-8',
+    });
+
+    expect(result.status).toBe(0);
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed.config_file).toBe(path.join(tempDir, '.kbrc.json'));
+    expect(parsed.entries).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        name: 'KNOWLEDGE_BASES_ROOT_DIR',
+        value: '/tmp/subprocess-kbs',
+        source: 'file',
+      }),
+      expect.objectContaining({
+        name: 'KB_RELEVANCE_GATE',
+        value: 'on',
+        source: 'file',
       }),
     ]));
   });

--- a/src/cli-config.ts
+++ b/src/cli-config.ts
@@ -8,6 +8,10 @@ import {
   type ConfigShowReport,
   type ConfigValidateReport,
 } from './config/schema.js';
+import {
+  getProjectConfig,
+  projectConfigAppliedSources,
+} from './config/project-config.js';
 
 export const CONFIG_HELP = `kb config — inspect and validate KB configuration
 
@@ -15,17 +19,18 @@ Usage:
   kb config validate [--file=.env] [--format=md|json]
   kb config show [--format=md|json] [--non-default-only]
 
-Validates known environment variables against the static KB config schema:
+Validates known runtime configuration against the static KB config schema:
 type, enum membership, numeric ranges, URL syntax, and cross-variable
-dependencies. The command is read-only and does not probe live endpoints.
+dependencies. Without --file, project config files are layered under
+process.env. The command is read-only and does not probe live endpoints.
 
 Shows the effective value and source for every known configuration variable.
 Secrets such as API keys and MCP_AUTH_TOKEN are redacted.
 
 Options:
-  --file=<path>             Parse this dotenv file instead of process.env.
+  --file=<path>             Parse this dotenv file instead of runtime config.
   --format=md|json          Output format (default: md).
-  --non-default-only        For show, print only values supplied by env.
+  --non-default-only        For show, print only env/file-supplied values.
   --help, -h                Show this help.
 
 Exit codes:
@@ -51,7 +56,18 @@ export async function runConfig(rest: string[]): Promise<number> {
   }
 
   if (parsed.action === 'show') {
-    const report = showConfigEnv(process.env, { nonDefaultOnly: parsed.nonDefaultOnly });
+    let projectConfig: ReturnType<typeof getProjectConfig>;
+    try {
+      projectConfig = getProjectConfig();
+    } catch (err) {
+      process.stderr.write(`kb config show: ${(err as Error).message}\n`);
+      return 2;
+    }
+    const report = showConfigEnv(process.env, {
+      nonDefaultOnly: parsed.nonDefaultOnly,
+      configFile: projectConfig.path,
+      sources: projectConfigAppliedSources(projectConfig),
+    });
     if (parsed.format === 'json') {
       process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
     } else {
@@ -75,6 +91,15 @@ export async function runConfig(rest: string[]): Promise<number> {
     const parsedEnv = parseDotEnvText(raw, source);
     env = parsedEnv.env;
     parseErrors = parsedEnv.errors;
+  } else {
+    let projectConfig: ReturnType<typeof getProjectConfig>;
+    try {
+      projectConfig = getProjectConfig();
+    } catch (err) {
+      process.stderr.write(`kb config validate: ${(err as Error).message}\n`);
+      return 2;
+    }
+    source = projectConfig.path === null ? 'process.env' : `process.env + ${projectConfig.path}`;
   }
 
   const report = validateConfigEnv(env, { source });
@@ -160,6 +185,7 @@ export function formatConfigShowMarkdown(report: ConfigShowReport): string {
   const lines = [
     '# kb config show',
     '',
+    ...(report.config_file === undefined ? [] : [`config_file: ${report.config_file ?? '(none)'}`, '']),
     '| Variable | Source | Kind | Value |',
     '| --- | --- | --- | --- |',
   ];

--- a/src/config/cache.ts
+++ b/src/config/cache.ts
@@ -1,3 +1,7 @@
+import { initializeProjectConfig } from './project-config.js';
+
+initializeProjectConfig();
+
 // ---------------------------------------------------------------------------
 // Query embedding cache configuration (#214).
 // ---------------------------------------------------------------------------

--- a/src/config/contextual-preface.ts
+++ b/src/config/contextual-preface.ts
@@ -1,4 +1,7 @@
 import { FAKE_LLM_ENDPOINT, isFakeLlmEnabled } from '../llm-fake-stub.js';
+import { initializeProjectConfig } from './project-config.js';
+
+initializeProjectConfig();
 
 // RFC 017 — Contextual Retrieval at Ingest.
 //

--- a/src/config/indexing.ts
+++ b/src/config/indexing.ts
@@ -1,4 +1,7 @@
 import { EMBEDDING_PROVIDER } from './provider.js';
+import { initializeProjectConfig } from './project-config.js';
+
+initializeProjectConfig();
 
 // ---------------------------------------------------------------------------
 // Indexing batch configuration (RFC 007 section6.2 / issue #236).

--- a/src/config/ingest.ts
+++ b/src/config/ingest.ts
@@ -1,3 +1,7 @@
+import { initializeProjectConfig } from './project-config.js';
+
+initializeProjectConfig();
+
 function parseCommaSeparatedList(raw: string | undefined): string[] {
   if (raw === undefined || raw.trim() === '') return [];
   return raw

--- a/src/config/llm-provider.ts
+++ b/src/config/llm-provider.ts
@@ -1,3 +1,7 @@
+import { initializeProjectConfig } from './project-config.js';
+
+initializeProjectConfig();
+
 // LLM provider resolution — local (default) vs OpenRouter (OpenAI-compatible).
 //
 // This mirrors the provider-neutral switch used by the sibling repos

--- a/src/config/logging.ts
+++ b/src/config/logging.ts
@@ -1,3 +1,7 @@
+import { initializeProjectConfig } from './project-config.js';
+
+initializeProjectConfig();
+
 // ---------------------------------------------------------------------------
 // Canonical log line configuration (#216).
 // ---------------------------------------------------------------------------

--- a/src/config/mcp-descriptions.ts
+++ b/src/config/mcp-descriptions.ts
@@ -6,6 +6,10 @@
 // load; set the env vars BEFORE the server process starts.
 // ---------------------------------------------------------------------------
 
+import { initializeProjectConfig } from './project-config.js';
+
+initializeProjectConfig();
+
 export const DEFAULT_RETRIEVE_KNOWLEDGE_DESCRIPTION =
   'Retrieves similar chunks from the knowledge base based on a query. Optionally, if a knowledge base is specified, only that one is searched; otherwise, all available knowledge bases are considered. By default, at most 10 documents are returned with a score below a threshold of 2. A different threshold can optionally be provided.';
 export const RETRIEVE_KNOWLEDGE_DESCRIPTION =

--- a/src/config/metrics-export.ts
+++ b/src/config/metrics-export.ts
@@ -1,3 +1,7 @@
+import { initializeProjectConfig } from './project-config.js';
+
+initializeProjectConfig();
+
 export function isMetricsExportEnabled(
   raw: string | undefined = process.env.KB_METRICS_EXPORT,
 ): boolean {

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -1,5 +1,8 @@
 import * as os from 'os';
 import * as path from 'path';
+import { initializeProjectConfig } from './project-config.js';
+
+initializeProjectConfig();
 
 export function resolveKnowledgeBasesRootDir(raw: string | undefined): string {
   return raw || path.join(os.homedir(), 'knowledge_bases');

--- a/src/config/project-config.ts
+++ b/src/config/project-config.ts
@@ -1,0 +1,162 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import yaml from 'js-yaml';
+
+export const PROJECT_CONFIG_FILE_NAMES = [
+  '.kbrc',
+  '.kbrc.json',
+  'kb.config.yaml',
+  'kb.config.yml',
+  'kb.config.json',
+] as const;
+
+export interface ProjectConfigLoadResult {
+  path: string | null;
+  env: Record<string, string>;
+  overriddenByEnv: string[];
+}
+
+export class ProjectConfigError extends Error {
+  readonly file: string;
+  readonly key?: string;
+
+  constructor(file: string, message: string, key?: string) {
+    super(`invalid project config ${file}${key === undefined ? '' : ` (${key})`}: ${message}`);
+    this.name = 'ProjectConfigError';
+    this.file = file;
+    this.key = key;
+  }
+}
+
+let cached: ProjectConfigLoadResult | null = null;
+let injectedKeys = new Set<string>();
+
+export function loadProjectConfig(cwd = process.cwd()): ProjectConfigLoadResult {
+  const configPath = findProjectConfig(cwd);
+  if (configPath === null) {
+    return { path: null, env: {}, overriddenByEnv: [] };
+  }
+  const env = readProjectConfigEnv(configPath);
+  const overriddenByEnv = Object.keys(env).filter((name) => process.env[name] !== undefined);
+  return { path: configPath, env, overriddenByEnv };
+}
+
+export function getProjectConfig(): ProjectConfigLoadResult {
+  if (cached === null) {
+    cached = loadProjectConfig();
+    applyProjectConfigDefaults(cached);
+  }
+  return cached;
+}
+
+export function initializeProjectConfig(): void {
+  try {
+    getProjectConfig();
+  } catch {
+    // Import-time bootstrap must not break --help or explicit --file validation.
+    // Commands that inspect runtime config call getProjectConfig() directly and
+    // surface the parse error with command context.
+  }
+}
+
+export function projectConfigAppliedSources(
+  config = getProjectConfig(),
+): Record<string, 'file'> {
+  const overridden = new Set(config.overriddenByEnv);
+  return Object.fromEntries(
+    Object.keys(config.env)
+      .filter((name) => !overridden.has(name))
+      .map((name) => [name, 'file' as const]),
+  );
+}
+
+export function applyProjectConfigDefaults(config = getProjectConfig()): void {
+  for (const [name, value] of Object.entries(config.env)) {
+    if (process.env[name] !== undefined) continue;
+    process.env[name] = value;
+    injectedKeys.add(name);
+  }
+}
+
+export function resetProjectConfigForTests(): void {
+  for (const name of injectedKeys) {
+    delete process.env[name];
+  }
+  injectedKeys = new Set<string>();
+  cached = null;
+}
+
+export function findProjectConfig(cwd = process.cwd()): string | null {
+  for (const dir of parentDirs(path.resolve(cwd))) {
+    const found = firstExistingConfigFile(dir, PROJECT_CONFIG_FILE_NAMES);
+    if (found !== null) return found;
+  }
+
+  const xdgConfigHome = process.env.XDG_CONFIG_HOME || path.join(os.homedir(), '.config');
+  return firstExistingConfigFile(path.join(xdgConfigHome, 'kb'), [
+    'kb.config.yaml',
+    'kb.config.yml',
+    'kb.config.json',
+    '.kbrc',
+    '.kbrc.json',
+  ]);
+}
+
+function firstExistingConfigFile(dir: string, names: readonly string[]): string | null {
+  for (const name of names) {
+    const candidate = path.join(dir, name);
+    try {
+      if (fs.statSync(candidate).isFile()) return candidate;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+    }
+  }
+  return null;
+}
+
+function parentDirs(start: string): string[] {
+  const dirs: string[] = [];
+  let current = start;
+  while (true) {
+    dirs.push(current);
+    const parent = path.dirname(current);
+    if (parent === current) return dirs;
+    current = parent;
+  }
+}
+
+function readProjectConfigEnv(file: string): Record<string, string> {
+  let parsed: unknown;
+  try {
+    const raw = fs.readFileSync(file, 'utf-8');
+    parsed = file.endsWith('.json') ? JSON.parse(raw) : yaml.load(raw);
+  } catch (err) {
+    throw new ProjectConfigError(file, (err as Error).message);
+  }
+
+  if (!isPlainObject(parsed)) {
+    throw new ProjectConfigError(file, 'expected a top-level object');
+  }
+
+  const source = isPlainObject(parsed.env) ? parsed.env : parsed;
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(source)) {
+    if (!/^[A-Z_][A-Z0-9_]*$/.test(key)) {
+      throw new ProjectConfigError(file, 'expected environment-style uppercase keys', key);
+    }
+    if (typeof value === 'string') {
+      env[key] = value;
+    } else if (typeof value === 'number' || typeof value === 'boolean') {
+      env[key] = String(value);
+    } else {
+      throw new ProjectConfigError(file, 'expected a string, number, or boolean value', key);
+    }
+  }
+  return env;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/src/config/provider.ts
+++ b/src/config/provider.ts
@@ -1,5 +1,9 @@
 // Embedding provider configuration.
 //
+import { initializeProjectConfig } from './project-config.js';
+
+initializeProjectConfig();
+
 // Issue #204 - `fake` is a deterministic, offline embedding provider used by
 // CI and local development. It produces hash-bag, L2-normalized vectors with
 // no network, no API key, and no Ollama daemon. Whitelisted here so callers

--- a/src/config/relevance-gate.ts
+++ b/src/config/relevance-gate.ts
@@ -1,4 +1,7 @@
 import { FAKE_LLM_ENDPOINT, isFakeLlmEnabled } from '../llm-fake-stub.js';
+import { initializeProjectConfig } from './project-config.js';
+
+initializeProjectConfig();
 
 export interface RelevanceGateConfig {
   enabled: boolean;

--- a/src/config/reranker.ts
+++ b/src/config/reranker.ts
@@ -1,3 +1,7 @@
+import { initializeProjectConfig } from './project-config.js';
+
+initializeProjectConfig();
+
 export const DEFAULT_RERANK_MODEL = 'Xenova/ms-marco-MiniLM-L-6-v2';
 export const DEFAULT_RERANK_TOP_N = 40;
 export const MAX_RERANK_TOP_N = 1000;

--- a/src/config/retrieval.ts
+++ b/src/config/retrieval.ts
@@ -1,3 +1,7 @@
+import { initializeProjectConfig } from './project-config.js';
+
+initializeProjectConfig();
+
 /**
  * When false (default), `frontmatter.extras` is stripped from every
  * `retrieve_knowledge` response before JSON serialization. Extras hold

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -64,7 +64,7 @@ export interface ConfigValidateReport {
   findings: ConfigFinding[];
 }
 
-export type ConfigValueSource = 'env' | 'default';
+export type ConfigValueSource = 'env' | 'file' | 'default';
 
 export interface ConfigShowEntry {
   name: string;
@@ -76,6 +76,7 @@ export interface ConfigShowEntry {
 
 export interface ConfigShowReport {
   schema_version: 'kb.config-show.v1';
+  config_file?: string | null;
   entries: ConfigShowEntry[];
 }
 
@@ -301,14 +302,19 @@ export function validateConfigEnv(
 
 export function showConfigEnv(
   env: NodeJS.ProcessEnv | Record<string, string | undefined>,
-  options: { nonDefaultOnly?: boolean } = {},
+  options: {
+    nonDefaultOnly?: boolean;
+    configFile?: string | null;
+    sources?: Record<string, ConfigValueSource | undefined>;
+  } = {},
 ): ConfigShowReport {
   const entries = CONFIG_SCHEMA
-    .map((spec) => showSpec(spec, env))
+    .map((spec) => showSpec(spec, env, options.sources))
     .filter((entry) => !options.nonDefaultOnly || entry.source !== 'default');
 
   return {
     schema_version: 'kb.config-show.v1',
+    ...(options.configFile !== undefined ? { config_file: options.configFile } : {}),
     entries,
   };
 }
@@ -400,6 +406,7 @@ function validateSpec(
 function showSpec(
   spec: ConfigSpec,
   env: NodeJS.ProcessEnv | Record<string, string | undefined>,
+  sources?: Record<string, ConfigValueSource | undefined>,
 ): ConfigShowEntry {
   const value = effectiveValue(env, spec.name);
   const redacted = isSecretSpec(spec) && value !== null && value !== '';
@@ -407,7 +414,7 @@ function showSpec(
     name: spec.name,
     kind: spec.kind,
     value: redacted ? '<redacted>' : value,
-    source: sourceForSpec(spec, env),
+    source: sourceForSpec(spec, env, sources),
     redacted,
   };
 }
@@ -593,11 +600,12 @@ function effectiveStringValue(
 function sourceForSpec(
   spec: ConfigSpec,
   env: NodeJS.ProcessEnv | Record<string, string | undefined>,
+  sources?: Record<string, ConfigValueSource | undefined>,
 ): ConfigValueSource {
   const value = normalizeSpecValue(spec, normalizeRaw(env[spec.name]));
   if (value === undefined) return 'default';
   if (value === '' && usesDefaultForEmpty(spec)) return 'default';
-  return 'env';
+  return sources?.[spec.name] ?? 'env';
 }
 
 function defaultForSpec(

--- a/src/config/watchers.ts
+++ b/src/config/watchers.ts
@@ -1,5 +1,8 @@
 import * as path from 'path';
 import { KNOWLEDGE_BASES_ROOT_DIR } from './paths.js';
+import { initializeProjectConfig } from './project-config.js';
+
+initializeProjectConfig();
 
 // ---------------------------------------------------------------------------
 // Reindex-trigger watcher (RFC 011 section5.5).


### PR DESCRIPTION
Closes #690

## Summary
- add optional project config discovery for `.kbrc`, `.kbrc.json`, and `kb.config.{yaml,yml,json}` with env-style scalar values
- layer project config defaults under explicit environment variables for runtime config modules
- show file provenance in `kb config show` and validate effective runtime config in `kb config validate`
- keep malformed project config from breaking help or explicit `--file` validation

## Verification
- KB miss: `kb search "project config loader .kbrc kb.config.yaml environment variables config precedence"` failed because the local FAISS index is not initialized (`INDEX_NOT_INITIALIZED`)
- PASS: `env -u KB_LOG_FORMAT -u KB_LOG_FILE -u LOG_FILE npx jest --runInBand --runTestsByPath src/cli-config.test.ts src/config/schema.test.ts src/config.test.ts src/config/reranker.test.ts`
- PASS: `git diff --check`
- Pre-PR review: conventions/correctness/dead-code/test specialists run; findings addressed
- NOTE: `npm run build` is blocked locally by an existing `src/cli-stale-check.ts` Node typings mismatch (`Dirent<string>[]` vs `Dirent<NonSharedBuffer>[]`)
- NOTE: `npx eslint ...` could not start because the shared worktree `node_modules` is missing `typescript-eslint` imported by `eslint.config.js`
