### PR TITLE
feat: add kb cli evolution harness

### DIFF
--- a/benchmarks/evolution/README.md
+++ b/benchmarks/evolution/README.md
@@ -1,0 +1,75 @@
+# KB CLI evolution harness
+
+This harness runs advisor-style champion/challenger evaluations for `kb` CLI
+performance and retrieval-efficiency changes. It is deliberately conservative:
+it emits `decision.json` and `report.md`, but it does not rewrite defaults,
+refresh baselines, or change code automatically.
+
+## Plan file
+
+```json
+{
+  "schema_version": "kb.evolution-plan.v1",
+  "run_id": "iter-001",
+  "objective": {
+    "metric_path": "scenarios.warm_query.p95_ms",
+    "direction": "lower",
+    "min_absolute_improvement": 5
+  },
+  "gate": {
+    "max_fail_rows": 0,
+    "max_warn_rows": null,
+    "require_metric_present": true
+  },
+  "champion": {
+    "id": "current-defaults",
+    "report": "benchmarks/results/baseline-stub-node24-linux-x64.json"
+  },
+  "candidates": [
+    {
+      "id": "chunk-768-overlap-128",
+      "hypothesis": "Smaller chunks reduce warm query tail latency without quality loss.",
+      "command": [
+        "npm",
+        "run",
+        "bench"
+      ],
+      "env": {
+        "BENCH_PROVIDER": "stub",
+        "KB_CHUNK_SIZE": "768",
+        "KB_CHUNK_OVERLAP": "128",
+        "BENCH_INCLUDE_CLI_SEARCH": "1"
+      }
+    }
+  ]
+}
+```
+
+Each arm may provide either a precomputed `report` path or a `command` array.
+Commands are executed with `BENCH_RESULTS_DIR` pointed at the run directory and
+`BENCH_RESULTS_PREFIX` derived from the arm id unless the arm overrides them.
+
+Run:
+
+```bash
+npm run bench:evol -- --plan=benchmarks/evolution/plan.json
+```
+
+Artifacts land under `benchmarks/results/evolution/<run-id>/`:
+
+- `decision.json` — deterministic promotion decision
+- `report.md` — human-readable summary
+- `reports/<arm>.json` — copied benchmark reports used for the decision
+
+## Promotion rule
+
+A candidate qualifies only when:
+
+- the objective metric improves by the configured absolute and/or relative
+  margin;
+- `budget-diff` reports no more fail/warn rows than the pre-registered gate
+  allows;
+- the objective metric exists unless `require_metric_present` is disabled.
+
+The winner is the qualified candidate with the largest objective improvement.
+If no candidate qualifies, the champion holds.

