### PR TITLE
feat: support kb serve unix sockets

### DIFF
--- a/docs/operations/daemon-lifecycle.md
+++ b/docs/operations/daemon-lifecycle.md
@@ -1,9 +1,10 @@
 # `kb serve` — Local CLI Daemon Lifecycle
 
-`kb serve` runs a loopback-only HTTP daemon that serves read-only `kb search`,
-`kb list`, and `kb stats` requests from CLI clients. The point is *warm
-reads*: the daemon keeps the FAISS index, model adapter, and lexical store
-loaded in memory so each CLI invocation skips the cold-start cost.
+`kb serve` runs a local HTTP daemon that serves read-only `kb search`, `kb list`,
+and `kb stats` requests from CLI clients over loopback TCP or a Unix-domain
+socket. The point is *warm reads*: the daemon keeps the FAISS index, model
+adapter, and lexical store loaded in memory so each CLI invocation skips the
+cold-start cost.
 
 CLI clients use the daemon when they pass `--daemon`. If the daemon is not
 reachable, they print a one-line notice on stderr and fall back to direct
@@ -112,8 +113,9 @@ Exit codes are deliberately distinct:
 CLI clients and `kb serve status` resolve the daemon URL in this order:
 
 1. `KB_DAEMON_URL` (explicit, used verbatim — must include scheme)
-2. `KB_DAEMON_HOST` + `KB_DAEMON_PORT` (composed)
-3. Default `http://127.0.0.1:17799/`
+2. `KB_DAEMON_SOCKET` (Unix-domain socket path)
+3. `KB_DAEMON_HOST` + `KB_DAEMON_PORT` (composed)
+4. Default `http://127.0.0.1:17799/`
 
 For a non-default port:
 
