### PR TITLE
feat: bound embedding-provider calls with a per-call timeout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -565,3 +565,9 @@ OTEL_EXPORTER_OTLP_ENDPOINT=
 # Standard OpenTelemetry service.name attached to exported traces when KB_OTEL_TRACES is enabled.
 # Default: knowledge-base-mcp-server
 OTEL_SERVICE_NAME=
+
+# Other
+
+# Per-call deadline for network embedding-provider calls; on expiry the call fails with PROVIDER_TIMEOUT and the circuit breaker records it.
+# Default: 120000
+KB_EMBED_TIMEOUT_MS=120000

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -29,6 +29,7 @@ Run `npm run docs:generate-config-reference` after changing the schema.
 | <code>KB_PROVIDER_BREAKER</code> | <code>boolean</code> | <code>on</code> | <code>on</code>, <code>off</code>, <code>true</code>, <code>false</code>, <code>1</code>, <code>0</code>, <code>yes</code>, <code>no</code> |  | uses default | Enables the process-shared open/half-open circuit breaker for embedding and LLM provider calls. |
 | <code>KB_PROVIDER_BREAKER_FAILURE_THRESHOLD</code> | <code>integer</code> | <code>3</code> |  | >= <code>1</code>; <= <code>100</code>; digits only | uses default | Consecutive provider failures before the circuit opens. |
 | <code>KB_PROVIDER_BREAKER_COOLDOWN_MS</code> | <code>duration</code> | <code>30000</code> |  | >= <code>1</code>; <= <code>3600000</code> | uses default | Open-circuit cooldown before a single half-open recovery probe is allowed. |
+| <code>KB_EMBED_TIMEOUT_MS</code> | <code>duration</code> | <code>120000</code> |  | >= <code>1</code> | uses default | Per-call deadline for network embedding-provider calls; on expiry the call fails with PROVIDER_TIMEOUT and the circuit breaker records it. |
 | <code>INDEXING_BATCH_SIZE</code> | <code>integer</code> | <code>64; 16 when EMBEDDING_PROVIDER=ollama</code> |  | >= <code>1</code>; <= <code>512</code> | uses default |  |
 | <code>KB_INDEXING_CONCURRENCY</code> | <code>integer</code> | <code>1</code> |  | >= <code>1</code>; <= <code>4</code> | uses default |  |
 | <code>KB_CHUNK_SIZE</code> | <code>integer</code> | <code>1000</code> |  | >= <code>1</code> | uses default |  |

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -19,6 +19,7 @@ import {
   KNOWN_EMBEDDING_PROVIDERS,
   parseEmbeddingProvider,
   parseEmbeddingTaskPrefixes,
+  parseKbEmbedTimeoutMs,
   parseKbFakeDim,
   UnknownEmbeddingProviderError,
 } from './config/provider.js';
@@ -467,6 +468,25 @@ describe('parseKbFakeDim (#204 — KB_FAKE_DIM)', () => {
     expect(parseKbFakeDim('not-a-number')).toBe(256);
     expect(parseKbFakeDim('0')).toBe(256);
     expect(parseKbFakeDim('-50')).toBe(256);
+  });
+});
+
+describe('parseKbEmbedTimeoutMs (#793 — KB_EMBED_TIMEOUT_MS)', () => {
+  it('returns the 120000ms default when unset or blank', () => {
+    expect(parseKbEmbedTimeoutMs(undefined)).toBe(120_000);
+    expect(parseKbEmbedTimeoutMs('')).toBe(120_000);
+    expect(parseKbEmbedTimeoutMs('   ')).toBe(120_000);
+  });
+
+  it('honors positive values and floors fractional ones', () => {
+    expect(parseKbEmbedTimeoutMs('5000')).toBe(5_000);
+    expect(parseKbEmbedTimeoutMs('250.9')).toBe(250);
+  });
+
+  it('falls back to default for non-numeric / non-positive inputs (stays bounded)', () => {
+    expect(parseKbEmbedTimeoutMs('not-a-number')).toBe(120_000);
+    expect(parseKbEmbedTimeoutMs('0')).toBe(120_000);
+    expect(parseKbEmbedTimeoutMs('-50')).toBe(120_000);
   });
 });
 

