### PR TITLE
feat: harden explain repro bundle permissions

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -584,12 +584,16 @@ Output:
 
 Repro bundle:
   --repro-bundle=<dir>    Write a redacted repro bundle to <dir> containing
-                          `query.txt`, `system.json`, `top-candidates.json`,
-                          and `freshness.json`. Chunk *content* is NOT
-                          included unless you also pass `--include-content`.
+                          `manifest.json`, `query.txt`, `system.json`,
+                          `top-candidates.json`, and `freshness.json`.
+                          Bundle dirs are private (0700) and files are private
+                          (0600) on POSIX. Chunk *content* is NOT included
+                          unless you also pass `--include-content`.
   --include-content       Bundle the candidate chunk text alongside the
                           metadata. Explicit consent for KB content to leave
                           the trust boundary; default is content-redacted.
+  --force                 If <dir> already exists with unsafe group/other
+                          permissions, set its mode to 0700 before writing.
 
 Misc:
   --help, -h              Show this help.

--- a/src/cli-explain.test.ts
+++ b/src/cli-explain.test.ts
@@ -13,6 +13,9 @@ import {
   EXPLAIN_DEFAULT_K,
   EXPLAIN_DEFAULT_NEAR_MISS,
   parseExplainArgs,
+  runExplain,
+  type RunExplainDeps,
+  writeReproBundle,
 } from './cli-explain.js';
 import {
   buildCandidates,
@@ -36,6 +39,7 @@ describe('parseExplainArgs', () => {
     expect(a.thresholdIsDefault).toBe(true);
     expect(a.reproBundle).toBeNull();
     expect(a.includeContent).toBe(false);
+    expect(a.reproBundleForce).toBe(false);
   });
 
   it('honors explicit --k and grows candidates to k + 5 near-misses', () => {
@@ -100,6 +104,12 @@ describe('parseExplainArgs', () => {
     const a = parseExplainArgs(['q', '--repro-bundle=./out', '--include-content']);
     expect(a.reproBundle).toBe('./out');
     expect(a.includeContent).toBe(true);
+  });
+
+  it('accepts --force only with --repro-bundle', () => {
+    const a = parseExplainArgs(['q', '--repro-bundle=./out', '--force']);
+    expect(a.reproBundleForce).toBe(true);
+    expect(() => parseExplainArgs(['q', '--force'])).toThrow(/--force requires --repro-bundle/);
   });
 
   it('rejects empty --repro-bundle path', () => {
@@ -384,12 +394,9 @@ describe('deriveDiagnostics', () => {
 
 // -- writeReproBundle redaction test ------------------------------------------
 //
-// We import the runtime helper indirectly by re-creating the bundle layout
-// the same way runExplain does. Verifying the *directory* output via fs is
-// the cheapest way to assert the redaction contract — including content is
-// strictly opt-in, default-off.
-
-import { runExplain } from './cli-explain.js';
+// Verifying the *directory* output via fs is the cheapest way to assert the
+// privacy and redaction contract: including content is strictly opt-in and
+// POSIX bundles are written with private directory/file permissions.
 
 describe('kb explain repro bundle', () => {
   it('refuses --include-content without --repro-bundle (defense in depth)', async () => {
@@ -422,4 +429,232 @@ describe('kb explain repro bundle', () => {
       await fsp.rm(tempRoot, { recursive: true, force: true });
     }
   });
+
+  it('writes a private redacted bundle manifest', async () => {
+    const tempRoot = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-explain-bundle-'));
+    try {
+      const bundleDir = path.join(tempRoot, 'bundle');
+      await writeReproBundle(bundleDir, makeTrace(), sampleBundleResults(), false);
+
+      const query = await fsp.readFile(path.join(bundleDir, 'query.txt'), 'utf-8');
+      expect(query).toBe('rollback procedure\n');
+
+      const topCandidates = JSON.parse(
+        await fsp.readFile(path.join(bundleDir, 'top-candidates.json'), 'utf-8'),
+      ) as { content_included: boolean; candidates: Array<{ content?: string }> };
+      expect(topCandidates.content_included).toBe(false);
+      expect(topCandidates.candidates[0]).not.toHaveProperty('content');
+
+      const manifest = JSON.parse(
+        await fsp.readFile(path.join(bundleDir, 'manifest.json'), 'utf-8'),
+      ) as ReproBundleManifestForTest;
+      expect(manifest.schema_version).toBe('kb-explain-repro-bundle.v1');
+      expect(manifest.trace_schema_version).toBe('kb-explain.v1');
+      expect(manifest.content_included).toBe(false);
+      expect(manifest.files.map((f) => f.path).sort()).toEqual([
+        'freshness.json',
+        'manifest.json',
+        'query.txt',
+        'system.json',
+        'top-candidates.json',
+      ]);
+
+      if (process.platform !== 'win32') {
+        expect(modeOf(await fsp.stat(bundleDir))).toBe('0700');
+        for (const file of manifest.files) {
+          expect(file.mode).toBe('0600');
+          expect(modeOf(await fsp.stat(path.join(bundleDir, file.path)))).toBe('0600');
+        }
+      } else {
+        expect(manifest.permissions.posix_permissions_enforced).toBe(false);
+      }
+    } finally {
+      await fsp.rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('records explicit content inclusion in the manifest', async () => {
+    const tempRoot = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-explain-bundle-'));
+    try {
+      const bundleDir = path.join(tempRoot, 'bundle');
+      await writeReproBundle(bundleDir, makeTrace(), sampleBundleResults(), true);
+
+      const topCandidates = JSON.parse(
+        await fsp.readFile(path.join(bundleDir, 'top-candidates.json'), 'utf-8'),
+      ) as { content_included: boolean; candidates: Array<{ content?: string }> };
+      expect(topCandidates.content_included).toBe(true);
+      expect(topCandidates.candidates[0].content).toBe('secret rollback text');
+
+      const manifest = JSON.parse(
+        await fsp.readFile(path.join(bundleDir, 'manifest.json'), 'utf-8'),
+      ) as ReproBundleManifestForTest;
+      expect(manifest.content_included).toBe(true);
+    } finally {
+      await fsp.rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('refuses an existing bundle directory containing non-bundle files', async () => {
+    const tempRoot = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-explain-bundle-'));
+    try {
+      const bundleDir = path.join(tempRoot, 'bundle');
+      await fsp.mkdir(bundleDir, { mode: 0o700 });
+      if (process.platform !== 'win32') await fsp.chmod(bundleDir, 0o700);
+      await fsp.writeFile(path.join(bundleDir, 'old-content.json'), 'stale sensitive content\n', 'utf-8');
+
+      await expect(writeReproBundle(bundleDir, makeTrace(), sampleBundleResults(), false))
+        .rejects.toThrow(/contains non-bundle file\(s\): old-content\.json/);
+      await expect(fsp.access(path.join(bundleDir, 'query.txt'))).rejects.toThrow();
+    } finally {
+      await fsp.rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  const itOnPosix = process.platform === 'win32' ? it.skip : it;
+
+  itOnPosix('refuses an existing bundle directory with group/other permissions', async () => {
+    const tempRoot = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-explain-bundle-'));
+    try {
+      const bundleDir = path.join(tempRoot, 'bundle');
+      await fsp.mkdir(bundleDir, { mode: 0o755 });
+      await fsp.chmod(bundleDir, 0o755);
+
+      await expect(writeReproBundle(bundleDir, makeTrace(), sampleBundleResults(), false))
+        .rejects.toThrow(/unsafe permissions 0755/);
+    } finally {
+      await fsp.rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  itOnPosix('force-chmods an unsafe existing bundle directory before writing', async () => {
+    const tempRoot = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-explain-bundle-'));
+    try {
+      const bundleDir = path.join(tempRoot, 'bundle');
+      await fsp.mkdir(bundleDir, { mode: 0o755 });
+      await fsp.chmod(bundleDir, 0o755);
+
+      await writeReproBundle(bundleDir, makeTrace(), sampleBundleResults(), false, true);
+
+      expect(modeOf(await fsp.stat(bundleDir))).toBe('0700');
+      const manifest = JSON.parse(
+        await fsp.readFile(path.join(bundleDir, 'manifest.json'), 'utf-8'),
+      ) as ReproBundleManifestForTest;
+      expect(manifest.permissions.directory.existing_mode).toBe('0755');
+      expect(manifest.permissions.directory.existing_directory_was_unsafe).toBe(true);
+      expect(manifest.permissions.directory.unsafe_existing_directory_forced).toBe(true);
+    } finally {
+      await fsp.rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  itOnPosix('runExplain forwards --force and --include-content to the repro writer', async () => {
+    const tempRoot = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-explain-bundle-'));
+    try {
+      const bundleDir = path.join(tempRoot, 'bundle');
+      await fsp.mkdir(bundleDir, { mode: 0o755 });
+      await fsp.chmod(bundleDir, 0o755);
+
+      const noForce = await captureExplainOutput(
+        ['rollback procedure', `--repro-bundle=${bundleDir}`],
+        makeRunExplainDeps(),
+      );
+      expect(noForce.code).toBe(1);
+      expect(noForce.stderr).toMatch(/unsafe permissions 0755/);
+
+      const forced = await captureExplainOutput(
+        ['rollback procedure', `--repro-bundle=${bundleDir}`, '--include-content', '--force'],
+        makeRunExplainDeps(),
+      );
+      expect(forced.code).toBe(0);
+      expect(modeOf(await fsp.stat(bundleDir))).toBe('0700');
+
+      const manifest = JSON.parse(
+        await fsp.readFile(path.join(bundleDir, 'manifest.json'), 'utf-8'),
+      ) as ReproBundleManifestForTest;
+      expect(manifest.content_included).toBe(true);
+      expect(manifest.permissions.directory.unsafe_existing_directory_forced).toBe(true);
+
+      const topCandidates = JSON.parse(
+        await fsp.readFile(path.join(bundleDir, 'top-candidates.json'), 'utf-8'),
+      ) as { candidates: Array<{ content?: string }> };
+      expect(topCandidates.candidates[0].content).toBe('secret rollback text');
+    } finally {
+      await fsp.rm(tempRoot, { recursive: true, force: true });
+    }
+  });
 });
+
+function sampleBundleResults(): Array<{ pageContent: string; metadata: Record<string, unknown>; score: number }> {
+  return [
+    { pageContent: 'secret rollback text', metadata: { frontmatter: { type: 'runbook' } }, score: 0.42 },
+    { pageContent: 'secret deploy text', metadata: {}, score: 0.61 },
+    { pageContent: 'secret other text', metadata: {}, score: 1.18 },
+  ];
+}
+
+function makeRunExplainDeps(): RunExplainDeps {
+  const manager = {
+    embeddingProvider: 'fake',
+    modelName: 'bag-256d',
+    async similaritySearch() {
+      return sampleBundleResults();
+    },
+    getStats() {
+      return { dim: 64 };
+    },
+  };
+  return {
+    bootstrapLayout: async () => {},
+    resolveActiveModel: async () => 'fake__bag-256d',
+    loadManagerForModel: async () => manager as never,
+    loadWithJsonRetry: async () => {},
+    computeStaleness: async () => ({ indexMtime: null, modifiedFiles: 0, newFiles: 0 }),
+    resolveFaissIndexBinaryPath: async () => null,
+    writeReproBundle,
+    readPackageVersion: () => 'test-version',
+  };
+}
+
+async function captureExplainOutput(
+  args: string[],
+  deps: RunExplainDeps,
+): Promise<{ code: number; stdout: string; stderr: string }> {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const origStdout = process.stdout.write.bind(process.stdout);
+  const origStderr = process.stderr.write.bind(process.stderr);
+  process.stdout.write = ((chunk: string | Uint8Array) => {
+    stdout.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf-8'));
+    return true;
+  }) as typeof process.stdout.write;
+  process.stderr.write = ((chunk: string | Uint8Array) => {
+    stderr.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf-8'));
+    return true;
+  }) as typeof process.stderr.write;
+  try {
+    const code = await runExplain(args, deps);
+    return { code, stdout: stdout.join(''), stderr: stderr.join('') };
+  } finally {
+    process.stdout.write = origStdout;
+    process.stderr.write = origStderr;
+  }
+}
+
+function modeOf(stats: { mode: number }): string {
+  return (stats.mode & 0o777).toString(8).padStart(4, '0');
+}
+
+interface ReproBundleManifestForTest {
+  schema_version: string;
+  trace_schema_version: string;
+  content_included: boolean;
+  permissions: {
+    posix_permissions_enforced: boolean;
+    directory: {
+      existing_mode: string | null;
+      existing_directory_was_unsafe: boolean;
+      unsafe_existing_directory_forced: boolean;
+    };
+  };
+  files: Array<{ path: string; mode: string | null }>;
+}

--- a/src/cli-explain.ts
+++ b/src/cli-explain.ts
@@ -75,12 +75,16 @@ Output:
 
 Repro bundle:
   --repro-bundle=<dir>    Write a redacted repro bundle to <dir> containing
-                          \`query.txt\`, \`system.json\`, \`top-candidates.json\`,
-                          and \`freshness.json\`. Chunk *content* is NOT
-                          included unless you also pass \`--include-content\`.
+                          \`manifest.json\`, \`query.txt\`, \`system.json\`,
+                          \`top-candidates.json\`, and \`freshness.json\`.
+                          Bundle dirs are private (0700) and files are private
+                          (0600) on POSIX. Chunk *content* is NOT included
+                          unless you also pass \`--include-content\`.
   --include-content       Bundle the candidate chunk text alongside the
                           metadata. Explicit consent for KB content to leave
                           the trust boundary; default is content-redacted.
+  --force                 If <dir> already exists with unsafe group/other
+                          permissions, set its mode to 0700 before writing.
 
 Misc:
   --help, -h              Show this help.
@@ -105,11 +109,34 @@ export interface ExplainArgs {
   format: ExplainFormat;
   reproBundle: string | null;
   includeContent: boolean;
+  reproBundleForce: boolean;
 }
 
 export const EXPLAIN_DEFAULT_K = 5;
 export const EXPLAIN_DEFAULT_NEAR_MISS = 5;
 const NO_THRESHOLD = Number.POSITIVE_INFINITY;
+
+export interface RunExplainDeps {
+  bootstrapLayout: () => Promise<void>;
+  resolveActiveModel: typeof resolveActiveModel;
+  loadManagerForModel: typeof loadManagerForModel;
+  loadWithJsonRetry: typeof loadWithJsonRetry;
+  computeStaleness: typeof computeStaleness;
+  resolveFaissIndexBinaryPath: typeof resolveFaissIndexBinaryPath;
+  writeReproBundle: typeof writeReproBundle;
+  readPackageVersion: () => string;
+}
+
+const DEFAULT_RUN_EXPLAIN_DEPS: RunExplainDeps = {
+  bootstrapLayout: () => FaissIndexManager.bootstrapLayout(),
+  resolveActiveModel,
+  loadManagerForModel,
+  loadWithJsonRetry,
+  computeStaleness,
+  resolveFaissIndexBinaryPath,
+  writeReproBundle,
+  readPackageVersion,
+};
 
 export function parseExplainArgs(rest: string[]): ExplainArgs {
   const out: ExplainArgs = {
@@ -121,10 +148,12 @@ export function parseExplainArgs(rest: string[]): ExplainArgs {
     format: 'md',
     reproBundle: null,
     includeContent: false,
+    reproBundleForce: false,
   };
   let candidatesExplicit = false;
   for (const raw of rest) {
     if (raw === '--include-content') { out.includeContent = true; continue; }
+    if (raw === '--force') { out.reproBundleForce = true; continue; }
     if (raw.startsWith('--kb=')) { out.kb = raw.slice('--kb='.length); continue; }
     if (raw.startsWith('--model=')) { out.model = raw.slice('--model='.length); continue; }
     if (raw.startsWith('--k=')) {
@@ -172,10 +201,16 @@ export function parseExplainArgs(rest: string[]): ExplainArgs {
   if (out.includeContent && out.reproBundle === null) {
     throw new Error(`--include-content requires --repro-bundle=<dir>`);
   }
+  if (out.reproBundleForce && out.reproBundle === null) {
+    throw new Error(`--force requires --repro-bundle=<dir>`);
+  }
   return out;
 }
 
-export async function runExplain(rest: string[]): Promise<number> {
+export async function runExplain(
+  rest: string[],
+  deps: RunExplainDeps = DEFAULT_RUN_EXPLAIN_DEPS,
+): Promise<number> {
   const totalStartedAt = nowMs();
   let parsed: ExplainArgs;
   try {
@@ -199,7 +234,7 @@ export async function runExplain(rest: string[]): Promise<number> {
 
   try {
     const startedAt = nowMs();
-    await FaissIndexManager.bootstrapLayout();
+    await deps.bootstrapLayout();
     timings.bootstrap = elapsedMs(startedAt);
   } catch (err) {
     return reportFailure(classifyKbSearchError(err), parsed.format);
@@ -208,7 +243,7 @@ export async function runExplain(rest: string[]): Promise<number> {
   let activeModelId: string;
   try {
     const startedAt = nowMs();
-    activeModelId = await resolveActiveModel({ explicitOverride: parsed.model });
+    activeModelId = await deps.resolveActiveModel({ explicitOverride: parsed.model });
     timings.model_resolution = elapsedMs(startedAt);
   } catch (err) {
     return reportFailure(classifyKbSearchError(err), parsed.format);
@@ -217,7 +252,7 @@ export async function runExplain(rest: string[]): Promise<number> {
   let manager: FaissIndexManager;
   try {
     const startedAt = nowMs();
-    manager = await loadManagerForModel(activeModelId);
+    manager = await deps.loadManagerForModel(activeModelId);
     timings.manager_load = elapsedMs(startedAt);
   } catch (err) {
     return reportFailure(classifyKbSearchError(err), parsed.format);
@@ -225,7 +260,7 @@ export async function runExplain(rest: string[]): Promise<number> {
 
   try {
     const startedAt = nowMs();
-    await loadWithJsonRetry(manager);
+    await deps.loadWithJsonRetry(manager);
     timings.index_load = elapsedMs(startedAt);
   } catch (err) {
     return reportFailure(classifyKbSearchError(err), parsed.format);
@@ -252,11 +287,11 @@ export async function runExplain(rest: string[]): Promise<number> {
   }
 
   const stalenessStartedAt = nowMs();
-  const staleness = await computeStaleness(activeModelId, parsed.kb);
+  const staleness = await deps.computeStaleness(activeModelId, parsed.kb);
   timings.staleness = elapsedMs(stalenessStartedAt);
 
   const stats = manager.getStats();
-  const binaryPath = await resolveFaissIndexBinaryPath(activeModelId);
+  const binaryPath = await deps.resolveFaissIndexBinaryPath(activeModelId);
 
   const trace = buildTrace({
     parsed,
@@ -266,7 +301,7 @@ export async function runExplain(rest: string[]): Promise<number> {
     embeddingModel: manager.modelName,
     indexBinaryPath: binaryPath,
     indexMtime: staleness.indexMtime,
-    cliVersion: readPackageVersion(),
+    cliVersion: deps.readPackageVersion(),
     dim: stats.dim,
     results,
     timings,
@@ -277,7 +312,7 @@ export async function runExplain(rest: string[]): Promise<number> {
 
   if (parsed.reproBundle !== null) {
     try {
-      await writeReproBundle(parsed.reproBundle, trace, results, parsed.includeContent);
+      await deps.writeReproBundle(parsed.reproBundle, trace, results, parsed.includeContent, parsed.reproBundleForce);
     } catch (err) {
       process.stderr.write(`kb explain: failed to write repro bundle: ${(err as Error).message}\n`);
       return 1;
@@ -386,23 +421,29 @@ function numberOrNull(value: number | undefined): number | null {
  * before attaching to a bug report; the README will document the gesture.
  * Chunk content is *redacted by default*; the operator must pass
  * `--include-content` to bundle it (explicit trust-boundary opt-in).
+ * Issue #717 hardens this export path: the target directory is private
+ * (0700), files are private (0600), and `manifest.json` records the privacy
+ * posture so bug reports can be audited before sharing.
  */
-async function writeReproBundle(
+export async function writeReproBundle(
   bundlePath: string,
   trace: ExplainTrace,
   results: ReadonlyArray<{ pageContent: string; metadata: Record<string, unknown>; score: number }>,
   includeContent: boolean,
+  forceUnsafeExistingDirectory = false,
 ): Promise<void> {
-  await fsp.mkdir(bundlePath, { recursive: true });
+  const directory = await ensurePrivateBundleDirectory(bundlePath, forceUnsafeExistingDirectory);
+  const files: ReproBundleFileManifest[] = [];
 
-  await fsp.writeFile(
-    path.join(bundlePath, 'query.txt'),
+  files.push(await writePrivateUtf8File(
+    bundlePath,
+    'query.txt',
     `${trace.query.raw}\n`,
-    'utf-8',
-  );
+  ));
 
-  await fsp.writeFile(
-    path.join(bundlePath, 'system.json'),
+  files.push(await writePrivateUtf8File(
+    bundlePath,
+    'system.json',
     `${JSON.stringify({
       schema_version: trace.schema_version,
       system: trace.system,
@@ -410,8 +451,7 @@ async function writeReproBundle(
       filters: trace.filters,
       timing: trace.timing,
     }, null, 2)}\n`,
-    'utf-8',
-  );
+  ));
 
   const topCandidates = trace.retrieval.candidates.map((c, idx) => ({
     rank: c.rank,
@@ -424,8 +464,9 @@ async function writeReproBundle(
     frontmatter: extractFrontmatter(results[idx]?.metadata ?? {}),
     ...(includeContent ? { content: results[idx]?.pageContent ?? '' } : {}),
   }));
-  await fsp.writeFile(
-    path.join(bundlePath, 'top-candidates.json'),
+  files.push(await writePrivateUtf8File(
+    bundlePath,
+    'top-candidates.json',
     `${JSON.stringify(
       {
         schema_version: trace.schema_version,
@@ -438,11 +479,11 @@ async function writeReproBundle(
       null,
       2,
     )}\n`,
-    'utf-8',
-  );
+  ));
 
-  await fsp.writeFile(
-    path.join(bundlePath, 'freshness.json'),
+  files.push(await writePrivateUtf8File(
+    bundlePath,
+    'freshness.json',
     `${JSON.stringify(
       {
         schema_version: trace.schema_version,
@@ -451,8 +492,178 @@ async function writeReproBundle(
       null,
       2,
     )}\n`,
-    'utf-8',
+  ));
+
+  const pendingManifestFile: ReproBundleFileManifest = {
+    path: 'manifest.json',
+    mode: isPosixPermissionsSupported() ? '0600' : null,
+  };
+  await writePrivateUtf8File(
+    bundlePath,
+    'manifest.json',
+    `${JSON.stringify(
+      buildReproBundleManifest(trace, includeContent, directory, [...files, pendingManifestFile]),
+      null,
+      2,
+    )}\n`,
   );
+  // Rewrite after statting the manifest so the manifest records its own final mode.
+  const manifestFile = await describeBundleFile(path.join(bundlePath, 'manifest.json'), 'manifest.json');
+  await writePrivateUtf8File(
+    bundlePath,
+    'manifest.json',
+    `${JSON.stringify(
+      buildReproBundleManifest(trace, includeContent, directory, [...files, manifestFile]),
+      null,
+      2,
+    )}\n`,
+  );
+}
+
+const PRIVATE_DIR_MODE = 0o700;
+const PRIVATE_FILE_MODE = 0o600;
+const UNSAFE_DIR_MODE_MASK = 0o077;
+const REPRO_BUNDLE_FILENAMES = new Set([
+  'query.txt',
+  'system.json',
+  'top-candidates.json',
+  'freshness.json',
+  'manifest.json',
+]);
+
+interface ReproBundleDirectoryManifest {
+  path: string;
+  mode: string | null;
+  existed: boolean;
+  existing_mode: string | null;
+  existing_directory_was_unsafe: boolean;
+  unsafe_existing_directory_forced: boolean;
+}
+
+interface ReproBundleFileManifest {
+  path: string;
+  mode: string | null;
+}
+
+interface ReproBundleManifest {
+  schema_version: 'kb-explain-repro-bundle.v1';
+  trace_schema_version: string;
+  content_included: boolean;
+  permissions: {
+    posix_permissions_enforced: boolean;
+    intended_directory_mode: '0700';
+    intended_file_mode: '0600';
+    directory: ReproBundleDirectoryManifest;
+  };
+  files: ReproBundleFileManifest[];
+}
+
+async function ensurePrivateBundleDirectory(
+  bundlePath: string,
+  forceUnsafeExistingDirectory: boolean,
+): Promise<ReproBundleDirectoryManifest> {
+  const posixPermissions = isPosixPermissionsSupported();
+  let existed = false;
+  let existingMode: string | null = null;
+  let existingDirectoryWasUnsafe = false;
+
+  try {
+    const existing = await fsp.stat(bundlePath);
+    existed = true;
+    if (!existing.isDirectory()) {
+      throw new Error(`${bundlePath} exists and is not a directory`);
+    }
+    if (posixPermissions) {
+      existingMode = formatMode(existing.mode);
+      existingDirectoryWasUnsafe = (existing.mode & UNSAFE_DIR_MODE_MASK) !== 0;
+      if (existingDirectoryWasUnsafe && !forceUnsafeExistingDirectory) {
+        throw new Error(
+          `${bundlePath} exists with unsafe permissions ${existingMode}; ` +
+          `rerun with --force to chmod it to 0700 before writing`,
+        );
+      }
+    }
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+    await fsp.mkdir(bundlePath, { recursive: true, mode: PRIVATE_DIR_MODE });
+  }
+
+  if (posixPermissions) {
+    await fsp.chmod(bundlePath, PRIVATE_DIR_MODE);
+  }
+  await assertBundleDirectoryHasOnlyBundleFiles(bundlePath);
+  const final = await fsp.stat(bundlePath);
+  return {
+    path: bundlePath,
+    mode: posixPermissions ? formatMode(final.mode) : null,
+    existed,
+    existing_mode: existingMode,
+    existing_directory_was_unsafe: existingDirectoryWasUnsafe,
+    unsafe_existing_directory_forced: existingDirectoryWasUnsafe && forceUnsafeExistingDirectory,
+  };
+}
+
+async function assertBundleDirectoryHasOnlyBundleFiles(bundlePath: string): Promise<void> {
+  const entries = await fsp.readdir(bundlePath, { withFileTypes: true });
+  const unsafeEntries = entries
+    .filter((entry) => !REPRO_BUNDLE_FILENAMES.has(entry.name) || !entry.isFile())
+    .map((entry) => entry.name)
+    .sort();
+  if (unsafeEntries.length > 0) {
+    throw new Error(
+      `${bundlePath} contains non-bundle file(s): ${unsafeEntries.join(', ')}; ` +
+      `choose an empty directory or remove stale files before writing`,
+    );
+  }
+}
+
+async function writePrivateUtf8File(
+  bundlePath: string,
+  relativePath: string,
+  body: string,
+): Promise<ReproBundleFileManifest> {
+  const filePath = path.join(bundlePath, relativePath);
+  await fsp.writeFile(filePath, body, { encoding: 'utf-8', mode: PRIVATE_FILE_MODE });
+  if (isPosixPermissionsSupported()) {
+    await fsp.chmod(filePath, PRIVATE_FILE_MODE);
+  }
+  return describeBundleFile(filePath, relativePath);
+}
+
+async function describeBundleFile(filePath: string, relativePath: string): Promise<ReproBundleFileManifest> {
+  if (!isPosixPermissionsSupported()) {
+    return { path: relativePath, mode: null };
+  }
+  const stats = await fsp.stat(filePath);
+  return { path: relativePath, mode: formatMode(stats.mode) };
+}
+
+function buildReproBundleManifest(
+  trace: ExplainTrace,
+  includeContent: boolean,
+  directory: ReproBundleDirectoryManifest,
+  files: ReproBundleFileManifest[],
+): ReproBundleManifest {
+  return {
+    schema_version: 'kb-explain-repro-bundle.v1',
+    trace_schema_version: trace.schema_version,
+    content_included: includeContent,
+    permissions: {
+      posix_permissions_enforced: isPosixPermissionsSupported(),
+      intended_directory_mode: '0700',
+      intended_file_mode: '0600',
+      directory,
+    },
+    files,
+  };
+}
+
+function isPosixPermissionsSupported(): boolean {
+  return process.platform !== 'win32';
+}
+
+function formatMode(mode: number): string {
+  return (mode & 0o777).toString(8).padStart(4, '0');
 }
 
 function extractFrontmatter(metadata: Record<string, unknown>): unknown {


### PR DESCRIPTION
Summary:
- make kb explain repro bundles private on POSIX with 0700 directories and 0600 files
- add manifest.json recording content inclusion and permission posture
- add --force to repair unsafe existing bundle directories before writing
- refuse reused bundle directories containing stale non-bundle files

Pre-PR review:
- reviewer specialists: conventions, correctness, dead-code, and test specialists run
- blocking correctness finding fixed: stale extra files in reused bundle dirs are now rejected before writing

Testing:
- npm run test:file -- src/cli-explain.test.ts
- npm run build
- npm run lint
- npm run docs:check-cli
- npm test

Closes #717
