### PR TITLE
feat: page-wise motion and incremental filter in kb search picker (#749)

### DIFF
--- a/src/cli-search-picker.test.ts
+++ b/src/cli-search-picker.test.ts
@@ -166,6 +166,137 @@ describe('applyKey navigation', () => {
   });
 });
 
+function makeBigState(n: number): PickerState {
+  const s = createPickerState(
+    Array.from({ length: n }, (_, i) => makeDoc(i, `f${i}.md`, `body number ${i}`, i / 100)),
+  );
+  s.viewportRows = 10;
+  return s;
+}
+
+describe('applyKey page-wise navigation', () => {
+  it('PageDown / PageUp move the focus by a full window height', () => {
+    let s = makeBigState(50);
+    s = applyKey(s, { name: 'pagedown' }).state;
+    expect(s.focusIndex).toBe(10);
+    s = applyKey(s, { name: 'pagedown' }).state;
+    expect(s.focusIndex).toBe(20);
+    s = applyKey(s, { name: 'pageup' }).state;
+    expect(s.focusIndex).toBe(10);
+  });
+
+  it('PageDown clamps at the last row', () => {
+    let s = makeBigState(15);
+    s.focusIndex = 10;
+    s = applyKey(s, { name: 'pagedown' }).state;
+    expect(s.focusIndex).toBe(14);
+  });
+
+  it('Ctrl-D / Ctrl-U move the focus by a half window height', () => {
+    let s = makeBigState(50);
+    s = applyKey(s, { name: 'd', ctrl: true }).state;
+    expect(s.focusIndex).toBe(5);
+    s = applyKey(s, { name: 'd', ctrl: true }).state;
+    expect(s.focusIndex).toBe(10);
+    s = applyKey(s, { name: 'u', ctrl: true }).state;
+    expect(s.focusIndex).toBe(5);
+  });
+
+  it('Ctrl-D never signals an exit (distinct from EOF/quit)', () => {
+    const s = makeBigState(50);
+    const r = applyKey(s, { name: 'd', ctrl: true });
+    expect(r.action).toEqual({ type: 'continue' });
+  });
+});
+
+describe('applyKey incremental filter', () => {
+  it('/ enters filter mode with an empty query', () => {
+    const s = makeState();
+    const r = applyKey(s, { sequence: '/' });
+    expect(r.state.filterActive).toBe(true);
+    expect(r.state.filterQuery).toBe('');
+    expect(r.action).toEqual({ type: 'continue' });
+  });
+
+  it('typing narrows the visible set and snaps focus to the first match', () => {
+    let s = makeState();
+    s = applyKey(s, { sequence: '/' }).state;
+    // "bravo" only appears in the second doc (index 1).
+    for (const ch of 'bravo') s = applyKey(s, { sequence: ch }).state;
+    expect(s.filterQuery).toBe('bravo');
+    expect(pickerItemCount(s)).toBe(3); // underlying item count is unchanged
+    expect(s.focusIndex).toBe(1); // focus snapped onto the only match
+  });
+
+  it('vi-motion keys are literal query text while filtering', () => {
+    let s = makeState();
+    s = applyKey(s, { sequence: '/' }).state;
+    s = applyKey(s, { sequence: 'j' }).state;
+    expect(s.filterQuery).toBe('j');
+    expect(s.focusIndex).toBe(0); // did not navigate
+  });
+
+  it('Enter within a filter selects the correct original result index', () => {
+    let s = makeState();
+    s = applyKey(s, { sequence: '/' }).state;
+    for (const ch of 'take two') s = applyKey(s, { sequence: ch }).state;
+    // "take two" matches only the third doc (index 2).
+    expect(s.focusIndex).toBe(2);
+    const r = applyKey(s, { name: 'return' });
+    expect(r.action).toEqual({ type: 'select', view: 'flat', index: 2 });
+    // The selection maps back to the original document.
+    const out = formatSelection(r.state, { view: 'flat', index: 2 });
+    expect(out).toMatch(/alpha content take two/);
+  });
+
+  it('Down / Up move within the filtered set', () => {
+    let s = makeState();
+    s = applyKey(s, { sequence: '/' }).state;
+    // "alpha" matches docs 0 and 2.
+    for (const ch of 'alpha') s = applyKey(s, { sequence: ch }).state;
+    expect(s.focusIndex).toBe(0);
+    s = applyKey(s, { name: 'down' }).state;
+    expect(s.focusIndex).toBe(2); // skips the non-matching doc 1
+    s = applyKey(s, { name: 'down' }).state;
+    expect(s.focusIndex).toBe(2); // clamps at the last match
+    s = applyKey(s, { name: 'up' }).state;
+    expect(s.focusIndex).toBe(0);
+  });
+
+  it('Backspace trims the query and re-widens the visible set', () => {
+    let s = makeState();
+    s = applyKey(s, { sequence: '/' }).state;
+    for (const ch of 'bravo') s = applyKey(s, { sequence: ch }).state;
+    s = applyKey(s, { name: 'backspace' }).state;
+    expect(s.filterQuery).toBe('brav');
+    s = applyKey(s, { name: 'backspace' }).state;
+    s = applyKey(s, { name: 'backspace' }).state;
+    s = applyKey(s, { name: 'backspace' }).state;
+    s = applyKey(s, { name: 'backspace' }).state;
+    expect(s.filterQuery).toBe('');
+  });
+
+  it('Esc clears the filter and restores the full list without exiting', () => {
+    let s = makeState();
+    s.focusIndex = 2;
+    s = applyKey(s, { sequence: '/' }).state;
+    for (const ch of 'bravo') s = applyKey(s, { sequence: ch }).state;
+    expect(s.focusIndex).toBe(1);
+    const r = applyKey(s, { name: 'escape' });
+    expect(r.action).toEqual({ type: 'continue' }); // does NOT exit in filter mode
+    expect(r.state.filterActive).toBe(false);
+    expect(r.state.filterQuery).toBe('');
+    expect(pickerItemCount(r.state)).toBe(3);
+  });
+
+  it('Ctrl-C still exits from within filter mode', () => {
+    let s = makeState();
+    s = applyKey(s, { sequence: '/' }).state;
+    const r = applyKey(s, { name: 'c', ctrl: true });
+    expect(r.action).toEqual({ type: 'exit' });
+  });
+});
+
 describe('renderPickerFrame', () => {
   it('shows a header with the result count and focus position', () => {
     const out = renderPickerFrame(makeState(), RENDER_OPTS);
@@ -255,6 +386,42 @@ describe('renderPickerFrame', () => {
     expect(out).toMatch(/view=grouped/);
     expect(out).toMatch(/demo\/a\.md \(2 chunks\)/);
     expect(out).toMatch(/demo\/b\.md \(1 chunk\)/);
+  });
+
+  it('advertises paging and filter keys in the flat footer hint', () => {
+    const out = renderPickerFrame(makeState(), RENDER_OPTS);
+    expect(out).toMatch(/\[PgUp\/PgDn\] page/);
+    expect(out).toMatch(/\[\/\] filter/);
+  });
+
+  it('renders the active filter query and a filtered count in filter mode', () => {
+    let s = makeState();
+    s = applyKey(s, { sequence: '/' }).state;
+    for (const ch of 'bravo') s = applyKey(s, { sequence: ch }).state;
+    const out = renderPickerFrame(s, RENDER_OPTS);
+    expect(out).toMatch(/filter: \/bravo/);
+    expect(out).toMatch(/filtered 1\/3/);
+    // Only the matching row is drawn.
+    expect(out).toMatch(/bravo content about deploy/);
+    expect(out).not.toMatch(/alpha content about rollback/);
+    // The footer hint is replaced by the filter prompt.
+    expect(out).not.toMatch(/\[Tab\] toggle view/);
+  });
+
+  it('reports "(no matches)" when a filter excludes every row', () => {
+    let s = makeState();
+    s = applyKey(s, { sequence: '/' }).state;
+    for (const ch of 'zzz') s = applyKey(s, { sequence: ch }).state;
+    const out = renderPickerFrame(s, RENDER_OPTS);
+    expect(out).toMatch(/\(no matches\)/);
+  });
+
+  it('documents paging and filter keys in the help body', () => {
+    let s = makeState();
+    s = applyKey(s, { sequence: '?' }).state;
+    const out = renderPickerFrame(s, RENDER_OPTS);
+    expect(out).toMatch(/PgDn \/ PgUp/);
+    expect(out).toMatch(/filter results/);
   });
 
   it('respects a small viewport by emitting a windowed slice of the rows', () => {

--- a/src/cli-search-picker.ts
+++ b/src/cli-search-picker.ts
@@ -22,6 +22,16 @@ export interface PickerState {
   focusIndex: number;
   selectedFlatIndexes: Set<number>;
   showHelp: boolean;
+  // Incremental "search-within-results" filter (#749). When `filterActive` is
+  // true the picker is in filter-input mode: printable keys append to
+  // `filterQuery`, which narrows the visible rows to a case-insensitive
+  // substring match; Esc exits filter mode and restores the full list.
+  filterActive: boolean;
+  filterQuery: string;
+  // Last-rendered visible window height, used to size page-wise motion
+  // (PageUp/PageDown, Ctrl-U/Ctrl-D). runPicker keeps this in sync with the
+  // terminal size on every render (#749).
+  viewportRows: number;
 }
 
 export interface PickerRenderOptions {
@@ -50,6 +60,9 @@ export function createPickerState(results: ScoredDocument[]): PickerState {
     focusIndex: 0,
     selectedFlatIndexes: new Set<number>(),
     showHelp: false,
+    filterActive: false,
+    filterQuery: '',
+    viewportRows: 10,
   };
 }
 
@@ -58,21 +71,24 @@ export function pickerItemCount(state: PickerState): number {
 }
 
 export function renderPickerFrame(state: PickerState, opts: PickerRenderOptions): string {
-  const count = pickerItemCount(state);
-  const helpLines = state.showHelp ? helpBodyLines() : [];
-  const reserved = 2 + helpLines.length + 1;
-  const viewport = Math.max(3, opts.rows - reserved);
+  const total = pickerItemCount(state);
+  const visible = visibleIndexes(state);
+  const count = visible.length;
+  const helpLines = state.showHelp && !state.filterActive ? helpBodyLines() : [];
+  const viewport = computeViewport(state, opts);
+  const focusPos = Math.max(0, visible.indexOf(state.focusIndex));
 
   const lines: string[] = [];
-  lines.push(renderHeader(state, count, opts));
+  lines.push(renderHeader(state, { total, count, focusPos }));
   lines.push('');
 
   if (count === 0) {
-    lines.push('  (no results)');
+    lines.push(state.filterActive && state.filterQuery !== '' ? '  (no matches)' : '  (no results)');
   } else {
-    const start = clamp(state.focusIndex - Math.floor(viewport / 2), 0, Math.max(0, count - viewport));
+    const start = clamp(focusPos - Math.floor(viewport / 2), 0, Math.max(0, count - viewport));
     const end = Math.min(count, start + viewport);
-    for (let i = start; i < end; i += 1) {
+    for (let p = start; p < end; p += 1) {
+      const i = visible[p];
       const focused = i === state.focusIndex;
       const row = state.view === 'flat'
         ? renderFlatRow(state.results[i], i, state.selectedFlatIndexes.has(i))
@@ -81,11 +97,12 @@ export function renderPickerFrame(state: PickerState, opts: PickerRenderOptions)
     }
   }
 
-  if (state.showHelp) {
-    lines.push('');
+  lines.push('');
+  if (state.filterActive) {
+    lines.push(renderFilterLine(state));
+  } else if (state.showHelp) {
     for (const helpLine of helpLines) lines.push(helpLine);
   } else {
-    lines.push('');
     lines.push(renderFooterHint(state, opts));
   }
 
@@ -93,11 +110,31 @@ export function renderPickerFrame(state: PickerState, opts: PickerRenderOptions)
 }
 
 export function applyKey(state: PickerState, key: PickerKey): { state: PickerState; action: PickerAction } {
-  const count = pickerItemCount(state);
   const name = key.name ?? '';
   const seq = key.sequence ?? '';
 
+  // Ctrl-C always exits, in either mode.
   if (key.ctrl && name === 'c') return { state, action: { type: 'exit' } };
+
+  // Half-page motion works in both normal and filter modes. Ctrl-D is bound to
+  // half-page-down here (raw-mode keypress, not line-mode EOF), so it never
+  // means quit — exit stays on Ctrl-C / q / Esc (#749).
+  if (key.ctrl && name === 'd') return moveBy(state, halfPage(state));
+  if (key.ctrl && name === 'u') return moveBy(state, -halfPage(state));
+
+  if (state.filterActive) return applyFilterKey(state, key, name, seq);
+
+  return applyNormalKey(state, key, name, seq);
+}
+
+function applyNormalKey(
+  state: PickerState,
+  key: PickerKey,
+  name: string,
+  seq: string,
+): { state: PickerState; action: PickerAction } {
+  const count = pickerItemCount(state);
+
   if (name === 'return') {
     if (count === 0) return { state, action: { type: 'exit' } };
     return { state, action: { type: 'select', view: state.view, index: state.focusIndex } };
@@ -117,17 +154,14 @@ export function applyKey(state: PickerState, key: PickerKey): { state: PickerSta
   if (name === 'escape' || seq === 'q' || seq === 'Q') {
     return { state, action: { type: 'exit' } };
   }
-  if (name === 'down' || seq === 'j') {
-    return { state: { ...state, focusIndex: Math.min(Math.max(0, count - 1), state.focusIndex + 1) }, action: { type: 'continue' } };
-  }
-  if (name === 'up' || seq === 'k') {
-    return { state: { ...state, focusIndex: Math.max(0, state.focusIndex - 1) }, action: { type: 'continue' } };
-  }
-  if (seq === 'g') {
-    return { state: { ...state, focusIndex: 0 }, action: { type: 'continue' } };
-  }
-  if (seq === 'G') {
-    return { state: { ...state, focusIndex: Math.max(0, count - 1) }, action: { type: 'continue' } };
+  if (name === 'down' || seq === 'j') return moveBy(state, 1);
+  if (name === 'up' || seq === 'k') return moveBy(state, -1);
+  if (name === 'pagedown') return moveBy(state, page(state));
+  if (name === 'pageup') return moveBy(state, -page(state));
+  if (seq === 'g') return moveToEdge(state, 'first');
+  if (seq === 'G') return moveToEdge(state, 'last');
+  if (seq === '/') {
+    return { state: { ...state, filterActive: true, filterQuery: '' }, action: { type: 'continue' } };
   }
   if (seq === '?') {
     return { state: { ...state, showHelp: !state.showHelp }, action: { type: 'continue' } };
@@ -138,6 +172,49 @@ export function applyKey(state: PickerState, key: PickerKey): { state: PickerSta
     const nextFocus = Math.min(state.focusIndex, Math.max(0, nextCount - 1));
     return {
       state: { ...state, view: nextView, focusIndex: nextFocus },
+      action: { type: 'continue' },
+    };
+  }
+  return { state, action: { type: 'continue' } };
+}
+
+// Filter-input mode (#749): printable keys extend the query, Backspace trims
+// it, Esc exits and restores the full list, Enter selects the focused row
+// (mapped back to its original result index by formatSelection), and the
+// arrow/page keys move the focus within the narrowed set. The vi-style motion
+// keys (j/k/g/G) and Space/? are treated as literal query text here.
+function applyFilterKey(
+  state: PickerState,
+  key: PickerKey,
+  name: string,
+  seq: string,
+): { state: PickerState; action: PickerAction } {
+  if (name === 'return') {
+    if (pickerItemCount(state) === 0) return { state, action: { type: 'exit' } };
+    const visible = visibleIndexes(state);
+    if (visible.length === 0) return { state, action: { type: 'continue' } };
+    return { state, action: { type: 'select', view: state.view, index: state.focusIndex } };
+  }
+  if (name === 'escape') {
+    return {
+      state: reconcileFocus({ ...state, filterActive: false, filterQuery: '' }),
+      action: { type: 'continue' },
+    };
+  }
+  if (name === 'backspace') {
+    return {
+      state: reconcileFocus({ ...state, filterQuery: state.filterQuery.slice(0, -1) }),
+      action: { type: 'continue' },
+    };
+  }
+  if (name === 'down') return moveBy(state, 1);
+  if (name === 'up') return moveBy(state, -1);
+  if (name === 'pagedown') return moveBy(state, page(state));
+  if (name === 'pageup') return moveBy(state, -page(state));
+  // A single printable character (space through ~) extends the query.
+  if (!key.ctrl && seq.length === 1 && seq >= ' ' && seq <= '~') {
+    return {
+      state: reconcileFocus({ ...state, filterQuery: state.filterQuery + seq }),
       action: { type: 'continue' },
     };
   }
@@ -192,7 +269,11 @@ export async function runPicker(opts: RunPickerOptions): Promise<number> {
 
   let lastFrameLines = 0;
   const renderFrame = (): void => {
-    const frame = renderPickerFrame(state, buildRenderOpts());
+    const renderOpts = buildRenderOpts();
+    // Keep the page-motion window height in step with the terminal size so
+    // PageUp/PageDown and Ctrl-U/Ctrl-D move by what is actually drawn (#749).
+    state = { ...state, viewportRows: computeViewport(state, renderOpts) };
+    const frame = renderPickerFrame(state, renderOpts);
     if (lastFrameLines > 0) {
       stderr.write(`\x1b[${lastFrameLines}A\x1b[J`);
     }
@@ -241,27 +322,105 @@ function clamp(n: number, lo: number, hi: number): number {
   return n;
 }
 
+// The ordered list of item indices (into results/grouped for the active view)
+// currently visible. With no active filter this is every index; while filtering
+// it is the case-insensitive substring matches over the row text (#749).
+function visibleIndexes(state: PickerState): number[] {
+  const count = pickerItemCount(state);
+  const all = Array.from({ length: count }, (_, i) => i);
+  const query = state.filterActive ? state.filterQuery.trim().toLowerCase() : '';
+  if (query === '') return all;
+  return all.filter((i) => rowFilterText(state, i).includes(query));
+}
+
+function rowFilterText(state: PickerState, i: number): string {
+  if (state.view === 'flat') {
+    const doc = state.results[i];
+    if (!doc) return '';
+    const metadata = (doc.metadata ?? {}) as Record<string, unknown>;
+    return `${pickSourceLabel(metadata)} ${doc.pageContent}`.toLowerCase();
+  }
+  const group = state.grouped[i];
+  return group ? group.source.toLowerCase() : '';
+}
+
+// Move the focus by `delta` positions within the visible (possibly filtered)
+// set, clamping to its bounds. Keeps focus on a matching row when a filter is
+// active (#749).
+function moveBy(state: PickerState, delta: number): { state: PickerState; action: PickerAction } {
+  const visible = visibleIndexes(state);
+  if (visible.length === 0) return { state, action: { type: 'continue' } };
+  const pos = visible.indexOf(state.focusIndex);
+  const from = pos < 0 ? 0 : pos;
+  const next = clamp(from + delta, 0, visible.length - 1);
+  return { state: { ...state, focusIndex: visible[next] }, action: { type: 'continue' } };
+}
+
+function moveToEdge(state: PickerState, edge: 'first' | 'last'): { state: PickerState; action: PickerAction } {
+  const visible = visibleIndexes(state);
+  if (visible.length === 0) return { state, action: { type: 'continue' } };
+  const focusIndex = edge === 'first' ? visible[0] : visible[visible.length - 1];
+  return { state: { ...state, focusIndex }, action: { type: 'continue' } };
+}
+
+// Ensure the focus lands on a visible row after the filter set changes; if the
+// current focus was filtered out, snap to the first remaining match (#749).
+function reconcileFocus(state: PickerState): PickerState {
+  const visible = visibleIndexes(state);
+  if (visible.length === 0) return state;
+  if (visible.includes(state.focusIndex)) return state;
+  return { ...state, focusIndex: visible[0] };
+}
+
+function page(state: PickerState): number {
+  return Math.max(1, state.viewportRows);
+}
+
+function halfPage(state: PickerState): number {
+  return Math.max(1, Math.floor(state.viewportRows / 2));
+}
+
+// Height of the row window, given the terminal size and the chrome (header,
+// blank spacers, and the footer / help / filter trailer) that surrounds it.
+// Shared by the renderer and by runPicker so page-wise motion matches what is
+// actually drawn (#749).
+function computeViewport(state: PickerState, opts: PickerRenderOptions): number {
+  const trailer = state.filterActive ? 1 : state.showHelp ? helpBodyLines().length : 1;
+  const reserved = 2 + 1 + trailer;
+  return Math.max(3, opts.rows - reserved);
+}
+
 function pickerColorEnabled(env: NodeJS.ProcessEnv): boolean {
   if (env.NO_COLOR !== undefined && env.NO_COLOR !== '') return false;
   return true;
 }
 
-function renderHeader(state: PickerState, count: number, _opts: PickerRenderOptions): string {
+function renderHeader(
+  state: PickerState,
+  counts: { total: number; count: number; focusPos: number },
+): string {
+  const { total, count, focusPos } = counts;
   const noun = state.view === 'flat' ? 'chunk' : 'source';
-  const plural = count === 1 ? noun : `${noun}s`;
+  const plural = total === 1 ? noun : `${noun}s`;
   const viewTag = state.view === 'flat' ? 'flat' : 'grouped';
-  const position = count === 0 ? '0/0' : `${state.focusIndex + 1}/${count}`;
+  const position = count === 0 ? '0/0' : `${focusPos + 1}/${count}`;
+  const filtering = state.filterActive && state.filterQuery !== '';
+  const filteredText = filtering ? ` · filtered ${count}/${total}` : '';
   const selected = state.selectedFlatIndexes.size;
   const selectedText = selected > 0 ? ` · selected=${selected}` : '';
-  return `kb search · ${count} ${plural} · view=${viewTag} · ${position}${selectedText}`;
+  return `kb search · ${total} ${plural} · view=${viewTag} · ${position}${filteredText}${selectedText}`;
+}
+
+function renderFilterLine(state: PickerState): string {
+  return `filter: /${state.filterQuery}  [Enter] print  [Esc] clear  [Up/Down] move`;
 }
 
 function renderFooterHint(state: PickerState, _opts: PickerRenderOptions): string {
   if (state.view === 'grouped') {
     const enter = state.selectedFlatIndexes.size > 0 ? '[Enter] print marks' : '[Enter] print source';
-    return `[j/k] move  ${enter}  [Tab] toggle view  [?] help  [q] quit`;
+    return `[j/k] move  [PgUp/PgDn] page  [/] filter  ${enter}  [Tab] toggle view  [?] help  [q] quit`;
   }
-  return '[j/k] move  [Space] mark  [Enter] print  [Tab] toggle view  [?] help  [q] quit';
+  return '[j/k] move  [PgUp/PgDn] page  [/] filter  [Space] mark  [Enter] print  [Tab] toggle view  [?] help  [q] quit';
 }
 
 function helpBodyLines(): string[] {
@@ -269,8 +428,11 @@ function helpBodyLines(): string[] {
     'Keys:',
     '  j / Down     next result',
     '  k / Up       previous result',
+    '  PgDn / PgUp  page down / up',
+    '  Ctrl-D/Ctrl-U  half page down / up',
     '  g            jump to top',
     '  G            jump to bottom',
+    '  /            filter results (type to narrow, Esc clears, Enter selects)',
     '  Space        mark / unmark focused chunk in flat view',
     '  Tab          toggle flat / grouped-by-source view',
     '  Enter        print marked chunks, or focused row/source if none are marked',


### PR DESCRIPTION
## Summary

Closes #749. Adds two keyboard-ergonomics affordances to the interactive `kb search -i` results picker, which previously supported only single-row `j`/`k`/arrow movement plus `g`/`G` jumps.

- **Page-wise motion** — `PageUp`/`PageDown` move the focus by a full visible window height; `Ctrl-U`/`Ctrl-D` by a half window. The window height is tracked in picker state and kept in sync with the terminal size on every render, so motion matches what is actually drawn. `Ctrl-D` is bound to half-page-down (raw-mode keypress, never EOF/quit — exit stays on `Ctrl-C`/`q`/`Esc`).
- **Incremental "search-within-results" filter** — `/` enters filter mode where printable keys narrow the visible rows to a case-insensitive substring match over the row text. `Backspace` trims the query, arrows/page keys move within the narrowed set, `Enter` selects the focused row (mapped back to its **original** result index so the chosen `kb://`/path is correct), and `Esc` clears the filter and restores the full list without exiting the picker. Works in both flat and grouped views.

Navigation and rendering now window over the visible (possibly filtered) index set rather than the raw range. The footer hint, `?` help overlay, and header (which gains a `filtered N/total` indicator) are updated accordingly. stdout discipline is unchanged — picker chrome still renders to stderr; only the chosen chunk(s) go to stdout.

## Testing

- `npx jest src/cli-search-picker.test.ts` — 48 tests pass (32 pre-existing + 16 new covering page/half-page motion, `Ctrl-D` non-exit, filter narrowing/focus-snap, vi-keys-as-literal-text while filtering, `Enter` original-index mapping, filtered navigation, `Backspace`, `Esc` clear, and the new footer/help/filter-line rendering).
- `npm run build`, `npm run lint` — clean.
- Docs-drift gates (`docs:check-cli`, `docs:check-anchors`, `docs:check-mcp-tools`) — green.
- End-to-end: drove the real `runPicker` event loop with a synthetic keypress stream — filter→Enter prints only the matching doc; PageDown→Enter selects the last row; Ctrl-C exits with empty stdout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)