--- a/src/config/provider.ts
+++ b/src/config/provider.ts
@@ -119,6 +119,29 @@ export function parseEmbeddingTaskPrefixes(raw: string | undefined): boolean {
 export const KB_EMBEDDING_TASK_PREFIXES: boolean =
   parseEmbeddingTaskPrefixes(process.env.KB_EMBEDDING_TASK_PREFIXES);
 
+// Issue #793 — per-call deadline (ms) that bounds every network
+// embedding-provider call (`embedQuery`/`embedDocuments`). The embed path is
+// the only network stage with no timeout, so a silently-hanging provider
+// socket can stall `retrieve`/`ask`/reindex indefinitely; the deadline
+// converts a hang into a `PROVIDER_TIMEOUT` the circuit breaker can record.
+// Default 120s: generous enough for a cold local Ollama first-load yet
+// bounded. Invalid / non-positive values fall back to the default (the call
+// stays bounded — there is no "disable" escape hatch by design).
+const DEFAULT_KB_EMBED_TIMEOUT_MS = 120_000;
+
+/**
+ * @internal exported only for config tests. Parses `KB_EMBED_TIMEOUT_MS`.
+ * Unset / blank / non-finite / `<= 0` -> default 120000; otherwise floored.
+ */
+export function parseKbEmbedTimeoutMs(raw: string | undefined): number {
+  if (raw === undefined || raw.trim() === '') return DEFAULT_KB_EMBED_TIMEOUT_MS;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_KB_EMBED_TIMEOUT_MS;
+  return Math.floor(parsed);
+}
+
+export const KB_EMBED_TIMEOUT_MS: number = parseKbEmbedTimeoutMs(process.env.KB_EMBED_TIMEOUT_MS);
+
 // Ollama configuration
 export const OLLAMA_BASE_URL = process.env.OLLAMA_BASE_URL || 'http://localhost:11434';
 export const OLLAMA_MODEL = process.env.OLLAMA_MODEL || 'dengcao/Qwen3-Embedding-0.6B:Q8_0';

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -177,6 +177,7 @@ export const CONFIG_SCHEMA: readonly ConfigSpec[] = [
   { name: 'KB_PROVIDER_BREAKER', kind: 'boolean', default: 'on', booleanValues: YES_NO_BOOL_VALUES, truthyValues: YES_NO_TRUTHY_VALUES, description: 'Enables the process-shared open/half-open circuit breaker for embedding and LLM provider calls.' },
   { name: 'KB_PROVIDER_BREAKER_FAILURE_THRESHOLD', kind: 'integer', default: '3', min: 1, max: 100, integerSyntax: 'digits', description: 'Consecutive provider failures before the circuit opens.' },
   { name: 'KB_PROVIDER_BREAKER_COOLDOWN_MS', kind: 'duration', default: '30000', min: 1, max: 3600000, description: 'Open-circuit cooldown before a single half-open recovery probe is allowed.' },
+  { name: 'KB_EMBED_TIMEOUT_MS', kind: 'duration', default: '120000', min: 1, description: 'Per-call deadline for network embedding-provider calls; on expiry the call fails with PROVIDER_TIMEOUT and the circuit breaker records it.' },
 
   { name: 'INDEXING_BATCH_SIZE', kind: 'integer', docDefault: '64; 16 when EMBEDDING_PROVIDER=ollama', defaultValue: (env) => String(defaultIndexingBatchSize(effectiveStringValue(env, 'EMBEDDING_PROVIDER', 'huggingface'))), min: 1, max: 512 },
   { name: 'KB_INDEXING_CONCURRENCY', kind: 'integer', default: '1', min: 1, max: 4 },

--- a/src/embedding-provider.test.ts
+++ b/src/embedding-provider.test.ts
@@ -4,6 +4,7 @@ const originalEnv = {
   EMBEDDING_PROVIDER: process.env.EMBEDDING_PROVIDER,
   KB_FAKE_DIM: process.env.KB_FAKE_DIM,
   KB_EMBEDDING_TASK_PREFIXES: process.env.KB_EMBEDDING_TASK_PREFIXES,
+  KB_EMBED_TIMEOUT_MS: process.env.KB_EMBED_TIMEOUT_MS,
   KB_PROVIDER_BREAKER: process.env.KB_PROVIDER_BREAKER,
   HUGGINGFACE_API_KEY: process.env.HUGGINGFACE_API_KEY,
   OPENAI_API_KEY: process.env.OPENAI_API_KEY,
@@ -216,7 +217,9 @@ describe('embedding task prefixes (issue #567 — nomic-embed-text family)', () 
     // Construction only — OllamaEmbeddings does not touch the network here.
     const client = await createEmbeddingsClient({ provider: 'ollama', modelName: 'nomic-embed-text' });
     expect(client).toBeInstanceOf(CircuitBrokenEmbeddings);
-    const inner = (client as unknown as { inner: unknown }).inner;
+    // Issue #793 — the breaker now wraps a TimeoutEmbeddings deadline layer,
+    // which in turn wraps the task-prefix layer.
+    const inner = (client as unknown as { inner: { inner: unknown } }).inner.inner;
     expect(inner).toBeInstanceOf(TaskPrefixedEmbeddings);
   });
 
@@ -229,7 +232,7 @@ describe('embedding task prefixes (issue #567 — nomic-embed-text family)', () 
       modelName: 'dengcao/Qwen3-Embedding-0.6B:Q8_0',
     });
     expect(client).toBeInstanceOf(CircuitBrokenEmbeddings);
-    const inner = (client as unknown as { inner: unknown }).inner;
+    const inner = (client as unknown as { inner: { inner: unknown } }).inner.inner;
     expect(inner).not.toBeInstanceOf(TaskPrefixedEmbeddings);
   });
 
