### PR TITLE
feat: emit resource list change notifications

### DIFF
--- a/docs/mcp-resources.md
+++ b/docs/mcp-resources.md
@@ -54,6 +54,19 @@ Clients that implement MCP `completion/complete` can ask the server for guided a
 | `kb` | Knowledge-base directory names under `KNOWLEDGE_BASES_ROOT_DIR`, prefix-matched against the in-progress value. |
 | `path` | Ingestable, non-quarantined KB-relative paths within the selected `kb`, prefix-matched against the in-progress value and capped to the MCP completion page size. |
 
+## Resource List Change Notifications
+
+The server emits MCP `notifications/resources/list_changed` whenever a successful mutation changes the concrete `resources/list` output:
+
+- `add_document` emits after creating a new ingestable file, but not when overwriting an existing URI.
+- `delete_document` emits after removing an ingestable file.
+- `refresh_knowledge_base` emits only when the resource listing differs from the last snapshot.
+- The optional filesystem watcher emits after a watched create or delete changes the resource listing.
+
+The notification means clients should invalidate cached `resources/list` results and request the list again. It is intentionally coarser than per-resource update streaming: the server does not yet implement `resources/subscribe` or `notifications/resources/updated`.
+
+In stdio mode the notification is sent on the root MCP server. In SSE and streamable HTTP modes it is fanned out to every live session; a failure in one session is logged at debug level and does not prevent delivery attempts to the remaining sessions.
+
 ## `kb://` URI Format
 
 Resource URIs use this form:

--- a/docs/rfcs/010-mcp-surface-v2.md
+++ b/docs/rfcs/010-mcp-surface-v2.md
@@ -566,13 +566,19 @@ extension is in the map above. A KB with mixed markdown and PDFs shows only
 the markdown in v1. CHANGELOG calls this out. `kb_stats` (§5.7) reports
 total file counts unconditionally so users see what's hidden.
 
-#### 5.3.4 `resources/subscribe` — explicitly v2
+#### 5.3.4 Resource change notifications
 
-Gated on RFC 007 stage 5.1's watcher being on-by-default (per RFC 007 §6.6
-and §9 decision gate B). Once live, a follow-up PR flips on
-`resources/subscribe` + emits `resources/updated` when the watcher's
-dirty-set flush completes. No design in this RFC — the watcher's
-notifications are what we subscribe to. Tracked as "follow-up to M5" in §8.
+Implemented for v1: the server emits MCP
+`notifications/resources/list_changed` after successful mutations that change
+the concrete `resources/list` output. This includes new ingestable files,
+deleted ingestable files, and reindex/watch events whose before/after resource
+URI fingerprints differ. Clients should treat this as a cache invalidation
+signal and call `resources/list` again.
+
+Still explicitly v2: `resources/subscribe` and per-resource
+`notifications/resources/updated`. Those require a separate subscription model
+and resource identity/change payload design. The v1 notification is intentionally
+coarse-grained and does not imply per-file streaming semantics.
 
 ### 5.4 Issue #51 — Ingest tools (`add_document`, `delete_document`, `refresh_knowledge_base`)
 

--- a/src/KnowledgeBaseServer.test.ts
+++ b/src/KnowledgeBaseServer.test.ts
@@ -670,6 +670,52 @@ describe('KnowledgeBaseServer handlers', () => {
     expect(notify).toHaveBeenCalledTimes(1);
   });
 
