### PR TITLE
feat: prewarm daemon startup indexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ kb reindex --with-context     # rebuild the FAISS index with RFC 017 contextual 
 kb reindex status --format=json  # ledger of recent / in-flight reindex passes (#417)
 kb logs show --request-id=<id>     # read canonical request logs by id (#397)
 kb logs recent --limit=20 --format=json  # most recent canonical log entries
-kb serve                      # start the loopback CLI daemon (warm reads); --port=17799 --idle-timeout-ms=300000
+kb serve                      # start the loopback CLI daemon (warm reads); add --warm to pre-load active indexes
 kb serve status               # daemon liveness + degraded-mode diagnostics (#420)
 kb config validate            # static env-var schema validation before startup
 kb doctor                     # availability snapshot (index, embedding backend, LLM)
@@ -147,7 +147,7 @@ Note: `KB_RERANK_DEVICE` (e.g. `cuda`, `cpu`) is an external ONNX Runtime / Tran
 
 `kb logs` is the canonical reader for the structured request log emitted under `KB_LOG_FORMAT=canonical` or `both`. Use `kb logs show --request-id=<id>` to pull every line of a specific retrieval, `kb logs show --query-sha=<hash>` to follow recurring queries, and `kb logs recent --limit=<n>` for the most recent entries. `--format=json` produces one line per record for downstream tooling.
 
-`kb serve` runs the loopback CLI daemon used by clients that pass `--daemon` for warm reads. The bare `kb serve [--host=127.0.0.1] [--port=17799] [--idle-timeout-ms=300000]` brings it up; `kb serve status [--json]` reports reachability, pid, idle timeout, and supported commands at the configured `KB_DAEMON_URL` (defaults to `http://127.0.0.1:17799`); SIGINT or SIGTERM stops it. CLI commands fall back to direct in-process execution when the daemon is unavailable. See [`docs/operations/daemon-lifecycle.md`](docs/operations/daemon-lifecycle.md).
+`kb serve` runs the loopback CLI daemon used by clients that pass `--daemon` for warm reads. The bare `kb serve [--host=127.0.0.1] [--port=17799] [--idle-timeout-ms=300000] [--warm]` brings it up; `--warm` or `KB_DAEMON_PREWARM=on` pre-loads the active model, FAISS index, and lexical indexes before readiness. `kb serve status [--json]` reports reachability, pid, idle timeout, supported commands, and prewarm state at the configured `KB_DAEMON_URL` (defaults to `http://127.0.0.1:17799`); SIGINT or SIGTERM stops it. CLI commands fall back to direct in-process execution when the daemon is unavailable. See [`docs/operations/daemon-lifecycle.md`](docs/operations/daemon-lifecycle.md).
 
 `kb reindex --with-context` rebuilds the FAISS index with RFC 017 contextual prefaces (requires `KB_CONTEXTUAL_RETRIEVAL=on` and an `KB_LLM_ENDPOINT`). `kb reindex status` reads the `.reindex.run.json` ledger and reports the current or most recent run (kb scope, model, started/finished timestamps, chunks processed, cache hit rate, and any failure code). The `--kb=<name>` flag is a guard/estimator hint only — the rebuild always covers the entire single-index-per-model FAISS layout (see RFC 017 §5).
 

--- a/docs/cli-json-contracts.md
+++ b/docs/cli-json-contracts.md
@@ -1650,7 +1650,13 @@ Reachable envelope:
     "pid": 41234,
     "uptime_ms": 124500,
     "idle_timeout_ms": 300000,
-    "commands": ["search", "list", "stats"]
+    "commands": ["search", "list", "stats"],
+    "prewarm": {
+      "enabled": true,
+      "status": "ready",
+      "model_id": "ollama__nomic-embed-text-latest",
+      "lexical_kbs": 3
+    }
   }
 }
 ```
@@ -1670,6 +1676,9 @@ Stable fields:
 - `daemon.commands` always lists the read-only commands the daemon accepts.
 - `daemon.pid`, `daemon.uptime_ms`, `daemon.idle_timeout_ms` are present when
   the daemon's `/health` payload supplies them.
+- `daemon.prewarm` is present on current daemons. `status` is `disabled`,
+  `ready`, or `failed`; successful prewarm includes `model_id` and
+  `lexical_kbs`, while failed prewarm includes `error`.
 
 Stdout/stderr and exit codes:
 

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -206,6 +206,7 @@ wrap-close vars below.
 | Daemon URL | `KB_DAEMON_URL` | composed from `KB_DAEMON_HOST` (default `127.0.0.1`) and `KB_DAEMON_PORT` (default `17799`) when unset | `kb serve` clients, `kb doctor --endpoints`, `kb serve status` | Implemented | none | `KB_DAEMON_URL=http://127.0.0.1:17799 kb serve status` |
 | Daemon host | `KB_DAEMON_HOST` | `127.0.0.1` | Daemon URL composition | Implemented | none | `KB_DAEMON_HOST=127.0.0.1 KB_DAEMON_PORT=17799 kb serve` |
 | Daemon port | `KB_DAEMON_PORT` | `17799` | Daemon URL composition | Implemented | none | `KB_DAEMON_PORT=18888 kb serve` |
