### PR TITLE
feat(search): cache query decomposition results

### DIFF
--- a/src/decomposition-cache.test.ts
+++ b/src/decomposition-cache.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from '@jest/globals';
+import * as fs from 'fs';
+import * as fsp from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  DECOMPOSITION_CACHE_SCHEMA_VERSION,
+  DiskTieredDecompositionCache,
+  decompositionCacheKey,
+  decompositionCacheRoot,
+  isDecompositionCacheEnabled,
+  normalizeDecompositionQuery,
+  resolveDecompositionCacheDiskMaxBytes,
+  resolveDecompositionCacheLruMax,
+} from './decomposition-cache.js';
+
+async function tempIndexPath(prefix: string): Promise<string> {
+  const dir = await fsp.mkdtemp(path.join(os.tmpdir(), prefix));
+  return path.join(dir, '.faiss');
+}
+
+describe('DiskTieredDecompositionCache (#736)', () => {
+  it('persists successful subqueries and promotes disk hits into the bounded LRU', async () => {
+    const indexPath = await tempIndexPath('kb-decomposition-cache-roundtrip-');
+    try {
+      const first = new DiskTieredDecompositionCache({ indexPath, enabled: true, lruMax: 1 });
+      first.set('model-a', ' First   Query ', ['hop one', 'hop two']);
+
+      const second = new DiskTieredDecompositionCache({ indexPath, enabled: true, lruMax: 1 });
+      expect(second.get('model-a', 'first query')).toEqual(['hop one', 'hop two']);
+      expect(second.stats()).toMatchObject({ disk_hits: 1, l1_hits: 0, l1_size: 1 });
+      expect(second.get('model-a', ' first\nquery ')).toEqual(['hop one', 'hop two']);
+      expect(second.stats().l1_hits).toBe(1);
+
+      second.set('model-a', 'second query', ['other']);
+      expect(second.stats().l1_size).toBe(1);
+    } finally {
+      await fsp.rm(path.dirname(indexPath), { recursive: true, force: true });
+    }
+  });
+
+  it('normalizes query identity while isolating models and schema versions', async () => {
+    const indexPath = await tempIndexPath('kb-decomposition-cache-key-');
+    try {
+      expect(normalizeDecompositionQuery('  A\u00a0B\nC  ')).toBe('a b c');
+      expect(decompositionCacheKey('model-a', '  Query   Text ')).toBe(
+        decompositionCacheKey('model-a', 'query text'),
+      );
+      expect(decompositionCacheKey('model-a', 'query')).not.toBe(
+        decompositionCacheKey('model-b', 'query'),
+      );
+      const cache = new DiskTieredDecompositionCache({ indexPath, enabled: true });
+      cache.set('model-a', 'query', ['hop']);
+      expect(cache.get('model-b', 'query')).toBeNull();
+      expect(DECOMPOSITION_CACHE_SCHEMA_VERSION).toBe('kb.search.query-decomposition.v1');
+    } finally {
+      await fsp.rm(path.dirname(indexPath), { recursive: true, force: true });
+    }
+  });
+
+  it('enforces the disk byte budget by evicting oldest entries', async () => {
+    const indexPath = await tempIndexPath('kb-decomposition-cache-budget-');
+    try {
+      const probe = new DiskTieredDecompositionCache({ indexPath, enabled: true });
+      probe.set('model', 'probe', ['probe result']);
+      const entryBytes = probe.diskSizeBytes();
+      await fsp.rm(decompositionCacheRoot(indexPath), { recursive: true, force: true });
+
+      const cache = new DiskTieredDecompositionCache({
+        indexPath,
+        enabled: true,
+        lruMax: 0,
+        diskMaxBytes: Math.floor(entryBytes * 2.5),
+      });
+      cache.set('model', 'q1', ['one']);
+      const q1Key = decompositionCacheKey('model', 'q1');
+      const q1File = path.join(decompositionCacheRoot(indexPath), q1Key.slice(0, 2), `${q1Key}.json`);
+      fs.utimesSync(q1File, new Date(1_000), new Date(1_000));
+      cache.set('model', 'q2', ['two']);
+      const q2Key = decompositionCacheKey('model', 'q2');
+      const q2File = path.join(decompositionCacheRoot(indexPath), q2Key.slice(0, 2), `${q2Key}.json`);
+      fs.utimesSync(q2File, new Date(2_000), new Date(2_000));
+      cache.set('model', 'q3', ['three']);
+
+      expect(cache.diskSizeBytes()).toBeLessThanOrEqual(Math.floor(entryBytes * 2.5));
+      expect(cache.get('model', 'q1')).toBeNull();
+      expect(cache.get('model', 'q3')).toEqual(['three']);
+    } finally {
+      await fsp.rm(path.dirname(indexPath), { recursive: true, force: true });
+    }
+  });
+
+  it('rejects invalid or tampered records and removes them', async () => {
+    const indexPath = await tempIndexPath('kb-decomposition-cache-corrupt-');
+    try {
+      const cache = new DiskTieredDecompositionCache({ indexPath, enabled: true, lruMax: 0 });
+      const key = decompositionCacheKey('model', 'broken');
+      const file = path.join(decompositionCacheRoot(indexPath), key.slice(0, 2), `${key}.json`);
+      fs.mkdirSync(path.dirname(file), { recursive: true });
+      fs.writeFileSync(file, JSON.stringify({
+        schema_version: DECOMPOSITION_CACHE_SCHEMA_VERSION,
+        model_id: 'model',
+        normalized_query: 'broken',
+        subqueries: ['poisoned'],
+        subqueries_sha256: '0'.repeat(64),
+      }));
+
+      expect(cache.get('model', 'broken')).toBeNull();
+      expect(cache.stats().corruptions).toBe(1);
+      expect(fs.existsSync(file)).toBe(false);
+    } finally {
+      await fsp.rm(path.dirname(indexPath), { recursive: true, force: true });
+    }
+  });
+
+  it('rejects disk records whose schema or identity does not match the key', async () => {
+    const indexPath = await tempIndexPath('kb-decomposition-cache-identity-');
+    try {
+      for (const field of ['schema_version', 'model_id', 'normalized_query'] as const) {
+        const cache = new DiskTieredDecompositionCache({ indexPath, enabled: true, lruMax: 0 });
+        cache.set('model', field, ['hop']);
+        const key = decompositionCacheKey('model', field);
+        const file = path.join(decompositionCacheRoot(indexPath), key.slice(0, 2), `${key}.json`);
+        const record = JSON.parse(fs.readFileSync(file, 'utf-8')) as Record<string, unknown>;
+        record[field] = 'wrong';
+        fs.writeFileSync(file, JSON.stringify(record), 'utf-8');
+
+        expect(cache.get('model', field)).toBeNull();
+        expect(fs.existsSync(file)).toBe(false);
+      }
+    } finally {
+      await fsp.rm(path.dirname(indexPath), { recursive: true, force: true });
+    }
+  });
+
+  it('does not write disabled, empty, or invalid entries', async () => {
+    const indexPath = await tempIndexPath('kb-decomposition-cache-disabled-');
+    try {
+      const disabled = new DiskTieredDecompositionCache({ indexPath, enabled: false });
+      disabled.set('model', 'query', ['hop']);
+      expect(disabled.get('model', 'query')).toBeNull();
+
+      const enabled = new DiskTieredDecompositionCache({ indexPath, enabled: true });
+      enabled.set('model', 'query', []);
+      enabled.set('', 'query', ['hop']);
+      expect(enabled.diskSizeBytes()).toBe(0);
+      expect(fs.existsSync(decompositionCacheRoot(indexPath))).toBe(false);
+    } finally {
+      await fsp.rm(path.dirname(indexPath), { recursive: true, force: true });
+    }
+  });
+
+  it('uses safe bounded defaults for malformed budgets', () => {
+    expect(isDecompositionCacheEnabled(undefined)).toBe(false);
+    expect(isDecompositionCacheEnabled('off')).toBe(false);
+    expect(isDecompositionCacheEnabled(' TRUE ')).toBe(true);
+    expect(isDecompositionCacheEnabled('1')).toBe(true);
+    expect(resolveDecompositionCacheLruMax('12')).toBe(12);
+    expect(resolveDecompositionCacheLruMax('0')).toBe(0);
+    expect(resolveDecompositionCacheLruMax('-1')).toBe(256);
+    expect(resolveDecompositionCacheLruMax('nope')).toBe(256);
+    expect(resolveDecompositionCacheDiskMaxBytes('1024')).toBe(1024);
+    expect(resolveDecompositionCacheDiskMaxBytes('0')).toBe(64 * 1024 * 1024);
+    expect(resolveDecompositionCacheDiskMaxBytes('nope')).toBe(64 * 1024 * 1024);
+  });
+});

