### PR TITLE
chore: opt out of pr-checklist env rule (.kookr/pr-checklist.json)

### DIFF
--- a/.kookr/pr-checklist.json
+++ b/.kookr/pr-checklist.json
@@ -1,0 +1,1 @@
+{ "disable": ["env"] }


### PR DESCRIPTION
## Summary

Adds `.kookr/pr-checklist.json` = `{ "disable": ["env"] }`.

Kookr's pr-checklist gate (rfc-pr-checklist-contract, P4a) machine-verifies a PR's anti-drift checklist against the diff. Its built-in `env` rule expects new `process.env.X` references to appear in a flat `.env.example`. This repo instead documents its 100+ config vars in typed `src/config/*.ts` modules and `docs/reference/configuration.md`, so that rule is a structural mismatch that would fail-closed-deny most PRs.

This declaratively disables **just** the `env` rule for this repo. The remaining built-ins stay active — notably `new-tests` (a new source file must have a co-located test), which fits this repo's TDD convention (135 co-located `*.test.ts`). Declarative-only: the config can only relax this repo's own gate; CI stays authoritative.

## Testing

- [ ] `npm test` passes — N/A: config-only, no source/test change.
- [x] Verified the JSON parses under the engine's config schema (`{ "disable": ["env"] }`).

## Changelog

N/A — internal tooling config, no user-visible behavior change.

## Follow-ups

Once merged, `jeanibarz/knowledge-base-mcp-server` gets added to Kookr's pr-checklist scope list so the gate activates for its PRs.
