### PR TITLE
feat: record write lock timing telemetry

### DIFF
--- a/docs/architecture/adr/0007-canonical-log-line-format.md
+++ b/docs/architecture/adr/0007-canonical-log-line-format.md
@@ -28,6 +28,10 @@ It never writes to stdout. The event contains stable request fields such as
 `query_sha256`, `result_count`, `top_score`, `top_sources`, timing fields, and
 an optional `{ code, category }` error object.
 
+Write-lock observability events use the same schema with `event: "write_lock"`
+and additive `lock_wait_ms`, `lock_hold_ms`, and `lock_resource_kind` fields.
+The resource kind is a bounded enum and does not serialize filesystem paths.
+
 Queries are redacted by default. The raw query is never serialized; only a
 16-character SHA-256 prefix of the whitespace-normalized query is emitted.
 `top_sources` is capped at three entries to bound line size and cardinality.

--- a/docs/operations/metrics-export.md
+++ b/docs/operations/metrics-export.md
@@ -42,6 +42,7 @@ The v1 exporter keeps labels bounded:
 | `mode` | `kb_search_*` | `dense`, `lexical`, `hybrid`, `auto`, `unknown` |
 | `stage` | `kb_search_stage_duration_ms` | fixed search timing stage names |
 | `status` | `kb_search_*` | `success`, `error` |
+| `resource_kind` | `kb_write_lock_*` | `active_index`, `model_index`, `other` |
 
 There are no query text, file path, user, request id, source URL, or raw error
 labels.
@@ -55,6 +56,8 @@ labels.
 | `kb_search_requests_total` | daemon-served search request totals by mode/status |
 | `kb_search_request_duration_ms` | end-to-end daemon-served search request latency histogram |
 | `kb_search_stage_duration_ms` | per-stage daemon-served search latency histogram |
+| `kb_write_lock_wait_duration_ms` | write-lock acquisition wait latency histogram by resource kind |
+| `kb_write_lock_hold_duration_ms` | write-lock function hold latency histogram by resource kind |
 | `kb_query_cache_*` | query embedding cache hits, misses, bypasses, disk usage |
 | `kb_relevance_gate_*` | relevance gate query and verdict counters |
 | `kb_remote_transport_*` | HTTP/SSE sessions, requests, auth failures, origin denials, status buckets |

--- a/jest.config.js
+++ b/jest.config.js
@@ -95,6 +95,9 @@ const coverageConfig = {
 };
 
 export default {
+  // Root-level coverage collection uses the root transform, not only the
+  // per-project transforms, when instrumenting untested source files.
+  ...baseConfig,
   ...coverageConfig,
   // Issue #661 — `--coverage` (istanbul) instrumentation roughly doubles
   // execution time, and a few tests lazily `import()` heavy modules

--- a/src/KnowledgeBaseServer.test.ts
+++ b/src/KnowledgeBaseServer.test.ts
@@ -1804,7 +1804,7 @@ describe('KnowledgeBaseServer handlers', () => {
     });
   });
 
