### PR TITLE
feat: add TTY progress spinner for long `kb reindex` and `kb ask` runs

### DIFF
--- a/src/cli-ask.ts
+++ b/src/cli-ask.ts
@@ -48,6 +48,7 @@ import {
   type SaveTranscriptInput,
   type SaveTranscriptResult,
 } from './ask-repl.js';
+import { createTtyProgress } from './tty-progress.js';
 
 export {
   DEFAULT_ASK_CONTEXT_BUDGET_TOKENS,
@@ -193,6 +194,11 @@ export async function runAsk(rest: string[], deps: RunAskDeps = defaultRunAskDep
 
   let result: AskKnowledgeResult;
   let streamedAnswer = false;
+  // #759 — retrieval + LLM latency can leave the terminal silent for many
+  // seconds. Show a stderr spinner while we wait; it self-suppresses for
+  // JSON / piped / NO_COLOR output and is cleared before any answer prints.
+  const progress = createTtyProgress({ label: 'kb ask: thinking', format: args.format });
+  progress.start();
   try {
     const streamMarkdown = args.format === 'md' && !args.noStream;
     result = await executeAsk({
@@ -201,13 +207,18 @@ export async function runAsk(rest: string[], deps: RunAskDeps = defaultRunAskDep
       ...(streamMarkdown
         ? {
             onAnswerToken: (token: string) => {
+              // Clear the spinner before the first streamed token so stdout
+              // never interleaves with the stderr spinner line.
+              progress.stop();
               streamedAnswer = true;
               process.stdout.write(token);
             },
           }
         : {}),
     }, toRunAskCoreDeps(deps), totalStartedAt);
+    progress.stop();
   } catch (err) {
+    progress.stop();
     if (err instanceof AskExecutionError) {
       if (err.failure !== undefined) {
         return reportAskFailure(args.format, err.failure, err.exitCode);

--- a/src/cli-reindex.ts
+++ b/src/cli-reindex.ts
@@ -19,6 +19,7 @@ import { FAISS_INDEX_PATH } from './config/paths.js';
 import { assertSufficientDiskSpace } from './disk-preflight.js';
 import { KBError } from './errors.js';
 import { logger } from './logger.js';
+import { createTtyProgress } from './tty-progress.js';
 
 export const REINDEX_HELP = `kb reindex — rebuild FAISS indexes (RFC 017)
 
@@ -184,6 +185,12 @@ export async function runReindexCli(rest: string[]): Promise<number> {
     throw err;
   }
 
+  // #759 — a contextual rebuild can run for many seconds while emitting
+  // nothing until it finishes. Show a stderr spinner so the operator can tell
+  // the process is working, not hung. It self-suppresses on non-TTY / NO_COLOR
+  // output and is cleared before the summary prints to stdout.
+  const progress = createTtyProgress({ label: 'kb reindex: rebuilding index', format: 'md' });
+  progress.start();
   let result: ReindexResult;
   try {
     result = await runReindex({
@@ -191,6 +198,7 @@ export async function runReindexCli(rest: string[]): Promise<number> {
       force: parsed.force,
     });
   } catch (err) {
+    progress.stop();
     const message = (err as Error).message;
     const code = (err as { code?: unknown }).code;
     if (code === 'KB_NOT_FOUND') {
@@ -201,6 +209,7 @@ export async function runReindexCli(rest: string[]): Promise<number> {
     return 1;
   }
 
+  progress.stop();
   process.stdout.write(formatHumanResult(result));
 
   switch (result.outcome) {

--- a/src/tty-progress.test.ts
+++ b/src/tty-progress.test.ts
@@ -1,0 +1,172 @@
+import {
+  TtyProgress,
+  createTtyProgress,
+  ttyProgressEnabled,
+} from './tty-progress.js';
+
+// A minimal stream stub: capture writes and advertise a TTY flag.
+function fakeStream(isTTY: boolean) {
+  const writes: string[] = [];
+  return {
+    isTTY,
+    write: (text: string) => {
+      writes.push(text);
+      return true;
+    },
+    writes,
+  };
+}
+
+describe('ttyProgressEnabled', () => {
+  it('is enabled on a TTY with no suppressors', () => {
+    expect(ttyProgressEnabled({ label: 'x', stream: fakeStream(true), env: {} })).toBe(true);
+  });
+
+  it('is disabled when the stream is not a TTY', () => {
+    expect(ttyProgressEnabled({ label: 'x', stream: fakeStream(false), env: {} })).toBe(false);
+  });
+
+  it('is disabled for --format=json even on a TTY', () => {
+    expect(
+      ttyProgressEnabled({ label: 'x', stream: fakeStream(true), env: {}, format: 'json' }),
+    ).toBe(false);
+  });
+
+  it('is disabled when NO_COLOR is set', () => {
+    expect(
+      ttyProgressEnabled({ label: 'x', stream: fakeStream(true), env: { NO_COLOR: '1' } }),
+    ).toBe(false);
+  });
+
+  it('is disabled when --color=never', () => {
+    expect(
+      ttyProgressEnabled({ label: 'x', stream: fakeStream(true), env: {}, colorFlag: 'never' }),
+    ).toBe(false);
+  });
+
+  it('does NOT spray ANSI into a pipe even with --color=always (hard TTY gate)', () => {
+    expect(
+      ttyProgressEnabled({ label: 'x', stream: fakeStream(false), env: {}, colorFlag: 'always' }),
+    ).toBe(false);
+  });
+});
+
+describe('TtyProgress when disabled', () => {
+  it('never writes anything — output is byte-identical to no spinner', () => {
+    const writes: string[] = [];
+    const progress = new TtyProgress({
+      label: 'kb ask: thinking',
+      enabled: false,
+      write: (t) => writes.push(t),
+    });
+    progress.start();
+    progress.tick();
+    progress.stop();
+    expect(writes).toEqual([]);
+  });
+});
+
+describe('TtyProgress when enabled', () => {
+  // Deterministic seams: a manual scheduler that never fires on its own, plus
+  // a controllable clock, so frame emission is driven explicitly by the test.
+  function harness(nowValues: number[]) {
+    const writes: string[] = [];
+    let scheduled: (() => void) | null = null;
+    let cleared = false;
+    let nowIdx = 0;
+    const progress = new TtyProgress({
+      label: 'kb ask: thinking',
+      enabled: true,
+      write: (t) => writes.push(t),
+      now: () => nowValues[Math.min(nowIdx++, nowValues.length - 1)]!,
+      scheduler: {
+        set: (cb) => {
+          scheduled = cb;
+          return 0 as unknown as ReturnType<typeof setInterval>;
+        },
+        clear: () => {
+          cleared = true;
+        },
+      },
+    });
+    return {
+      progress,
+      writes,
+      fireTimer: () => scheduled?.(),
+      wasCleared: () => cleared,
+    };
+  }
+
+  it('renders a frame with a carriage return, clear-line, spinner glyph and label on start', () => {
+    const h = harness([0]);
+    h.progress.start();
+    expect(h.writes).toHaveLength(1);
+    expect(h.writes[0]).toContain('\r\x1b[K');
+    expect(h.writes[0]).toMatch(/kb ask: thinking \(0s\)$/);
+    // The first glyph is the first frame of the spinner set.
+    expect(h.writes[0]).toContain('⠋');
+  });
+
+  it('advances the spinner glyph and elapsed clock on tick', () => {
+    const h = harness([0, 2000]);
+    h.progress.start();
+    h.progress.tick();
+    expect(h.writes).toHaveLength(2);
+    expect(h.writes[0]).toContain('⠋');
+    expect(h.writes[1]).toContain('⠙');
+    expect(h.writes[1]).toMatch(/\(2s\)$/);
+  });
+
+  it('animates via the scheduled timer callback', () => {
+    const h = harness([0, 500]);
+    h.progress.start();
+    h.fireTimer();
+    expect(h.writes).toHaveLength(2);
+  });
+
+  it('clears its line and stops the timer on stop()', () => {
+    const h = harness([0]);
+    h.progress.start();
+    h.progress.stop();
+    expect(h.writes[h.writes.length - 1]).toBe('\r\x1b[K');
+    expect(h.wasCleared()).toBe(true);
+  });
+
+  it('is idempotent: a second stop() is a no-op', () => {
+    const h = harness([0]);
+    h.progress.start();
+    h.progress.stop();
+    const countAfterFirstStop = h.writes.length;
+    h.progress.stop();
+    expect(h.writes).toHaveLength(countAfterFirstStop);
+  });
+
+  it('does not render after stop() even if a stale timer fires', () => {
+    const h = harness([0]);
+    h.progress.start();
+    h.progress.stop();
+    const countAfterStop = h.writes.length;
+    h.fireTimer();
+    expect(h.writes).toHaveLength(countAfterStop);
+  });
+});
+
+describe('createTtyProgress', () => {
+  it('produces an inert instance that writes nothing on a non-TTY stream', () => {
+    const stream = fakeStream(false);
+    const progress = createTtyProgress({ label: 'kb reindex', stream, env: {} });
+    progress.start();
+    progress.tick();
+    progress.stop();
+    expect(stream.writes).toEqual([]);
+  });
+
+  it('writes spinner frames to the stream when enabled', () => {
+    const stream = fakeStream(true);
+    const progress = createTtyProgress({ label: 'kb reindex', stream, env: {}, now: () => 0 });
+    progress.start();
+    expect(stream.writes.length).toBeGreaterThan(0);
+    progress.stop();
+    expect(stream.writes[stream.writes.length - 1]).toBe('\r\x1b[K');
+  });
+});

--- a/src/tty-progress.ts
+++ b/src/tty-progress.ts
@@ -1,0 +1,172 @@
+// Issue #759 — opt-out, TTY-only progress indicator for long-running CLI
+// commands (`kb reindex --with-context`, `kb ask`).
+//
+// Both commands can run for many seconds — a whole-corpus rebuild or an LLM
+// generation — while emitting nothing until they finish, so the user cannot
+// tell whether the process is working or hung. This renders a lightweight
+// spinner + elapsed clock to stderr while the slow work runs, then erases it
+// before any real output prints.
+//
+// Suppression rules (mirroring `src/color.ts`, so a piped or scripted
+// invocation is byte-identical to before this feature existed):
+//   - never when the target stream is not a TTY (piped / redirected output);
+//   - never for `--format=json` output;
+//   - honor NO_COLOR / `--color` / `KB_COLOR` via the shared color resolver.
+//
+// The renderer writes ONLY to its stderr stream and clears its own line on
+// stop, so it can never corrupt stdout (the JSON / markdown answer) or piped
+// output. Every method is a no-op when disabled.
+
+import { resolveColorEnabled, type ColorMode } from './color.js';
+
+// Braille spinner frames — the widely-used cli-spinners "dots" set. Single
+// display-width glyphs so the `\r`-rewrite stays on one column.
+const SPINNER_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+
+const DEFAULT_INTERVAL_MS = 100;
+
+// Carriage-return + erase-to-end-of-line: return to column 0 and clear the
+// previously-rendered frame so the next frame (or the caller's output) starts
+// from a clean line.
+const CLEAR_LINE = '\r\x1b[K';
+
+interface Scheduler {
+  set: (cb: () => void, ms: number) => ReturnType<typeof setInterval>;
+  clear: (handle: ReturnType<typeof setInterval>) => void;
+}
+
+export interface TtyProgressOptions {
+  /** Human label rendered before the spinner + elapsed clock. */
+  label: string;
+  /** When false, every method is a no-op (nothing is ever written). */
+  enabled: boolean;
+  /** Frame sink. Defaults to `process.stderr.write`. Tests pass a capture. */
+  write?: (text: string) => void;
+  /** Monotonic-ish clock for the elapsed counter. Defaults to `Date.now`. */
+  now?: () => number;
+  /** Frame cadence in milliseconds. Defaults to 100ms. */
+  intervalMs?: number;
+  /** Timer seam. Defaults to global `setInterval`/`clearInterval`. */
+  scheduler?: Scheduler;
+}
+
+/**
+ * A minimal start/tick/stop spinner. Construct it via {@link createTtyProgress}
+ * so enablement is resolved consistently; the class is exported for tests that
+ * want to drive frames deterministically.
+ */
+export class TtyProgress {
+  private readonly label: string;
+  private readonly enabled: boolean;
+  private readonly write: (text: string) => void;
+  private readonly now: () => number;
+  private readonly intervalMs: number;
+  private readonly scheduler: Scheduler;
+
+  private frame = 0;
+  private startedAtMs = 0;
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private active = false;
+
+  constructor(options: TtyProgressOptions) {
+    this.label = options.label;
+    this.enabled = options.enabled;
+    this.write = options.write ?? ((text) => void process.stderr.write(text));
+    this.now = options.now ?? Date.now;
+    this.intervalMs = options.intervalMs ?? DEFAULT_INTERVAL_MS;
+    this.scheduler = options.scheduler ?? {
+      set: (cb, ms) => setInterval(cb, ms),
+      clear: (handle) => clearInterval(handle),
+    };
+  }
+
+  /** Begin animating. No-op when disabled or already running. */
+  start(): void {
+    if (!this.enabled || this.active) return;
+    this.active = true;
+    this.startedAtMs = this.now();
+    this.render();
+    // Guard the timer callback on `active` too: a stale fire that races a
+    // `stop()` (or a test scheduler that ignores `clear`) must not repaint the
+    // line after it was erased.
+    this.timer = this.scheduler.set(() => {
+      if (this.active) this.render();
+    }, this.intervalMs);
+    // Never keep the process alive just for the spinner — the awaited work
+    // owns the event loop; the spinner is decoration on top of it.
+    const timer = this.timer as unknown as { unref?: () => void };
+    if (typeof timer.unref === 'function') timer.unref();
+  }
+
+  /** Render the next frame immediately. No-op when disabled or stopped. */
+  tick(): void {
+    if (!this.enabled || !this.active) return;
+    this.render();
+  }
+
+  /** Erase the spinner line and stop animating. Idempotent; safe to call
+   * before any stdout/stderr write so real output starts on a clean line. */
+  stop(): void {
+    if (!this.enabled || !this.active) return;
+    if (this.timer !== null) {
+      this.scheduler.clear(this.timer);
+      this.timer = null;
+    }
+    this.active = false;
+    this.write(CLEAR_LINE);
+  }
+
+  private render(): void {
+    const elapsedS = Math.floor((this.now() - this.startedAtMs) / 1000);
+    const glyph = SPINNER_FRAMES[this.frame % SPINNER_FRAMES.length];
+    this.frame += 1;
+    this.write(`${CLEAR_LINE}${glyph} ${this.label} (${elapsedS}s)`);
+  }
+}
+
+export interface TtyProgressResolveInput {
+  /** Human label rendered before the spinner + elapsed clock. */
+  label: string;
+  /** Output format of the command; `json` always suppresses the spinner. */
+  format?: 'md' | 'json';
+  /** Target stream. Defaults to `process.stderr`. */
+  stream?: Pick<NodeJS.WriteStream, 'isTTY' | 'write'>;
+  /** Explicit `--color` mode when the command parses one. */
+  colorFlag?: ColorMode;
+  /** Environment for NO_COLOR / KB_COLOR resolution. Defaults to process env. */
+  env?: NodeJS.ProcessEnv;
+  /** Clock seam forwarded to {@link TtyProgress}. */
+  now?: () => number;
+}
+
+/**
+ * Decide whether a progress spinner should render. The stream must be a TTY
+ * (a hard gate — even `--color=always` must not spray ANSI into a pipe), the
+ * format must not be `json`, and color must be enabled per the shared
+ * precedence rule in `src/color.ts` (which honors NO_COLOR / KB_COLOR).
+ */
+export function ttyProgressEnabled(input: TtyProgressResolveInput): boolean {
+  if (input.format === 'json') return false;
+  const stream = input.stream ?? process.stderr;
+  if (!stream.isTTY) return false;
+  return resolveColorEnabled({
+    ...(input.colorFlag !== undefined ? { flag: input.colorFlag } : {}),
+    ...(input.env !== undefined ? { env: input.env } : {}),
+    isTTY: true,
+  });
+}
+
+/**
+ * Build a {@link TtyProgress} whose enablement is resolved from the stream,
+ * format, and color settings. When suppressed, the returned instance is an
+ * inert no-op — callers can unconditionally `start()`/`stop()` it.
+ */
+export function createTtyProgress(input: TtyProgressResolveInput): TtyProgress {
+  const stream = input.stream ?? process.stderr;
+  return new TtyProgress({
+    label: input.label,
+    enabled: ttyProgressEnabled(input),
+    write: (text) => void stream.write(text),
+    ...(input.now !== undefined ? { now: input.now } : {}),
+  });
+}


### PR DESCRIPTION
## Summary
- Add `src/tty-progress.ts` — a small, injectable `TtyProgress` helper (`start`/`tick`/`stop`) that renders a braille spinner + elapsed clock to **stderr** while long work runs, then erases its own line.
- Wire it into `kb ask` (spinner during the retrieval + LLM wait, cleared on the first streamed token or before the answer prints) and `kb reindex --with-context` (spinner during the rebuild, cleared before the summary).
- Suppression reuses the existing color precedence (`resolveColorEnabled`): the spinner is off when stderr is **not a TTY**, for **`--format=json`**, and when **`NO_COLOR` / `--color=never` / `KB_COLOR`** disable color. A hard TTY gate means even `--color=always` never sprays ANSI into a pipe.
- JSON and piped output stay **byte-identical** — the renderer only touches stderr and no-ops entirely when disabled.

## Design choices (issue left open)
- **Elapsed-time spinner rather than reindex counts/ETA.** The issue's ideal was "spinner + counts/ETA for reindex". `kb reindex` delegates to `FaissIndexManager.updateIndex(undefined, {force})`, which exposes no cheap mid-run progress callback; surfacing live per-file counts would require threading a callback through the manager rebuild — a larger cross-cutting change. This PR ships the smallest thing that satisfies the core need ("is it working or hung?") with an elapsed spinner. A follow-up can add `updateIndex` progress callbacks and upgrade the reindex label to counts/ETA.
- **No `--quiet` flag added.** The issue mentioned honoring a "quiet flag", but neither command has one today; the existing color/NO_COLOR/TTY controls are the suppression surface. Adding a new flag was out of scope.

## Test plan
- [x] `src/tty-progress.test.ts` — 15 cases: enable/disable matrix (TTY, json, NO_COLOR, `--color=never`, `--color=always` on a pipe), byte-identical no-op when disabled, frame/glyph/elapsed rendering, timer animation, idempotent stop, and no repaint after stop.
- [x] Existing `cli-ask` / `cli-reindex` suites pass unchanged (35 tests).
- [x] `tsc --noEmit` and `eslint src` clean.

_Note: the local embedding provider was flagged degraded at launch, so the two commands were not driven end-to-end against a live index; the deterministic unit tests cover the spinner gating and clear-before-output behavior that constitute the runtime surface._

Closes #759

🤖 Generated with [Claude Code](https://claude.com/claude-code)