### PR TITLE
feat: add MCP argument completions

### DIFF
--- a/docs/mcp-prompts.md
+++ b/docs/mcp-prompts.md
@@ -49,6 +49,11 @@ pins the retrieval to that single shelf. Every template instructs the agent to
 ground its answer in the retrieved chunks, cite source paths, and abstain rather
 than invent when the KB does not cover the request.
 
+The server advertises MCP `completion/complete` so clients can request argument
+suggestions. Prompt `knowledge_base_name` arguments complete from registered KB
+names. Model-style prompt arguments are completed from registered `model_id`
+values when a future prompt template declares one.
+
 ## Example: `prompts/get`
 
 Request:

--- a/docs/mcp-resources.md
+++ b/docs/mcp-resources.md
@@ -47,6 +47,13 @@ Paginated response shape:
 
 The server also handles `resources/templates/list`, returning a `kb://{kb}/{path}` URI template for clients that support templated discovery. Clients can use the template, concrete URIs returned by `resources/list`, or retrieval citations.
 
+Clients that implement MCP `completion/complete` can ask the server for guided argument values for this template:
+
+| Template argument | Completion values |
+| --- | --- |
+| `kb` | Knowledge-base directory names under `KNOWLEDGE_BASES_ROOT_DIR`, prefix-matched against the in-progress value. |
+| `path` | Ingestable, non-quarantined KB-relative paths within the selected `kb`, prefix-matched against the in-progress value and capped to the MCP completion page size. |
+
 ## `kb://` URI Format
 
 Resource URIs use this form:

--- a/src/KnowledgeBaseServer.test.ts
+++ b/src/KnowledgeBaseServer.test.ts
@@ -1,6 +1,7 @@
 import * as fsp from 'fs/promises';
 import * as os from 'os';
 import * as path from 'path';
