### PR TITLE
[codex] Add convenient kb evolution chain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ benchmarks/results/**/*.trec
 # Stryker mutation testing output (issue #651)
 .stryker-tmp/
 reports/mutation/
+
+# Local evolution chain controls
+STOP
+.chain-heartbeat

--- a/.kookr/playbooks/evolve.md
+++ b/.kookr/playbooks/evolve.md
@@ -1,0 +1,76 @@
+---
+name: KB MCP - unattended kb CLI evolution chain
+description: Run kb CLI performance/efficiency evolution one iteration at a time from durable state.json. Each iteration benchmarks the current champion against untried candidate arms, applies the objective and budget gates, records history, and advances the state cursor.
+tags: [kb, cli, evolution, benchmark, self-continuation]
+cwd: $HOME/git/knowledge-base-mcp-server
+parameters:
+  - name: maxIter
+    description: "Optional cap on iterations for this chain run. 0 = run until STOP/state cap/no candidates."
+    required: false
+    default: "0"
+  - name: sleep
+    description: "Seconds to wait between iterations in the shell chain."
+    required: false
+    default: "1"
+---
+
+# Unattended kb CLI evolution chain
+
+This playbook gives the repo the same operator shape as the other evolution
+repos: durable state, a single-iteration driver, a chain driver, a STOP file,
+and append-only history.
+
+## How to run
+
+Single iteration:
+
+```bash
+cd ~/git/knowledge-base-mcp-server
+bin/run-iteration.sh
+```
+
+Run until stopped, no candidates remain, or a cap is reached:
+
+```bash
+cd ~/git/knowledge-base-mcp-server
+bin/run-chain.sh --max-iter {{maxIter}} --sleep {{sleep}}
+```
+
+Stop with `Ctrl-C`, `touch ./STOP`, or `kill <pid>`; the chain writes
+`.chain-heartbeat` while active.
+
+## Self-continuation contract
+
+When run as a Kookr self-continuation task chain, each task must:
+
+1. Read durable state from `state.json`; never rely on prior conversation.
+2. Do exactly one iteration: `bin/run-iteration.sh`.
+3. Treat `benchmarks/results/evolution/<run-id>/decision.json` as the mechanical
+   result for that iteration.
+4. Record state/history before spawning any successor. The driver updates
+   `state.json` and appends `history.md`.
+5. Stop without spawning when:
+   - `bin/run-iteration.sh` exits non-zero,
+   - `./STOP` exists,
+   - `state.json: chain.stop_after_iter` is reached,
+   - no eligible candidate remains for the current champion.
+6. Otherwise spawn the successor with this same contract and a uniqueness cursor
+   derived from fresh state, for example:
+   `cursor: iter=<state.chain.iter> champion=<state.current_champion.id> last=<state.last_run_id>`.
+
+The successor prompt must be self-contained and written through a prompt file,
+not embedded as a shell argv string.
+
+## State model
+
+- `current_champion` is the benchmark arm future candidates compare against.
+- `candidate_pool` contains candidate env/command mutations.
+- `candidate_history` prevents rerunning the same candidate against the same
+  champion.
+- `chain.candidates_per_iteration` controls batch size.
+- `chain.stop_after_iter` is a persistent cap; `null` means no persistent cap.
+
+The harness is advisory. A promotion updates `state.json`'s benchmark champion,
+but it does not rewrite production defaults or refresh committed baselines. If a
+candidate should become code or defaults, create a normal PR from the winning
+decision/report.

--- a/benchmarks/evolution/README.md
+++ b/benchmarks/evolution/README.md
@@ -5,6 +5,19 @@ performance and retrieval-efficiency changes. It is deliberately conservative:
 it emits `decision.json` and `report.md`, but it does not rewrite defaults,
 refresh baselines, or change code automatically.
 