--- a/src/decomposition-cache.ts
+++ b/src/decomposition-cache.ts
@@ -1,0 +1,293 @@
+import { createHash } from 'crypto';
+import * as fs from 'fs';
+import * as path from 'path';
+import { FAISS_INDEX_PATH } from './config/paths.js';
+import { logger } from './logger.js';
+
+export const DECOMPOSITION_CACHE_SCHEMA_VERSION = 'kb.search.query-decomposition.v1';
+export const DEFAULT_DECOMPOSITION_CACHE_LRU_MAX = 256;
+export const DEFAULT_DECOMPOSITION_CACHE_DISK_MAX_BYTES = 64 * 1024 * 1024;
+
+const MAX_CACHED_SUBQUERIES = 64;
+const MAX_CACHED_SUBQUERY_LENGTH = 16_384;
+
+export interface DecompositionCache {
+  get(modelId: string, query: string): string[] | null;
+  set(modelId: string, query: string, subqueries: readonly string[]): void;
+}
+
+export interface DiskTieredDecompositionCacheOptions {
+  indexPath?: string;
+  enabled?: boolean;
+  lruMax?: number;
+  diskMaxBytes?: number;
+}
+
+export interface DecompositionCacheStats {
+  enabled: boolean;
+  l1_hits: number;
+  disk_hits: number;
+  misses: number;
+  writes: number;
+  corruptions: number;
+  l1_size: number;
+  disk_size_bytes: number;
+}
+
+interface DecompositionCacheRecord {
+  schema_version: typeof DECOMPOSITION_CACHE_SCHEMA_VERSION;
+  model_id: string;
+  normalized_query: string;
+  subqueries: string[];
+  subqueries_sha256: string;
+}
+
+export function isDecompositionCacheEnabled(
+  raw: string | undefined = readEnvironment('KB_DECOMPOSE_CACHE_ENABLED'),
+): boolean {
+  const value = (raw ?? '').trim().toLowerCase();
+  return value === 'on' || value === 'true' || value === '1' || value === 'yes' || value === 'enabled';
+}
+
+export function resolveDecompositionCacheLruMax(
+  raw: string | undefined = readEnvironment('KB_DECOMPOSE_CACHE_LRU_MAX'),
+): number {
+  const parsed = raw === undefined || raw.trim() === '' ? NaN : Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) return DEFAULT_DECOMPOSITION_CACHE_LRU_MAX;
+  return Math.floor(parsed);
+}
+
+export function resolveDecompositionCacheDiskMaxBytes(
+  raw: string | undefined = readEnvironment('KB_DECOMPOSE_CACHE_DISK_MAX_BYTES'),
+): number {
+  const parsed = raw === undefined || raw.trim() === '' ? NaN : Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_DECOMPOSITION_CACHE_DISK_MAX_BYTES;
+  return Math.floor(parsed);
+}
+
+export function normalizeDecompositionQuery(query: string): string {
+  return query.normalize('NFKC').trim().replace(/\s+/g, ' ').toLocaleLowerCase();
+}
+
+export function decompositionCacheKey(modelId: string, query: string): string {
+  return createHash('sha256')
+    .update(DECOMPOSITION_CACHE_SCHEMA_VERSION)
+    .update('\x1f')
+    .update(modelId)
+    .update('\x1f')
+    .update(normalizeDecompositionQuery(query))
+    .digest('hex');
+}
+
+export function decompositionCacheRoot(indexPath: string = FAISS_INDEX_PATH): string {
+  return path.join(indexPath, 'cache', 'query-decompositions');
+}
+
+export class DiskTieredDecompositionCache implements DecompositionCache {
+  private readonly enabled: boolean;
+  private readonly cacheRoot: string;
+  private readonly diskMaxBytes: number;
+  private readonly lruMax: number;
+  private readonly l1 = new Map<string, string[]>();
+  private l1Hits = 0;
+  private diskHits = 0;
+  private misses = 0;
+  private writes = 0;
+  private corruptions = 0;
+
+  constructor(options: DiskTieredDecompositionCacheOptions = {}) {
+    this.enabled = options.enabled ?? isDecompositionCacheEnabled();
+    this.cacheRoot = decompositionCacheRoot(options.indexPath ?? FAISS_INDEX_PATH);
+    this.diskMaxBytes = options.diskMaxBytes ?? resolveDecompositionCacheDiskMaxBytes();
+    this.lruMax = options.lruMax ?? resolveDecompositionCacheLruMax();
+  }
+
+  get(modelId: string, query: string): string[] | null {
+    if (!this.enabled || !isValidIdentity(modelId, query)) return null;
+    const key = decompositionCacheKey(modelId, query);
+    const memoryHit = this.l1.get(key);
+    if (memoryHit !== undefined) {
+      this.l1.delete(key);
+      this.l1.set(key, memoryHit);
+      this.l1Hits += 1;
+      return memoryHit.slice();
+    }
+    const diskHit = this.readDisk(key, modelId, normalizeDecompositionQuery(query));
+    if (diskHit !== null) {
+      this.diskHits += 1;
+      this.l1Set(key, diskHit);
+      return diskHit.slice();
+    }
+    this.misses += 1;
+    return null;
+  }
+
+  set(modelId: string, query: string, subqueries: readonly string[]): void {
+    if (!this.enabled || !isValidIdentity(modelId, query) || !isValidSubqueries(subqueries)) return;
+    const stable = Array.from(subqueries);
+    const key = decompositionCacheKey(modelId, query);
+    this.l1Set(key, stable);
+    try {
+      this.writeDisk(key, modelId, normalizeDecompositionQuery(query), stable);
+      this.writes += 1;
+      this.enforceDiskLimit();
+    } catch (err) {
+      logger.warn(`query decomposition cache write skipped: ${(err as Error).message}`);
+    }
+  }
+
+  clearMemory(): void {
+    this.l1.clear();
+  }
+
+  stats(): DecompositionCacheStats {
+    return {
+      enabled: this.enabled,
+      l1_hits: this.l1Hits,
+      disk_hits: this.diskHits,
+      misses: this.misses,
+      writes: this.writes,
+      corruptions: this.corruptions,
+      l1_size: this.l1.size,
+      disk_size_bytes: this.diskSizeBytes(),
+    };
+  }
+
+  diskSizeBytes(): number {
+    return listEntryFiles(this.cacheRoot).reduce((sum, file) => sum + file.size, 0);
+  }
+
+  private l1Set(key: string, subqueries: readonly string[]): void {
+    if (this.lruMax <= 0) return;
+    if (this.l1.has(key)) this.l1.delete(key);
+    this.l1.set(key, Array.from(subqueries));
+    while (this.l1.size > this.lruMax) {
+      const oldest = this.l1.keys().next().value as string | undefined;
+      if (oldest === undefined) break;
+      this.l1.delete(oldest);
+    }
+  }
+
+  private entryPath(key: string): string {
+    return path.join(this.cacheRoot, key.slice(0, 2), `${key}.json`);
+  }
+
+  private readDisk(key: string, modelId: string, normalizedQuery: string): string[] | null {
+    const file = this.entryPath(key);
+    let record: unknown;
+    try {
+      record = JSON.parse(fs.readFileSync(file, 'utf-8')) as unknown;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null;
+      this.recordCorrupt(file);
+      return null;
+    }
+    if (!isValidRecord(record, modelId, normalizedQuery)) {
+      this.recordCorrupt(file);
+      return null;
+    }
+    return record.subqueries.slice();
+  }
+
+  private writeDisk(key: string, modelId: string, normalizedQuery: string, subqueries: string[]): void {
+    const file = this.entryPath(key);
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    const record: DecompositionCacheRecord = {
+      schema_version: DECOMPOSITION_CACHE_SCHEMA_VERSION,
+      model_id: modelId,
+      normalized_query: normalizedQuery,
+      subqueries,
+      subqueries_sha256: subqueriesChecksum(subqueries),
+    };
+    const tmp = `${file}.${process.pid}.tmp`;
+    try {
+      fs.writeFileSync(tmp, `${JSON.stringify(record)}\n`, 'utf-8');
+      fs.renameSync(tmp, file);
+    } catch (err) {
+      try { fs.unlinkSync(tmp); } catch { /* best-effort temp cleanup */ }
+      throw err;
+    }
+  }
+
+  private recordCorrupt(file: string): void {
+    this.corruptions += 1;
+    try { fs.unlinkSync(file); } catch { /* best-effort corrupt entry cleanup */ }
+  }
+
+  private enforceDiskLimit(): void {
+    const files = listEntryFiles(this.cacheRoot);
+    let total = files.reduce((sum, file) => sum + file.size, 0);
+    if (total <= this.diskMaxBytes) return;
+    files.sort((left, right) => left.mtimeMs - right.mtimeMs);
+    for (const file of files) {
+      if (total <= this.diskMaxBytes) break;
+      try {
+        fs.unlinkSync(file.path);
+        total -= file.size;
+      } catch { /* another process may already have removed it */ }
+    }
+  }
+}
+
+function isValidIdentity(modelId: string, query: string): boolean {
+  return modelId.trim() !== '' && normalizeDecompositionQuery(query) !== '';
+}
+
+function isValidSubqueries(value: readonly string[]): value is string[] {
+  return value.length > 0 && value.length <= MAX_CACHED_SUBQUERIES && value.every(
+    (item) => typeof item === 'string' && item.trim() !== '' && item.length <= MAX_CACHED_SUBQUERY_LENGTH,
+  );
+}
+
+function isValidRecord(
+  value: unknown,
+  modelId: string,
+  normalizedQuery: string,
+): value is DecompositionCacheRecord {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return false;
+  const record = value as Partial<DecompositionCacheRecord>;
+  return record.schema_version === DECOMPOSITION_CACHE_SCHEMA_VERSION &&
+    record.model_id === modelId &&
+    record.normalized_query === normalizedQuery &&
+    Array.isArray(record.subqueries) &&
+    isValidSubqueries(record.subqueries) &&
+    typeof record.subqueries_sha256 === 'string' &&
+    record.subqueries_sha256 === subqueriesChecksum(record.subqueries);
+}
+
+function subqueriesChecksum(subqueries: readonly string[]): string {
+  return createHash('sha256').update(JSON.stringify(subqueries), 'utf-8').digest('hex');
+}
+
+// Keep decomposition-cache configuration local to this issue's four-file
+// scope. A follow-up can promote these knobs into the shared config schema.
+function readEnvironment(name: string): string | undefined {
+  return process.env[name];
+}
+
+function listEntryFiles(root: string): Array<{ path: string; size: number; mtimeMs: number }> {
+  const out: Array<{ path: string; size: number; mtimeMs: number }> = [];
+  const walk = (dir: string): void => {
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return;
+      throw err;
+    }
+    for (const entry of entries) {
+      const child = path.join(dir, entry.name);
+      if (entry.isDirectory()) walk(child);
+      else if (entry.isFile() && entry.name.endsWith('.json')) {
+        try {
+          const stat = fs.statSync(child);
+          out.push({ path: child, size: stat.size, mtimeMs: stat.mtimeMs });
+        } catch (err) {
+          if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+        }
+      }
+    }
+  };
+  walk(root);
+  return out;
+}