--- a/benchmarks/evolution/decision.test.ts
+++ b/benchmarks/evolution/decision.test.ts
@@ -1,0 +1,147 @@
+import type { BenchmarkReport } from '../types.js';
+import { decideEvolutionPromotion, readNumericPath, readObjectiveDelta } from './decision.js';
+
+const championReport = reportWith({});
+
+describe('kb evolution promotion decision', () => {
+  it('promotes the fastest candidate that clears objective and budget gates', () => {
+    const candidateA = reportWith({ warmP95Ms: 88 });
+    const candidateB = reportWith({ warmP95Ms: 82 });
+
+    const decision = decideEvolutionPromotion({
+      champion: { arm: { id: 'champion' }, report: championReport },
+      candidates: [
+        { arm: { id: 'candidate-a', hypothesis: 'small speedup' }, report: candidateA },
+        { arm: { id: 'candidate-b', hypothesis: 'larger speedup' }, report: candidateB },
+      ],
+      generatedAt: new Date('2026-06-20T00:00:00.000Z'),
+      objective: {
+        metric_path: 'scenarios.warm_query.p95_ms',
+        direction: 'lower',
+        min_absolute_improvement: 5,
+      },
+      runId: 'iter-test',
+    });
+
+    expect(decision).toMatchObject({
+      champion: 'champion',
+      winner: 'candidate-b',
+      promoted: true,
+    });
+    expect(decision.candidates[1]).toMatchObject({
+      arm_id: 'candidate-b',
+      qualifies: true,
+      objective: {
+        baseline: 100,
+        current: 82,
+        improvement: 18,
+      },
+    });
+  });
+
+  it('holds a faster candidate when it causes a protected quality regression', () => {
+    const candidate = reportWith({ warmP95Ms: 75, retrievalRecall: 0.9 });
+
+    const decision = decideEvolutionPromotion({
+      champion: { arm: { id: 'champion' }, report: championReport },
+      candidates: [{ arm: { id: 'fast-but-worse' }, report: candidate }],
+      generatedAt: new Date('2026-06-20T00:00:00.000Z'),
+      objective: {
+        metric_path: 'scenarios.warm_query.p95_ms',
+        direction: 'lower',
+        min_absolute_improvement: 5,
+      },
+      runId: 'iter-test',
+    });
+
+    expect(decision.promoted).toBe(false);
+    expect(decision.winner).toBe('champion');
+    expect(decision.candidates[0].reasons).toContain('budget fail rows 1 > 0');
+  });
+
+  it('holds candidates below the pre-registered objective margin', () => {
+    const candidate = reportWith({ warmP95Ms: 97 });
+
+    const decision = decideEvolutionPromotion({
+      champion: { arm: { id: 'champion' }, report: championReport },
+      candidates: [{ arm: { id: 'too-small' }, report: candidate }],
+      generatedAt: new Date('2026-06-20T00:00:00.000Z'),
+      objective: {
+        metric_path: 'scenarios.warm_query.p95_ms',
+        direction: 'lower',
+        min_absolute_improvement: 5,
+      },
+      runId: 'iter-test',
+    });
+
+    expect(decision.promoted).toBe(false);
+    expect(decision.candidates[0].reasons[0]).toContain('objective improvement 3');
+  });
+
+  it('reads numeric metric paths and computes higher-is-better deltas', () => {
+    expect(readNumericPath(championReport, 'scenarios.warm_query.p99_ms')).toBe(120);
+    expect(readNumericPath(championReport, 'scenarios.missing.value')).toBeUndefined();
+
+    const delta = readObjectiveDelta(championReport, reportWith({ retrievalRecall: 1 }), {
+      metric_path: 'scenarios.retrieval_quality.default_recall_at_10',
+      direction: 'higher',
+      min_relative_improvement: 0.01,
+    });
+
+    expect(delta).toMatchObject({
+      baseline: 0.98,
+      current: 1,
+      passed: true,
+    });
+    expect(delta?.improvement).toBeCloseTo(0.02);
+  });
+});
+
+function reportWith(overrides: {
+  coldIndexMs?: number;
+  memoryRssBytes?: number;
+  retrievalRecall?: number;
+  warmP50Ms?: number;
+  warmP95Ms?: number;
+  warmP99Ms?: number;
+}): BenchmarkReport {
+  return {
+    arch: 'x64',
+    git_sha: 'abc123',
+    node_version: 'v24.11.1',
+    os: 'linux',
+    provider: 'stub',
+    scenarios: {
+      cold_index: {
+        chunks: 600,
+        files: 100,
+        ms: overrides.coldIndexMs ?? 10_000,
+      },
+      cold_start: {
+        fixture_documents: 100,
+        ms: 40,
+        rss_bytes: 90 * 1024 * 1024,
+      },
+      memory_peak: {
+        chunk_count: 600,
+        files: 100,
+        heap_used_bytes: 50 * 1024 * 1024,
+        rss_bytes: overrides.memoryRssBytes ?? 120 * 1024 * 1024,
+      },
+      retrieval_quality: {
+        default_fanout_factor: 3,
+        default_loaded_kbs: 5,
+        default_recall_at_10: overrides.retrievalRecall ?? 0.98,
+        query_count: 50,
+        sweep: [],
+      },
+      warm_query: {
+        p50_ms: overrides.warmP50Ms ?? 80,
+        p95_ms: overrides.warmP95Ms ?? 100,
+        p99_ms: overrides.warmP99Ms ?? 120,
+        repetitions: 30,
+      },
+    },
+    version: 1,
+  };
+}

