### PR TITLE
fix: align docs and implementation and improve docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,8 @@ kb models list
 kb models add ollama nomic-embed-text          # local, free
 kb models add openai text-embedding-3-small    # paid; estimate first
 kb models add huggingface BAAI/bge-small-en-v1.5
+kb models add ollama nomic-embed-text --index-type=sq8   # FAISS scalar quantization
+kb models add ollama nomic-embed-text --index-type=hnsw  # HNSW approximate search backend
 
 # Query a specific model without changing the default.
 kb search "your query" --model=openai__text-embedding-3-small
@@ -276,7 +278,7 @@ kb models set-active openai__text-embedding-3-small
 kb models remove huggingface__BAAI-bge-small-en-v1.5
 ```
 
-`<model_id>` is `<provider>__<filesystem-safe-slug>`, derived deterministically from `(provider, model_name)` as typed (e.g. `OLLAMA_MODEL=nomic-embed-text:latest` → `ollama__nomic-embed-text-latest`). On-disk layout: each model lives at `${FAISS_INDEX_PATH}/models/<id>/`. The active model is recorded in `${FAISS_INDEX_PATH}/active.txt` and overridable per-process via `KB_ACTIVE_MODEL`. See [`docs/reference/embedding-models.md`](docs/reference/embedding-models.md) for the supported defaults, vector dimensions, task-prefix requirements, and reindex caveats; see [`docs/rfcs/013-multimodel-support.md`](docs/rfcs/013-multimodel-support.md) for the full design.
+`<model_id>` is `<provider>__<filesystem-safe-slug>`, derived deterministically from `(provider, model_name)` as typed (e.g. `OLLAMA_MODEL=nomic-embed-text:latest` → `ollama__nomic-embed-text-latest`). On-disk layout: each model lives at `${FAISS_INDEX_PATH}/models/<id>/`. The active model is recorded in `${FAISS_INDEX_PATH}/active.txt` and overridable per-process via `KB_ACTIVE_MODEL`. `KB_INDEX_TYPE` or `kb models add --index-type=flat|sq8|hnsw` selects the per-model search index type; see [docs/operations/index-quantization.md](docs/operations/index-quantization.md). See [`docs/reference/embedding-models.md`](docs/reference/embedding-models.md) for the supported defaults, vector dimensions, task-prefix requirements, and reindex caveats; see [`docs/rfcs/013-multimodel-support.md`](docs/rfcs/013-multimodel-support.md) for the full design.
 
 **Migration from the legacy single-model layout** is automatic on first server (or `kb`) start: the existing single-model index is moved into `${FAISS_INDEX_PATH}/models/<derived_id>/` and `active.txt` is written. Cross-process starts coordinate the migration with `${FAISS_INDEX_PATH}/.kb-migration.lock`; MCP and CLI processes no longer rely on a long-lived single-instance PID advisory. Keep a backup of the previous `${FAISS_INDEX_PATH}` if you need rollback safety before upgrading from an older checkout.
 

--- a/docs/architecture/adr/0001-faiss-over-qdrant.md
+++ b/docs/architecture/adr/0001-faiss-over-qdrant.md
@@ -1,6 +1,6 @@
 # 0001 — FAISS (embedded) over a standalone vector DB
 
-- **Status:** Accepted; concurrency and layout notes superseded by RFC 013/014
+- **Status:** Accepted for the default embedded store; concurrency/layout notes superseded by RFC 013/014 and opt-in HNSW backend added later
 - **Date:** 2026-04-24 (back-documented)
 - **Deciders:** Repo owner
 
@@ -25,9 +25,10 @@ The server needs a vector store. It must persist across restarts, survive the us
 
 ## Decision Outcome
 
-**Option 1 — embedded FAISS.** The implementation still uses FAISS through the
-LangChain community store and `faiss-node`, wrapped by local layout and adapter
-helpers.
+**Option 1 — embedded FAISS.** The default implementation still uses FAISS
+through the LangChain community store and `faiss-node`, wrapped by local layout
+and adapter helpers. Later HNSW work added an opt-in embedded `hnswlib-node`
+backend under the same local-file model; it does not add a standalone vector DB.
 
 Current layout note: the original root-level `$FAISS_INDEX_PATH/faiss.index`
 description is historical. Current saves are per model under

--- a/docs/architecture/adr/0010-hnsw-binding-evaluation.md
+++ b/docs/architecture/adr/0010-hnsw-binding-evaluation.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted.
+Accepted; hnswlib backend path implemented.
 
 ## Context
 
@@ -65,6 +65,20 @@ Recommended path for #596:
 
 In short: **no-go for status-quo `faiss-node` HNSW factory work; conditional
 go for either FAISS accessors or a dedicated `hnswlib-node` backend.**
+
+## Current Implementation
+
+The project has since taken the dedicated `hnswlib-node` backend path. The
+implemented surface is `KB_INDEX_TYPE=hnsw` or
+`kb models add --index-type=hnsw`, with tuning through `KB_HNSW_M`,
+`KB_HNSW_EF_CONSTRUCTION`, `KB_HNSW_EF_SEARCH`, and
+`KB_HNSW_RANDOM_SEED`.
+
+The layout follows the recommendation in this ADR: HNSW stores
+`index.vN/hnsw.index`, a project-owned JSON `docstore.json`, and HNSW
+parameters in `integrity.json`; the loader reapplies `efSearch` after every
+load. FAISS `flat` and `sq8` remain the default/recommended modes unless local
+fixtures show the approximate HNSW trade-off is worthwhile for a shelf.
 
 ## Comparison
 

--- a/docs/architecture/c4-component.md
+++ b/docs/architecture/c4-component.md
@@ -1,190 +1,163 @@
 # C4 — Component
 
-Zooming into the server process from [`c4-container.md`](./c4-container.md). The current source tree is an acyclic set of focused helpers around three orchestration surfaces: the MCP server, the FAISS index manager, and the CLI.
+Zooming into the package from [`c4-container.md`](./c4-container.md). The current source tree is still organized around three orchestration surfaces: the MCP server, the `kb` CLI dispatcher, and `FaissIndexManager`. The implementation below those surfaces is broader than the first architecture snapshot: retrieval now includes dense, lexical, hybrid, reranking, gate, metrics, FAISS/HNSW backends, and multiple operator workflows.
 
 ## Diagram
 
 ```mermaid
 flowchart TB
-  Entry["index.ts:1-11<br/>process entrypoint"]
-  CLI["cli.ts:62-150<br/>kb command dispatcher"]
+  Entry["index.ts<br/>server process entrypoint"]
+  CLI["cli.ts<br/>35-command kb dispatcher"]
 
-  subgraph cli["CLI handlers"]
-    CliList["cli-list.ts:1-15<br/>list command"]
-    CliSearch["cli-search.ts:37-250<br/>search command"]
-    CliCompare["cli-compare.ts:1-125<br/>compare command"]
-    CliModels["cli-models.ts:22-327<br/>models command"]
-    CliShared["cli-shared.ts:1-52<br/>CLI manager loading"]
+  subgraph cli["CLI command families"]
+    ReadCli["read/search<br/>list, search, open, related, stats, explain, where"]
+    WriteCli["KB writes<br/>remember, capture, import-url, ask --save-transcript"]
+    OpsCli["operations<br/>doctor, logs, backup, restore, verify, quarantine, stale-check, superseded, promote"]
+    EvalCli["evaluation<br/>eval, eval-gate, feedback, research"]
+    ModelCli["models and services<br/>models, compare, reindex, cache, llm, serve, config, completion"]
+    CliShared["cli-shared.ts / *-core.ts<br/>shared command-independent helpers"]
   end
 
   subgraph server["MCP runtime"]
