### PR TITLE
feat: emit MCP notifications/progress for long-running tool calls

### DIFF
--- a/src/KnowledgeBaseServer.test.ts
+++ b/src/KnowledgeBaseServer.test.ts
@@ -1035,7 +1035,7 @@ describe('KnowledgeBaseServer handlers', () => {
     });
 
     expect(result.isError).toBeUndefined();
-    expect(updateIndexMock).toHaveBeenCalledWith('alpha', { force: true });
+    expect(updateIndexMock).toHaveBeenCalledWith('alpha', { force: true, onProgress: expect.any(Function) });
     const payload = JSON.parse(result.content[0].text);
     // The rebuild always covers every KB (FAISS has no per-vector delete),
     // so the response advertises scope: 'global' even when a KB name was
@@ -1061,7 +1061,7 @@ describe('KnowledgeBaseServer handlers', () => {
     });
 
     expect(result.isError).toBeUndefined();
-    expect(updateIndexMock).toHaveBeenCalledWith('alpha', { force: true });
+    expect(updateIndexMock).toHaveBeenCalledWith('alpha', { force: true, onProgress: expect.any(Function) });
     expect(notify).toHaveBeenCalledTimes(1);
   });
 
@@ -1073,7 +1073,7 @@ describe('KnowledgeBaseServer handlers', () => {
     const result = await server['handleReindexKnowledgeBase']({});
 
     expect(result.isError).toBeUndefined();
-    expect(updateIndexMock).toHaveBeenCalledWith(undefined, { force: true });
+    expect(updateIndexMock).toHaveBeenCalledWith(undefined, { force: true, onProgress: expect.any(Function) });
     const payload = JSON.parse(result.content[0].text);
     expect(payload).toEqual({ knowledge_base_name: null, reindexed: true, scope: 'global' });
   });

--- a/src/KnowledgeBaseServer.ts
+++ b/src/KnowledgeBaseServer.ts
@@ -9,8 +9,11 @@ import {
   type ListResourcesRequest,
   type ListResourcesResult,
   type ReadResourceResult,
+  type ServerNotification,
+  type ServerRequest,
   type TextContent,
 } from '@modelcontextprotocol/sdk/types.js';