--- a/benchmarks/evolution/decision.ts
+++ b/benchmarks/evolution/decision.ts
@@ -1,0 +1,151 @@
+import type { BenchmarkReport } from '../types.js';
+import { buildBudgetRows, summarizeBudgetRows } from '../budget-diff.js';
+import {
+  EVOLUTION_DECISION_SCHEMA_VERSION,
+  type EvolutionArmRun,
+  type EvolutionCandidateDecision,
+  type EvolutionDecision,
+  type EvolutionGate,
+  type EvolutionObjective,
+  type EvolutionObjectiveDelta,
+} from './types.js';
+
+const DEFAULT_GATE: Required<Pick<EvolutionGate, 'max_fail_rows' | 'require_metric_present'>> & Pick<EvolutionGate, 'max_warn_rows'> = {
+  max_fail_rows: 0,
+  max_warn_rows: null,
+  require_metric_present: true,
+};
+
+export function decideEvolutionPromotion(input: {
+  champion: EvolutionArmRun;
+  candidates: EvolutionArmRun[];
+  generatedAt?: Date;
+  objective: EvolutionObjective;
+  gate?: EvolutionGate;
+  runId: string;
+}): EvolutionDecision {
+  const gate = { ...DEFAULT_GATE, ...input.gate };
+  const candidates = input.candidates.map((candidate) =>
+    evaluateCandidate(input.champion.report, candidate, input.objective, gate));
+  const eligible = candidates
+    .filter((candidate) => candidate.qualifies && candidate.objective !== null)
+    .sort((left, right) =>
+      (right.objective!.improvement - left.objective!.improvement) ||
+      left.arm_id.localeCompare(right.arm_id));
+
+  const winner = eligible[0]?.arm_id ?? input.champion.arm.id;
+
+  return {
+    schema_version: EVOLUTION_DECISION_SCHEMA_VERSION,
+    generated_at: (input.generatedAt ?? new Date()).toISOString(),
+    run_id: input.runId,
+    objective: input.objective,
+    champion: input.champion.arm.id,
+    winner,
+    promoted: winner !== input.champion.arm.id,
+    candidates,
+  };
+}
+
+function evaluateCandidate(
+  championReport: BenchmarkReport,
+  candidate: EvolutionArmRun,
+  objective: EvolutionObjective,
+  gate: EvolutionGate,
+): EvolutionCandidateDecision {
+  const reasons: string[] = [];
+  const budgetRows = buildBudgetRows(championReport, candidate.report);
+  const budgetSummary = summarizeBudgetRows(budgetRows);
+
+  if (budgetSummary.fail > (gate.max_fail_rows ?? DEFAULT_GATE.max_fail_rows)) {
+    reasons.push(`budget fail rows ${budgetSummary.fail} > ${gate.max_fail_rows ?? DEFAULT_GATE.max_fail_rows}`);
+  }
+  if (gate.max_warn_rows !== null && gate.max_warn_rows !== undefined && budgetSummary.warn > gate.max_warn_rows) {
+    reasons.push(`budget warn rows ${budgetSummary.warn} > ${gate.max_warn_rows}`);
+  }
+
+  const objectiveDelta = readObjectiveDelta(championReport, candidate.report, objective);
+  if (objectiveDelta === null) {
+    if (gate.require_metric_present ?? DEFAULT_GATE.require_metric_present) {
+      reasons.push(`objective metric missing: ${objective.metric_path}`);
+    }
+  } else if (!objectiveDelta.passed) {
+    reasons.push(formatObjectiveMiss(objectiveDelta, objective));
+  }
+
+  return {
+    arm_id: candidate.arm.id,
+    ...(candidate.arm.hypothesis ? { hypothesis: candidate.arm.hypothesis } : {}),
+    qualifies: reasons.length === 0,
+    reasons,
+    objective: objectiveDelta,
+    budget_summary: {
+      fail: budgetSummary.fail,
+      pass: budgetSummary.pass,
+      skip: budgetSummary.skip,
+      warn: budgetSummary.warn,
+    },
+    budget_rows: budgetRows,
+  };
+}
+
+export function readObjectiveDelta(
+  baseline: BenchmarkReport,
+  current: BenchmarkReport,
+  objective: EvolutionObjective,
+): EvolutionObjectiveDelta | null {
+  const baselineValue = readNumericPath(baseline, objective.metric_path);
+  const currentValue = readNumericPath(current, objective.metric_path);
+  if (baselineValue === undefined || currentValue === undefined) {
+    return null;
+  }
+
+  const delta = currentValue - baselineValue;
+  const improvement = objective.direction === 'higher' ? delta : -delta;
+  const relativeImprovement = baselineValue === 0 ? null : improvement / Math.abs(baselineValue);
+  const minAbsolute = objective.min_absolute_improvement ?? 0;
+  const minRelative = objective.min_relative_improvement ?? 0;
+  const absolutePassed = improvement >= minAbsolute;
+  const relativePassed = minRelative === 0 || (relativeImprovement !== null && relativeImprovement >= minRelative);
+
+  return {
+    baseline: baselineValue,
+    current: currentValue,
+    delta,
+    direction: objective.direction,
+    improvement,
+    relative_improvement: relativeImprovement,
+    passed: absolutePassed && relativePassed,
+  };
+}
+
+export function readNumericPath(value: unknown, metricPath: string): number | undefined {
+  let cursor: unknown = value;
+  for (const part of metricPath.split('.')) {
+    if (Array.isArray(cursor)) {
+      const index = Number(part);
+      if (!Number.isInteger(index) || index < 0 || index >= cursor.length) return undefined;
+      cursor = cursor[index];
+    } else if (cursor !== null && typeof cursor === 'object' && part in cursor) {
+      cursor = (cursor as Record<string, unknown>)[part];
+    } else {
+      return undefined;
+    }
+  }
+  return typeof cursor === 'number' && Number.isFinite(cursor) ? cursor : undefined;
+}
+
+function formatObjectiveMiss(delta: EvolutionObjectiveDelta, objective: EvolutionObjective): string {
+  const pieces = [`objective improvement ${round(delta.improvement)}`];
+  if (objective.min_absolute_improvement !== undefined) {
+    pieces.push(`absolute required ${objective.min_absolute_improvement}`);
+  }
+  if (objective.min_relative_improvement !== undefined) {
+    pieces.push(`relative ${delta.relative_improvement === null ? 'n/a' : round(delta.relative_improvement)} required ${objective.min_relative_improvement}`);
+  }
+  return pieces.join('; ');
+}
+
+function round(value: number): number {
+  return Number(value.toFixed(6));
+}