+import { CompleteRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import type { SimilaritySearchTiming } from './FaissIndexManager.js';
 
 const initializeMock = jest.fn();
@@ -2395,6 +2396,16 @@ describe('KnowledgeBaseServer handlers', () => {
 
     const resources = await readOnlyServer['handleListResources']();
     expect(resources.resources.map((resource: { uri: string }) => resource.uri)).toContain('kb://alpha/note.md');
+  });
+
+  it('advertises MCP completions and registers completion/complete', async () => {
+    await setRetrieveEnv();
+
+    const server = await freshServer();
+    const mcp = server['mcp'];
+
+    expect(mcp.server.getCapabilities()).toMatchObject({ completions: {} });
+    expect(mcp.server._requestHandlers.has(CompleteRequestSchema.shape.method.value)).toBe(true);
   });
 
   it('with neither override env set, tool descriptions match the legacy hard-coded strings', async () => {

--- a/src/KnowledgeBaseServer.ts
+++ b/src/KnowledgeBaseServer.ts
@@ -85,6 +85,7 @@ import {
   readResource,
   registerResources,
 } from './mcp-resources.js';
+import { registerCompletions } from './mcp-completions.js';
 import { KB_MCP_PROMPTS, registerPrompts } from './mcp-prompts.js';
 import {
   handleAddDocument,
@@ -327,6 +328,7 @@ export class KnowledgeBaseServer {
     mcp.server.onerror = (error) => logger.error('[MCP Error]', error);
     this.registerTools(mcp);
     registerResources(mcp);
+    registerCompletions(mcp);
     // #642 — opt-in MCP prompts surface. Off by default; gated by
     // KB_MCP_PROMPTS so the capability is only advertised when enabled.
     if (KB_MCP_PROMPTS) {

--- a/src/mcp-completions.test.ts
+++ b/src/mcp-completions.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+  CompleteRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import {
+  KB_RESOURCE_TEMPLATE_URI,
+  MAX_COMPLETION_VALUES,
+  completeMcpArgument,
+  registerCompletions,
+} from './mcp-completions.js';
+
+describe('completeMcpArgument', () => {
+  it('completes kb:// resource-template KB authority values', async () => {
+    const result = await completeMcpArgument({
+      ref: { type: 'ref/resource', uri: KB_RESOURCE_TEMPLATE_URI },
+      argument: { name: 'kb', value: 'wo' },
+    }, {
+      listKnowledgeBaseNames: async () => ['work', 'research', 'work-archive'],
+    });
+
+    expect(result).toEqual({
+      completion: {
+        values: ['work', 'work-archive'],
+        total: 2,
+        hasMore: false,
+      },
+    });
+  });
+
+  it('completes kb:// resource-template paths inside the selected KB', async () => {
+    const calls: Array<{ kbName: string; prefix: string; limit: number }> = [];
+    const result = await completeMcpArgument({
+      ref: { type: 'ref/resource', uri: KB_RESOURCE_TEMPLATE_URI },
+      argument: { name: 'path', value: 'run' },
+      context: { arguments: { kb: 'work' } },
+    }, {
+      listResourcePaths: async (kbName, prefix, limit) => {
+        calls.push({ kbName, prefix, limit });
+        return {
+          values: ['runbooks/deploy.md', 'runbooks/rollback.md'],
+          hasMore: false,
+        };
+      },
+    });
+
+    expect(calls).toEqual([{ kbName: 'work', prefix: 'run', limit: MAX_COMPLETION_VALUES + 1 }]);
+    expect(result.completion.values).toEqual(['runbooks/deploy.md', 'runbooks/rollback.md']);
+    expect(result.completion.hasMore).toBe(false);
+  });
+
+  it('reports hasMore and caps path completion values at the MCP limit', async () => {
+    const values = Array.from({ length: MAX_COMPLETION_VALUES + 1 }, (_, i) => `notes/${i}.md`);
+    const result = await completeMcpArgument({
+      ref: { type: 'ref/resource', uri: KB_RESOURCE_TEMPLATE_URI },
+      argument: { name: 'path', value: 'notes/' },
+      context: { arguments: { kb: 'research' } },
+    }, {
+      listResourcePaths: async () => ({ values, hasMore: true }),
+    });
+
+    expect(result.completion.values).toHaveLength(MAX_COMPLETION_VALUES);
+    expect(result.completion.hasMore).toBe(true);
+  });
+
+  it('returns an empty completion for missing KB context or unknown resource refs', async () => {
+    await expect(completeMcpArgument({
+      ref: { type: 'ref/resource', uri: KB_RESOURCE_TEMPLATE_URI },
+      argument: { name: 'path', value: '' },
+    })).resolves.toEqual({ completion: { values: [], hasMore: false } });
+
+    await expect(completeMcpArgument({
+      ref: { type: 'ref/resource', uri: 'kb://{other}/{path}' },
+      argument: { name: 'kb', value: '' },
+    })).resolves.toEqual({ completion: { values: [], hasMore: false } });
+  });
+
+  it('completes prompt knowledge_base_name arguments from KB names', async () => {
+    const result = await completeMcpArgument({
+      ref: { type: 'ref/prompt', name: 'cite_sources' },
+      argument: { name: 'knowledge_base_name', value: 're' },
+    }, {
+      listKnowledgeBaseNames: async () => ['work', 'research', 'reference'],
+    });
+
+    expect(result.completion.values).toEqual(['reference', 'research']);
+    expect(result.completion.total).toBe(2);
+  });
+
+  it('returns empty completions for unknown prompt refs, including model-style arguments', async () => {
+    const result = await completeMcpArgument({
+      ref: { type: 'ref/prompt', name: 'model_probe' },
+      argument: { name: 'model_id', value: 'ollama' },
+    }, {
+      listModelIds: async () => [
+        'huggingface__BAAI-bge-small-en-v1.5',
+        'ollama__nomic-embed-text-latest',
+      ],
+    });
+
+    expect(result.completion.values).toEqual([]);
+  });
+
+  it('returns empty completions for non-completable prompt arguments', async () => {
+    const result = await completeMcpArgument({
+      ref: { type: 'ref/prompt', name: 'cite_sources' },
+      argument: { name: 'question', value: 'how' },
+    }, {
+      listKnowledgeBaseNames: async () => ['work'],
+      listModelIds: async () => ['ollama__nomic-embed-text-latest'],
+    });
+
+    expect(result).toEqual({ completion: { values: [], hasMore: false } });
+  });
+});
+
+describe('registerCompletions', () => {
+  it('declares completions and wires completion/complete', () => {
+    const capabilities: Array<Record<string, unknown>> = [];
+    const handlers = new Map<unknown, unknown>();
+    const fakeMcp = {
+      server: {
+        registerCapabilities: (cap: Record<string, unknown>) => capabilities.push(cap),
+        setRequestHandler: (schema: unknown, handler: unknown) => handlers.set(schema, handler),
+      },
+    } as unknown as McpServer;
+
+    registerCompletions(fakeMcp);
+
+    expect(capabilities).toContainEqual({ completions: {} });
+    expect(handlers.has(CompleteRequestSchema)).toBe(true);
+  });
+});

--- a/src/mcp-completions.ts
+++ b/src/mcp-completions.ts
@@ -1,0 +1,179 @@
+// mcp-completions.ts — MCP completion/complete support (#684).
+//
+// This module owns server-driven completions for argument values. It keeps the
+// resolver pure and dependency-injected for tests, while the registered server
+// path uses the same KB, resource, and model registries as the existing MCP
+// surfaces.
+
+import {
+  CompleteRequestSchema,
+  type CompleteRequest,
+  type CompleteResult,
+} from '@modelcontextprotocol/sdk/types.js';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { listRegisteredModels } from './active-model.js';
+import { KNOWLEDGE_BASES_ROOT_DIR } from './config/paths.js';
+import { KB_PROMPT_TEMPLATES } from './config/mcp-descriptions.js';
+import { listKnowledgeBases } from './kb-fs.js';
+import { listResources, parseKnowledgeBaseResourceUri } from './mcp-resources.js';
+
+const KB_RESOURCE_TEMPLATE_URI = 'kb://{kb}/{path}';
+const MAX_COMPLETION_VALUES = 100;
+
+type CompletionParams = CompleteRequest['params'];
+
+interface PathCompletionPage {
+  values: string[];
+  hasMore: boolean;
+  total?: number;
+}
+
+export interface McpCompletionDependencies {
+  listKnowledgeBaseNames?: () => Promise<string[]>;
+  listModelIds?: () => Promise<string[]>;
+  listResourcePaths?: (kbName: string, prefix: string, limit: number) => Promise<PathCompletionPage>;
+}
+
+const EMPTY_COMPLETION: CompleteResult = {
+  completion: {
+    values: [],
+    hasMore: false,
+  },
+};
+
+function resultFromValues(values: readonly string[], options: { total?: number; hasMore?: boolean } = {}): CompleteResult {
+  const page = values.slice(0, MAX_COMPLETION_VALUES);
+  return {
+    completion: {
+      values: page,
+      ...(options.total !== undefined ? { total: options.total } : {}),
+      hasMore: options.hasMore ?? values.length > MAX_COMPLETION_VALUES,
+    },
+  };
+}
+
+function filterPrefix(values: readonly string[], prefix: string): string[] {
+  return [...values]
+    .filter((value) => value.startsWith(prefix))
+    .sort((a, b) => a.localeCompare(b));
+}
+
+function isKnowledgeBaseArgument(name: string): boolean {
+  return name === 'kb' || name === 'kbName' || name === 'knowledge_base_name' || name === 'knowledgeBase';
+}
+
+function isModelArgument(name: string): boolean {
+  return name === 'model_id' || name === 'model_name' || name === 'modelId' || name === 'modelName';
+}
+
+function knownPromptArgument(promptName: string, argumentName: string): boolean {
+  const template = KB_PROMPT_TEMPLATES.find((prompt) => prompt.name === promptName);
+  if (template === undefined) return false;
+  return template.arguments.some((arg) => arg.name === argumentName);
+}
+
+async function defaultListKnowledgeBaseNames(): Promise<string[]> {
+  return listKnowledgeBases(KNOWLEDGE_BASES_ROOT_DIR);
+}
+
+async function defaultListModelIds(): Promise<string[]> {
+  return (await listRegisteredModels()).map((model) => model.model_id);
+}
+
+async function defaultListResourcePaths(kbName: string, prefix: string, limit: number): Promise<PathCompletionPage> {
+  const listed = await listResources({
+    kbName,
+    prefix,
+    limit,
+  });
+  const values: string[] = [];
+  for (const resource of listed.resources) {
+    try {
+      values.push(parseKnowledgeBaseResourceUri(resource.uri).relativePath);
+    } catch {
+      // listResources only returns kb:// URIs from this process. If a future
+      // resource slips through, omit it from completion rather than failing the
+      // entire completion request.
+    }
+  }
+  return {
+    values,
+    hasMore: listed.nextCursor !== undefined,
+  };
+}
+
+async function completeKnowledgeBaseName(prefix: string, deps: Required<McpCompletionDependencies>): Promise<CompleteResult> {
+  const matches = filterPrefix(await deps.listKnowledgeBaseNames(), prefix);
+  return resultFromValues(matches, { total: matches.length });
+}
+
+async function completeModelId(prefix: string, deps: Required<McpCompletionDependencies>): Promise<CompleteResult> {
+  const matches = filterPrefix(await deps.listModelIds(), prefix);
+  return resultFromValues(matches, { total: matches.length });
+}
+
+async function completeResourcePath(
+  params: CompletionParams,
+  deps: Required<McpCompletionDependencies>,
+): Promise<CompleteResult> {
+  const kbName = params.context?.arguments?.kb;
+  if (kbName === undefined || kbName.trim() === '') return EMPTY_COMPLETION;
+
+  const page = await deps.listResourcePaths(kbName, params.argument.value, MAX_COMPLETION_VALUES + 1);
+  return resultFromValues(page.values, {
+    total: page.total,
+    hasMore: page.hasMore || page.values.length > MAX_COMPLETION_VALUES,
+  });
+}
+
+function requiredDependencies(deps: McpCompletionDependencies): Required<McpCompletionDependencies> {
+  return {
+    listKnowledgeBaseNames: deps.listKnowledgeBaseNames ?? defaultListKnowledgeBaseNames,
+    listModelIds: deps.listModelIds ?? defaultListModelIds,
+    listResourcePaths: deps.listResourcePaths ?? defaultListResourcePaths,
+  };
+}
+
+export async function completeMcpArgument(
+  params: CompletionParams,
+  deps: McpCompletionDependencies = {},
+): Promise<CompleteResult> {
+  const resolvedDeps = requiredDependencies(deps);
+  const argumentName = params.argument.name;
+  const argumentValue = params.argument.value;
+
+  if (params.ref.type === 'ref/resource') {
+    if (params.ref.uri !== KB_RESOURCE_TEMPLATE_URI) return EMPTY_COMPLETION;
+    if (isKnowledgeBaseArgument(argumentName)) {
+      return completeKnowledgeBaseName(argumentValue, resolvedDeps);
+    }
+    if (argumentName === 'path') {
+      return completeResourcePath(params, resolvedDeps);
+    }
+    return EMPTY_COMPLETION;
+  }
+
+  if (params.ref.type === 'ref/prompt') {
+    if (!knownPromptArgument(params.ref.name, argumentName)) return EMPTY_COMPLETION;
+    if (isKnowledgeBaseArgument(argumentName)) {
+      return completeKnowledgeBaseName(argumentValue, resolvedDeps);
+    }
+    if (isModelArgument(argumentName)) {
+      return completeModelId(argumentValue, resolvedDeps);
+    }
+  }
+
+  return EMPTY_COMPLETION;
+}
+
+export function registerCompletions(mcp: McpServer): void {
+  mcp.server.registerCapabilities({
+    completions: {},
+  });
+
+  mcp.server.setRequestHandler(CompleteRequestSchema, async (request) =>
+    completeMcpArgument(request.params),
+  );
+}
+
+export { KB_RESOURCE_TEMPLATE_URI, MAX_COMPLETION_VALUES };


### PR DESCRIPTION
## Summary
- advertise the MCP `completions` capability and register a `completion/complete` handler
- complete `kb://{kb}/{path}` resource-template arguments from KB names and paginated resource paths
- complete prompt `knowledge_base_name` arguments from KB names, with model-id support for future model-style prompt args
- document the resource/prompt completion behavior

Closes #684

## Verification
- `npm ci` (35 existing vulnerabilities reported by npm audit)
- `npx jest --runInBand --runTestsByPath src/mcp-completions.test.ts`
- `npx jest --runInBand --runTestsByPath src/mcp-completions.test.ts src/mcp-resources.test.ts src/mcp-prompts.test.ts`
- `npx jest --runInBand --runTestsByPath src/KnowledgeBaseServer.test.ts src/mcp-completions.test.ts`
- `npm run build`
- `npm run lint`
- `npm run docs:check-anchors`
- `npm run check` (passes; coverage collection still prints the repo's existing `src/cli.ts` `import.meta` warning but exits 0)
- `git diff --cached --check`
- staged portability scan for user-specific absolute paths
