### PR TITLE
fix: redact relevance judge requests

### DIFF
--- a/src/relevance-gate.test.ts
+++ b/src/relevance-gate.test.ts
@@ -293,6 +293,61 @@ describe('relevance gate', () => {
     expect(userMessage.content).toContain('</untrusted-doc>');
   });
 
+  it('redacts secrets from judge request content when outbound redaction is enabled', async () => {
+    const previousRedaction = process.env.KB_ASK_REDACT_OUTBOUND;
+    process.env.KB_ASK_REDACT_OUTBOUND = 'on';
+    try {
+      const secret = 'ghp_abcdefghijklmnopqrstuvwxyz123456';
+      const rows = [
+        candidate('/kb/secret.md', 0, 0.1, `deployment token: ${secret}`),
+      ];
+      const fetchImpl = fakeFetchJson('{"overall":"relevant","verdicts":[{"id":"/kb/secret.md#0","decision":"keep","reason":"deployment"}]}');
+
+      await applyRelevanceGate({
+        query: `find ${secret}`,
+        taskContext: `answer the deployment question using Authorization: Bearer ${secret} with precise operational context`,
+        candidates: rows,
+        config: config(),
+        fetchImpl,
+      });
+
+      const body = ((fetchImpl as unknown as jest.Mock).mock.calls[0][1] as RequestInit).body as string;
+      expect(body).not.toContain(secret);
+      expect(body).toContain('[REDACTED]');
+    } finally {
+      if (previousRedaction === undefined) delete process.env.KB_ASK_REDACT_OUTBOUND;
+      else process.env.KB_ASK_REDACT_OUTBOUND = previousRedaction;
+    }
+  });
+
+  it('preserves judge request content when outbound redaction is explicitly disabled', async () => {
+    const previousRedaction = process.env.KB_ASK_REDACT_OUTBOUND;
+    const previousProvider = process.env.KB_LLM_PROVIDER;
+    process.env.KB_ASK_REDACT_OUTBOUND = 'off';
+    process.env.KB_LLM_PROVIDER = 'openrouter';
+    try {
+      const secret = 'ghp_abcdefghijklmnopqrstuvwxyz123456';
+      const fetchImpl = fakeFetchJson('{"overall":"relevant","verdicts":[{"id":"/kb/secret.md#0","decision":"keep","reason":"deployment"}]}');
+
+      await applyRelevanceGate({
+        query: 'find the deployment token',
+        taskContext: 'answer the deployment question with precise operational context from the candidate',
+        candidates: [candidate('/kb/secret.md', 0, 0.1, `deployment token: ${secret}`)],
+        config: config(),
+        fetchImpl,
+      });
+
+      const body = ((fetchImpl as unknown as jest.Mock).mock.calls[0][1] as RequestInit).body as string;
+      expect(body).toContain(secret);
+      expect(body).not.toContain('[REDACTED]');
+    } finally {
+      if (previousRedaction === undefined) delete process.env.KB_ASK_REDACT_OUTBOUND;
+      else process.env.KB_ASK_REDACT_OUTBOUND = previousRedaction;
+      if (previousProvider === undefined) delete process.env.KB_LLM_PROVIDER;
+      else process.env.KB_LLM_PROVIDER = previousProvider;
+    }
+  });
+
   it('rescues top-1 when per-chunk drops empty the set', async () => {
     const rows = [candidate('/kb/a.md', 0, 0.1, 'states v2 default')];
     const input = {

--- a/src/relevance-judge.ts
+++ b/src/relevance-judge.ts
@@ -4,7 +4,9 @@ import {
   type ChatCompletionResult,
   type LlmChatMessage,
 } from './llm-client.js';
+import { resolveLlmProvider } from './config/llm-provider.js';
 import { wrapUntrustedContent } from './injection-guard.js';
+import { redactSecrets } from './redaction.js';
 
 export interface RelevanceJudgeCandidate {
   id: string;
@@ -84,9 +86,15 @@ const STOP_WORDS = new Set([
   'would',
 ]);
 
+const REDACT_TRUTHY_VALUES = new Set(['on', 'true', '1', 'yes']);
+const REDACT_FALSY_VALUES = new Set(['off', 'false', '0', 'no']);
+
 export async function judgeRelevance(options: RelevanceJudgeOptions): Promise<RelevanceJudgeResult> {
   const shuffled = deterministicShuffle(options.candidates, options.seed);
-  const messages = buildJudgeMessages(options.query, options.taskContext, shuffled);
+  const messages = redactJudgeMessages(
+    buildJudgeMessages(options.query, options.taskContext, shuffled),
+    resolveJudgeRedactionEnabled(),
+  );
   const response = await callChatCompletion({
     endpoint: options.endpoint,
     model: options.model,
@@ -100,6 +108,26 @@ export async function judgeRelevance(options: RelevanceJudgeOptions): Promise<Re
     shuffledIds: shuffled.map((candidate) => candidate.id),
     promptHash: hashPrompt(messages),
   };
+}
+
+function resolveJudgeRedactionEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const raw = env.KB_ASK_REDACT_OUTBOUND?.trim().toLowerCase();
+  if (raw !== undefined && raw !== '') {
+    if (REDACT_TRUTHY_VALUES.has(raw)) return true;
+    if (REDACT_FALSY_VALUES.has(raw)) return false;
+  }
+  return resolveLlmProvider(env).remote;
+}
+
+function redactJudgeMessages(
+  messages: LlmChatMessage[],
+  enabled: boolean,
+): LlmChatMessage[] {
+  if (!enabled) return messages;
+  return messages.map((message) => ({
+    ...message,
+    content: redactSecrets(message.content).text,
+  }));
 }
 
 export function normalizeJudgeResponse(


### PR DESCRIPTION
Closes #740

## Summary
- scrub relevance-judge chat messages with the existing outbound secret-redaction engine immediately before LLM egress
- reuse `KB_ASK_REDACT_OUTBOUND`, including explicit on/off values and the remote-provider default
- prove through a fake judge endpoint that secrets are absent from serialized requests while `[REDACTED]` placeholders remain
- preserve and test the existing explicit opt-out behavior

## Root cause
The relevance judge assembles and posts its own chat-completion payload, bypassing the ask path where outbound redaction was previously applied. Retrieved secrets could therefore reach `KB_GATE_LLM_ENDPOINT` unchanged.

## Configuration choice
This intentionally reuses the existing `KB_ASK_REDACT_OUTBOUND` setting for the smallest implementation and adds no configuration surface. A dedicated gate-specific override such as `KB_GATE_REDACT_OUTBOUND` remains a possible follow-up if operators need independent ask and judge policies.

## Verification
Before this change, the fake judge endpoint received the injected GitHub-token-shaped secret verbatim because `buildJudgeMessages` fed directly into `callChatCompletion`. After this change, the same end-to-end gate request contains `[REDACTED]` and not the secret. A complementary remote-provider test verifies explicit `KB_ASK_REDACT_OUTBOUND=off` still sends unchanged content.

- `npm run test:file -- src/relevance-gate.test.ts` (19/19 passed)
- `npm test`
- `npm run check:fast`
- pre-push CI-parity checks

## Review
Forced security-sensitive pre-PR panel: correctness, conventions, dead code, tests, and docs drift. The sole test-coverage suggestion was incorporated; no findings remain.