### PR TITLE
test(mcp): pin emitted tool schemas

### DIFF
--- a/src/__fixtures__/mcp-tool-schemas.json
+++ b/src/__fixtures__/mcp-tool-schemas.json
@@ -1,0 +1,247 @@
+{
+  "add_document": {
+    "type": "object",
+    "properties": {
+      "knowledge_base_name": {
+        "type": "string"
+      },
+      "path": {
+        "type": "string"
+      },
+      "content": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "knowledge_base_name",
+      "path",
+      "content"
+    ],
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-07/schema#"
+  },
+  "ask_knowledge": {
+    "type": "object",
+    "properties": {
+      "query": {
+        "type": "string",
+        "maxLength": 8192
+      },
+      "knowledge_base_name": {
+        "type": "string"
+      },
+      "model_name": {
+        "type": "string"
+      },
+      "llm_profile": {
+        "type": "string"
+      },
+      "k": {
+        "type": "integer",
+        "minimum": 1,
+        "maximum": 50
+      },
+      "context_budget_tokens": {
+        "type": "integer",
+        "minimum": 64
+      },
+      "task_context": {
+        "type": "string"
+      },
+      "gate": {
+        "type": "string",
+        "enum": [
+          "on",
+          "off"
+        ]
+      },
+      "timing": {
+        "type": "boolean"
+      }
+    },
+    "required": [
+      "query"
+    ],
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-07/schema#"
+  },
+  "delete_document": {
+    "type": "object",
+    "properties": {
+      "knowledge_base_name": {
+        "type": "string"
+      },
+      "path": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "knowledge_base_name",
+      "path"
+    ],
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-07/schema#"
+  },
+  "diff_index": {
+    "type": "object",
+    "properties": {
+      "before": {
+        "type": "string"
+      },
+      "after": {
+        "type": "string"
+      },
+      "queries": {
+        "type": "array",
+        "items": {
+          "type": "string",
+          "maxLength": 8192
+        },
+        "minItems": 1,
+        "maxItems": 64
+      },
+      "model_name": {
+        "type": "string"
+      },
+      "knowledge_base_name": {
+        "type": "string"
+      },
+      "top_k": {
+        "type": "integer",
+        "minimum": 1,
+        "maximum": 100
+      },
+      "threshold": {
+        "type": "number"
+      },
+      "format": {
+        "type": "string",
+        "enum": [
+          "json",
+          "markdown"
+        ]
+      }
+    },
+    "required": [
+      "before",
+      "after",
+      "queries"
+    ],
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-07/schema#"
+  },
+  "kb_stats": {
+    "type": "object",
+    "properties": {
+      "knowledge_base_name": {
+        "type": "string"
+      }
+    },
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-07/schema#"
+  },
+  "list_knowledge_bases": {
+    "type": "object",
+    "properties": {}
+  },
+  "list_models": {
+    "type": "object",
+    "properties": {}
+  },
+  "reindex_knowledge_base": {
+    "type": "object",
+    "properties": {
+      "knowledge_base_name": {
+        "type": "string"
+      }
+    },
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-07/schema#"
+  },
+  "retrieve_knowledge": {
+    "type": "object",
+    "properties": {
+      "query": {
+        "type": "string",
+        "maxLength": 8192
+      },
+      "knowledge_base_name": {
+        "type": "string"
+      },
+      "threshold": {
+        "type": "number"
+      },
+      "model_name": {
+        "type": "string"
+      },
+      "extensions": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "maxItems": 64
+      },
+      "path_glob": {
+        "type": "string",
+        "maxLength": 1024
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "maxItems": 64
+      },
+      "since": {
+        "type": "string"
+      },
+      "until": {
+        "type": "string"
+      },
+      "context_before": {
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 5
+      },
+      "context_after": {
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 5
+      },
+      "context_window": {
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 5
+      },
+      "search_mode": {
+        "type": "string",
+        "enum": [
+          "dense",
+          "hybrid"
+        ]
+      },
+      "task_context": {
+        "type": "string"
+      },
+      "gate": {
+        "type": "string",
+        "enum": [
+          "on",
+          "off"
+        ]
+      },
+      "rerank": {
+        "type": "string",
+        "enum": [
+          "on",
+          "off"
+        ]
+      }
+    },
+    "required": [
+      "query"
+    ],
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-07/schema#"
+  }
+}

--- a/src/mcp-tool-schemas.test.ts
+++ b/src/mcp-tool-schemas.test.ts
@@ -1,0 +1,52 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { KnowledgeBaseServer } from './KnowledgeBaseServer.js';
+
+type JsonValue = null | boolean | number | string | JsonValue[] | { [key: string]: JsonValue };
+
+function withoutDescriptions(value: JsonValue): JsonValue {
+  if (Array.isArray(value)) return value.map(withoutDescriptions);
+  if (value === null || typeof value !== 'object') return value;
+
+  return Object.fromEntries(
+    Object.entries(value)
+      .filter(([key]) => key !== 'description')
+      .map(([key, child]) => [key, withoutDescriptions(child)]),
+  );
+}
+
+describe('MCP tool JSON Schema contract', () => {
+  it('pins structurally meaningful schemas emitted by a real listTools round trip', async () => {
+    const fixturePath = resolve('src/__fixtures__/mcp-tool-schemas.json');
+    const server = new KnowledgeBaseServer();
+    const mcp = (server as unknown as { mcp: McpServer }).mcp;
+    const client = new Client({ name: 'schema-contract-test', version: '0.0.0-test' });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+    try {
+      await mcp.connect(serverTransport);
+      await client.connect(clientTransport);
+
+      const response = await client.listTools();
+      expect(response.tools).toHaveLength(9);
+
+      const emitted = Object.fromEntries(
+        response.tools
+          .map((tool) => [tool.name, withoutDescriptions(tool.inputSchema as JsonValue)] as const)
+          .sort(([left], [right]) => left.localeCompare(right)),
+      );
+
+      if (process.argv.includes('-u') || process.argv.includes('--updateSnapshot')) {
+        await writeFile(fixturePath, `${JSON.stringify(emitted, null, 2)}\n`);
+      }
+      const expected = JSON.parse(await readFile(fixturePath, 'utf8')) as JsonValue;
+      expect(emitted).toEqual(expected);
+    } finally {
+      await client.close();
+      await mcp.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- exercise the production `KnowledgeBaseServer` through paired in-memory MCP transports
- call `Client.listTools()` and pin the emitted input schemas for all 9 tools
- recursively omit `description` fields so copy-only edits do not churn the golden
- support intentional golden refreshes through `jest -u`

## Smallest design choice

The test reaches the existing production `McpServer` instance through its registered transport boundary and normalizes only `description` keys before exact comparison. This keeps the change test-only while covering the SDK's zod-to-JSON-Schema conversion and the real `listTools` response.

Alternatives considered:

- serializing `mcp-tool-specs.ts` directly: smaller setup, but tautological and unable to catch server/SDK wire conversion drift
- a raw snapshot of the complete tool response: catches conversion drift, but creates description-only churn
- a spawned stdio server: exercises a wider boundary, but adds process/filesystem cost without improving the schema contract signal over the real in-memory MCP round trip

## Verification

- `npm run test:file -- -u src/mcp-tool-schemas.test.ts`
- `npm run build`
- `npm run lint`
- `npm test` (197 parallel suites / 2,540 passing tests; 11 serial suites / 427 passing tests)
- staged diff review and diff-adaptive correctness, conventions/dead-code, and test specialist reviews: clean

Closes #799