@@ -239,7 +242,7 @@ describe('embedding task prefixes (issue #567 — nomic-embed-text family)', () 
     });
     const client = await createEmbeddingsClient({ provider: 'ollama', modelName: 'nomic-embed-text' });
     expect(client).toBeInstanceOf(CircuitBrokenEmbeddings);
-    const inner = (client as unknown as { inner: unknown }).inner;
+    const inner = (client as unknown as { inner: { inner: unknown } }).inner.inner;
     expect(inner).not.toBeInstanceOf(TaskPrefixedEmbeddings);
   });
 
@@ -261,7 +264,11 @@ describe('embedding task prefixes (issue #567 — nomic-embed-text family)', () 
     const circuit = client as InstanceType<typeof CircuitBrokenEmbeddings> & {
       embedQuery(text: string): Promise<number[]>;
     };
-    const prefixWrapper = (circuit as unknown as { inner: InstanceType<typeof TaskPrefixedEmbeddings> }).inner;
+    // Issue #793 — unwrap the TimeoutEmbeddings deadline layer that now sits
+    // between the breaker and the task-prefix wrapper.
+    const prefixWrapper = (circuit as unknown as {
+      inner: { inner: InstanceType<typeof TaskPrefixedEmbeddings> };
+    }).inner.inner;
     expect(prefixWrapper).toBeInstanceOf(TaskPrefixedEmbeddings);
     const inner = (prefixWrapper as unknown as { inner: { embedQuery(text: string): Promise<number[]> } }).inner;
     inner.embedQuery = async () => [1];
@@ -318,6 +325,82 @@ describe('embedding task prefixes (issue #567 — nomic-embed-text family)', () 
       state: 'closed',
       consecutive_failures: 0,
     })]);
