### PR TITLE
test: cover the tags subcommand in the cli-smoke matrix (#778)

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -9,7 +9,7 @@ surface. Run `npm run build && node scripts/gen-cli-reference.mjs` after
 changing a command or its help text, and commit the result. The
 `docs:check-cli` gate (part of `npm run check`) fails if this file drifts.
 
-The `kb` CLI exposes 36 commands.
+The `kb` CLI exposes 37 commands.
 
 ## Commands
 
@@ -49,6 +49,7 @@ The `kb` CLI exposes 36 commands.
 | [`kb stale-check`](#kb-stale-check) | Scan markdown notes for path / URL references that no longer resolve. |
 | [`kb stats`](#kb-stats) | Read-only index/corpus stats (mirrors the MCP kb_stats payload). |
 | [`kb superseded`](#kb-superseded) | Scan a KB for obsolete / contradicted / deprecated / stale notes. |
+| [`kb tags`](#kb-tags) | Enumerate frontmatter facet values (tags/status/type) with counts. |
 | [`kb verify`](#kb-verify) | Run slow integrity checks for persisted indexes and sidecars. |
 | [`kb where`](#kb-where) | Recommend the best KB and file for a given topic. |
 
@@ -1691,6 +1692,52 @@ Examples:
   kb superseded --kb=work
   kb superseded --kb=work --format=json
   kb superseded --kb=work --include-clean --k=10
+```
+
+## `kb tags`
+
+Enumerate frontmatter facet values (tags/status/type) with counts.
+
+```text
+kb tags — enumerate frontmatter facet values with counts (read-only)
+
+Usage:
+  kb tags [--kb=<name>] [--facet=<name>] [--format=md|json]
+
+Walks every `.md` / `.markdown` note under one or all KBs, parses YAML
+frontmatter, and reports each facet's distinct values with the number of
+notes carrying that value (sorted by count, then value). Use it to learn
+the valid vocabulary for `kb search --tags` / `--status` / `--type`
+filters before constructing a query. Strictly read-only.
+
+By default the taxonomy facets `tags`, `status`, and `type` are reported.
+`--facet=<name>` narrows the scan to a single frontmatter key (any key,
+so you can discover facets beyond the defaults).
+
+Values are counted per note: a note listing a value more than once counts
+once, and array-valued facets (e.g. `tags`) count each distinct element.
+
+Options:
+  --kb=<name>           Scope to one knowledge base. Omit for all KBs.
+  --facet=<name>        Report a single frontmatter key instead of the
+                        default tags/status/type set.
+  --format=md|json      Output format (default: md). `json` is a stable
+                        shape suitable for agent shells.
+  --help, -h            Show this help.
+
+Environment:
+  KNOWLEDGE_BASES_ROOT_DIR  Root directory containing one folder per KB.
+
+Exit codes:
+  0   facet report printed (may be empty)
+  1   runtime error (unreadable KB or note)
+  2   argv error (bad flag, --format, or empty --kb / --facet)
+
+Examples:
+  kb tags
+  kb tags --kb=work
+  kb tags --facet=status
+  kb tags --format=json
 ```
 
 ## `kb verify`

--- a/src/cli-smoke.test.ts
+++ b/src/cli-smoke.test.ts
@@ -249,6 +249,26 @@ describe('kb CLI smoke matrix without an embedding backend', () => {
       },
     },
     {
+      name: 'tags JSON reports empty facet buckets for a frontmatter-free corpus',
+      subcommand: 'tags',
+      args: ['tags', '--kb=alpha', '--format=json'],
+      assert: (result) => {
+        expect(result.code).toBe(0);
+        const body = parseStdoutJson(result) as {
+          schemaVersion?: string;
+          knowledgeBases?: string[];
+          notesScanned?: number;
+          facets?: Record<string, unknown[]>;
+        };
+        expect(body).toMatchObject({
+          schemaVersion: 'kb.tags.v1',
+          knowledgeBases: ['alpha'],
+          notesScanned: 1,
+          facets: { tags: [], status: [], type: [] },
+        });
+      },
+    },
+    {
       name: 'quarantine list JSON emits an empty entries array',
       subcommand: 'quarantine',
       args: ['quarantine', 'list', '--format=json'],
@@ -322,6 +342,7 @@ describe('kb CLI smoke matrix without an embedding backend', () => {
     { subcommand: 'eval', args: ['eval'], expected: 'missing <fixture>' },
     { subcommand: 'eval-gate', args: ['eval-gate'], expected: 'missing <fixture>' },
     { subcommand: 'where', args: ['where'], expected: 'missing --topic=<query>' },
+    { subcommand: 'tags', args: ['tags', '--format=xml'], expected: 'invalid --format' },
     { subcommand: 'promote', args: ['promote'], expected: 'missing --kb=<name>' },
     { subcommand: 'reindex', args: ['reindex'], expected: '--with-context is required' },
     { subcommand: 'completion', args: ['completion'], expected: 'expected one shell' },


### PR DESCRIPTION
## What

Unbreaks the `test` CI check on `main` (`npm run check`), which had **two** red causes, both introduced by #777 adding the `kb tags` subcommand without updating its dependent artifacts:

1. **`cli-smoke.test.ts` alignment failure** — `SUBCOMMANDS` gained `tags` but neither `outputCases` nor `invalidArgCases` had a `tags` entry, so the `keeps the matrix aligned with every registered subcommand` assertion failed deterministically (`npm run test:coverage`).
2. **`docs:check-cli` drift** — `cli.ts` registered `kb tags` but `docs/reference/cli.md` was never regenerated (36 → 37 commands, missing the `kb tags` section), so the CLI-reference drift gate failed.

Both surfaced sequentially: fixing (1) let the coverage suite pass, exposing (2) later in the same `check` chain.

## Change

- `src/cli-smoke.test.ts`
  - `outputCases`: a `tags --kb=alpha --format=json` case asserting the stable `kb.tags.v1` JSON shape over the frontmatter-free smoke KB.
  - `invalidArgCases`: a `tags --format=xml` case asserting the `exit 2` + `invalid --format` argv error.
  - Both mirror sibling read-only subcommands (`stats`, `superseded`, `quarantine`).
- `docs/reference/cli.md`: regenerated via `scripts/gen-cli-reference.mjs` (generated file; only the `tags` command was missing).

## Verification

- `npm run build` / `npm run lint` — clean
- `npx jest src/cli-smoke.test.ts` — 59 passed, 1 todo
- Full `npm run check` — green (test:coverage 2909 passed; all docs/config drift gates pass)

Closes #778

🤖 Generated with [Claude Code](https://claude.com/claude-code)