+| Daemon startup prewarm | `KB_DAEMON_PREWARM` / `kb serve --warm` | `off` | `kb serve`, `/health`, `kb serve status` | Implemented, opt-in | `kb serve --warm` | `KB_DAEMON_PREWARM=on kb serve status --json` |
 
 ## Managed LLM Profiles
 

--- a/docs/operations/daemon-lifecycle.md
+++ b/docs/operations/daemon-lifecycle.md
@@ -22,7 +22,7 @@ only when daemon-capable reads should try to start `kb serve` automatically.
 ## Start the daemon
 
 ```bash
-kb serve [--host=127.0.0.1] [--port=17799] [--idle-timeout-ms=300000]
+kb serve [--host=127.0.0.1] [--port=17799] [--idle-timeout-ms=300000] [--warm]
 ```
 
 Defaults:
@@ -30,6 +30,13 @@ Defaults:
 - `--host=127.0.0.1` (loopback only; non-loopback bind is rejected)
 - `--port=17799`
 - `--idle-timeout-ms=300000` (5 minutes; `0` disables auto-exit)
+- `--warm` pre-loads the active model, FAISS index, and lexical indexes
+  before the daemon reports ready. `KB_DAEMON_PREWARM=on` enables the same
+  behavior from the environment.
+
+Startup prewarm is best-effort: if active model or index loading fails, the
+daemon still starts, reports `"prewarm": {"status": "failed", ...}` in
+`/health`, and falls back to lazy loading on the first real request.
 
 The process logs `kb serve: listening on http://127.0.0.1:17799/` to stdout
 and stays in the foreground. SIGINT / SIGTERM stops it cleanly. Run it under
@@ -86,7 +93,13 @@ Exit codes are deliberately distinct:
     "uptime_ms": 124500,
     "idle_timeout_ms": 300000,
     "ownership": "manual",
-    "commands": ["search", "list", "stats"]
+    "commands": ["search", "list", "stats"],
+    "prewarm": {
+      "enabled": true,
+      "status": "ready",
+      "model_id": "ollama__nomic-embed-text-latest",
+      "lexical_kbs": 3
+    }
   }
 }
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -313,17 +313,18 @@ Usage:
   kb config validate [--file=.env] [--format=md|json]
   kb config show [--format=md|json] [--non-default-only]
 
-Validates known environment variables against the static KB config schema:
+Validates known runtime configuration against the static KB config schema:
 type, enum membership, numeric ranges, URL syntax, and cross-variable
-dependencies. The command is read-only and does not probe live endpoints.
+dependencies. Without --file, project config files are layered under
+process.env. The command is read-only and does not probe live endpoints.
 
 Shows the effective value and source for every known configuration variable.
 Secrets such as API keys and MCP_AUTH_TOKEN are redacted.
 
 Options:
-  --file=<path>             Parse this dotenv file instead of process.env.
+  --file=<path>             Parse this dotenv file instead of runtime config.
   --format=md|json          Output format (default: md).
-  --non-default-only        For show, print only values supplied by env.
+  --non-default-only        For show, print only env/file-supplied values.
   --help, -h                Show this help.
 
 Exit codes:
@@ -1428,6 +1429,10 @@ Output:
                         emphasis. auto uses ANSI only on a TTY (default);
                         always also works through pipes; never disables it.
   --no-highlight        Alias for --highlight=never.
+  --snippet[=N]         Markdown/JSON: show an N-line focused excerpt centered
+                        on the densest query-term match. Default N is 5.
+                        Also set via KB_SEARCH_SNIPPET=true|N.
+  --full                Disable snippet mode and render full result bodies.
   --color=auto|always|never
                         Unified control for all ANSI color/emphasis output.
                         auto colorizes only on a TTY with NO_COLOR unset
@@ -1481,7 +1486,7 @@ Run a localhost daemon for warm read-only CLI requests.
 kb serve — resident local daemon for warm CLI reads
 
 Usage:
-  kb serve [--host=127.0.0.1] [--port=17799] [--idle-timeout-ms=300000]
+  kb serve [--host=127.0.0.1] [--port=17799] [--idle-timeout-ms=300000] [--warm]
   kb serve status [--json]
 
 Starts a localhost-only JSON HTTP daemon used by `kb search --daemon`.
@@ -1497,6 +1502,8 @@ Options:
   --host=<host>             Loopback host to bind (default: 127.0.0.1).
   --port=<port>             TCP port to bind (default: 17799; 0 for tests).
   --idle-timeout-ms=<ms>    Stop after this much idle time (default: 300000).
+  --warm                    Pre-warm the active model, FAISS index, and
+                            lexical indexes before the daemon reports ready.
   --json                    `kb serve status`: emit the daemon health JSON.
   --help, -h                Show this help.
 
