### PR TITLE
feat: expose --tag/--extension/--path-glob filters on kb search CLI

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1393,6 +1393,16 @@ Scope:
   --until=<time>        Dense-only: keep chunks whose current source-file
                         mtime is at or before this bound. File mtime can
                         differ from indexed-content time on stale indexes.
+  --tag=<name>          Dense-only: keep only chunks whose source file has
+                        the given tag in its YAML frontmatter. Repeatable;
+                        multiple tags are ANDed (a chunk must carry ALL of
+                        them), mirroring retrieve_knowledge.
+  --extension=<ext>     Dense-only: keep only chunks whose source file has
+                        one of these extensions (e.g. .md, .pdf).
+                        Case-insensitive; leading dot optional. Repeatable.
+  --path-glob=<glob>    Dense-only: keep only chunks whose KB-internal
+                        relative path matches this glob (e.g. "runbooks/**").
+                        The KB-name segment is stripped before matching.
 
 Result tuning:
   --threshold=<float>   Max similarity score; lower = closer match (default 2).

--- a/src/cli-search.test.ts
+++ b/src/cli-search.test.ts
@@ -9,10 +9,16 @@ import {
   formatRefreshProgressLine,
   parseSearchArgs,
   runSearch,
+  searchFiltersFromArgs,
   shouldUsePicker,
   takeLastSearchCanonicalTelemetry,
   type RunSearchDeps,
 } from './cli-search.js';
+import type { Document } from '@langchain/core/documents';
+import {
+  createSimilaritySearchPostFilter,
+  type ScoredDocument as EngineScoredDocument,
+} from './search-filters.js';
 import { KNOWLEDGE_BASES_ROOT_DIR } from './config/paths.js';
 import { compactTimingPayload, type TimingPayload } from './timing-core.js';
 import type { ScoredDocument } from './formatter.js';
@@ -229,6 +235,100 @@ describe('parseSearchArgs recency filters (#609)', () => {
     expect(() => parseSearchArgs(['query', '--since=24h', '--until=30d'])).toThrow(
       /invalid recency range/,
     );
+  });
+});
+
+describe('parseSearchArgs metadata filters (#790)', () => {
+  it('parses repeatable --tag / --extension and single --path-glob', () => {
+    expect(parseSearchArgs([
+      'query',
+      '--tag=alpha',
+      '--tag=beta',
+      '--extension=.md',
+      '--extension=pdf',
+      '--path-glob=runbooks/**',
+    ])).toMatchObject({
+      tags: ['alpha', 'beta'],
+      extensions: ['.md', 'pdf'],
+      pathGlob: 'runbooks/**',
+    });
+  });
+
+  it('defaults to empty filter arrays and undefined path glob', () => {
+    const parsed = parseSearchArgs(['query']);
+    expect(parsed).toMatchObject({ tags: [], extensions: [] });
+    expect(parsed.pathGlob).toBeUndefined();
+  });
+
+  it('rejects empty filter values', () => {
+    expect(() => parseSearchArgs(['query', '--tag='])).toThrow(/--tag/);
+    expect(() => parseSearchArgs(['query', '--extension='])).toThrow(/--extension/);
+    expect(() => parseSearchArgs(['query', '--path-glob='])).toThrow(/--path-glob/);
+  });
+
+  it('omits filters entirely when no metadata or recency flag is set', () => {
+    expect(searchFiltersFromArgs(parseSearchArgs(['query']))).toBeUndefined();
+  });
+
+  it('carries parsed metadata flags into SimilaritySearchFilters', () => {
+    expect(searchFiltersFromArgs(parseSearchArgs([
+      'query',
+      '--tag=alpha',
+      '--tag=beta',
+      '--extension=.md',
+      '--path-glob=runbooks/**',
+    ]))).toEqual({
+      since: undefined,
+      until: undefined,
+      tags: ['alpha', 'beta'],
+      extensions: ['.md'],
+      pathGlob: 'runbooks/**',
+    });
+  });
+});
+
+describe('kb search metadata filters scope results via the shared engine (#790)', () => {
+  function doc(
+    pageContent: string,
+    metadata: Record<string, unknown>,
+    score = 0.1,
+  ): EngineScoredDocument {
+    return [{ pageContent, metadata } as Document, score];
+  }
+
+  function applyFrom(args: string[], docs: EngineScoredDocument[]): string[] {
+    const filter = createSimilaritySearchPostFilter({
+      threshold: 2,
+      knowledgeBasesRootDir: '/kb-root',
+      filters: searchFiltersFromArgs(parseSearchArgs(['query', ...args])),
+    });
+    return filter.apply(docs).map(([d]) => d.pageContent);
+  }
+
+  const docs: EngineScoredDocument[] = [
+    doc('md-runbook', { extension: '.md', relativePath: 'ops/runbooks/rollback.md', tags: ['ops', 'urgent'] }),
+    doc('md-note', { extension: '.md', relativePath: 'ops/notes/idea.md', tags: ['ops'] }),
+    doc('pdf-runbook', { extension: '.pdf', relativePath: 'ops/runbooks/deploy.pdf', tags: ['ops', 'urgent'] }),
+  ];
+
+  it('--extension keeps only matching source extensions (case-insensitive)', () => {
+    expect(applyFrom(['--extension=md'], docs).sort()).toEqual(['md-note', 'md-runbook']);
+    expect(applyFrom(['--extension=.PDF'], docs)).toEqual(['pdf-runbook']);
+  });
+
+  it('--path-glob keeps only KB-internal paths matching the glob', () => {
+    expect(applyFrom(['--path-glob=runbooks/**'], docs).sort()).toEqual(['md-runbook', 'pdf-runbook']);
+  });
+
+  it('--tag is ALL-match: every tag must be present', () => {
+    expect(applyFrom(['--tag=ops'], docs).sort()).toEqual(['md-note', 'md-runbook', 'pdf-runbook']);
+    expect(applyFrom(['--tag=ops', '--tag=urgent'], docs).sort()).toEqual(['md-runbook', 'pdf-runbook']);
+    expect(applyFrom(['--tag=ops', '--tag=missing'], docs)).toEqual([]);
+  });
+
+  it('combines metadata filters with AND semantics', () => {
+    expect(applyFrom(['--extension=md', '--path-glob=runbooks/**', '--tag=urgent'], docs))
+      .toEqual(['md-runbook']);
   });
 });
 
