### PR TITLE
fix: retry transient Ollama embedding socket errors and correct non-retryable labeling

### DIFF
--- a/src/ollama-error.test.ts
+++ b/src/ollama-error.test.ts
@@ -1,6 +1,7 @@
 import {
   isOllamaContextLengthError,
   isNonRetryableOllamaError,
+  isTransientOllamaSocketError,
   translateOllamaEmbeddingError,
   makeOllamaOnFailedAttempt,
 } from './ollama-error.js';
@@ -90,6 +91,65 @@ describe('isNonRetryableOllamaError', () => {
     });
     expect(isNonRetryableOllamaError(err)).toBe(true);
   });
+
+  // Issue #801 — transient runner-socket drops must stay retryable, even if a
+  // future daemon build wraps one in a ResponseError with an odd status.
+  it('leaves a raw EOF socket error retryable', () => {
+    const err = new Error(
+      'do embedding request: Post "http://127.0.0.1:40757/v1/embeddings": EOF',
+    );
+    expect(isNonRetryableOllamaError(err)).toBe(false);
+  });
+
+  it('does not flag a ResponseError-wrapped EOF as non-retryable', () => {
+    const err = new FakeOllamaResponseError(
+      'do embedding request: Post "http://127.0.0.1:40757/v1/embeddings": EOF',
+      500,
+    );
+    expect(isNonRetryableOllamaError(err)).toBe(false);
+  });
+});
+
+describe('isTransientOllamaSocketError', () => {
+  it.each([
+    'do embedding request: Post "http://127.0.0.1:40757/v1/embeddings": EOF',
+    'read ECONNRESET',
+    'socket hang up',
+    'ETIMEDOUT',
+    'connect ECONNREFUSED 127.0.0.1:40757',
+  ])('classifies %j as transient', (message) => {
+    expect(isTransientOllamaSocketError(new Error(message))).toBe(true);
+  });
+
+  it('classifies a fetch failure nested in .cause as transient', () => {
+    const err = Object.assign(new TypeError('fetch failed'), {
+      cause: new Error('read ECONNRESET'),
+    });
+    expect(isTransientOllamaSocketError(err)).toBe(true);
+  });
+
+  it('classifies by node error .code', () => {
+    const err = Object.assign(new Error('socket error'), { code: 'ECONNRESET' });
+    expect(isTransientOllamaSocketError(err)).toBe(true);
+  });
+
+  it('does not classify a 4xx schema violation as transient', () => {
+    const err = new FakeOllamaResponseError('not found', 404);
+    expect(isTransientOllamaSocketError(err)).toBe(false);
+  });
+
+  it('does not classify a context-length overflow as transient', () => {
+    const err = new FakeOllamaResponseError(
+      'the input length exceeds the context length',
+      400,
+    );
+    expect(isTransientOllamaSocketError(err)).toBe(false);
+  });
+
+  it('returns false for non-objects', () => {
+    expect(isTransientOllamaSocketError(undefined)).toBe(false);
+    expect(isTransientOllamaSocketError('EOF')).toBe(false);
+  });
 });
 
 describe('translateOllamaEmbeddingError', () => {
@@ -131,6 +191,44 @@ describe('translateOllamaEmbeddingError', () => {
     expect(translated.message).toContain('fake-model');
     expect(translated.message).toContain('not found');
   });
+
+  it('still labels a genuinely terminal 4xx "non-retryable"', () => {
+    const err = new FakeOllamaResponseError('forbidden', 403);
+    const translated = translateOllamaEmbeddingError(err, 'fake-model');
+    expect(translated.message).toContain('non-retryable');
+  });
+
+  // Issue #801 — a transient EOF must NOT be reported as "non-retryable".
+  it('describes a transient EOF accurately, not as "non-retryable"', () => {
+    const err = new FakeOllamaResponseError(
+      'do embedding request: Post "http://127.0.0.1:40757/v1/embeddings": EOF',
+      500,
+    );
+    const translated = translateOllamaEmbeddingError(err, 'nomic-embed-text:latest');
+    expect(translated).toBeInstanceOf(KBError);
+    expect(translated.code).toBe('PROVIDER_UNAVAILABLE');
+    expect(translated.message).not.toContain('non-retryable');
+    expect(translated.message).toContain('transient socket error');
+    expect(translated.message).toContain('nomic-embed-text:latest');
+    // Preserve the underlying detail for diagnosis.
+    expect(translated.message).toContain('EOF');
+  });
+
+  it('describes a raw ECONNRESET as transient, not non-retryable', () => {
+    const translated = translateOllamaEmbeddingError(
+      new Error('read ECONNRESET'),
+      'nomic-embed-text:latest',
+    );
+    expect(translated.message).not.toContain('non-retryable');
+    expect(translated.message).toContain('transient socket error');
+  });
+
+  it('does not claim "non-retryable" for an unknown non-context error', () => {
+    const err = new FakeOllamaResponseError('internal server error', 500);
+    const translated = translateOllamaEmbeddingError(err, 'fake-model');
+    expect(translated.message).not.toContain('non-retryable');
+    expect(translated.message).toContain('internal server error');
+  });
 });
 
 describe('makeOllamaOnFailedAttempt', () => {
@@ -166,5 +264,16 @@ describe('makeOllamaOnFailedAttempt', () => {
   it('does NOT throw on plain Error (network jitter etc.)', () => {
     const handler = makeOllamaOnFailedAttempt('foo');
     expect(() => handler(new Error('ECONNRESET'))).not.toThrow();
+  });
+
+  // Issue #801 — a transient runner-socket EOF must stay retryable so the
+  // AsyncCaller keeps retrying instead of aborting the whole rebuild.
+  it('does NOT throw on a transient EOF (keeps retrying)', () => {
+    const handler = makeOllamaOnFailedAttempt('nomic-embed-text:latest');
+    const err = new FakeOllamaResponseError(
+      'do embedding request: Post "http://127.0.0.1:40757/v1/embeddings": EOF',
+      500,
+    );
+    expect(() => handler(err)).not.toThrow();
   });
 });

--- a/src/ollama-error.ts
+++ b/src/ollama-error.ts
@@ -25,10 +25,51 @@ interface OllamaResponseErrorShape {
   response?: { status?: number };
   message?: string;
   name?: string;
+  code?: string;
+  cause?: unknown;
 }
 
 function readStatus(err: OllamaResponseErrorShape): number | undefined {
   return err.status_code ?? err.status ?? err.response?.status;
+}
+
+// Transient socket / connection drops that mean "the model runner hiccuped,
+// try again" rather than "your request is malformed" (issue #801). On
+// CPU-based Ollama (e.g. WSL2) the dynamic model-runner subprocess can drop a
+// connection or respawn mid-batch; the daemon surfaces this as a bare `EOF`,
+// `ECONNRESET`, `socket hang up`, or a fetch `TypeError: fetch failed`. None of
+// these carry a 4xx status, so they are safe to retry once the runner is back.
+const TRANSIENT_SOCKET_PATTERNS = [
+  /\bEOF\b/,
+  /ECONNRESET/,
+  /socket hang up/i,
+  /fetch failed/i,
+  /ECONNREFUSED/,
+  /ETIMEDOUT/,
+  /EPIPE/,
+];
+
+/**
+ * True when `err` looks like a transient socket/connection drop from the
+ * Ollama model runner. These are RETRYABLE — the runner typically respawns
+ * and a re-attempt succeeds — and must never be labelled "non-retryable".
+ * Walks `.message`, `.code`, and a nested `.cause` (fetch failures wrap the
+ * real socket error there).
+ */
+export function isTransientOllamaSocketError(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false;
+  const e = err as OllamaResponseErrorShape;
+  const msg = typeof e.message === 'string' ? e.message : '';
+  const code = typeof e.code === 'string' ? e.code : '';
+  if (TRANSIENT_SOCKET_PATTERNS.some((p) => p.test(msg) || (code && p.test(code)))) {
+    return true;
+  }
+  // fetch() rejections carry `TypeError: fetch failed` with the underlying
+  // socket error nested in `.cause` — unwrap one level.
+  if (e.cause && e.cause !== err) {
+    return isTransientOllamaSocketError(e.cause);
+  }
+  return false;
 }
 
 export function isOllamaContextLengthError(err: unknown): boolean {
@@ -47,6 +88,10 @@ export function isOllamaContextLengthError(err: unknown): boolean {
 
 export function isNonRetryableOllamaError(err: unknown): boolean {
   if (isOllamaContextLengthError(err)) return true;
+  // Transient socket drops (EOF, ECONNRESET, ...) are retryable even when the
+  // Ollama daemon happens to wrap them in a ResponseError (issue #801) — guard
+  // before the status check so they never fall through to a terminal verdict.
+  if (isTransientOllamaSocketError(err)) return false;
   if (!err || typeof err !== 'object') return false;
   const e = err as OllamaResponseErrorShape;
   if (e.name !== 'ResponseError') return false;
@@ -76,15 +121,37 @@ export function translateOllamaEmbeddingError(err: unknown, model: string): KBEr
       `(e.g. ${suggestions}) and retry. See README → Ollama Configuration.`;
     return new KBError('VALIDATION', message, err);
   }
-  // Generic non-retryable Ollama 4xx — keep the original message but tag it
-  // so callers know we already decided not to retry.
   const original =
     err && typeof err === 'object' && 'message' in err
       ? String((err as { message?: unknown }).message ?? '')
       : String(err);
+  // Transient socket drop (issue #801). This is NOT deterministic — the model
+  // runner dropped or respawned mid-request. Say so accurately instead of
+  // mislabelling it "non-retryable", which sends operators hunting for a
+  // config bug that isn't there.
+  if (isTransientOllamaSocketError(err)) {
+    return new KBError(
+      'PROVIDER_UNAVAILABLE',
+      `Ollama embedding request for model \`${model}\` failed after exhausting retries on a ` +
+        `transient socket error (the model runner dropped the connection or was respawning). ` +
+        `This is not a deterministic failure — re-running usually succeeds. Original error: ${original}`,
+      err,
+    );
+  }
+  // Genuinely terminal Ollama 4xx schema violation — keep the original message
+  // but tag it so callers know we deliberately did not retry.
+  if (isNonRetryableOllamaError(err)) {
+    return new KBError(
+      'PROVIDER_UNAVAILABLE',
+      `Ollama embedding request for model \`${model}\` failed with a non-retryable error: ${original}`,
+      err,
+    );
+  }
+  // Unknown / retryable-but-exhausted failure — do not claim it was
+  // non-retryable, since we cannot prove that.
   return new KBError(
     'PROVIDER_UNAVAILABLE',
-    `Ollama embedding request for model \`${model}\` failed with a non-retryable error: ${original}`,
+    `Ollama embedding request for model \`${model}\` failed: ${original}`,
     err,
   );
 }


### PR DESCRIPTION
## What

Fixes the diagnosis half of #801: a single transient Ollama model-runner socket drop (`EOF`, `ECONNRESET`, `socket hang up`, fetch `TypeError: fetch failed`) during `kb reindex` was surfaced to operators as a **"non-retryable"** error, even though re-running succeeded. This change makes the classification and the operator-facing message accurate.

All work is confined to `src/ollama-error.ts` and its test — the retry predicate (`makeOllamaOnFailedAttempt`), classifier (`isNonRetryableOllamaError`), and message builder (`translateOllamaEmbeddingError`) all live there.

## Changes

- **New `isTransientOllamaSocketError(err)`** — classifies runner-socket drops as transient by scanning `.message`, node `.code`, and a nested `.cause` (fetch failures wrap the real socket error there). Patterns: `EOF`, `ECONNRESET`, `socket hang up`, `fetch failed`, `ECONNREFUSED`, `ETIMEDOUT`, `EPIPE`.
- **`isNonRetryableOllamaError`** now short-circuits to `false` for transient socket errors *before* the status check, so a drop stays retryable even if a future daemon build wraps it in a `ResponseError` with an odd status. The `onFailedAttempt` handler therefore does **not** throw on these → the AsyncCaller keeps retrying instead of aborting the whole rebuild.
- **`translateOllamaEmbeddingError` generic branch reworked** into three cases:
  1. transient socket drop → accurate "failed after exhausting retries on a transient socket error … not a deterministic failure" message (no "non-retryable");
  2. genuinely terminal 4xx → keeps the existing "non-retryable error" label;
  3. unknown / retryable-but-exhausted → plain "failed: …" with no false "non-retryable" claim.

Context-length overflow and 4xx schema violations stay terminal exactly as before.

## Tests

Extended `src/ollama-error.test.ts` (50 pass):
- raw `EOF` and `ResponseError`-wrapped `EOF` classified retryable;
- new `isTransientOllamaSocketError` suite (message, `.code`, nested `.cause`; 4xx and context-overflow correctly excluded);
- transient EOF / ECONNRESET produce an accurate message that does **not** contain "non-retryable" but preserves the underlying detail;
- terminal 4xx and context-overflow remain terminal and keep their labels.

`npm run build` and `jest src/ollama-error.test.ts` both pass.

## Scope / deferred

Implements **items 1 and 2** only from the issue. **Item 3 (embedding-batch checkpoint/resume)** is explicitly called out in the issue as "Larger" and is **deferred** — it requires threading checkpoint state through the FAISS full-rebuild path (out of this file's scope) and is better handled alongside the companion "avoid full rebuilds entirely" issue. This change shrinks the blast radius by keeping transient drops inside the existing retry loop and by no longer mislabeling them, but does not add resume.

Note: the retry backoff itself is governed by the AsyncCaller config in `embedding-provider.ts` (owned by a concurrent task and intentionally untouched here); this PR ensures transient drops remain *inside* that retry loop rather than escaping it as terminal.

Closes #801