### PR TITLE
feat: implement MCP logging/setLevel handler with per-session filtering

### DIFF
--- a/src/KnowledgeBaseServer.ts
+++ b/src/KnowledgeBaseServer.ts
@@ -4,6 +4,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { z } from 'zod';
 import {
+  SetLevelRequestSchema,
   type CallToolResult,
   type ListResourcesRequest,
   type ListResourcesResult,
@@ -331,6 +332,33 @@ export class KnowledgeBaseServer {
       version: SERVER_VERSION,
     });
     mcp.server.onerror = (error) => logger.error('[MCP Error]', error);
+    // #796 — advertise the MCP `logging` capability and own the
+    // `logging/setLevel` request. `registerCapabilities` must run before
+    // `setRequestHandler` (the SDK gates the handler on the capability) and
+    // before `connect` (it throws once a transport is attached), so both
+    // happen here at build time. The client-chosen minimum level is stored on
+    // the HTTP/SSE host's per-session map and enforced in `notify()`; stdio
+    // has a single session and no host, so `setLevel` is a no-op there
+    // (per-session filtering only matters where sessions exist).
+    mcp.server.registerCapabilities({ logging: {} });
+    mcp.server.setRequestHandler(SetLevelRequestSchema, async (request, extra) => {
+      const host = this.transportMode === 'sse'
+        ? this.sseHost
+        : this.transportMode === 'http'
+          ? this.httpHost
+          : undefined;
+      // Prefer the transport session id; fall back to the request header the
+      // same way the SDK's default handler does, since streamable HTTP can
+      // route a request without `extra.sessionId` set. Array-valued headers
+      // are collapsed to the first entry (session ids are single-valued).
+      const headerSessionId = extra.requestInfo?.headers['mcp-session-id'];
+      const sessionId = extra.sessionId
+        ?? (Array.isArray(headerSessionId) ? headerSessionId[0] : headerSessionId);
+      if (host !== undefined && sessionId !== undefined) {
+        host.setSessionLevel(sessionId, request.params.level);
+      }
+      return {};
+    });
     this.registerTools(mcp);
     registerResources(mcp);
     registerCompletions(mcp);