@@ -1511,6 +1518,8 @@ Environment:
   KB_DAEMON_QUEUE_MAX       Max requests queued beyond the concurrency cap
                             before the daemon replies 429 + Retry-After
                             (default 128; 0 rejects immediately when full).
+  KB_DAEMON_PREWARM         Set to `on` to enable the same startup pre-warm
+                            as `kb serve --warm`.
 
 Exit codes:
   0   daemon started, or `kb serve status` found a reachable daemon

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -90,6 +90,7 @@ Run `npm run docs:generate-config-reference` after changing the schema.
 | <code>KB_DAEMON_HOST</code> | <code>string</code> | <code>127.0.0.1</code> |  |  | uses default |  |
 | <code>KB_DAEMON_PORT</code> | <code>integer</code> | <code>17799</code> |  | >= <code>1</code>; <= <code>65535</code> | uses default |  |
 | <code>KB_DAEMON_AUTOSTART</code> | <code>boolean</code> | <code>off</code> | <code>on</code>, <code>off</code>, <code>true</code>, <code>false</code>, <code>1</code>, <code>0</code>, <code>yes</code>, <code>no</code> |  | uses default |  |
+| <code>KB_DAEMON_PREWARM</code> | <code>boolean</code> | <code>off</code> | <code>on</code>, <code>off</code>, <code>true</code>, <code>false</code>, <code>1</code>, <code>0</code>, <code>yes</code>, <code>no</code> |  | uses default |  |
 | <code>MCP_TRANSPORT</code> | <code>enum</code> | <code>stdio</code> | <code>stdio</code>, <code>sse</code>, <code>http</code> |  | uses default | MCP server transport. |
 | <code>MCP_PORT</code> | <code>integer</code> | <code>8765</code> |  | >= <code>1</code>; <= <code>65535</code> | uses default |  |
 | <code>MCP_BIND_ADDR</code> | <code>string</code> | <code>127.0.0.1</code> |  |  | kept as empty |  |