+## Convenient chain
+
+For normal use, start with durable repo state instead of hand-writing a plan:
+
+```bash
+bin/run-iteration.sh          # one champion/challenger iteration
+bin/run-chain.sh --max-iter 0 # repeat until STOP, state cap, or no candidates
+```
+
+The chain reads `state.json`, writes artifacts under
+`benchmarks/results/evolution/<run-id>/`, advances `state.json`, and appends
+`history.md`. The Kookr playbook is `.kookr/playbooks/evolve.md`.
+
 ## Plan file
 
 ```json

--- a/benchmarks/evolution/iteration.test.ts
+++ b/benchmarks/evolution/iteration.test.ts
@@ -1,0 +1,195 @@
+import { execFile } from 'child_process';
+import * as fsp from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { promisify } from 'util';
+import type { BenchmarkReport } from '../types.js';
+import type { EvolutionState } from './types.js';
+
+const execFileAsync = promisify(execFile);
+
+describe('bench:evol iteration runner', () => {
+  it('runs one iteration from durable state and records state/history artifacts', async () => {
+    const tmp = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-evol-iteration-test-'));
+    const statePath = path.join(tmp, 'state.json');
+    const historyPath = path.join(tmp, 'history.md');
+    const outRoot = path.join(tmp, 'out');
+    const fakeBenchPath = path.join(tmp, 'fake-bench.js');
+    await fsp.writeFile(fakeBenchPath, fakeBenchProgram(), 'utf-8');
+    await fsp.writeFile(statePath, JSON.stringify(stateWith({
+      bench_command: ['node', fakeBenchPath],
+      candidate_pool: [
+        {
+          id: 'candidate',
+          env: { KB_CHUNK_SIZE: '768' },
+          hypothesis: 'synthetic CLI p95 improvement',
+        },
+      ],
+    }), null, 2), 'utf-8');
+    await fsp.writeFile(historyPath, '# history\n', 'utf-8');
+
+    const completed = await execFileAsync('node', [
+      '--import',
+      'tsx',
+      path.join(process.cwd(), 'benchmarks/evolution/iteration.ts'),
+      `--state=${statePath}`,
+      `--history=${historyPath}`,
+      `--out-root=${outRoot}`,
+    ], { cwd: process.cwd() });
+
+    expect(completed.stdout).toContain('iteration complete: iter-001');
+    await expect(fileExists(path.join(outRoot, 'iter-001', 'plan.json'))).resolves.toBe(true);
+    await expect(fileExists(path.join(outRoot, 'iter-001', 'decision.json'))).resolves.toBe(true);
+    const nextState = JSON.parse(await fsp.readFile(statePath, 'utf-8')) as EvolutionState;
+    expect(nextState.chain.iter).toBe(1);
+    expect(nextState.current_champion.id).toBe('candidate');
+    expect(nextState.last_promoted_run_id).toBe('iter-001');
+    const history = await fsp.readFile(historyPath, 'utf-8');
+    expect(history).toContain('`iter-001` PROMOTE');
+  });
+
+  it('exits with the chain-complete code when the state cap is reached', async () => {
+    const tmp = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-evol-iteration-cap-test-'));
+    const statePath = path.join(tmp, 'state.json');
+    await fsp.writeFile(statePath, JSON.stringify(stateWith({
+      chain: {
+        iter: 1,
+        candidates_per_iteration: 1,
+        stop_after_iter: 1,
+      },
+    }), null, 2), 'utf-8');
+
+    await expect(execFileAsync('node', [
+      '--import',
+      'tsx',
+      path.join(process.cwd(), 'benchmarks/evolution/iteration.ts'),
+      `--state=${statePath}`,
+      `--history=${path.join(tmp, 'history.md')}`,
+      `--out-root=${path.join(tmp, 'out')}`,
+    ], { cwd: process.cwd() })).rejects.toMatchObject({
+      code: 3,
+      stdout: expect.stringContaining('chain cap reached'),
+    });
+  });
+});
+
+function stateWith(overrides: Partial<EvolutionState>): EvolutionState {
+  return {
+    schema_version: 1,
+    playbook: '.kookr/playbooks/evolve.md',
+    current_champion: {
+      id: 'current-defaults',
+      env: {},
+    },
+    last_run_id: null,
+    last_promoted_run_id: null,
+    bench_command: ['npm', 'run', 'bench'],
+    champion_env: {
+      BENCH_PROVIDER: 'stub',
+      BENCH_INCLUDE_CLI_SEARCH: '1',
+      BENCH_CLI_SEARCH_REPETITIONS: '3',
+    },
+    objective: {
+      metric_path: 'scenarios.cli_search.variants.0.wall_p95_ms',
+      direction: 'lower',
+      min_absolute_improvement: 5,
+    },
+    gate: {
+      max_fail_rows: 0,
+      max_warn_rows: null,
+      require_metric_present: true,
+    },
+    chain: {
+      iter: 0,
+      candidates_per_iteration: 1,
+      stop_after_iter: null,
+    },
+    candidate_pool: [],
+    candidate_history: [],
+    last_decision: null,
+    ...overrides,
+  };
+}
+
+function fakeBenchProgram(): string {
+  return `
+const fs = require('fs');
+const path = require('path');
+const out = process.env.BENCH_RESULTS_DIR || process.cwd();
+fs.mkdirSync(out, { recursive: true });
+const wall = process.env.KB_CHUNK_SIZE === '768' ? 80 : 100;
+const report = ${JSON.stringify(reportWith(0))};
+report.scenarios.cli_search.variants[0].wall_p50_ms = wall;
+report.scenarios.cli_search.variants[0].wall_p95_ms = wall;
+report.scenarios.cli_search.variants[0].wall_p99_ms = wall;
+const file = path.join(out, \`\${process.env.BENCH_RESULTS_PREFIX}.json\`);
+fs.writeFileSync(file, JSON.stringify(report));
+console.log(\`JSON:\${file}\`);
+`;
+}
+
+function reportWith(warmP95Ms: number): BenchmarkReport {
+  return {
+    arch: 'x64',
+    git_sha: 'iteration-test',
+    node_version: process.version,
+    os: process.platform,
+    provider: 'stub',
+    scenarios: {
+      cold_index: { chunks: 10, files: 2, ms: 1000 },
+      cold_start: { fixture_documents: 2, ms: 40, rss_bytes: 1000 },
+      memory_peak: { chunk_count: 10, files: 2, heap_used_bytes: 1000, rss_bytes: 2000 },
+      retrieval_quality: {
+        default_fanout_factor: 3,
+        default_loaded_kbs: 1,
+        default_recall_at_10: 1,
+        query_count: 1,
+        sweep: [],
+      },
+      warm_query: { p50_ms: 10, p95_ms: 12, p99_ms: 14, repetitions: 3 },
+      cli_search: {
+        schema_version: 2,
+        profile: 'default',
+        fixture_knowledge_bases: 1,
+        fixture_files: 2,
+        fixture_chunk_count: 10,
+        variants: [{
+          variant: 'iteration-test',
+          format: 'json',
+          mode: 'dense',
+          effective_mode: 'dense',
+          scope: 'global',
+          query_shape: 'prose',
+          k: 5,
+          group_by_source: false,
+          repetitions: 3,
+          wall_p50_ms: warmP95Ms,
+          wall_p95_ms: warmP95Ms,
+          wall_p99_ms: warmP95Ms,
+          phase_percentiles: {},
+          process_start_p50_ms: null,
+          bootstrap_p50_ms: null,
+          model_resolution_p50_ms: null,
+          manager_load_p50_ms: null,
+          index_load_p50_ms: null,
+          embed_query_p50_ms: null,
+          faiss_search_p50_ms: null,
+          post_filter_p50_ms: null,
+          staleness_p50_ms: null,
+          cli_total_p50_ms: null,
+          rss_peak_bytes: null,
+        }],
+      },
+    },
+    version: 1,
+  };
+}
+
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    await fsp.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/benchmarks/evolution/iteration.ts
+++ b/benchmarks/evolution/iteration.ts
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+import * as fsp from 'fs/promises';
+import * as path from 'path';
+import { ensureDirectory, writeJsonFile } from '../utils.js';
+import { runEvolutionPlan } from './run.js';
+import {
+  appendHistory,
+  applyDecisionToState,
+  buildIterationPlan,
+  readEvolutionState,
+  renderHistoryLine,
+  writeEvolutionState,
+} from './state.js';
+import type { EvolutionDecision } from './types.js';
+
+interface IterationArgs {
+  historyPath: string;
+  outRoot: string;
+  statePath: string;
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const state = await readEvolutionState(args.statePath);
+  if (state.chain.stop_after_iter !== null && state.chain.iter >= state.chain.stop_after_iter) {
+    process.stdout.write(`chain cap reached: iter ${state.chain.iter} >= ${state.chain.stop_after_iter}\n`);
+    process.exitCode = 3;
+    return;
+  }
+
+  let built;
+  try {
+    built = buildIterationPlan(state);
+  } catch (error) {
+    process.stdout.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 3;
+    return;
+  }
+
+  const outDir = path.join(args.outRoot, built.plan.run_id!);
+  await ensureDirectory(outDir);
+  const planPath = path.join(outDir, 'plan.json');
+  await writeJsonFile(planPath, built.plan);
+
+  const result = await runEvolutionPlan({ planPath, outDir });
+  const decision = JSON.parse(await fsp.readFile(result.decisionPath, 'utf-8')) as EvolutionDecision;
+  const nextState = applyDecisionToState(state, built.plan, decision);
+  await writeEvolutionState(args.statePath, nextState);
+  await appendHistory(args.historyPath, renderHistoryLine(decision));
+
+  process.stdout.write(`iteration complete: ${decision.run_id}\n`);
+  process.stdout.write(`Decision: ${result.decisionPath}\n`);
+  process.stdout.write(`Report: ${result.reportPath}\n`);
+  process.stdout.write(`State: ${args.statePath}\n`);
+}
+
+function parseArgs(argv: string[]): IterationArgs {
+  const repoRoot = process.cwd();
+  let statePath = path.join(repoRoot, 'state.json');
+  let historyPath = path.join(repoRoot, 'history.md');
+  let outRoot = path.join(repoRoot, 'benchmarks', 'results', 'evolution');
+
+  for (const arg of argv) {
+    if (arg.startsWith('--state=')) statePath = arg.slice('--state='.length);
+    else if (arg.startsWith('--history=')) historyPath = arg.slice('--history='.length);
+    else if (arg.startsWith('--out-root=')) outRoot = arg.slice('--out-root='.length);
+    else throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return { historyPath, outRoot, statePath };
+}
+
+main().catch((error) => {
+  process.stderr.write(`${error instanceof Error ? error.stack ?? error.message : String(error)}\n`);
+  process.exitCode = 1;
+});

--- a/benchmarks/evolution/run.ts
+++ b/benchmarks/evolution/run.ts
@@ -2,6 +2,7 @@
 import * as fsp from 'fs/promises';
 import * as path from 'path';
 import { execFile } from 'child_process';
+import { fileURLToPath } from 'url';
 import { promisify } from 'util';
 import type { BenchmarkReport } from '../types.js';
 import { ensureDirectory, writeJsonFile } from '../utils.js';
@@ -16,8 +17,26 @@ import {
 
 const execFileAsync = promisify(execFile);
 
+export interface RunEvolutionPlanOptions {
+  outDir?: string;
+  planPath: string;
+}
+
+export interface RunEvolutionPlanResult {
+  decisionPath: string;
+  outDir: string;
+  reportPath: string;
+}
+
 async function main(): Promise<void> {
   const args = parseArgs(process.argv.slice(2));
+  const result = await runEvolutionPlan(args);
+  process.stdout.write(`Decision: ${result.decisionPath}\n`);
+  process.stdout.write(`Report: ${result.reportPath}\n`);
+}
+
+export async function runEvolutionPlan(options: RunEvolutionPlanOptions): Promise<RunEvolutionPlanResult> {
+  const args = options;
   const plan = await readPlan(args.planPath);
   const runId = plan.run_id ?? timestampRunId(new Date());
   const outDir = args.outDir ?? path.join(process.cwd(), 'benchmarks', 'results', 'evolution', runId);
@@ -37,10 +56,11 @@ async function main(): Promise<void> {
     runId,
   });
 
-  await writeJsonFile(path.join(outDir, 'decision.json'), decision);
-  await fsp.writeFile(path.join(outDir, 'report.md'), renderEvolutionMarkdown(decision), 'utf-8');
-  process.stdout.write(`Decision: ${path.join(outDir, 'decision.json')}\n`);
-  process.stdout.write(`Report: ${path.join(outDir, 'report.md')}\n`);
+  const decisionPath = path.join(outDir, 'decision.json');
+  const reportPath = path.join(outDir, 'report.md');
+  await writeJsonFile(decisionPath, decision);
+  await fsp.writeFile(reportPath, renderEvolutionMarkdown(decision), 'utf-8');
+  return { decisionPath, outDir, reportPath };
 }
 
 interface CliArgs {
@@ -134,7 +154,9 @@ function safeFileSegment(value: string): string {
   return value.replace(/[^A-Za-z0-9._-]+/g, '-').replace(/^-+|-+$/g, '') || 'arm';
 }
 
-main().catch((error) => {
-  process.stderr.write(`${error instanceof Error ? error.stack ?? error.message : String(error)}\n`);
-  process.exitCode = 1;
-});
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.stack ?? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/benchmarks/evolution/state.test.ts
+++ b/benchmarks/evolution/state.test.ts
@@ -1,0 +1,222 @@
+import type { EvolutionDecision, EvolutionState } from './types.js';
+import {
+  applyDecisionToState,
+  buildIterationPlan,
+  nextRunId,
+  renderHistoryLine,
+} from './state.js';
+
+const baseState: EvolutionState = {
+  schema_version: 1,
+  playbook: '.kookr/playbooks/evolve.md',
+  current_champion: {
+    id: 'current-defaults',
+    env: {
+      BENCH_PROVIDER: 'stub',
+      BENCH_INCLUDE_CLI_SEARCH: '1',
+    },
+  },
+  last_run_id: null,
+  last_promoted_run_id: null,
+  bench_command: ['npm', 'run', 'bench'],
+  champion_env: {
+    BENCH_PROVIDER: 'stub',
+    BENCH_CLI_SEARCH_REPETITIONS: '3',
+  },
+  objective: {
+    metric_path: 'scenarios.cli_search.variants.0.wall_p95_ms',
+    direction: 'lower',
+    min_absolute_improvement: 5,
+  },
+  gate: {
+    max_fail_rows: 0,
+    max_warn_rows: null,
+    require_metric_present: true,
+  },
+  chain: {
+    iter: 0,
+    candidates_per_iteration: 2,
+    stop_after_iter: null,
+  },
+  candidate_pool: [
+    {
+      id: 'chunk-768-overlap-128',
+      hypothesis: 'Try smaller chunks.',
+      axis: 'chunking',
+      env: {
+        KB_CHUNK_SIZE: '768',
+        KB_CHUNK_OVERLAP: '128',
+      },
+    },
+    {
+      id: 'batch-32',
+      hypothesis: 'Try a smaller embedding batch.',
+      axis: 'indexing-batch',
+      env: {
+        INDEXING_BATCH_SIZE: '32',
+      },
+    },
+    {
+      id: 'batch-128',
+      hypothesis: 'Try a larger embedding batch.',
+      axis: 'indexing-batch',
+      env: {
+        INDEXING_BATCH_SIZE: '128',
+      },
+    },
+  ],
+  candidate_history: [],
+  last_decision: null,
+};
+
+describe('evolution iteration state', () => {
+  it('builds a plan from durable state and selects untried candidates', () => {
+    const plan = buildIterationPlan({
+      ...baseState,
+      candidate_history: [
+        {
+          run_id: 'iter-001',
+          champion_id: 'current-defaults',
+          candidate_ids: ['chunk-768-overlap-128'],
+          winner: 'current-defaults',
+          promoted: false,
+          generated_at: '2026-06-20T00:00:00.000Z',
+        },
+      ],
+    });
+
+    expect(nextRunId(baseState)).toBe('iter-001');
+    expect(plan.plan.run_id).toBe('iter-001');
+    expect(plan.plan.champion).toMatchObject({
+      id: 'current-defaults',
+      command: ['npm', 'run', 'bench'],
+      env: {
+        BENCH_PROVIDER: 'stub',
+        BENCH_INCLUDE_CLI_SEARCH: '1',
+        BENCH_CLI_SEARCH_REPETITIONS: '3',
+      },
+    });
+    expect(plan.plan.candidates.map((candidate) => candidate.id)).toEqual(['batch-32', 'batch-128']);
+  });
+
+  it('promotes a winning candidate into the next champion state', () => {
+    const built = buildIterationPlan(baseState);
+    const decision = decisionFor({
+      promoted: true,
+      winner: 'chunk-768-overlap-128',
+    });
+
+    const next = applyDecisionToState(baseState, built.plan, decision);
+
+    expect(next.current_champion).toMatchObject({
+      id: 'chunk-768-overlap-128',
+    });
+    expect(next.current_champion.env).toEqual({
+      BENCH_PROVIDER: 'stub',
+      BENCH_CLI_SEARCH_REPETITIONS: '3',
+      BENCH_INCLUDE_CLI_SEARCH: '1',
+      KB_CHUNK_SIZE: '768',
+      KB_CHUNK_OVERLAP: '128',
+    });
+    expect(next.chain.iter).toBe(1);
+    expect(next.last_promoted_run_id).toBe('iter-001');
+    expect(next.candidate_history[0]).toMatchObject({
+      champion_id: 'current-defaults',
+      candidate_ids: ['chunk-768-overlap-128', 'batch-32'],
+    });
+  });
+
+  it('preserves a promoted command-bearing candidate as the next champion', () => {
+    const commandState: EvolutionState = {
+      ...baseState,
+      candidate_pool: [
+        {
+          id: 'custom-command',
+          command: ['node', 'bench.js'],
+          env: {
+            KB_CHUNK_SIZE: '900',
+          },
+        },
+      ],
+    };
+    const built = buildIterationPlan(commandState);
+    const next = applyDecisionToState(commandState, built.plan, decisionFor({
+      promoted: true,
+      winner: 'custom-command',
+    }));
+    const followup = buildIterationPlan({
+      ...next,
+      candidate_pool: [{ id: 'next-candidate', env: { INDEXING_BATCH_SIZE: '32' } }],
+    });
+
+    expect(next.current_champion.command).toEqual(['node', 'bench.js']);
+    expect(followup.plan.champion.command).toEqual(['node', 'bench.js']);
+  });
+
+  it('renders an append-only history line with candidate reasons', () => {
+    const line = renderHistoryLine(decisionFor({
+      promoted: false,
+      winner: 'current-defaults',
+      reason: 'budget fail rows 1 > 0',
+    }));
+
+    expect(line).toContain('`iter-001` HOLD');
+    expect(line).toContain('budget fail rows 1 > 0');
+  });
+
+  it('throws when no eligible candidates remain for the current champion', () => {
+    expect(() => buildIterationPlan({
+      ...baseState,
+      chain: { ...baseState.chain, candidates_per_iteration: 1 },
+      candidate_history: [
+        {
+          run_id: 'iter-001',
+          champion_id: 'current-defaults',
+          candidate_ids: ['chunk-768-overlap-128', 'batch-32', 'batch-128'],
+          winner: 'current-defaults',
+          promoted: false,
+          generated_at: '2026-06-20T00:00:00.000Z',
+        },
+      ],
+    })).toThrow('no eligible candidates remain');
+  });
+});
+
+function decisionFor(input: {
+  promoted: boolean;
+  reason?: string;
+  winner: string;
+}): EvolutionDecision {
+  return {
+    schema_version: 'kb.evolution-decision.v1',
+    generated_at: '2026-06-20T00:00:00.000Z',
+    run_id: 'iter-001',
+    objective: baseState.objective,
+    champion: 'current-defaults',
+    winner: input.winner,
+    promoted: input.promoted,
+    candidates: [
+      {
+        arm_id: 'chunk-768-overlap-128',
+        qualifies: input.promoted,
+        reasons: input.reason ? [input.reason] : [],
+        objective: {
+          baseline: 100,
+          current: input.promoted ? 80 : 110,
+          delta: input.promoted ? -20 : 10,
+          direction: 'lower',
+          improvement: input.promoted ? 20 : -10,
+          relative_improvement: input.promoted ? 0.2 : -0.1,
+          passed: input.promoted,
+        },
+        budget_summary: {
+          fail: input.reason ? 1 : 0,
+          pass: 8,
+          skip: 0,
+          warn: 0,
+        },
+        budget_rows: [],
+      },
+    ],
+  };
+}

--- a/benchmarks/evolution/state.ts
+++ b/benchmarks/evolution/state.ts
@@ -1,0 +1,143 @@
+import * as fsp from 'fs/promises';
+import * as path from 'path';
+import { writeJsonFile } from '../utils.js';
+import {
+  EVOLUTION_PLAN_SCHEMA_VERSION,
+  type EvolutionDecision,
+  type EvolutionPlan,
+  type EvolutionState,
+} from './types.js';
+
+export interface BuiltIterationPlan {
+  plan: EvolutionPlan;
+}
+
+export function nextRunId(state: EvolutionState): string {
+  return `iter-${String((state.chain?.iter ?? 0) + 1).padStart(3, '0')}`;
+}
+
+export function buildIterationPlan(state: EvolutionState): BuiltIterationPlan {
+  const runId = nextRunId(state);
+  const currentChampion = state.current_champion;
+  const command = currentChampion.command?.length
+    ? currentChampion.command
+    : state.bench_command?.length
+      ? state.bench_command
+      : ['npm', 'run', 'bench'];
+  const championEnv = {
+    ...(state.champion_env ?? {}),
+    ...(currentChampion.env ?? {}),
+  };
+  const triedAgainstChampion = new Set(
+    (state.candidate_history ?? [])
+      .filter((entry) => entry.champion_id === currentChampion.id)
+      .flatMap((entry) => entry.candidate_ids),
+  );
+  const eligible = (state.candidate_pool ?? [])
+    .filter((candidate) => candidate.id !== currentChampion.id)
+    .filter((candidate) => !triedAgainstChampion.has(candidate.id));
+  const selected = eligible.slice(0, Math.max(1, state.chain?.candidates_per_iteration ?? 1));
+
+  if (selected.length === 0) {
+    throw new Error(`no eligible candidates remain for champion ${currentChampion.id}`);
+  }
+
+  return {
+    plan: {
+      schema_version: EVOLUTION_PLAN_SCHEMA_VERSION,
+      run_id: runId,
+      objective: state.objective,
+      gate: state.gate,
+      champion: {
+        id: currentChampion.id,
+        ...(currentChampion.hypothesis ? { hypothesis: currentChampion.hypothesis } : {}),
+        command,
+        env: championEnv,
+      },
+      candidates: selected.map((candidate) => ({
+        ...candidate,
+        command: candidate.command ?? command,
+        env: {
+          ...championEnv,
+          ...(candidate.env ?? {}),
+        },
+      })),
+    },
+  };
+}
+
+export function applyDecisionToState(
+  state: EvolutionState,
+  plan: EvolutionPlan,
+  decision: EvolutionDecision,
+): EvolutionState {
+  const winningArm = plan.candidates.find((candidate) => candidate.id === decision.winner);
+  const nextChampion = decision.promoted && winningArm
+    ? {
+        id: winningArm.id,
+        ...(winningArm.hypothesis ? { hypothesis: winningArm.hypothesis } : {}),
+        ...(winningArm.command?.length ? { command: winningArm.command } : {}),
+        env: winningArm.env ?? {},
+      }
+    : state.current_champion;
+
+  return {
+    ...state,
+    current_champion: nextChampion,
+    last_run_id: decision.run_id,
+    last_promoted_run_id: decision.promoted ? decision.run_id : state.last_promoted_run_id,
+    chain: {
+      ...state.chain,
+      iter: (state.chain?.iter ?? 0) + 1,
+    },
+    candidate_history: [
+      ...(state.candidate_history ?? []),
+      {
+        run_id: decision.run_id,
+        champion_id: decision.champion,
+        candidate_ids: plan.candidates.map((candidate) => candidate.id),
+        winner: decision.winner,
+        promoted: decision.promoted,
+        generated_at: decision.generated_at,
+      },
+    ],
+    last_decision: {
+      run_id: decision.run_id,
+      champion: decision.champion,
+      winner: decision.winner,
+      promoted: decision.promoted,
+      candidate_ids: plan.candidates.map((candidate) => candidate.id),
+    },
+  };
+}
+
+export function renderHistoryLine(decision: EvolutionDecision): string {
+  const status = decision.promoted ? 'PROMOTE' : 'HOLD';
+  const candidateSummary = decision.candidates
+    .map((candidate) => {
+      const objective = candidate.objective
+        ? `improvement=${round(candidate.objective.improvement)}`
+        : 'objective=n/a';
+      const gate = candidate.qualifies ? 'qualified' : `blocked=${candidate.reasons.join('; ')}`;
+      return `${candidate.arm_id}(${objective}, ${gate})`;
+    })
+    .join('; ');
+  return `- ${decision.generated_at.slice(0, 10)} \`${decision.run_id}\` ${status} - champion ${decision.champion}; winner ${decision.winner}; candidates: ${candidateSummary}\n`;
+}
+
+export async function readEvolutionState(statePath: string): Promise<EvolutionState> {
+  return JSON.parse(await fsp.readFile(statePath, 'utf-8')) as EvolutionState;
+}
+
+export async function writeEvolutionState(statePath: string, state: EvolutionState): Promise<void> {
+  await writeJsonFile(statePath, state);
+}
+
+export async function appendHistory(historyPath: string, line: string): Promise<void> {
+  await fsp.mkdir(path.dirname(historyPath), { recursive: true });
+  await fsp.appendFile(historyPath, line, 'utf-8');
+}
+
+function round(value: number): number {
+  return Number(value.toFixed(6));
+}

--- a/benchmarks/evolution/types.ts
+++ b/benchmarks/evolution/types.ts
@@ -3,6 +3,7 @@ import type { BudgetRow, BudgetStatus } from '../budget-diff.js';
 
 export const EVOLUTION_PLAN_SCHEMA_VERSION = 'kb.evolution-plan.v1';
 export const EVOLUTION_DECISION_SCHEMA_VERSION = 'kb.evolution-decision.v1';
+export const EVOLUTION_STATE_SCHEMA_VERSION = 1;
 
 export type EvolutionMetricDirection = 'higher' | 'lower';
 
@@ -22,6 +23,7 @@ export interface EvolutionGate {
 export interface EvolutionArm {
   id: string;
   hypothesis?: string;
+  axis?: string;
   env?: Record<string, string>;
   command?: string[];
   report?: string;
@@ -71,4 +73,48 @@ export interface EvolutionDecision {
   winner: string;
   promoted: boolean;
   candidates: EvolutionCandidateDecision[];
+}
+
+export interface EvolutionChampion {
+  id: string;
+  hypothesis?: string;
+  command?: string[];
+  env?: Record<string, string>;
+}
+
+export interface EvolutionCandidateHistoryEntry {
+  run_id: string;
+  champion_id: string;
+  candidate_ids: string[];
+  winner: string;
+  promoted: boolean;
+  generated_at: string;
+}
+
+export interface EvolutionChainState {
+  iter: number;
+  candidates_per_iteration: number;
+  stop_after_iter: number | null;
+}
+
+export interface EvolutionState {
+  schema_version: typeof EVOLUTION_STATE_SCHEMA_VERSION;
+  playbook: string;
+  current_champion: EvolutionChampion;
+  last_run_id: string | null;
+  last_promoted_run_id: string | null;
+  bench_command: string[];
+  champion_env: Record<string, string>;
+  objective: EvolutionObjective;
+  gate: EvolutionGate;
+  chain: EvolutionChainState;
+  candidate_pool: EvolutionArm[];
+  candidate_history: EvolutionCandidateHistoryEntry[];
+  last_decision: {
+    run_id: string;
+    champion: string;
+    winner: string;
+    promoted: boolean;
+    candidate_ids: string[];
+  } | null;
 }

--- a/bin/run-chain.sh
+++ b/bin/run-chain.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Run kb CLI evolution iterations back to back until STOP, max-iter, or a state cap.
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+REPO=$(cd "$SCRIPT_DIR/.." && pwd)
+STOP_FLAG="$REPO/STOP"
+HEARTBEAT="$REPO/.chain-heartbeat"
+
+MAX_ITER=0
+SLEEP_S=1
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --max-iter) MAX_ITER="$2"; shift 2 ;;
+    --sleep) SLEEP_S="$2"; shift 2 ;;
+    *) echo "unknown flag: $1" >&2; exit 64 ;;
+  esac
+done
+
+stopping=0
+on_signal() { echo; echo "[chain] stop signal received; finishing cleanly."; stopping=1; }
+trap on_signal INT TERM
+
+cleanup() { rm -f "$HEARTBEAT"; }
+trap cleanup EXIT
+
+[ -f "$STOP_FLAG" ] && { echo "[chain] STOP flag present at $STOP_FLAG; remove it to run."; exit 0; }
+echo "pid=$$ started=$(date -u +%FT%TZ)" > "$HEARTBEAT"
+echo "[chain] starting (pid $$). sleep=${SLEEP_S}s max_iter=$([ "$MAX_ITER" -eq 0 ] && echo "unlimited" || echo "$MAX_ITER")."
+echo "[chain] stop with: Ctrl-C | touch $STOP_FLAG | kill $$"
+
+count=0
+while :; do
+  [ "$stopping" -eq 1 ] && { echo "[chain] stopped after $count iteration(s)."; break; }
+  if [ -f "$STOP_FLAG" ]; then
+    echo "[chain] STOP flag detected; stopping after $count iteration(s)."; break
+  fi
+  if [ "$MAX_ITER" -ne 0 ] && [ "$count" -ge "$MAX_ITER" ]; then
+    echo "[chain] reached --max-iter $MAX_ITER; stopping."; break
+  fi
+
+  set +e
+  "$REPO/bin/run-iteration.sh"
+  rc=$?
+  set -e
+  count=$((count + 1))
+  echo "iters_done=$count last_rc=$rc updated=$(date -u +%FT%TZ)" >> "$HEARTBEAT"
+
+  case "$rc" in
+    0) : ;;
+    3) echo "[chain] no eligible candidates or state cap reached; chain complete."; break ;;
+    *) echo "[chain] iteration error (rc=$rc); stopping for safety."; break ;;
+  esac
+
+  sleep "$SLEEP_S"
+done
+echo "[chain] done. $count iteration(s) this run. State in $REPO/state.json, log in $REPO/history.md."