--- a/src/query-decomposition.test.ts
+++ b/src/query-decomposition.test.ts
@@ -1,10 +1,12 @@
-import { describe, expect, it } from '@jest/globals';
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
 import {
+  createLocalLlmQueryDecomposer,
   createRuleBasedQueryDecomposer,
   defaultQueryDecompositionBudget,
   queryDecompositionTraceToJson,
   runQueryDecomposition,
 } from './query-decomposition.js';
+import type { DecompositionCache } from './decomposition-cache.js';
 import type { HybridChunk } from './hybrid-retrieval.js';
 
 function chunk(source: string, chunkIndex: number, body: string): HybridChunk {
@@ -23,6 +25,64 @@ describe('rule-based query decomposition', () => {
       'Which kinase regulates MAPK',
       'where is it expressed?',
     ]);
+  });
+});
+
+describe('LLM query decomposition cache (#736)', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('reuses a successful result for a normalized query and resolved model', async () => {
+    const fetchMock = jest.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify({
+      choices: [{ message: { content: '{"subqueries":["hop one","hop two"]}' } }],
+      model: 'model-a',
+    }), { status: 200, headers: { 'content-type': 'application/json' } }));
+    const values = new Map<string, string[]>();
+    const get = jest.fn<DecompositionCache['get']>((model, query) =>
+      values.get(`${model}:${query.toLowerCase().replace(/\s+/g, ' ')}`)?.slice() ?? null);
+    const set = jest.fn<DecompositionCache['set']>((model, query, subqueries) => {
+      values.set(`${model}:${query.toLowerCase().replace(/\s+/g, ' ')}`, [...subqueries]);
+    });
+    const cache: DecompositionCache = {
+      get,
+      set,
+    };
+    const provider = createLocalLlmQueryDecomposer(undefined, {
+      endpoint: 'http://llm.test',
+      model: 'model-a',
+      cache,
+    });
+
+    await expect(provider.decompose('Multi   hop query')).resolves.toEqual(['hop one', 'hop two']);
+    await expect(provider.decompose('multi hop query')).resolves.toEqual(['hop one', 'hop two']);
+    expect(get).toHaveBeenNthCalledWith(1, 'model-a', 'Multi   hop query');
+    expect(set).toHaveBeenCalledWith('model-a', 'Multi   hop query', ['hop one', 'hop two']);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('never caches provider failures, invalid responses, or offline fallback results', async () => {
+    const fallback = createRuleBasedQueryDecomposer();
+    const cache: DecompositionCache = {
+      get: jest.fn<DecompositionCache['get']>().mockReturnValue(null),
+      set: jest.fn<DecompositionCache['set']>(),
+    };
+    const fetchMock = jest.spyOn(globalThis, 'fetch')
+      .mockRejectedValueOnce(new Error('offline'))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        choices: [{ message: { content: '{"subqueries":[]}' } }],
+        model: 'model-a',
+      }), { status: 200, headers: { 'content-type': 'application/json' } }));
+    const provider = createLocalLlmQueryDecomposer(fallback, {
+      endpoint: 'http://llm.test',
+      model: 'model-a',
+      cache,
+    });
+
+    await provider.decompose('alpha and beta');
+    await provider.decompose('alpha and beta');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(cache.set).not.toHaveBeenCalled();
   });
 });
 