+  });
+});
+
+describe('TimeoutEmbeddings (issue #793 — per-call embedding deadline)', () => {
+  it('rejects with PROVIDER_TIMEOUT when the inner call hangs past the deadline', async () => {
+    const { TimeoutEmbeddings } = await loadFresh({});
+    const inner = {
+      embedDocuments: () => new Promise<number[][]>(() => {}),
+      embedQuery: () => new Promise<number[]>(() => {}),
+    };
+    const wrapped = new TimeoutEmbeddings(inner, 20);
+
+    await expect(wrapped.embedQuery('hang')).rejects.toMatchObject({ code: 'PROVIDER_TIMEOUT' });
+    await expect(wrapped.embedDocuments(['hang'])).rejects.toMatchObject({ code: 'PROVIDER_TIMEOUT' });
+  });
+
+  it('passes through a fast result without tripping the deadline', async () => {
+    const { TimeoutEmbeddings } = await loadFresh({});
+    const inner = {
+      embedDocuments: async () => [[1, 2, 3]],
+      embedQuery: async () => [1, 2, 3],
+    };
+    const wrapped = new TimeoutEmbeddings(inner, 1_000);
+
+    await expect(wrapped.embedQuery('fast')).resolves.toEqual([1, 2, 3]);
+    await expect(wrapped.embedDocuments(['fast'])).resolves.toEqual([[1, 2, 3]]);
+  });
+
+  it('a hang surfaces PROVIDER_TIMEOUT through the breaker, which records the failure and opens', async () => {
+    const { CircuitBrokenEmbeddings, TimeoutEmbeddings } = await loadFresh({});
+    const { ProviderBreakerRegistry } = await import('./provider-breaker.js');
+    const breaker = new ProviderBreakerRegistry({ failureThreshold: 1, cooldownMs: 1_000 });
+    const hangingInner = {
+      embedDocuments: () => new Promise<number[][]>(() => {}),
+      embedQuery: () => new Promise<number[]>(() => {}),
+    };
+    const key = 'embedding:ollama:http://localhost:11434:nomic';
+    const wrapped = new CircuitBrokenEmbeddings(
+      new TimeoutEmbeddings(hangingInner, 20),
+      key,
+      breaker,
+    );
+
+    await expect(wrapped.embedQuery('hang')).rejects.toMatchObject({ code: 'PROVIDER_TIMEOUT' });
+    // Threshold is 1, so the recorded timeout opens the circuit; the next
+    // call fast-fails with PROVIDER_UNAVAILABLE instead of hanging again.
+    await expect(wrapped.embedQuery('again')).rejects.toMatchObject({
+      name: 'ProviderCircuitOpenError',
+      code: 'PROVIDER_UNAVAILABLE',
+    });
+    expect(breaker.snapshot()).toEqual([expect.objectContaining({
+      key,
+      state: 'open',
+      consecutive_failures: 1,
+    })]);
+  });
+
+  it('createEmbeddingsClient wraps the network arm with a TimeoutEmbeddings inside the breaker', async () => {
+    const { CircuitBrokenEmbeddings, TimeoutEmbeddings, createEmbeddingsClient } = await loadFresh({
+      KB_EMBED_TIMEOUT_MS: '4321',
+      KB_EMBEDDING_TASK_PREFIXES: '0',
+    });
+    const client = await createEmbeddingsClient({ provider: 'ollama', modelName: 'mxbai-embed-large' });
+    expect(client).toBeInstanceOf(CircuitBrokenEmbeddings);
+    const timeout = (client as unknown as { inner: unknown }).inner;
+    expect(timeout).toBeInstanceOf(TimeoutEmbeddings);
+    expect((timeout as InstanceType<typeof TimeoutEmbeddings>).timeoutMs).toBe(4321);
+  });
+
+  it('does not wrap the fake provider with a deadline (offline, no breaker)', async () => {
+    const { CircuitBrokenEmbeddings, TimeoutEmbeddings, FakeEmbeddings, createEmbeddingsClient } =
+      await loadFresh({ KB_FAKE_DIM: '32' });
+    const client = await createEmbeddingsClient({ provider: 'fake', modelName: 'fake-model' });
+    expect(client).toBeInstanceOf(FakeEmbeddings);
+    expect(client).not.toBeInstanceOf(CircuitBrokenEmbeddings);
+    expect(client).not.toBeInstanceOf(TimeoutEmbeddings);
   });
 });
 