--- a/bin/run-iteration.sh
+++ b/bin/run-iteration.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Mechanical wrapper: run exactly one kb CLI evolution iteration from durable state.
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+REPO=$(cd "$SCRIPT_DIR/.." && pwd)
+
+cd "$REPO"
+exec npm run bench:evol:iteration -- "$@"

--- a/docs/requirements/INDEX.md
+++ b/docs/requirements/INDEX.md
@@ -22,6 +22,9 @@
 - [x] Given a candidate improves the objective metric but triggers a protected quality or performance budget failure, then the decision holds the champion.
 - [x] Given a candidate improvement is below the pre-registered objective margin, then the decision holds the champion.
 - [x] Given an arm supplies a command instead of a report path, then the harness can execute the command with arm-specific environment variables and consume the emitted benchmark JSON artifact.
+- [x] Given durable evolution state, when a single iteration runs, then the system shall generate a plan, run the champion/challenger benchmark, update `state.json`, and append `history.md`.
+- [x] Given no eligible candidate remains for the current champion, when the iteration wrapper runs, then the chain shall stop with a cap/no-work exit instead of rerunning stale arms.
+- [x] Given an operator wants unattended convenience, when they use the Kookr playbook or `bin/run-chain.sh`, then the system shall provide the same one-iteration/self-continuation contract used by the sibling evolution repositories.
 
 **Linked Tests:** TS-BENCH-712
 **Dependencies:** NFR-INDEX-236, RFC020