@@ -124,9 +126,20 @@ kb serve status
 # kb serve: daemon running at http://127.0.0.1:18888/
 ```
 
-For a per-user instance on a multi-tenant host, run on a unique port and
-export `KB_DAEMON_URL` in the user's shell profile so every CLI call hits the
-right daemon.
+For a per-user instance on a multi-tenant host, prefer a Unix-domain socket so
+filesystem permissions control access and no TCP port allocation is needed:
+
+```bash
+export KB_DAEMON_SOCKET="$XDG_RUNTIME_DIR/kb-daemon.sock"
+kb serve &
+kb serve status
+# kb serve: daemon running at unix:///run/user/1000/kb-daemon.sock
+```
+
+`kb serve --socket=/path/to/kb-daemon.sock` binds the foreground daemon to a
+socket path directly. The daemon creates the socket with `0600` permissions,
+removes stale socket files before binding, and refuses to replace a socket that
+already accepts connections.
 
 ## Use the daemon from CLI clients
 

--- a/docs/operations/metrics-export.md
+++ b/docs/operations/metrics-export.md
@@ -9,7 +9,8 @@ monitoring:
 
 The endpoint is disabled by default. It includes KB names and model ids, so do
 not expose it on an untrusted interface. Remote transports already require
-`MCP_AUTH_TOKEN`; the local `kb serve` daemon remains loopback-only.
+`MCP_AUTH_TOKEN`; the local `kb serve` daemon is not exposed remotely by
+default.
 
 ## Enable
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1539,10 +1539,10 @@ Run a localhost daemon for warm read-only CLI requests.
 kb serve — resident local daemon for warm CLI reads
 
 Usage:
-  kb serve [--host=127.0.0.1] [--port=17799] [--idle-timeout-ms=300000] [--warm]
+  kb serve [--host=127.0.0.1] [--port=17799] [--socket=/path/to/kb.sock] [--idle-timeout-ms=300000] [--warm]
   kb serve status [--json]
 
-Starts a localhost-only JSON HTTP daemon used by `kb search --daemon`.
+Starts a local JSON HTTP daemon used by `kb search --daemon`.
 The daemon accepts read-only search/list/stats requests and exits after the
 idle timeout.
 
@@ -1554,6 +1554,7 @@ daemon it prints a one-line notice to stderr and runs the search directly.
 Options:
   --host=<host>             Loopback host to bind (default: 127.0.0.1).
   --port=<port>             TCP port to bind (default: 17799; 0 for tests).
+  --socket=<path>           Unix-domain socket to bind instead of TCP.
   --idle-timeout-ms=<ms>    Stop after this much idle time (default: 300000).
   --warm                    Pre-warm the active model, FAISS index, and
                             lexical indexes before the daemon reports ready.
@@ -1564,6 +1565,8 @@ Environment:
   KB_DAEMON_URL             Daemon URL queried by `kb serve status` and
                             `kb search --daemon` (default
                             http://127.0.0.1:17799).
+  KB_DAEMON_SOCKET          Unix-domain socket path queried by clients and
+                            bound by `kb serve` when KB_DAEMON_URL is unset.
   KB_METRICS_EXPORT         Set to `on` to expose OpenMetrics text at
                             `GET /metrics` on the loopback daemon.
   KB_DAEMON_MAX_CONCURRENCY Max requests the daemon runs at once before

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -90,6 +90,7 @@ Run `npm run docs:generate-config-reference` after changing the schema.
 | <code>KB_MUTATION_AUDIT_LOG</code> | <code>path</code> | _unset_ |  |  | uses default |  |
 | <code>KB_AGE_BUDGET_HOURS</code> | <code>integer</code> | _unset_ |  | >= <code>1</code> | uses default |  |
 | <code>KB_DAEMON_URL</code> | <code>url</code> | _unset_ | protocols: <code>http:</code>, <code>https:</code> |  | uses default |  |
+| <code>KB_DAEMON_SOCKET</code> | <code>path</code> | _unset_ |  |  | uses default |  |
 | <code>KB_DAEMON_HOST</code> | <code>string</code> | <code>127.0.0.1</code> |  |  | uses default |  |
 | <code>KB_DAEMON_PORT</code> | <code>integer</code> | <code>17799</code> |  | >= <code>1</code>; <= <code>65535</code> | uses default |  |
 | <code>KB_DAEMON_AUTOSTART</code> | <code>boolean</code> | <code>off</code> | <code>on</code>, <code>off</code>, <code>true</code>, <code>false</code>, <code>1</code>, <code>0</code>, <code>yes</code>, <code>no</code> |  | uses default |  |

--- a/docs/troubleshooting-local-kb.md
+++ b/docs/troubleshooting-local-kb.md
@@ -213,10 +213,11 @@ If read-only results are acceptable, keep working from the existing index and re
 
 ## Warm Daemon (`kb serve`)
 
-`kb serve` starts a localhost-only HTTP daemon that keeps the index warm so
+`kb serve` starts a local HTTP daemon that keeps the index warm so
 repeated `kb search --daemon` calls skip cold-start cost. The daemon is
-read-only (search/list/stats), binds loopback only, and exits after its idle
-timeout. `kb serve` itself adds no start/stop supervision — run it under your
+read-only (search/list/stats), binds loopback TCP or a Unix-domain socket, and
+exits after its idle timeout. `kb serve` itself adds no start/stop supervision —
+run it under your
 own shell, `tmux`, or a user service.
 
 Use `kb serve status` to inspect lifecycle without starting anything:

--- a/src/cli-serve.test.ts
+++ b/src/cli-serve.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, describe, expect, it, jest } from '@jest/globals';
+import * as fsp from 'node:fs/promises';
 import * as http from 'node:http';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import {
   appendDaemonAdmissionMetrics,
   createDaemonCommandHandlers,
@@ -14,7 +17,7 @@ import {
   DEFAULT_DAEMON_MAX_CONCURRENCY,
   DEFAULT_DAEMON_QUEUE_MAX,
 } from './daemon-admission.js';
-import type { DaemonRunResult } from './daemon-client.js';
+import { fetchDaemonHealth, runDaemonCommand, type DaemonRunResult } from './daemon-client.js';
 import type { KbStatsPayload } from './kb-stats.js';
 import type { RunSearchDeps } from './cli-search.js';
 import type { LexicalIndex } from './lexical-index.js';
@@ -58,6 +61,8 @@ function request(
 describe('kb serve daemon', () => {
   const originalMetricsExport = process.env.KB_METRICS_EXPORT;
   const originalDaemonPrewarm = process.env.KB_DAEMON_PREWARM;
+  const originalDaemonSocket = process.env.KB_DAEMON_SOCKET;
+  const itUnix = process.platform === 'win32' ? it.skip : it;
 
   afterEach(() => {
     searchLatencyMetrics.reset();
@@ -65,6 +70,8 @@ describe('kb serve daemon', () => {
     else process.env.KB_METRICS_EXPORT = originalMetricsExport;
     if (originalDaemonPrewarm === undefined) delete process.env.KB_DAEMON_PREWARM;
     else process.env.KB_DAEMON_PREWARM = originalDaemonPrewarm;
+    if (originalDaemonSocket === undefined) delete process.env.KB_DAEMON_SOCKET;
+    else process.env.KB_DAEMON_SOCKET = originalDaemonSocket;
   });
 
   it('serves health and dispatches read-only commands through handlers', async () => {
@@ -261,6 +268,20 @@ describe('kb serve daemon', () => {
     expect(() => parseServeArgs(['--host=0.0.0.0'])).toThrow(/non-loopback/);
   });
 
+  itUnix('parses explicit and environment Unix-domain socket paths', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-serve-parse-'));
+    const envSocket = path.join(tempDir, 'env.sock');
+    const cliSocket = path.join(tempDir, 'cli.sock');
+    try {
+      process.env.KB_DAEMON_SOCKET = envSocket;
+      expect(parseServeArgs([]).socketPath).toBe(envSocket);
+      expect(parseServeArgs([`--socket=${cliSocket}`]).socketPath).toBe(cliSocket);
+      expect(() => parseServeArgs(['--socket='])).toThrow(/empty path/);
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it('enables startup prewarm from --warm or KB_DAEMON_PREWARM=on', () => {
     delete process.env.KB_DAEMON_PREWARM;
     expect(parseServeArgs(['--warm']).warm).toBe(true);
@@ -281,6 +302,60 @@ describe('kb serve daemon', () => {
       });
     } finally {
       await daemon.stop();
+    }
+  });
+
+  itUnix('serves health and read-only commands over a Unix-domain socket', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-serve-uds-'));
+    const socketPath = path.join(tempDir, 'daemon.sock');
+    const daemon = await startDaemonServer({
+      socketPath,
+      idleTimeoutMs: 0,
+      handlers: {
+        search: async () => ({ exitCode: 0, stdout: 'socket search\n', stderr: '' }),
+        list: async () => ({ exitCode: 0, stdout: '', stderr: '' }),
+        stats: async () => ({ exitCode: 0, stdout: '', stderr: '' }),
+      },
+    });
+    try {
+      expect(daemon.url.href).toBe(`unix://${socketPath}`);
+      const stat = await fsp.stat(socketPath);
+      expect(stat.mode & 0o777).toBe(0o600);
+      await expect(fetchDaemonHealth({ env: { KB_DAEMON_SOCKET: socketPath } }))
+        .resolves.toMatchObject({ status: 'ok', url: `unix://${socketPath}` });
+      await expect(runDaemonCommand('search', ['hello'], { env: { KB_DAEMON_SOCKET: socketPath } }))
+        .resolves.toEqual({ exitCode: 0, stdout: 'socket search\n', stderr: '' });
+    } finally {
+      await daemon.stop();
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  itUnix('unlinks a stale socket before listening and refuses an active socket', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-serve-stale-'));
+    const staleSocket = path.join(tempDir, 'stale.sock');
+    const activeSocket = path.join(tempDir, 'active.sock');
+    const staleServer = http.createServer();
+    await new Promise<void>((resolve, reject) => {
+      staleServer.once('error', reject);
+      staleServer.listen(staleSocket, () => resolve());
+    });
+    await new Promise<void>((resolve) => staleServer.close(() => resolve()));
+
+    const daemon = await startDaemonServer({ socketPath: staleSocket, idleTimeoutMs: 0 });
+    await daemon.stop();
+
+    const activeServer = http.createServer();
+    await new Promise<void>((resolve, reject) => {
+      activeServer.once('error', reject);
+      activeServer.listen(activeSocket, () => resolve());
+    });
+    try {
+      await expect(startDaemonServer({ socketPath: activeSocket, idleTimeoutMs: 0 }))
+        .rejects.toThrow(/already in use/);
+    } finally {
+      await new Promise<void>((resolve) => activeServer.close(() => resolve()));
+      await fsp.rm(tempDir, { recursive: true, force: true });
     }
   });
 