--- a/benchmarks/evolution/report.ts
+++ b/benchmarks/evolution/report.ts
@@ -1,0 +1,42 @@
+import type { EvolutionDecision } from './types.js';
+
+export function renderEvolutionMarkdown(decision: EvolutionDecision): string {
+  const lines = [
+    `# Evolution run ${decision.run_id}`,
+    '',
+    `Champion: \`${decision.champion}\``,
+    `Winner: \`${decision.winner}\``,
+    `Promoted: ${decision.promoted ? 'yes' : 'no'}`,
+    `Objective: \`${decision.objective.metric_path}\` (${decision.objective.direction})`,
+    '',
+    '| Candidate | Verdict | Objective | Budget | Reasons |',
+    '| --- | --- | ---: | --- | --- |',
+  ];
+
+  for (const candidate of decision.candidates) {
+    const objective = candidate.objective === null
+      ? 'n/a'
+      : `${formatNumber(candidate.objective.current)} (${formatSigned(candidate.objective.improvement)} improvement)`;
+    const budget = `${candidate.budget_summary.fail} fail, ${candidate.budget_summary.warn} warn`;
+    const reasons = candidate.reasons.length ? candidate.reasons.join('; ') : 'qualified';
+    lines.push([
+      candidate.arm_id,
+      candidate.qualifies ? 'QUALIFY' : 'HOLD',
+      objective,
+      budget,
+      reasons,
+    ].join(' | ').replace(/^/, '| ').replace(/$/, ' |'));
+  }
+
+  lines.push('', 'Promotion is advisory: apply defaults or code changes through a normal reviewed PR.');
+  return `${lines.join('\n')}\n`;
+}
+
+function formatNumber(value: number): string {
+  return Number(value.toFixed(3)).toString();
+}
+
+function formatSigned(value: number): string {
+  const rounded = formatNumber(value);
+  return value >= 0 ? `+${rounded}` : rounded;
+}