--- a/src/query-decomposition.ts
+++ b/src/query-decomposition.ts
@@ -1,6 +1,9 @@
 import { callChatCompletion } from './llm-client.js';
 import type { HybridChunk } from './hybrid-retrieval.js';
 import { chunkIdFromMetadata } from './rrf.js';
+import { DiskTieredDecompositionCache } from './decomposition-cache.js';
+import type { DecompositionCache } from './decomposition-cache.js';
+import { resolveLlmProvider } from './config/llm-provider.js';
 
 export const QUERY_DECOMPOSITION_SCHEMA_VERSION = 'kb.search.query-decomposition.v1';
 
@@ -87,6 +90,7 @@ export interface LocalLlmQueryDecomposerOptions {
   endpoint?: string;
   model?: string;
   timeoutMs?: number;
+  cache?: DecompositionCache;
 }
 
 const PROVIDER_TIMEOUT = Symbol('query-decomposition-provider-timeout');
@@ -166,15 +170,19 @@ export function createLocalLlmQueryDecomposer(
   fallback: QueryDecompositionProvider = createRuleBasedQueryDecomposer(),
   options: LocalLlmQueryDecomposerOptions = {},
 ): QueryDecompositionProvider {
+  const cache = options.cache ?? new DiskTieredDecompositionCache();
   return {
     name: 'local-llm',
     async decompose(query) {
       const endpoint = resolveLocalLlmEndpoint(options);
       if (endpoint === null) return fallback.decompose(query);
+      const model = resolveLocalLlmModel(options);
+      const cached = cache.get(model, query);
+      if (cached !== null) return cached;
       try {
         const result = await callChatCompletion({
           endpoint,
-          model: options.model ?? process.env.KB_DECOMPOSE_LLM_MODEL ?? process.env.KB_LLM_MODEL,
+          model,
           temperature: 0,
           timeoutMs: options.timeoutMs ?? 30_000,
           retry: false,
@@ -187,7 +195,9 @@ export function createLocalLlmQueryDecomposer(
           ],
         });
         const parsed = parseLlmSubqueries(result.content);
-        return parsed.length > 0 ? parsed : fallback.decompose(query);
+        if (parsed.length === 0) return fallback.decompose(query);
+        cache.set(model, query, parsed);
+        return parsed;
       } catch {
         // Local LLM decomposition is best-effort; endpoint errors degrade to the
         // deterministic rule provider so opt-in retrieval stays usable offline.
@@ -555,6 +565,10 @@ function resolveLocalLlmEndpoint(options: LocalLlmQueryDecomposerOptions): strin
   const raw = options.endpoint ?? process.env.KB_DECOMPOSE_LLM_ENDPOINT ?? process.env.KB_LLM_ENDPOINT;
   if (raw === undefined || raw.trim() === '') return null;
   return raw.trim();
+}
+
+function resolveLocalLlmModel(options: LocalLlmQueryDecomposerOptions): string {
+  return options.model ?? process.env.KB_DECOMPOSE_LLM_MODEL ?? resolveLlmProvider().model ?? 'local-model';
 }
 
 function dedupeQueries(queries: readonly string[]): string[] {


### PR DESCRIPTION
Closes #736

## Summary

- add an opt-in bounded LRU plus persistent disk cache for successful LLM query decompositions
- key entries by NFKC/whitespace/case-normalized query, effective provider model identity, and `kb.search.query-decomposition.v1`
- validate model/query/schema, subquery shape and bounds, and a SHA-256 payload checksum before serving disk records
- preserve offline and failure recovery by caching only non-empty, successfully parsed provider results

## Smallest reuse and alternatives

This mirrors the smallest proven pieces of `rerank-cache-disk.ts`: a `Map`-backed LRU, SHA-256 content addressing with two-character directory sharding, atomic write-then-rename records, corrupt-record deletion, and oldest-first byte-budget eviction. It intentionally does not extract a shared cache framework or edit existing cache modules, because that would widen this issue and couple synchronous scalar/vector caches to decomposition-specific record validation.

The key includes the schema version directly so parser/prompt contract changes invalidate old entries without migration. The effective model is resolved once through the shared provider resolver before lookup and passed unchanged to the LLM call, avoiding cache identity drift while preserving provider defaults such as OpenRouter. Query normalization follows the existing cache family (NFKC, trim, whitespace collapse, lowercase); preserving case or raw whitespace was rejected because it would reduce useful hits without changing decomposition semantics.

Configuration stays local and opt-in: `KB_DECOMPOSE_CACHE_ENABLED`, `KB_DECOMPOSE_CACHE_LRU_MAX` (default 256), and `KB_DECOMPOSE_CACHE_DISK_MAX_BYTES` (default 64 MiB). Invalid budgets fall back to safe bounded defaults, matching existing cache behavior. Shared config/schema and docs files were intentionally not changed per the issue scope. Constructor options remain injectable for deterministic tests and embedding callers. A follow-up should register/document these knobs in the shared configuration reference when that scope is available.

## Review findings addressed

Pre-PR specialist review found that an initial explicit `local-model` fallback would have bypassed centralized provider defaults. The final implementation resolves through `resolveLlmProvider()` and uses the same identity for the request and cache. Test review suggestions were also incorporated for exact model/query cache-boundary arguments, toggle parsing, cross-model misses, and schema/model/query disk-record rejection. Final correctness, lint-like/dead-code/docs-drift, and test re-reviews found no remaining blocking issue.

## Validation

- focused cache/decomposition Jest suites after final rebase: 13 passed
- `npm run build` after final rebase
- ESLint on changed source files
- config environment-usage gate
- full `npm run check`: 209 suites passed, 2,985 tests passed; coverage and all documentation/config consistency gates passed
- pre-push fast CI-parity checks passed
