### PR TITLE
feat: sub-batch cross-encoder reranker via KB_RERANK_BATCH_SIZE (#746)

### DIFF
--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -110,6 +110,7 @@ provider load or scoring failures degrade to the fused order.
 | Cross-encoder reranker | `KB_RERANK` | `off` | CLI hybrid search, MCP hybrid retrieval, retrieval eval | Implemented, opt-in | `kb search --rerank`, `kb search --no-rerank`, MCP `rerank: "on"\|"off"` | `KB_RERANK=on kb search "query" --mode=hybrid --timing --format=json` |
 | Reranker model | `KB_RERANK_MODEL` | `Xenova/ms-marco-MiniLM-L-6-v2` | Local `@huggingface/transformers` provider | Implemented | none | `KB_RERANK=on kb doctor --format=json` |
 | Rerank candidate count | `KB_RERANK_TOP_N` | `40` | Reranker stage | Implemented | none | `KB_RERANK_TOP_N=20 KB_RERANK=on kb search "query" --mode=hybrid --timing` |
+| Rerank input sub-batch size | `KB_RERANK_BATCH_SIZE` | `0` (single call) | Reranker stage (cross-encoder inference) | Implemented | none | `KB_RERANK_BATCH_SIZE=16 KB_RERANK=on kb search "query" --mode=hybrid --timing` |
 | Skip-rerank fallback (per-domain gate) | `KB_RERANK_SKIP_DOMAINS` | _(empty)_ | Reranker stage (CLI/MCP/eval) | Implemented | none | `KB_RERANK=on KB_RERANK_SKIP_DOMAINS=code,skills kb search "query" --kb code --mode=hybrid --timing` |
 
 ## Untrusted Content Hardening

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -77,6 +77,7 @@ Run `npm run docs:generate-config-reference` after changing the schema.
 | <code>KB_RERANK</code> | <code>boolean</code> | <code>off</code> | <code>on</code>, <code>off</code>, <code>true</code>, <code>false</code>, <code>1</code>, <code>0</code> |  | uses default | Enables optional cross-encoder reranking. |
 | <code>KB_RERANK_MODEL</code> | <code>string</code> | <code>Xenova/ms-marco-MiniLM-L-6-v2</code> |  |  | kept as empty |  |
 | <code>KB_RERANK_TOP_N</code> | <code>integer</code> | <code>40</code> |  | >= <code>1</code>; <= <code>1000</code>; digits only | uses default |  |
+| <code>KB_RERANK_BATCH_SIZE</code> | <code>integer</code> | <code>0</code> |  | >= <code>0</code>; <= <code>1000</code>; digits only | uses default | Sub-batches cross-encoder inference to bound peak memory; 0 = single call (default). |
 | <code>KB_RERANK_SKIP_DOMAINS</code> | <code>csv</code> | _unset_ | comma-separated strings |  | uses default |  |
 | <code>KB_RERANK_CACHE</code> | <code>boolean</code> | <code>off</code> | <code>on</code>, <code>off</code>, <code>true</code>, <code>false</code>, <code>1</code>, <code>0</code>, <code>enabled</code>, <code>disabled</code> |  | uses default | Enables the persistent disk-tiered rerank-score cache. |
 | <code>KB_RERANK_CACHE_DISK_MAX_BYTES</code> | <code>integer</code> | <code>67108864</code> |  | >= <code>1</code> | uses default | Disk-size cap in bytes for the persistent rerank-score cache. |

--- a/docs/requirements/reranker.md
+++ b/docs/requirements/reranker.md
@@ -15,6 +15,7 @@
 - [x] Given a reranked JSON search result, when the result is serialized, then the payload shall include `rerank_score` without replacing the original retrieval `score`.
 - [x] Given the reranker provider fails or returns an invalid score array, when retrieval runs, then the system shall degrade to the original fused order and shall not fail retrieval.
 - [x] Given repeated query/candidate pairs in a process, when reranking runs, then an in-memory score cache shall avoid duplicate provider calls.
+- [x] Given `KB_RERANK_BATCH_SIZE=N` with `N > 0`, when the reranker scores `M` cache-miss candidates, then it shall issue `ceil(M / N)` model calls over fixed-size sub-batches and return scores in the original candidate order; `0`/unset preserves the single-call behavior. This bounds peak tokenizer/activation memory to the batch size (useful on CPU/memory-constrained hosts) without changing the resulting ranking. (#746)
 
 **Linked Tests:** TS-SEARCH-374
 **Dependencies:** RFC019, FR-SEARCH-206, FR-SEARCH-313, RFC018

--- a/src/config/reranker.test.ts
+++ b/src/config/reranker.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from '@jest/globals';
 
 import {
+  DEFAULT_RERANK_BATCH_SIZE,
   DEFAULT_RERANK_MODEL,
   DEFAULT_RERANK_TOP_N,
   isRerankSkippedForDomain,
+  parseRerankBatchSize,
   parseRerankFlag,
   parseRerankTopN,
   parseSkipRerankDomains,
@@ -38,6 +40,19 @@ describe('reranker config (RFC 019)', () => {
     expect(() => parseRerankTopN('7.9')).toThrow(/KB_RERANK_TOP_N/);
     expect(() => parseRerankTopN('0')).toThrow(/KB_RERANK_TOP_N/);
     expect(() => parseRerankTopN('1001')).toThrow(/KB_RERANK_TOP_N/);
+  });
+
+  it('parses KB_RERANK_BATCH_SIZE as a non-negative bounded integer with 0 as the off sentinel (#746)', () => {
+    expect(parseRerankBatchSize(undefined)).toBe(DEFAULT_RERANK_BATCH_SIZE);
+    expect(parseRerankBatchSize('')).toBe(DEFAULT_RERANK_BATCH_SIZE);
+    expect(parseRerankBatchSize('   ')).toBe(DEFAULT_RERANK_BATCH_SIZE);
+    // 0 is valid here (unlike KB_RERANK_TOP_N) — it means "single call".
+    expect(parseRerankBatchSize('0')).toBe(0);
+    expect(parseRerankBatchSize('16')).toBe(16);
+    expect(() => parseRerankBatchSize('16.5')).toThrow(/KB_RERANK_BATCH_SIZE/);
+    expect(() => parseRerankBatchSize('-1')).toThrow(/KB_RERANK_BATCH_SIZE/);
+    expect(() => parseRerankBatchSize('nope')).toThrow(/KB_RERANK_BATCH_SIZE/);
+    expect(() => parseRerankBatchSize('1001')).toThrow(/KB_RERANK_BATCH_SIZE/);
   });
 
   it('lets per-call overrides win over the environment flag', () => {

--- a/src/config/reranker.ts
+++ b/src/config/reranker.ts
@@ -6,6 +6,15 @@ export const DEFAULT_RERANK_MODEL = 'Xenova/ms-marco-MiniLM-L-6-v2';
 export const DEFAULT_RERANK_TOP_N = 40;
 export const MAX_RERANK_TOP_N = 1000;
 
+// #746 — cross-encoder input sub-batching. The reranker sends all top-N
+// candidates to the model in a single padded call, so peak tokenizer/activation
+// memory scales with topN × longest-passage and can OOM on CPU/constrained
+// hosts. KB_RERANK_BATCH_SIZE slices the candidate list into fixed-size
+// sub-batches, bounding peak memory at a small per-batch overhead. 0/unset keeps
+// the original single-call behavior (and today's GPU throughput) unchanged.
+export const DEFAULT_RERANK_BATCH_SIZE = 0;
+export const MAX_RERANK_BATCH_SIZE = 1000;
+
 // ---------------------------------------------------------------------------
 // Disk-tiered rerank-score cache configuration (#646).
 //
@@ -98,6 +107,27 @@ export function parseRerankTopN(raw: string | undefined): number {
   const value = Number(trimmed);
   if (!Number.isInteger(value) || value < 1 || value > MAX_RERANK_TOP_N) {
     throw new RerankerConfigError(`invalid KB_RERANK_TOP_N=${JSON.stringify(raw)} (expected integer 1-${MAX_RERANK_TOP_N})`);
+  }
+  return value;
+}
+
+/**
+ * Parse `KB_RERANK_BATCH_SIZE` into a bounded non-negative integer. `0` (the
+ * default and the meaning of an unset/blank value) disables sub-batching, so the
+ * reranker keeps issuing a single model call for the whole top-N block — today's
+ * behavior. A positive value chunks the candidate list into slices of that size.
+ * Unlike `KB_RERANK_TOP_N`, `0` is valid here (it is the "off" sentinel), so the
+ * accepted range is `0-${MAX_RERANK_BATCH_SIZE}`.
+ */
+export function parseRerankBatchSize(raw: string | undefined = process.env.KB_RERANK_BATCH_SIZE): number {
+  if (raw === undefined || raw.trim() === '') return DEFAULT_RERANK_BATCH_SIZE;
+  const trimmed = raw.trim();
+  if (!/^\d+$/.test(trimmed)) {
+    throw new RerankerConfigError(`invalid KB_RERANK_BATCH_SIZE=${JSON.stringify(raw)} (expected integer 0-${MAX_RERANK_BATCH_SIZE})`);
+  }
+  const value = Number(trimmed);
+  if (!Number.isInteger(value) || value < 0 || value > MAX_RERANK_BATCH_SIZE) {
+    throw new RerankerConfigError(`invalid KB_RERANK_BATCH_SIZE=${JSON.stringify(raw)} (expected integer 0-${MAX_RERANK_BATCH_SIZE})`);
   }
   return value;
 }

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -10,6 +10,7 @@ describe('config schema validation (FR-OBS-470)', () => {
       KB_RERANK: 'on',
       KB_RERANK_MODEL: 'Xenova/ms-marco-MiniLM-L-6-v2',
       KB_RERANK_TOP_N: '12',
+      KB_RERANK_BATCH_SIZE: '16',
       KB_RELEVANCE_GATE: 'on',
       KB_GATE_LLM_ENDPOINT: 'http://127.0.0.1:8080/v1/chat/completions',
       KB_GATE_SCORE_FLOOR: '0.75',
@@ -28,6 +29,7 @@ describe('config schema validation (FR-OBS-470)', () => {
       expect.objectContaining({ name: 'KB_AGE_BUDGET_HOURS_ALPHA', status: 'ok', value: '24' }),
       expect.objectContaining({ name: 'KB_FLAT_SEARCH_P95_ADVISORY_MS', status: 'ok', value: '75' }),
       expect.objectContaining({ name: 'KB_RERANK_TOP_N', status: 'ok', value: '12' }),
+      expect.objectContaining({ name: 'KB_RERANK_BATCH_SIZE', status: 'ok', value: '16' }),
       expect.objectContaining({ name: 'MCP_AUTH_TOKEN', status: 'ok', value: '<redacted>' }),
     ]));
   });

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -26,8 +26,10 @@ import {
   KNOWN_EMBEDDING_PROVIDERS,
 } from './provider.js';
 import {
+  DEFAULT_RERANK_BATCH_SIZE,
   DEFAULT_RERANK_MODEL,
   DEFAULT_RERANK_TOP_N,
+  MAX_RERANK_BATCH_SIZE,
   MAX_RERANK_TOP_N,
 } from './reranker.js';
 
@@ -223,6 +225,7 @@ export const CONFIG_SCHEMA: readonly ConfigSpec[] = [
   { name: 'KB_RERANK', kind: 'boolean', default: 'off', description: 'Enables optional cross-encoder reranking.' },
   { name: 'KB_RERANK_MODEL', kind: 'string', default: DEFAULT_RERANK_MODEL },
   { name: 'KB_RERANK_TOP_N', kind: 'integer', default: String(DEFAULT_RERANK_TOP_N), min: 1, max: MAX_RERANK_TOP_N, integerSyntax: 'digits' },
+  { name: 'KB_RERANK_BATCH_SIZE', kind: 'integer', default: String(DEFAULT_RERANK_BATCH_SIZE), min: 0, max: MAX_RERANK_BATCH_SIZE, integerSyntax: 'digits', description: 'Sub-batches cross-encoder inference to bound peak memory; 0 = single call (default).' },
   { name: 'KB_RERANK_SKIP_DOMAINS', kind: 'csv' },
   { name: 'KB_RERANK_CACHE', kind: 'boolean', default: 'off', booleanValues: RERANK_CACHE_BOOL_VALUES, truthyValues: ['on', 'true', '1', 'enabled'], description: 'Enables the persistent disk-tiered rerank-score cache.' },
   { name: 'KB_RERANK_CACHE_DISK_MAX_BYTES', kind: 'integer', default: String(64 * 1024 * 1024), min: 1, description: 'Disk-size cap in bytes for the persistent rerank-score cache.' },

--- a/src/reranker.test.ts
+++ b/src/reranker.test.ts
@@ -4,6 +4,7 @@ import {
   applyRerankerIfEnabled,
   InMemoryRerankScoreCache,
   rerankFusedResults,
+  scoreInSubBatches,
   scoresFromSequenceClassifierOutput,
   setRerankerFactoryForTests,
   type Reranker,
@@ -228,6 +229,60 @@ describe('applyRerankerIfEnabled — per-domain skip-rerank fallback (RFC 020 §
     } finally {
       restore();
     }
+  });
+});
+
+describe('scoreInSubBatches (#746 — cross-encoder input sub-batching)', () => {
+  // A stand-in for the model call: scores each candidate by its string length so
+  // batched and unbatched runs are trivially comparable and order-sensitive.
+  const scoreByLength = jest.fn(async (slice: string[]) => slice.map((s) => s.length));
+
+  beforeEach(() => {
+    scoreByLength.mockClear();
+  });
+
+  it('issues a single call for the empty and single-fit cases regardless of batch size', async () => {
+    expect(await scoreInSubBatches([], 4, scoreByLength)).toEqual([]);
+    expect(scoreByLength).not.toHaveBeenCalled();
+
+    const three = ['a', 'bb', 'ccc'];
+    // batchSize >= length and batchSize 0 (disabled) both take the single-call path.
+    expect(await scoreInSubBatches(three, 8, scoreByLength)).toEqual([1, 2, 3]);
+    expect(await scoreInSubBatches(three, 0, scoreByLength)).toEqual([1, 2, 3]);
+    expect(scoreByLength).toHaveBeenCalledTimes(2);
+    expect(scoreByLength).toHaveBeenCalledWith(three);
+  });
+
+  it('chunks into ceil(n / batchSize) calls and concatenates scores in original order', async () => {
+    const candidates = ['a', 'bb', 'ccc', 'dddd', 'eeeee'];
+
+    const scores = await scoreInSubBatches(candidates, 2, scoreByLength);
+
+    // 5 candidates / batch 2 => ceil(5/2) = 3 model calls.
+    expect(scoreByLength).toHaveBeenCalledTimes(3);
+    expect(scoreByLength.mock.calls.map((c) => c[0])).toEqual([
+      ['a', 'bb'],
+      ['ccc', 'dddd'],
+      ['eeeee'],
+    ]);
+    // Concatenated in original order — identical to the single-call result.
+    expect(scores).toEqual([1, 2, 3, 4, 5]);
+    expect(scores).toEqual(await scoreInSubBatches(candidates, 0, scoreByLength));
+  });
+
+  it('produces the same score ordering batched or unbatched for the same inputs', async () => {
+    const candidates = Array.from({ length: 7 }, (_, i) => 'x'.repeat(i + 1));
+    const unbatched = await scoreInSubBatches(candidates, 0, scoreByLength);
+    for (const batchSize of [1, 2, 3, 7, 100]) {
+      expect(await scoreInSubBatches(candidates, batchSize, scoreByLength)).toEqual(unbatched);
+    }
+  });
+
+  it('throws when a sub-batch returns the wrong number of scores', async () => {
+    const shortReturn = jest.fn(async () => [0.5]);
+    await expect(scoreInSubBatches(['a', 'bb', 'ccc'], 2, shortReturn)).rejects.toThrow(
+      /wrong-length score array: expected 2 scores, got 1/,
+    );
   });
 });
 

--- a/src/reranker.ts
+++ b/src/reranker.ts
@@ -2,11 +2,14 @@ import { createHash } from 'crypto';
 import type { Document } from '@langchain/core/documents';
 import { emitCanonicalLog, type CanonicalProcess, type CanonicalSearchMode } from './canonical-log.js';
 import {
+  DEFAULT_RERANK_BATCH_SIZE,
   DEFAULT_RERANK_MODEL,
   DEFAULT_RERANK_TOP_N,
   isRerankSkippedForDomain,
   KB_RERANK_CACHE_ENABLED,
+  MAX_RERANK_BATCH_SIZE,
   normalizeRerankDomain,
+  parseRerankBatchSize,
   parseRerankFlag,
   parseRerankTopN,
   parseSkipRerankDomains,
@@ -20,10 +23,13 @@ import { logger } from './logger.js';
 import { rerankMetrics } from './metrics.js';
 
 export {
+  DEFAULT_RERANK_BATCH_SIZE,
   DEFAULT_RERANK_MODEL,
   DEFAULT_RERANK_TOP_N,
   isRerankSkippedForDomain,
+  MAX_RERANK_BATCH_SIZE,
   normalizeRerankDomain,
+  parseRerankBatchSize,
   parseRerankFlag,
   parseRerankTopN,
   parseSkipRerankDomains,
@@ -371,6 +377,8 @@ class TransformersJsReranker implements Reranker {
     readonly id: string,
     private readonly tokenizer: Tokenizer,
     private readonly model: SequenceClassificationModel,
+    // #746 — 0 keeps the single-call path; >0 sub-batches inference to bound peak memory.
+    private readonly batchSize: number,
   ) {}
 
   static async create(model: string): Promise<TransformersJsReranker> {
@@ -388,11 +396,17 @@ class TransformersJsReranker implements Reranker {
       mod.AutoTokenizer.from_pretrained(model),
       mod.AutoModelForSequenceClassification.from_pretrained(model, modelOptions),
     ]);
-    return new TransformersJsReranker(model, tokenizer, classifier);
+    return new TransformersJsReranker(model, tokenizer, classifier, parseRerankBatchSize());
   }
 
   async rerank(query: string, candidates: string[]): Promise<number[]> {
-    if (candidates.length === 0) return [];
+    // #746 — sub-batch the candidate list when KB_RERANK_BATCH_SIZE is set, so
+    // peak tokenizer/activation memory is bounded by the batch size rather than
+    // the full top-N. Disabled (0) falls back to a single call for all misses.
+    return scoreInSubBatches(candidates, this.batchSize, (slice) => this.scoreBatch(query, slice));
+  }
+
+  private async scoreBatch(query: string, candidates: string[]): Promise<number[]> {
     const inputs = this.tokenizer(
       candidates.map(() => query),
       {
@@ -404,6 +418,42 @@ class TransformersJsReranker implements Reranker {
     const output = await this.model(inputs);
     return scoresFromSequenceClassifierOutput(output, this.model.config);
   }
+}
+
+/**
+ * Score `candidates` through the cross-encoder in fixed-size sub-batches (#746).
+ *
+ * When `batchSize <= 0` (disabled) or the candidate count already fits in a
+ * single batch, `runBatch` is invoked exactly once with the full list —
+ * preserving the original single-call behavior and today's GPU throughput.
+ * Otherwise the list is sliced into `ceil(n / batchSize)` contiguous chunks,
+ * each scored in order, and the per-chunk scores are concatenated. This is
+ * order-preserving and deterministic: it changes only peak memory and call
+ * shape, never the relative ranking. Padding is applied per-slice, so a smaller
+ * batch may pad to a shorter max length, but that does not reorder scores for
+ * the same query.
+ */
+export async function scoreInSubBatches(
+  candidates: string[],
+  batchSize: number,
+  runBatch: (slice: string[]) => Promise<number[]>,
+): Promise<number[]> {
+  if (candidates.length === 0) return [];
+  if (!Number.isInteger(batchSize) || batchSize <= 0 || candidates.length <= batchSize) {
+    return runBatch(candidates);
+  }
+  const scores: number[] = [];
+  for (let start = 0; start < candidates.length; start += batchSize) {
+    const slice = candidates.slice(start, start + batchSize);
+    const sliceScores = await runBatch(slice);
+    if (sliceScores.length !== slice.length) {
+      throw new Error(
+        `reranker sub-batch returned wrong-length score array: expected ${slice.length} scores, got ${sliceScores.length}`,
+      );
+    }
+    for (const score of sliceScores) scores.push(score);
+  }
+  return scores;
 }
 
 export function scoresFromSequenceClassifierOutput(


### PR DESCRIPTION
Closes #746.

## Problem
The cross-encoder reranker sends *all* top-N cache-miss candidates to the model in a single `model(inputs)` call with `padding: true`, so peak tokenizer + activation memory scales with `topN × longest-passage`. On CPU and memory-constrained hosts this spikes resident memory and can OOM with long passages.

## Change
Add a `KB_RERANK_BATCH_SIZE` knob (`src/config/reranker.ts`):
- `0`/unset (default) → current single-call behavior, preserving today's throughput (notably on GPU).
- `N > 0` → the candidate list is sliced into fixed-size sub-batches; each is scored in order and the per-slice scores are concatenated.

The batching is **order-preserving and deterministic** — it changes only peak memory and call shape, never the relative ranking. `0` is a valid value here (the "off" sentinel), unlike `KB_RERANK_TOP_N`.

### Implementation
- `parseRerankBatchSize` + `DEFAULT_RERANK_BATCH_SIZE` / `MAX_RERANK_BATCH_SIZE` in `src/config/reranker.ts`.
- `scoreInSubBatches(candidates, batchSize, runBatch)` helper in `src/reranker.ts`, wired into `TransformersJsReranker.rerank`; the single-batch inference is extracted into a private `scoreBatch`.
- Registered `KB_RERANK_BATCH_SIZE` in `CONFIG_SCHEMA` (`min: 0`) and regenerated `docs/reference/configuration.md`.
- Docs: `docs/feature-flags.md`, `docs/requirements/reranker.md`.

## Tests
- `scoreInSubBatches`: asserts `ceil(M/N)` model calls, contiguous slicing, and identical score ordering batched vs. unbatched; plus a wrong-length guard.
- `parseRerankBatchSize`: bounds/`0`-sentinel parsing.
- Schema validation test covers the new knob.
- `npm test` full suite green (427 passed); lint, `docs:check-config-reference`, and `config:check-env-usage` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)