--- a/history.md
+++ b/history.md
@@ -1,0 +1,4 @@
+# KB CLI evolution history
+
+Append-only log. Each line is written by `bin/run-iteration.sh` after the
+decision artifact is produced and `state.json` is advanced.

--- a/mutation-axes.md
+++ b/mutation-axes.md
@@ -1,0 +1,9 @@
+# KB CLI evolution mutation axes
+
+Candidate axes currently seeded in `state.json`:
+
+- `chunking` — `KB_CHUNK_SIZE` / `KB_CHUNK_OVERLAP` retrieval-layout levers.
+- `indexing-batch` — `INDEXING_BATCH_SIZE` provider-call and memory tradeoff.
+
+When adding candidate arms, append the new axis here with the reason it is worth
+testing and any closed forms that should not be reopened.

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "bench:mteb:submit": "python3 benchmarks/mteb_submit.py",
     "bench:compare": "npm run build && tsc -p tsconfig.bench.json && node build/benchmarks/compare/run.js",
     "bench:evol": "npm run build && tsc -p tsconfig.bench.json && node build/benchmarks/evolution/run.js",
+    "bench:evol:iteration": "npm run build && tsc -p tsconfig.bench.json && node build/benchmarks/evolution/iteration.js",
     "bench:tune": "python3 benchmarks/optuna_tune.py",
     "docs:check-anchors": "node scripts/check-doc-anchors.mjs",
     "docs:generate-config-reference": "npm run build && node scripts/generate-config-reference.mjs",

