### PR TITLE
fix: include embedding cost in reindex estimate

### DIFF
--- a/src/reindex-runner.test.ts
+++ b/src/reindex-runner.test.ts
@@ -235,9 +235,11 @@ describe('cache-aware reindex estimate (#408)', () => {
     expect(est).toEqual({ total_chunks: 4, cache_hits: 2, retry_skips: 0, cold_chunks: 2 });
   });
 
-  it('prices only cold chunks for the LRA-window guard', async () => {
+  it('adds embedding rebuild cost to cold-preface cost for the LRA-window guard', async () => {
     // 1000 chunks × 8s = 8000s (~2h13m) would cross 06:00 UTC from a
-    // 04:00 start. With 990 chunks cached, only 10 are cold → 80s.
+    // 04:00 start.
+    // With 990 chunks cached, only 10 are cold: 80s of preface work plus
+    // 30s to rebuild embeddings for all 1000 chunks = 110s.
     await writeManifest('alpha', 'note', 1000);
     const cp = (await import('./contextual-preface.js')) as ContextualPrefaceModule;
     const cachedChunks = Array.from({ length: 990 }, (_unused, i) => ({
@@ -254,12 +256,39 @@ describe('cache-aware reindex estimate (#408)', () => {
       runUpdateIndex: async () => makeNeverRunSummary(),
     });
     expect(result.outcome).toBe('completed');
-    expect(result.estimated_seconds).toBe(80);
+    expect(result.estimated_seconds).toBe(110);
     expect(result.contextual_estimate).toEqual({
       total_chunks: 1000,
       cache_hits: 990,
       retry_skips: 0,
       cold_chunks: 10,
+    });
+  });
+
+  it('prices embedding rebuilds when every contextual preface is cached', async () => {
+    await writeManifest('alpha', 'note', 1000);
+    const cp = (await import('./contextual-preface.js')) as ContextualPrefaceModule;
+    const cachedChunks = Array.from({ length: 1000 }, (_unused, i) => ({
+      chunk_index: i,
+      chunk_hash: `h${i}`,
+      preface: `ctx ${i}`,
+    }));
+    await writeSidecar(cp, 'alpha', 'note', cachedChunks);
+
+    const result = await runner.runReindex({
+      knowledgeBases: [],
+      force: false,
+      now: new Date(Date.UTC(2026, 4, 15, 5, 59, 45)),
+      resolveKbs: async () => ['alpha'],
+      runUpdateIndex: async () => makeNeverRunSummary(),
+    });
+
+    expect(result.outcome).toBe('guard_blocked');
+    expect(result.estimated_seconds).toBe(30);
+    expect(result.contextual_estimate).toMatchObject({
+      total_chunks: 1000,
+      cache_hits: 1000,
+      cold_chunks: 0,
     });
   });
 

--- a/src/reindex-runner.ts
+++ b/src/reindex-runner.ts
@@ -10,8 +10,8 @@
 // get re-embedded every day. M0b's job is the orchestration around it:
 //
 //  1. Resolve in-scope KBs (default: every registered KB). Count total
-//     chunks from existing chunk manifests and estimate runtime as
-//     `total_chunks * 8s` (cold-case ceiling).
+//     chunks from existing chunk manifests and estimate cold-preface plus
+//     possible whole-index embedding-rebuild work.
 //  2. Refuse to start inside the LRA cron window (06:00-10:30 UTC) or
 //     when the estimated runtime would cross it, unless `--force`.
 //  3. Check for a peer reindex via `.reindex.run.json` + PID liveness;
@@ -57,6 +57,12 @@ import { logger } from './logger.js';
 // latency observed against Qwen3.6-35B-A3B at the deployed context;
 // warm tenancy lands closer to 1-2s but the guard uses the ceiling.
 export const REINDEX_PER_CHUNK_ESTIMATE_MS = 8_000;
+
+// A changed file can make the incremental FAISS path rebuild the whole
+// index because individual vectors cannot be deleted. Price that possible
+// rebuild at the observed steady-state throughput (~30ms/chunk) so a warm
+// contextual-preface cache does not reduce a non-trivial run to 0 seconds.
+export const REINDEX_EMBEDDING_PER_CHUNK_ESTIMATE_MS = 30;
 
 // RFC 017 §5 step 2 — LRA cron guard window in UTC. Hard-coded rather
 // than env-tunable: there is exactly one operator and one downstream
@@ -107,8 +113,9 @@ export interface ReindexOptions {
 /**
  * RFC 017 §5 step 1 (cache-aware refinement, #408) — breakdown of the
  * contextual-preface work the runtime estimate is built from. `cold_chunks`
- * is the count actually priced at the 8s cold-LLM ceiling; `cache_hits` and
- * `retry_skips` are reused from per-source sidecars at no LLM cost.
+ * is the count priced at the 8s cold-LLM ceiling; every `total_chunks` entry
+ * is also priced at the embedding rebuild rate because the incremental FAISS
+ * path may rebuild the whole index.
  */
 export interface ContextualReindexEstimate {
   /** Total chunks across all in-scope KBs, summed from chunk manifests. */
@@ -385,9 +392,9 @@ async function readManifestChunkCount(manifestPath: string): Promise<number> {
  *     not-yet-due retry skip, or a cold LLM call (see
  *     `classifyContextualSidecarChunks`).
  *
- * `cold_chunks * REINDEX_PER_CHUNK_ESTIMATE_MS` is then the cache-aware
- * runtime upper bound. A first-ever reindex (no sidecars) yields
- * `cold_chunks === total_chunks`, identical to the pre-#408 estimate.
+ * The cache-aware runtime estimate adds cold-preface work to the possible
+ * whole-index embedding rebuild. A first-ever reindex (no sidecars) yields
+ * `cold_chunks === total_chunks`; a warm cache still retains embedding cost.
  */
 export async function estimateContextualReindexWork(
   kbs: readonly string[],
@@ -466,12 +473,18 @@ export async function runReindex(options: ReindexOptions): Promise<ReindexResult
 
   // 1. Resolve scope + estimate runtime. The estimate is cache-aware
   //    (#408): only chunks without a valid contextual-preface sidecar are
-  //    priced at the 8s cold-LLM ceiling, so a reindex following a partial
-  //    run is not needlessly guard-blocked for work it would skip.
+  //    priced at the 8s cold-LLM ceiling. Every chunk is additionally priced
+  //    at the observed embedding rebuild rate because an incremental update
+  //    can escalate to a whole-index FAISS rebuild.
   const kbs = await resolveKbsInScope(options);
   const estimate = await estimateContextualReindexWork(kbs, now);
   const totalChunks = estimate.total_chunks;
-  const estimatedSeconds = Math.ceil((estimate.cold_chunks * REINDEX_PER_CHUNK_ESTIMATE_MS) / 1_000);
+  const estimatedSeconds = Math.ceil(
+    (
+      estimate.cold_chunks * REINDEX_PER_CHUNK_ESTIMATE_MS
+      + estimate.total_chunks * REINDEX_EMBEDDING_PER_CHUNK_ESTIMATE_MS
+    ) / 1_000,
+  );
 
   emitCanonicalLog({
     process: 'cli',


### PR DESCRIPTION
Closes #800.

## What changed

- add a 30 ms per-chunk embedding-rebuild term to the reindex runtime estimate
- keep the existing 8 s term limited to cold contextual-preface chunks
- cover both mixed-cache work and the steady-state `cold_chunks=0` rebuild case

## Estimate choice

The guard now calculates:

`cold_chunks × 8 s + total_chunks × 30 ms`

Thirty milliseconds per chunk is the smallest estimate supported by the observed issue data (about 31k chunks rebuilt in 16.5 minutes). The guard must price all manifest chunks because, before `updateIndex` runs, it cannot know whether changed files will force the incremental FAISS path to rebuild the whole index.

Alternatives considered:

- pricing only changed chunks is not available at guard time and would miss whole-index fallback behavior
- using the full observed 16.5-minute duration as a fixed floor would overestimate small indexes
- retaining cold-preface-only pricing leaves warm-cache rebuilds at zero and does not fix the issue

The existing RFC prose still describes the older cold-preface-only formula. It was not changed here because this task explicitly assigns the two runner files and other documentation scope is owned separately.

## Verification

Before the fix, a 1,000-chunk manifest with 1,000 cached prefaces produced `estimated_seconds=0` and a run at 05:59:45 UTC proceeded.

After the fix, the same case produces `estimated_seconds=30` and returns `guard_blocked`. A mixed case with 10 cold prefaces and 1,000 total chunks produces 110 seconds (80 s preface + 30 s embedding).

- `npm run test:file -- src/reindex-runner.test.ts`
- `npm run build`
- `npm run lint`
- `npm test` (196 parallel suites / 2,539 passing tests; 11 serial suites / 428 passing tests)

## Pre-PR review

- correctness: no findings
- lint-like: comment findings fixed; no dead code; RFC drift noted above
- tests: no findings; the `runReindex` guard path is exercised directly
