### PR TITLE
fix: add durable atomic write helper

### DIFF
--- a/src/active-model.ts
+++ b/src/active-model.ts
@@ -21,7 +21,7 @@ import {
   OLLAMA_MODEL,
   OPENAI_MODEL_NAME,
 } from './config/provider.js';
-import { pathExists } from './file-utils.js';
+import { pathExists, writeFileAtomicDurable } from './file-utils.js';
 import { deriveModelId, EmbeddingProvider, isValidModelId, parseModelId } from './model-id.js';
 import { logger } from './logger.js';
 import {
@@ -433,9 +433,7 @@ export async function readStoredIndexType(modelId: string): Promise<SearchIndexT
 
 export async function writeIndexTypeAtomic(modelId: string, indexType: SearchIndexType): Promise<void> {
   const target = indexTypeFilePath(modelId);
-  const tmp = `${target}.${process.pid}.tmp`;
-  await fsp.writeFile(tmp, `${indexType}\n`, 'utf-8');
-  await fsp.rename(tmp, target);
+  await writeFileAtomicDurable(target, `${indexType}\n`);
 }
 
 /**
@@ -536,9 +534,7 @@ export async function writeActiveModelAtomic(modelId: string): Promise<void> {
     throw new Error(`Refusing to write invalid model_id "${modelId}" to active.txt`);
   }
   await fsp.mkdir(FAISS_INDEX_PATH, { recursive: true });
-  const tmp = `${ACTIVE_FILE}.${process.pid}.tmp`;
-  await fsp.writeFile(tmp, modelId, 'utf-8');
-  await fsp.rename(tmp, ACTIVE_FILE);
+  await writeFileAtomicDurable(ACTIVE_FILE, modelId);
 }
 
 export async function activeFileExists(): Promise<boolean> {

--- a/src/file-mutation.ts
+++ b/src/file-mutation.ts
@@ -1,6 +1,7 @@
 import * as fsp from 'fs/promises';
 import * as path from 'path';
 import * as properLockfile from 'proper-lockfile';
+import { writeFileAtomicDurable } from './file-utils.js';
 import { assertKbWritePolicyAllowsMutation } from './kb-write-policy.js';
 
 interface AtomicWriteHooks {
@@ -49,26 +50,7 @@ export async function atomicWriteFile(
   mode?: number,
   hooks: AtomicWriteHooks = {},
 ): Promise<void> {
-  const tmpPath = `${targetPath}.kb-tmp.${process.pid}.${Date.now()}.${Math.random().toString(16).slice(2)}`;
-  const permissions = mode === undefined ? undefined : mode & 0o7777;
-  const handle = await fsp.open(tmpPath, 'w', permissions);
-  try {
-    if (permissions !== undefined) {
-      await handle.chmod(permissions);
-    }
-    await handle.writeFile(data, 'utf-8');
-    await handle.sync();
-  } finally {
-    await handle.close();
-  }
-
-  try {
-    await (hooks.rename ?? fsp.rename)(tmpPath, targetPath);
-    await syncDirectoryBestEffort(path.dirname(targetPath));
-  } catch (err) {
-    await fsp.unlink(tmpPath).catch(() => {});
-    throw err;
-  }
+  await writeFileAtomicDurable(targetPath, data, { mode, hooks });
 }
 
 async function withFileMutationLock<T>(targetPath: string, action: () => Promise<T>): Promise<T> {
@@ -92,19 +74,5 @@ async function withFileMutationLock<T>(targetPath: string, action: () => Promise
     return await action();
   } finally {
     await release().catch(() => {});
-  }
-}
-
-async function syncDirectoryBestEffort(dirPath: string): Promise<void> {
-  let handle: fsp.FileHandle | null = null;
-  try {
-    handle = await fsp.open(dirPath, 'r');
-    await handle.sync();
-  } catch {
-    // Some filesystems/platforms do not allow fsync on directories. The temp
-    // file is still fsynced before the atomic rename; directory sync is a
-    // best-effort durability upgrade.
-  } finally {
-    await handle?.close().catch(() => {});
   }
 }

--- a/src/file-utils.test.ts
+++ b/src/file-utils.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from '@jest/globals';
+import * as fsp from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { writeFileAtomicDurable } from './file-utils.js';
+
+describe('writeFileAtomicDurable', () => {
+  it('writes through a durable temp file and syncs the parent directory', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-atomic-durable-'));
+    try {
+      const target = path.join(tempDir, 'state.json');
+      const syncedDirs: string[] = [];
+
+      await writeFileAtomicDurable(target, '{"ok":true}\n', {
+        hooks: {
+          syncDirectory: async (dir) => {
+            syncedDirs.push(dir);
+          },
+        },
+      });
+
+      await expect(fsp.readFile(target, 'utf-8')).resolves.toBe('{"ok":true}\n');
+      expect(syncedDirs).toEqual([tempDir]);
+      const leftovers = (await fsp.readdir(tempDir)).filter((name) => name.includes('.kb-tmp.'));
+      expect(leftovers).toEqual([]);
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps the original file and removes the temp file when rename fails', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-atomic-durable-fail-'));
+    try {
+      const target = path.join(tempDir, 'state.json');
+      await fsp.writeFile(target, '{"version":1}\n', 'utf-8');
+
+      await expect(
+        writeFileAtomicDurable(target, '{"version":2}\n', {
+          hooks: {
+            rename: async () => {
+              throw Object.assign(new Error('simulated cross-device rename'), { code: 'EXDEV' });
+            },
+          },
+        }),
+      ).rejects.toThrow('simulated cross-device rename');
+
+      await expect(fsp.readFile(target, 'utf-8')).resolves.toBe('{"version":1}\n');
+      const leftovers = (await fsp.readdir(tempDir)).filter((name) => name.includes('.kb-tmp.'));
+      expect(leftovers).toEqual([]);
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/file-utils.ts
+++ b/src/file-utils.ts
@@ -5,6 +5,18 @@ import { logger } from './logger.js';
 
 type FsError = NodeJS.ErrnoException & { code?: string };
 
+export interface WriteFileAtomicDurableHooks {
+  rename?: (oldPath: string, newPath: string) => Promise<void>;
+  syncDirectory?: (dirPath: string) => Promise<void>;
+}
+
+export interface WriteFileAtomicDurableOptions {
+  mode?: number;
+  encoding?: BufferEncoding;
+  syncParentDirectory?: boolean;
+  hooks?: WriteFileAtomicDurableHooks;
+}
+
 export interface FilesystemEnumerationFailure {
   path: string;
   code: string | null;
@@ -53,6 +65,52 @@ export async function calculateSHA256(filePath: string): Promise<string> {
   const hashSum = crypto.createHash('sha256');
   hashSum.update(fileBuffer);
   return hashSum.digest('hex');
+}
+
+export async function writeFileAtomicDurable(
+  targetPath: string,
+  data: string | Uint8Array,
+  options: WriteFileAtomicDurableOptions = {},
+): Promise<void> {
+  const tmpPath = `${targetPath}.kb-tmp.${process.pid}.${Date.now()}.${Math.random().toString(16).slice(2)}`;
+  const permissions = options.mode === undefined ? undefined : options.mode & 0o7777;
+  let handle: fsp.FileHandle | null = await fsp.open(tmpPath, 'w', permissions);
+  try {
+    if (permissions !== undefined) {
+      await handle.chmod(permissions);
+    }
+    if (typeof data === 'string') {
+      await handle.writeFile(data, options.encoding ?? 'utf-8');
+    } else {
+      await handle.writeFile(data);
+    }
+    await handle.sync();
+    await handle.close();
+    handle = null;
+
+    await (options.hooks?.rename ?? fsp.rename)(tmpPath, targetPath);
+    if (options.syncParentDirectory ?? true) {
+      await (options.hooks?.syncDirectory ?? syncDirectoryBestEffort)(path.dirname(targetPath));
+    }
+  } catch (err) {
+    await handle?.close().catch(() => {});
+    await fsp.unlink(tmpPath).catch(() => {});
+    throw err;
+  }
+}
+
+export async function syncDirectoryBestEffort(dirPath: string): Promise<void> {
+  let handle: fsp.FileHandle | null = null;
+  try {
+    handle = await fsp.open(dirPath, 'r');
+    await handle.sync();
+  } catch {
+    // Some filesystems/platforms do not allow fsync on directories. The temp
+    // file is still fsynced before the atomic rename; directory sync is a
+    // best-effort durability upgrade.
+  } finally {
+    await handle?.close().catch(() => {});
+  }
 }
 
 /**

--- a/src/freshness-manifest.ts
+++ b/src/freshness-manifest.ts
@@ -10,6 +10,7 @@ import {
 } from './config/paths.js';
 import { INGEST_BASE_EXTENSIONS } from './ingest-filter.js';
 import { enumerateIngestableKbFiles, listKnowledgeBases } from './kb-fs.js';
+import { writeFileAtomicDurable } from './file-utils.js';
 
 export const FRESHNESS_MANIFEST_SCHEMA_VERSION = 'kb.freshness-manifest.v1';
 export const FRESHNESS_MANIFEST_FILE = 'freshness.json';
@@ -240,7 +241,5 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 async function writeJsonAtomic(targetPath: string, value: unknown): Promise<void> {
   await fsp.mkdir(path.dirname(targetPath), { recursive: true });
-  const tmpPath = `${targetPath}.${process.pid}.${Date.now()}.tmp`;
-  await fsp.writeFile(tmpPath, `${JSON.stringify(value, null, 2)}\n`, 'utf-8');
-  await fsp.rename(tmpPath, targetPath);
+  await writeFileAtomicDurable(targetPath, `${JSON.stringify(value, null, 2)}\n`);
 }

--- a/src/reindex-progress.ts
+++ b/src/reindex-progress.ts
@@ -29,6 +29,7 @@ import {
   readContextualSidecarStatuses,
   type ContextualSidecarStatus,
 } from './contextual-preface.js';
+import { writeFileAtomicDurable } from './file-utils.js';
 import { logger } from './logger.js';
 import { checkReindexRunState } from './reindex-runner.js';
 
@@ -225,10 +226,8 @@ export async function computeReindexProgress(
  */
 export async function writeReindexProgress(progress: ReindexProgress): Promise<void> {
   const target = reindexProgressFilePath();
-  const tmp = `${target}.tmp`;
   await fsp.mkdir(path.dirname(target), { recursive: true });
-  await fsp.writeFile(tmp, `${JSON.stringify(progress, null, 2)}\n`, 'utf-8');
-  await fsp.rename(tmp, target);
+  await writeFileAtomicDurable(target, `${JSON.stringify(progress, null, 2)}\n`);
 }
 
 /** Read a previously-written ledger, or null when absent / unreadable. */

--- a/src/reindex-runner.ts
+++ b/src/reindex-runner.ts
@@ -48,6 +48,7 @@ import {
 } from './contextual-preface.js';
 import { KBError } from './errors.js';
 import { FaissIndexManager, type IndexUpdateSummary } from './FaissIndexManager.js';
+import { writeFileAtomicDurable } from './file-utils.js';
 import { listKnowledgeBases } from './kb-fs.js';
 import { logger } from './logger.js';
 
@@ -207,10 +208,8 @@ export function runStateFilePath(): string {
 
 async function writeRunState(state: RunStateFile): Promise<void> {
   const target = runStateFilePath();
-  const tmp = `${target}.tmp`;
   await fsp.mkdir(path.dirname(target), { recursive: true });
-  await fsp.writeFile(tmp, JSON.stringify(state, null, 2), 'utf-8');
-  await fsp.rename(tmp, target);
+  await writeFileAtomicDurable(target, JSON.stringify(state, null, 2));
 }
 
 async function readRunState(): Promise<RunStateFile | null> {


### PR DESCRIPTION
## Summary
- add a shared `writeFileAtomicDurable` helper that writes through a temp file, fsyncs it, renames, and best-effort syncs the parent directory
- route active model pointers, freshness manifest writes, and reindex ledger writes through the shared helper
- keep existing file mutation behavior by delegating `atomicWriteFile` to the shared durable writer

## Test plan
- [x] npm run build
- [x] npm run lint
- [x] npm run test:file -- src/file-utils.test.ts src/file-mutation.test.ts src/active-model.test.ts src/freshness-manifest.test.ts src/reindex-progress.test.ts src/reindex-runner.test.ts
- [x] npm test

Closes #755