### PR TITLE
feat: export rerank metrics

### DIFF
--- a/src/kb-stats.ts
+++ b/src/kb-stats.ts
@@ -38,11 +38,14 @@ import { logger } from './logger.js';
 import {
   providerCallMetrics,
   quantileFromBuckets,
+  rerankMetrics,
   searchLatencyMetrics,
   type ProviderCallMetrics,
   type ProviderCallSnapshot,
-  type SearchLatencyMetricsSnapshot,
+  type RerankMetrics,
+  type RerankMetricsSnapshot,
   type SearchLatencyMetrics,
+  type SearchLatencyMetricsSnapshot,
 } from './metrics.js';
 import { countIngestQuarantine } from './ingest-quarantine.js';
 import { queryEmbeddingCache, type QueryCacheStats } from './query-cache.js';
@@ -130,6 +133,8 @@ export interface KbStatsPayload {
   search_latency: SearchLatencyMetricsSnapshot;
   query_cache: QueryCacheStats;
   relevance_gate: RelevanceGateMetricsSnapshot;
+  /** Issue #689 — process-lifetime reranker-stage counters and latency histograms. */
+  rerank?: RerankMetricsSnapshot;
   /**
    * Issue #430 — live counters for the optional HTTP/SSE MCP transport.
    * Omitted for stdio-only processes and for local `kb stats` invocations
@@ -175,6 +180,8 @@ export interface ComputeKbStatsOptions {
   metrics?: ProviderCallMetrics;
   /** Issue #597 — test seam for daemon-served search latency telemetry. */
   searchMetrics?: SearchLatencyMetrics;
+  /** Issue #689 — test seam for reranker-stage telemetry. */
+  rerankMetrics?: RerankMetrics;
   /** Process-local HTTP/SSE counters, supplied by KnowledgeBaseServer when active. */
   remoteTransportStats?: TransportRuntimeStatsSnapshot;
 }
@@ -256,6 +263,7 @@ export async function computeKbStats(
 
   const metricsSource = options.metrics ?? providerCallMetrics;
   const searchMetricsSource = options.searchMetrics ?? searchLatencyMetrics;
+  const rerankMetricsSource = options.rerankMetrics ?? rerankMetrics;
   const searchMetricsSnapshot = searchMetricsSource.snapshot();
   const activeIndexType = indexStats.indexType ?? 'flat';
   const activeIndexFactory = indexFactoryForType(activeIndexType);
@@ -297,6 +305,7 @@ export async function computeKbStats(
     search_latency: searchMetricsSnapshot,
     query_cache: await queryEmbeddingCache.stats(),
     relevance_gate: relevanceGateMetrics.snapshot(),
+    rerank: rerankMetricsSource.snapshot(),
     ...(options.remoteTransportStats !== undefined
       ? { remote_transport: options.remoteTransportStats }
       : {}),

--- a/src/metrics.test.ts
+++ b/src/metrics.test.ts
@@ -5,6 +5,7 @@ import {
   LATENCY_BUCKET_BOUNDS_MS,
   ProviderCallMetrics,
   quantileFromBuckets,
+  RerankMetrics,
   SearchLatencyMetrics,
 } from './metrics.js';
 
@@ -197,6 +198,44 @@ describe('SearchLatencyMetrics', () => {
     expect(metrics.snapshot().requests.dense?.success?.count).toBe(1);
     metrics.reset();
     expect(metrics.snapshot()).toEqual({ requests: {}, stages: {}, degraded: {} });
+  });
+});
+
+describe('RerankMetrics', () => {
+  it('records skips, invocation counts, candidate sources, and latency source histograms', () => {
+    const metrics = new RerankMetrics({ now: () => 1_700_000_000_000 });
+
+    metrics.recordSkipped('disabled');
+    metrics.recordSkipped('skip_domain');
+    metrics.recordSkipped('skip_domain');
+    metrics.recordInvocation({ latencyMs: 12, candidatesIn: 3, cacheHits: 1 });
+    metrics.recordInvocation({ latencyMs: 2, candidatesIn: 2, cacheHits: 2 });
+
+    const snap = metrics.snapshot();
+    expect(snap.invocations).toBe(2);
+    expect(snap.skipped).toEqual({ disabled: 1, skip_domain: 2 });
+    expect(snap.candidates).toEqual({ cache_hit: 3, model_scored: 2 });
+    expect(snap.latency.model_scored).toMatchObject({
+      count: 1,
+      sum_ms: 12,
+      since_started_at: '2023-11-14T22:13:20.000Z',
+    });
+    expect(snap.latency.cache_hit).toMatchObject({ count: 1, sum_ms: 2 });
+  });
+
+  it('reset() clears rerank telemetry', () => {
+    const metrics = new RerankMetrics();
+    metrics.recordSkipped('no_candidates');
+    metrics.recordInvocation({ latencyMs: 1, candidatesIn: 1, cacheHits: 0 });
+
+    metrics.reset();
+
+    expect(metrics.snapshot()).toEqual({
+      invocations: 0,
+      skipped: {},
+      candidates: {},
+      latency: {},
+    });
   });
 });
 

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -90,6 +90,16 @@ export interface SearchLatencyMetricsSnapshot {
   degraded: Partial<Record<SearchLatencyMode, Partial<Record<DenseDegradationReason, number>>>>;
 }
 
