### PR TITLE
feat: centralize kb CLI exit-code taxonomy (#733)

### DIFF
--- a/src/cli-exit-codes.test.ts
+++ b/src/cli-exit-codes.test.ts
@@ -1,0 +1,89 @@
+// Unit + integration coverage for the centralized `kb` CLI exit-code taxonomy
+// (issue #733). Asserts the frozen map itself and that the shipped CLI's
+// top-level help manifest and help prose are both derived from it — so the
+// runtime and its documentation cannot drift.
+
+import { describe, expect, it } from '@jest/globals';
+import { spawnSync } from 'child_process';
+import * as path from 'path';
+import {
+  EXIT,
+  EXIT_DESCRIPTIONS,
+  exitCodeDocs,
+  formatExitCodesHelp,
+} from './cli-exit-codes.js';
+
+const cliPath = path.join(process.cwd(), 'build', 'cli.js');
+
+function runCli(args: string[]): { status: number; stdout: string } {
+  const result = spawnSync(process.execPath, [cliPath, ...args], {
+    encoding: 'utf-8',
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  return { status: result.status ?? -1, stdout: result.stdout ?? '' };
+}
+
+describe('EXIT taxonomy', () => {
+  it('pins the documented numeric codes and keeps 0/1 backward-compatible', () => {
+    expect(EXIT).toEqual({
+      OK: 0,
+      INTERNAL: 1,
+      USAGE: 2,
+      CONFIG: 3,
+      NO_RESULTS: 4,
+      BACKEND_UNAVAILABLE: 5,
+    });
+    // 0 = success, 1 = generic failure must never move (existing scripts rely on it).
+    expect(EXIT.OK).toBe(0);
+    expect(EXIT.INTERNAL).toBe(1);
+  });
+
+  it('assigns a unique code to every name', () => {
+    const codes = Object.values(EXIT);
+    expect(new Set(codes).size).toBe(codes.length);
+  });
+
+  it('is frozen so callers cannot mutate the taxonomy at runtime', () => {
+    expect(Object.isFrozen(EXIT)).toBe(true);
+    expect(Object.isFrozen(EXIT_DESCRIPTIONS)).toBe(true);
+    expect(() => {
+      (EXIT as unknown as Record<string, number>).OK = 99;
+    }).toThrow();
+    expect(EXIT.OK).toBe(0);
+  });
+
+  it('documents every code', () => {
+    for (const name of Object.keys(EXIT) as (keyof typeof EXIT)[]) {
+      expect(EXIT_DESCRIPTIONS[name]).toEqual(expect.any(String));
+      expect(EXIT_DESCRIPTIONS[name].length).toBeGreaterThan(0);
+    }
+  });
+
+  it('exposes ordered { code, description } docs', () => {
+    const docs = exitCodeDocs();
+    expect(docs.map((d) => d.code)).toEqual([0, 1, 2, 3, 4, 5]);
+    expect(docs[0]).toEqual({ code: 0, description: EXIT_DESCRIPTIONS.OK });
+  });
+
+  it('renders an aligned help section body', () => {
+    const help = formatExitCodesHelp();
+    expect(help.split('\n')).toHaveLength(exitCodeDocs().length);
+    expect(help).toContain('  0   success (results found or empty)');
+    expect(help).toContain('  5   backend unavailable (transient / retryable)');
+  });
+});
+
+describe('help manifest is derived from the taxonomy (no prose parsing)', () => {
+  it('kb help --format=json exit_codes equal exitCodeDocs()', () => {
+    const { status, stdout } = runCli(['help', '--format=json']);
+    expect(status).toBe(0);
+    const manifest = JSON.parse(stdout) as { exit_codes: Array<{ code: number; description: string }> };
+    expect(manifest.exit_codes).toEqual(exitCodeDocs());
+  });
+
+  it('kb --help prose renders the taxonomy from the shared map', () => {
+    const { status, stdout } = runCli(['--help']);
+    expect(status).toBe(0);
+    expect(stdout).toContain(formatExitCodesHelp());
+  });
+});

--- a/src/cli-exit-codes.ts
+++ b/src/cli-exit-codes.ts
@@ -1,0 +1,79 @@
+// Centralized `kb` CLI exit-code taxonomy (issue #733).
+//
+// Historically exit codes were ad-hoc: most commands collapsed every failure to
+// `1`, the top-level `kb --help` documented a 0/1/2/3 scheme in prose, and
+// `src/cli.ts` regex-parsed those codes back out of the help text to build its
+// JSON help manifest. That let the runtime literals and the documented codes
+// drift apart.
+//
+// This module is the single source of truth. The runtime references the named
+// constants, and both the top-level help prose and the help manifest are
+// rendered from `EXIT` / `EXIT_DESCRIPTIONS` here — so adding or changing a code
+// is a one-line edit that stays consistent everywhere by construction.
+//
+// Backward compatibility: `0` (success) and `1` (generic/internal failure) keep
+// their historical meanings. Codes `2`-`5` name the failure classes callers in
+// scripts and CI gates want to branch on without scraping stderr.
+
+/**
+ * Frozen map of exit-code names to their numeric values.
+ *
+ * Semantic meanings:
+ * - `OK` (0)                  — success (results found or empty).
+ * - `INTERNAL` (1)            — generic runtime / index error (the catch-all).
+ * - `USAGE` (2)               — bad argv / env / model-resolution.
+ * - `CONFIG` (3)              — missing or invalid environment / configuration.
+ * - `NO_RESULTS` (4)          — the operation ran but produced no matching results.
+ * - `BACKEND_UNAVAILABLE` (5) — a transient / retryable backend was unreachable.
+ */
+export const EXIT = Object.freeze({
+  OK: 0,
+  INTERNAL: 1,
+  USAGE: 2,
+  CONFIG: 3,
+  NO_RESULTS: 4,
+  BACKEND_UNAVAILABLE: 5,
+} as const);
+
+export type ExitCodeName = keyof typeof EXIT;
+export type ExitCode = (typeof EXIT)[ExitCodeName];
+
+/**
+ * Human-readable descriptions for each exit code. Kept alongside `EXIT` so the
+ * help prose and the JSON manifest render from one source and cannot drift.
+ */
+export const EXIT_DESCRIPTIONS: Readonly<Record<ExitCodeName, string>> = Object.freeze({
+  OK: 'success (results found or empty)',
+  INTERNAL: 'runtime / index error',
+  USAGE: 'argv / env / model-resolution error',
+  CONFIG: 'configuration error (missing or invalid environment / config)',
+  NO_RESULTS: 'no matching results',
+  BACKEND_UNAVAILABLE: 'backend unavailable (transient / retryable)',
+});
+
+export interface ExitCodeDoc {
+  code: number;
+  description: string;
+}
+
+/**
+ * The taxonomy as ordered `{ code, description }` entries (ascending by code).
+ * Consumed by the top-level help manifest and the help-prose renderer.
+ */
+export function exitCodeDocs(): ExitCodeDoc[] {
+  return (Object.keys(EXIT) as ExitCodeName[])
+    .map((name) => ({ code: EXIT[name], description: EXIT_DESCRIPTIONS[name] }))
+    .sort((a, b) => a.code - b.code);
+}
+
+/**
+ * Render the taxonomy as the indented body of the top-level `Exit codes:`
+ * help section (without the heading), aligning the numeric codes.
+ */
+export function formatExitCodesHelp(): string {
+  const docs = exitCodeDocs();
+  const width = docs.reduce((max, doc) => Math.max(max, String(doc.code).length), 0);
+  return docs
+    .map((doc) => `  ${String(doc.code).padStart(width)}   ${doc.description}`)
+    .join('\n');
+}

--- a/src/cli-serve.ts
+++ b/src/cli-serve.ts
@@ -6,6 +6,7 @@ import * as fsp from 'node:fs/promises';
 import { runList } from './cli-list.js';
 import { createRunSearchDeps, runSearch, type RunSearchDeps } from './cli-search.js';
 import { captureProcessOutput } from './cli-shared.js';
+import { EXIT } from './cli-exit-codes.js';
 import { runStats } from './cli-stats.js';
 import {
   isMetricsExportEnabled,
@@ -176,7 +177,7 @@ export async function runServe(rest: string[]): Promise<number> {
     parsed = parseServeArgs(rest);
   } catch (err) {
     process.stderr.write(`kb serve: ${(err as Error).message}\n`);
-    return 2;
+    return EXIT.USAGE;
   }
 
   let daemon: ResidentDaemon;
@@ -184,7 +185,7 @@ export async function runServe(rest: string[]): Promise<number> {
     daemon = await startDaemonServer(parsed);
   } catch (err) {
     process.stderr.write(`kb serve: ${(err as Error).message}\n`);
-    return 1;
+    return EXIT.INTERNAL;
   }
 
   process.stdout.write(`kb serve: listening on ${daemon.url.href}\n`);
@@ -209,7 +210,7 @@ export async function runServe(rest: string[]): Promise<number> {
   await daemon.closed;
   process.off('SIGINT', stop);
   process.off('SIGTERM', stop);
-  return 0;
+  return EXIT.OK;
 }
 
 /** Grace beyond the drain budget for `server.close()` before force-exit. */

--- a/src/cli-shared.ts
+++ b/src/cli-shared.ts
@@ -53,6 +53,7 @@ export async function loadWithJsonRetry(manager: FaissIndexManager): Promise<voi
 }
 
 export interface CapturedProcessOutput {
+  /** Process exit code from the captured handler; see the `EXIT` taxonomy in `./cli-exit-codes.js`. */
   exitCode: number;
   stdout: string;
   stderr: string;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -51,6 +51,7 @@ import { WHERE_HELP, runWhere } from './cli-where.js';
 import { daemonUrlFromEnv, tryRunDaemonCommand } from './daemon-client.js';
 import { emitCanonicalLog } from './canonical-log.js';
 import { buildDaemonSearchArgs, resolveSearchPager } from './cli-pager.js';
+import { exitCodeDocs, formatExitCodesHelp } from './cli-exit-codes.js';
 
 // ----- Subcommand registry --------------------------------------------------
 
@@ -81,11 +82,6 @@ interface HelpManifestCommand {
 
 interface HelpManifestDefinition {
   name: string;
-  description: string;
-}
-
-interface HelpManifestExitCode {
-  code: number;
   description: string;
 }
 
@@ -179,10 +175,8 @@ Environment:
                             Provider-specific config; see the provider's docs.
 
 Exit codes:
-  0   success (results found or empty)
-  1   runtime / index error
-  2   argv / env / model-resolution error
-  3   \`kb remember\` similarity guard refused to write
+${formatExitCodesHelp()}
+  Some commands document additional command-specific codes; see \`kb <command> --help\`.
 `;
 }
 
@@ -420,7 +414,7 @@ function buildTopLevelHelpManifest() {
     usage: extractUsageLines(HELP),
     commands: SUBCOMMANDS.map(buildCommandHelpManifest),
     environment: extractDefinitionList(HELP, 'Environment:'),
-    exit_codes: extractExitCodes(HELP),
+    exit_codes: exitCodeDocs(),
     stability: 'stable' as const,
   };
 }
@@ -594,23 +588,6 @@ function pushDefinitions(
   })).filter((definition) => definition.name !== '');
   definitions.push(...current);
   return current;
-}
-
-function extractExitCodes(help: string): HelpManifestExitCode[] {
-  const lines = help.split('\n');
-  const headingIndex = lines.findIndex((line) => line.trim() === 'Exit codes:');
-  if (headingIndex === -1) return [];
-  const exitCodes: HelpManifestExitCode[] = [];
-  for (const line of lines.slice(headingIndex + 1)) {
-    if (line.trim() === '') {
-      if (exitCodes.length > 0) break;
-      continue;
-    }
-    const match = /^ {2}(\d+)\s{2,}(.*)$/.exec(line);
-    if (!match) break;
-    exitCodes.push({ code: Number(match[1]), description: match[2].trim() });
-  }
-  return exitCodes;
 }
 
 function isContinuationLine(line: string): boolean {


### PR DESCRIPTION
## Summary

Introduces a single source of truth for `kb` CLI process exit codes, eliminating the drift between runtime literals and the codes documented in help prose.

- **New `src/cli-exit-codes.ts`** exports a frozen `EXIT` map with doc strings:
  `OK=0`, `INTERNAL=1`, `USAGE=2`, `CONFIG=3`, `NO_RESULTS=4`, `BACKEND_UNAVAILABLE=5`. It also exports `exitCodeDocs()` (ordered `{code, description}` entries) and `formatExitCodesHelp()` (the aligned help-section body).
- **`src/cli.ts`**: the top-level help manifest previously regex-parsed exit codes back out of the help text (`extractExitCodes`). It now derives `exit_codes` from `exitCodeDocs()`, and the top-level `Exit codes:` help section renders from `formatExitCodesHelp()`. The dead `extractExitCodes` helper and `HelpManifestExitCode` interface are removed.
- **`src/cli-serve.ts`**: `runServe` returns the named `EXIT.*` constants instead of bare `0`/`1`/`2` literals.
- **`src/cli-shared.ts`**: documents that `CapturedProcessOutput.exitCode` follows the shared taxonomy.
- **`src/cli-exit-codes.test.ts`**: asserts the frozen map, uniqueness, descriptions, and — crucially — that the shipped CLI's `help --format=json` `exit_codes` equal `exitCodeDocs()` and that `kb --help` prose renders `formatExitCodesHelp()`, proving both are derived from the map (no prose parsing).

Codes `0` and `1` keep their historical meanings for backward compatibility.

## Design choices not settled by the issue

- **Code numbers** follow the issue's recommended map verbatim (`CONFIG=3`, `NO_RESULTS=4`, `BACKEND_UNAVAILABLE=5`). This reassigns the *top-level* documented meaning of code `3` from the old `kb remember` similarity-guard note to `CONFIG`. `kb remember` (guard refusal) and `kb serve status` (no daemon) still return their own command-specific `3`, documented in their own `--help`. A trailing note in the top-level help now points readers to `kb <command> --help` for command-specific codes. Fully reconciling every command's exit path is explicitly out of scope per the issue ("do NOT do a sweeping refactor").
- **Migration scope**: only `runServe`'s unambiguous `0/1/2` literals were migrated to constants. `runServeStatus`/`cli-reindex` use `3/4/5` with command-specific meanings that would be *mis*-mapped by the shared taxonomy, so they were intentionally left untouched. `cli-shared.ts` threads `exitCode` as a value and had no bare literal to swap. Broader per-command adoption can follow incrementally.

## Testing

- `npm run build` — pass
- `npm run lint` — pass
- `npm run docs:check-cli` — pass (top-level help body is not part of the generated `docs/reference/cli.md`, so it is unaffected)
- `jest src/cli-exit-codes.test.ts` — 8/8 pass
- `jest src/cli.test.ts src/cli-serve.test.ts src/cli-json-contracts.test.ts` — pass

Closes #733

🤖 Generated with [Claude Code](https://claude.com/claude-code)