### PR TITLE
feat(daemon): configure client request timeouts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -412,6 +412,14 @@ KB_DAEMON_HOST=127.0.0.1
 # Default: 17799
 KB_DAEMON_PORT=17799
 
+# Timeout in milliseconds for daemon command requests.
+# Default: 1500
+KB_DAEMON_CLIENT_TIMEOUT_MS=1500
+
+# Timeout in milliseconds for daemon health requests, capped by any outer autostart deadline.
+# Default: 500
+KB_DAEMON_HEALTH_TIMEOUT_MS=500
+
 # boolean configuration value.
 # Default: off
 KB_DAEMON_AUTOSTART=off

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -105,6 +105,8 @@ Run `npm run docs:generate-config-reference` after changing the schema.
 | <code>KB_DAEMON_SOCKET</code> | <code>path</code> | _unset_ |  |  | uses default |  |
 | <code>KB_DAEMON_HOST</code> | <code>string</code> | <code>127.0.0.1</code> |  |  | uses default |  |
 | <code>KB_DAEMON_PORT</code> | <code>integer</code> | <code>17799</code> |  | >= <code>1</code>; <= <code>65535</code> | uses default |  |
+| <code>KB_DAEMON_CLIENT_TIMEOUT_MS</code> | <code>duration</code> | <code>1500</code> |  | >= <code>1</code>; <= <code>300000</code>; digits only | uses default | Timeout in milliseconds for daemon command requests. |
+| <code>KB_DAEMON_HEALTH_TIMEOUT_MS</code> | <code>duration</code> | <code>500</code> |  | >= <code>1</code>; <= <code>300000</code>; digits only | uses default | Timeout in milliseconds for daemon health requests, capped by any outer autostart deadline. |
 | <code>KB_DAEMON_AUTOSTART</code> | <code>boolean</code> | <code>off</code> | <code>on</code>, <code>off</code>, <code>true</code>, <code>false</code>, <code>1</code>, <code>0</code>, <code>yes</code>, <code>no</code> |  | uses default |  |
 | <code>KB_DAEMON_PREWARM</code> | <code>boolean</code> | <code>off</code> | <code>on</code>, <code>off</code>, <code>true</code>, <code>false</code>, <code>1</code>, <code>0</code>, <code>yes</code>, <code>no</code> |  | uses default |  |
 | <code>MCP_TRANSPORT</code> | <code>enum</code> | <code>stdio</code> | <code>stdio</code>, <code>sse</code>, <code>http</code> |  | uses default | MCP server transport. |

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -233,6 +233,16 @@ describe('config schema validation (FR-OBS-470)', () => {
         source: 'default',
         redacted: false,
       }),