-  it('handleRetrieveKnowledge emits one canonical event with redacted query and result fields (#216)', async () => {
+  it('handleRetrieveKnowledge emits canonical events with redacted query and result fields (#216)', async () => {
     const tempDir = await setRetrieveEnv();
     const logFile = path.join(tempDir, 'canonical.log');
     process.env.LOG_FILE = logFile;
@@ -1835,8 +1835,8 @@ describe('KnowledgeBaseServer handlers', () => {
 
     expect(result.isError).toBeUndefined();
     const events = await readCanonicalEvents(logFile);
-    expect(events).toHaveLength(1);
-    expect(events[0]).toMatchObject({
+    const retrieveEvent = events.find((event) => event.tool === 'retrieve_knowledge');
+    expect(retrieveEvent).toMatchObject({
       schema_version: 'kb-canonical.v1',
       process: 'mcp',
       tool: 'retrieve_knowledge',
@@ -1856,8 +1856,14 @@ describe('KnowledgeBaseServer handlers', () => {
         elapsed_ms: 2,
       },
     });
-    expect(events[0].query_sha256).toMatch(/^[a-f0-9]{16}$/);
-    expect(JSON.stringify(events[0])).not.toContain('raw private query');
+    expect(retrieveEvent?.query_sha256).toMatch(/^[a-f0-9]{16}$/);
+    expect(JSON.stringify(retrieveEvent)).not.toContain('raw private query');
+    expect(events).toContainEqual(expect.objectContaining({
+      event: 'write_lock',
+      lock_resource_kind: 'model_index',
+      lock_wait_ms: expect.any(Number),
+      lock_hold_ms: expect.any(Number),
+    }));
   });
 
   it('handleRetrieveKnowledge returns "_No similar results found._" when similaritySearch returns []', async () => {
@@ -2022,8 +2028,8 @@ describe('KnowledgeBaseServer handlers', () => {
 
     expect(result.isError).toBe(true);
     const events = await readCanonicalEvents(logFile);
-    expect(events).toHaveLength(1);
-    expect(events[0]).toMatchObject({
+    const retrieveEvent = events.find((event) => event.tool === 'retrieve_knowledge');
+    expect(retrieveEvent).toMatchObject({
       schema_version: 'kb-canonical.v1',
       process: 'mcp',
       tool: 'retrieve_knowledge',
@@ -2032,6 +2038,14 @@ describe('KnowledgeBaseServer handlers', () => {
         category: 'provider',
       },
     });
+    expect(events).toContainEqual(expect.objectContaining({
+      event: 'write_lock',
+      lock_resource_kind: 'model_index',
+      error: {
+        code: 'PROVIDER_TIMEOUT',
+        category: 'provider',
+      },
+    }));
   });
 
   it('threshold argument flows through to similaritySearch(query, 10, threshold, kb, filters)', async () => {

--- a/src/canonical-log.test.ts
+++ b/src/canonical-log.test.ts
@@ -42,6 +42,9 @@ describe('canonical log line schema (#216)', () => {
       tool: 'retrieve_knowledge',
       took_ms: 5,
       top_sources: ['a.md', 'b.md', 'c.md', 'd.md'],
+      lock_wait_ms: 1.2,
+      lock_hold_ms: 8.7,
+      lock_resource_kind: 'model_index',
       cache: 'memory_hit',
       query_cache: {
         enabled: true,
@@ -64,6 +67,9 @@ describe('canonical log line schema (#216)', () => {
       tool: 'retrieve_knowledge',
       top_sources: ['a.md', 'b.md', 'c.md'],
       took_ms: 5,
+      lock_wait_ms: 1,
+      lock_hold_ms: 9,
+      lock_resource_kind: 'model_index',
       cache: 'memory_hit',
       query_cache: {
         enabled: true,
@@ -78,6 +84,10 @@ describe('canonical log line schema (#216)', () => {
     });
     expect(json.indexOf('"schema_version"')).toBeLessThan(json.indexOf('"request_id"'));
     expect(json.indexOf('"top_sources"')).toBeLessThan(json.indexOf('"took_ms"'));
+    expect(json.indexOf('"took_ms"')).toBeLessThan(json.indexOf('"lock_wait_ms"'));
+    expect(json.indexOf('"lock_wait_ms"')).toBeLessThan(json.indexOf('"lock_hold_ms"'));
+    expect(json.indexOf('"lock_hold_ms"')).toBeLessThan(json.indexOf('"lock_resource_kind"'));
+    expect(json.indexOf('"lock_resource_kind"')).toBeLessThan(json.indexOf('"cache"'));
     expect(json.indexOf('"cache"')).toBeLessThan(json.indexOf('"query_cache"'));
     expect(json.indexOf('"error"')).toBeLessThan(json.indexOf('"degraded"'));
     expect(json.indexOf('"degraded"')).toBeLessThan(json.indexOf('"degraded_stages"'));

--- a/src/canonical-log.ts
+++ b/src/canonical-log.ts
@@ -5,6 +5,7 @@ import { ActiveModelResolutionError } from './active-model.js';
 import type { QueryCacheOutcome, QueryCacheTelemetry } from './query-cache.js';
 import { readKBSlowQueryMs } from './config/logging.js';
 import type { DenseDegradationReason } from './search-core.js';
+import type { WriteLockResourceKind } from './metrics.js';
 
 export const CANONICAL_SCHEMA_VERSION = 'kb-canonical.v1';
 
@@ -75,6 +76,9 @@ export interface CanonicalLogEvent {
   top_score?: number;
   top_sources?: string[];
   took_ms: number;
+  lock_wait_ms?: number;
+  lock_hold_ms?: number;
+  lock_resource_kind?: WriteLockResourceKind;
   embed_ms?: number;
   faiss_ms?: number;
   format_ms?: number;
@@ -122,6 +126,9 @@ const CANONICAL_FIELD_ORDER: readonly (keyof CanonicalLogEvent)[] = [
   'top_score',
   'top_sources',
   'took_ms',
+  'lock_wait_ms',
+  'lock_hold_ms',
+  'lock_resource_kind',
   'embed_ms',
   'faiss_ms',
   'format_ms',
@@ -179,6 +186,9 @@ export function normalizeCanonicalEvent(input: CanonicalLogInput): CanonicalLogE
   assignIfDefined(event, 'result_count', input.result_count);
   assignIfDefined(event, 'top_score', input.top_score);
   assignIfDefined(event, 'top_sources', input.top_sources?.slice(0, 3));
+  assignIfDefined(event, 'lock_wait_ms', roundNonNegative(input.lock_wait_ms));
+  assignIfDefined(event, 'lock_hold_ms', roundNonNegative(input.lock_hold_ms));
+  assignIfDefined(event, 'lock_resource_kind', input.lock_resource_kind);
   assignIfDefined(event, 'embed_ms', roundNonNegative(input.embed_ms));
   assignIfDefined(event, 'faiss_ms', roundNonNegative(input.faiss_ms));
   assignIfDefined(event, 'format_ms', roundNonNegative(input.format_ms));

--- a/src/cli-research.test.ts
+++ b/src/cli-research.test.ts
@@ -116,6 +116,10 @@ function statsPayload(overrides: Partial<KbStatsPayload> = {}): KbStatsPayload {
         warn_threshold: 0.1,
       },
     },
+    write_locks: {
+      wait: {},
+      hold: {},
+    },
     ...overrides,
   };
 }

--- a/src/cli-serve.test.ts
+++ b/src/cli-serve.test.ts
@@ -633,6 +633,10 @@ describe('kb serve metrics formatting', () => {
           warn_threshold: 0.1,
         },
       },
+      write_locks: {
+        wait: {},
+        hold: {},
+      },
     };
 
     const text = formatStatsRunResultAsOpenMetrics({

--- a/src/cli-stats.test.ts
+++ b/src/cli-stats.test.ts
@@ -106,6 +106,10 @@ function payload(): KbStatsPayload {
         warn_threshold: 0.1,
       },
     },
+    write_locks: {
+      wait: {},
+      hold: {},
+    },
   };
 }
 

--- a/src/kb-stats.test.ts
+++ b/src/kb-stats.test.ts
@@ -428,6 +428,47 @@ describe('computeKbStats', () => {
     }
   });
 
+  it('surfaces write-lock wait and hold telemetry when recorded (issue #714)', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-stats-write-locks-'));
+    try {
+      await fsp.mkdir(path.join(tempDir, 'alpha'));
+      await fsp.writeFile(path.join(tempDir, 'alpha', 'a.md'), 'a');
+
+      const { computeKbStats } = await freshKbStats({
+        KNOWLEDGE_BASES_ROOT_DIR: tempDir,
+        FAISS_INDEX_PATH: path.join(tempDir, '.faiss'),
+      });
+      const { WriteLockMetrics } = await import('./metrics.js');
+      const writeLockMetrics = new WriteLockMetrics({ now: () => 1_700_000_000_000 });
+
+      const empty = await computeKbStats(makeManager({}) as any, {
+        serverVersion: '0.0.0',
+        startedAt: Date.now(),
+        writeLockMetrics,
+      });
+      expect(empty.write_locks).toEqual({ wait: {}, hold: {} });
+
+      writeLockMetrics.record({ resourceKind: 'model_index', waitMs: 12, holdMs: 80 });
+
+      const populated = await computeKbStats(makeManager({}) as any, {
+        serverVersion: '0.0.0',
+        startedAt: Date.now(),
+        writeLockMetrics,
+      });
+      expect(populated.write_locks.wait.model_index).toMatchObject({
+        count: 1,
+        sum_ms: 12,
+        since_started_at: new Date(1_700_000_000_000).toISOString(),
+      });
+      expect(populated.write_locks.hold.model_index).toMatchObject({
+        count: 1,
+        sum_ms: 80,
+      });
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it('summarizes dense flat-search latency and emits an advisory above the p95 threshold (#604)', async () => {
     const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-stats-search-latency-'));
     try {

--- a/src/kb-stats.ts
+++ b/src/kb-stats.ts
@@ -40,12 +40,15 @@ import {
   quantileFromBuckets,
   rerankMetrics,
   searchLatencyMetrics,
+  writeLockMetrics,
   type ProviderCallMetrics,
   type ProviderCallSnapshot,
   type RerankMetrics,
   type RerankMetricsSnapshot,
   type SearchLatencyMetrics,
   type SearchLatencyMetricsSnapshot,
+  type WriteLockMetrics,
+  type WriteLockMetricsSnapshot,
 } from './metrics.js';
 import { countIngestQuarantine } from './ingest-quarantine.js';
 import { queryEmbeddingCache, type QueryCacheStats } from './query-cache.js';
@@ -136,6 +139,11 @@ export interface KbStatsPayload {
   /** Issue #689 — process-lifetime reranker-stage counters and latency histograms. */
   rerank?: RerankMetricsSnapshot;
   /**
+   * Issue #714 — process-lifetime write-lock wait and hold histograms by
+   * coarse resource kind. No filesystem paths or model ids are used as labels.
+   */
+  write_locks: WriteLockMetricsSnapshot;
+  /**
    * Issue #430 — live counters for the optional HTTP/SSE MCP transport.
    * Omitted for stdio-only processes and for local `kb stats` invocations
    * that are not serving a remote transport.
@@ -182,6 +190,8 @@ export interface ComputeKbStatsOptions {
   searchMetrics?: SearchLatencyMetrics;
   /** Issue #689 — test seam for reranker-stage telemetry. */
   rerankMetrics?: RerankMetrics;
+  /** Issue #714 — test seam for write-lock wait/hold telemetry. */
+  writeLockMetrics?: WriteLockMetrics;
   /** Process-local HTTP/SSE counters, supplied by KnowledgeBaseServer when active. */
   remoteTransportStats?: TransportRuntimeStatsSnapshot;
 }
@@ -264,6 +274,7 @@ export async function computeKbStats(
   const metricsSource = options.metrics ?? providerCallMetrics;
   const searchMetricsSource = options.searchMetrics ?? searchLatencyMetrics;
   const rerankMetricsSource = options.rerankMetrics ?? rerankMetrics;
+  const writeLockMetricsSource = options.writeLockMetrics ?? writeLockMetrics;
   const searchMetricsSnapshot = searchMetricsSource.snapshot();
   const activeIndexType = indexStats.indexType ?? 'flat';
   const activeIndexFactory = indexFactoryForType(activeIndexType);
@@ -306,6 +317,7 @@ export async function computeKbStats(
     query_cache: await queryEmbeddingCache.stats(),
     relevance_gate: relevanceGateMetrics.snapshot(),
     rerank: rerankMetricsSource.snapshot(),
+    write_locks: writeLockMetricsSource.snapshot(),
     ...(options.remoteTransportStats !== undefined
       ? { remote_transport: options.remoteTransportStats }
       : {}),

--- a/src/metrics.test.ts
+++ b/src/metrics.test.ts
@@ -7,6 +7,7 @@ import {
   quantileFromBuckets,
   RerankMetrics,
   SearchLatencyMetrics,
+  WriteLockMetrics,
 } from './metrics.js';
 
 describe('bucketIndexForLatency (issue #210 — fixed-bucket histogram)', () => {
@@ -236,6 +237,34 @@ describe('RerankMetrics', () => {
       candidates: {},
       latency: {},
     });
+  });
+});
+
+describe('WriteLockMetrics', () => {
+  it('records wait and hold histograms by bounded resource kind', () => {
+    const metrics = new WriteLockMetrics({ now: () => 1_700_000_000_000 });
+
+    metrics.record({ resourceKind: 'model_index', waitMs: 12, holdMs: 80 });
+    metrics.record({ resourceKind: 'active_index', waitMs: 2, holdMs: 5 });
+
+    const snap = metrics.snapshot();
+    expect(snap.wait.model_index).toMatchObject({
+      count: 1,
+      sum_ms: 12,
+      since_started_at: '2023-11-14T22:13:20.000Z',
+    });
+    expect(snap.hold.model_index).toMatchObject({ count: 1, sum_ms: 80 });
+    expect(snap.wait.active_index).toMatchObject({ count: 1, sum_ms: 2 });
+    expect(snap.wait.other).toBeUndefined();
+  });
+
+  it('reset() clears write-lock telemetry', () => {
+    const metrics = new WriteLockMetrics();
+    metrics.record({ resourceKind: 'other', waitMs: 1, holdMs: 2 });
+
+    metrics.reset();
+
+    expect(metrics.snapshot()).toEqual({ wait: {}, hold: {} });
   });
 });
 

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -92,12 +92,18 @@ export interface SearchLatencyMetricsSnapshot {
 
 export type RerankSkipReason = 'disabled' | 'skip_domain' | 'no_candidates';
 export type RerankCandidateSource = 'cache_hit' | 'model_scored';
+export type WriteLockResourceKind = 'active_index' | 'model_index' | 'other';
 
 export interface RerankMetricsSnapshot {
   invocations: number;
   skipped: Partial<Record<RerankSkipReason, number>>;
   candidates: Partial<Record<RerankCandidateSource, number>>;
   latency: Partial<Record<RerankCandidateSource, LatencyHistogramSnapshot>>;
+}
+
+export interface WriteLockMetricsSnapshot {
+  wait: Partial<Record<WriteLockResourceKind, LatencyHistogramSnapshot>>;
+  hold: Partial<Record<WriteLockResourceKind, LatencyHistogramSnapshot>>;
 }
 
 function emptyState(now: number): MetricsState {
@@ -419,6 +425,59 @@ export class RerankMetrics {
   }
 }
 
+/**
+ * Process-lifetime write-lock telemetry. Labels stay bounded to coarse
+ * resource kinds so model directories and KB paths never enter metrics.
+ */
+export class WriteLockMetrics {
+  private readonly waitStates = new Map<WriteLockResourceKind, HistogramState>();
+  private readonly holdStates = new Map<WriteLockResourceKind, HistogramState>();
+  private readonly now: () => number;
+
+  constructor(options: { now?: () => number } = {}) {
+    this.now = options.now ?? Date.now;
+  }
+
+  record(sample: { resourceKind: WriteLockResourceKind; waitMs: number; holdMs: number }): void {
+    recordHistogramSample(this.getState(this.waitStates, sample.resourceKind), sample.waitMs);
+    recordHistogramSample(this.getState(this.holdStates, sample.resourceKind), sample.holdMs);
+  }
+
+  snapshot(): WriteLockMetricsSnapshot {
+    return {
+      wait: this.snapshotStates(this.waitStates),
+      hold: this.snapshotStates(this.holdStates),
+    };
+  }
+
+  reset(): void {
+    this.waitStates.clear();
+    this.holdStates.clear();
+  }
+
+  private getState(
+    states: Map<WriteLockResourceKind, HistogramState>,
+    resourceKind: WriteLockResourceKind,
+  ): HistogramState {
+    let state = states.get(resourceKind);
+    if (state === undefined) {
+      state = emptyHistogramState(this.now());
+      states.set(resourceKind, state);
+    }
+    return state;
+  }
+
+  private snapshotStates(
+    states: Map<WriteLockResourceKind, HistogramState>,
+  ): Partial<Record<WriteLockResourceKind, LatencyHistogramSnapshot>> {
+    const out: Partial<Record<WriteLockResourceKind, LatencyHistogramSnapshot>> = {};
+    for (const [resourceKind, state] of states.entries()) {
+      out[resourceKind] = snapshotHistogram(state);
+    }
+    return out;
+  }
+}
+
 function clampCount(value: number): number {
   return Number.isFinite(value) && value > 0 ? Math.floor(value) : 0;
 }
@@ -442,6 +501,8 @@ export const providerCallMetrics = new ProviderCallMetrics();
 export const searchLatencyMetrics = new SearchLatencyMetrics();
 
 export const rerankMetrics = new RerankMetrics();
+
+export const writeLockMetrics = new WriteLockMetrics();
 
 /**
  * Wrap a langchain-shaped embeddings client so every `embedQuery` /

--- a/src/prometheus-export.test.ts
+++ b/src/prometheus-export.test.ts
@@ -35,6 +35,12 @@ describe('formatKbStatsOpenMetrics', () => {
     expect(text).toContain('# TYPE kb_rerank_latency_ms histogram');
     expect(text).toContain('kb_rerank_latency_ms_bucket{le="30",source="model_scored"} 1');
     expect(text).toContain('kb_rerank_latency_ms_sum{source="model_scored"} 12');
+    expect(text).toContain('# TYPE kb_write_lock_wait_duration_ms histogram');
+    expect(text).toContain('kb_write_lock_wait_duration_ms_bucket{le="30",resource_kind="model_index"} 1');
+    expect(text).toContain('kb_write_lock_wait_duration_ms_sum{resource_kind="model_index"} 12');
+    expect(text).toContain('# TYPE kb_write_lock_hold_duration_ms histogram');
+    expect(text).toContain('kb_write_lock_hold_duration_ms_bucket{le="100",resource_kind="model_index"} 1');
+    expect(text).toContain('kb_write_lock_hold_duration_ms_sum{resource_kind="model_index"} 80');
     expect(text).toContain('kb_remote_transport_requests_total 9');
     expect(text).toContain('# TYPE kb_remote_transport_responses_4xx counter');
     expect(text).toContain('kb_remote_transport_responses_4xx_total 2');
@@ -172,6 +178,14 @@ function samplePayload(): KbStatsPayload {
       },
       latency: {
         model_scored: histogramSnapshot(12),
+      },
+    },
+    write_locks: {
+      wait: {
+        model_index: histogramSnapshot(12),
+      },
+      hold: {
+        model_index: histogramSnapshot(80),
       },
     },
     remote_transport: {

--- a/src/prometheus-export.ts
+++ b/src/prometheus-export.ts
@@ -6,6 +6,7 @@ import {
   type SearchLatencyMetricsSnapshot,
   type SearchLatencyMode,
   type SearchLatencyStatus,
+  type WriteLockMetricsSnapshot,
 } from './metrics.js';
 
 interface MetricSample {
@@ -186,6 +187,7 @@ export function formatKbStatsOpenMetrics(payload: KbStatsPayload): string {
   }
   lines.push(...searchLatencyHistogramLines(payload.search_latency));
   lines.push(...rerankLatencyHistogramLines(payload.rerank));
+  lines.push(...writeLockHistogramLines(payload.write_locks));
   lines.push('# EOF');
   return `${lines.join('\n')}\n`;
 }
@@ -397,6 +399,32 @@ function rerankLatencyHistogramLines(snapshot: RerankMetricsSnapshot | undefined
     help: 'Reranker-stage latency in milliseconds, split by bounded scoring source.',
     rows,
   });
+}
+
+function writeLockHistogramLines(snapshot: WriteLockMetricsSnapshot): string[] {
+  return [
+    ...renderHistogramFamily({
+      name: 'kb_write_lock_wait_duration_ms',
+      help: 'Write-lock acquisition wait time in milliseconds, split by bounded resource kind.',
+      rows: writeLockHistogramRows(snapshot.wait),
+    }),
+    ...renderHistogramFamily({
+      name: 'kb_write_lock_hold_duration_ms',
+      help: 'Write-lock function hold time in milliseconds, split by bounded resource kind.',
+      rows: writeLockHistogramRows(snapshot.hold),
+    }),
+  ];
+}
+
+function writeLockHistogramRows(
+  snapshots: WriteLockMetricsSnapshot['wait'],
+): HistogramRow[] {
+  const rows: HistogramRow[] = [];
+  for (const [resourceKind, histogram] of Object.entries(snapshots)) {
+    if (histogram === undefined) continue;
+    rows.push({ labels: { resource_kind: resourceKind }, histogram });
+  }
+  return rows;
 }
 
 function requestHistogramRows(snapshot: SearchLatencyMetricsSnapshot): HistogramRow[] {

--- a/src/write-lock.test.ts
+++ b/src/write-lock.test.ts
@@ -28,6 +28,7 @@ describe('withWriteLock', () => {
 
   it('acquires the lock, runs fn, releases', async () => {
     jest.resetModules();
+    const { writeLockMetrics } = await import('./metrics.js');
     const { withWriteLock, writeLockOwnerPathFor } = await import('./write-lock.js');
 
     let observed: { lockedDuringFn: boolean; ownerPid: number | null } = {
@@ -47,9 +48,20 @@ describe('withWriteLock', () => {
     expect(result).toBe('value');
     expect(observed.lockedDuringFn).toBe(true);
     expect(observed.ownerPid).toBe(process.pid);
+    expect(writeLockMetrics.snapshot().wait.active_index).toMatchObject({ count: 1 });
+    expect(writeLockMetrics.snapshot().hold.active_index).toMatchObject({ count: 1 });
     // Lock released after fn.
     await expect(fsp.stat(lockPath)).rejects.toMatchObject({ code: 'ENOENT' });
     await expect(fsp.stat(writeLockOwnerPathFor(tempDir))).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('classifies write-lock resources without exposing raw paths', async () => {
+    jest.resetModules();
+    const { writeLockResourceKindFor } = await import('./write-lock.js');
+
+    expect(writeLockResourceKindFor(tempDir)).toBe('active_index');
+    expect(writeLockResourceKindFor(path.join(tempDir, 'models', 'ollama__model'))).toBe('model_index');
+    expect(writeLockResourceKindFor(path.join(os.tmpdir(), 'outside-kb-index'))).toBe('other');
   });
 
   it('serializes concurrent callers (second waits for the first)', async () => {

--- a/src/write-lock.ts
+++ b/src/write-lock.ts
@@ -15,8 +15,10 @@ import * as fsp from 'fs/promises';
 import * as os from 'os';
 import * as path from 'path';
 import * as properLockfile from 'proper-lockfile';
+import { classifyCanonicalError, emitCanonicalLog, type CanonicalError } from './canonical-log.js';
 import { FAISS_INDEX_PATH } from './config/paths.js';
 import { logger } from './logger.js';
+import { writeLockMetrics, type WriteLockResourceKind } from './metrics.js';
 
 export const WRITE_LOCK_STALE_MS = 10_000;
 
@@ -93,6 +95,8 @@ export async function withWriteLock<T>(resource: string, fn: () => Promise<T>): 
 
   const lockfilePath = path.join(resource, '.kb-write.lock');
   const ownerPath = writeLockOwnerPathFor(resource);
+  const resourceKind = writeLockResourceKindFor(resource);
+  const waitStart = performanceNow();
   let release: () => Promise<void>;
   try {
     release = await properLockfile.lock(resource, {
@@ -109,10 +113,25 @@ export async function withWriteLock<T>(resource: string, fn: () => Promise<T>): 
     }
     throw err;
   }
+  const waitMs = performanceNow() - waitStart;
   await writeLockOwnerMetadata(ownerPath);
+  const holdStart = performanceNow();
+  let holdMs = 0;
+  let canonicalError: CanonicalError | undefined;
   try {
     return await fn();
+  } catch (err) {
+    canonicalError = classifyCanonicalError(err);
+    throw err;
   } finally {
+    holdMs = performanceNow() - holdStart;
+    writeLockMetrics.record({ resourceKind, waitMs, holdMs });
+    emitWriteLockTiming({
+      resourceKind,
+      waitMs,
+      holdMs,
+      error: canonicalError,
+    });
     try {
       await fsp.rm(ownerPath, { force: true });
     } catch (err) {
@@ -139,6 +158,18 @@ export function writeLockOwnerPathFor(resource: string): string {
   return path.join(resource, '.kb-write.lock.owner.json');
 }
 
+export function writeLockResourceKindFor(resource: string): WriteLockResourceKind {
+  const resolvedResource = path.resolve(resource);
+  const resolvedFaissRoot = path.resolve(FAISS_INDEX_PATH);
+  if (resolvedResource === resolvedFaissRoot) return 'active_index';
+  const modelsRoot = path.join(resolvedFaissRoot, 'models');
+  const relativeToModels = path.relative(modelsRoot, resolvedResource);
+  if (relativeToModels !== '' && !relativeToModels.startsWith('..') && !path.isAbsolute(relativeToModels)) {
+    return 'model_index';
+  }
+  return 'other';
+}
+
 async function writeLockOwnerMetadata(ownerPath: string): Promise<void> {
   const metadata: WriteLockOwnerMetadata = {
     schema_version: WRITE_LOCK_OWNER_SCHEMA_VERSION,
@@ -161,6 +192,35 @@ function safeCwd(): string | null {
   } catch {
     return null;
   }
+}
+
+function emitWriteLockTiming(input: {
+  resourceKind: WriteLockResourceKind;
+  waitMs: number;
+  holdMs: number;
+  error?: CanonicalError;
+}): void {
+  emitCanonicalLog({
+    process: canonicalProcessKind(),
+    event: 'write_lock',
+    took_ms: input.waitMs + input.holdMs,
+    lock_wait_ms: input.waitMs,
+    lock_hold_ms: input.holdMs,
+    lock_resource_kind: input.resourceKind,
+    ...(input.error === undefined ? {} : { error: input.error }),
+  });
+}
+
+function canonicalProcessKind(): 'cli' | 'mcp' {
+  const argv = process.argv.map((entry) => path.basename(entry));
+  return argv.some((entry) => entry === 'kb' || entry === 'cli.js') ? 'cli' : 'mcp';
+}
+
+function performanceNow(): number {
+  if (typeof performance !== 'undefined' && typeof performance.now === 'function') {
+    return performance.now();
+  }
+  return Date.now();
 }
 
 /**


### PR DESCRIPTION
## Summary
- record write-lock acquisition wait and function hold timings in canonical logs
- expose process-lifetime write-lock wait/hold histograms through kb_stats and OpenMetrics
- document the bounded resource_kind label and keep coverage collection using the root ts-jest transform

## Test plan
- npm run build
- npm run test:file -- src/metrics.test.ts src/canonical-log.test.ts src/write-lock.test.ts src/kb-stats.test.ts src/prometheus-export.test.ts src/cli-stats.test.ts src/cli-research.test.ts src/cli-serve.test.ts
- npm run test:file -- src/KnowledgeBaseServer.test.ts
- npm run lint
- npm run check

Closes #714