### PR TITLE
feat: label search relevance metrics

### DIFF
--- a/src/formatter.test.ts
+++ b/src/formatter.test.ts
@@ -141,12 +141,22 @@ describe('formatRetrievalAsMarkdown', () => {
     expect(formatRetrievalAsMarkdown(undefined, false)).toContain('No similar results');
   });
 
-  it('renders one result with score, content, and source block', () => {
+  it('labels an otherwise opaque retrieval score without assuming its numeric direction', () => {
     const out = formatRetrievalAsMarkdown([sampleDoc], false);
     expect(out).toContain('**Result 1:**');
-    expect(out).toContain('**Score:** 0.42');
+    expect(out).toContain('**Score:** 0.42 (mode-specific; results ordered best first)');
     expect(out).toContain('sample content');
     expect(out).toContain('"source": "kb/doc.md"');
+  });
+
+  it('uses the rerank score and its higher-is-better direction for reranked rows', () => {
+    const reranked = { ...sampleDoc, score: 0.03, rerankScore: 0.87 } as ScoredDocument;
+
+    const out = formatRetrievalAsMarkdown([reranked, sampleDoc], false);
+
+    expect(out).toContain('**Rerank score:** 0.87 (higher = better)');
+    expect(out).not.toContain('**Score:** 0.03');
+    expect(out).toContain('**Score:** 0.42 (mode-specific; results ordered best first)');
   });
 
   it('adds a chunk citation link when stable chunk metadata is present', () => {
@@ -298,7 +308,7 @@ describe('formatRetrievalAsMarkdown', () => {
 
 **Result 1:**
 
-**Score:** 0.12
+**Score:** 0.12 (mode-specific; results ordered best first)
 
 # Deploy rollback
 
@@ -330,7 +340,7 @@ Verify pods before cutting traffic.
 
 **Result 2:**
 
-**Score:** 12.35
+**Score:** 12.35 (mode-specific; results ordered best first)
 
 Incident review notes
 Owner handoff happens after mitigation is confirmed.
@@ -385,7 +395,7 @@ describe('renderSearchSnippet', () => {
 });
 
 describe('formatRetrievalAsCompactTable', () => {
-  it('renders a fixed-width scan table with rank, score, KB, path, lines, mode, gate, and preview', () => {
+  it('renders a fixed-width scan table with rank, metric, KB, path, lines, mode, gate, and preview', () => {
     const docs: ScoredDocument[] = [
       {
         pageContent: '# Deploy rollback\n\nUse the blue-green rollback playbook.',
@@ -415,9 +425,10 @@ describe('formatRetrievalAsCompactTable', () => {
       width: 140,
     });
 
-    expect(out).toContain('Rank  Score     KB');
+    expect(out).toContain('Rank  Score');
     expect(out).toContain('Mode     Gate');
-    expect(out).toContain('1     0.123     ops');
+    expect(out).toContain('1     D↓0.123');
+    expect(out).toContain('D = distance (lower = better)');
     expect(out).toContain('42-58');
     expect(out).toContain('dense    kept');
     expect(out).toContain('Deploy rollback');
@@ -463,10 +474,34 @@ describe('formatRetrievalAsCompactTable', () => {
 [
   "Rank  Score     KB              Path                                  Lines        Mode     Gate      Preview                       ",
   "----  --------  --------------  ------------------------------------  -----------  -------  --------  ------------------------------",
-  "1     0.123     ops             runbooks/deployments/rollback.md      42-46        hybrid   kept      Deploy rollback               ",
-  "2     12.35     team            notes/incident-review.md              7-9          hybrid   kept      Incident review notes         ",
+  "1     RRF↑0.12  ops             runbooks/deployments/rollback.md      42-46        hybrid   kept      Deploy rollback               ",
+  "2     RRF↑12.3  team            notes/incident-review.md              7-9          hybrid   kept      Incident review notes         ",
+  "Metric: D = distance (lower = better); B = BM25, RRF = fusion, R = rerank (higher = better).",
 ]
 `);
+  });
+
+  it('labels compact metrics per mode and prefers rerank scores per row', () => {
+    const docs = [
+      { ...goldenSearchResults()[0], score: 0.02, rerankScore: 0.91 },
+      goldenSearchResults()[1],
+    ] as ScoredDocument[];
+
+    const hybrid = formatRetrievalAsCompactTable(docs, {
+      mode: 'hybrid',
+      gate: 'kept',
+      width: 160,
+    });
+    const lexical = formatRetrievalAsCompactTable([docs[1]], {
+      mode: 'lexical',
+      gate: 'kept',
+      width: 160,
+    });
+
+    expect(hybrid).toContain('R↑0.910');
+    expect(hybrid).toContain('RRF↑12.3');
+    expect(lexical).toContain('B↑12.345');
+    expect(hybrid).toContain('RRF = fusion, R = rerank (higher = better)');
   });
 });
 
@@ -500,6 +535,20 @@ describe('formatRetrievalAsJson', () => {
     expect(formatRetrievalAsJson([], false)).toEqual([]);
     expect(formatRetrievalAsJson(null, false)).toEqual([]);
     expect(formatRetrievalAsJson(undefined, false)).toEqual([]);
+  });
+
+  it('preserves raw and rerank scores when human output prefers the rerank metric', () => {
+    const doc: ScoredDocument = {
+      pageContent: 'reranked content',
+      metadata: { source: 'kb/reranked.md' },
+      score: 0.03,
+      rerankScore: 0.87,
+    } as unknown as ScoredDocument;
+
+    expect(formatRetrievalAsJson([doc], false)[0]).toMatchObject({
+      score: 0.03,
+      rerank_score: 0.87,
+    });
   });
 
   it('returns shape { score, content, metadata, injection_signals } per result', () => {
@@ -964,7 +1013,8 @@ describe('formatRetrievalGroupedBySourceAsMarkdown', () => {
 
     expect(out).toContain('**Source 1:** `kb/repeated.md`');
     expect(out).not.toContain('**Source 2:**');
-    expect(out).toContain('**Best score:** 0.30');
+    expect(out).toContain('**Best distance:** 0.30 (lower = better)');
+    expect(out).toContain('**Distance:** 0.70 (lower = better)');
     expect(out).toContain('**Chunk count:** 2');
     expect(out).toContain('"from":1');
     expect(out).toContain('"from":20');

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -179,7 +179,7 @@ export function formatRetrievalAsMarkdown(
       );
       const citation = buildChunkCitation(guarded.metadata, editorUriMode);
       const metadata = JSON.stringify(guarded.metadata, null, 2);
-      const scoreText = doc.score !== undefined ? `**Score:** ${doc.score.toFixed(2)}\n\n` : '';
+      const scoreText = formatMarkdownRelevance(doc);
       const signals = getShieldSignals(doc.pageContent, sanitizedMetadata, guardOptions);
       const shieldFooter = formatInjectionMarkdown(signals);
       const contextText = formatContextChunksAsMarkdown(doc, extrasVisible, editorUriMode, highlight);
@@ -211,12 +211,12 @@ export function formatRetrievalGroupedBySourceAsMarkdown(
           const typeText = chunk.match_type ? `\n   **Type:** ${chunk.match_type}` : '';
           const content = applyRetrievalHighlight((chunk.snippet ?? chunk.content).trim(), highlight);
           const contextText = formatJsonContextChunksForGroupedMarkdown(chunk.context_chunks, highlight);
-          return `${chunkIdx + 1}. **Score:** ${scoreText}${typeText}\n   **Location:** ${locationText}${openText}\n\n   ${indentChunkContent(content)}${shieldText}${contextText}`;
+          return `${chunkIdx + 1}. **Distance:** ${scoreText} (lower = better)${typeText}\n   **Location:** ${locationText}${openText}\n\n   ${indentChunkContent(content)}${shieldText}${contextText}`;
         })
         .join('\n\n');
       return (
         `**Source ${idx + 1}:** \`${group.source}\`\n\n` +
-        `**Best score:** ${formatScore(group.best_score)}\n\n` +
+        `**Best distance:** ${formatScore(group.best_score)} (lower = better)\n\n` +
         `**Chunk count:** ${group.chunk_count}\n\n` +
         `**Matching chunks:**\n\n${chunks}`
       );
@@ -475,7 +475,7 @@ export function formatRetrievalAsCompactTable(
     );
     const guarded = guardRetrievalChunk(doc.pageContent, metadata, guardOptions);
     const identity = compactIdentity(guarded.metadata, idx);
-    const score = doc.score === undefined ? 'n/a' : formatCompactScore(doc.score);
+    const score = formatCompactRelevance(doc, options.mode);
     return [
       padCompact(String(idx + 1), columns.rank),
       padCompact(score, columns.score),
@@ -487,7 +487,12 @@ export function formatRetrievalAsCompactTable(
       padCompact(compactPreview(guarded.content), columns.preview),
     ].join('  ');
   });
-  return [header, separator, ...rows].join('\n');
+  return [
+    header,
+    separator,
+    ...rows,
+    'Metric: D = distance (lower = better); B = BM25, RRF = fusion, R = rerank (higher = better).',
+  ].join('\n');
 }
 
 function getSourcePath(metadata: Record<string, unknown>, idx: number): string {
@@ -611,6 +616,33 @@ function formatCompactScore(score: number): string {
   if (Math.abs(score) >= 100) return score.toFixed(1);
   if (Math.abs(score) >= 10) return score.toFixed(2);
   return score.toFixed(3);
+}
+
+function formatMarkdownRelevance(doc: ScoredDocument): string {
+  if (doc.rerankScore !== undefined) {
+    return `**Rerank score:** ${doc.rerankScore.toFixed(2)} (higher = better)\n\n`;
+  }
+  if (doc.score !== undefined) {
+    return `**Score:** ${doc.score.toFixed(2)} (mode-specific; results ordered best first)\n\n`;
+  }
+  return '';
+}
+
+function formatCompactRelevance(doc: ScoredDocument, mode: CompactRetrievalOptions['mode']): string {
+  if (doc.rerankScore !== undefined) return formatCompactMetric('R↑', doc.rerankScore);
+  if (doc.score === undefined) return 'n/a';
+  const metric = mode === 'dense' ? 'D↓' : mode === 'lexical' ? 'B↑' : 'RRF↑';
+  return formatCompactMetric(metric, doc.score);
+}
+
+function formatCompactMetric(metric: string, score: number): string {
+  const available = 8 - metric.length;
+  if (!Number.isFinite(score)) return `${metric}${String(score).slice(0, available)}`;
+  for (let decimals = 3; decimals >= 0; decimals -= 1) {
+    const value = score.toFixed(decimals);
+    if (value.length <= available) return `${metric}${value}`;
+  }
+  return `${metric}${String(score).slice(0, available)}`;
 }
 
 function padCompact(value: string, width: number): string {


### PR DESCRIPTION
Closes #797.

## Summary

- label reranked Markdown rows as `Rerank score` with `higher = better`
- keep ambiguous non-reranked Markdown rows honest as mode-specific values ordered best-first, instead of inventing a universal numeric direction
- label compact rows with the active metric (`D`, `B`, `RRF`, or per-row `R`) and an explicit direction legend
- label grouped dense output as distance with `lower = better`
- preserve the JSON `score` and `rerank_score` contract unchanged

## Mixed and reranked rows

`formatRetrievalAsMarkdown` is shared by dense, lexical, hybrid, and MCP callers but does not receive the active retrieval mode. The smallest accurate formatter-only behavior is therefore per-row: when `rerankScore` exists, render that known higher-is-better metric; otherwise retain the raw mode-specific score and state only the reliable ordering fact (best result first). Compact output does receive `mode`, so it names distance, BM25, or RRF exactly, while a row-level rerank score takes precedence.

## Verification

- `npm run check:fast`
- `npm run lint`
- formatter + CLI focused suites: 177 passed
- formatter + MCP focused suites: 164 passed
- full parallel suite: 196 suites, 2,542 tests passed
- full serial suite: 11 suites, 427 tests passed
- independent correctness, lint-like, and test reviews; no blocking findings after fixes