--- a/state.json
+++ b/state.json
@@ -1,0 +1,74 @@
+{
+  "schema_version": 1,
+  "playbook": ".kookr/playbooks/evolve.md",
+  "current_champion": {
+    "id": "current-defaults",
+    "hypothesis": "Repository defaults on origin/main.",
+    "env": {}
+  },
+  "last_run_id": null,
+  "last_promoted_run_id": null,
+  "bench_command": [
+    "npm",
+    "run",
+    "bench"
+  ],
+  "champion_env": {
+    "BENCH_PROVIDER": "stub",
+    "BENCH_INCLUDE_CLI_SEARCH": "1",
+    "BENCH_CLI_SEARCH_REPETITIONS": "3"
+  },
+  "objective": {
+    "metric_path": "scenarios.cli_search.variants.0.wall_p95_ms",
+    "direction": "lower",
+    "min_absolute_improvement": 5
+  },
+  "gate": {
+    "max_fail_rows": 0,
+    "max_warn_rows": null,
+    "require_metric_present": true
+  },
+  "chain": {
+    "iter": 0,
+    "candidates_per_iteration": 2,
+    "stop_after_iter": null
+  },
+  "candidate_pool": [
+    {
+      "id": "chunk-768-overlap-128",
+      "axis": "chunking",
+      "hypothesis": "Smaller chunks with moderate overlap may reduce CLI search tail latency without recall or budget regressions.",
+      "env": {
+        "KB_CHUNK_SIZE": "768",
+        "KB_CHUNK_OVERLAP": "128"
+      }
+    },
+    {
+      "id": "chunk-1200-overlap-160",
+      "axis": "chunking",
+      "hypothesis": "Larger chunks with lower relative overlap may reduce index and search overhead while preserving source coverage.",
+      "env": {
+        "KB_CHUNK_SIZE": "1200",
+        "KB_CHUNK_OVERLAP": "160"
+      }
+    },
+    {
+      "id": "index-batch-32",
+      "axis": "indexing-batch",
+      "hypothesis": "A smaller indexing batch may lower memory/RSS risk while keeping CLI latency within budget.",
+      "env": {
+        "INDEXING_BATCH_SIZE": "32"
+      }
+    },
+    {
+      "id": "index-batch-128",
+      "axis": "indexing-batch",
+      "hypothesis": "A larger indexing batch may reduce provider-call overhead and cold index time without RSS regressions.",
+      "env": {
+        "INDEXING_BATCH_SIZE": "128"
+      }
+    }
+  ],
+  "candidate_history": [],
+  "last_decision": null
+}