--- a/src/cli-serve.test.ts
+++ b/src/cli-serve.test.ts
@@ -57,11 +57,14 @@ function request(
 
 describe('kb serve daemon', () => {
   const originalMetricsExport = process.env.KB_METRICS_EXPORT;
+  const originalDaemonPrewarm = process.env.KB_DAEMON_PREWARM;
 
   afterEach(() => {
     searchLatencyMetrics.reset();
     if (originalMetricsExport === undefined) delete process.env.KB_METRICS_EXPORT;
     else process.env.KB_METRICS_EXPORT = originalMetricsExport;
+    if (originalDaemonPrewarm === undefined) delete process.env.KB_DAEMON_PREWARM;
+    else process.env.KB_DAEMON_PREWARM = originalDaemonPrewarm;
   });
 
   it('serves health and dispatches read-only commands through handlers', async () => {
@@ -146,6 +149,57 @@ describe('kb serve daemon', () => {
     expect(lexicalIndexLoader).toHaveBeenCalledWith('alpha', '/kb/alpha');
   });
 
+  it('prewarms the active model manager, FAISS index, and lexical indexes on demand', async () => {
+    const lexicalIndex = { numFiles: () => 1 } as unknown as LexicalIndex;
+    const manager = { marker: 'manager', modelId: 'ollama__nomic' };
+    let denseMtimeMs = 1;
+    const lexicalIndexLoader = jest.fn(async () => lexicalIndex);
+    const denseIndexMetadataReader = jest.fn(async () => ({
+      path: '/faiss/index',
+      mtimeMs: denseMtimeMs,
+      size: 10,
+    }));
+    const resolveActiveModelImpl = jest.fn(async () => 'ollama__nomic');
+    const loadManagerForModel = jest.fn(async () => manager as never);
+    const loadWithJsonRetry = jest.fn(async () => undefined);
+    const listKnowledgeBasesImpl = jest.fn(async () => ['alpha', 'beta']);
+    const runSearchImpl = jest.fn(async (_args: string[], deps: RunSearchDeps = {} as RunSearchDeps) => {
+      const loaded = await deps.loadManagerForModel('ollama__nomic');
+      await deps.loadWithJsonRetry(loaded);
+      return 0;
+    });
+    const handlers = createDaemonCommandHandlers({
+      lexicalIndexLoader,
+      denseIndexMetadataReader,
+      resolveActiveModelImpl,
+      loadManagerForModel,
+      loadWithJsonRetry,
+      listKnowledgeBasesImpl,
+      knowledgeBasesRootDir: '/kb-root',
+      runSearchImpl,
+    });
+
+    await expect(handlers.prewarm?.()).resolves.toEqual({
+      modelId: 'ollama__nomic',
+      lexicalKbs: 2,
+    });
+
+    expect(resolveActiveModelImpl).toHaveBeenCalledTimes(1);
+    expect(loadManagerForModel).toHaveBeenCalledWith('ollama__nomic');
+    expect(loadWithJsonRetry).toHaveBeenCalledWith(manager);
+    expect(lexicalIndexLoader).toHaveBeenCalledWith('alpha', '/kb-root/alpha');
+    expect(lexicalIndexLoader).toHaveBeenCalledWith('beta', '/kb-root/beta');
+
+    await expect(handlers.search(['query'])).resolves.toMatchObject({ exitCode: 0 });
+    expect(loadManagerForModel).toHaveBeenCalledTimes(1);
+    expect(loadWithJsonRetry).toHaveBeenCalledTimes(1);
+
+    denseMtimeMs = 2;
+    await expect(handlers.search(['query'])).resolves.toMatchObject({ exitCode: 0 });
+    expect(loadManagerForModel).toHaveBeenCalledTimes(1);
+    expect(loadWithJsonRetry).toHaveBeenCalledTimes(2);
+  });
+
   it('records successful daemon-served search timings through the search deps hook', async () => {
     const runSearchImpl = jest.fn(async (_args: string[], deps: RunSearchDeps = {} as RunSearchDeps) => {
       deps.onSearchTiming?.({
@@ -207,6 +261,14 @@ describe('kb serve daemon', () => {
     expect(() => parseServeArgs(['--host=0.0.0.0'])).toThrow(/non-loopback/);
   });
 
+  it('enables startup prewarm from --warm or KB_DAEMON_PREWARM=on', () => {
+    delete process.env.KB_DAEMON_PREWARM;
+    expect(parseServeArgs(['--warm']).warm).toBe(true);
+    expect(parseServeArgs([]).warm).toBe(false);
+    process.env.KB_DAEMON_PREWARM = 'on';
+    expect(parseServeArgs([]).warm).toBe(true);
+  });
+
   it('advertises autostart ownership from the hidden owner flag', async () => {
     const parsed = parseServeArgs(['--port=0', '--idle-timeout-ms=0', '--owner=autostart']);
     const daemon = await startDaemonServer(parsed);
@@ -217,6 +279,56 @@ describe('kb serve daemon', () => {
         status: 'ok',
         ownership: 'autostart',
       });
+    } finally {
+      await daemon.stop();
+    }
+  });
+
+  it('surfaces successful startup prewarm in daemon health', async () => {
+    const lexicalIndex = { numFiles: () => 1 } as unknown as LexicalIndex;
+    const manager = { marker: 'manager', modelId: 'ollama__nomic' };
+    const lexicalIndexLoader = jest.fn(async () => lexicalIndex);
+    const denseIndexMetadataReader = jest.fn(async () => ({
+      path: '/faiss/index',
+      mtimeMs: 1,
+      size: 10,
+    }));
+    const resolveActiveModelImpl = jest.fn(async () => 'ollama__nomic');
+    const loadManagerForModel = jest.fn(async () => manager as never);
+    const loadWithJsonRetry = jest.fn(async () => undefined);
+    const listKnowledgeBasesImpl = jest.fn(async () => ['alpha', 'beta']);
+    const handlers = createDaemonCommandHandlers({
+      lexicalIndexLoader,
+      denseIndexMetadataReader,
+      resolveActiveModelImpl,
+      loadManagerForModel,
+      loadWithJsonRetry,
+      listKnowledgeBasesImpl,
+      knowledgeBasesRootDir: '/kb-root',
+    });
+    const daemon = await startDaemonServer({
+      port: 0,
+      idleTimeoutMs: 0,
+      warm: true,
+      handlers,
+    });
+    try {
+      const health = await request(daemon.url, { path: '/health' });
+      expect(health.statusCode).toBe(200);
+      expect(JSON.parse(health.body)).toMatchObject({
+        status: 'ok',
+        prewarm: {
+          enabled: true,
+          status: 'ready',
+          model_id: 'ollama__nomic',
+          lexical_kbs: 2,
+        },
+      });
+      expect(resolveActiveModelImpl).toHaveBeenCalledTimes(1);
+      expect(loadManagerForModel).toHaveBeenCalledWith('ollama__nomic');
+      expect(loadWithJsonRetry).toHaveBeenCalledWith(manager);
+      expect(lexicalIndexLoader).toHaveBeenCalledWith('alpha', '/kb-root/alpha');
+      expect(lexicalIndexLoader).toHaveBeenCalledWith('beta', '/kb-root/beta');
     } finally {
       await daemon.stop();
     }
@@ -570,7 +682,17 @@ describe('kb serve status', () => {
   }
 
   it('reports a reachable daemon with its lifecycle details', async () => {
-    const daemon = await startDaemonServer({ port: 0, idleTimeoutMs: 0 });
+    const daemon = await startDaemonServer({
+      port: 0,
+      idleTimeoutMs: 0,
+      warm: true,
+      handlers: {
+        search: async () => ({ exitCode: 0, stdout: '', stderr: '' }),
+        list: async () => ({ exitCode: 0, stdout: '', stderr: '' }),
+        stats: async () => ({ exitCode: 0, stdout: '', stderr: '' }),
+        prewarm: async () => ({ modelId: 'ollama__nomic', lexicalKbs: 2 }),
+      },
+    });
     process.env.KB_DAEMON_URL = daemon.url.href;
     try {
       const result = await captureStatus([]);
@@ -579,6 +701,7 @@ describe('kb serve status', () => {
       expect(result.stdout).toContain(`pid:          ${process.pid}`);
       expect(result.stdout).toContain('ownership:    manual');
       expect(result.stdout).toContain('commands:     search, list, stats');
+      expect(result.stdout).toContain('prewarm:      ready (ollama__nomic, lexical_kbs=2)');
     } finally {
       await daemon.stop();
     }

--- a/src/cli-serve.ts
+++ b/src/cli-serve.ts
@@ -1,5 +1,7 @@
 import * as http from 'node:http';
 import type { AddressInfo } from 'node:net';
+import * as path from 'node:path';
+import * as fsp from 'node:fs/promises';
 import { runList } from './cli-list.js';
 import { createRunSearchDeps, runSearch, type RunSearchDeps } from './cli-search.js';
 import { captureProcessOutput } from './cli-shared.js';
@@ -14,6 +16,7 @@ import {
   type DaemonCommand,
   type DaemonHealth,
   type DaemonOwnership,
+  type DaemonPrewarmHealth,
   type DaemonRunResult,
 } from './daemon-client.js';
 import {
@@ -28,11 +31,15 @@ import { searchStageDurationsFromTiming } from './timing-core.js';
 import type { KbStatsPayload } from './kb-stats.js';
 import { LexicalIndexCache } from './lexical-index-cache.js';
 import type { LexicalIndex } from './lexical-index.js';
+import { KNOWLEDGE_BASES_ROOT_DIR } from './config/paths.js';
+import { modelDir, resolveActiveModel, resolveFaissIndexBinaryPath } from './active-model.js';
+import { listKnowledgeBases } from './kb-fs.js';
+import { logger } from './logger.js';
 
 export const SERVE_HELP = `kb serve — resident local daemon for warm CLI reads
 
 Usage:
-  kb serve [--host=127.0.0.1] [--port=17799] [--idle-timeout-ms=300000]
+  kb serve [--host=127.0.0.1] [--port=17799] [--idle-timeout-ms=300000] [--warm]
   kb serve status [--json]
 
 Starts a localhost-only JSON HTTP daemon used by \`kb search --daemon\`.
@@ -48,6 +55,8 @@ Options:
   --host=<host>             Loopback host to bind (default: 127.0.0.1).
   --port=<port>             TCP port to bind (default: 17799; 0 for tests).
   --idle-timeout-ms=<ms>    Stop after this much idle time (default: 300000).
+  --warm                    Pre-warm the active model, FAISS index, and
+                            lexical indexes before the daemon reports ready.
   --json                    \`kb serve status\`: emit the daemon health JSON.
   --help, -h                Show this help.
 
@@ -62,6 +71,8 @@ Environment:
   KB_DAEMON_QUEUE_MAX       Max requests queued beyond the concurrency cap
                             before the daemon replies 429 + Retry-After
                             (default 128; 0 rejects immediately when full).
+  KB_DAEMON_PREWARM         Set to \`on\` to enable the same startup pre-warm
+                            as \`kb serve --warm\`.
 
 Exit codes:
   0   daemon started, or \`kb serve status\` found a reachable daemon
@@ -78,12 +89,19 @@ interface ServeArgs {
   port: number;
   idleTimeoutMs: number;
   ownership: DaemonOwnership;
+  warm: boolean;
+}
+
+export interface DaemonPrewarmResult {
+  modelId: string;
+  lexicalKbs: number;
 }
 
 export interface DaemonCommandHandlers {
   search: (args: string[]) => Promise<DaemonRunResult>;
   list: (args: string[]) => Promise<DaemonRunResult>;
   stats: (args: string[]) => Promise<DaemonRunResult>;
+  prewarm?: () => Promise<DaemonPrewarmResult>;
 }
 
 export interface StartDaemonServerOptions extends Partial<ServeArgs> {
@@ -99,9 +117,21 @@ export interface StartDaemonServerOptions extends Partial<ServeArgs> {
 
 export interface DaemonCommandHandlerOptions {
   lexicalIndexLoader?: (kbName: string, kbPath: string) => Promise<LexicalIndex>;
+  denseIndexMetadataReader?: (modelId: string) => Promise<DenseIndexMetadata>;
+  knowledgeBasesRootDir?: string;
+  listKnowledgeBasesImpl?: typeof listKnowledgeBases;
+  resolveActiveModelImpl?: typeof resolveActiveModel;
+  loadManagerForModel?: RunSearchDeps['loadManagerForModel'];
+  loadWithJsonRetry?: RunSearchDeps['loadWithJsonRetry'];
   runSearchImpl?: typeof runSearch;
   runListImpl?: typeof runList;
   runStatsImpl?: typeof runStats;
+}
+
+interface DenseIndexMetadata {
+  path: string | null;
+  mtimeMs: number;
+  size: number;
 }
 
 export interface ResidentDaemon {
@@ -116,6 +146,7 @@ const DEFAULT_SERVE_ARGS: ServeArgs = {
   port: 17799,
   idleTimeoutMs: 300_000,
   ownership: 'manual',
+  warm: false,
 };
 
 export async function runServe(rest: string[]): Promise<number> {
@@ -222,7 +253,21 @@ function formatServeStatus(health: DaemonHealth, queriedUrl: URL): string {
   if (health.commands !== undefined) {
     lines.push(`  commands:     ${health.commands.join(', ')}`);
   }
+  if (health.prewarm !== undefined) {
+    lines.push(`  prewarm:      ${formatPrewarmStatus(health.prewarm)}`);
+  }
   return `${lines.join('\n')}\n`;
+}
+
+function formatPrewarmStatus(prewarm: DaemonPrewarmHealth): string {
+  if (!prewarm.enabled || prewarm.status === 'disabled') return 'disabled';
+  if (prewarm.status === 'ready') {
+    return `ready${prewarm.model_id ? ` (${prewarm.model_id}, lexical_kbs=${prewarm.lexical_kbs ?? 0})` : ''}`;
+  }
+  if (prewarm.status === 'failed') {
+    return `failed${prewarm.error ? ` (${prewarm.error})` : ''}`;
+  }
+  return prewarm.status;
 }
 
 function formatDuration(ms: number): string {
@@ -240,9 +285,17 @@ export async function startDaemonServer(
     port: options.port ?? DEFAULT_SERVE_ARGS.port,
     idleTimeoutMs: options.idleTimeoutMs ?? DEFAULT_SERVE_ARGS.idleTimeoutMs,
     ownership: options.ownership ?? DEFAULT_SERVE_ARGS.ownership,
+    warm: options.warm ?? DEFAULT_SERVE_ARGS.warm,
   };
   assertLoopbackHost(parsed.host);
   const handlers = options.handlers ?? createDaemonCommandHandlers();
+  let prewarmHealth: DaemonPrewarmHealth = {
+    enabled: parsed.warm,
+    status: 'disabled',
+  };
+  if (parsed.warm) {
+    prewarmHealth = await runDaemonPrewarm(handlers);
+  }
   const baseMetricsHandler = options.metricsHandler ?? defaultMetricsHandler;
   const admission = new DaemonAdmissionGate(
     options.admission ?? resolveDaemonAdmissionConfig(),
@@ -269,6 +322,7 @@ export async function startDaemonServer(
     ownership: parsed.ownership,
     commands: [...DAEMON_COMMANDS],
     uptime_ms: Date.now() - startedAt,
+    prewarm: prewarmHealth,
   });
 
   const server = http.createServer((req, res) => {
@@ -326,7 +380,7 @@ export async function startDaemonServer(
 }
 
 export function parseServeArgs(rest: string[]): ServeArgs {
-  const out = { ...DEFAULT_SERVE_ARGS };
+  const out = { ...DEFAULT_SERVE_ARGS, warm: daemonPrewarmEnabledFromEnv(process.env) };
   for (const raw of rest) {
     if (raw.startsWith('--host=')) {
       out.host = raw.slice('--host='.length);
@@ -356,6 +410,10 @@ export function parseServeArgs(rest: string[]): ServeArgs {
       out.ownership = ownership;
       continue;
     }
+    if (raw === '--warm') {
+      out.warm = true;
+      continue;
+    }
     if (raw.startsWith('--')) throw new Error(`unknown flag: ${raw}`);
     throw new Error(`unexpected argument: ${raw}`);
   }
@@ -363,10 +421,47 @@ export function parseServeArgs(rest: string[]): ServeArgs {
   return out;
 }
 
+function daemonPrewarmEnabledFromEnv(env: NodeJS.ProcessEnv): boolean {
+  const raw = env.KB_DAEMON_PREWARM?.trim().toLowerCase();
+  return raw === 'on' || raw === '1' || raw === 'true' || raw === 'yes';
+}
+
 export function createDaemonCommandHandlers(options: DaemonCommandHandlerOptions = {}): DaemonCommandHandlers {
   const cache = new LexicalIndexCache();
   const loadLexicalIndex = options.lexicalIndexLoader ?? cache.load.bind(cache);
+  const defaultSearchDeps = createRunSearchDeps();
+  type SearchManager = Awaited<ReturnType<RunSearchDeps['loadManagerForModel']>>;
+  const baseLoadManagerForModel = options.loadManagerForModel ?? defaultSearchDeps.loadManagerForModel;
+  const baseLoadWithJsonRetry = options.loadWithJsonRetry ?? defaultSearchDeps.loadWithJsonRetry;
+  const readDenseIndexMetadata = options.denseIndexMetadataReader ?? readCurrentDenseIndexMetadata;
+  const managerCache = new Map<string, Promise<SearchManager>>();
+  const loadedManagers = new WeakMap<object, DenseIndexMetadata>();
+  const loadManagerForModel: RunSearchDeps['loadManagerForModel'] = async (modelId) => {
+    const cached = managerCache.get(modelId);
+    if (cached) return cached;
+    const promise = baseLoadManagerForModel(modelId);
+    managerCache.set(modelId, promise);
+    try {
+      return await promise;
+    } catch (err) {
+      if (managerCache.get(modelId) === promise) managerCache.delete(modelId);
+      throw err;
+    }
+  };
+  const loadWithJsonRetry: RunSearchDeps['loadWithJsonRetry'] = async (manager) => {
+    const before = await readDenseIndexMetadata(manager.modelId);
+    const loaded = loadedManagers.get(manager);
+    if (loaded !== undefined && sameDenseIndexMetadata(loaded, before)) return;
+    await baseLoadWithJsonRetry(manager);
+    loadedManagers.set(manager, await readDenseIndexMetadata(manager.modelId));
+  };
+  const resolveActiveModelImpl = options.resolveActiveModelImpl ?? resolveActiveModel;
+  const listKnowledgeBasesImpl = options.listKnowledgeBasesImpl ?? listKnowledgeBases;
+  const knowledgeBasesRootDir = options.knowledgeBasesRootDir ?? KNOWLEDGE_BASES_ROOT_DIR;
   const searchDeps: RunSearchDeps = createRunSearchDeps({
+    resolveActiveModel: resolveActiveModelImpl,
+    loadManagerForModel,
+    loadWithJsonRetry,
     loadLexicalIndex,
     onSearchTiming: (record) => {
       searchLatencyMetrics.record({
@@ -395,7 +490,95 @@ export function createDaemonCommandHandlers(options: DaemonCommandHandlerOptions
     },
     list: async (args) => captureProcessOutput(() => runListImpl(args)),
     stats: async (args) => captureProcessOutput(() => runStatsImpl(args, undefined, { preferDaemon: false })),
+    prewarm: async () => {
+      const activeModelId = await resolveActiveModelImpl();
+      const manager = await loadManagerForModel(activeModelId);
+      await loadWithJsonRetry(manager);
+      const kbNames = await listKnowledgeBasesImpl(knowledgeBasesRootDir);
+      for (const kbName of kbNames) {
+        await loadLexicalIndex(kbName, path.join(knowledgeBasesRootDir, kbName));
+      }
+      return { modelId: activeModelId, lexicalKbs: kbNames.length };
+    },
   };
+}
+
+async function readCurrentDenseIndexMetadata(modelId: string): Promise<DenseIndexMetadata> {
+  const activeVersionMetadata = await readActiveVersionIndexMetadata(modelId);
+  if (activeVersionMetadata !== null) return activeVersionMetadata;
+  const indexPath = await resolveFaissIndexBinaryPath(modelId);
+  if (indexPath === null) return { path: null, mtimeMs: 0, size: 0 };
+  try {
+    const stat = await fsp.stat(indexPath);
+    return { path: indexPath, mtimeMs: stat.mtimeMs, size: stat.size };
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT' || code === 'ENOTDIR') return { path: null, mtimeMs: 0, size: 0 };
+    throw err;
+  }
+}
+
+async function readActiveVersionIndexMetadata(modelId: string): Promise<DenseIndexMetadata | null> {
+  const symlinkPath = path.join(modelDir(modelId), 'index');
+  let resolvedDir: string;
+  try {
+    const st = await fsp.lstat(symlinkPath);
+    if (!st.isSymbolicLink()) return null;
+    resolvedDir = await fsp.realpath(symlinkPath);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT' || code === 'ENOTDIR') return null;
+    throw err;
+  }
+
+  for (const filename of ['faiss.index', 'hnsw.index']) {
+    const indexPath = path.join(resolvedDir, filename);
+    try {
+      const stat = await fsp.stat(indexPath);
+      return { path: indexPath, mtimeMs: stat.mtimeMs, size: stat.size };
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code !== 'ENOENT' && code !== 'ENOTDIR') throw err;
+    }
+  }
+  return null;
+}
+
+function sameDenseIndexMetadata(a: DenseIndexMetadata, b: DenseIndexMetadata): boolean {
+  return a.path === b.path && a.mtimeMs === b.mtimeMs && a.size === b.size;
+}
+
+async function runDaemonPrewarm(handlers: DaemonCommandHandlers): Promise<DaemonPrewarmHealth> {
+  if (handlers.prewarm === undefined) {
+    return {
+      enabled: true,
+      status: 'failed',
+      error: 'daemon handlers do not support prewarm',
+      updated_at: new Date().toISOString(),
+    };
+  }
+  try {
+    const result = await handlers.prewarm();
+    logger.info(
+      `kb serve: prewarmed active model ${result.modelId} and ${result.lexicalKbs} lexical indexes`,
+    );
+    return {
+      enabled: true,
+      status: 'ready',
+      model_id: result.modelId,
+      lexical_kbs: result.lexicalKbs,
+      updated_at: new Date().toISOString(),
+    };
+  } catch (err) {
+    const error = (err as Error).message;
+    logger.warn(`kb serve: startup prewarm failed; continuing with lazy loading: ${error}`);
+    return {
+      enabled: true,
+      status: 'failed',
+      error,
+      updated_at: new Date().toISOString(),
+    };
+  }
 }
 
 function requestedSearchModeFromArgs(args: readonly string[]): SearchLatencyMode {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -238,6 +238,7 @@ export const CONFIG_SCHEMA: readonly ConfigSpec[] = [
   { name: 'KB_DAEMON_HOST', kind: 'string', default: '127.0.0.1', emptyUsesDefault: true },
   { name: 'KB_DAEMON_PORT', kind: 'integer', default: '17799', min: 1, max: 65535 },
   { name: 'KB_DAEMON_AUTOSTART', kind: 'boolean', default: 'off', booleanValues: YES_NO_BOOL_VALUES, truthyValues: YES_NO_TRUTHY_VALUES },
+  { name: 'KB_DAEMON_PREWARM', kind: 'boolean', default: 'off', booleanValues: YES_NO_BOOL_VALUES, truthyValues: YES_NO_TRUTHY_VALUES },
   { name: 'MCP_TRANSPORT', kind: 'enum', values: ['stdio', 'sse', 'http'], default: 'stdio', description: 'MCP server transport.' },
   { name: 'MCP_PORT', kind: 'integer', default: '8765', min: 1, max: 65535 },
   { name: 'MCP_BIND_ADDR', kind: 'string', default: '127.0.0.1' },

--- a/src/daemon-client.ts
+++ b/src/daemon-client.ts
@@ -9,6 +9,15 @@ export interface DaemonRunResult {
 export type DaemonCommand = 'search' | 'list' | 'stats';
 export type DaemonOwnership = 'manual' | 'autostart';
 
+export interface DaemonPrewarmHealth {
+  enabled: boolean;
+  status: 'disabled' | 'ready' | 'failed';
+  model_id?: string;
+  lexical_kbs?: number;
+  error?: string;
+  updated_at?: string;
+}
+
 /**
  * Lifecycle snapshot returned by the daemon's `GET /health` endpoint and
  * surfaced verbatim by `kb serve status --json`. Every field beyond `status`
@@ -23,6 +32,7 @@ export interface DaemonHealth {
   ownership?: DaemonOwnership;
   commands?: string[];
   uptime_ms?: number;
+  prewarm?: DaemonPrewarmHealth;
 }
 
 interface SpawnedDaemonProcess {
@@ -225,7 +235,31 @@ function parseDaemonHealth(payload: unknown): DaemonHealth {
     health.commands = obj.commands as string[];
   }
   if (typeof obj.uptime_ms === 'number') health.uptime_ms = obj.uptime_ms;
+  const prewarm = parseDaemonPrewarmHealth(obj.prewarm);
+  if (prewarm !== null) health.prewarm = prewarm;
   return health;
+}
+
+function parseDaemonPrewarmHealth(payload: unknown): DaemonPrewarmHealth | null {
+  if (typeof payload !== 'object' || payload === null) return null;
+  const obj = payload as Record<string, unknown>;
+  if (typeof obj.enabled !== 'boolean') return null;
+  if (
+    obj.status !== 'disabled' &&
+    obj.status !== 'ready' &&
+    obj.status !== 'failed'
+  ) {
+    return null;
+  }
+  const out: DaemonPrewarmHealth = {
+    enabled: obj.enabled,
+    status: obj.status,
+  };
+  if (typeof obj.model_id === 'string') out.model_id = obj.model_id;
+  if (typeof obj.lexical_kbs === 'number') out.lexical_kbs = obj.lexical_kbs;
+  if (typeof obj.error === 'string') out.error = obj.error;
+  if (typeof obj.updated_at === 'string') out.updated_at = obj.updated_at;
+  return out;
 }
 
 async function runDaemonCommandAfterAutostart(


### PR DESCRIPTION
## Summary
- add opt-in `kb serve --warm` / `KB_DAEMON_PREWARM=on` startup prewarm for the active model manager, dense index, and lexical indexes
- cache daemon dense managers while reloading when the active on-disk FAISS/HNSW index signature changes
- surface prewarm state in `/health`, `kb serve status`, config schema, and docs

Closes #688

## Verification
- KB hits: none; `kb search "kb serve startup pre-warm active model FAISS lexical index"` could not complete because the local FAISS index is uninitialized (`INDEX_NOT_INITIALIZED`)
- `unset KB_LOG_FORMAT KB_LOG_FILE LOG_FILE; npx jest --runInBand --runTestsByPath src/cli-serve.test.ts src/daemon-client.test.ts src/config/schema.test.ts`
- `git diff --check`
- reviewer specialists run: conventions, correctness, dead-code, test; findings addressed
- `npx eslint src/cli-serve.ts src/cli-serve.test.ts src/daemon-client.ts` could not start because linked `node_modules` is missing `typescript-eslint` required by `eslint.config.js`
- `npm run docs:check-config-reference` and `npm run docs:check-cli` could not run in this fresh worktree because `build/config/schema.js` / `build/cli.js` are absent; full local build/tsc is left to CI per worktree OOM guidance