### PR TITLE
feat: add code→schema config env drift guard (#753)

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json && chmod +x build/index.js build/cli.js",
     "build:clean": "rm -rf build",
-    "check": "npm run build && npm run lint && npm run test:coverage && npm run docs:check-anchors && npm run docs:check-config-reference && npm run docs:check-cli && npm run docs:check-mcp-tools && npm run docs:check-embedding-models && npm run docs:check-metrics-reference",
+    "check": "npm run build && npm run lint && npm run test:coverage && npm run docs:check-anchors && npm run docs:check-config-reference && npm run config:check-env-usage && npm run docs:check-cli && npm run docs:check-mcp-tools && npm run docs:check-embedding-models && npm run docs:check-metrics-reference",
     "lint": "eslint src",
     "lint:commit-message": "commitlint",
     "lint:fix": "eslint src --fix",
@@ -40,6 +40,7 @@
     "docs:check-anchors": "node scripts/check-doc-anchors.mjs",
     "docs:generate-config-reference": "npm run build && node scripts/generate-config-reference.mjs",
     "docs:check-config-reference": "node scripts/check-config-reference.mjs",
+    "config:check-env-usage": "npm run build && node scripts/check-config-env-usage.mjs",
     "docs:check-cli": "node scripts/gen-cli-reference.mjs --check",
     "docs:gen-mcp-tools": "npm run build && node scripts/gen-mcp-tools-doc.mjs",
     "docs:check-mcp-tools": "node scripts/gen-mcp-tools-doc.mjs --check",

--- a/scripts/check-config-env-usage.mjs
+++ b/scripts/check-config-env-usage.mjs
@@ -1,0 +1,184 @@
+#!/usr/bin/env node
+// Code→schema config drift guard.
+//
+// `kb config validate` warns at *runtime* when an operator sets an unknown
+// controlled env var. This guard covers the opposite, contributor-facing
+// direction: a `process.env.KB_*` (or other controlled-prefix) read added in
+// source that was never registered in `CONFIG_SCHEMA`. Such a var silently
+// escapes schema validation, `kb config show`, and the generated config
+// reference. Wired into `npm run check`; fails when production code reads a
+// controlled env var that is neither registered nor explicitly allowlisted.
+//
+// Only *literal* env names are inspected (`process.env.NAME` and
+// `process.env['NAME']`). Dynamic `process.env[variable]` access is ignored,
+// so intentionally-dynamic reads never produce false positives.
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import {
+  CONTROLLED_PREFIXES,
+  isControlledEnvName,
+  isRegisteredConfigName,
+} from '../build/config/schema.js';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const SRC_DIR = path.join(REPO_ROOT, 'src');
+
+// Controlled-prefix env vars read in production source that are intentionally
+// NOT registered in CONFIG_SCHEMA. Every entry needs a reason. Keep this list
+// shrinking: prefer registering a var in src/config/schema.ts over adding it
+// here. The entries below are pre-existing reads baselined when this guard
+// landed (#753) and are tracked for schema registration or explicit
+// justification.
+export const ALLOWLIST = new Map([
+  ['KB_DECOMPOSE_LLM_ENDPOINT', 'query-decomposition LLM override; baseline #753'],
+  ['KB_DECOMPOSE_LLM_MODEL', 'query-decomposition LLM override; baseline #753'],
+  ['KB_DENSE_DEGRADE_ON_PROVIDER_ERROR', 'dense-retrieval degrade toggle; baseline #753'],
+  ['KB_EMBEDDING_TASK_PREFIXES', 'embedding task-prefix override; baseline #753'],
+  ['KB_LOG_MAX_BYTES', 'log rotation size cap; baseline #753'],
+  ['KB_LOG_MAX_FILES', 'log rotation file count; baseline #753'],
+  ['KB_MAX_FILTER_ITEMS', 'MCP tool arg guardrail; baseline #753'],
+  ['KB_MAX_GLOB_CHARS', 'MCP tool arg guardrail; baseline #753'],
+  ['KB_MAX_GLOB_WILDCARDS', 'MCP tool arg guardrail; baseline #753'],
+  ['KB_MAX_QUERY_CHARS', 'MCP tool arg guardrail; baseline #753'],
+  ['KB_MIN_FREE_DISK_BYTES', 'disk-preflight threshold; baseline #753'],
+  ['KB_RERANK_CACHE', 'reranker cache toggle; baseline #753'],
+  ['KB_RERANK_CACHE_DISK_MAX_BYTES', 'reranker cache disk cap; baseline #753'],
+  ['KB_RERANK_DEVICE', 'reranker inference device; baseline #753'],
+  ['KB_RERANK_DTYPE', 'reranker inference dtype; baseline #753'],
+  ['KB_SEARCH_SNIPPET', 'kb search snippet toggle; baseline #753'],
+  ['KB_SHIELD', 'formatter shield toggle; baseline #753'],
+]);
+
+const DOTTED_READ = /process\.env\.([A-Za-z_][A-Za-z0-9_]*)/g;
+const BRACKET_READ = /process\.env\[\s*['"]([A-Za-z_][A-Za-z0-9_]*)['"]\s*\]/g;
+
+// Directory / file names excluded from the production scan. Tests, fixtures,
+// and the opt-in e2e suite legitimately read env knobs that are not part of
+// the operator-facing config surface.
+const EXCLUDED_DIR_NAMES = new Set(['__mocks__', '__property-tests__', '__fixtures__', 'e2e']);
+
+function isProductionSourceFile(name) {
+  return name.endsWith('.ts') && !name.endsWith('.test.ts') && !name.endsWith('.d.ts');
+}
+
+/** Recursively collect production TypeScript source files under `dir`. */
+export function collectSourceFiles(dir) {
+  const out = [];
+  let entries;
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch (err) {
+    if (err.code === 'ENOENT') return out;
+    throw err;
+  }
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (EXCLUDED_DIR_NAMES.has(entry.name)) continue;
+      out.push(...collectSourceFiles(full));
+    } else if (entry.isFile() && isProductionSourceFile(entry.name)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+/** Extract literal controlled-prefix env names read in `content`. */
+function controlledReadsIn(content) {
+  const names = new Set();
+  for (const re of [DOTTED_READ, BRACKET_READ]) {
+    for (const match of content.matchAll(re)) {
+      const name = match[1];
+      if (isControlledEnvName(name)) names.add(name);
+    }
+  }
+  return names;
+}
+
+/**
+ * Scan the given roots for controlled-prefix env reads and classify them.
+ * Returns unregistered reads (drift) and stale allowlist entries that have
+ * since been registered in the schema.
+ */
+export function scanConfigEnvUsage(roots = [SRC_DIR]) {
+  const usedControlled = new Map(); // name -> Set<relative file>
+  for (const root of roots) {
+    for (const file of collectSourceFiles(root)) {
+      const content = fs.readFileSync(file, 'utf8');
+      const rel = path.relative(REPO_ROOT, file);
+      for (const name of controlledReadsIn(content)) {
+        if (!usedControlled.has(name)) usedControlled.set(name, new Set());
+        usedControlled.get(name).add(rel);
+      }
+    }
+  }
+
+  const drift = [];
+  for (const [name, files] of usedControlled) {
+    if (isRegisteredConfigName(name)) continue;
+    if (ALLOWLIST.has(name)) continue;
+    drift.push({ name, files: [...files].sort() });
+  }
+  drift.sort((a, b) => a.name.localeCompare(b.name));
+
+  // Allowlist hygiene: an entry that is now registered in the schema is
+  // redundant and should be removed so the allowlist keeps shrinking.
+  const redundantAllowlist = [...ALLOWLIST.keys()]
+    .filter((name) => isRegisteredConfigName(name))
+    .sort();
+
+  return { drift, redundantAllowlist };
+}
+
+function main(argv) {
+  const extraRoots = argv.slice(2).map((p) => path.resolve(p));
+  const { drift, redundantAllowlist } = scanConfigEnvUsage([SRC_DIR, ...extraRoots]);
+
+  if (drift.length === 0 && redundantAllowlist.length === 0) {
+    process.stderr.write(
+      `config:check-env-usage: ${ALLOWLIST.size} allowlisted; no unregistered controlled env reads.\n`,
+    );
+    return;
+  }
+
+  const lines = [];
+  if (drift.length > 0) {
+    lines.push(
+      'config:check-env-usage: controlled env vars read in code but not registered in CONFIG_SCHEMA:',
+      '',
+    );
+    for (const { name, files } of drift) {
+      lines.push(`  ${name}`);
+      for (const file of files) lines.push(`    ${file}`);
+    }
+    lines.push(
+      '',
+      `Controlled prefixes: ${CONTROLLED_PREFIXES.join(', ')}`,
+      'Fix: register the var in src/config/schema.ts (CONFIG_SCHEMA), or, if it is',
+      'intentionally not part of the config surface, add it to the ALLOWLIST in',
+      'scripts/check-config-env-usage.mjs with a reason.',
+    );
+  }
+  if (redundantAllowlist.length > 0) {
+    lines.push(
+      '',
+      'config:check-env-usage: allowlist entries are now registered in CONFIG_SCHEMA',
+      'and should be removed from scripts/check-config-env-usage.mjs:',
+      ...redundantAllowlist.map((name) => `  ${name}`),
+    );
+  }
+  lines.push('');
+  process.stderr.write(lines.join('\n'));
+  process.exitCode = 1;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    main(process.argv);
+  } catch (err) {
+    process.stderr.write(`config:check-env-usage: ${err.message}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/src/check-config-env-usage.test.ts
+++ b/src/check-config-env-usage.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from '@jest/globals';
+import { spawnSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const scriptPath = path.join(process.cwd(), 'scripts', 'check-config-env-usage.mjs');
+
+function runGuard(extraRoots: string[]): { status: number | null; stderr: string } {
+  const result = spawnSync(process.execPath, [scriptPath, ...extraRoots], {
+    encoding: 'utf-8',
+    env: { ...process.env, LOG_FILE: '' },
+  });
+  if (result.error) throw result.error;
+  return { status: result.status, stderr: result.stderr };
+}
+
+describe('config:check-env-usage guard', () => {
+  it('passes on the current production source (main stays green)', () => {
+    const { status, stderr } = runGuard([]);
+    expect(stderr).toContain('no unregistered controlled env reads');
+    expect(status).toBe(0);
+  });
+
+  it('fails when code reads a controlled env var that is not registered or allowlisted', () => {
+    const fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kb-env-usage-'));
+    try {
+      const fixtureFile = path.join(fixtureDir, 'fake-config.ts');
+      fs.writeFileSync(
+        fixtureFile,
+        'export const flag = process.env.KB_FAKE_UNREGISTERED_XYZ ?? "off";\n',
+      );
+      const { status, stderr } = runGuard([fixtureDir]);
+      expect(status).toBe(1);
+      expect(stderr).toContain('KB_FAKE_UNREGISTERED_XYZ');
+      expect(stderr).toContain('not registered in CONFIG_SCHEMA');
+    } finally {
+      fs.rmSync(fixtureDir, { recursive: true, force: true });
+    }
+  });
+
+  it('ignores dynamic process.env[var] access (only literal names are checked)', () => {
+    const fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kb-env-usage-'));
+    try {
+      fs.writeFileSync(
+        path.join(fixtureDir, 'dynamic.ts'),
+        'export const read = (name: string) => process.env[name];\n',
+      );
+      const { status } = runGuard([fixtureDir]);
+      expect(status).toBe(0);
+    } finally {
+      fs.rmSync(fixtureDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -129,7 +129,7 @@ const STRICT_TRUTHY_VALUES = ['on', 'true', '1'] as const;
 const YES_NO_BOOL_VALUES = [...STRICT_BOOL_VALUES, 'yes', 'no'] as const;
 const YES_NO_TRUTHY_VALUES = [...STRICT_TRUTHY_VALUES, 'yes'] as const;
 const QUERY_CACHE_BOOL_VALUES = [...YES_NO_BOOL_VALUES, 'enabled', 'disabled'] as const;
-const CONTROLLED_PREFIXES = [
+export const CONTROLLED_PREFIXES = [
   'KB_',
   'MCP_',
   'OLLAMA_',
@@ -143,7 +143,7 @@ const CONTROLLED_PREFIXES = [
   'REINDEX_',
   'FRONTMATTER_',
   'LOG_FILE',
-];
+] as const;
 
 export const CONFIG_SCHEMA: readonly ConfigSpec[] = [
   { name: 'KNOWLEDGE_BASES_ROOT_DIR', kind: 'path', docDefault: '$HOME/knowledge_bases', description: 'Root directory containing knowledge base shelves.', defaultValue: (env) => resolveKnowledgeBasesRootDir(env.KNOWLEDGE_BASES_ROOT_DIR) },
@@ -672,8 +672,19 @@ function booleanValuesFor(spec: Pick<BaseSpec<'boolean'>, 'booleanValues'>): Set
   return new Set(spec.booleanValues ?? STRICT_BOOL_VALUES);
 }
 
-function isControlledEnvName(name: string): boolean {
+export function isControlledEnvName(name: string): boolean {
   return CONTROLLED_PREFIXES.some((prefix) => name === prefix || name.startsWith(prefix));
+}
+
+/**
+ * True when `name` is registered with the config system: either an explicit
+ * entry in {@link CONFIG_SCHEMA} or a name matched by a dynamic spec pattern
+ * (e.g. `KB_AGE_BUDGET_HOURS_<KB>`). Used by the code→schema drift guard
+ * (`scripts/check-config-env-usage.mjs`) to distinguish registered reads from
+ * contributor drift.
+ */
+export function isRegisteredConfigName(name: string): boolean {
+  return SCHEMA_BY_NAME.has(name) || dynamicSpecForName(name) !== null;
 }
 
 function parseDotEnvValue(rawValue: string): string {


### PR DESCRIPTION
## Summary
Closes #753.

`kb config validate` warns at **runtime** when an operator *sets* an unknown controlled `KB_*` var, but nothing catches the opposite, contributor-facing drift: a new `process.env.KB_*` (or other controlled-prefix) read added in source that was never registered in `CONFIG_SCHEMA`. Such a var silently escapes schema validation, `kb config show`, and the generated config reference.

This adds `scripts/check-config-env-usage.mjs`, wired into `npm run check` beside the existing doc-drift gates (`docs:check-config-reference`, `docs:check-cli`, `docs:check-mcp-tools`). It scans **production** source for **literal** controlled-prefix env reads and fails when one is neither registered in `CONFIG_SCHEMA` (including dynamic specs like `KB_AGE_BUDGET_HOURS_<KB>`) nor explicitly allowlisted.

## Design
- **Authoritative, not re-declared.** Exports `CONTROLLED_PREFIXES`, `isControlledEnvName`, and a new `isRegisteredConfigName` from `src/config/schema.ts`; the guard imports them so the prefix list and registration check never drift from the schema module.
- **Literal names only.** `process.env.NAME` and `process.env['NAME']` are inspected; dynamic `process.env[variable]` access is ignored, so intentionally-dynamic reads never produce false positives (addresses the issue's stated risk).
- **Scans production source.** Tests, fixtures, `__property-tests__`, `__mocks__`, and the opt-in `e2e/` suite are excluded — they legitimately exercise env knobs that are not part of the operator-facing config surface.
- **Allowlist hygiene.** An allowlist entry that later becomes registered in the schema is flagged as redundant, so the list keeps shrinking.

## Baseline (`main` stays green)
The scan surfaced **17 pre-existing production reads** that are used in code but absent from `CONFIG_SCHEMA` (e.g. `KB_SEARCH_SNIPPET`, `KB_RERANK_DEVICE`, `KB_MAX_QUERY_CHARS`, `KB_DECOMPOSE_LLM_ENDPOINT`). These are baselined in the guard's `ALLOWLIST` with reasons so this change is a pure ratchet — it locks in the current state and blocks **new** drift. Each is a candidate for schema registration or explicit justification (see Follow-ups).

## Verification
- `npm run build` — clean (TS 5.7.3).
- `npm run lint` — clean.
- `node scripts/check-config-env-usage.mjs` — `17 allowlisted; no unregistered controlled env reads`, exit 0.
- New `src/check-config-env-usage.test.ts` (spawn-based, 3 tests, all pass):
  1. passes on current production source,
  2. fails (exit 1) on a fixture reading an unregistered `process.env.KB_FAKE_UNREGISTERED_XYZ`,
  3. ignores dynamic `process.env[var]` access.
- `src/config/schema.test.ts` + `src/cli-config.test.ts` — 26 tests pass (export changes are non-breaking).

## Follow-ups
- Register or explicitly justify the 17 baselined vars currently in the guard's `ALLOWLIST` (tracking issue to be filed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)