--- a/src/cli-serve.ts
+++ b/src/cli-serve.ts
@@ -1,4 +1,5 @@
 import * as http from 'node:http';
+import * as net from 'node:net';
 import type { AddressInfo } from 'node:net';
 import * as path from 'node:path';
 import * as fsp from 'node:fs/promises';
@@ -12,6 +13,7 @@ import {
 } from './config/metrics-export.js';
 import {
   daemonUrlFromEnv,
+  assertDaemonSocketPath,
   tryFetchDaemonHealth,
   type DaemonCommand,
   type DaemonHealth,
@@ -39,10 +41,10 @@ import { logger } from './logger.js';
 export const SERVE_HELP = `kb serve — resident local daemon for warm CLI reads
 
 Usage:
-  kb serve [--host=127.0.0.1] [--port=17799] [--idle-timeout-ms=300000] [--warm]
+  kb serve [--host=127.0.0.1] [--port=17799] [--socket=/path/to/kb.sock] [--idle-timeout-ms=300000] [--warm]
   kb serve status [--json]
 
-Starts a localhost-only JSON HTTP daemon used by \`kb search --daemon\`.
+Starts a local JSON HTTP daemon used by \`kb search --daemon\`.
 The daemon accepts read-only search/list/stats requests and exits after the
 idle timeout.
 
@@ -54,6 +56,7 @@ daemon it prints a one-line notice to stderr and runs the search directly.
 Options:
   --host=<host>             Loopback host to bind (default: 127.0.0.1).
   --port=<port>             TCP port to bind (default: 17799; 0 for tests).
+  --socket=<path>           Unix-domain socket to bind instead of TCP.
   --idle-timeout-ms=<ms>    Stop after this much idle time (default: 300000).
   --warm                    Pre-warm the active model, FAISS index, and
                             lexical indexes before the daemon reports ready.
@@ -64,6 +67,8 @@ Environment:
   KB_DAEMON_URL             Daemon URL queried by \`kb serve status\` and
                             \`kb search --daemon\` (default
                             http://127.0.0.1:17799).
+  KB_DAEMON_SOCKET          Unix-domain socket path queried by clients and
+                            bound by \`kb serve\` when KB_DAEMON_URL is unset.
   KB_METRICS_EXPORT         Set to \`on\` to expose OpenMetrics text at
                             \`GET /metrics\` on the loopback daemon.
   KB_DAEMON_MAX_CONCURRENCY Max requests the daemon runs at once before
@@ -87,6 +92,7 @@ const DAEMON_COMMANDS: readonly DaemonCommand[] = ['search', 'list', 'stats'];
 interface ServeArgs {
   host: string;
   port: number;
+  socketPath: string | null;
   idleTimeoutMs: number;
   ownership: DaemonOwnership;
   warm: boolean;
@@ -144,6 +150,7 @@ export interface ResidentDaemon {
 const DEFAULT_SERVE_ARGS: ServeArgs = {
   host: '127.0.0.1',
   port: 17799,
+  socketPath: null,
   idleTimeoutMs: 300_000,
   ownership: 'manual',
   warm: false,
@@ -283,11 +290,13 @@ export async function startDaemonServer(
   const parsed: ServeArgs = {
     host: options.host ?? DEFAULT_SERVE_ARGS.host,
     port: options.port ?? DEFAULT_SERVE_ARGS.port,
+    socketPath: options.socketPath ?? socketPathFromEnv(process.env),
     idleTimeoutMs: options.idleTimeoutMs ?? DEFAULT_SERVE_ARGS.idleTimeoutMs,
     ownership: options.ownership ?? DEFAULT_SERVE_ARGS.ownership,
     warm: options.warm ?? DEFAULT_SERVE_ARGS.warm,
   };
-  assertLoopbackHost(parsed.host);
+  if (parsed.socketPath === null) assertLoopbackHost(parsed.host);
+  else assertDaemonSocketPath(parsed.socketPath);
   const handlers = options.handlers ?? createDaemonCommandHandlers();
   let prewarmHealth: DaemonPrewarmHealth = {
     enabled: parsed.warm,
@@ -335,6 +344,10 @@ export async function startDaemonServer(
     resolveClosed();
   });
 
+  if (parsed.socketPath !== null) {
+    await prepareSocketPath(parsed.socketPath);
+  }
+
   await new Promise<void>((resolve, reject) => {
     const onError = (err: Error) => {
       server.off('listening', onListening);
@@ -346,13 +359,17 @@ export async function startDaemonServer(
     };
     server.once('error', onError);
     server.once('listening', onListening);
-    server.listen(parsed.port, parsed.host);
+    if (parsed.socketPath === null) server.listen(parsed.port, parsed.host);
+    else server.listen(parsed.socketPath);
   });
 
   resetIdleTimer();
-  const address = server.address() as AddressInfo;
-  const hostForUrl = parsed.host.includes(':') ? `[${parsed.host}]` : parsed.host;
-  const url = new URL(`http://${hostForUrl}:${address.port}`);
+  if (parsed.socketPath !== null) {
+    await fsp.chmod(parsed.socketPath, 0o600);
+  }
+  const url = parsed.socketPath === null
+    ? daemonTcpUrl(server.address() as AddressInfo, parsed.host)
+    : daemonSocketUrl(parsed.socketPath);
   boundUrl = url.href;
   return {
     server,
@@ -363,8 +380,11 @@ export async function startDaemonServer(
         return;
       }
       server.close((err) => {
-        if (err) reject(err);
-        else resolve();
+        if (err) {
+          reject(err);
+          return;
+        }
+        cleanupSocketPath(parsed.socketPath).then(resolve, reject);
       });
     }),
     closed,