+      expect.objectContaining({
+        name: 'KB_DAEMON_CLIENT_TIMEOUT_MS',
+        value: '1500',
+        source: 'default',
+      }),
+      expect.objectContaining({
+        name: 'KB_DAEMON_HEALTH_TIMEOUT_MS',
+        value: '500',
+        source: 'default',
+      }),
     ]));
   });
 

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -15,6 +15,8 @@ describe('config schema validation (FR-OBS-470)', () => {
       KB_GATE_LLM_ENDPOINT: 'http://127.0.0.1:8080/v1/chat/completions',
       KB_GATE_SCORE_FLOOR: '0.75',
       KB_FLAT_SEARCH_P95_ADVISORY_MS: '75',
+      KB_DAEMON_CLIENT_TIMEOUT_MS: '1500',
+      KB_DAEMON_HEALTH_TIMEOUT_MS: '500',
       KB_AGE_BUDGET_HOURS_ALPHA: '24',
       MCP_TRANSPORT: 'http',
       MCP_AUTH_TOKEN: 'x'.repeat(32),
@@ -28,6 +30,8 @@ describe('config schema validation (FR-OBS-470)', () => {
       expect.objectContaining({ name: 'EMBEDDING_PROVIDER', status: 'ok', value: 'fake' }),
       expect.objectContaining({ name: 'KB_AGE_BUDGET_HOURS_ALPHA', status: 'ok', value: '24' }),
       expect.objectContaining({ name: 'KB_FLAT_SEARCH_P95_ADVISORY_MS', status: 'ok', value: '75' }),
+      expect.objectContaining({ name: 'KB_DAEMON_CLIENT_TIMEOUT_MS', status: 'ok', value: '1500' }),
+      expect.objectContaining({ name: 'KB_DAEMON_HEALTH_TIMEOUT_MS', status: 'ok', value: '500' }),
       expect.objectContaining({ name: 'KB_RERANK_TOP_N', status: 'ok', value: '12' }),
       expect.objectContaining({ name: 'KB_RERANK_BATCH_SIZE', status: 'ok', value: '16' }),
       expect.objectContaining({ name: 'MCP_AUTH_TOKEN', status: 'ok', value: '<redacted>' }),
@@ -43,6 +47,8 @@ describe('config schema validation (FR-OBS-470)', () => {
       KB_FLAT_SEARCH_P95_ADVISORY_MS: '0',
       KB_GATE_LLM_ENDPOINT: 'not a url',
       MCP_PORT: '70000',
+      KB_DAEMON_CLIENT_TIMEOUT_MS: '0',
+      KB_DAEMON_HEALTH_TIMEOUT_MS: '300001',
     }, { source: '/tmp/bad.env' });
 
     expect(report.status).toBe('error');
@@ -55,6 +61,8 @@ describe('config schema validation (FR-OBS-470)', () => {
       expect.objectContaining({ name: 'KB_FLAT_SEARCH_P95_ADVISORY_MS', status: 'error', message: expect.stringContaining('>= 1') }),
       expect.objectContaining({ name: 'KB_GATE_LLM_ENDPOINT', status: 'error', message: expect.stringContaining('URL') }),
       expect.objectContaining({ name: 'MCP_PORT', status: 'error', message: expect.stringContaining('<= 65535') }),
+      expect.objectContaining({ name: 'KB_DAEMON_CLIENT_TIMEOUT_MS', status: 'error', message: expect.stringContaining('>= 1') }),
+      expect.objectContaining({ name: 'KB_DAEMON_HEALTH_TIMEOUT_MS', status: 'error', message: expect.stringContaining('<= 300000') }),
     ]));
     expect(report.findings.every((finding) => finding.source === '/tmp/bad.env')).toBe(true);
   });

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -256,6 +256,8 @@ export const CONFIG_SCHEMA: readonly ConfigSpec[] = [
   { name: 'KB_DAEMON_SOCKET', kind: 'path' },
   { name: 'KB_DAEMON_HOST', kind: 'string', default: '127.0.0.1', emptyUsesDefault: true },
   { name: 'KB_DAEMON_PORT', kind: 'integer', default: '17799', min: 1, max: 65535 },
+  { name: 'KB_DAEMON_CLIENT_TIMEOUT_MS', kind: 'duration', default: '1500', min: 1, max: 300000, integerSyntax: 'digits', description: 'Timeout in milliseconds for daemon command requests.' },
+  { name: 'KB_DAEMON_HEALTH_TIMEOUT_MS', kind: 'duration', default: '500', min: 1, max: 300000, integerSyntax: 'digits', description: 'Timeout in milliseconds for daemon health requests, capped by any outer autostart deadline.' },
   { name: 'KB_DAEMON_AUTOSTART', kind: 'boolean', default: 'off', booleanValues: YES_NO_BOOL_VALUES, truthyValues: YES_NO_TRUTHY_VALUES },
   { name: 'KB_DAEMON_PREWARM', kind: 'boolean', default: 'off', booleanValues: YES_NO_BOOL_VALUES, truthyValues: YES_NO_TRUTHY_VALUES },
   { name: 'MCP_TRANSPORT', kind: 'enum', values: ['stdio', 'sse', 'http'], default: 'stdio', description: 'MCP server transport.' },

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -32,6 +32,11 @@ import {
   MAX_RERANK_BATCH_SIZE,
   MAX_RERANK_TOP_N,
 } from './reranker.js';
+import {
+  DEFAULT_DAEMON_CLIENT_TIMEOUT_MS,
+  DEFAULT_DAEMON_HEALTH_TIMEOUT_MS,
+  MAX_DAEMON_CLIENT_TIMEOUT_MS,
+} from '../daemon-client.js';
 
 export type ConfigFindingStatus = 'ok' | 'warn' | 'error';
 export type ConfigValueKind =
@@ -256,8 +261,8 @@ export const CONFIG_SCHEMA: readonly ConfigSpec[] = [
   { name: 'KB_DAEMON_SOCKET', kind: 'path' },
   { name: 'KB_DAEMON_HOST', kind: 'string', default: '127.0.0.1', emptyUsesDefault: true },
   { name: 'KB_DAEMON_PORT', kind: 'integer', default: '17799', min: 1, max: 65535 },
-  { name: 'KB_DAEMON_CLIENT_TIMEOUT_MS', kind: 'duration', default: '1500', min: 1, max: 300000, integerSyntax: 'digits', description: 'Timeout in milliseconds for daemon command requests.' },
-  { name: 'KB_DAEMON_HEALTH_TIMEOUT_MS', kind: 'duration', default: '500', min: 1, max: 300000, integerSyntax: 'digits', description: 'Timeout in milliseconds for daemon health requests, capped by any outer autostart deadline.' },
+  { name: 'KB_DAEMON_CLIENT_TIMEOUT_MS', kind: 'duration', default: String(DEFAULT_DAEMON_CLIENT_TIMEOUT_MS), min: 1, max: MAX_DAEMON_CLIENT_TIMEOUT_MS, integerSyntax: 'digits', description: 'Timeout in milliseconds for daemon command requests.' },
+  { name: 'KB_DAEMON_HEALTH_TIMEOUT_MS', kind: 'duration', default: String(DEFAULT_DAEMON_HEALTH_TIMEOUT_MS), min: 1, max: MAX_DAEMON_CLIENT_TIMEOUT_MS, integerSyntax: 'digits', description: 'Timeout in milliseconds for daemon health requests, capped by any outer autostart deadline.' },
   { name: 'KB_DAEMON_AUTOSTART', kind: 'boolean', default: 'off', booleanValues: YES_NO_BOOL_VALUES, truthyValues: YES_NO_TRUTHY_VALUES },
   { name: 'KB_DAEMON_PREWARM', kind: 'boolean', default: 'off', booleanValues: YES_NO_BOOL_VALUES, truthyValues: YES_NO_TRUTHY_VALUES },
   { name: 'MCP_TRANSPORT', kind: 'enum', values: ['stdio', 'sse', 'http'], default: 'stdio', description: 'MCP server transport.' },

--- a/src/daemon-client.test.ts
+++ b/src/daemon-client.test.ts
@@ -5,6 +5,8 @@ import type { AddressInfo } from 'node:net';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import {
+  DEFAULT_DAEMON_CLIENT_TIMEOUT_MS,
+  DEFAULT_DAEMON_HEALTH_TIMEOUT_MS,
   DaemonProtocolError,
   DaemonUnavailableError,
   daemonEndpointFromEnv,
@@ -55,6 +57,11 @@ async function withUnixSocketServer(
 describe('daemon client', () => {
   const itUnix = process.platform === 'win32' ? it.skip : it;
 
+  it('preserves the legacy request and health timeout defaults', () => {
+    expect(DEFAULT_DAEMON_CLIENT_TIMEOUT_MS).toBe(1500);
+    expect(DEFAULT_DAEMON_HEALTH_TIMEOUT_MS).toBe(500);
+  });
+
   it('builds a default loopback URL from env overrides', () => {
     expect(daemonUrlFromEnv({ KB_DAEMON_PORT: '18888' }).href).toBe('http://127.0.0.1:18888/');
     expect(daemonUrlFromEnv({ KB_DAEMON_URL: 'http://127.0.0.1:19999' }).href).toBe('http://127.0.0.1:19999/');
@@ -96,6 +103,51 @@ describe('daemon client', () => {
       await expect(runDaemonCommand('search', ['hello'], { env: { KB_DAEMON_URL: url.href } }))
         .resolves.toEqual({ exitCode: 0, stdout: 'ok\n', stderr: '' });
     });
+  });
+
+  it('uses the configured daemon request timeout and preserves the explicit override', async () => {
+    jest.useFakeTimers();
+    try {
+      const fetchImpl = jest.fn((_url: URL | RequestInfo, init?: RequestInit) => new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => reject(new DOMException('aborted', 'AbortError')));
+      }));
+      const configured = runDaemonCommand('search', ['q'], {
+        env: {
+          KB_DAEMON_URL: 'http://127.0.0.1:17799/',
+          KB_DAEMON_CLIENT_TIMEOUT_MS: '2400',
+        },
+        fetchImpl,
+      });
+      const configuredRejection = expect(configured).rejects.toBeInstanceOf(DaemonUnavailableError);
+      await jest.advanceTimersByTimeAsync(2399);
+      expect(fetchImpl.mock.calls[0]?.[1]?.signal?.aborted).toBe(false);
+      await jest.advanceTimersByTimeAsync(1);
+      await configuredRejection;
+
+      const overridden = runDaemonCommand('search', ['q'], {
+        env: {
+          KB_DAEMON_URL: 'http://127.0.0.1:17799/',
+          KB_DAEMON_CLIENT_TIMEOUT_MS: '2400',
+        },
+        fetchImpl,
+        timeoutMs: 25,
+      });
+      const overriddenRejection = expect(overridden).rejects.toBeInstanceOf(DaemonUnavailableError);
+      await jest.advanceTimersByTimeAsync(25);
+      await overriddenRejection;
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('rejects invalid configured daemon request timeouts', async () => {
+    await expect(runDaemonCommand('search', ['q'], {
+      env: {
+        KB_DAEMON_URL: 'http://127.0.0.1:17799/',
+        KB_DAEMON_CLIENT_TIMEOUT_MS: '300001',
+      },
+      fetchImpl: jest.fn<typeof fetch>(),
+    })).rejects.toThrow('invalid KB_DAEMON_CLIENT_TIMEOUT_MS: 300001');
   });
 
   itUnix('posts command requests over a Unix-domain socket', async () => {
@@ -162,6 +214,30 @@ describe('daemon client', () => {
         uptime_ms: 1234,
       });
     });
+  });
+
+  it('uses the configured health timeout independently of the request timeout', async () => {
+    jest.useFakeTimers();
+    try {
+      const fetchImpl = jest.fn((_url: URL | RequestInfo, init?: RequestInit) => new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => reject(new DOMException('aborted', 'AbortError')));
+      }));
+      const health = fetchDaemonHealth({
+        env: {
+          KB_DAEMON_URL: 'http://127.0.0.1:17799/',
+          KB_DAEMON_CLIENT_TIMEOUT_MS: '2400',
+          KB_DAEMON_HEALTH_TIMEOUT_MS: '700',
+        },
+        fetchImpl,
+      });
+      const healthRejection = expect(health).rejects.toBeInstanceOf(DaemonUnavailableError);
+      await jest.advanceTimersByTimeAsync(699);
+      expect(fetchImpl.mock.calls[0]?.[1]?.signal?.aborted).toBe(false);
+      await jest.advanceTimersByTimeAsync(1);
+      await healthRejection;
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
   it('tolerates an older daemon that only answers { status }', async () => {

--- a/src/daemon-client.test.ts
+++ b/src/daemon-client.test.ts
@@ -57,9 +57,40 @@ async function withUnixSocketServer(
 describe('daemon client', () => {
   const itUnix = process.platform === 'win32' ? it.skip : it;
 
-  it('preserves the legacy request and health timeout defaults', () => {
-    expect(DEFAULT_DAEMON_CLIENT_TIMEOUT_MS).toBe(1500);
-    expect(DEFAULT_DAEMON_HEALTH_TIMEOUT_MS).toBe(500);
+  it('preserves the legacy request timeout default', async () => {
+    jest.useFakeTimers();
+    try {
+      const fetchImpl = pendingFetch();
+      const request = runDaemonCommand('search', ['q'], {
+        env: { KB_DAEMON_URL: 'http://127.0.0.1:17799/' },
+        fetchImpl,
+      });
+      const rejection = expect(request).rejects.toBeInstanceOf(DaemonUnavailableError);
+      await jest.advanceTimersByTimeAsync(DEFAULT_DAEMON_CLIENT_TIMEOUT_MS - 1);
+      expect(fetchImpl.mock.calls[0]?.[1]?.signal?.aborted).toBe(false);
+      await jest.advanceTimersByTimeAsync(1);
+      await rejection;
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('preserves the legacy health timeout default', async () => {
+    jest.useFakeTimers();
+    try {
+      const fetchImpl = pendingFetch();
+      const health = fetchDaemonHealth({
+        env: { KB_DAEMON_URL: 'http://127.0.0.1:17799/' },
+        fetchImpl,
+      });
+      const rejection = expect(health).rejects.toBeInstanceOf(DaemonUnavailableError);
+      await jest.advanceTimersByTimeAsync(DEFAULT_DAEMON_HEALTH_TIMEOUT_MS - 1);
+      expect(fetchImpl.mock.calls[0]?.[1]?.signal?.aborted).toBe(false);
+      await jest.advanceTimersByTimeAsync(1);
+      await rejection;
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
   it('builds a default loopback URL from env overrides', () => {
@@ -108,9 +139,7 @@ describe('daemon client', () => {
   it('uses the configured daemon request timeout and preserves the explicit override', async () => {
     jest.useFakeTimers();
     try {
-      const fetchImpl = jest.fn((_url: URL | RequestInfo, init?: RequestInit) => new Promise<Response>((_resolve, reject) => {
-        init?.signal?.addEventListener('abort', () => reject(new DOMException('aborted', 'AbortError')));
-      }));
+      const fetchImpl = pendingFetch();
       const configured = runDaemonCommand('search', ['q'], {
         env: {
           KB_DAEMON_URL: 'http://127.0.0.1:17799/',
@@ -219,9 +248,7 @@ describe('daemon client', () => {
   it('uses the configured health timeout independently of the request timeout', async () => {
     jest.useFakeTimers();
     try {
-      const fetchImpl = jest.fn((_url: URL | RequestInfo, init?: RequestInit) => new Promise<Response>((_resolve, reject) => {
-        init?.signal?.addEventListener('abort', () => reject(new DOMException('aborted', 'AbortError')));
-      }));
+      const fetchImpl = pendingFetch();
       const health = fetchDaemonHealth({
         env: {
           KB_DAEMON_URL: 'http://127.0.0.1:17799/',
@@ -389,6 +416,42 @@ describe('daemon client', () => {
       'kb daemon autostart: kb serve was not ready after 250ms; running command directly.\n',
     ]);
   });
+
+  it('caps autostart preflight health by the outer readiness deadline', async () => {
+    jest.useFakeTimers();
+    try {
+      const child = { once: jest.fn(() => child), unref: jest.fn() };
+      const healthSignals: AbortSignal[] = [];
+      const fetchImpl = jest.fn((url: URL | RequestInfo, init?: RequestInit): Promise<Response> => {
+        if (new URL(String(url)).pathname === '/v1/run') {
+          return Promise.reject(Object.assign(new TypeError('fetch failed'), { cause: { code: 'ECONNREFUSED' } }));
+        }
+        if (init?.signal != null) healthSignals.push(init.signal);
+        return new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () => reject(new DOMException('aborted', 'AbortError')));
+        });
+      });
+      const result = tryRunDaemonCommand('search', ['q'], {
+        env: {
+          KB_DAEMON_AUTOSTART: 'on',
+          KB_DAEMON_URL: 'http://127.0.0.1:17799/',
+          KB_DAEMON_HEALTH_TIMEOUT_MS: '1000',
+        },
+        fetchImpl,
+        spawnImpl: jest.fn<SpawnDaemon>(() => child),
+        autostartDeadlineMs: 250,
+        notice: () => undefined,
+      });
+      const resultExpectation = expect(result).resolves.toBeNull();
+      await jest.advanceTimersByTimeAsync(249);
+      expect(healthSignals[0]?.aborted).toBe(false);
+      await jest.advanceTimersByTimeAsync(2);
+      await resultExpectation;
+      expect(healthSignals[0]?.aborted).toBe(true);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
 });
 
 function jsonResponse(payload: unknown, init: { status?: number } = {}): Response {
@@ -396,4 +459,10 @@ function jsonResponse(payload: unknown, init: { status?: number } = {}): Respons
     status: init.status ?? 200,
     headers: { 'Content-Type': 'application/json' },
   });
+}
+
+function pendingFetch(): jest.MockedFunction<typeof fetch> {
+  return jest.fn((_url: URL | RequestInfo, init?: RequestInit) => new Promise<Response>((_resolve, reject) => {
+    init?.signal?.addEventListener('abort', () => reject(new DOMException('aborted', 'AbortError')));
+  })) as jest.MockedFunction<typeof fetch>;
 }

--- a/src/daemon-client.test.ts
+++ b/src/daemon-client.test.ts
@@ -421,6 +421,7 @@ describe('daemon client', () => {
     jest.useFakeTimers();
     try {
       const child = { once: jest.fn(() => child), unref: jest.fn() };
+      const spawnImpl = jest.fn<SpawnDaemon>(() => child);
       const healthSignals: AbortSignal[] = [];
       const fetchImpl = jest.fn((url: URL | RequestInfo, init?: RequestInit): Promise<Response> => {
         if (new URL(String(url)).pathname === '/v1/run') {
@@ -438,7 +439,7 @@ describe('daemon client', () => {
           KB_DAEMON_HEALTH_TIMEOUT_MS: '1000',
         },
         fetchImpl,
-        spawnImpl: jest.fn<SpawnDaemon>(() => child),
+        spawnImpl,
         autostartDeadlineMs: 250,
         notice: () => undefined,
       });
@@ -448,6 +449,7 @@ describe('daemon client', () => {
       await jest.advanceTimersByTimeAsync(2);
       await resultExpectation;
       expect(healthSignals[0]?.aborted).toBe(true);
+      expect(spawnImpl).not.toHaveBeenCalled();
     } finally {
       jest.useRealTimers();
     }

--- a/src/daemon-client.ts
+++ b/src/daemon-client.ts
@@ -397,6 +397,10 @@ async function runDaemonCommandAfterAutostart(
   }
 
   if (preflight === null) {
+    if (now() >= deadlineAt) {
+      writeNotice(options, autostartTimeoutNotice(options));
+      return null;
+    }
     const started = startDetachedDaemon(options);
     const health = await pollDaemonReady(options, deadlineAt);
     if (health === null) {
@@ -469,7 +473,7 @@ async function pollDaemonReady(options: DaemonClientOptions, deadlineAt: number)
   const pollIntervalMs = options.autostartPollIntervalMs ?? DEFAULT_AUTOSTART_POLL_INTERVAL_MS;
   const now = options.now ?? Date.now;
   const sleep = options.sleep ?? defaultSleep;
-  while (now() <= deadlineAt) {
+  while (now() < deadlineAt) {
     const health = await tryFetchDaemonHealth({
       ...options,
       timeoutMs: Math.min(daemonHealthTimeoutMs(options), Math.max(1, deadlineAt - now())),

--- a/src/daemon-client.ts
+++ b/src/daemon-client.ts
@@ -382,9 +382,14 @@ async function runDaemonCommandAfterAutostart(
   args: string[],
   options: DaemonClientOptions,
 ): Promise<DaemonRunResult | null> {
+  const now = options.now ?? Date.now;
+  const deadlineAt = now() + (options.autostartDeadlineMs ?? DEFAULT_AUTOSTART_DEADLINE_MS);
   let preflight: DaemonHealth | null;
   try {
-    preflight = await tryFetchDaemonHealth(options);
+    preflight = await tryFetchDaemonHealth({
+      ...options,
+      timeoutMs: Math.min(daemonHealthTimeoutMs(options), Math.max(1, deadlineAt - now())),
+    });
   } catch (err) {
     // Something is already answering at the URL, but not with the kb daemon
     // health contract. Do not start another process into a foreign listener.
@@ -393,7 +398,7 @@ async function runDaemonCommandAfterAutostart(
 
   if (preflight === null) {
     const started = startDetachedDaemon(options);
-    const health = await pollDaemonReady(options);
+    const health = await pollDaemonReady(options, deadlineAt);
     if (health === null) {
       writeNotice(options, autostartTimeoutNotice(options));
       return null;
@@ -460,12 +465,10 @@ function ignoreSpawnError(child: SpawnedDaemonProcess): void {
   child.once('error', () => undefined);
 }
 
-async function pollDaemonReady(options: DaemonClientOptions): Promise<DaemonHealth | null> {
-  const deadlineMs = options.autostartDeadlineMs ?? DEFAULT_AUTOSTART_DEADLINE_MS;
+async function pollDaemonReady(options: DaemonClientOptions, deadlineAt: number): Promise<DaemonHealth | null> {
   const pollIntervalMs = options.autostartPollIntervalMs ?? DEFAULT_AUTOSTART_POLL_INTERVAL_MS;
   const now = options.now ?? Date.now;
   const sleep = options.sleep ?? defaultSleep;
-  const deadlineAt = now() + deadlineMs;
   while (now() <= deadlineAt) {
     const health = await tryFetchDaemonHealth({
       ...options,

--- a/src/daemon-client.ts
+++ b/src/daemon-client.ts
@@ -66,6 +66,9 @@ export interface DaemonClientOptions {
 
 const DEFAULT_AUTOSTART_DEADLINE_MS = 3_000;
 const DEFAULT_AUTOSTART_POLL_INTERVAL_MS = 100;
+export const DEFAULT_DAEMON_CLIENT_TIMEOUT_MS = 1_500;
+export const DEFAULT_DAEMON_HEALTH_TIMEOUT_MS = 500;
+export const MAX_DAEMON_CLIENT_TIMEOUT_MS = 300_000;
 const MAX_UNIX_SOCKET_PATH_BYTES = 107;
 
 export class DaemonUnavailableError extends Error {
@@ -130,7 +133,7 @@ export async function runDaemonCommand(
   const endpoint = new URL('/v1/run', baseEndpoint.url);
   const fetchImpl = options.fetchImpl ?? fetch;
   const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), options.timeoutMs ?? 1500);
+  const timeout = setTimeout(() => controller.abort(), daemonRequestTimeoutMs(options));
   try {
     const response = await requestDaemonEndpoint(baseEndpoint, endpoint, {
       fetchImpl,
@@ -165,7 +168,7 @@ export async function fetchDaemonHealth(
   const endpoint = new URL('/health', baseEndpoint.url);
   const fetchImpl = options.fetchImpl ?? fetch;
   const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), options.timeoutMs ?? 1500);
+  const timeout = setTimeout(() => controller.abort(), daemonHealthTimeoutMs(options));
   try {
     const response = await requestDaemonEndpoint(baseEndpoint, endpoint, {
       fetchImpl,
@@ -466,7 +469,7 @@ async function pollDaemonReady(options: DaemonClientOptions): Promise<DaemonHeal
   while (now() <= deadlineAt) {
     const health = await tryFetchDaemonHealth({
       ...options,
-      timeoutMs: Math.min(options.timeoutMs ?? 500, Math.max(1, deadlineAt - now())),
+      timeoutMs: Math.min(daemonHealthTimeoutMs(options), Math.max(1, deadlineAt - now())),
     });
     if (health !== null) return health;
     const remainingMs = deadlineAt - now();
@@ -474,6 +477,39 @@ async function pollDaemonReady(options: DaemonClientOptions): Promise<DaemonHeal
     await sleep(Math.min(pollIntervalMs, remainingMs));
   }
   return null;
+}
+
+function daemonRequestTimeoutMs(options: DaemonClientOptions): number {
+  return options.timeoutMs ?? daemonTimeoutFromEnv(
+    options.env,
+    'KB_DAEMON_CLIENT_TIMEOUT_MS',
+    DEFAULT_DAEMON_CLIENT_TIMEOUT_MS,
+  );
+}
+
+function daemonHealthTimeoutMs(options: DaemonClientOptions): number {
+  return options.timeoutMs ?? daemonTimeoutFromEnv(
+    options.env,
+    'KB_DAEMON_HEALTH_TIMEOUT_MS',
+    DEFAULT_DAEMON_HEALTH_TIMEOUT_MS,
+  );
+}
+
+function daemonTimeoutFromEnv(
+  env: NodeJS.ProcessEnv | undefined,
+  name: 'KB_DAEMON_CLIENT_TIMEOUT_MS' | 'KB_DAEMON_HEALTH_TIMEOUT_MS',
+  fallback: number,
+): number {
+  const raw = (env ?? process.env)[name]?.trim();
+  if (raw === undefined || raw === '') return fallback;
+  if (!/^\d+$/.test(raw)) {
+    throw new DaemonProtocolError(`invalid ${name}: ${raw}`);
+  }
+  const value = Number(raw);
+  if (!Number.isSafeInteger(value) || value < 1 || value > MAX_DAEMON_CLIENT_TIMEOUT_MS) {
+    throw new DaemonProtocolError(`invalid ${name}: ${raw}`);
+  }
+  return value;
 }
 
 function autostartTimeoutNotice(options: DaemonClientOptions): string {


### PR DESCRIPTION
## Summary

- add validated `KB_DAEMON_CLIENT_TIMEOUT_MS` and `KB_DAEMON_HEALTH_TIMEOUT_MS` settings
- preserve the existing 1500 ms command and 500 ms health defaults
- share the autostart readiness deadline across preflight and polling so inner health probes never outlive the outer budget or spawn after expiry
- regenerate the configuration reference and environment template

## Bounds and alternatives

Both settings accept digit-only values from 1 through 300000 ms. The positive lower bound prevents disabled/non-meaningful deadlines; the five-minute ceiling accommodates slow cold model loads without allowing accidental effectively-hung CLI requests.

I kept separate command and health settings because health probes should remain cheap while cold command execution may need a longer allowance. A single shared timeout would couple those distinct paths. I also kept explicit per-call `timeoutMs` as the highest-priority override for existing programmatic callers. An unbounded value or a loading-state-specific first-request timeout was not chosen because the former weakens failure bounds and the latter requires a broader daemon protocol change.

## Verification

- `npm run test:file -- src/daemon-client.test.ts src/config/schema.test.ts` (35 passed)
- `npm run check:fast`
- `npm run check` before the final base sync (208 suites passed, 2 skipped; 2981 tests passed; coverage thresholds met)
- generated config reference and `.env.example` drift checks
- independent correctness, test, conventions, dead-code, and docs-drift review; all findings resolved

Closes #738