--- a/src/transport/base-http-host.ts
+++ b/src/transport/base-http-host.ts
@@ -22,6 +22,7 @@ import * as http from 'node:http';
 import { Buffer } from 'node:buffer';
 import { timingSafeEqual } from 'node:crypto';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { LoggingLevelSchema, type LoggingLevel } from '@modelcontextprotocol/sdk/types.js';
 
 import {
   isMetricsExportEnabled,
@@ -61,6 +62,30 @@ export interface BaseHttpHostOptions {
 export interface BaseSessionEntry<TTransport> {
   transport: TTransport;
   mcp: McpServer;
+  // #796 — per-session minimum log level requested by the client via
+  // `logging/setLevel`. When unset the session receives every level the
+  // server emits (byte-compatible with pre-#796 fanout behaviour).
+  minLevel?: LoggingLevel;
+}
+
+// #796 — MCP log-level severity order (least → most severe), mirroring the
+// SDK's `LoggingLevelSchema` option order. A message reaches a session only
+// when its severity is at or above the session's requested minimum.
+const LOG_LEVEL_SEVERITY = new Map<string, number>(
+  LoggingLevelSchema.options.map((level, index) => [level, index]),
+);
+
+function sessionAcceptsLevel(
+  minLevel: LoggingLevel | undefined,
+  level: LoggingLevel,
+): boolean {
+  if (minLevel === undefined) return true;
+  const messageSeverity = LOG_LEVEL_SEVERITY.get(level);
+  const minSeverity = LOG_LEVEL_SEVERITY.get(minLevel);
+  // An unknown level (should not happen — both are `LoggingLevel`) fails open
+  // so a mapping gap never silently swallows a notification.
+  if (messageSeverity === undefined || minSeverity === undefined) return true;
+  return messageSeverity >= minSeverity;
 }
 
 interface AccessLog {
@@ -205,13 +230,17 @@ export abstract class BaseHttpHost<TTransport extends { close(): Promise<void> }
    * `transport.onclose` deletes mid-iteration.
    */
   async notify(
-    level: 'info' | 'warning' | 'error',
+    level: LoggingLevel,
     logger_: string,
     data: string,
   ): Promise<void> {
+    // #796 — respect the per-session minimum level chosen via
+    // `logging/setLevel`. Sessions that never called it keep receiving
+    // everything (`minLevel` undefined).
     await this.fanoutMcpServers(
       (target) => target.sendLoggingMessage({ level, logger: logger_, data }),
       'notify error',
+      (entry) => sessionAcceptsLevel(entry.minLevel, level),
     );
   }
 
@@ -222,11 +251,26 @@ export abstract class BaseHttpHost<TTransport extends { close(): Promise<void> }
     );
   }
 
+  /**
+   * #796 — record the minimum log level a session wants to receive, in
+   * response to a `logging/setLevel` request. Returns `false` when the
+   * session is unknown (e.g. already closed) so the caller can no-op safely.
+   */
+  setSessionLevel(sessionId: string, level: LoggingLevel): boolean {
+    const entry = this.sessions.get(sessionId);
+    if (entry === undefined) return false;
+    entry.minLevel = level;
+    return true;
+  }
+
   private async fanoutMcpServers(
     action: (target: McpServer) => Promise<void>,
     errorLabel: string,
+    filter?: (entry: BaseSessionEntry<TTransport>) => boolean,
   ): Promise<void> {
-    const targets = [...this.sessions.values()].map((entry) => entry.mcp);
+    const entries = [...this.sessions.values()];
+    const targets = (filter === undefined ? entries : entries.filter(filter))
+      .map((entry) => entry.mcp);
     if (targets.length === 0) return;
     await Promise.all(
       targets.map(async (target) => {

--- a/src/transport/http.test.ts
+++ b/src/transport/http.test.ts
@@ -506,6 +506,44 @@ describe('StreamableHttpHost — endpoints', () => {
     sessions.clear();
   });
 
+  it('#796 notify filters each session by its logging/setLevel minimum', async () => {
+    const started = await startHost({});
+    stop = started.stop;
+    const sessionA = { sendLoggingMessage: jest.fn().mockResolvedValue(undefined) };
+    const sessionB = { sendLoggingMessage: jest.fn().mockResolvedValue(undefined) };
+    const sessions: Map<string, { transport: unknown; mcp: unknown; minLevel?: string }> =
+      (started.host as unknown as {
+        sessions: Map<string, { transport: unknown; mcp: unknown; minLevel?: string }>;
+      }).sessions;
+    sessions.set('a', { transport: {}, mcp: sessionA });
+    sessions.set('b', { transport: {}, mcp: sessionB });
+
+    // Session A only wants warning and above; session B wants everything.
+    expect(started.host.setSessionLevel('a', 'warning')).toBe(true);
+    expect(started.host.setSessionLevel('b', 'debug')).toBe(true);
+
+    await started.host.notify('info', 'kb-test', 'below A threshold');
+    await started.host.notify('error', 'kb-test', 'above A threshold');
+
+    // A: the info is dropped, only the error reaches it.
+    expect(sessionA.sendLoggingMessage).toHaveBeenCalledTimes(1);
+    expect(sessionA.sendLoggingMessage).toHaveBeenCalledWith({
+      level: 'error',
+      logger: 'kb-test',
+      data: 'above A threshold',
+    });
+    // B: both notifications arrive.
+    expect(sessionB.sendLoggingMessage).toHaveBeenCalledTimes(2);
+
+    sessions.clear();
+  });
+
+  it('#796 setSessionLevel returns false for an unknown session', async () => {
+    const started = await startHost({});
+    stop = started.stop;
+    expect(started.host.setSessionLevel('nope', 'error')).toBe(false);
+  });
+
   it('notify swallows per-session errors so one bad client cannot poison the rest', async () => {
     const started = await startHost({});
     stop = started.stop;

--- a/src/transport/sse.test.ts
+++ b/src/transport/sse.test.ts
@@ -891,6 +891,44 @@ describe('SseHost — endpoints', () => {
     sessions.clear();
   });
 
+  it('#796 notify filters each session by its logging/setLevel minimum', async () => {
+    const started = await startHost({});
+    stop = started.stop;
+    const sessionA = { sendLoggingMessage: jest.fn().mockResolvedValue(undefined) };
+    const sessionB = { sendLoggingMessage: jest.fn().mockResolvedValue(undefined) };
+    const sessions: Map<string, { transport: unknown; mcp: unknown; minLevel?: string }> =
+      (started.host as unknown as {
+        sessions: Map<string, { transport: unknown; mcp: unknown; minLevel?: string }>;
+      }).sessions;
+    sessions.set('a', { transport: {}, mcp: sessionA });
+    sessions.set('b', { transport: {}, mcp: sessionB });
+
+    // Session A only wants warning and above; session B wants everything.
+    expect(started.host.setSessionLevel('a', 'warning')).toBe(true);
+    expect(started.host.setSessionLevel('b', 'debug')).toBe(true);
+
+    await started.host.notify('info', 'kb-test', 'below A threshold');
+    await started.host.notify('error', 'kb-test', 'above A threshold');
+
+    // A: the info is dropped, only the error reaches it.
+    expect(sessionA.sendLoggingMessage).toHaveBeenCalledTimes(1);
+    expect(sessionA.sendLoggingMessage).toHaveBeenCalledWith({
+      level: 'error',
+      logger: 'kb-test',
+      data: 'above A threshold',
+    });
+    // B: both notifications arrive.
+    expect(sessionB.sendLoggingMessage).toHaveBeenCalledTimes(2);
+
+    sessions.clear();
+  });
+
+  it('#796 setSessionLevel returns false for an unknown session', async () => {
+    const started = await startHost({});
+    stop = started.stop;
+    expect(started.host.setSessionLevel('nope', 'error')).toBe(false);
+  });
+
   it('notify swallows per-session errors so one bad client cannot poison the rest', async () => {
     const started = await startHost({});
     stop = started.stop;


### PR DESCRIPTION
## Summary

Implements the client→server half of the MCP `logging` capability: a `logging/setLevel` request handler plus per-session minimum-level filtering of `notifications/message`. Previously the server fanned out `sendLoggingMessage` notifications but had no `setLevel` handler, so a client could not raise or lower the verbosity it received.

Closes #796

## What changed

- **`src/KnowledgeBaseServer.ts` (`buildMcpServer`)** — advertise the `logging` capability (`registerCapabilities({ logging: {} })`) and register a `SetLevelRequestSchema` handler on each per-session `McpServer`. The handler resolves the transport session id (from `extra.sessionId`, falling back to the `Mcp-Session-Id` header exactly as the SDK's default handler does) and records the client's chosen minimum level on the active HTTP/SSE host's session map.
- **`src/transport/base-http-host.ts`** — store an optional per-session `minLevel` on `BaseSessionEntry`, add `setSessionLevel(sessionId, level)`, and filter the `notify()` fanout by MCP log-level severity so a session only receives notifications at or above its requested level. Sessions that never call `setLevel` keep receiving everything (byte-compatible with the previous fanout).
- **Transport tests (`sse.test.ts` / `http.test.ts`)** — set session A to `warning`, emit `info`+`error`, assert only `error` reaches A while a `debug` session B gets both; plus an unknown-session `setSessionLevel` → `false` case.

## Design notes / choices

- **Scope: HTTP/SSE only.** Per-session filtering only matters where multiple sessions exist. stdio has a single session and no host, so `setLevel` is accepted but a no-op there (matches the issue's "scope the first cut to HTTP/SSE" guidance).
- **Own handler instead of the SDK's built-in.** The SDK auto-registers its own `setLevel` handler only when `logging` capability is passed in the constructor, keying levels by session id in an internal map. Registering the capability post-construction (via `registerCapabilities`) advertises it *without* the auto-handler, letting us route the level to the host's session map and keep filtering visible/testable in `notify()`. Alternative considered: pass `capabilities.logging` in the constructor and thread the session id into `sendLoggingMessage(params, sessionId)` to reuse the SDK's internal filter — rejected because it hides the filter in SDK internals and is harder to unit-test against the existing `notify()` harness.
- **Latent fix:** `sendLoggingMessage` was previously a silent no-op because the `logging` capability was never advertised. Advertising it also makes the existing warm-up log notifications actually reach clients.

## Testing

- `npm run build` — passes.
- `jest src/transport/sse.test.ts src/transport/http.test.ts` — 78 passed (this repo uses Jest; the SDK `logging/setLevel` filtering is covered by the new per-session tests).
- `jest src/KnowledgeBaseServer.test.ts src/mcp-tool-schemas.test.ts` — 105 passed (no capability-assertion regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)