@@ -374,13 +394,21 @@ export async function startDaemonServer(
     if (idleTimer) clearTimeout(idleTimer);
     if (parsed.idleTimeoutMs <= 0) return;
     idleTimer = setTimeout(() => {
-      void new Promise<void>((resolve) => server.close(() => resolve()));
+      void new Promise<void>((resolve) => {
+        server.close(() => {
+          void cleanupSocketPath(parsed.socketPath).finally(resolve);
+        });
+      });
     }, parsed.idleTimeoutMs);
   }
 }
 
 export function parseServeArgs(rest: string[]): ServeArgs {
-  const out = { ...DEFAULT_SERVE_ARGS, warm: daemonPrewarmEnabledFromEnv(process.env) };
+  const out = {
+    ...DEFAULT_SERVE_ARGS,
+    socketPath: socketPathFromEnv(process.env),
+    warm: daemonPrewarmEnabledFromEnv(process.env),
+  };
   for (const raw of rest) {
     if (raw.startsWith('--host=')) {
       out.host = raw.slice('--host='.length);
@@ -392,6 +420,12 @@ export function parseServeArgs(rest: string[]): ServeArgs {
         throw new Error(`invalid --port: ${raw}`);
       }
       out.port = port;
+      continue;
+    }
+    if (raw.startsWith('--socket=')) {
+      const socketPath = raw.slice('--socket='.length);
+      assertDaemonSocketPath(socketPath, '--socket');
+      out.socketPath = socketPath;
       continue;
     }
     if (raw.startsWith('--idle-timeout-ms=')) {
@@ -417,13 +451,73 @@ export function parseServeArgs(rest: string[]): ServeArgs {
     if (raw.startsWith('--')) throw new Error(`unknown flag: ${raw}`);
     throw new Error(`unexpected argument: ${raw}`);
   }
-  assertLoopbackHost(out.host);
+  if (out.socketPath === null) assertLoopbackHost(out.host);
   return out;
 }
 
 function daemonPrewarmEnabledFromEnv(env: NodeJS.ProcessEnv): boolean {
   const raw = env.KB_DAEMON_PREWARM?.trim().toLowerCase();
   return raw === 'on' || raw === '1' || raw === 'true' || raw === 'yes';
+}
+
+function socketPathFromEnv(env: NodeJS.ProcessEnv): string | null {
+  const raw = env.KB_DAEMON_SOCKET?.trim();
+  if (raw === undefined || raw === '') return null;
+  assertDaemonSocketPath(raw, 'KB_DAEMON_SOCKET');
+  return raw;
+}
+
+function daemonTcpUrl(address: AddressInfo, host: string): URL {
+  const hostForUrl = host.includes(':') ? `[${host}]` : host;
+  return new URL(`http://${hostForUrl}:${address.port}`);
+}
+
+function daemonSocketUrl(socketPath: string): URL {
+  return new URL(`unix://${socketPath}`);
+}
+
+async function prepareSocketPath(socketPath: string): Promise<void> {
+  try {
+    const stat = await fsp.lstat(socketPath);
+    if (!stat.isSocket()) {
+      throw new Error(`socket path exists and is not a Unix-domain socket: ${socketPath}`);
+    }
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return;
+    throw err;
+  }
+
+  if (await unixSocketAcceptsConnections(socketPath)) {
+    throw new Error(`socket path is already in use: ${socketPath}`);
+  }
+  await fsp.unlink(socketPath);
+}
+
+function unixSocketAcceptsConnections(socketPath: string): Promise<boolean> {
+  return new Promise((resolve, reject) => {
+    const socket = net.createConnection(socketPath);
+    socket.once('connect', () => {
+      socket.destroy();
+      resolve(true);
+    });
+    socket.once('error', (err) => {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === 'ECONNREFUSED' || code === 'ENOENT') {
+        resolve(false);
+        return;
+      }
+      reject(err);
+    });
+  });
+}
+
+async function cleanupSocketPath(socketPath: string | null): Promise<void> {
+  if (socketPath === null) return;
+  try {
+    await fsp.unlink(socketPath);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+  }
 }
 
 export function createDaemonCommandHandlers(options: DaemonCommandHandlerOptions = {}): DaemonCommandHandlers {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -238,6 +238,7 @@ export const CONFIG_SCHEMA: readonly ConfigSpec[] = [
   { name: 'KB_AGE_BUDGET_HOURS', kind: 'integer', min: 1 },
 
   { name: 'KB_DAEMON_URL', kind: 'url', protocols: ['http:', 'https:'] },
+  { name: 'KB_DAEMON_SOCKET', kind: 'path' },
   { name: 'KB_DAEMON_HOST', kind: 'string', default: '127.0.0.1', emptyUsesDefault: true },
   { name: 'KB_DAEMON_PORT', kind: 'integer', default: '17799', min: 1, max: 65535 },
   { name: 'KB_DAEMON_AUTOSTART', kind: 'boolean', default: 'off', booleanValues: YES_NO_BOOL_VALUES, truthyValues: YES_NO_TRUTHY_VALUES },

--- a/src/daemon-client.test.ts
+++ b/src/daemon-client.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, it, jest } from '@jest/globals';
+import * as fsp from 'node:fs/promises';
 import * as http from 'node:http';
 import type { AddressInfo } from 'node:net';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import {
   DaemonProtocolError,
   DaemonUnavailableError,
+  daemonEndpointFromEnv,
   daemonUrlFromEnv,
   fetchDaemonHealth,
   runDaemonCommand,
@@ -29,10 +33,49 @@ async function withServer(
   }
 }
 
+async function withUnixSocketServer(
+  handler: http.RequestListener,
+  fn: (socketPath: string) => Promise<void>,
+): Promise<void> {
+  const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-daemon-client-'));
+  const socketPath = path.join(tempDir, 'daemon.sock');
+  const server = http.createServer(handler);
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(socketPath, () => resolve());
+  });
+  try {
+    await fn(socketPath);
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    await fsp.rm(tempDir, { recursive: true, force: true });
+  }
+}
+
 describe('daemon client', () => {
+  const itUnix = process.platform === 'win32' ? it.skip : it;
+
   it('builds a default loopback URL from env overrides', () => {
     expect(daemonUrlFromEnv({ KB_DAEMON_PORT: '18888' }).href).toBe('http://127.0.0.1:18888/');
     expect(daemonUrlFromEnv({ KB_DAEMON_URL: 'http://127.0.0.1:19999' }).href).toBe('http://127.0.0.1:19999/');
+  });
+
+  itUnix('builds a Unix-domain socket endpoint from KB_DAEMON_SOCKET', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-daemon-client-'));
+    const socketPath = path.join(tempDir, 'daemon.sock');
+    try {
+      expect(daemonUrlFromEnv({ KB_DAEMON_SOCKET: socketPath }).href).toBe(`unix://${socketPath}`);
+      expect(daemonEndpointFromEnv({ KB_DAEMON_SOCKET: socketPath })).toEqual({
+        url: new URL(`unix://${socketPath}`),
+        socketPath,
+      });
+      expect(daemonUrlFromEnv({
+        KB_DAEMON_URL: 'http://127.0.0.1:19999',
+        KB_DAEMON_SOCKET: socketPath,
+      }).href).toBe('http://127.0.0.1:19999/');
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
   });
 
   it('posts command requests and parses daemon output', async () => {
@@ -52,6 +95,26 @@ describe('daemon client', () => {
     }, async (url) => {
       await expect(runDaemonCommand('search', ['hello'], { env: { KB_DAEMON_URL: url.href } }))
         .resolves.toEqual({ exitCode: 0, stdout: 'ok\n', stderr: '' });
+    });
+  });
+
+  itUnix('posts command requests over a Unix-domain socket', async () => {
+    await withUnixSocketServer((req, res) => {
+      expect(req.method).toBe('POST');
+      expect(req.url).toBe('/v1/run');
+      const chunks: Buffer[] = [];
+      req.on('data', (chunk) => chunks.push(Buffer.from(chunk)));
+      req.on('end', () => {
+        expect(JSON.parse(Buffer.concat(chunks).toString('utf-8'))).toEqual({
+          command: 'stats',
+          args: ['--format=json'],
+        });
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ exitCode: 0, stdout: '{}\n', stderr: '' }));
+      });
+    }, async (socketPath) => {
+      await expect(runDaemonCommand('stats', ['--format=json'], { env: { KB_DAEMON_SOCKET: socketPath } }))
+        .resolves.toEqual({ exitCode: 0, stdout: '{}\n', stderr: '' });
     });
   });
 