@@ -1426,6 +1526,32 @@ describe('runSearch timing guard (#331)', () => {
 
     expect(out.code).toBe(2);
     expect(out.stderr).toContain('--candidate-pool-k is only supported with --mode=hybrid');
+  });
+
+  it('rejects metadata filters outside dense mode (#790)', async () => {
+    const { deps } = makeDeps();
+
+    const out = await captureSearchOutput(['query', '--mode=hybrid', '--tag=ops'], deps);
+
+    expect(out.code).toBe(2);
+    expect(out.stderr).toContain('--tag/--extension/--path-glob are only supported with --mode=dense');
+  });
+
+  it('forwards metadata filters into dense similaritySearch (#790)', async () => {
+    const { deps, manager } = makeDeps();
+
+    const out = await captureSearchOutput(
+      ['query', '--extension=.md', '--path-glob=runbooks/**', '--tag=ops', '--tag=urgent', '--format=json'],
+      deps,
+    );
+
+    expect(out.code).toBe(0);
+    const filtersArg = (manager.similaritySearch as jest.Mock).mock.calls[0][4];
+    expect(filtersArg).toMatchObject({
+      extensions: ['.md'],
+      pathGlob: 'runbooks/**',
+      tags: ['ops', 'urgent'],
+    });
   });
 
   it('rejects query decomposition outside hybrid mode', async () => {

--- a/src/cli-search.ts
+++ b/src/cli-search.ts
@@ -181,6 +181,16 @@ Scope:
   --until=<time>        Dense-only: keep chunks whose current source-file
                         mtime is at or before this bound. File mtime can
                         differ from indexed-content time on stale indexes.
+  --tag=<name>          Dense-only: keep only chunks whose source file has
+                        the given tag in its YAML frontmatter. Repeatable;
+                        multiple tags are ANDed (a chunk must carry ALL of
+                        them), mirroring retrieve_knowledge.
+  --extension=<ext>     Dense-only: keep only chunks whose source file has
+                        one of these extensions (e.g. .md, .pdf).
+                        Case-insensitive; leading dot optional. Repeatable.
+  --path-glob=<glob>    Dense-only: keep only chunks whose KB-internal
+                        relative path matches this glob (e.g. "runbooks/**").
+                        The KB-name segment is stripped before matching.
 
 Result tuning:
   --threshold=<float>   Max similarity score; lower = closer match (default 2).
@@ -342,6 +352,9 @@ interface SearchArgs {
   thresholdAuto: boolean;
   since?: string;
   until?: string;
+  extensions: string[];
+  pathGlob?: string;
+  tags: string[];
   k: number;
   format: SearchFormat;
   refresh: boolean;
@@ -510,6 +523,10 @@ export async function runSearch(
   }
   if (hasRecencyFilter(parsed) && effectiveMode !== 'dense') {
     process.stderr.write('kb search: --since/--until are only supported with --mode=dense\n');
+    return 2;
+  }
+  if (hasMetadataFilter(parsed) && effectiveMode !== 'dense') {
+    process.stderr.write('kb search: --tag/--extension/--path-glob are only supported with --mode=dense\n');
     return 2;
   }
   if (parsed.candidatePoolK !== undefined && effectiveMode !== 'hybrid') {
@@ -968,6 +985,8 @@ export function parseSearchArgs(rest: string[]): SearchArgs {
     antiQueries: [],
     plusQueries: [],
     minusQueries: [],
+    extensions: [],
+    tags: [],
     lexicalUnit: 'chunk',
     decompose: false,
     decomposeProvider: 'rule',
@@ -1091,6 +1110,18 @@ export function parseSearchArgs(rest: string[]): SearchArgs {
     }
     if (raw.startsWith('--since=')) { out.since = raw.slice('--since='.length); continue; }
     if (raw.startsWith('--until=')) { out.until = raw.slice('--until='.length); continue; }
+    if (raw.startsWith('--extension=')) {
+      out.extensions.push(parseNonEmptyComponent(raw, '--extension='));
+      continue;
+    }
+    if (raw.startsWith('--tag=')) {
+      out.tags.push(parseNonEmptyComponent(raw, '--tag='));
+      continue;
+    }
+    if (raw.startsWith('--path-glob=')) {
+      out.pathGlob = parseNonEmptyComponent(raw, '--path-glob=');
+      continue;
+    }
     if (raw.startsWith('--k=')) {
       const n = Number(raw.slice('--k='.length));
       if (!Number.isInteger(n) || n <= 0) throw new Error(`invalid --k: ${raw}`);
@@ -1147,10 +1178,27 @@ function hasRecencyFilter(args: Pick<SearchArgs, 'since' | 'until'>): boolean {
   return args.since !== undefined || args.until !== undefined;
 }
 
-function searchFiltersFromArgs(args: Pick<SearchArgs, 'since' | 'until'>): SimilaritySearchFilters | undefined {
-  return hasRecencyFilter(args)
-    ? { since: args.since, until: args.until }
-    : undefined;
+function hasMetadataFilter(args: Pick<SearchArgs, 'extensions' | 'pathGlob' | 'tags'>): boolean {
+  return args.extensions.length > 0 || args.pathGlob !== undefined || args.tags.length > 0;
+}
+
+// Mirror the MCP `retrieve_knowledge` filter semantics exactly (#790): the
+// engine ANDs `extensions`/`path_glob`/`tags` with each other and with the
+// KB scope + threshold, and requires ALL tags to be present. We hand the
+// parsed flags straight to `SimilaritySearchFilters` so normalization (case-
+// insensitive extensions, KB-name-stripped glob, ALL-match tags) stays owned
+// by the shared engine rather than duplicated on the CLI.
+export function searchFiltersFromArgs(
+  args: Pick<SearchArgs, 'since' | 'until' | 'extensions' | 'pathGlob' | 'tags'>,
+): SimilaritySearchFilters | undefined {
+  if (!hasRecencyFilter(args) && !hasMetadataFilter(args)) return undefined;
+  return {
+    since: args.since,
+    until: args.until,
+    extensions: args.extensions.length > 0 ? args.extensions : undefined,
+    pathGlob: args.pathGlob,
+    tags: args.tags.length > 0 ? args.tags : undefined,
+  };
 }
 
 function parseNonEmptyComponent(raw: string, prefix: string): string {


### PR DESCRIPTION
## Summary

`kb search` only understood `--since`/`--until`, even though the shared
`SimilaritySearchFilters` engine already supports scoping by tag, file
extension, and KB-internal path glob — and those filters are already exposed
on the MCP `retrieve_knowledge` tool (#53 / PR #123). This closes that
CLI↔MCP capability gap.

## What changed

- **`src/cli-search.ts`**
  - Parse `--tag` (repeatable), `--extension` (repeatable), and `--path-glob`
    (single) in `parseSearchArgs`.
  - Extend `searchFiltersFromArgs` to carry them straight into the existing
    engine, so normalization (case-insensitive extensions, KB-name-stripped
    glob, ALL-match tags) stays owned by `src/search-filters.ts` (unchanged).
  - Gate the filters to `--mode=dense`, consistent with the existing
    `--since`/`--until` behavior.
  - Update `SEARCH_HELP`.
- **`docs/reference/cli.md`** — regenerated via `scripts/gen-cli-reference.mjs`
  (not hand-edited); `npm run docs:check-cli` passes.
- **`src/cli-search.test.ts`** — focused tests asserting each flag scopes
  results through the real engine, that `--tag` is ALL-match, that filters AND
  together, that flags forward into dense `similaritySearch`, and that they are
  rejected outside `--mode=dense`.

## Semantics (mirrors `retrieve_knowledge` exactly)

- `--tag` is **ALL-match**: a chunk must carry every provided tag.
- `--extension` is case-insensitive; leading dot optional.
- `--path-glob` matches the KB-internal relative path (the KB-name segment is
  stripped before matching).
- All filters AND together and with the KB scope + threshold.

## Design notes (choices the issue left open)

- **Repeatable flags, not comma-split**, matching the MCP array schema:
  `--tag a --tag b`, `--extension .md --extension .pdf`.
- **Dense-only**, mirroring how `--since`/`--until` are gated in the CLI; the
  hybrid/lexical CLI paths do not thread post-filters today, so keeping the
  smallest consistent surface.
- The MCP-only DoS input caps (`KB_MAX_FILTER_ITEMS` etc.) are intentionally
  **not** replicated: they guard untrusted MCP input, whereas the CLI is a
  trusted local surface. Filtering semantics are identical.

## Checks

- `npm run build` ✅
- `npx jest src/cli-search.test.ts` — 128 passed ✅ (repo test runner is Jest)
- `npm run docs:check-cli` ✅
- `eslint src/cli-search.ts` ✅

Closes #790

🤖 Generated with [Claude Code](https://claude.com/claude-code)