--- a/benchmarks/evolution/run.test.ts
+++ b/benchmarks/evolution/run.test.ts
@@ -1,0 +1,89 @@
+import * as fsp from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import type { BenchmarkReport } from '../types.js';
+
+const execFileAsync = promisify(execFile);
+
+describe('bench:evol runner', () => {
+  it('writes decision and markdown artifacts from precomputed reports', async () => {
+    const tmp = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-evol-run-test-'));
+    const championPath = path.join(tmp, 'champion.json');
+    const candidatePath = path.join(tmp, 'candidate.json');
+    const planPath = path.join(tmp, 'plan.json');
+    const outDir = path.join(tmp, 'out');
+
+    await fsp.writeFile(championPath, JSON.stringify(reportWith(100)), 'utf-8');
+    await fsp.writeFile(candidatePath, JSON.stringify(reportWith(80)), 'utf-8');
+    await fsp.writeFile(planPath, JSON.stringify({
+      schema_version: 'kb.evolution-plan.v1',
+      run_id: 'iter-artifact',
+      objective: {
+        metric_path: 'scenarios.warm_query.p95_ms',
+        direction: 'lower',
+        min_absolute_improvement: 5,
+      },
+      champion: { id: 'champion', report: championPath },
+      candidates: [{ id: 'candidate', report: candidatePath }],
+    }), 'utf-8');
+
+    const completed = await execFileAsync('node', [
+      '--import',
+      'tsx',
+      path.join(process.cwd(), 'benchmarks/evolution/run.ts'),
+      `--plan=${planPath}`,
+      `--out-dir=${outDir}`,
+    ], { cwd: process.cwd() });
+
+    expect(completed.stdout).toContain('Decision:');
+    const decision = JSON.parse(await fsp.readFile(path.join(outDir, 'decision.json'), 'utf-8'));
+    const report = await fsp.readFile(path.join(outDir, 'report.md'), 'utf-8');
+    expect(decision).toMatchObject({
+      schema_version: 'kb.evolution-decision.v1',
+      winner: 'candidate',
+      promoted: true,
+    });
+    expect(report).toContain('Promoted: yes');
+    expect(await exists(path.join(outDir, 'reports', 'candidate.json'))).toBe(true);
+  });
+});
+
+function reportWith(warmP95Ms: number): BenchmarkReport {
+  return {
+    arch: 'x64',
+    git_sha: 'abc123',
+    node_version: 'v24.11.1',
+    os: 'linux',
+    provider: 'stub',
+    scenarios: {
+      cold_index: { chunks: 600, files: 100, ms: 10_000 },
+      cold_start: { fixture_documents: 100, ms: 40, rss_bytes: 90 * 1024 * 1024 },
+      memory_peak: {
+        chunk_count: 600,
+        files: 100,
+        heap_used_bytes: 50 * 1024 * 1024,
+        rss_bytes: 120 * 1024 * 1024,
+      },
+      retrieval_quality: {
+        default_fanout_factor: 3,
+        default_loaded_kbs: 5,
+        default_recall_at_10: 0.98,
+        query_count: 50,
+        sweep: [],
+      },
+      warm_query: { p50_ms: 80, p95_ms: warmP95Ms, p99_ms: 120, repetitions: 30 },
+    },
+    version: 1,
+  };
+}
+
+async function exists(filePath: string): Promise<boolean> {
+  try {
+    await fsp.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/benchmarks/evolution/run.ts
+++ b/benchmarks/evolution/run.ts
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+import * as fsp from 'fs/promises';
+import * as path from 'path';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import type { BenchmarkReport } from '../types.js';
+import { ensureDirectory, writeJsonFile } from '../utils.js';
+import { decideEvolutionPromotion } from './decision.js';
+import { renderEvolutionMarkdown } from './report.js';
+import {
+  EVOLUTION_PLAN_SCHEMA_VERSION,
+  type EvolutionArm,
+  type EvolutionArmRun,
+  type EvolutionPlan,
+} from './types.js';
+
+const execFileAsync = promisify(execFile);
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const plan = await readPlan(args.planPath);
+  const runId = plan.run_id ?? timestampRunId(new Date());
+  const outDir = args.outDir ?? path.join(process.cwd(), 'benchmarks', 'results', 'evolution', runId);
+  await ensureDirectory(outDir);
+
+  const champion = await resolveArm(plan.champion, outDir, 'champion');
+  const candidates: EvolutionArmRun[] = [];
+  for (const candidate of plan.candidates) {
+    candidates.push(await resolveArm(candidate, outDir, 'candidate'));
+  }
+
+  const decision = decideEvolutionPromotion({
+    champion,
+    candidates,
+    objective: plan.objective,
+    gate: plan.gate,
+    runId,
+  });
+
+  await writeJsonFile(path.join(outDir, 'decision.json'), decision);
+  await fsp.writeFile(path.join(outDir, 'report.md'), renderEvolutionMarkdown(decision), 'utf-8');
+  process.stdout.write(`Decision: ${path.join(outDir, 'decision.json')}\n`);
+  process.stdout.write(`Report: ${path.join(outDir, 'report.md')}\n`);
+}
+
+interface CliArgs {
+  outDir?: string;
+  planPath: string;
+}
+
+function parseArgs(argv: string[]): CliArgs {
+  let planPath: string | undefined;
+  let outDir: string | undefined;
+  for (const arg of argv) {
+    if (arg.startsWith('--plan=')) planPath = arg.slice('--plan='.length);
+    else if (arg.startsWith('--out-dir=')) outDir = arg.slice('--out-dir='.length);
+    else if (!arg.startsWith('--') && planPath === undefined) planPath = arg;
+    else throw new Error(`Unknown argument: ${arg}`);
+  }
+  if (!planPath) {
+    throw new Error('usage: node build/benchmarks/evolution/run.js --plan=<plan.json> [--out-dir=<dir>]');
+  }
+  return { planPath, ...(outDir ? { outDir } : {}) };
+}
+
+async function readPlan(planPath: string): Promise<EvolutionPlan> {
+  const parsed = JSON.parse(await fsp.readFile(planPath, 'utf-8')) as EvolutionPlan;
+  if (parsed.schema_version !== EVOLUTION_PLAN_SCHEMA_VERSION) {
+    throw new Error(`evolution plan schema_version must be ${EVOLUTION_PLAN_SCHEMA_VERSION}`);
+  }
+  if (!parsed.champion?.id) throw new Error('evolution plan must include champion.id');
+  if (!Array.isArray(parsed.candidates) || parsed.candidates.length === 0) {
+    throw new Error('evolution plan must include at least one candidate');
+  }
+  if (!parsed.objective?.metric_path || !['higher', 'lower'].includes(parsed.objective.direction)) {
+    throw new Error('evolution plan objective must include metric_path and direction');
+  }
+  return parsed;
+}
+
+async function resolveArm(arm: EvolutionArm, outDir: string, role: 'champion' | 'candidate'): Promise<EvolutionArmRun> {
+  if (!arm.id) throw new Error(`${role} arm is missing id`);
+  let reportPath = arm.report;
+  if (!reportPath) {
+    if (!arm.command || arm.command.length === 0) {
+      throw new Error(`${role} arm ${arm.id} must provide report or command`);
+    }
+    reportPath = await runArmCommand(arm, outDir);
+  }
+  const report = JSON.parse(await fsp.readFile(reportPath, 'utf-8')) as BenchmarkReport;
+  const copiedPath = path.join(outDir, 'reports', `${safeFileSegment(arm.id)}.json`);
+  await writeJsonFile(copiedPath, report);
+  return { arm, report, report_path: copiedPath };
+}
+
+async function runArmCommand(arm: EvolutionArm, outDir: string): Promise<string> {
+  const [file, ...args] = arm.command ?? [];
+  if (!file) throw new Error(`arm ${arm.id} command is empty`);
+  const resultsDir = path.join(outDir, 'raw');
+  await ensureDirectory(resultsDir);
+  const env = {
+    ...process.env,
+    ...arm.env,
+    BENCH_RESULTS_DIR: arm.env?.BENCH_RESULTS_DIR ?? resultsDir,
+    BENCH_RESULTS_PREFIX: arm.env?.BENCH_RESULTS_PREFIX ?? `evol-${safeFileSegment(arm.id)}`,
+  };
+  const completed = await execFileAsync(file, args, {
+    cwd: process.cwd(),
+    env,
+    maxBuffer: 10 * 1024 * 1024,
+  });
+  return findJsonArtifact(completed.stdout);
+}
+
+function findJsonArtifact(stdout: string): string {
+  const candidates: string[] = [];
+  for (const line of stdout.split('\n')) {
+    const text = line.trim();
+    if (text.startsWith('JSON:')) candidates.push(text.slice('JSON:'.length).trim());
+    else if (text.endsWith('.json')) candidates.push(text);
+  }
+  const found = candidates.at(-1);
+  if (!found) {
+    throw new Error(`arm command did not print a JSON artifact path\nstdout:\n${stdout}`);
+  }
+  return found;
+}
+
+function timestampRunId(now: Date): string {
+  return now.toISOString().replace(/[-:]/g, '').replace(/\.\d{3}Z$/, 'Z');
+}
+
+function safeFileSegment(value: string): string {
+  return value.replace(/[^A-Za-z0-9._-]+/g, '-').replace(/^-+|-+$/g, '') || 'arm';
+}
+
+main().catch((error) => {
+  process.stderr.write(`${error instanceof Error ? error.stack ?? error.message : String(error)}\n`);
+  process.exitCode = 1;
+});

--- a/benchmarks/evolution/types.ts
+++ b/benchmarks/evolution/types.ts
@@ -1,0 +1,74 @@
+import type { BenchmarkReport } from '../types.js';
+import type { BudgetRow, BudgetStatus } from '../budget-diff.js';
+
+export const EVOLUTION_PLAN_SCHEMA_VERSION = 'kb.evolution-plan.v1';
+export const EVOLUTION_DECISION_SCHEMA_VERSION = 'kb.evolution-decision.v1';
+
+export type EvolutionMetricDirection = 'higher' | 'lower';
+
+export interface EvolutionObjective {
+  direction: EvolutionMetricDirection;
+  metric_path: string;
+  min_absolute_improvement?: number;
+  min_relative_improvement?: number;
+}
+
+export interface EvolutionGate {
+  max_fail_rows?: number;
+  max_warn_rows?: number | null;
+  require_metric_present?: boolean;
+}
+
+export interface EvolutionArm {
+  id: string;
+  hypothesis?: string;
+  env?: Record<string, string>;
+  command?: string[];
+  report?: string;
+}
+
+export interface EvolutionPlan {
+  schema_version: typeof EVOLUTION_PLAN_SCHEMA_VERSION;
+  run_id?: string;
+  objective: EvolutionObjective;
+  gate?: EvolutionGate;
+  champion: EvolutionArm;
+  candidates: EvolutionArm[];
+}
+
+export interface EvolutionArmRun {
+  arm: EvolutionArm;
+  report: BenchmarkReport;
+  report_path?: string;
+}
+
+export interface EvolutionObjectiveDelta {
+  baseline: number;
+  current: number;
+  delta: number;
+  direction: EvolutionMetricDirection;
+  improvement: number;
+  relative_improvement: number | null;
+  passed: boolean;
+}
+
+export interface EvolutionCandidateDecision {
+  arm_id: string;
+  hypothesis?: string;
+  qualifies: boolean;
+  reasons: string[];
+  objective: EvolutionObjectiveDelta | null;
+  budget_summary: Record<BudgetStatus, number>;
+  budget_rows: BudgetRow[];
+}
+
+export interface EvolutionDecision {
+  schema_version: typeof EVOLUTION_DECISION_SCHEMA_VERSION;
+  generated_at: string;
+  run_id: string;
+  objective: EvolutionObjective;
+  champion: string;
+  winner: string;
+  promoted: boolean;
+  candidates: EvolutionCandidateDecision[];
+}

--- a/docs/requirements/INDEX.md
+++ b/docs/requirements/INDEX.md
@@ -9,6 +9,23 @@
 
 ## Indexing
 
+### NFR-BENCH-712: KB CLI Evolution Harness
+**Status:** Implemented
+**Priority:** Medium
+
+**Requirement:** The system shall provide an advisory evolution harness that compares `kb` CLI benchmark champion and challenger arms, applies pre-registered objective and budget gates, and emits deterministic promotion artifacts without mutating defaults or benchmark baselines.
+**Rationale:** Performance and efficiency improvements need a repeatable champion/challenger loop that can explore configuration and implementation hypotheses while preserving retrieval quality and regression budgets.
+
+**Acceptance Criteria:**
+- [x] Given a plan with a champion report and candidate reports, when the evolution harness runs, then it writes `decision.json`, `report.md`, and copied arm reports under a run directory.
+- [x] Given a candidate improves the configured objective metric and has no disallowed budget rows, then the decision promotes that candidate over the champion.
+- [x] Given a candidate improves the objective metric but triggers a protected quality or performance budget failure, then the decision holds the champion.
+- [x] Given a candidate improvement is below the pre-registered objective margin, then the decision holds the champion.
+- [x] Given an arm supplies a command instead of a report path, then the harness can execute the command with arm-specific environment variables and consume the emitted benchmark JSON artifact.
+
+**Linked Tests:** TS-BENCH-712
+**Dependencies:** NFR-INDEX-236, RFC020
+
 ### NFR-INDEX-358: Default Text-First Ingest Filter
 **Status:** Implemented
 **Priority:** High

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "bench:mteb": "npm run build && tsc -p tsconfig.bench.json && node build/benchmarks/mteb/run.js",
     "bench:mteb:submit": "python3 benchmarks/mteb_submit.py",
     "bench:compare": "npm run build && tsc -p tsconfig.bench.json && node build/benchmarks/compare/run.js",
+    "bench:evol": "npm run build && tsc -p tsconfig.bench.json && node build/benchmarks/evolution/run.js",
     "bench:tune": "python3 benchmarks/optuna_tune.py",
     "docs:check-anchors": "node scripts/check-doc-anchors.mjs",
     "docs:generate-config-reference": "npm run build && node scripts/generate-config-reference.mjs",

--- a/tsconfig.bench.json
+++ b/tsconfig.bench.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "ignoreDeprecations": "5.0",
     "outDir": "build/benchmarks",
     "rootDir": "benchmarks",
     "tsBuildInfoFile": "build/benchmarks/.tsbuildinfo"


### PR DESCRIPTION
## Summary

Adds an advisory evolution harness for `kb` CLI performance and efficiency experiments. The harness compares a champion benchmark report against candidate arms, applies a pre-registered objective plus existing budget-diff gates, and writes deterministic `decision.json` and `report.md` artifacts without mutating defaults or benchmark baselines.

## Changes

- Add `benchmarks/evolution/` with plan types, decision logic, markdown reporting, CLI runner, README, and focused tests.
- Add `npm run bench:evol`.
- Document requirement `NFR-BENCH-712`.
- Add `ignoreDeprecations: "5.0"` to the benchmark tsconfig so benchmark builds remain compatible with the local TypeScript version.

## Validation

- `npm run test:file -- benchmarks/evolution/decision.test.ts benchmarks/evolution/run.test.ts`
- `tsc -p tsconfig.bench.json`
- `npm run bench:evol -- --plan=<synthetic-plan> --out-dir=<tmp>`

Note: `npm install` in the fresh worktree reported existing dependency audit findings, but this PR adds no dependencies and leaves `package-lock.json` unchanged.