+export type RerankSkipReason = 'disabled' | 'skip_domain' | 'no_candidates';
+export type RerankCandidateSource = 'cache_hit' | 'model_scored';
+
+export interface RerankMetricsSnapshot {
+  invocations: number;
+  skipped: Partial<Record<RerankSkipReason, number>>;
+  candidates: Partial<Record<RerankCandidateSource, number>>;
+  latency: Partial<Record<RerankCandidateSource, LatencyHistogramSnapshot>>;
+}
+
 function emptyState(now: number): MetricsState {
   return {
     buckets: new Array<number>(LATENCY_BUCKET_BOUNDS_MS.length + 1).fill(0),
@@ -348,6 +358,72 @@ export class SearchLatencyMetrics {
 }
 
 /**
+ * Process-lifetime reranker-stage telemetry. Labels are intentionally bounded:
+ * skip reason and candidate/latency source are fixed enums, never query text,
+ * KB name, path, model id, or error message.
+ */
+export class RerankMetrics {
+  private invocations = 0;
+  private readonly skippedCounts = new Map<RerankSkipReason, number>();
+  private readonly candidateCounts = new Map<RerankCandidateSource, number>();
+  private readonly latencyStates = new Map<RerankCandidateSource, HistogramState>();
+  private readonly now: () => number;
+
+  constructor(options: { now?: () => number } = {}) {
+    this.now = options.now ?? Date.now;
+  }
+
+  recordSkipped(reason: RerankSkipReason): void {
+    this.skippedCounts.set(reason, (this.skippedCounts.get(reason) ?? 0) + 1);
+  }
+
+  recordInvocation(sample: { latencyMs: number; candidatesIn: number; cacheHits: number }): void {
+    this.invocations += 1;
+    const cacheHits = clampCount(sample.cacheHits);
+    const candidatesIn = clampCount(sample.candidatesIn);
+    const modelScored = Math.max(0, candidatesIn - cacheHits);
+    if (cacheHits > 0) {
+      this.candidateCounts.set('cache_hit', (this.candidateCounts.get('cache_hit') ?? 0) + cacheHits);
+    }
+    if (modelScored > 0) {
+      this.candidateCounts.set('model_scored', (this.candidateCounts.get('model_scored') ?? 0) + modelScored);
+    }
+
+    const latencySource: RerankCandidateSource = candidatesIn > 0 && modelScored === 0 ? 'cache_hit' : 'model_scored';
+    let state = this.latencyStates.get(latencySource);
+    if (state === undefined) {
+      state = emptyHistogramState(this.now());
+      this.latencyStates.set(latencySource, state);
+    }
+    recordHistogramSample(state, sample.latencyMs);
+  }
+
+  snapshot(): RerankMetricsSnapshot {
+    const skipped: RerankMetricsSnapshot['skipped'] = {};
+    for (const [reason, count] of this.skippedCounts.entries()) skipped[reason] = count;
+
+    const candidates: RerankMetricsSnapshot['candidates'] = {};
+    for (const [source, count] of this.candidateCounts.entries()) candidates[source] = count;
+
+    const latency: RerankMetricsSnapshot['latency'] = {};
+    for (const [source, state] of this.latencyStates.entries()) latency[source] = snapshotHistogram(state);
+
+    return { invocations: this.invocations, skipped, candidates, latency };
+  }
+
+  reset(): void {
+    this.invocations = 0;
+    this.skippedCounts.clear();
+    this.candidateCounts.clear();
+    this.latencyStates.clear();
+  }
+}
+
+function clampCount(value: number): number {
+  return Number.isFinite(value) && value > 0 ? Math.floor(value) : 0;
+}
+
+/**
  * Round a latency to 3 significant decimal places. The histogram
  * resolution is bounded by bucket width, so reporting full
  * floating-point precision overstates accuracy; one decimal in
@@ -364,6 +440,8 @@ function roundLatency(latencyMs: number): number {
 export const providerCallMetrics = new ProviderCallMetrics();
 
 export const searchLatencyMetrics = new SearchLatencyMetrics();
+
+export const rerankMetrics = new RerankMetrics();
 
 /**
  * Wrap a langchain-shaped embeddings client so every `embedQuery` /

--- a/src/prometheus-export.test.ts
+++ b/src/prometheus-export.test.ts
@@ -28,6 +28,13 @@ describe('formatKbStatsOpenMetrics', () => {
     expect(text).toContain('# TYPE kb_search_stage_duration_ms histogram');
     expect(text).toContain('kb_search_stage_duration_ms_bucket{le="30",mode="dense",stage="embed_query",status="success"} 1');
     expect(text).toContain('kb_search_stage_duration_ms_sum{mode="dense",stage="embed_query",status="success"} 12');
+    expect(text).toContain('# TYPE kb_rerank_invocations counter');
+    expect(text).toContain('kb_rerank_invocations_total 3');
+    expect(text).toContain('kb_rerank_skipped_total{reason="skip_domain"} 2');
+    expect(text).toContain('kb_rerank_candidates_total{source="model_scored"} 4');
+    expect(text).toContain('# TYPE kb_rerank_latency_ms histogram');
+    expect(text).toContain('kb_rerank_latency_ms_bucket{le="30",source="model_scored"} 1');
+    expect(text).toContain('kb_rerank_latency_ms_sum{source="model_scored"} 12');
     expect(text).toContain('kb_remote_transport_requests_total 9');
     expect(text).toContain('# TYPE kb_remote_transport_responses_4xx counter');
     expect(text).toContain('kb_remote_transport_responses_4xx_total 2');
@@ -151,6 +158,20 @@ function samplePayload(): KbStatsPayload {
         degraded: 0,
         rate: 0,
         warn_threshold: 0.1,
+      },
+    },
+    rerank: {
+      invocations: 3,
+      skipped: {
+        skip_domain: 2,
+        disabled: 1,
+      },
+      candidates: {
+        cache_hit: 5,
+        model_scored: 4,
+      },
+      latency: {
+        model_scored: histogramSnapshot(12),
       },
     },
     remote_transport: {

--- a/src/prometheus-export.ts
+++ b/src/prometheus-export.ts
@@ -2,6 +2,7 @@ import type { KbStatsPayload } from './kb-stats.js';
 import {
   LATENCY_BUCKET_BOUNDS_MS,
   type LatencyHistogramSnapshot,
+  type RerankMetricsSnapshot,
   type SearchLatencyMetricsSnapshot,
   type SearchLatencyMode,
   type SearchLatencyStatus,
@@ -112,6 +113,7 @@ export function formatKbStatsOpenMetrics(payload: KbStatsPayload): string {
     ...providerLatencyMetrics(payload),
     ...searchLatencyCounterMetrics(payload.search_latency),
     ...searchDegradedCounterMetrics(payload.search_latency),
+    ...rerankCounterMetrics(payload.rerank),
     {
       name: 'kb_query_cache_hits_total',
       help: 'Query embedding cache hits.',
@@ -183,6 +185,7 @@ export function formatKbStatsOpenMetrics(payload: KbStatsPayload): string {
     }
   }
   lines.push(...searchLatencyHistogramLines(payload.search_latency));
+  lines.push(...rerankLatencyHistogramLines(payload.rerank));
   lines.push('# EOF');
   return `${lines.join('\n')}\n`;
 }
@@ -325,6 +328,48 @@ function searchDegradedCounterMetrics(snapshot: SearchLatencyMetricsSnapshot): M
   }];
 }
 
+function rerankCounterMetrics(snapshot: RerankMetricsSnapshot | undefined): MetricDefinition[] {
+  if (snapshot === undefined) return [];
+  const skippedSamples: MetricSample[] = [];
+  for (const [reason, count] of Object.entries(snapshot.skipped)) {
+    skippedSamples.push({
+      name: 'kb_rerank_skipped_total',
+      labels: { reason },
+      value: count ?? 0,
+    });
+  }
+
+  const candidateSamples: MetricSample[] = [];
+  for (const [source, count] of Object.entries(snapshot.candidates)) {
+    candidateSamples.push({
+      name: 'kb_rerank_candidates_total',
+      labels: { source },
+      value: count ?? 0,
+    });
+  }
+
+  return [
+    {
+      name: 'kb_rerank_invocations_total',
+      help: 'Reranker-stage invocations.',
+      type: 'counter',
+      samples: [{ name: 'kb_rerank_invocations_total', value: snapshot.invocations }],
+    },
+    {
+      name: 'kb_rerank_skipped_total',
+      help: 'Reranker-stage skips by bounded reason.',
+      type: 'counter',
+      samples: skippedSamples,
+    },
+    {
+      name: 'kb_rerank_candidates_total',
+      help: 'Reranker-stage candidates by scoring source.',
+      type: 'counter',
+      samples: candidateSamples,
+    },
+  ];
+}
+
 function searchLatencyHistogramLines(snapshot: SearchLatencyMetricsSnapshot): string[] {
   const lines: string[] = [];
   lines.push(...renderHistogramFamily({
@@ -338,6 +383,20 @@ function searchLatencyHistogramLines(snapshot: SearchLatencyMetricsSnapshot): st
     rows: stageHistogramRows(snapshot),
   }));
   return lines;
+}
+
+function rerankLatencyHistogramLines(snapshot: RerankMetricsSnapshot | undefined): string[] {
+  if (snapshot === undefined) return [];
+  const rows: HistogramRow[] = [];
+  for (const [source, histogram] of Object.entries(snapshot.latency)) {
+    if (histogram === undefined) continue;
+    rows.push({ labels: { source }, histogram });
+  }
+  return renderHistogramFamily({
+    name: 'kb_rerank_latency_ms',
+    help: 'Reranker-stage latency in milliseconds, split by bounded scoring source.',
+    rows,
+  });
 }
 
 function requestHistogramRows(snapshot: SearchLatencyMetricsSnapshot): HistogramRow[] {

--- a/src/reranker.test.ts
+++ b/src/reranker.test.ts
@@ -9,6 +9,7 @@ import {
   type Reranker,
   type RerankableDocument,
 } from './reranker.js';
+import { rerankMetrics } from './metrics.js';
 
 function doc(source: string, score: number, body = source): RerankableDocument {
   return {
@@ -118,6 +119,7 @@ describe('applyRerankerIfEnabled — per-domain skip-rerank fallback (RFC 020 §
   beforeEach(() => {
     saved = {};
     for (const key of ENV_KEYS) saved[key] = process.env[key];
+    rerankMetrics.reset();
   });
 
   afterEach(() => {
@@ -125,6 +127,7 @@ describe('applyRerankerIfEnabled — per-domain skip-rerank fallback (RFC 020 §
       if (saved[key] === undefined) delete process.env[key];
       else process.env[key] = saved[key];
     }
+    rerankMetrics.reset();
   });
 
   it('does NOT invoke the cross-encoder when the scoped domain is on KB_RERANK_SKIP_DOMAINS', async () => {
@@ -146,6 +149,7 @@ describe('applyRerankerIfEnabled — per-domain skip-rerank fallback (RFC 020 §
       expect(out.degraded).toBe(false);
       expect(out.candidatesIn).toBe(0);
       expect(out.results.map((r) => r.metadata.source)).toEqual(['a.md', 'b.md']);
+      expect(rerankMetrics.snapshot().skipped).toEqual({ skip_domain: 1 });
     } finally {
       restore();
     }
@@ -169,6 +173,58 @@ describe('applyRerankerIfEnabled — per-domain skip-rerank fallback (RFC 020 §
       expect(out.degraded).toBe(false);
       // b.md outscores a.md after reranking.
       expect(out.results.map((r) => r.metadata.source)).toEqual(['b.md', 'a.md']);
+      expect(rerankMetrics.snapshot()).toMatchObject({
+        invocations: 1,
+        candidates: { model_scored: 2 },
+      });
+    } finally {
+      restore();
+    }
+  });
+
+  it('records a no-candidates skip without invoking the cross-encoder', async () => {
+    const reranker = stubReranker([]);
+    const restore = setRerankerFactoryForTests(async () => reranker);
+    try {
+      setEnv({ KB_RERANK: 'on' });
+
+      const out = await applyRerankerIfEnabled({
+        query: 'q',
+        results: [],
+        k: 2,
+        kbScope: 'prose',
+      });
+
+      expect(reranker.rerank).not.toHaveBeenCalled();
+      expect(out.results).toEqual([]);
+      expect(out.degraded).toBe(false);
+      expect(out.candidatesIn).toBe(0);
+      expect(rerankMetrics.snapshot().skipped).toEqual({ no_candidates: 1 });
+    } finally {
+      restore();
+    }
+  });
+
+  it('records cache-hit rerank paths separately from model-scored candidates', async () => {
+    const reranker = stubReranker([0.8, 0.2]);
+    const restore = setRerankerFactoryForTests(async () => reranker);
+    try {
+      setEnv({ KB_RERANK: 'on' });
+      const fused = [doc('a.md', 0.030, 'same body'), doc('b.md', 0.020, 'other body')];
+
+      await applyRerankerIfEnabled({ query: 'q', results: fused, k: 2, kbScope: 'prose' });
+      await applyRerankerIfEnabled({ query: 'q', results: fused, k: 2, kbScope: 'prose' });
+
+      expect(reranker.rerank).toHaveBeenCalledTimes(1);
+      expect(rerankMetrics.snapshot()).toMatchObject({
+        invocations: 2,
+        candidates: {
+          cache_hit: 2,
+          model_scored: 2,
+        },
+      });
+      expect(rerankMetrics.snapshot().latency.cache_hit?.count).toBe(1);
+      expect(rerankMetrics.snapshot().latency.model_scored?.count).toBe(1);
     } finally {
       restore();
     }

--- a/src/reranker.ts
+++ b/src/reranker.ts
@@ -17,6 +17,7 @@ import {
 } from './config/reranker.js';
 import { DiskTieredRerankScoreCache } from './rerank-cache-disk.js';
 import { logger } from './logger.js';
+import { rerankMetrics } from './metrics.js';
 
 export {
   DEFAULT_RERANK_MODEL,
@@ -151,7 +152,8 @@ export async function applyRerankerIfEnabled<T extends RerankableDocument>(
   // KB_RERANK_SKIP_DOMAINS is never reranked. Treated as a disable (not a
   // degrade) — the cross-encoder simply does not run for this corpus.
   const skippedForDomain = input.kbScope != null && isRerankSkippedForDomain(process.env, input.kbScope);
-  if (!config.enabled || skippedForDomain) {
+  if (!config.enabled || skippedForDomain || input.results.length === 0) {
+    rerankMetrics.recordSkipped(skippedForDomain ? 'skip_domain' : (!config.enabled ? 'disabled' : 'no_candidates'));
     return {
       results: input.results.slice(0, input.k),
       degraded: false,
@@ -188,6 +190,11 @@ export async function applyRerankerIfEnabled<T extends RerankableDocument>(
   }
 
   if (out.degraded && out.degradeReason !== null) warnOnce(out.degradeReason, out.model);
+  rerankMetrics.recordInvocation({
+    latencyMs: out.tookMs,
+    candidatesIn: out.candidatesIn,
+    cacheHits: out.cacheHits,
+  });
   if (input.process !== undefined) {
     emitRerankStageLog({
       process: input.process,


### PR DESCRIPTION
## Summary

- add process-lifetime reranker metrics for invocations, skips, candidate source totals, and latency
- expose the new `kb_rerank_*` series through `/metrics`
- cover skip-domain, no-candidate, model-scored, cache-hit, and OpenMetrics rendering paths

Closes #689

## KB grounding

KB miss: `kb search "reranker metrics cache hit latency prometheus"` failed because the local FAISS KB index is not initialized (`INDEX_NOT_INITIALIZED`). I used the issue's linked KB lesson and existing repo metrics patterns instead.

## Verification

- `unset KB_LOG_FORMAT KB_LOG_FILE LOG_FILE; npx jest --runInBand --runTestsByPath src/metrics.test.ts src/prometheus-export.test.ts src/reranker.test.ts src/kb-stats.test.ts`
- `unset KB_LOG_FORMAT KB_LOG_FILE LOG_FILE; npx jest --runInBand --runTestsByPath src/metrics.test.ts src/prometheus-export.test.ts src/reranker.test.ts src/kb-stats.test.ts src/cli-stats.test.ts src/cli-research.test.ts src/cli-serve.test.ts`
- `git diff --check`
- manual portability scan of added lines for machine-local paths: clean (`scripts/check-portability.sh` is not present in this repo)

Pre-PR review:
- detected project type: npm
- type/build checks: targeted Jest suites passed with ts-jest type checking; full `npm run build` skipped per task convention because full-project `tsc --noEmit` can OOM in worktrees and is left to CI
- tests: passed, 105 targeted tests
- diff review: done
- portability check: clean by manual scan
- reviewer specialists: run; correctness/test findings fixed, dead-code clean
- OSS base-branch policy: skipped, internal repo PR
- gate file: created