-    KBS["KnowledgeBaseServer.ts:191-790<br/>tools, resources, transports, warmup"]
-    SSE["transport/sse.ts<br/>SSE host and session dispatch"]
-    Watcher["triggerWatcher.ts:41-209<br/>polling reindex trigger"]
+    KBS["KnowledgeBaseServer.ts<br/>tools, resources, prompts, transports"]
+    ToolSpecs["mcp-tool-specs.ts<br/>tool schema source of truth"]
+    Resources["mcp-resources.ts<br/>kb:// list/read"]
+    Prompts["mcp-prompts.ts<br/>optional prompt templates"]
+    Http["transport/http.ts + transport/sse.ts<br/>remote MCP hosts"]
+    Watchers["triggerWatcher.ts + recursive-fs-watch.ts<br/>optional refresh triggers"]
   end
 
-  subgraph index["Indexing and retrieval"]
-    FIM["FaissIndexManager.ts:244-1413<br/>provider, ingest, search, stats"]
-    FaissLayout["faiss-store-layout.ts:13-211<br/>versioned FAISS load/save"]
-    Loaders["loaders.ts:28-101<br/>extension-routed file loading"]
-    Format["formatter.ts:25-88<br/>retrieval wire formatting"]
-    Lock["write-lock.ts:17-72<br/>per-resource write locks"]
+  subgraph retrieval["Retrieval and answering"]
+    FIM["FaissIndexManager.ts<br/>model-scoped ingest/search/stats"]
+    SearchCore["search-core.ts / hybrid-retrieval.ts / lexical-index.ts<br/>dense, lexical, hybrid retrieval"]
+    Ask["ask-core.ts / llm-client.ts<br/>answer generation"]
+    Gate["relevance-gate.ts / reranker.ts<br/>optional post-retrieval stages"]
+    Formatter["formatter.ts / injection-guard.ts<br/>wire formatting and untrusted-content guard"]
   end
 
-  subgraph model["Model and KB filesystem"]
-    Active["active-model.ts:32-381<br/>model dirs, registration, active resolution"]
-    ModelId["model-id.ts:8-66<br/>model id parsing and validation"]
-    KbFs["kb-fs.ts:11-90<br/>KB listing and document path resolution"]
-    FileUtils["file-utils.ts:6-46<br/>SHA256 and recursive walk"]
-    IngestFilter["ingest-filter.ts<br/>ingestable path rules"]
-    KbPaths["kb-paths.ts<br/>KB name validation"]
-    Frontmatter["frontmatter.ts:16-83<br/>YAML frontmatter parsing"]
-    ErrorUtils["error-utils.ts:1-23<br/>unknown-to-Error coercion"]
+  subgraph storage["Storage and indexing"]
+    Active["active-model.ts<br/>model registry and active model"]
+    Layout["faiss-store-layout.ts<br/>versioned index load/save"]
+    FaissAdapter["faiss-store-adapter.ts<br/>FAISS backend adapter"]
+    HnswAdapter["hnsw-index-adapter.ts<br/>HNSW backend adapter"]
+    DocstoreCas["docstore-cas.ts<br/>docstore hardlink CAS"]
+    FileIngest["file-ingest.ts / loaders.ts<br/>chunking, manifests, loaders"]
+    KbFs["kb-fs.ts / kb-paths.ts / ingest-filter.ts<br/>KB enumeration and path safety"]
   end
 
-  Config["config/*.ts<br/>env-derived runtime config"]
-  Logger["logger.ts:14-74<br/>stderr logger + optional file mirror"]
-  Errors["errors.ts:1-23<br/>typed KB errors"]
-  OllamaErr["ollama-error.ts:34-108<br/>Ollama retry/error translation"]
-  Costs["cost-estimates.ts:11-60<br/>CLI model-add estimates"]
+  subgraph cross["Cross-cutting"]
+    Config["config/*.ts + transport-config.ts<br/>env/config schema"]
+    Lock["write-lock.ts<br/>per-model and sidecar locks"]
+    Logs["logger.ts / canonical-log.ts<br/>stderr, canonical logs"]
+    Metrics["metrics.ts / prometheus-export.ts / otel-trace.ts<br/>observability"]
+    Errors["errors.ts / error-utils.ts<br/>typed errors"]
+  end
 
   Entry --> KBS
-  CLI --> FIM
-  CLI --> CliList
-  CLI --> CliSearch
-  CLI --> CliCompare
-  CLI --> CliModels
-  CliList --> KbFs
-  CliSearch --> Active
-  CliSearch --> FIM
-  CliSearch --> Format
-  CliSearch --> Lock
-  CliSearch --> FileUtils
-  CliSearch --> IngestFilter
-  CliSearch --> CliShared
-  CliCompare --> Active
-  CliCompare --> FIM
-  CliCompare --> Format
-  CliCompare --> CliShared
-  CliModels --> Active
-  CliModels --> FIM
-  CliModels --> KbFs
-  CliModels --> Lock
-  CliModels --> Costs
-  CliModels --> FileUtils
-  CliModels --> IngestFilter
+  CLI --> ReadCli
+  CLI --> WriteCli
+  CLI --> OpsCli
+  CLI --> EvalCli
+  CLI --> ModelCli
+  ReadCli --> CliShared
+  WriteCli --> CliShared
+  OpsCli --> CliShared
+  EvalCli --> CliShared
+  ModelCli --> CliShared
   CliShared --> FIM
+  CliShared --> Active
 
+  KBS --> ToolSpecs
+  KBS --> Resources
+  KBS --> Prompts
+  KBS --> Http
+  KBS --> Watchers
   KBS --> FIM
-  KBS --> Active
-  KBS --> Config
-  KBS --> Format
-  KBS --> KbFs
-  KBS --> Lock
-  KBS --> SSE
-  KBS --> Watcher
-  KBS --> ErrorUtils
-  KBS --> FileUtils
-  KBS --> IngestFilter
-  KBS --> KbPaths
-  KBS --> Errors
+  KBS --> Ask
+  KBS --> Gate
+  KBS --> Formatter
 
+  FIM --> SearchCore
   FIM --> Active
-  FIM --> Config
-  FIM --> Errors
+  FIM --> Layout
+  FIM --> FileIngest
   FIM --> KbFs
-  FIM --> FaissLayout
-  FIM --> FileUtils
-  FIM --> Frontmatter
-  FIM --> IngestFilter
-  FIM --> Loaders
-  FIM --> Logger
-  FIM --> ModelId
-  FIM --> OllamaErr
-  FIM --> ErrorUtils
+  Layout --> FaissAdapter
+  Layout --> HnswAdapter
+  Layout --> DocstoreCas
+  SearchCore --> Formatter
+  Ask --> SearchCore
 