+  it('handleAddDocument sends resource list notifications through the HTTP host in HTTP mode', async () => {
+    const tempDir = await setRetrieveEnv();
+    await fsp.mkdir(path.join(tempDir, 'alpha'));
+    updateIndexMock.mockResolvedValue(undefined);
+
+    const server = await freshServer();
+    await server['refreshResourceListFingerprint']();
+    const rootNotify = jest.spyOn(server['mcp'], 'sendResourceListChanged');
+    const hostNotify = jest.fn().mockResolvedValue(undefined);
+    server['transportMode'] = 'http';
+    server['httpHost'] = { notifyResourceListChanged: hostNotify };
+
+    const result = await server['handleAddDocument']({
+      knowledge_base_name: 'alpha',
+      path: 'notes/http.md',
+      content: '# HTTP\n',
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(hostNotify).toHaveBeenCalledTimes(1);
+    expect(rootNotify).not.toHaveBeenCalled();
+  });
+
+  it('handleAddDocument sends resource list notifications through the SSE host in SSE mode', async () => {
+    const tempDir = await setRetrieveEnv();
+    await fsp.mkdir(path.join(tempDir, 'alpha'));
+    updateIndexMock.mockResolvedValue(undefined);
+
+    const server = await freshServer();
+    await server['refreshResourceListFingerprint']();
+    const rootNotify = jest.spyOn(server['mcp'], 'sendResourceListChanged');
+    const hostNotify = jest.fn().mockResolvedValue(undefined);
+    server['transportMode'] = 'sse';
+    server['sseHost'] = { notifyResourceListChanged: hostNotify };
+
+    const result = await server['handleAddDocument']({
+      knowledge_base_name: 'alpha',
+      path: 'notes/sse.md',
+      content: '# SSE\n',
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(hostNotify).toHaveBeenCalledTimes(1);
+    expect(rootNotify).not.toHaveBeenCalled();
+  });
+
   it('handleAddDocument does not notify resources/list_changed for an overwrite', async () => {
     const tempDir = await setRetrieveEnv();
     const documentPath = path.join(tempDir, 'alpha', 'notes', 'existing.md');

--- a/src/KnowledgeBaseServer.test.ts
+++ b/src/KnowledgeBaseServer.test.ts
@@ -648,6 +648,8 @@ describe('KnowledgeBaseServer handlers', () => {
     updateIndexMock.mockResolvedValue(undefined);
 
     const server = await freshServer();
+    await server['refreshResourceListFingerprint']();
+    const notify = jest.spyOn(server['mcp'], 'sendResourceListChanged');
     const result = await server['handleAddDocument']({
       knowledge_base_name: 'alpha',
       path: 'notes/new.md',
@@ -665,6 +667,30 @@ describe('KnowledgeBaseServer handlers', () => {
       absolute_path: documentPath,
       indexed: true,
     });
+    expect(notify).toHaveBeenCalledTimes(1);
+  });
+
+  it('handleAddDocument does not notify resources/list_changed for an overwrite', async () => {
+    const tempDir = await setRetrieveEnv();
+    const documentPath = path.join(tempDir, 'alpha', 'notes', 'existing.md');
+    await fsp.mkdir(path.dirname(documentPath), { recursive: true });
+    await fsp.writeFile(documentPath, 'old content');
+    updateIndexMock.mockResolvedValue(undefined);
+
+    const server = await freshServer();
+    await server['refreshResourceListFingerprint']();
+    const notify = jest.spyOn(server['mcp'], 'sendResourceListChanged');
+
+    const result = await server['handleAddDocument']({
+      knowledge_base_name: 'alpha',
+      path: 'notes/existing.md',
+      content: 'new content',
+    });
+
+    expect(result.isError).toBeUndefined();
+    await expect(fsp.readFile(documentPath, 'utf-8')).resolves.toBe('new content');
+    expect(updateIndexMock).toHaveBeenCalledWith('alpha');
+    expect(notify).not.toHaveBeenCalled();
   });
 
   it('handleAddDocument removes a new file when indexing fails after the write', async () => {
@@ -893,6 +919,8 @@ describe('KnowledgeBaseServer handlers', () => {
     await fsp.writeFile(sidecarPath, 'hash');
 
     const server = await freshServer();
+    await server['refreshResourceListFingerprint']();
+    const notify = jest.spyOn(server['mcp'], 'sendResourceListChanged');
     const result = await server['handleDeleteDocument']({
       knowledge_base_name: 'alpha',
       path: 'notes/old.md',
@@ -910,6 +938,7 @@ describe('KnowledgeBaseServer handlers', () => {
       sidecar_path: sidecarPath,
       deleted: true,
     });
+    expect(notify).toHaveBeenCalledTimes(1);
   });
 
   it('handleDeleteDocument rejects path traversal and leaves files intact', async () => {
@@ -953,6 +982,8 @@ describe('KnowledgeBaseServer handlers', () => {
     updateIndexMock.mockResolvedValue(undefined);
 
     const server = await freshServer();
+    await server['refreshResourceListFingerprint']();
+    const notify = jest.spyOn(server['mcp'], 'sendResourceListChanged');
     const result = await server['handleReindexKnowledgeBase']({
       knowledge_base_name: 'alpha',
     });
@@ -964,6 +995,28 @@ describe('KnowledgeBaseServer handlers', () => {
     // so the response advertises scope: 'global' even when a KB name was
     // passed. The KB name is preserved as a caller-provided echo.
     expect(payload).toEqual({ knowledge_base_name: 'alpha', reindexed: true, scope: 'global' });
+    expect(notify).not.toHaveBeenCalled();
+  });
+
+  it('handleReindexKnowledgeBase notifies when the resource listing changed since the last snapshot', async () => {
+    const tempDir = await setRetrieveEnv();
+    const documentPath = path.join(tempDir, 'alpha', 'notes', 'new.md');
+    await fsp.mkdir(path.join(tempDir, 'alpha'), { recursive: true });
+    updateIndexMock.mockResolvedValue(undefined);
+
+    const server = await freshServer();
+    await server['refreshResourceListFingerprint']();
+    const notify = jest.spyOn(server['mcp'], 'sendResourceListChanged');
+    await fsp.mkdir(path.dirname(documentPath), { recursive: true });
+    await fsp.writeFile(documentPath, '# New\n');
+
+    const result = await server['handleReindexKnowledgeBase']({
+      knowledge_base_name: 'alpha',
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(updateIndexMock).toHaveBeenCalledWith('alpha', { force: true });
+    expect(notify).toHaveBeenCalledTimes(1);
   });
 
   it('handleReindexKnowledgeBase forces a global update when no KB is named', async () => {

--- a/src/KnowledgeBaseServer.ts
+++ b/src/KnowledgeBaseServer.ts
@@ -307,6 +307,7 @@ export class KnowledgeBaseServer {
   // Complements `triggerWatcher` (root-level dotfile poller); this one
   // observes per-file edits *inside* each KB tree.
   private fsWatcher?: RecursiveKbWatcher;
+  private resourceListFingerprint: string | null = null;
   private shutdownInstalled = false;
   // Issue #54 — uptime baseline for kb_stats.server.uptime_ms.
   private readonly startedAt: number = Date.now();
@@ -695,19 +696,27 @@ export class KnowledgeBaseServer {
   }
 
   private async handleAddDocument(args: AddDocumentArgs): Promise<CallToolResult> {
-    return handleAddDocument(args, {
+    const result = await handleAddDocument(args, {
       getActiveManagerForMutation: () => this.getActiveManagerForMutation(),
       withCanonicalTool: (base, operation, enrich) =>
         this.withCanonicalTool(base, operation, enrich),
     });
+    if (!result.isError) {
+      await this.notifyResourceListChangedIfListingChanged();
+    }
+    return result;
   }
 
   private async handleDeleteDocument(args: DeleteDocumentArgs): Promise<CallToolResult> {
-    return handleDeleteDocument(args, {
+    const result = await handleDeleteDocument(args, {
       getActiveManagerForMutation: () => this.getActiveManagerForMutation(),
       withCanonicalTool: (base, operation, enrich) =>
         this.withCanonicalTool(base, operation, enrich),
     });
+    if (!result.isError) {
+      await this.notifyResourceListChangedIfListingChanged();
+    }
+    return result;
   }
 
   private async handleReindexKnowledgeBase(args: {
@@ -718,36 +727,37 @@ export class KnowledgeBaseServer {
       kb_scope: args.knowledge_base_name ?? null,
     }, async () => {
       try {
-      const manager = await this.getActiveManagerForMutation();
-      await withWriteLock(manager.modelDir, async () => {
-        if (args.knowledge_base_name !== undefined) {
-          await resolveKnowledgeBaseDir(KNOWLEDGE_BASES_ROOT_DIR, args.knowledge_base_name);
-        }
-        await manager.updateIndex(args.knowledge_base_name, { force: true });
-      });
+        const manager = await this.getActiveManagerForMutation();
+        await withWriteLock(manager.modelDir, async () => {
+          if (args.knowledge_base_name !== undefined) {
+            await resolveKnowledgeBaseDir(KNOWLEDGE_BASES_ROOT_DIR, args.knowledge_base_name);
+          }
+          await manager.updateIndex(args.knowledge_base_name, { force: true });
+        });
+        await this.notifyResourceListChangedIfListingChanged();
 
-      return {
-        content: [{
-          type: 'text',
-          text: JSON.stringify({
-            knowledge_base_name: args.knowledge_base_name ?? null,
-            reindexed: true,
-            // FAISS has no per-vector deletion in this server, so every
-            // forced rebuild covers all KBs (see FaissIndexManager.updateIndex).
-            scope: 'global',
-          }, null, 2),
-        }],
-      };
-    } catch (error: unknown) {
-      if (error instanceof ActiveModelResolutionError) {
-        return { content: [{ type: 'text', text: error.message }], isError: true };
-      }
-      const err = toError(error);
-      logger.error('Error re-indexing knowledge base:', err);
-      if (err.stack) {
-        logger.error(err.stack);
-      }
-      return { content: [mcpErrorContent(err)], isError: true };
+        return {
+          content: [{
+            type: 'text',
+            text: JSON.stringify({
+              knowledge_base_name: args.knowledge_base_name ?? null,
+              reindexed: true,
+              // FAISS has no per-vector deletion in this server, so every
+              // forced rebuild covers all KBs (see FaissIndexManager.updateIndex).
+              scope: 'global',
+            }, null, 2),
+          }],
+        };
+      } catch (error: unknown) {
+        if (error instanceof ActiveModelResolutionError) {
+          return { content: [{ type: 'text', text: error.message }], isError: true };
+        }
+        const err = toError(error);
+        logger.error('Error re-indexing knowledge base:', err);
+        if (err.stack) {
+          logger.error(err.stack);
+        }
+        return { content: [mcpErrorContent(err)], isError: true };
       }
     });
   }
@@ -1462,6 +1472,7 @@ export class KnowledgeBaseServer {
     await this.mcp.connect(transport);
     this.transportMode = 'stdio';
     logger.info('Knowledge Base MCP server running on stdio');
+    await this.refreshResourceListFingerprint();
     this.startActiveManagerWarmup();
     this.startTriggerWatcher();
     await this.startFsWatcher();
@@ -1480,6 +1491,7 @@ export class KnowledgeBaseServer {
     // host.start() unwinds without leaving a dangling polling timer.
     await host.start();
     this.transportMode = 'sse';
+    await this.refreshResourceListFingerprint();
     this.startActiveManagerWarmup();
     this.startTriggerWatcher();
     await this.startFsWatcher();
@@ -1496,6 +1508,7 @@ export class KnowledgeBaseServer {
     this.installHttpShutdown();
     await host.start();
     this.transportMode = 'http';
+    await this.refreshResourceListFingerprint();
     this.startActiveManagerWarmup();
     this.startTriggerWatcher();
     await this.startFsWatcher();
@@ -1597,6 +1610,55 @@ export class KnowledgeBaseServer {
     }
   }
 
+  private async readResourceListFingerprint(): Promise<string> {
+    const result = await listResources();
+    return result.resources.map((resource) => resource.uri).sort().join('\0');
+  }
+
+  private async refreshResourceListFingerprint(): Promise<void> {
+    try {
+      this.resourceListFingerprint = await this.readResourceListFingerprint();
+    } catch (err) {
+      logger.warn(`Unable to snapshot MCP resource list: ${toError(err).message}`);
+      this.resourceListFingerprint = null;
+    }
+  }
+
+  private async notifyResourceListChangedIfListingChanged(): Promise<void> {
+    let nextFingerprint: string;
+    try {
+      nextFingerprint = await this.readResourceListFingerprint();
+    } catch (err) {
+      logger.warn(`Unable to compare MCP resource list after mutation: ${toError(err).message}`);
+      await this.sendResourceListChanged();
+      this.resourceListFingerprint = null;
+      return;
+    }
+
+    const previousFingerprint = this.resourceListFingerprint;
+    this.resourceListFingerprint = nextFingerprint;
+    if (previousFingerprint !== null && previousFingerprint === nextFingerprint) {
+      return;
+    }
+    await this.sendResourceListChanged();
+  }
+
+  private async sendResourceListChanged(): Promise<void> {
+    if (this.transportMode === 'sse') {
+      if (this.sseHost) await this.sseHost.notifyResourceListChanged();
+      return;
+    }
+    if (this.transportMode === 'http') {
+      if (this.httpHost) await this.httpHost.notifyResourceListChanged();
+      return;
+    }
+    try {
+      this.mcp.sendResourceListChanged();
+    } catch (err) {
+      logger.debug(`Unable to emit MCP resource list change: ${toError(err).message}`);
+    }
+  }
+
   /**
    * RFC 007 §6.6 / issue #212 — opt-in recursive `fs.watch` watcher.
    * Off by default; `KB_FS_WATCH=1` enables it. Failure to enumerate
@@ -1631,6 +1693,7 @@ export class KnowledgeBaseServer {
           const activeId = await resolveActiveModel();
           const manager = await this.managers.getOrCreate(activeId);
           await withWriteLock(manager.modelDir, () => manager.updateIndex(kbName));
+          await this.notifyResourceListChangedIfListingChanged();
         } catch (err) {
           logger.warn(
             `RecursiveKbWatcher updateIndex(${kbName}) failed: ${(err as Error).message}`,
@@ -1662,6 +1725,7 @@ export class KnowledgeBaseServer {
           const activeId = await resolveActiveModel();
           const manager = await this.managers.getOrCreate(activeId);
           await withWriteLock(manager.modelDir, () => manager.updateIndex(undefined));
+          await this.notifyResourceListChangedIfListingChanged();
         } catch (err) {
           logger.warn(`Trigger watcher updateIndex failed: ${(err as Error).message}`);
         }

--- a/src/KnowledgeBaseServer.ts
+++ b/src/KnowledgeBaseServer.ts
@@ -1630,6 +1630,8 @@ export class KnowledgeBaseServer {
       nextFingerprint = await this.readResourceListFingerprint();
     } catch (err) {
       logger.warn(`Unable to compare MCP resource list after mutation: ${toError(err).message}`);
+      // The mutation already succeeded; fail open so clients drop stale
+      // listing caches instead of missing a possible create/delete.
       await this.sendResourceListChanged();
       this.resourceListFingerprint = null;
       return;

--- a/src/transport/base-http-host.ts
+++ b/src/transport/base-http-host.ts
@@ -202,28 +202,31 @@ export abstract class BaseHttpHost<TTransport extends { close(): Promise<void> }
     logger_: string,
     data: string,
   ): Promise<void> {
-    const targets = [...this.sessions.values()].map((entry) => entry.mcp);
-    if (targets.length === 0) return;
-    await Promise.all(
-      targets.map(async (target) => {
-        try {
-          await target.sendLoggingMessage({ level, logger: logger_, data });
-        } catch (err) {
-          logger.debug(`[${this.logPrefix}] notify error: ${(err as Error).message}`);
-        }
-      }),
+    await this.fanoutMcpServers(
+      (target) => target.sendLoggingMessage({ level, logger: logger_, data }),
+      'notify error',
     );
   }
 
   async notifyResourceListChanged(): Promise<void> {
+    await this.fanoutMcpServers(
+      (target) => target.server.sendResourceListChanged(),
+      'resources/list_changed notify error',
+    );
+  }
+
+  private async fanoutMcpServers(
+    action: (target: McpServer) => Promise<void>,
+    errorLabel: string,
+  ): Promise<void> {
     const targets = [...this.sessions.values()].map((entry) => entry.mcp);
     if (targets.length === 0) return;
     await Promise.all(
       targets.map(async (target) => {
         try {
-          target.sendResourceListChanged();
+          await action(target);
         } catch (err) {
-          logger.debug(`[${this.logPrefix}] resources/list_changed notify error: ${(err as Error).message}`);
+          logger.debug(`[${this.logPrefix}] ${errorLabel}: ${(err as Error).message}`);
         }
       }),
     );

--- a/src/transport/base-http-host.ts
+++ b/src/transport/base-http-host.ts
@@ -215,6 +215,20 @@ export abstract class BaseHttpHost<TTransport extends { close(): Promise<void> }
     );
   }
 
+  async notifyResourceListChanged(): Promise<void> {
+    const targets = [...this.sessions.values()].map((entry) => entry.mcp);
+    if (targets.length === 0) return;
+    await Promise.all(
+      targets.map(async (target) => {
+        try {
+          target.sendResourceListChanged();
+        } catch (err) {
+          logger.debug(`[${this.logPrefix}] resources/list_changed notify error: ${(err as Error).message}`);
+        }
+      }),
+    );
+  }
+
   async start(): Promise<http.Server> {
     if (this.server) {
       throw new Error(`${this.constructor.name} already started`);

--- a/src/transport/http.test.ts
+++ b/src/transport/http.test.ts
@@ -522,16 +522,42 @@ describe('StreamableHttpHost — endpoints', () => {
   it('notifyResourceListChanged fans out to every live session McpServer', async () => {
     const started = await startHost({});
     stop = started.stop;
-    const sessionA = { sendResourceListChanged: jest.fn() };
-    const sessionB = { sendResourceListChanged: jest.fn() };
+    const sessionA = { server: { sendResourceListChanged: jest.fn().mockResolvedValue(undefined) } };
+    const sessionB = { server: { sendResourceListChanged: jest.fn().mockResolvedValue(undefined) } };
     const sessions: Map<string, { transport: unknown; mcp: unknown }> =
       (started.host as unknown as { sessions: Map<string, { transport: unknown; mcp: unknown }> }).sessions;
     sessions.set('a', { transport: {}, mcp: sessionA });
     sessions.set('b', { transport: {}, mcp: sessionB });
 
     await expect(started.host.notifyResourceListChanged()).resolves.toBeUndefined();
-    expect(sessionA.sendResourceListChanged).toHaveBeenCalledTimes(1);
-    expect(sessionB.sendResourceListChanged).toHaveBeenCalledTimes(1);
+    expect(sessionA.server.sendResourceListChanged).toHaveBeenCalledTimes(1);
+    expect(sessionB.server.sendResourceListChanged).toHaveBeenCalledTimes(1);
+
+    sessions.clear();
+  });
+
+  it('notifyResourceListChanged no-ops when there are no live sessions', async () => {
+    const started = await startHost({});
+    stop = started.stop;
+
+    await expect(started.host.notifyResourceListChanged()).resolves.toBeUndefined();
+  });
+
+  it('notifyResourceListChanged swallows per-session errors so one bad client cannot poison the rest', async () => {
+    const started = await startHost({});
+    stop = started.stop;
+    const happy = { server: { sendResourceListChanged: jest.fn().mockResolvedValue(undefined) } };
+    const sad = {
+      server: { sendResourceListChanged: jest.fn().mockRejectedValue(new Error('client gone')) },
+    };
+    const sessions: Map<string, { transport: unknown; mcp: unknown }> =
+      (started.host as unknown as { sessions: Map<string, { transport: unknown; mcp: unknown }> }).sessions;
+    sessions.set('happy', { transport: {}, mcp: happy });
+    sessions.set('sad', { transport: {}, mcp: sad });
+
+    await expect(started.host.notifyResourceListChanged()).resolves.toBeUndefined();
+    expect(happy.server.sendResourceListChanged).toHaveBeenCalledTimes(1);
+    expect(sad.server.sendResourceListChanged).toHaveBeenCalledTimes(1);
 
     sessions.clear();
   });

--- a/src/transport/http.test.ts
+++ b/src/transport/http.test.ts
@@ -518,6 +518,23 @@ describe('StreamableHttpHost — endpoints', () => {
 
     sessions.clear();
   });
+
+  it('notifyResourceListChanged fans out to every live session McpServer', async () => {
+    const started = await startHost({});
+    stop = started.stop;
+    const sessionA = { sendResourceListChanged: jest.fn() };
+    const sessionB = { sendResourceListChanged: jest.fn() };
+    const sessions: Map<string, { transport: unknown; mcp: unknown }> =
+      (started.host as unknown as { sessions: Map<string, { transport: unknown; mcp: unknown }> }).sessions;
+    sessions.set('a', { transport: {}, mcp: sessionA });
+    sessions.set('b', { transport: {}, mcp: sessionB });
+
+    await expect(started.host.notifyResourceListChanged()).resolves.toBeUndefined();
+    expect(sessionA.sendResourceListChanged).toHaveBeenCalledTimes(1);
+    expect(sessionB.sendResourceListChanged).toHaveBeenCalledTimes(1);
+
+    sessions.clear();
+  });
 });
 
 const UUID_REGEX =

--- a/src/transport/sse.test.ts
+++ b/src/transport/sse.test.ts
@@ -838,4 +838,21 @@ describe('SseHost — endpoints', () => {
 
     sessions.clear();
   });
+
+  it('notifyResourceListChanged fans out to every live session McpServer', async () => {
+    const started = await startHost({});
+    stop = started.stop;
+    const sessionA = { sendResourceListChanged: jest.fn() };
+    const sessionB = { sendResourceListChanged: jest.fn() };
+    const sessions: Map<string, { transport: unknown; mcp: unknown }> =
+      (started.host as unknown as { sessions: Map<string, { transport: unknown; mcp: unknown }> }).sessions;
+    sessions.set('a', { transport: {}, mcp: sessionA });
+    sessions.set('b', { transport: {}, mcp: sessionB });
+
+    await expect(started.host.notifyResourceListChanged()).resolves.toBeUndefined();
+    expect(sessionA.sendResourceListChanged).toHaveBeenCalledTimes(1);
+    expect(sessionB.sendResourceListChanged).toHaveBeenCalledTimes(1);
+
+    sessions.clear();
+  });
 });

--- a/src/transport/sse.test.ts
+++ b/src/transport/sse.test.ts
@@ -842,16 +842,42 @@ describe('SseHost — endpoints', () => {
   it('notifyResourceListChanged fans out to every live session McpServer', async () => {
     const started = await startHost({});
     stop = started.stop;
-    const sessionA = { sendResourceListChanged: jest.fn() };
-    const sessionB = { sendResourceListChanged: jest.fn() };
+    const sessionA = { server: { sendResourceListChanged: jest.fn().mockResolvedValue(undefined) } };
+    const sessionB = { server: { sendResourceListChanged: jest.fn().mockResolvedValue(undefined) } };
     const sessions: Map<string, { transport: unknown; mcp: unknown }> =
       (started.host as unknown as { sessions: Map<string, { transport: unknown; mcp: unknown }> }).sessions;
     sessions.set('a', { transport: {}, mcp: sessionA });
     sessions.set('b', { transport: {}, mcp: sessionB });
 
     await expect(started.host.notifyResourceListChanged()).resolves.toBeUndefined();
-    expect(sessionA.sendResourceListChanged).toHaveBeenCalledTimes(1);
-    expect(sessionB.sendResourceListChanged).toHaveBeenCalledTimes(1);
+    expect(sessionA.server.sendResourceListChanged).toHaveBeenCalledTimes(1);
+    expect(sessionB.server.sendResourceListChanged).toHaveBeenCalledTimes(1);
+
+    sessions.clear();
+  });
+
+  it('notifyResourceListChanged no-ops when there are no live sessions', async () => {
+    const started = await startHost({});
+    stop = started.stop;
+
+    await expect(started.host.notifyResourceListChanged()).resolves.toBeUndefined();
+  });
+
+  it('notifyResourceListChanged swallows per-session errors so one bad client cannot poison the rest', async () => {
+    const started = await startHost({});
+    stop = started.stop;
+    const happy = { server: { sendResourceListChanged: jest.fn().mockResolvedValue(undefined) } };
+    const sad = {
+      server: { sendResourceListChanged: jest.fn().mockRejectedValue(new Error('client gone')) },
+    };
+    const sessions: Map<string, { transport: unknown; mcp: unknown }> =
+      (started.host as unknown as { sessions: Map<string, { transport: unknown; mcp: unknown }> }).sessions;
+    sessions.set('happy', { transport: {}, mcp: happy });
+    sessions.set('sad', { transport: {}, mcp: sad });
+
+    await expect(started.host.notifyResourceListChanged()).resolves.toBeUndefined();
+    expect(happy.server.sendResourceListChanged).toHaveBeenCalledTimes(1);
+    expect(sad.server.sendResourceListChanged).toHaveBeenCalledTimes(1);
 
     sessions.clear();
   });


### PR DESCRIPTION
## Summary
- Emit MCP `notifications/resources/list_changed` when successful KB mutations change the concrete `resources/list` output.
- Fan the notification out across SSE and streamable HTTP sessions with per-session error isolation.
- Document the implemented list-invalidation behavior and keep per-resource subscriptions marked as future work.

## Design choices
- The implementation compares a sorted URI fingerprint of `resources/list` before and after successful mutations. This keeps overwrites quiet and avoids treating every reindex as a list change.
- If listing comparison fails after a successful mutation, the server fails open and emits `list_changed` so clients do not keep stale resource-list caches.
- HTTP/SSE fanout uses the SDK's lower-level async server notification method so rejected sends are caught per session.

## Test plan
- [x] `npm run build`
- [x] `npm run test:file -- src/KnowledgeBaseServer.test.ts src/transport/http.test.ts src/transport/sse.test.ts`
- [x] `npm run check` (exits 0; the existing Jest coverage collection warning for `src/cli.ts` `import.meta` is still printed)
- [x] `git diff --check`
- [x] Manual portability scan of changed lines; project portability helper scripts are not present on this branch

Closes #745

🤖 Generated with [Claude Code](https://claude.com/claude-code)