--- a/src/embedding-provider.ts
+++ b/src/embedding-provider.ts
@@ -13,6 +13,7 @@ import {
   HUGGINGFACE_ENDPOINT_URL,
   HUGGINGFACE_ENDPOINT_URL_OVERRIDDEN,
   HUGGINGFACE_PROVIDER,
+  KB_EMBED_TIMEOUT_MS,
   KB_EMBEDDING_TASK_PREFIXES,
   KB_FAKE_DIM,
   OLLAMA_BASE_URL,
@@ -138,12 +139,75 @@ export class CircuitBrokenEmbeddings {
   }
 }
 
+/**
+ * Issue #793 — bounds every network embedding call with a per-call deadline.
+ * The embed path is the only network stage with no timeout, so a
+ * silently-hanging (not-erroring) provider socket can stall `retrieve`,
+ * `ask`, and reindex indefinitely. This decorator sits INSIDE the circuit
+ * breaker (the breaker wraps it) so an expired deadline throws
+ * `KBError('PROVIDER_TIMEOUT')`, which `shouldRecordEmbeddingBreakerFailure`
+ * counts as a breaker failure — making the previously-dead `PROVIDER_TIMEOUT`
+ * branch reachable on the embed path.
+ *
+ * Cancellation caveat: the LangChain embeddings interface
+ * (`embedDocuments`/`embedQuery`) does not accept a per-call `AbortSignal`,
+ * so on expiry we ABANDON the in-flight promise — the underlying fetch may
+ * keep running to completion — rather than truly cancelling it. We still
+ * create an `AbortController` and `abort()` it on the deadline so a
+ * signal-aware inner client can observe the cancellation; today's providers
+ * do not, which is the pragmatic fallback the issue calls out.
+ */
+export class TimeoutEmbeddings {
+  constructor(
+    private readonly inner: {
+      embedDocuments(texts: string[]): Promise<number[][]>;
+      embedQuery(text: string): Promise<number[]>;
+    },
+    readonly timeoutMs: number,
+  ) {}
+
+  async embedDocuments(texts: string[]): Promise<number[][]> {
+    return this.withDeadline('embedDocuments', () => this.inner.embedDocuments(texts));
+  }
+
+  async embedQuery(text: string): Promise<number[]> {
+    return this.withDeadline('embedQuery', () => this.inner.embedQuery(text));
+  }
+
+  private async withDeadline<T>(method: string, call: () => Promise<T>): Promise<T> {
+    const controller = new AbortController();
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const deadline = new Promise<never>((_, reject) => {
+      timer = setTimeout(() => {
+        controller.abort();
+        reject(
+          new KBError(
+            'PROVIDER_TIMEOUT',
+            `embedding provider ${method} exceeded ${this.timeoutMs}ms deadline`,
+          ),
+        );
+      }, this.timeoutMs);
+    });
+    const inFlight = call();
+    // If the deadline wins the race, `inFlight` is abandoned; swallow any late
+    // rejection on that orphaned branch so it does not surface as an
+    // unhandledRejection after we have already thrown PROVIDER_TIMEOUT.
+    inFlight.catch(() => {});
+    try {
+      return await Promise.race([inFlight, deadline]);
+    } finally {
+      if (timer !== null) clearTimeout(timer);
+    }
+  }
+}
+
 export type EmbeddingsClient =
   | HuggingFaceInferenceEmbeddings
   | OllamaEmbeddings
   | OpenAIEmbeddings
   | FakeEmbeddings
   | TaskPrefixedEmbeddings
