### PR TITLE
feat: add opt-in pre-push git hook for fast CI-parity checks

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Fast, local CI-parity gate that runs BEFORE a push reaches CI.
+#
+# Runs the deterministic fast subset of `npm run check` — ESLint plus the
+# generated-doc drift gates (`npm run check:fast`) — to catch the two most
+# common red-build causes (lint violations and stale reference docs) in
+# seconds locally instead of after a full CI round-trip. The slow test suite
+# (`test:coverage`) is deliberately excluded; CI remains the source of truth
+# for the full suite. `check:fast` runs one incremental `tsc` build first (the
+# doc gates read the compiled schema / specs), so push latency stays low.
+#
+# Enable once with:  npm run dev:setup
+# Manual enable:     git config core.hooksPath .githooks
+#
+# Opt-in by construction: this hook only fires when git hooks point at this
+# directory. Contributors who never ran `dev:setup` are unaffected.
+#
+# Bypass for emergencies:  git push --no-verify
+
+set -uo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root" || exit 1
+
+# A fresh clone that has not run `npm install` cannot run the gate. Don't block
+# the push over missing tooling — warn and let it through; CI still enforces.
+if [[ ! -d node_modules ]]; then
+  echo "[pre-push] node_modules missing — skipping fast checks (run 'npm install' to enable)." >&2
+  exit 0
+fi
+
+echo "[pre-push] running fast CI-parity checks (lint + doc-drift)…" >&2
+if npm run check:fast --silent; then
+  echo "[pre-push] fast checks passed." >&2
+  exit 0
+fi
+
+cat >&2 <<'EOF'
+
+[pre-push] BLOCKED: fast CI-parity checks failed (lint or doc-drift).
+
+Regenerate the drifted reference docs, then re-check:
+  - Lint:            npm run lint:fix
+  - Config docs:     npm run docs:generate-config-reference
+  - CLI docs:        node scripts/gen-cli-reference.mjs
+  - MCP-tool docs:   npm run docs:gen-mcp-tools
+  - Error-code docs: npm run docs:gen-error-codes
+  - Metrics docs:    npm run docs:generate-metrics-reference
+  - Embedding docs:  npm run docs:generate-embedding-models
+
+Re-run locally with:  npm run check:fast
+Bypass (emergencies): git push --no-verify
+EOF
+exit 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,15 @@ Please use the [Feature Request issue template](./.github/ISSUE_TEMPLATE/feature
 
 Use `npm run check` before opening a PR; it runs the TypeScript build, ESLint, the full Jest suite, and documentation anchor verifier.
 
+## Local Git Hooks
+
+`npm run dev:setup` points git at the tracked [`.githooks/`](./.githooks/) directory (`git config core.hooksPath .githooks`). Two lifecycle hooks then run automatically:
+
+- **`post-merge` / `post-rewrite`** rebuild the linked `kb` bins after every `git pull` / `git merge` / `git pull --rebase`.
+- **`pre-push`** runs the fast CI-parity subset — `npm run check:fast` (ESLint plus the generated-doc drift gates) — before a push reaches CI. This catches the two most common red-build causes (lint violations and stale reference docs) in seconds locally, instead of after a full CI round-trip. It deliberately skips the slow `test:coverage` step, so CI remains the source of truth for the full test suite.
+
+`check:fast` is `npm run check` minus the slow `test:coverage` step (the leading `tsc` build is incremental, so it is quick); you can run it directly (`npm run check:fast`) any time. The hook is **opt-in** — it only fires once `dev:setup` has pointed `core.hooksPath` at `.githooks/`, so contributors who never ran setup are unaffected. Bypass it for emergencies with `git push --no-verify`.
+
 ## Linting
 
 Use `npm run lint` (`eslint src`) to run the type-aware ESLint gate, or `npm run lint:fix` to apply autofixes. It is also wired into `npm run check` and the CI Tests workflow, so a clean `npm run lint` is required before a PR is mergeable.

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "build": "tsc -p tsconfig.json && chmod +x build/index.js build/cli.js",
     "build:clean": "rm -rf build",
     "check": "npm run build && npm run lint && npm run test:coverage && npm run docs:check-anchors && npm run docs:check-config-reference && npm run config:check-env-usage && npm run docs:check-cli && npm run docs:check-mcp-tools && npm run docs:check-embedding-models && npm run docs:check-metrics-reference && npm run docs:check-error-codes",
+    "check:fast": "npm run build && npm run lint && npm run docs:check-anchors && npm run docs:check-config-reference && npm run config:check-env-usage && npm run docs:check-cli && npm run docs:check-mcp-tools && npm run docs:check-embedding-models && npm run docs:check-metrics-reference && npm run docs:check-error-codes",
     "lint": "eslint src",
     "lint:commit-message": "commitlint",
     "lint:fix": "eslint src --fix",

--- a/scripts/dev-setup.sh
+++ b/scripts/dev-setup.sh
@@ -46,8 +46,8 @@ echo "==> Linking bins into npm global prefix: ${resolved_prefix}"
 echo "    (override with PREFIX, NPM_CONFIG_PREFIX, or ~/.npmrc 'prefix=' if wrong)"
 npm link
 
-echo "==> Configuring git hooks path -> .githooks (post-merge + post-rewrite)"
-chmod +x .githooks/post-merge scripts/*.sh 2>/dev/null || true
+echo "==> Configuring git hooks path -> .githooks (post-merge + post-rewrite + pre-push)"
+chmod +x .githooks/post-merge .githooks/pre-push scripts/*.sh 2>/dev/null || true
 git config core.hooksPath .githooks
 
 cat <<EOF
@@ -57,6 +57,8 @@ this checkout (${resolved_prefix}/bin/). From now on:
 
   - \`git pull\` (merge or rebase) auto-rebuilds via the post-merge /
     post-rewrite hooks.
+  - \`git push\` first runs the fast CI-parity gate (\`npm run check:fast\`:
+    lint + doc-drift) via the pre-push hook. Bypass with \`git push --no-verify\`.
   - Edit src/, run \`npm run build\`, and the global bins reflect it
     immediately — no re-link needed.
   - To unlink: \`npm unlink -g @jeanibarz/knowledge-base-mcp-server\`


### PR DESCRIPTION
## Summary

Adds a `.githooks/pre-push` hook that runs the fast, deterministic subset of `npm run check` — ESLint plus the generated-doc drift gates — before a push reaches CI, via a new `npm run check:fast` script. This catches the two most common red-build causes (lint violations and stale reference docs) in seconds locally instead of after a full CI round-trip.

Implements the recommendation in #743.

## Changes

- **`package.json`**: new `check:fast` script = `npm run check` minus the slow `test:coverage` step. The leading `tsc` build is incremental (per CONTRIBUTING "Incremental Builds"), so it stays quick, and the doc gates (`docs:check-config-reference`, `docs:check-cli`, `docs:check-mcp-tools`) read the freshly compiled schema/specs they depend on.
- **`.githooks/pre-push`**: bash hook mirroring the defensive style of `post-merge` (`set -uo pipefail`, `cd` to repo root, friendly failure message with per-gate remediation hints). Runs `npm run check:fast`.
- **`scripts/dev-setup.sh`**: `chmod +x` the new hook and mention it in the setup summary.
- **`CONTRIBUTING.md`**: new "Local Git Hooks" section documenting `post-merge`/`pre-push` and `check:fast`.

## Design notes

- **Opt-in by construction**: the hook only fires once `core.hooksPath` points at `.githooks/` (done by `npm run dev:setup`). Contributors who never ran setup are unaffected — CI remains the source of truth.
- **Bypassable**: honors `git push --no-verify` for emergencies (git's built-in behavior).
- **Graceful**: skips with a warning (exit 0) when `node_modules` is absent, so a fresh clone that hasn't run `npm install` can still push.
- **Fast**: deliberately excludes `test:coverage`; the doc gates need one incremental build, which is quick.

## Verification

- `npm run check:fast` passes on a clean `origin/main` tree (exit 0).
- Directly invoking `.githooks/pre-push`: passes on a clean tree; **blocks (exit 1)** with the `BLOCKED` remediation message when a generated doc is drifted (verified against `docs/reference/cli.md`).
- The push that opened this PR ran the new hook itself: `[pre-push] fast checks passed.`

Closes #743