-  Active --> Config
-  Active --> Logger
-  Active --> ModelId
-  KbFs --> KbPaths
-  SSE --> Config
-  SSE --> Logger
-  Watcher --> Logger
-  FaissLayout --> Logger
-  FileUtils --> Logger
-  IngestFilter --> Logger
-  Lock --> Logger
-  OllamaErr --> Errors
+  KBS --> Config
+  CLI --> Config
+  FIM --> Config
+  KBS --> Lock
+  CLI --> Lock
+  FIM --> Lock
+  KBS --> Logs
+  CLI --> Logs
+  FIM --> Logs
+  KBS --> Metrics
+  SearchCore --> Metrics
+  KBS --> Errors
+  FIM --> Errors
 ```
 
 ## Components
 
 | Component | File | Responsibility | Public surface touched elsewhere |
 | --- | --- | --- | --- |
-| Process entrypoint | `src/index.ts:1-11` | Constructs `KnowledgeBaseServer`, runs it, and converts top-level failures to process exit code 1. | Imported by no source module. |
-| MCP server | `src/KnowledgeBaseServer.ts:191-790` | Registers MCP tools/resources, resolves model managers, coordinates retrieval, starts stdio/SSE transports, warmup, shutdown, and reindex watcher. | `KnowledgeBaseServer.run()` from `src/index.ts:8`. |
-| FAISS index manager | `src/FaissIndexManager.ts:244-1413` | Owns embedding provider instances, ingest/update, search, index stats, and chunk metadata shaping. | `initialize()`, `updateIndex()`, `similaritySearch()`, `stats()`, `resolveActiveIndexFilePath()`. |
-| FAISS store layout | `src/faiss-store-layout.ts:13-211` | Owns versioned FAISS `index -> index.vN` load/save, legacy fallback, symlink swaps, and version garbage collection. | Used by FAISS manager wrappers and active-model index path resolution. |
-| CLI dispatcher | `src/cli.ts:62-150` | Implements help/version handling, subcommand dispatch, and process-driver detection for the `kb` binary. | `main(argv)` and the package `bin` entries in `package.json:5-9`. |
-| CLI search handler | `src/cli-search.ts:37-250` | Parses search args, optionally refreshes under the write lock, runs similarity search, and reports staleness. | Called only by the CLI dispatcher. |
-| CLI model handler | `src/cli-models.ts:22-327` | Handles model list/add/set-active/remove, cost estimates, model registration, active model writes, and incomplete-add cleanup. | Called only by the CLI dispatcher. |
-| CLI compare/list/shared helpers | `src/cli-compare.ts:1-125`, `src/cli-list.ts:1-15`, `src/cli-shared.ts:1-52` | Keep compare/list output and CLI manager loading separate from search/model flows. | Called only by CLI handlers. |
-| Active model store | `src/active-model.ts:32-381` | Single owner of `models/<id>/` paths, registered-model discovery, active-model resolution, and `active.txt` writes. | Used by CLI, MCP server, and FAISS manager. |
-| Model id helpers | `src/model-id.ts:8-66` | Validates and derives provider-qualified model ids. | Used by active-model, CLI, FAISS manager, and cost estimates. |
-| KB filesystem helpers | `src/kb-fs.ts:11-90` | Lists KB directories and resolves exposed MCP resource document paths. | Used by CLI, MCP server, and FAISS manager. |
-| File utilities | `src/file-utils.ts:6-46` | SHA256 hashing and recursive, dotfile-skipping file walks. | Used by CLI handlers and FAISS manager. |
-| Ingest filter | `src/ingest-filter.ts` | Applies corpus inclusion/exclusion rules and public skipped-filename patterns. | Used by CLI handlers, MCP server, and FAISS manager. |
-| KB path validation | `src/kb-paths.ts` | Validates KB names. Document path resolution without traversal or symlink escape lives in `src/kb-fs.ts` and `src/mcp-resources.ts`. | Used by MCP server, resources, and KB FS. |
-| Frontmatter parser | `src/frontmatter.ts:16-83` | Parses bounded FAILSAFE YAML frontmatter into tags/body/raw object. | Used by FAISS manager chunk metadata shaping. |
-| Error utilities | `src/error-utils.ts:1-23` | Converts unknown thrown values into stable `Error` instances at catch boundaries. | Used by MCP server and FAISS manager. |
-| Config | `src/config/*.ts`, `src/transport-config.ts` | Reads env-derived runtime config at module load; validates MCP transport settings at startup. | Used by most runtime modules. |
-| Formatter | `src/formatter.ts:25-88` | Sanitizes metadata and formats retrieval results as markdown/JSON. | Used by CLI and MCP server. |
-| Loaders | `src/loaders.ts:28-101` | Routes file loading by extension for plain text, PDF, and HTML. | Used by FAISS manager. |
-| Write lock | `src/write-lock.ts:17-72` | Serializes write paths with `proper-lockfile`. | Used by CLI and MCP server. |
-| SSE host | `src/transport/sse.ts` | Hosts MCP-over-SSE sessions with auth/origin checks and per-session `McpServer` instances. | Used by `KnowledgeBaseServer.runSse()`. |
-| Trigger watcher | `src/triggerWatcher.ts:41-209` | Polls a trigger file and requests reindexing when mtime changes. | Used by `KnowledgeBaseServer.startTriggerWatcher()`. |
-| Logger | `src/logger.ts:14-74` | Writes logs to stderr and optional `LOG_FILE`, preserving stdout for JSON-RPC/CLI output. | Imported by runtime modules. |
-| Error taxonomy | `src/errors.ts:1-23` | Defines `KBError` codes for operator-facing failure paths. | Used by FAISS manager, MCP server, and Ollama error translation. |
-| Ollama error translation | `src/ollama-error.ts:34-108` | Detects non-retryable Ollama context-length failures and maps them to `KBError`. | Used by FAISS manager provider setup. |
+| Process entrypoint | `src/index.ts` | Constructs `KnowledgeBaseServer`, runs it, and converts top-level failures to process exit code 1. | Package `knowledge-base-mcp-server` bin. |
+| MCP server | `src/KnowledgeBaseServer.ts` | Registers MCP tools/resources/prompts, resolves model managers, coordinates retrieval/ask/write handlers, starts stdio/SSE/HTTP transports, warmup, shutdown, and reindex watchers. | `KnowledgeBaseServer.run()` from the process entrypoint. |
+| MCP tool specs | `src/mcp-tool-specs.ts` | Single source of truth for MCP tool names, descriptions, input schemas, and ingest gating. | Used by server registration and generated `docs/reference/mcp-tools.md`. |
+| MCP resources and prompts | `src/mcp-resources.ts`, `src/mcp-prompts.ts` | Expose `kb://` source-document list/read and optional prompt templates. | Registered from `KnowledgeBaseServer.buildMcpServer()`. |
+| Remote transports | `src/transport/http.ts`, `src/transport/sse.ts`, `src/transport/base-http-host.ts`, `src/transport-config.ts` | Host streamable HTTP/SSE sessions with bearer auth, origin checks, backoff, runtime counters, and health/metrics endpoints. | Selected by `MCP_TRANSPORT`. |
+| CLI dispatcher | `src/cli.ts` | Loads package `.env`, owns help/version/daemon routing, and dispatches 35 subcommands from the `SUBCOMMANDS` registry. | Package `kb` bin and generated `docs/reference/cli.md`. |
+| CLI command modules | `src/cli-*.ts` | Implement shell workflows: search/list/open/related, ask/remember/capture/import-url, model management, diagnostics, logs, backup/restore, eval/feedback/research, daemon/service helpers, cache, config, and completion. | Called only by `src/cli.ts` or other CLI modules. |
+| Shared CLI/core helpers | `src/cli-shared.ts`, `src/*-core.ts` | Keep command-independent logic reusable by CLI, MCP, tests, and benchmarks. | Used by CLI handlers and selected server paths. |
+| FAISS index manager | `src/FaissIndexManager.ts` | Model-scoped owner of embedding clients, ingest/update, sidecars, backend load/save, similarity search, stats, and chunk metadata shaping. | Constructed by CLI shared loading, `ManagerRegistry`, and read-only server helpers. |
+| Search backends | `src/faiss-store-adapter.ts`, `src/hnsw-index-adapter.ts`, `src/search-index-adapter.ts` | Present FAISS and HNSW stores behind a shared search-index adapter surface. | Loaded/saved by `faiss-store-layout.ts`, queried by `FaissIndexManager`. |
+| Versioned store layout | `src/faiss-store-layout.ts` | Owns `index -> index.vN` load/save, backend/integrity manifests, legacy fallback, symlink swaps, retention pruning, and HNSW/FAISS backend dispatch. | Used by `FaissIndexManager` and diff/verify flows. |
+| Docstore CAS | `src/docstore-cas.ts` | Canonicalizes FAISS `docstore.json` payloads and hardlinks identical docstores through `$FAISS_INDEX_PATH/.docstore-cas/`. | Called during FAISS atomic saves. |
+| Active model store | `src/active-model.ts` | Single owner of `models/<id>/` paths, registered-model discovery, `model_name.txt`, `index-type.txt`, incomplete-add state, and `active.txt` resolution/writes. | Used by CLI, MCP server, manager registry, and FAISS manager. |
+| Ingest and loaders | `src/file-ingest.ts`, `src/loaders.ts`, `src/ingest-quarantine.ts`, `src/secret-scanner.ts` | Build chunks/manifests, route extension-specific extraction, quarantine failed/secret-bearing files, and write sidecars. | Used by `FaissIndexManager` and inspect/doctor surfaces. |
+| Retrieval composition | `src/search-core.ts`, `src/hybrid-retrieval.ts`, `src/lexical-index.ts`, `src/rrf.ts`, `src/retrieval-views.ts` | Implement dense, lexical, hybrid RRF, retrieval views, scoring/diagnostics, and fallback/degradation behavior. | Used by CLI search, MCP retrieval, eval, and research flows. |
+| Answering and relevance | `src/ask-core.ts`, `src/llm-client.ts`, `src/relevance-gate.ts`, `src/reranker.ts` | Pack retrieval context, call local/OpenAI-compatible LLMs, optionally gate/rerank candidates, and report timing/provenance. | Used by CLI `ask`, MCP `ask_knowledge`, MCP/CLI retrieval, eval-gate. |
+| Formatting and content guard | `src/formatter.ts`, `src/injection-guard.ts`, `src/kb-shield.ts` | Sanitize metadata, format markdown/JSON retrieval output, and tag/wrap untrusted retrieved content. | Used by CLI and MCP retrieval surfaces. |
+| KB filesystem helpers | `src/kb-fs.ts`, `src/kb-paths.ts`, `src/file-utils.ts`, `src/ingest-filter.ts` | List KBs, validate names/paths, walk files, hash content, and apply inclusion/exclusion rules. | Used by CLI, MCP resources/writes, and FAISS manager. |
+| Locking and lifecycle | `src/write-lock.ts`, `src/manager-registry.ts`, `src/triggerWatcher.ts`, `src/recursive-fs-watch.ts` | Serialize mutating index/sidecar paths, cache managers per model, and trigger refreshes from polling/fs-watch inputs. | Used by server and CLI mutation/refresh flows. |
+| Observability and diagnostics | `src/logger.ts`, `src/canonical-log.ts`, `src/metrics.ts`, `src/prometheus-export.ts`, `src/otel-trace.ts`, `src/kb-stats.ts` | Keep stdout clean, emit canonical events, expose stats/metrics/traces, and power doctor/logs/stats surfaces. | Used across CLI/MCP runtime modules. |
+| Configuration and errors | `src/config/*.ts`, `src/errors.ts`, `src/error-utils.ts`, `src/ollama-error.ts` | Resolve env/config defaults, validate schemas, and translate provider/filesystem failures into stable operator-facing errors. | Imported by runtime modules and generated config docs. |
 
 ## Key Cross-Component Interactions
 
-### Request path
+### Request Path
 
-`retrieve_knowledge` is registered in `src/KnowledgeBaseServer.ts`. At request
-time, `handleRetrieveKnowledge` resolves the active or explicit model, runs
-`manager.updateIndex()` under the per-model write lock, queries
-`manager.similaritySearch()` or the hybrid search path, then formats results
-through `formatRetrievalAsMarkdown()`.
+`retrieve_knowledge` is registered in `src/KnowledgeBaseServer.ts` from schemas in `src/mcp-tool-specs.ts`. At request time, `handleRetrieveKnowledge` resolves the active or explicit model, loads a model manager from `ManagerRegistry`, refreshes under the per-model write lock for MCP retrieval, queries dense or hybrid retrieval, applies optional relevance gate/reranker stages, and formats through `formatRetrievalAsMarkdown()`.
 
-### Startup path
+### Startup Path
 
-`src/index.ts:8` calls `server.run()`. `KnowledgeBaseServer.run()` loads transport config, bootstraps the FAISS layout, then starts stdio, SSE, or streamable HTTP. Active-manager warmup is best-effort and starts after transport connect.
+`src/index.ts` calls `server.run()`. `KnowledgeBaseServer.run()` bootstraps the index layout, validates transport config, then starts stdio, SSE, or streamable HTTP. Active-manager warmup and file/trigger watchers are optional runtime concerns, not persistence owners.
 
-### Model layout path
+### Model Layout Path
 
-`active-model.ts` owns the filesystem schema and active resolution rules. `modelDir()` validates ids before joining paths at `src/active-model.ts:36-42`; `isRegisteredModel()` defines registration at `src/active-model.ts:111-140`; and `resolveActiveModel()` applies explicit override, `KB_ACTIVE_MODEL`, `active.txt`, then legacy env-derived fallback at `src/active-model.ts:291-359`.
+`active-model.ts` owns the filesystem schema and active resolution rules: model directory derivation, registration checks, `model_name.txt`, `index-type.txt`, `.adding`, and `active.txt`. New model-loading code should read model metadata there instead of reconstructing paths or assuming the process-level `KB_INDEX_TYPE`.
 
-### Index persistence path
+### Index Persistence Path
 
-`FaissIndexManager.initialize()` creates embeddings lazily and loads the current
-store. The manager delegates versioned persistence to
-`loadFaissStoreAtomic()` and `saveFaissStoreAtomic()` in
-`src/faiss-store-layout.ts`; those helpers prefer the RFC 014 symlink layout,
-fall back to legacy `faiss.index/`, write a new `index.vN/`, atomically swap the
-`index` symlink, and garbage-collect old versions.
+`FaissIndexManager.initialize()` creates embeddings lazily and loads the current backend. The manager delegates versioned persistence to `loadFaissStoreAtomic()` / `saveFaissStoreAtomic()` and `loadHnswIndexAtomic()` / `saveHnswIndexAtomic()` in `src/faiss-store-layout.ts`. The layout helpers prefer the RFC 014 symlink layout, fall back to legacy FAISS when valid, write new `index.vN/` directories, atomically swap `index`, and prune old versions.
 
-### CLI path
+### CLI Path
 
-`main()` in `src/cli.ts:62-93` is a dispatcher only. Command-specific behavior lives in `runSearch()` at `src/cli-search.ts:37-132`, `runModels()` at `src/cli-models.ts:22-42`, `runCompare()` at `src/cli-compare.ts:1-125`, and `runList()` at `src/cli-list.ts:1-15`; shared manager loading stays in `src/cli-shared.ts:1-52`.
+`src/cli.ts` is the dispatcher. Command-specific behavior lives in `src/cli-*.ts`; shared manager loading and process-capture helpers live in `src/cli-shared.ts`; command-independent logic belongs in `*-core.ts` modules so non-CLI runtime code does not depend on CLI adapters.
 
 ## Dependency Rules In Force
 
-- **No source import cycles.** The current non-test TypeScript graph has 43 internal edges and no direct or transitive cycles.
-- **Runtime orchestration points outward.** `KnowledgeBaseServer` and `cli.ts` may depend on indexing/model/filesystem helpers; those helpers do not import either orchestration surface.
-- **Non-CLI modules never import `cli-*` adapters.** Only `cli.ts` and `cli-*.ts` command modules may import a `cli-*` adapter. Shared, server, and transport modules import command-independent `*-core` modules (`search-core.ts`, `search-errors-core.ts`, `timing-core.ts`) instead. `src/non-cli-import-boundary.test.ts` scans every production module and fails on a regression; `src/search-core.boundaries.test.ts` pins two specific consumers.
+- **No source import cycles.** Production modules should remain acyclic; keep orchestration modules at the edge.
+- **Runtime orchestration points outward.** `KnowledgeBaseServer` and `cli.ts` may depend on indexing/model/filesystem helpers; those helpers should not import either orchestration surface.
+- **Non-CLI modules never import `cli-*` adapters.** Only `cli.ts` and `cli-*.ts` command modules may import a `cli-*` adapter. Shared, server, and transport modules import command-independent `*-core` modules (`search-core.ts`, `search-errors-core.ts`, `timing-core.ts`) instead. `src/non-cli-import-boundary.test.ts` scans production modules for regressions.
 - **`logger` remains a leaf.** It has no source imports and must continue writing logs away from stdout.
-- **`active-model.ts` is the model layout authority.** New code should not reconstruct `models/<id>/` paths independently.
-- **FAISS store layout is not embedded in the manager.** Versioned index load/save behavior belongs in `faiss-store-layout.ts`; `FaissIndexManager` remains the ingest/search orchestrator.
-- **Shared helpers are domain-scoped.** Prefer `file-utils.ts`, `ingest-filter.ts`, `kb-paths.ts`, `frontmatter.ts`, and `error-utils.ts` over reintroducing broad utility barrels.
+- **`active-model.ts` is the model layout authority.** New code should not reconstruct `models/<id>/` paths, `model_name.txt`, or `index-type.txt` independently.
+- **Versioned store layout is not embedded in the manager.** Backend-specific load/save behavior belongs in `faiss-store-layout.ts`; `FaissIndexManager` remains the ingest/search orchestrator.
+- **Shared helpers are domain-scoped.** Prefer existing domain helpers over broad utility barrels.
 - **Config is read at module load except transport validation.** `loadTransportConfig()` in `src/transport-config.ts` is the explicit startup validation boundary for MCP transport settings.

--- a/docs/architecture/data-model.md
+++ b/docs/architecture/data-model.md
@@ -23,13 +23,16 @@ flowchart LR
     Models["models/"]
     ModelDir["&lt;model_id&gt;/<br/>provider__filesystem-safe-slug"]
       ModelName["model_name.txt<br/>configured embedding model name"]
-      IndexType["index-type.txt<br/>flat or sq8"]
+      IndexType["index-type.txt<br/>flat, sq8, or hnsw"]
       LastUpdate["last-index-update.json<br/>latest update summary"]
       MetadataSidecar["metadata-sidecar.jsonl<br/>filter fast-path rows"]
       IndexLink["index<br/>symlink to index.vN"]
       Version["index.vN/"]
-      Faiss["faiss.index<br/>faiss-node binary vector index"]
-      Docs["docstore.json<br/>LangChain docstore sibling"]
+      Faiss["faiss.index<br/>FAISS binary, when backend=faiss"]
+      Hnsw["hnsw.index<br/>HNSW binary, when backend=hnsw"]
+      Docs["docstore.json<br/>FAISS LangChain tuple or HNSW JSON docstore"]
+      Integrity["integrity.json<br/>backend, index type, hashes, HNSW params"]
+      Cas[".docstore-cas/<br/>canonical FAISS docstore payloads"]
       QueryCache["cache/queries/&lt;model_id&gt;/<br/>query embedding cache"]
       Legacy["faiss.index/<br/>legacy layout, read fallback"]
 
@@ -42,7 +45,10 @@ flowchart LR
     ModelDir --> IndexLink
     IndexLink --> Version
     Version --> Faiss
+    Version --> Hnsw
     Version --> Docs
+    Version --> Integrity
+    Docs -.hardlink when FAISS dedup succeeds.-> Cas
     ModelDir --> QueryCache
     ModelDir -.pre-RFC-014.-> Legacy
   end
@@ -83,27 +89,42 @@ Normal completion removes the manifest after all sidecars are durable. On startu
 
 A model is registered only when its directory exists, `model_name.txt` exists, and `.adding` does not exist (`src/active-model.ts:107-127`). `model_name.txt` is written per model during `FaissIndexManager.initialize()` (`src/FaissIndexManager.ts:327-334`) and stores the configured embedding model name, not the derived model id.
 
-### Versioned FAISS store
+### Versioned search-index store
 
-New saves use the RFC 014 layout in each model directory:
+New saves use the RFC 014 layout in each model directory. The active
+`index-type.txt` value selects the backend: `flat` and `sq8` use the FAISS
+adapter, while `hnsw` uses the HNSW adapter.
 
 ```text
 models/<model_id>/
   model_name.txt
+  index-type.txt
   index -> index.vN
   index.vN/
-    faiss.index
+    faiss.index | hnsw.index
     docstore.json
+    integrity.json
   index.vN-1/
-    faiss.index
+    faiss.index | hnsw.index
     docstore.json
+    integrity.json
 ```
 
-`saveFaissStoreAtomic` writes the next `index.vN/`, creates a temporary symlink, atomically renames it to `index`, and then prunes inactive version directories (`src/faiss-store-layout.ts`). The default retention policy keeps the active version plus two inactive retained versions. Operators can set `KB_INDEX_VERSION_RETENTION=<non-negative integer>` to change the inactive-version count; `0` keeps only the active version after a successful save. Pruning reads the active `index` symlink before deleting anything and never removes that target, even if it is outside the newest retained versions. `kb doctor` reports active, inactive, and total version-directory storage so retained-version cost is visible during health checks.
+`saveFaissStoreAtomic` and `saveHnswIndexAtomic` write the next `index.vN/`, create a temporary symlink, atomically rename it to `index`, and then prune inactive version directories (`src/faiss-store-layout.ts`). The default retention policy keeps the active version plus two inactive retained versions. Operators can set `KB_INDEX_VERSION_RETENTION=<non-negative integer>` to change the inactive-version count; `0` keeps only the active version after a successful save. Pruning reads the active `index` symlink before deleting anything and never removes that target, even if it is outside the newest retained versions. `kb doctor` reports active, inactive, and total version-directory storage so retained-version cost is visible during health checks.
 
-`loadFaissStoreAtomic` pins reads by resolving the `index` symlink once before calling `FaissStore.load`, so `faiss.index` and `docstore.json` come from the same version directory even if another writer swaps the symlink later (`src/faiss-store-layout.ts:58-120`).
+`loadFaissStoreAtomic` and `loadHnswIndexAtomic` pin reads by resolving the `index` symlink once before loading backend files, so the vector index, `docstore.json`, and `integrity.json` come from the same version directory even if another writer swaps the symlink later.
 
-`faiss.index` is the binary vector index in `faiss-node`'s native format. `docstore.json` is the LangChain docstore sibling emitted by `FaissStore.save`; it is part of the `$FAISS_INDEX_PATH` code-exec trust boundary because loading attacker-controlled serialized data is unsafe. See [`threat-model.md`](./threat-model.md).
+For FAISS models, `faiss.index` is the binary vector index in `faiss-node`'s native format and `docstore.json` is the LangChain docstore sibling emitted by `FaissStore.save`. That FAISS docstore is part of the `$FAISS_INDEX_PATH` code-exec trust boundary because loading attacker-controlled serialized data is unsafe. For HNSW models, `hnsw.index` is the `hnswlib-node` native index and `docstore.json` is the project-owned `kb.hnsw-docstore.v1` JSON payload. `integrity.json` records the backend, index type, file hashes, embedding canary, and HNSW tuning fields when applicable. See [`threat-model.md`](./threat-model.md).
+
+### Docstore CAS
+
+For FAISS saves, `$FAISS_INDEX_PATH/.docstore-cas/` stores canonicalized
+`docstore.json` payloads keyed by SHA-256. `saveFaissStoreAtomic` can replace a
+per-model `index.vN/docstore.json` with a hardlink to the shared CAS payload so
+multiple embedding models over the same chunks do not duplicate the same text
+and metadata. CAS writes and garbage collection run under `.docstore-cas/.lock`;
+if hardlinking is unsupported or crosses devices, saves fall back to ordinary
+per-model `docstore.json` files without changing retrieval behavior.
 
 ### Legacy FAISS store
 
@@ -122,7 +143,7 @@ with `KB_QUERY_CACHE=off` or per-call CLI flags where supported.
 
 Each model directory can also contain:
 
-- `index-type.txt` — index creation type such as `flat` or `sq8`.
+- `index-type.txt` — index creation type: `flat`, `sq8`, or `hnsw`.
 - `last-index-update.json` — latest sanitized `updateIndex` summary for fresh
   process stats and doctor reports.
 - `metadata-sidecar.jsonl` — per-doc metadata rows used to speed filtered search
@@ -158,6 +179,7 @@ type ChunkMetadata = {
   tags: string[];
   frontmatter?: LiftedFrontmatter;
   pdf_path?: string;
+  contextual_preface?: string;
 };
 ```
 
@@ -173,6 +195,7 @@ type ChunkMetadata = {
 | `tags` | `string[]` | yes | `parseFrontmatter(content)` at `src/file-ingest.ts:68`, `:92-100` | visible |
 | `frontmatter` | `LiftedFrontmatter` | no | `liftFrontmatter(frontmatter, filePath)` at `src/file-ingest.ts:74-100` | visible after sanitization; `extras` hidden by default |
 | `pdf_path` | `string` KB-relative POSIX path | no | `detectSiblingPdfPath` for markdown files at `src/file-ingest.ts:80-101` | visible |
+| `contextual_preface` | `string` | no | `resolveContextualPrefaces` when contextual retrieval is enabled in `src/file-ingest.ts` | stored for embedding/lexical input; not a source-content replacement |
 
 ### Lifted frontmatter
 
@@ -201,6 +224,8 @@ This page is verified against the following source files. If one of these files 
 - Chunk metadata wire shape: `src/file-ingest.ts:37-104`.
 - Frontmatter whitelist + sanitisation: `src/frontmatter-lift.ts:19-218`, `src/formatter.ts:34-90`.
 - Atomic FAISS save / pinned load / version retention: `src/faiss-store-layout.ts`.
+- HNSW backend files and JSON docstore: `src/hnsw-index-adapter.ts`, `src/faiss-store-layout.ts`.
+- Docstore CAS hardlink dedup: `src/docstore-cas.ts`, `src/faiss-store-layout.ts`.
 - Query embedding cache: `src/query-cache.ts`.
 - Model registry, model sidecars, incomplete-add sentinel: `src/active-model.ts`.
 - Sidecar write path: `src/file-ingest.ts:118-144`, `src/FaissIndexManager.ts:782-793`.

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -178,7 +178,7 @@ wrap-close vars below.
 | Splitter chunk size | `KB_CHUNK_SIZE` | `1000` | Ingest and refresh | Implemented | none | `KB_CHUNK_SIZE=500 kb search "query" --refresh` |
 | Splitter chunk overlap | `KB_CHUNK_OVERLAP` | `200` (auto-scales as `floor(chunkSize/5)` when only `KB_CHUNK_SIZE` is set) | Ingest and refresh | Implemented | none | `KB_CHUNK_SIZE=500 KB_CHUNK_OVERLAP=100 kb search "query" --refresh` |
 | Indexing batch size | `INDEXING_BATCH_SIZE` | `64` (Ollama: `16`) | Embedding ingest | Implemented | none | `INDEXING_BATCH_SIZE=32 kb search "query" --refresh` |
-| FAISS index type | `KB_INDEX_TYPE=flat\|sq8`, or `kb models add --index-type=flat\|sq8` | `flat` | Per-model FAISS index creation | Implemented, opt-in SQ8 | model registration flag | `KB_INDEX_TYPE=sq8 kb models add ollama nomic-embed-text --dry-run` |
+| Search index type | `KB_INDEX_TYPE=flat\|sq8\|hnsw`, or `kb models add --index-type=flat\|sq8\|hnsw` | `flat` | Per-model index creation | Implemented; `sq8` uses FAISS scalar quantization, `hnsw` uses the HNSW backend | model registration flag | `KB_INDEX_TYPE=hnsw kb models add ollama nomic-embed-text --dry-run` |
 | Filesystem watcher | `KB_FS_WATCH` | off | KB root watcher (auto-refresh on file change) | Implemented, opt-in | none | `KB_FS_WATCH=1 node build/index.js` |
 | FS watcher debounce | `KB_FS_WATCH_DEBOUNCE_MS` | `250` | KB root watcher | Implemented | none | `KB_FS_WATCH=1 KB_FS_WATCH_DEBOUNCE_MS=500 node build/index.js` |
 | Index version retention | `KB_INDEX_VERSION_RETENTION` | `2` | FAISS version rotation | Implemented | none | `KB_INDEX_VERSION_RETENTION=4 kb reindex --with-context` |

--- a/docs/operations/index-quantization.md
+++ b/docs/operations/index-quantization.md
@@ -1,28 +1,41 @@
-# FAISS Index Quantization
+# Search Index Types
 
-The default FAISS index type is `flat`, which preserves the existing exact
-IndexFlatL2 behavior. `sq8` is an opt-in scalar-quantized index for corpora
-where vector memory is the bottleneck and a small recall trade-off is
-acceptable.
+The default search index type is `flat`, which preserves exact FAISS
+IndexFlatL2 behavior. `sq8` is an opt-in FAISS scalar-quantized index for
+corpora where vector memory is the bottleneck and a small recall trade-off is
+acceptable. `hnsw` is an opt-in HNSW backend for larger corpora where lower
+query latency is worth approximate-nearest-neighbor tuning.
 
-## Enable SQ8
+## Enable SQ8 or HNSW
 
 For a new model, use either the environment default:
 
 ```bash
 KB_INDEX_TYPE=sq8 kb models add ollama nomic-embed-text --yes
+KB_INDEX_TYPE=hnsw kb models add ollama nomic-embed-text --yes
 ```
 
 or an explicit per-model registration flag:
 
 ```bash
 kb models add ollama nomic-embed-text --index-type=sq8 --yes
+kb models add ollama nomic-embed-text --index-type=hnsw --yes
 ```
 
 Existing models keep their current index until rebuilt. To change an existing
 model, remove and re-add it or build a fresh model id, then run the same
-retrieval evaluation fixture against the flat and SQ8 versions before making it
-active.
+retrieval evaluation fixture against the old and new index types before making
+the new model active.
+
+HNSW tuning is controlled by environment variables and recorded in
+`index.vN/integrity.json`:
+
+| Env var | Default | Meaning |
+| --- | ---: | --- |
+| `KB_HNSW_M` | `32` | Graph connectivity. |
+| `KB_HNSW_EF_CONSTRUCTION` | `200` | Build-time candidate list size. Must be at least `KB_HNSW_M`. |
+| `KB_HNSW_EF_SEARCH` | `100` | Query-time candidate list size, reapplied after every load. |
+| `KB_HNSW_RANDOM_SEED` | `100` | Build seed recorded in the manifest. |
 
 ## Verify
 
@@ -32,7 +45,7 @@ kb stats --format=json
 ```
 
 The stats payload exposes `embedding.index_type`; markdown output prints
-`Index type: flat` or `Index type: sq8`.
+`Index type: flat`, `Index type: sq8`, or `Index type: hnsw`.
 
 Use `kb eval` on the same fixture before and after SQ8. Promote only if the
 Recall@K delta is acceptable for the shelf. SQ8 is most appropriate for large,
@@ -41,14 +54,14 @@ retrieval.
 
 ## HNSW / ANN Status
 
-Do not enable HNSW by passing an arbitrary FAISS factory string to the current
-`faiss-node` binding. ADR
-[`0010-hnsw-binding-evaluation`](../architecture/adr/0010-hnsw-binding-evaluation.md)
-records the binding decision for issue #596: status-quo `faiss-node` can encode
-`M` through descriptors such as `HNSW32,SQ8`, but it exposes no
-`efConstruction` or `efSearch` setter. That leaves recall tied to FAISS defaults
-instead of repo policy.
+HNSW is implemented as a dedicated `hnswlib-node` backend, not as an arbitrary
+FAISS factory string. This follows ADR
+[`0010-hnsw-binding-evaluation`](../architecture/adr/0010-hnsw-binding-evaluation.md):
+status-quo `faiss-node` can encode `M` through descriptors such as
+`HNSW32,SQ8`, but it exposes no `efConstruction` or `efSearch` setter. The
+current backend stores `hnsw.index`, a project-owned JSON `docstore.json`, and
+explicit HNSW parameters in the integrity manifest under each `index.vN/`.
 
-Future ANN work should either add proven FAISS HNSW parameter accessors first or
-introduce a dedicated `hnswlib-node` backend with explicit `index.vN`
-persistence, manifest parameters, and recall/latency evaluation gates.
+HNSW is approximate. Promote it only after comparing recall, nDCG, latency, and
+memory against `flat` or `sq8` on representative fixtures. Keep `flat` for small
+corpora or recall-sensitive shelves where exact search latency is acceptable.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -873,7 +873,7 @@ kb models — manage embedding models (RFC 013)
 
 Usage:
   kb models list
-  kb models add <provider> <model> [--index-type=flat|sq8] [--yes] [--dry-run] [--recover]
+  kb models add <provider> <model> [--index-type=flat|sq8|hnsw] [--yes] [--dry-run] [--recover]
   kb models set-active <id>
   kb models remove <id>
   kb models gc --dry-run [--format=json]
@@ -911,8 +911,9 @@ Options for `add`:
   --recover             When a previous add left a stale .adding sentinel
                         whose writer PID is dead, delete that incomplete
                         model directory before retrying. Requires --yes.
-  --index-type=flat|sq8 Select the FAISS index type for this model. Default
-                        is KB_INDEX_TYPE when set, otherwise flat.
+  --index-type=flat|sq8|hnsw
+                        Select the search index type for this model. Default is
+                        KB_INDEX_TYPE when set, otherwise flat.
 
 Options for `gc`:
   --dry-run             Required. Print the cleanup plan; never delete.

--- a/src/KnowledgeBaseServer.test.ts
+++ b/src/KnowledgeBaseServer.test.ts
@@ -37,7 +37,7 @@ const getLastIndexUpdateSummaryMock = jest.fn(() => ({
   failures: [],
 }));
 
-const FaissIndexManagerMock: any = jest.fn().mockImplementation((opts?: { provider?: string; modelName?: string }) => {
+const FaissIndexManagerMock: any = jest.fn().mockImplementation((opts?: { provider?: string; modelName?: string; indexType?: string }) => {
   // RFC 013 M1+M2: the manager exposes modelDir / modelId / modelName for
   // callers (KnowledgeBaseServer's per-call lock acquisition + cache key).
   // Mock these so handleRetrieveKnowledge can do withWriteLock(manager.modelDir, ...).
@@ -97,6 +97,7 @@ describe('KnowledgeBaseServer handlers', () => {
   };
 
   beforeEach(() => {
+    FaissIndexManagerMock.mockClear();
     initializeMock.mockReset();
     updateIndexMock.mockReset();
     reloadPersistedIndexMock.mockReset();
@@ -315,6 +316,47 @@ describe('KnowledgeBaseServer handlers', () => {
     const result = await server['handleRetrieveKnowledge']({ query: 'q', model_name: idB });
     expect(result.isError).toBeUndefined();
     expect(result.content[0].text).toContain(`Model: ${idB}`);
+  });
+
+  it('handleRetrieveKnowledge constructs managers with the stored index type', async () => {
+    await setRetrieveEnv();
+    const faissDir = process.env.FAISS_INDEX_PATH!;
+    const idB = 'ollama__nomic-embed-text-latest';
+    await fsp.mkdir(path.join(faissDir, 'models', idB), { recursive: true });
+    await fsp.writeFile(path.join(faissDir, 'models', idB, 'model_name.txt'), 'nomic-embed-text:latest');
+    await fsp.writeFile(path.join(faissDir, 'models', idB, 'index-type.txt'), 'hnsw\n');
+
+    updateIndexMock.mockResolvedValue(undefined);
+    similaritySearchMock.mockResolvedValue([
+      { pageContent: 'hello', metadata: { source: '/tmp/x.md' }, score: 0.5 },
+    ]);
+
+    const server = await freshServer();
+    const result = await server['handleRetrieveKnowledge']({ query: 'q', model_name: idB });
+
+    expect(result.isError).toBeUndefined();
+    expect(FaissIndexManagerMock).toHaveBeenCalledWith({
+      provider: 'ollama',
+      modelName: 'nomic-embed-text:latest',
+      indexType: 'hnsw',
+    });
+  });
+
+  it('createReadOnlyManagerForModel constructs managers with the stored index type', async () => {
+    await setRetrieveEnv();
+    const faissDir = process.env.FAISS_INDEX_PATH!;
+    const id = 'huggingface__BAAI-bge-small-en-v1.5';
+    await fsp.writeFile(path.join(faissDir, 'models', id, 'index-type.txt'), 'sq8\n');
+
+    const server = await freshServer();
+    await server['createReadOnlyManagerForModel'](id);
+
+    expect(FaissIndexManagerMock).toHaveBeenCalledWith({
+      provider: 'huggingface',
+      modelName: 'BAAI/bge-small-en-v1.5',
+      indexType: 'sq8',
+    });
+    expect(initializeMock).toHaveBeenCalledWith({ readOnly: true });
   });
 
   it('handleRetrieveKnowledge without model_name does NOT prepend model_id footer (back-compat)', async () => {

--- a/src/KnowledgeBaseServer.ts
+++ b/src/KnowledgeBaseServer.ts
@@ -22,6 +22,7 @@ import {
   listRegisteredModels,
   modelDir,
   parseModelId,
+  readStoredIndexType,
   readStoredModelName,
   resolveActiveModel,
   resolveFaissIndexBinaryPath,
@@ -682,6 +683,7 @@ export class KnowledgeBaseServer {
     const manager = new FaissIndexManager({
       provider: provider as EmbeddingProvider,
       modelName,
+      indexType: await readStoredIndexType(modelId),
     });
     await manager.initialize({ readOnly: true });
     return manager;

--- a/src/ask-answer-cache.test.ts
+++ b/src/ask-answer-cache.test.ts
@@ -133,7 +133,10 @@ describe('AnswerCache storage (#656)', () => {
     // Size the cap to exactly one entry so the second write evicts the first.
     const probe = new AnswerCache({ enabled: true, indexPath: dir });
     await probe.set(keyOld, { answer: 'old answer', model: null });
-    const entrySize = (await fsp.stat(path.join(answerCacheDir(dir), `${keyOld}.json`))).size;
+    const oldEntry = path.join(answerCacheDir(dir), `${keyOld}.json`);
+    const entrySize = (await fsp.stat(oldEntry)).size;
+    const oldTimestamp = new Date(Date.now() - 60_000);
+    await fsp.utimes(oldEntry, oldTimestamp, oldTimestamp);
 
     const cache = new AnswerCache({ enabled: true, indexPath: dir, diskMaxBytes: entrySize });
     await cache.set(keyNew, { answer: 'new answer', model: null });

--- a/src/cli-models.ts
+++ b/src/cli-models.ts
@@ -19,7 +19,7 @@ import {
   writeAddingSentinel,
   writeActiveModelAtomic,
 } from './active-model.js';
-import { resolveFaissIndexType, type FaissIndexType } from './config/indexing.js';
+import { resolveIndexType, type SearchIndexType } from './config/indexing.js';
 import { KB_ACTIVE_MODEL } from './config/provider.js';
 import { deriveModelId, type EmbeddingProvider } from './model-id.js';
 import { KNOWLEDGE_BASES_ROOT_DIR } from './config/paths.js';
@@ -32,7 +32,7 @@ export const MODELS_HELP = `kb models — manage embedding models (RFC 013)
 
 Usage:
   kb models list
-  kb models add <provider> <model> [--index-type=flat|sq8] [--yes] [--dry-run] [--recover]
+  kb models add <provider> <model> [--index-type=flat|sq8|hnsw] [--yes] [--dry-run] [--recover]
   kb models set-active <id>
   kb models remove <id>
   kb models gc --dry-run [--format=json]
@@ -70,8 +70,9 @@ Options for \`add\`:
   --recover             When a previous add left a stale .adding sentinel
                         whose writer PID is dead, delete that incomplete
                         model directory before retrying. Requires --yes.
-  --index-type=flat|sq8 Select the FAISS index type for this model. Default
-                        is KB_INDEX_TYPE when set, otherwise flat.
+  --index-type=flat|sq8|hnsw
+                        Select the search index type for this model. Default is
+                        KB_INDEX_TYPE when set, otherwise flat.
 
 Options for \`gc\`:
   --dry-run             Required. Print the cleanup plan; never delete.
@@ -149,7 +150,7 @@ async function runModelsAdd(rest: string[]): Promise<number> {
   let yes = false;
   let dryRun = false;
   let recover = false;
-  let indexType: FaissIndexType = resolveFaissIndexType();
+  let indexType: SearchIndexType = resolveIndexType();
   for (const raw of rest) {
     if (raw === '--yes') { yes = true; continue; }
     if (raw === '--dry-run') { dryRun = true; continue; }
@@ -157,7 +158,7 @@ async function runModelsAdd(rest: string[]): Promise<number> {
     if (raw.startsWith('--index-type=')) {
       const value = raw.slice('--index-type='.length);
       const normalized = value.trim().toLowerCase();
-      const parsed = resolveFaissIndexType(value);
+      const parsed = resolveIndexType(value);
       if (normalized !== parsed) {
         process.stderr.write(`kb models add: invalid --index-type: ${raw}\n`);
         return 2;

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -2638,6 +2638,30 @@ describe('kb search — active-model resolution (RFC 013 §4.7)', () => {
     }
   });
 
+  it('kb models add accepts an HNSW index type override', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-cli-add-hnsw-dryrun-'));
+    try {
+      const faissDir = path.join(tempDir, '.faiss');
+      await fsp.mkdir(faissDir, { recursive: true });
+      const kbDir = path.join(tempDir, 'kb');
+      await fsp.mkdir(path.join(kbDir, 'sample'), { recursive: true });
+      await fsp.writeFile(path.join(kbDir, 'sample', 'doc.md'), '# t\n\nbody');
+
+      const r = runCli(['models', 'add', 'ollama', 'nomic-embed-text', '--index-type=HNSW', '--dry-run'], {
+        KNOWLEDGE_BASES_ROOT_DIR: kbDir,
+        FAISS_INDEX_PATH: faissDir,
+        EMBEDDING_PROVIDER: 'ollama',
+        OLLAMA_MODEL: 'nomic-embed-text',
+      });
+
+      expect(r.code).toBe(0);
+      expect(r.stderr).toContain('Index type: hnsw');
+      await expect(fsp.access(path.join(faissDir, 'models'))).rejects.toMatchObject({ code: 'ENOENT' });
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it('kb models add blocks while a live .adding writer PID still exists', async () => {
     const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-cli-add-live-'));
     try {

--- a/src/manager-registry.ts
+++ b/src/manager-registry.ts
@@ -11,7 +11,7 @@
 // resolved cache so a hard failure on first init doesn't poison
 // subsequent retries (the entry is removed in the `finally`).
 
-import { parseModelId, readStoredModelName } from './active-model.js';
+import { parseModelId, readStoredIndexType, readStoredModelName } from './active-model.js';
 import { FaissIndexManager } from './FaissIndexManager.js';
 import type { EmbeddingProvider } from './model-id.js';
 
@@ -39,6 +39,7 @@ export class ManagerRegistry {
       const manager = new FaissIndexManager({
         provider: provider as EmbeddingProvider,
         modelName,
+        indexType: await readStoredIndexType(modelId),
       });
       await manager.initialize();
       this.cache.set(modelId, manager);


### PR DESCRIPTION
## Summary

Fixes misalignments between design docs and current implementation based on gap analysis.

### Changes
- Preserve per-model stored index type when MCP/server manager paths construct `FaissIndexManager`.
- Allow `kb models add --index-type=hnsw` and update generated CLI docs.
- Document HNSW, docstore CAS, and current index storage layout in architecture and operator docs.
- Refresh the component architecture map for the current CLI/MCP/retrieval/storage module families.
- Update ADR notes for default FAISS plus opt-in HNSW backend.
- Stabilize the answer-cache disk-cap eviction test that surfaced as a full-suite flake during verification.

### Gaps deferred
- None; user requested all identified gaps.