+  | TimeoutEmbeddings
   | CircuitBrokenEmbeddings;
 
 export interface CreateEmbeddingsOptions {
@@ -195,6 +259,10 @@ export async function createEmbeddingsClient(
   }
   const breakerKey = embeddingProviderBreakerKey(provider, modelName);
   if (breakerKey !== null) {
+    // Issue #793 — bound the call BEFORE the breaker wraps it, so an expired
+    // deadline surfaces as PROVIDER_TIMEOUT and the breaker records it. The
+    // fake provider (breakerKey === null) is offline and needs no deadline.
+    client = new TimeoutEmbeddings(client, KB_EMBED_TIMEOUT_MS);
     client = new CircuitBrokenEmbeddings(client, breakerKey);
   }
   if (options.modelId !== undefined) {


### PR DESCRIPTION
## Summary

The embedding-provider call was the only network stage in the retrieval/reindex pipeline with **no timeout**. A silently-hanging (not-erroring) provider socket could stall `retrieve`, `ask`, and reindex indefinitely — and, critically, the provider circuit breaker's `PROVIDER_TIMEOUT` failure branch (`src/embedding-provider.ts` `shouldRecordEmbeddingBreakerFailure`) was effectively dead code on this path, because nothing ever converted an embedding hang into a failure.

This adds a per-call deadline that trips the breaker.

## Changes

- **`TimeoutEmbeddings` decorator** (`src/embedding-provider.ts`): wraps the inner client so every `embedQuery` / `embedDocuments` call races against an `AbortController`-backed deadline. On expiry it throws `KBError('PROVIDER_TIMEOUT')`.
- **Wired INSIDE the circuit breaker**: the breaker wraps the timeout decorator (`… → TaskPrefixed → Timeout → CircuitBroken`), so an expired deadline surfaces as `PROVIDER_TIMEOUT` and the existing breaker predicate records the failure — making the previously-unreachable recovery path live. Applied only to network providers (the offline `fake` provider is skipped).
- **New config `KB_EMBED_TIMEOUT_MS`** (`src/config/provider.ts`, additive schema entry in `src/config/schema.ts`): duration, default **120000ms** — generous enough for a cold local Ollama first-load yet bounded. Invalid / non-positive values fall back to the default (stays bounded; no disable escape hatch by design).
- Regenerated `docs/reference/configuration.md` and `.env.example` from the schema.

## Design note (smallest implementation)

LangChain's embeddings interface (`embedDocuments`/`embedQuery`) does not accept a per-call `AbortSignal`, so on expiry the in-flight promise is **abandoned** (the underlying fetch may run to completion) rather than truly cancelled — the pragmatic fallback the issue calls out. An `AbortController` is still created and `abort()`-ed on the deadline so a future signal-aware inner client can observe cancellation, and the orphaned promise's late rejection is swallowed to avoid an `unhandledRejection`.

## Tests

- `TimeoutEmbeddings` rejects with `PROVIDER_TIMEOUT` when the inner call hangs past the deadline, and passes fast results through untouched.
- A hang surfaces `PROVIDER_TIMEOUT` **through the breaker**, which records the failure and opens the circuit (next call fast-fails with `PROVIDER_UNAVAILABLE`).
- `createEmbeddingsClient` wraps the network arm with `TimeoutEmbeddings` inside the breaker; the `fake` provider is not wrapped.
- `parseKbEmbedTimeoutMs` unit tests for defaults / flooring / non-positive fallback.

`npm run build`, `npm run lint`, and the targeted jest suites (`embedding-provider`, `provider-breaker`, `config`) pass; config-reference / env-example / env-usage doc checks pass.

Closes #793

🤖 Generated with [Claude Code](https://claude.com/claude-code)