### PR DESCRIPTION
## Summary

Adds the repo-level convenience layer for the kb CLI evolution harness:

- durable `state.json`, `history.md`, and `mutation-axes.md`
- one-iteration and chain shell drivers under `bin/`
- Kookr playbook at `.kookr/playbooks/evolve.md`
- state/iteration TypeScript helpers for generating plans, applying promotion decisions, and advancing the chain cursor
- tests covering state transitions, command-bearing promoted champions, and the iteration CLI path

## Operator impact

After merge, evolutions can be started with:

```bash
bin/run-iteration.sh
bin/run-chain.sh --max-iter 0 --sleep 1
```

The chain stops on `STOP`, state cap, no eligible candidates, or iteration failure. It writes artifacts under `benchmarks/results/evolution/<run-id>/`, advances `state.json`, and appends `history.md`.

## Review notes

Pre-PR specialist review found and I addressed:

- unused iteration-plan metadata
- command-bearing candidate promotions not retaining their command in `current_champion`
- test coverage gaps around exact champion env and the iteration entrypoint
- docs separator consistency

## Verification

- `npm run test:file -- benchmarks/evolution/decision.test.ts benchmarks/evolution/run.test.ts benchmarks/evolution/state.test.ts benchmarks/evolution/iteration.test.ts`
- `./node_modules/.bin/tsc -p tsconfig.bench.json`
- `npm run build`
- `npm test`
- synthetic `bin/run-iteration.sh` smoke test with temporary state/history/out paths
- `git diff --check`