+import type { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js';
 import { FaissIndexManager } from './FaissIndexManager.js';
 import type {
   IndexUpdateProgress,
@@ -161,6 +164,25 @@ import { readBuildInfo } from './build-info.js';
 const SERVER_NAME = 'knowledge-base-server';
 const SERVER_VERSION = '0.1.0';
 const SERVER_BUILD_INFO = readBuildInfo();
+
+// Issue #795 — the SDK hands every tool callback a per-request `extra`
+// (RequestHandlerExtra) as its second argument. We thread it through the tool
+// wrapper so long-running handlers can emit `notifications/progress` when the
+// client opted in via `_meta.progressToken`.
+type ToolExtra = RequestHandlerExtra<ServerRequest, ServerNotification>;
+
+/** Coarse progress update a handler feeds to {@link progressReporter}. */
+interface ProgressUpdate {
+  progress: number;
+  total?: number;
+  message?: string;
+}
+
+/**
+ * Emits an ordered `notifications/progress` frame per call, or a strict no-op
+ * when the client did not opt in. Returns once the frame has been dispatched.
+ */
+type ProgressReporter = (update: ProgressUpdate) => Promise<void>;
 
 // ---------------------------------------------------------------------------
 // MCP tool input bounds (#660).
@@ -385,7 +407,7 @@ export class KnowledgeBaseServer {
     name: string,
     description: string,
     shape: z.ZodRawShape,
-    handler: (args: Args) => Promise<CallToolResult>,
+    handler: (args: Args, extra: ToolExtra) => Promise<CallToolResult>,
   ): void {
     // Call mcp.tool through a loosened signature: its generic
     // `tool<Args extends ZodRawShapeCompat>` overload instantiates ShapeOutput
@@ -393,13 +415,53 @@ export class KnowledgeBaseServer {
     // rather than an inline literal. The 4-arg (name, description, shape, cb)
     // runtime form is unchanged; zod still validates `args` against `shape`
     // before the handler runs.
+    //
+    // Issue #795 — forward the SDK's second `extra` argument so handlers can
+    // reach `_meta.progressToken` / `sendNotification`. Handlers that don't
+    // emit progress simply omit the second parameter (fewer params stay
+    // assignable), so the change is a no-op for them.
     const registerTool = mcp.tool.bind(mcp) as unknown as (
       name: string,
       description: string,
       shape: z.ZodRawShape,
-      cb: (args: unknown) => Promise<CallToolResult>,
+      cb: (args: unknown, extra: ToolExtra) => Promise<CallToolResult>,
     ) => void;
-    registerTool(name, description, shape, (args) => handler(args as Args));
+    registerTool(name, description, shape, (args, extra) => handler(args as Args, extra));
+  }
+
+  /**
+   * Issue #795 — build a progress reporter bound to the current request. When
+   * the client did NOT supply `_meta.progressToken` this is a strict no-op, so
+   * calls that don't opt in behave exactly as before (the MCP spec forbids
+   * unsolicited progress frames). Otherwise each call emits an ordered
+   * `notifications/progress` frame; a monotonic guard drops any non-increasing
+   * update so the wire stream always carries strictly increasing `progress`.
+   * A failed dispatch is swallowed (debug-logged) — progress is best-effort and
+   * must never fail the underlying tool call.
+   */
+  private progressReporter(extra?: ToolExtra): ProgressReporter {
+    const progressToken = extra?._meta?.progressToken;
+    if (progressToken === undefined || progressToken === null) {
+      return async () => {};
+    }
+    let last = Number.NEGATIVE_INFINITY;
+    return async ({ progress, total, message }) => {
+      if (!(progress > last)) return;
+      last = progress;
+      try {
+        await extra!.sendNotification({
+          method: 'notifications/progress',
+          params: {
+            progressToken,
+            progress,
+            ...(total !== undefined ? { total } : {}),
+            ...(message !== undefined ? { message } : {}),
+          },
+        });
+      } catch (err) {
+        logger.debug(`Unable to emit MCP progress notification: ${toError(err).message}`);
+      }
+    };
   }
 
   private registerTools(mcp: McpServer) {
@@ -751,7 +813,8 @@ export class KnowledgeBaseServer {
 
   private async handleReindexKnowledgeBase(args: {
     knowledge_base_name?: string;
-  }): Promise<CallToolResult> {
+  }, extra?: ToolExtra): Promise<CallToolResult> {
+    const report = this.progressReporter(extra);
     return this.withCanonicalTool({
       tool: 'reindex_knowledge_base',
       kb_scope: args.knowledge_base_name ?? null,
@@ -762,7 +825,18 @@ export class KnowledgeBaseServer {
           if (args.knowledge_base_name !== undefined) {
             await resolveKnowledgeBaseDir(KNOWLEDGE_BASES_ROOT_DIR, args.knowledge_base_name);
           }
-          await manager.updateIndex(args.knowledge_base_name, { force: true });
+          // Issue #795 — drive MCP progress off the existing reindex plumbing.
+          // `processedFiles` climbs within a phase; the reporter's monotonic
+          // guard coalesces the per-phase resets (scan → load → embed) into a
+          // strictly increasing wire stream.
+          await manager.updateIndex(args.knowledge_base_name, {
+            force: true,
+            onProgress: (p) => report({
+              progress: p.processedFiles,
+              total: p.totalFiles,
+              message: `Embedded ${p.processedFiles}/${p.totalFiles} files`,
+            }),
+          });
         });
         await this.notifyResourceListChangedIfListingChanged();
 
@@ -809,7 +883,12 @@ export class KnowledgeBaseServer {
     task_context?: string;
     gate?: 'on' | 'off';
     rerank?: 'on' | 'off';
-  }): Promise<CallToolResult> {
+  }, extra?: ToolExtra): Promise<CallToolResult> {
+    // Issue #795 — coarse stage progress for the dense retrieval path. Hybrid
+    // delegates to handleRetrieveKnowledgeHybrid which is left as a no-op for
+    // now (the reporter is a no-op unless the client opted in either way).
+    const report = this.progressReporter(extra);
+    const RETRIEVE_STAGES = 4;
     const canonical: Partial<CanonicalLogInput> = {};
     const requestStartedAt = Date.now();
     const query: string = args.query;
@@ -925,6 +1004,7 @@ export class KnowledgeBaseServer {
       if (process.env.KB_LOG_VERBOSE === '1') {
         logger.debug(`[${Date.now()}] FAISS index update completed`);
       }
+      await report({ progress: 1, total: RETRIEVE_STAGES, message: 'index ready' });
 
       // Perform similarity search using the provided query.
       const timing: SimilaritySearchTiming = {};
@@ -984,6 +1064,7 @@ export class KnowledgeBaseServer {
           lexicalHitIds?.add(id);
         }
       }
+      await report({ progress: 2, total: RETRIEVE_STAGES, message: 'search complete' });
       const gateStartedAt = Date.now();
       const gate = await withSpan('kb.retrieve.gate', {
         'kb.candidates_in': similaritySearchResults.length,
@@ -1003,6 +1084,7 @@ export class KnowledgeBaseServer {
       });
       const gateMs = Date.now() - gateStartedAt;
       similaritySearchResults = gate.results;
+      await report({ progress: 3, total: RETRIEVE_STAGES, message: 'relevance gate complete' });
       emitRelevanceGateDecision({
         process: 'mcp',
         query,
@@ -1078,6 +1160,7 @@ export class KnowledgeBaseServer {
         logger.debug(`[${endTime}] handleRetrieveKnowledge completed in ${endTime - startTime}ms`);
       }
 
+      await report({ progress: 4, total: RETRIEVE_STAGES, message: 'response ready' });
       const content: TextContent = { type: 'text', text: responseText };
       const response = withGateVerdict({ content: [content] }, gate.verdict);
       const responseWithSummary = withDegradationSummary(response, degradation.degraded_stages);
@@ -1110,7 +1193,8 @@ export class KnowledgeBaseServer {
     task_context?: string;
     gate?: 'on' | 'off';
     timing?: boolean;
-  }): Promise<CallToolResult> {
+  }, extra?: ToolExtra): Promise<CallToolResult> {
+    const report = this.progressReporter(extra);
     return this.withCanonicalTool({
       tool: 'ask_knowledge',
       query: args.query,
@@ -1135,7 +1219,7 @@ export class KnowledgeBaseServer {
           loadReadOnlyIndex: async () => {},
           withWriteLock,
           callChatCompletion,
-        });
+        }, report);
         return {
           content: [{ type: 'text', text: JSON.stringify(payload, null, 2) }],
           structuredContent: payload as unknown as Record<string, unknown>,

--- a/src/ask-core.ts
+++ b/src/ask-core.ts
@@ -154,6 +154,19 @@ export interface AskKnowledgeResult {
   timing?: Record<string, unknown>;
 }
 
+/**
+ * Issue #795 — coarse stage callback used to surface `ask_knowledge` progress
+ * over the MCP wire. The MCP server passes a reporter that turns each update
+ * into a `notifications/progress` frame; callers that don't care (the CLI) omit
+ * it entirely, so this is optional everywhere.
+ */
+export interface AskProgressUpdate {
+  progress: number;
+  total?: number;
+  message?: string;
+}
+export type AskProgressReporter = (update: AskProgressUpdate) => void | Promise<void>;
+
 export interface RunAskCoreDeps {
   bootstrapLayout: () => Promise<void>;
   resolveActiveModel: typeof resolveActiveModel;
@@ -194,6 +207,7 @@ export class AskExecutionError extends Error {
 export async function askKnowledge(
   input: AskKnowledgeInput,
   deps: RunAskCoreDeps,
+  onProgress?: AskProgressReporter,
 ): Promise<AskKnowledgeResult> {
   const query = input.query.trim();
   if (query === '') throw new Error('ask_knowledge requires a non-empty query');
@@ -215,7 +229,7 @@ export async function askKnowledge(
     timing: input.timing ?? false,
     taskContext: input.task_context,
     gate: input.gate,
-  }, deps, nowMs());
+  }, deps, nowMs(), onProgress);
 }
 
 export interface AskEvidence {
@@ -507,14 +521,24 @@ export async function executeAsk(
   args: AskExecutionArgs,
   deps: RunAskCoreDeps,
   totalStartedAt: number,
+  onProgress?: AskProgressReporter,
 ): Promise<AskKnowledgeResult> {
   const timing: TimingPayload | null = args.timing ? {} : null;
   return withSpan('kb.ask', {
     'kb.scope': args.kb ?? null,
     'kb.k': args.k,
   }, async () => {
+    // Issue #795 — two coarse stage boundaries flank the two expensive halves
+    // (retrieval, then LLM synthesis) so an MCP client sees progress on a call
+    // that can run for many seconds. `onProgress` is a no-op unless the client
+    // opted in via `_meta.progressToken`.
+    const ASK_STAGES = 2;
+    await onProgress?.({ progress: 0, total: ASK_STAGES, message: 'retrieving evidence' });
     const evidence = await retrieveAskEvidence(args, deps, timing);
-    return answerWithEvidence(args, evidence, deps, totalStartedAt, timing);
+    await onProgress?.({ progress: 1, total: ASK_STAGES, message: 'synthesizing answer' });
+    const result = await answerWithEvidence(args, evidence, deps, totalStartedAt, timing);
+    await onProgress?.({ progress: 2, total: ASK_STAGES, message: 'answer ready' });
+    return result;
   });
 }
 

--- a/src/mcp-progress.test.ts
+++ b/src/mcp-progress.test.ts
@@ -1,0 +1,158 @@
+// Issue #795 — MCP `notifications/progress` for long-running tool calls.
+//
+// Drives a real in-memory MCP transport: a client calls `retrieve_knowledge`
+// with a `_meta.progressToken` (the SDK sets it automatically when an
+// `onprogress` callback is supplied) and we assert the server streams ordered
+// `notifications/progress` frames with strictly increasing `progress`. A second
+// case with no token asserts the strict no-op contract — a call that did not
+// opt in must not receive any progress frame.
+import * as fsp from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+const updateIndexMock = jest.fn().mockResolvedValue(undefined);
+const similaritySearchMock = jest.fn().mockResolvedValue([
+  { pageContent: 'hello world', metadata: { source: '/tmp/doc.md' }, score: 0.5 },
+]);
+
+const FaissIndexManagerMock: any = jest.fn().mockImplementation(
+  (opts?: { provider?: string; modelName?: string }) => {
+    const provider = opts?.provider ?? 'huggingface';
+    const modelName = opts?.modelName ?? 'BAAI/bge-small-en-v1.5';
+    const modelId = `${provider}__${modelName.replace(/[^A-Za-z0-9._-]/g, '-').replace(/-+/g, '-')}`;
+    const faissPath = process.env.FAISS_INDEX_PATH ?? '/tmp/kb-progress-mock';
+    return {
+      initialize: jest.fn(),
+      updateIndex: updateIndexMock,
+      similaritySearch: similaritySearchMock,
+      expandWithNeighborContext: (results: unknown) => results,
+      getStats: () => ({ totalChunks: 0, chunkCountsByKb: {}, dim: null }),
+      modelDir: path.join(faissPath, 'models', modelId),
+      modelId,
+      modelName,
+      embeddingProvider: provider,
+      get hasLoadedIndex() {
+        return true;
+      },
+    };
+  },
+);
+FaissIndexManagerMock.bootstrapLayout = jest.fn().mockResolvedValue(undefined);
+
+jest.mock('./FaissIndexManager.js', () => ({
+  __esModule: true,
+  FaissIndexManager: FaissIndexManagerMock,
+}));
+
+// The constructor registers a SIGINT listener per server instance.
+process.setMaxListeners(100);
+
+interface ProgressFrame {
+  progress: number;
+  total?: number;
+  message?: string;
+}
+
+describe('MCP notifications/progress (issue #795)', () => {
+  const originalEnv = {
+    KNOWLEDGE_BASES_ROOT_DIR: process.env.KNOWLEDGE_BASES_ROOT_DIR,
+    FAISS_INDEX_PATH: process.env.FAISS_INDEX_PATH,
+    EMBEDDING_PROVIDER: process.env.EMBEDDING_PROVIDER,
+    HUGGINGFACE_API_KEY: process.env.HUGGINGFACE_API_KEY,
+    KB_LOG_FORMAT: process.env.KB_LOG_FORMAT,
+  };
+
+  afterEach(() => {
+    for (const key of Object.keys(originalEnv) as Array<keyof typeof originalEnv>) {
+      const value = originalEnv[key];
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    process.removeAllListeners('SIGINT');
+    jest.clearAllMocks();
+    updateIndexMock.mockResolvedValue(undefined);
+    similaritySearchMock.mockResolvedValue([
+      { pageContent: 'hello world', metadata: { source: '/tmp/doc.md' }, score: 0.5 },
+    ]);
+  });
+
+  async function seedActiveModel(): Promise<void> {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-progress-'));
+    const faissDir = path.join(tempDir, '.faiss');
+    process.env.KNOWLEDGE_BASES_ROOT_DIR = tempDir;
+    process.env.FAISS_INDEX_PATH = faissDir;
+    process.env.EMBEDDING_PROVIDER = 'huggingface';
+    process.env.HUGGINGFACE_API_KEY = 'test-key';
+    process.env.KB_LOG_FORMAT = 'text';
+
+    const modelId = 'huggingface__BAAI-bge-small-en-v1.5';
+    const modelDir = path.join(faissDir, 'models', modelId);
+    await fsp.mkdir(modelDir, { recursive: true });
+    await fsp.writeFile(path.join(modelDir, 'model_name.txt'), 'BAAI/bge-small-en-v1.5');
+    await fsp.writeFile(path.join(faissDir, 'active.txt'), modelId);
+  }
+
+  async function connectedClient(): Promise<{ client: Client; mcp: McpServer }> {
+    jest.resetModules();
+    const { KnowledgeBaseServer } = await import('./KnowledgeBaseServer.js');
+    const server = new KnowledgeBaseServer();
+    const mcp = (server as unknown as { mcp: McpServer }).mcp;
+    const client = new Client({ name: 'progress-test', version: '0.0.0-test' });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await mcp.connect(serverTransport);
+    await client.connect(clientTransport);
+    return { client, mcp };
+  }
+
+  it('streams ordered, strictly-increasing progress frames when a progressToken is supplied', async () => {
+    await seedActiveModel();
+    const { client, mcp } = await connectedClient();
+    const frames: ProgressFrame[] = [];
+
+    try {
+      const result = await client.callTool(
+        { name: 'retrieve_knowledge', arguments: { query: 'hello' } },
+        undefined,
+        { onprogress: (p) => frames.push(p as ProgressFrame) },
+      );
+      expect(result.isError).toBeFalsy();
+    } finally {
+      await client.close();
+      await mcp.close();
+    }
+
+    // The dense retrieve path emits one frame per coarse stage.
+    expect(frames.length).toBeGreaterThanOrEqual(2);
+    for (let i = 1; i < frames.length; i += 1) {
+      expect(frames[i].progress).toBeGreaterThan(frames[i - 1].progress);
+    }
+    // `total` is advertised so hosts can render a determinate bar.
+    expect(frames.every((f) => f.total === 4)).toBe(true);
+  });
+
+  it('emits no progress frames when the client did not opt in', async () => {
+    await seedActiveModel();
+    const { client, mcp } = await connectedClient();
+    // A progress frame carrying an unknown token trips the SDK's built-in
+    // progress handler, which surfaces via `onerror`. An unsolicited frame
+    // (the spec violation we must avoid) would therefore land here.
+    const errors: Error[] = [];
+    client.onerror = (err) => errors.push(err);
+
+    try {
+      const result = await client.callTool({
+        name: 'retrieve_knowledge',
+        arguments: { query: 'hello' },
+      });
+      expect(result.isError).toBeFalsy();
+    } finally {
+      await client.close();
+      await mcp.close();
+    }
+
+    expect(errors).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

MCP tool handlers discarded the SDK's per-request `extra` (`RequestHandlerExtra`), so a client that supplied `_meta.progressToken` received no progress updates — long `ask_knowledge`, `retrieve_knowledge`, and `reindex_knowledge_base` calls looked hung to MCP hosts. This threads `extra` through the tool wrapper and emits `notifications/progress` when a token is present.

Closes #795

## What changed

- **`registerShapedTool` wrapper** (`src/KnowledgeBaseServer.ts`) now forwards the SDK's second `extra` argument into handlers. The change is mechanical: handlers that don't emit progress simply omit the second parameter (fewer params stay assignable), so it's a no-op for the other 6 tools.
- **`progressReporter(extra)`** helper builds a per-request reporter. When the client did **not** supply `_meta.progressToken` it's a strict no-op (the MCP spec forbids unsolicited frames). Otherwise each call emits an ordered `notifications/progress` frame via `extra.sendNotification` (per-request association, correct in SSE/HTTP multi-session mode). A monotonic guard drops any non-increasing update, and a failed dispatch is swallowed (debug-logged) so progress never fails the tool call.
- **`reindex_knowledge_base`** drives progress off the existing reindex `onProgress` plumbing (`processedFiles`/`totalFiles`).
- **`retrieve_knowledge`** (dense path) emits four coarse stage boundaries: index ready → search complete → gate complete → response ready.
- **`ask_knowledge`** emits two coarse boundaries flanking the two expensive halves (retrieval, LLM synthesis), plumbed through ask-core's `executeAsk` via an optional `onProgress` reporter.

## Test

`src/mcp-progress.test.ts` — in-memory MCP transport, calls `retrieve_knowledge` with a `progressToken` (set automatically by the SDK when an `onprogress` callback is supplied) and asserts ordered, strictly-increasing `progress` frames with `total`; a second case asserts no frames / no error when the client did not opt in.

Existing `handleReindexKnowledgeBase` assertions were updated to reflect the added `onProgress` option.

## Design choices (issue left these open)

- **Stage boundaries — coarse, not fine.** `retrieve_knowledge`/`ask_knowledge` emit a small fixed set of stage frames (the smallest set that makes a determinate bar meaningful) rather than per-chunk/per-token granularity. Alternative considered: streaming per-candidate progress — rejected as more coupling for little host value.
- **`total` is advertised.** Coarse-stage tools send `total` = number of stages so hosts can render a determinate bar. Reindex forwards `totalFiles`. Alternative: omit `total` (indeterminate) — rejected since the stage count is known up front.
- **Reindex monotonicity.** `processedFiles` climbs within a phase but resets across phases (scan → load → embed); the reporter's strictly-increasing guard coalesces the resets into a valid wire stream rather than emitting decreasing `progress`.
- **`search-core.ts` unchanged.** The dense retrieval orchestration lives in the handler (not in `search-core`), so the coarse stage emissions sit there. `search-core` needed no changes.
- **Hybrid `retrieve_knowledge` emits no progress** for now (still a strict no-op for non-opted-in clients); can be added in a follow-up if hosts want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)