### PR TITLE
feat: add daemonless kb stats --format=openmetrics (#748)

### DIFF
--- a/docs/operations/metrics-export.md
+++ b/docs/operations/metrics-export.md
@@ -35,6 +35,35 @@ curl -s \
   http://127.0.0.1:8765/metrics
 ```
 
+## Daemonless one-shot dump
+
+Hosts without a long-lived `kb serve` daemon (single-shot CLI usage, cron jobs,
+node-exporter textfile collectors) can render the same OpenMetrics exposition
+from a one-shot `kb stats` run — no daemon and no `KB_METRICS_EXPORT` flag
+required:
+
+```bash
+kb stats --format=openmetrics > /var/lib/node_exporter/textfile/kb.prom
+# or push to a Pushgateway:
+kb stats --format=openmetrics | curl --data-binary @- http://pushgateway:9091/metrics/job/kb
+```
+
+The output is pipe-clean on stdout (diagnostics go to stderr). It covers the
+process-derivable families — corpus (`kb_knowledge_base_*`), index
+(`kb_index_embedding_dimensions`, `kb_build_info`), provider
+(`kb_provider_*`), query cache (`kb_query_cache_*`), rerank (`kb_rerank_*`),
+search-latency, and relevance-gate counters.
+
+Daemon-instance-only gauges are **omitted** rather than emitted as misleading
+zeros, because they only have meaning inside a running daemon:
+
+- `kb_daemon_inflight` / `kb_daemon_rejected_total` — admission control (`kb serve`).
+- Provider circuit-breaker state — resets each process.
+- Remote-transport counters (`kb_remote_transport_*`) — only present when the
+  metrics come from an HTTP/SSE transport instance.
+
+Use the daemon `GET /metrics` endpoint when you need those live gauges.
+
 ## Label Contract
 
 The v1 exporter keeps labels bounded:

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1629,7 +1629,7 @@ Read-only index/corpus stats (mirrors the MCP kb_stats payload).
 kb stats — read-only index/corpus stats
 
 Usage:
-  kb stats [--kb=<name>] [--format=md|json|csv|tsv|ndjson]
+  kb stats [--kb=<name>] [--format=md|json|csv|tsv|ndjson|openmetrics]
 
 Mirrors the MCP `kb_stats` payload for local shell use: per-KB file/chunk/byte
 counts, last-indexed time, embedding model, index path, and version context.
@@ -1641,16 +1641,24 @@ Strictly read-only — does not refresh the index.
 
 Options:
   --kb=<name>           Scope to one knowledge base. Omit for all KBs.
-  --format=md|json|csv|tsv|ndjson
+  --format=md|json|csv|tsv|ndjson|openmetrics
                         Output format (default: md). `json` emits the
                         underlying `KbStatsPayload` shape verbatim; delimited
-                        formats emit one row per knowledge base.
+                        formats emit one row per knowledge base. `openmetrics`
+                        emits a daemonless Prometheus/OpenMetrics text exposition
+                        of the corpus, index, provider, cache, rerank, and
+                        relevance-gate families derived from this one-shot run —
+                        pipe-clean on stdout for cron scrapers and node-exporter
+                        textfile collectors. Daemon-instance gauges (admission
+                        control, circuit breaker) are omitted since they are
+                        unavailable without a running `kb serve` daemon.
   --help, -h            Show this help.
 
 Examples:
   kb stats
   kb stats --kb=work
   kb stats --format=json
+  kb stats --format=openmetrics
 ```
 
 ## `kb superseded`

--- a/src/cli-stats.test.ts
+++ b/src/cli-stats.test.ts
@@ -223,6 +223,51 @@ describe('kb stats CLI', () => {
     ]);
   });
 
