### PR TITLE
ci: add machine-verified PR drift checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,18 @@
+<!--
+Work every checklist row carrying a `kookr:check:*` marker. The PR checklist
+workflow verifies these rows against the merge-base diff with Kookr's pinned,
+deterministic verifier:
+
+- check a row when you performed it;
+- strike the whole row through and add a one-line reason when it is not applicable;
+- do not leave marked rows blank.
+
+The verifier also checks new source modules for test coverage and scans added
+non-documentation lines for common committed-secret patterns. It does not judge
+whether prose is semantically correct, so review the documentation contract in
+CLAUDE.md as well.
+-->
+
 ## Summary
 
 Brief description of the change and which issue is fixed. Include relevant motivation and context.
@@ -9,10 +24,21 @@ Fixes # (issue)
 - [ ] `npm test` passes
 - [ ] End-to-end verified for tool/transport changes (see `CLAUDE.md`)
 - [ ] Benchmark run if performance-relevant: `BENCH_PROVIDER=stub npm run bench`
+- [ ] <!-- kookr:check:tests --> Tests were added or updated for changed behavior; bug fixes include a regression test
+
+## Documentation contract
+
+- [ ] <!-- kookr:check:readme --> `README.md` reflects user-visible CLI, MCP, installation, or configuration changes
+- [ ] <!-- kookr:check:docs --> Relevant operator, API, configuration, and retrieval documentation under `docs/` is consistent with the implementation
+- [ ] <!-- kookr:check:mbse --> RFCs are updated when this PR implements, supersedes, or changes an accepted design
 
 ## Changelog
 
-Add an entry under `## [Unreleased]` in `CHANGELOG.md` for any user-visible change.
+- [ ] <!-- kookr:check:changelog --> `CHANGELOG.md` has an `Unreleased` entry for user-visible changes
+
+## Retrieval and performance evidence
+
+- [ ] <!-- kookr:check:benchmarks --> Retrieval-quality or performance changes include the relevant benchmark/evaluation evidence, or this row is waived with a reason
 
 ## Follow-ups
 

--- a/.github/workflows/pr-checklist.yml
+++ b/.github/workflows/pr-checklist.yml
@@ -1,0 +1,53 @@
+name: PR checklist
+
+# Machine-verifies marked anti-drift checklist rows against the PR body and
+# merge-base diff using Kookr's shared deterministic engine. The full commit SHA
+# prevents upstream changes from silently altering this repository's gate.
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+concurrency:
+  group: pr-checklist-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+env:
+  # Kookr PR-checklist conventional-evidence fix. Pin remains immutable even
+  # while the corresponding Kookr PR is reviewed.
+  KOOKR_ENGINE_REF: dbedfc798b6b619a3c80bd6bc3f9d8b91fdc890d
+  TSX_VERSION: 4.22.4
+
+jobs:
+  checklist:
+    name: Anti-drift checklist
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout (full history for merge-base diff)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Fetch Kookr PR-checklist engine (pinned)
+        uses: actions/checkout@v4
+        with:
+          repository: kookr-ai/kookr
+          ref: ${{ env.KOOKR_ENGINE_REF }}
+          path: .kookr-engine
+          persist-credentials: false
+
+      - name: Verify checklist against diff
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          git fetch --no-tags origin "${{ github.base_ref }}"
+          printf '%s' "$PR_BODY" | npx --yes "tsx@${TSX_VERSION}" \
+            .kookr-engine/bin/kookr.js pr-checklist verify \
+            --base "${{ github.base_ref }}" \
+            --pr-body -

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,9 +12,14 @@ Thank you for your interest in contributing! Please read [`CLAUDE.md`](./CLAUDE.
 6. Commit using **conventional commits** — `feat:`, `fix(scope):`, `docs:`, `chore:` (see `git log` for prior style). PR titles are checked with `npm run lint:commit-message` because squash merges use the PR title as the final commit message.
 7. Push to the branch and open a Pull Request using the PR template.
 
+The marked rows in the PR template are verified against the actual diff by the
+`PR checklist` workflow. Check a marked row only when it is true; otherwise
+strike the row through and add a one-line reason. A blank marked row fails CI.
+
 ## Reporting Bugs
 
 Please use the [Bug Report issue template](./.github/ISSUE_TEMPLATE/bug_report.yml) and include:
+
 - What you observed
 - Where it occurs (`file.ts:line` or URL)
 - Why it matters


### PR DESCRIPTION
## Summary

Add a machine-verified anti-drift PR checklist backed by Kookr's shared, SHA-pinned deterministic verifier. The repository template now records tests, documentation, RFC, changelog, and benchmark obligations, while `CONTRIBUTING.md` explains checked rows and explicit waivers.

## Testing

- [x] `npm test` passes — 198 parallel suites/2,607 tests and 11 serial suites/432 tests
- [ ] End-to-end verified for tool/transport changes (see `CLAUDE.md`) — not applicable; no tool or transport runtime changed
- [ ] Benchmark run if performance-relevant: `BENCH_PROVIDER=stub npm run bench` — not applicable; no retrieval or performance behavior changed
- [ ] ~~<!-- kookr:check:tests --> Tests were added or updated for changed behavior; bug fixes include a regression test~~ — workflow/template-only rollout with no runtime behavior change; the shared engine has 79 focused regression tests in Kookr PR #1344

## Documentation contract

- [ ] ~~<!-- kookr:check:readme --> `README.md` reflects user-visible CLI, MCP, installation, or configuration changes~~ — no user-visible CLI, MCP, installation, or configuration behavior changed
- [ ] ~~<!-- kookr:check:docs --> Relevant operator, API, configuration, and retrieval documentation under `docs/` is consistent with the implementation~~ — no operator, API, configuration, or retrieval behavior changed
- [ ] ~~<!-- kookr:check:mbse --> RFCs are updated when this PR implements, supersedes, or changes an accepted design~~ — adopts the already-documented Kookr checklist contract without changing a KB-server design decision

## Changelog

- [ ] ~~<!-- kookr:check:changelog --> `CHANGELOG.md` has an `Unreleased` entry for user-visible changes~~ — contributor workflow only; no user-visible product change

## Retrieval and performance evidence

- [ ] ~~<!-- kookr:check:benchmarks --> Retrieval-quality or performance changes include the relevant benchmark/evaluation evidence, or this row is waived with a reason~~ — no retrieval-quality or performance behavior changed

## Follow-ups

- After this workflow lands and its status context exists, configure `Anti-drift checklist` as a required check on `main`.
- Shared engine enhancement: kookr-ai/kookr#1344.
