### PR TITLE
feat: coalesce concurrent query cache misses

### DIFF
--- a/src/query-cache.test.ts
+++ b/src/query-cache.test.ts
@@ -26,6 +26,131 @@ function sha256(buffer: Buffer): string {
 }
 
 describe('query embedding cache (#214)', () => {
+  it('coalesces concurrent identical misses when single-flight is enabled', async () => {
+    const indexPath = await tempIndexPath('kb-query-cache-single-flight-');
+    try {
+      let calls = 0;
+      let release!: (embedding: number[]) => void;
+      const pending = new Promise<number[]>((resolve) => {
+        release = resolve;
+      });
+      const cache = new QueryEmbeddingCache({ indexPath, lruMax: 8, singleFlight: true });
+      const embed = async (): Promise<number[]> => {
+        calls += 1;
+        return pending;
+      };
+
+      const first = cache.getOrCompute({ modelId: 'fake__one', query: 'same query', embed });
+      const second = cache.getOrCompute({ modelId: 'fake__one', query: 'same query', embed });
+      await new Promise((resolve) => setImmediate(resolve));
+      release([1.25, 2.5]);
+
+      const results = await Promise.all([first, second]);
+      expect(calls).toBe(1);
+      expect(results.map((result) => result.embedding)).toEqual([[1.25, 2.5], [1.25, 2.5]]);
+
+      const paths = queryCachePaths({ indexPath, modelId: 'fake__one', query: 'same query' });
+      cache.clearMemory();
+      await Promise.all([fsp.unlink(paths.metaPath), fsp.unlink(paths.vectorPath)]);
+      await cache.getOrCompute({ modelId: 'fake__one', query: 'same query', embed });
+      expect(calls).toBe(2);
+    } finally {
+      await fsp.rm(path.dirname(indexPath), { recursive: true, force: true });
+    }
+  });
+
+  it('leaves concurrent identical misses independent by default', async () => {
+    const indexPath = await tempIndexPath('kb-query-cache-single-flight-off-');
+    try {
+      let calls = 0;
+      let release!: (embedding: number[]) => void;
+      let markBothStarted!: () => void;
+      const pending = new Promise<number[]>((resolve) => {
+        release = resolve;
+      });
+      const bothStarted = new Promise<void>((resolve) => {
+        markBothStarted = resolve;
+      });
+      const cache = new QueryEmbeddingCache({ indexPath, lruMax: 8 });
+      const embed = async (): Promise<number[]> => {
+        calls += 1;
+        if (calls === 2) markBothStarted();
+        return pending;
+      };
+
+      const first = cache.getOrCompute({ modelId: 'fake__one', query: 'same query', embed });
+      const second = cache.getOrCompute({ modelId: 'fake__one', query: 'same query', embed });
+      await bothStarted;
+      release([1, 2]);
+      await Promise.all([first, second]);
+      expect(calls).toBe(2);
+    } finally {
+      await fsp.rm(path.dirname(indexPath), { recursive: true, force: true });
+    }
+  });
+
+  it('clears a rejected single-flight so the next call can retry', async () => {
+    const indexPath = await tempIndexPath('kb-query-cache-single-flight-reject-');
+    try {
+      let calls = 0;
+      let reject!: (error: Error) => void;
+      let markStarted!: () => void;
+      const started = new Promise<void>((resolve) => {
+        markStarted = resolve;
+      });
+      const pending = new Promise<number[]>((_resolve, rejectPromise) => {
+        reject = rejectPromise;
+      });
+      const cache = new QueryEmbeddingCache({ indexPath, lruMax: 8, singleFlight: true });
+      const embed = async (): Promise<number[]> => {
+        calls += 1;
+        if (calls === 1) {
+          markStarted();
+          return pending;
+        }
+        return [3, 4];
+      };
+
+      const first = cache.getOrCompute({ modelId: 'fake__one', query: 'retry me', embed });
+      const second = cache.getOrCompute({ modelId: 'fake__one', query: 'retry me', embed });
+      await started;
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(calls).toBe(1);
+      reject(new Error('transient failure'));
+      await expect(Promise.all([first, second])).rejects.toThrow('transient failure');
+      await expect(cache.getOrCompute({ modelId: 'fake__one', query: 'retry me', embed }))
+        .resolves.toMatchObject({ embedding: [3, 4], status: 'miss' });
+      expect(calls).toBe(2);
+    } finally {
+      await fsp.rm(path.dirname(indexPath), { recursive: true, force: true });
+    }
+  });
+
+  it('does not coalesce bypassed or disabled lookups', async () => {
+    const indexPath = await tempIndexPath('kb-query-cache-single-flight-exclusions-');
+    try {
+      for (const options of [
+        { singleFlight: true },
+        { singleFlight: true, enabled: false },
+      ]) {
+        let calls = 0;
+        const cache = new QueryEmbeddingCache({ indexPath, lruMax: 8, ...options });
+        const embed = async (): Promise<number[]> => {
+          calls += 1;
+          await new Promise((resolve) => setImmediate(resolve));
+          return [calls];
+        };
+        await Promise.all([
+          cache.getOrCompute({ modelId: 'fake__one', query: 'excluded', bypass: true, embed }),
+          cache.getOrCompute({ modelId: 'fake__one', query: 'excluded', bypass: true, embed }),
+        ]);
+        expect(calls).toBe(2);
+      }
+    } finally {
+      await fsp.rm(path.dirname(indexPath), { recursive: true, force: true });
+    }
+  });
+
   it('round-trips a query embedding through the disk tier across cache instances', async () => {
     const indexPath = await tempIndexPath('kb-query-cache-roundtrip-');
     try {

--- a/src/query-cache.ts
+++ b/src/query-cache.ts
@@ -50,6 +50,7 @@ export interface QueryCacheOptions {
   enabled?: boolean;
   lruMax?: number;
   diskMaxBytes?: number;
+  singleFlight?: boolean;
 }
 
 interface CacheMeta {
@@ -96,7 +97,9 @@ export class QueryEmbeddingCache {
   private readonly indexPath: string;
   private readonly enabled: boolean;
   private readonly diskMaxBytes: number;
+  private readonly singleFlight: boolean;
   private readonly l1: LruVectorCache;
+  private readonly inFlight = new Map<string, Promise<number[]>>();
   private hitsL1 = 0;
   private hitsDisk = 0;
   private misses = 0;
@@ -108,6 +111,7 @@ export class QueryEmbeddingCache {
     this.indexPath = options.indexPath ?? FAISS_INDEX_PATH;
     this.enabled = options.enabled ?? KB_QUERY_CACHE_ENABLED;
     this.diskMaxBytes = options.diskMaxBytes ?? KB_QUERY_CACHE_DISK_MAX_BYTES;
+    this.singleFlight = options.singleFlight ?? false;
     this.l1 = new LruVectorCache(options.lruMax ?? KB_QUERY_CACHE_LRU_MAX);
   }
 
@@ -168,17 +172,29 @@ export class QueryEmbeddingCache {
     }
 
     this.misses += 1;
-    const embedding = await args.embed();
-    const stableEmbedding = toFloat32Numbers(embedding);
-    this.l1.set(paths.cacheKey, stableEmbedding);
-    try {
-      await this.writeDisk(paths, stableEmbedding);
-      this.writes += 1;
-      await this.enforceDiskLimit();
-    } catch (err) {
-      logger.warn(`query embedding cache write skipped for ${args.modelId}: ${(err as Error).message}`);
+    let pending = this.singleFlight ? this.inFlight.get(paths.cacheKey) : undefined;
+    const ownsFlight = pending === undefined;
+    if (pending === undefined) {
+      pending = (async () => {
+        const embedding = await args.embed();
+        const stableEmbedding = toFloat32Numbers(embedding);
+        this.l1.set(paths.cacheKey, stableEmbedding);
+        try {
+          await this.writeDisk(paths, stableEmbedding);
+          this.writes += 1;
+          await this.enforceDiskLimit();
+        } catch (err) {
+          logger.warn(`query embedding cache write skipped for ${args.modelId}: ${(err as Error).message}`);
+        }
+        return stableEmbedding;
+      })();
+      if (this.singleFlight) this.inFlight.set(paths.cacheKey, pending);
     }
-    return record(stableEmbedding, 'miss', 'miss');
+    try {
+      return record(await pending, 'miss', 'miss');
+    } finally {
+      if (this.singleFlight && ownsFlight) this.inFlight.delete(paths.cacheKey);
+    }
   }
 
   async stats(): Promise<QueryCacheStats> {


### PR DESCRIPTION
## Summary

- add opt-in single-flight coalescing for concurrent identical query embedding cache misses
- clear the per-key in-flight promise after both fulfillment and rejection so later calls can retry
- keep disabled and per-call bypass paths outside coalescing
- cover concurrent success, default-off behavior, settle cleanup, and excluded paths

## Opt-in choice and alternatives

`QueryCacheOptions.singleFlight` defaults to `false`, preserving existing behavior while duplicate-rate and provider-failure effects are still unmeasured. Callers opt in programmatically per cache instance, which keeps this change inside the cache-only scope and avoids introducing an incomplete operator configuration surface.

Alternatives considered:

- Default-on coalescing would maximize provider-load reduction immediately, but changes failure coupling for all callers before workload benefit is measured.
- A registered environment/config flag would make the production singleton operator-toggleable, but requires schema and documentation changes beyond this issue’s explicitly restricted file scope; that can be added separately if operational rollout is desired.
- Coalescing only `embed()` would still duplicate cache writes and disk-limit enforcement, so the shared promise covers compute plus cache persistence.

## Validation

- `npm run test:file -- src/query-cache.test.ts` (15/15 passed)
- `npm run build`
- `npx eslint src/query-cache.ts --max-warnings=0`
- pre-push fast CI-parity checks (lint and doc drift)
- full `npm test`: parallel project 196/196 suites and 2542 tests passed; serial project had one transient unrelated ordering failure in `src/write-lock.test.ts`
- isolated `src/write-lock.test.ts`: 8/8 passed on rerun

Closes #794