+  it('renders a daemonless OpenMetrics exposition from a one-shot run', async () => {
+    const { deps, stdout, stderr } = makeDeps();
+
+    const code = await runStats(['--format=openmetrics'], deps);
+
+    expect(code).toBe(0);
+    expect(stderr.join('')).toBe('');
+    const out = stdout.join('');
+    // Well-formed OpenMetrics: HELP/TYPE lines present and the exposition
+    // terminates with the mandatory EOF marker followed by a trailing newline.
+    expect(out).toContain('# HELP kb_knowledge_base_files Number of ingestable source files by knowledge base.');
+    expect(out).toContain('# TYPE kb_knowledge_base_files gauge');
+    expect(out).toContain('kb_knowledge_base_files{kb="alpha"} 2');
+    expect(out).toContain('kb_knowledge_base_files{kb="beta"} 1');
+    expect(out).toContain('kb_knowledge_base_chunks{kb="alpha"} 4');
+    expect(out.endsWith('# EOF\n')).toBe(true);
+    // Local index state must still be loaded (no daemon short-circuit here).
+    expect(deps.computeKbStats).toHaveBeenCalledTimes(1);
+  });
+
+  it('omits daemon-instance-only families from the one-shot OpenMetrics dump', async () => {
+    const { deps, stdout } = makeDeps();
+
+    const code = await runStats(['--format=openmetrics'], deps);
+
+    expect(code).toBe(0);
+    const out = stdout.join('');
+    // Admission-control and circuit-breaker gauges only exist inside a running
+    // `kb serve`; a daemonless dump must not fabricate them (issue #748).
+    expect(out).not.toContain('kb_daemon_inflight');
+    expect(out).not.toContain('kb_daemon_rejected');
+  });
+
+  it('sends failures to stderr (not stdout) for --format=openmetrics', async () => {
+    const { deps, stdout, stderr } = makeDeps({
+      computeError: new KBError('KB_NOT_FOUND', 'Knowledge base "missing" not found.'),
+    });
+
+    const code = await runStats(['--format=openmetrics'], deps);
+
+    expect(code).not.toBe(0);
+    expect(stdout.join('')).toBe('');
+    expect(stderr.join('')).toContain('kb stats:');
+  });
+
   it('passes --kb through as knowledgeBaseName without mutating the payload shape', async () => {
     const scoped = payload();
     scoped.knowledge_bases = { alpha: scoped.knowledge_bases.alpha };

--- a/src/cli-stats.ts
+++ b/src/cli-stats.ts
@@ -19,6 +19,7 @@ import {
   type KbStatsContextualPrefaceBlock,
   type KbStatsPayload,
 } from './kb-stats.js';
+import { formatKbStatsOpenMetrics } from './prometheus-export.js';
 import { readBuildInfo, type BuildInfo } from './build-info.js';
 
 const CLI_STARTED_AT = Date.now();
@@ -26,7 +27,7 @@ const CLI_STARTED_AT = Date.now();
 export const STATS_HELP = `kb stats — read-only index/corpus stats
 
 Usage:
-  kb stats [--kb=<name>] [--format=md|json|csv|tsv|ndjson]
+  kb stats [--kb=<name>] [--format=md|json|csv|tsv|ndjson|openmetrics]
 
 Mirrors the MCP \`kb_stats\` payload for local shell use: per-KB file/chunk/byte
 counts, last-indexed time, embedding model, index path, and version context.
@@ -38,21 +39,29 @@ Strictly read-only — does not refresh the index.
 
 Options:
   --kb=<name>           Scope to one knowledge base. Omit for all KBs.
-  --format=md|json|csv|tsv|ndjson
+  --format=md|json|csv|tsv|ndjson|openmetrics
                         Output format (default: md). \`json\` emits the
                         underlying \`KbStatsPayload\` shape verbatim; delimited
-                        formats emit one row per knowledge base.
+                        formats emit one row per knowledge base. \`openmetrics\`
+                        emits a daemonless Prometheus/OpenMetrics text exposition
+                        of the corpus, index, provider, cache, rerank, and
+                        relevance-gate families derived from this one-shot run —
+                        pipe-clean on stdout for cron scrapers and node-exporter
+                        textfile collectors. Daemon-instance gauges (admission
+                        control, circuit breaker) are omitted since they are
+                        unavailable without a running \`kb serve\` daemon.
   --help, -h            Show this help.
 
 Examples:
   kb stats
   kb stats --kb=work
   kb stats --format=json
+  kb stats --format=openmetrics
 `;
 
 export interface StatsArgs {
   kb?: string;
-  format: 'md' | 'json' | DelimitedOutputFormat;
+  format: 'md' | 'json' | 'openmetrics' | DelimitedOutputFormat;
 }
 
 export interface RunStatsDeps {
@@ -174,12 +183,14 @@ export function parseStatsArgs(rest: string[]): StatsArgs {
 }
 
 function isStatsFormat(value: string): value is StatsArgs['format'] {
-  return value === 'md' || value === 'json' || value === 'csv' || value === 'tsv' || value === 'ndjson';
+  return value === 'md' || value === 'json' || value === 'openmetrics'
+    || value === 'csv' || value === 'tsv' || value === 'ndjson';
 }
 
 function formatStatsOutput(payload: KbStatsPayload, format: StatsArgs['format']): string {
   if (format === 'json') return `${JSON.stringify(payload, null, 2)}\n`;
   if (format === 'md') return formatStatsMarkdown(payload);
+  if (format === 'openmetrics') return formatKbStatsOpenMetrics(payload);
   return renderRecords(statsRows(payload), format, { columns: STATS_COLUMNS });
 }
 


### PR DESCRIPTION
Closes #748.

## What

Adds `kb stats --format=openmetrics`, a daemonless one-shot OpenMetrics/Prometheus text dump. Hosts without a long-lived `kb serve` daemon (single-shot CLI, cron, node-exporter textfile collectors) previously had no way to emit Prometheus-format metrics — the `formatKbStatsOpenMetrics` renderer was transport-independent but only reachable over HTTP from the daemon (gated by `KB_METRICS_EXPORT=on`).

## How

- Route the existing `kb stats` payload through the existing `formatKbStatsOpenMetrics` formatter under a new `--format=openmetrics` value in `src/cli-stats.ts` (`isStatsFormat` + `formatStatsOutput`). Output is pipe-clean on stdout; diagnostics stay on stderr.
- Daemon-instance-only gauges (admission control `kb_daemon_inflight`/`kb_daemon_rejected_total`, circuit-breaker state) are absent from the pure formatter, so the one-shot dump omits them rather than emitting misleading zeros.
- Regenerated `docs/reference/cli.md`; documented the daemonless path and the omitted daemon-only families in `docs/operations/metrics-export.md`.

## Verification

- `npm run build`, `npm run lint` clean.
- `src/cli-stats.test.ts`: 22 pass (3 new — well-formed HELP/TYPE/EOF exposition, no daemon-only families, failures routed to stderr for the new format).
- Docs-drift gates green: `docs:check-cli`, `docs:check-anchors`, `docs:check-config-reference`, `docs:check-mcp-tools`.
- End-to-end: ran the real `node build/cli.js stats --format=openmetrics` against a live index — exit 0, valid OpenMetrics (16 families, terminating `# EOF`), no `kb_daemon_*` families, logs on stderr only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)