--- a/src/daemon-client.ts
+++ b/src/daemon-client.ts
@@ -1,4 +1,5 @@
 import { spawn } from 'node:child_process';
+import * as http from 'node:http';
 
 export interface DaemonRunResult {
   exitCode: number;
@@ -35,6 +36,11 @@ export interface DaemonHealth {
   prewarm?: DaemonPrewarmHealth;
 }
 
+export interface DaemonEndpoint {
+  url: URL;
+  socketPath?: string;
+}
+
 interface SpawnedDaemonProcess {
   once(event: 'error', listener: (err: Error) => void): SpawnedDaemonProcess;
   unref(): void;
@@ -60,6 +66,7 @@ export interface DaemonClientOptions {
 
 const DEFAULT_AUTOSTART_DEADLINE_MS = 3_000;
 const DEFAULT_AUTOSTART_POLL_INTERVAL_MS = 100;
+const MAX_UNIX_SOCKET_PATH_BYTES = 107;
 
 export class DaemonUnavailableError extends Error {
   constructor(message: string, options?: ErrorOptions) {
@@ -78,8 +85,16 @@ export class DaemonProtocolError extends Error {
 }
 
 export function daemonUrlFromEnv(env: NodeJS.ProcessEnv = process.env): URL {
+  return daemonEndpointFromEnv(env).url;
+}
+
+export function daemonEndpointFromEnv(env: NodeJS.ProcessEnv = process.env): DaemonEndpoint {
   if (env.KB_DAEMON_URL !== undefined && env.KB_DAEMON_URL.trim() !== '') {
-    return new URL(env.KB_DAEMON_URL);
+    return { url: new URL(env.KB_DAEMON_URL) };
+  }
+  const socketPath = daemonSocketPathFromEnv(env);
+  if (socketPath !== null) {
+    return { url: daemonSocketUrl(socketPath), socketPath };
   }
   const host = env.KB_DAEMON_HOST?.trim() || '127.0.0.1';
   const portRaw = env.KB_DAEMON_PORT?.trim() || '17799';
@@ -87,7 +102,7 @@ export function daemonUrlFromEnv(env: NodeJS.ProcessEnv = process.env): URL {
   if (!Number.isInteger(port) || port <= 0 || port > 65535) {
     throw new DaemonProtocolError(`invalid KB_DAEMON_PORT: ${portRaw}`);
   }
-  return new URL(`http://${host}:${port}`);
+  return { url: new URL(`http://${host}:${port}`) };
 }
 
 export async function tryRunDaemonCommand(
@@ -111,13 +126,14 @@ export async function runDaemonCommand(
   args: string[],
   options: DaemonClientOptions = {},
 ): Promise<DaemonRunResult> {
-  const baseUrl = daemonUrlFromEnv(options.env);
-  const endpoint = new URL('/v1/run', baseUrl);
+  const baseEndpoint = daemonEndpointFromEnv(options.env);
+  const endpoint = new URL('/v1/run', baseEndpoint.url);
   const fetchImpl = options.fetchImpl ?? fetch;
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), options.timeoutMs ?? 1500);
   try {
-    const response = await fetchImpl(endpoint, {
+    const response = await requestDaemonEndpoint(baseEndpoint, endpoint, {
+      fetchImpl,
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ command, args }),
@@ -130,7 +146,7 @@ export async function runDaemonCommand(
     const payload = await response.json();
     return parseDaemonRunResult(payload);
   } catch (err) {
-    rethrowDaemonFetchError(err, endpoint.href);
+    rethrowDaemonFetchError(err, baseEndpoint.url.href);
   } finally {
     clearTimeout(timeout);
   }
@@ -145,22 +161,118 @@ export async function runDaemonCommand(
 export async function fetchDaemonHealth(
   options: DaemonClientOptions = {},
 ): Promise<DaemonHealth> {
-  const endpoint = new URL('/health', daemonUrlFromEnv(options.env));
+  const baseEndpoint = daemonEndpointFromEnv(options.env);
+  const endpoint = new URL('/health', baseEndpoint.url);
   const fetchImpl = options.fetchImpl ?? fetch;
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), options.timeoutMs ?? 1500);
   try {
-    const response = await fetchImpl(endpoint, { method: 'GET', signal: controller.signal });
+    const response = await requestDaemonEndpoint(baseEndpoint, endpoint, {
+      fetchImpl,
+      method: 'GET',
+      signal: controller.signal,
+    });
     if (!response.ok) {
       const text = await response.text().catch(() => '');
       throw new DaemonProtocolError(`daemon returned HTTP ${response.status}${text ? `: ${text}` : ''}`);
     }
     return parseDaemonHealth(await response.json());
   } catch (err) {
-    rethrowDaemonFetchError(err, endpoint.href);
+    rethrowDaemonFetchError(err, baseEndpoint.url.href);
   } finally {
     clearTimeout(timeout);
   }
+}
+
+function daemonSocketPathFromEnv(env: NodeJS.ProcessEnv): string | null {
+  const raw = env.KB_DAEMON_SOCKET?.trim();
+  if (raw === undefined || raw === '') return null;
+  assertDaemonSocketPath(raw, 'KB_DAEMON_SOCKET');
+  return raw;
+}
+
+export function assertDaemonSocketPath(socketPath: string, source = 'socket path'): void {
+  if (socketPath.trim() === '') {
+    throw new DaemonProtocolError(`invalid ${source}: empty path`);
+  }
+  if (process.platform === 'win32') {
+    throw new DaemonProtocolError(`${source} is not supported on Windows`);
+  }
+  if (Buffer.byteLength(socketPath) > MAX_UNIX_SOCKET_PATH_BYTES) {
+    throw new DaemonProtocolError(
+      `invalid ${source}: path is too long for a Unix-domain socket (${Buffer.byteLength(socketPath)} > ${MAX_UNIX_SOCKET_PATH_BYTES} bytes)`,
+    );
+  }
+}
+
+function daemonSocketUrl(socketPath: string): URL {
+  return new URL(`unix://${socketPath}`);
+}
+
+interface DaemonRequestOptions {
+  fetchImpl: typeof fetch;
+  method: string;
+  headers?: Record<string, string>;
+  body?: string;
+  signal: AbortSignal;
+}
+
+interface DaemonResponse {
+  ok: boolean;
+  status: number;
+  text: () => Promise<string>;
+  json: () => Promise<unknown>;
+}
+
+async function requestDaemonEndpoint(
+  baseEndpoint: DaemonEndpoint,
+  endpoint: URL,
+  options: DaemonRequestOptions,
+): Promise<DaemonResponse> {
+  if (baseEndpoint.socketPath === undefined) {
+    return options.fetchImpl(endpoint, {
+      method: options.method,
+      headers: options.headers,
+      body: options.body,
+      signal: options.signal,
+    });
+  }
+
+  return requestUnixSocketEndpoint(baseEndpoint.socketPath, endpoint, options);
+}
+
+function requestUnixSocketEndpoint(
+  socketPath: string,
+  endpoint: URL,
+  options: DaemonRequestOptions,
+): Promise<DaemonResponse> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        socketPath,
+        method: options.method,
+        path: `${endpoint.pathname}${endpoint.search}`,
+        headers: options.headers,
+        signal: options.signal,
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on('data', (chunk) => chunks.push(Buffer.from(chunk)));
+        res.on('end', () => {
+          const text = Buffer.concat(chunks).toString('utf-8');
+          resolve({
+            ok: (res.statusCode ?? 0) >= 200 && (res.statusCode ?? 0) < 300,
+            status: res.statusCode ?? 0,
+            text: async () => text,
+            json: async () => JSON.parse(text),
+          });
+        });
+      },
+    );
+    req.on('error', reject);
+    if (options.body !== undefined) req.write(options.body);
+    req.end();
+  });
 }
 
 /**
@@ -382,7 +494,8 @@ function defaultSleep(ms: number): Promise<void> {
 }
 
 function isSafeNoListenerFailure(err: DaemonUnavailableError): boolean {
-  return errorCode(err.cause) === 'ECONNREFUSED';
+  const code = errorCode(err.cause);
+  return code === 'ECONNREFUSED' || code === 'ENOENT';
 }
 
 function errorCode(err: unknown): string | undefined {


### PR DESCRIPTION
## Summary
- add `KB_DAEMON_SOCKET` and `kb serve --socket=` support for Unix-domain socket daemon/client transport
- create socket files with restrictive permissions, clean stale socket files, and refuse active socket replacement
- document socket-mode daemon operation and update generated CLI/config references

## Test plan
- npm run build
- npm run lint
- npm run docs:check-config-reference && npm run docs:check-cli
- npm run test:file -- src/daemon-client.test.ts src/cli-serve.test.ts
- npm test
- npm run docs:check-anchors && npm run docs:check-cli && npm run docs:check-config-reference

Closes #758