### PR TITLE
feat: set MCP tool annotations (readOnly/destructive/idempotent hints) on all 9 tools

### DIFF
--- a/src/KnowledgeBaseServer.test.ts
+++ b/src/KnowledgeBaseServer.test.ts
@@ -2520,6 +2520,74 @@ describe('KnowledgeBaseServer handlers', () => {
     return Object.keys(registered);
   }
 
+  function annotationsOf(server: any, toolName: string): Record<string, unknown> | undefined {
+    const registered = server['mcp']._registeredTools as Record<
+      string,
+      { annotations?: Record<string, unknown> }
+    >;
+    expect(registered).toBeDefined();
+    expect(registered[toolName]).toBeDefined();
+    return registered[toolName].annotations;
+  }
+
+  // Issue #798 — every tool must advertise its advisory ToolAnnotations so MCP
+  // clients can gate auto-approval and confirm destructive writes. The six
+  // readers are read-only; the three ingest-gated writes carry hand-reviewed
+  // destructive/idempotent hints (delete is the only destructive one).
+  it('registers each of the 9 tools with the expected ToolAnnotations hints', async () => {
+    await setRetrieveEnv();
+    process.env.KB_INGEST_ENABLED = 'true';
+    const server = await freshServer();
+
+    // All 9 tools present so we can assert the writes too.
+    expect(registeredToolNames(server)).toEqual(
+      expect.arrayContaining([
+        'list_knowledge_bases',
+        'retrieve_knowledge',
+        'ask_knowledge',
+        'list_models',
+        'kb_stats',
+        'diff_index',
+        'add_document',
+        'delete_document',
+        'reindex_knowledge_base',
+      ]),
+    );
+
+    for (const readOnlyTool of [
+      'list_knowledge_bases',
+      'retrieve_knowledge',
+      'ask_knowledge',
+      'list_models',
+      'kb_stats',
+      'diff_index',
+    ]) {
+      expect(annotationsOf(server, readOnlyTool)).toMatchObject({ readOnlyHint: true });
+    }
+
+    // add_document / reindex: mutating but additive and idempotent.
+    expect(annotationsOf(server, 'add_document')).toMatchObject({
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+    });
+    expect(annotationsOf(server, 'reindex_knowledge_base')).toMatchObject({
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+    });
+
+    // delete_document: the sole destructive write.
+    expect(annotationsOf(server, 'delete_document')).toMatchObject({
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+    });
+
+    // A read-only tool must never advertise a destructive hint.
+    expect(annotationsOf(server, 'retrieve_knowledge')).not.toMatchObject({ destructiveHint: true });
+  });
+
   it('KB_INGEST_ENABLED=false hides MCP ingest tools while preserving read tools and resources', async () => {
     const tempDir = await setRetrieveEnv();
     await fsp.mkdir(path.join(tempDir, 'alpha'));

--- a/src/KnowledgeBaseServer.ts
+++ b/src/KnowledgeBaseServer.ts
@@ -12,6 +12,7 @@ import {
   type ServerNotification,
   type ServerRequest,
   type TextContent,
+  type ToolAnnotations,
 } from '@modelcontextprotocol/sdk/types.js';
 import type { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js';
 import { FaissIndexManager } from './FaissIndexManager.js';
@@ -51,6 +52,7 @@ import {
   KB_STATS_INPUT,
   REINDEX_KNOWLEDGE_BASE_INPUT,
   RETRIEVE_KNOWLEDGE_INPUT,
+  toolAnnotations,
 } from './mcp-tool-specs.js';
 import {
   FRONTMATTER_EXTRAS_WIRE_VISIBLE,
@@ -407,16 +409,22 @@ export class KnowledgeBaseServer {
     name: string,
     description: string,
     shape: z.ZodRawShape,
+    annotations: ToolAnnotations,
     handler: (args: Args, extra: ToolExtra) => Promise<CallToolResult>,
   ): void {
     // Call mcp.tool through a loosened signature: its generic
     // `tool<Args extends ZodRawShapeCompat>` overload instantiates ShapeOutput
     // over the shape, which trips TS2589 once the shape is a runtime value
-    // rather than an inline literal. The 4-arg (name, description, shape, cb)
-    // runtime form is unchanged; zod still validates `args` against `shape`
-    // before the handler runs.
+    // rather than an inline literal. The 5-arg
+    // (name, description, shape, annotations, cb) runtime form is unchanged;
+    // zod still validates `args` against `shape` before the handler runs.
     //
-    // Issue #795 — forward the SDK's second `extra` argument so handlers can
+    // Issue #798 — restore the SDK's
+    // `tool(name, description, paramsSchema, annotations, cb)` overload so each
+    // tool advertises its `ToolAnnotations` (readOnlyHint / destructiveHint /
+    // idempotentHint). The earlier loosening dropped that overload.
+    //
+    // Issue #795 — forward the SDK's trailing `extra` argument so handlers can
     // reach `_meta.progressToken` / `sendNotification`. Handlers that don't
     // emit progress simply omit the second parameter (fewer params stay
     // assignable), so the change is a no-op for them.
@@ -424,9 +432,10 @@ export class KnowledgeBaseServer {
       name: string,
       description: string,
       shape: z.ZodRawShape,
+      annotations: ToolAnnotations,
       cb: (args: unknown, extra: ToolExtra) => Promise<CallToolResult>,
     ) => void;
-    registerTool(name, description, shape, (args, extra) => handler(args as Args, extra));
+    registerTool(name, description, shape, annotations, (args, extra) => handler(args as Args, extra));
   }
 
   /**
@@ -465,9 +474,15 @@ export class KnowledgeBaseServer {
   }
 
   private registerTools(mcp: McpServer) {
+    // Issue #798 — each registration advertises its advisory ToolAnnotations
+    // (readOnlyHint / destructiveHint / idempotentHint) from the spec registry
+    // so MCP clients can gate auto-approval and confirm destructive writes. The
+    // zero-arg readers use the SDK's (name, description, annotations, cb)
+    // overload; shaped tools thread annotations through registerShapedTool.
     mcp.tool(
       'list_knowledge_bases',
       LIST_KNOWLEDGE_BASES_DESCRIPTION,
+      toolAnnotations('list_knowledge_bases'),
       async () => this.handleListKnowledgeBases()
     );
 
@@ -476,6 +491,7 @@ export class KnowledgeBaseServer {
       'retrieve_knowledge',
       RETRIEVE_KNOWLEDGE_DESCRIPTION,
       RETRIEVE_KNOWLEDGE_INPUT,
+      toolAnnotations('retrieve_knowledge'),
       this.handleRetrieveKnowledge.bind(this)
     );
 
@@ -484,6 +500,7 @@ export class KnowledgeBaseServer {
       'ask_knowledge',
       ASK_KNOWLEDGE_DESCRIPTION,
       ASK_KNOWLEDGE_INPUT,
+      toolAnnotations('ask_knowledge'),
       this.handleAskKnowledge.bind(this)
     );
 
@@ -492,6 +509,7 @@ export class KnowledgeBaseServer {
     mcp.tool(
       'list_models',
       LIST_MODELS_DESCRIPTION,
+      toolAnnotations('list_models'),
       async () => this.handleListModels()
     );
 
@@ -502,6 +520,7 @@ export class KnowledgeBaseServer {
       'kb_stats',
       KB_STATS_DESCRIPTION,
       KB_STATS_INPUT,
+      toolAnnotations('kb_stats'),
       this.handleKbStats.bind(this)
     );
 
@@ -510,6 +529,7 @@ export class KnowledgeBaseServer {
       'diff_index',
       DIFF_INDEX_DESCRIPTION,
       DIFF_INDEX_INPUT,
+      toolAnnotations('diff_index'),
       this.handleDiffIndex.bind(this)
     );
 
@@ -519,6 +539,7 @@ export class KnowledgeBaseServer {
         'add_document',
         ADD_DOCUMENT_DESCRIPTION,
         ADD_DOCUMENT_INPUT,
+        toolAnnotations('add_document'),
         this.handleAddDocument.bind(this)
       );
 
@@ -527,6 +548,7 @@ export class KnowledgeBaseServer {
         'delete_document',
         DELETE_DOCUMENT_DESCRIPTION,
         DELETE_DOCUMENT_INPUT,
+        toolAnnotations('delete_document'),
         this.handleDeleteDocument.bind(this)
       );
 
@@ -535,6 +557,7 @@ export class KnowledgeBaseServer {
         'reindex_knowledge_base',
         REINDEX_KNOWLEDGE_BASE_DESCRIPTION,
         REINDEX_KNOWLEDGE_BASE_INPUT,
+        toolAnnotations('reindex_knowledge_base'),
         this.handleReindexKnowledgeBase.bind(this)
       );
     }

--- a/src/mcp-tool-specs.ts
+++ b/src/mcp-tool-specs.ts
@@ -11,6 +11,7 @@
 // can therefore import the built `build/mcp-tool-specs.js` without booting a
 // server.
 
+import type { ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
 import { z, type ZodRawShape } from 'zod';
 
 import {
@@ -148,18 +149,76 @@ export interface McpToolSpec {
   inputShape?: ZodRawShape;
   /** True when the tool is only registered if KB_INGEST_ENABLED is set. */
   ingestGated?: boolean;
+  /**
+   * Issue #798 — advisory MCP `ToolAnnotations` (readOnlyHint / destructiveHint
+   * / idempotentHint) the server passes to `mcp.tool()`. These are hints an MCP
+   * client's policy layer keys on to gate auto-approval and confirm destructive
+   * actions; they are NOT server-side enforcement (the ingest gate remains the
+   * enforcement layer). Read-only tools mirror `!ingestGated`; the three
+   * ingest-gated writes are annotated by hand since a single boolean cannot
+   * distinguish a destructive delete from an idempotent add/reindex.
+   */
+  annotations: ToolAnnotations;
 }
+
+// Shared annotation objects. The six readers do not modify their environment;
+// per the MCP spec `destructiveHint`/`idempotentHint` are meaningful only when
+// `readOnlyHint === false`, so a lone `readOnlyHint: true` is the complete hint
+// for a reader.
+const READ_ONLY_ANNOTATIONS: ToolAnnotations = { readOnlyHint: true };
 
 // Order mirrors registration in KnowledgeBaseServer.registerTools so the
 // generated doc reads top-to-bottom like the server surface.
 export const MCP_TOOL_SPECS: McpToolSpec[] = [
-  { name: 'list_knowledge_bases', description: LIST_KNOWLEDGE_BASES_DESCRIPTION },
-  { name: 'retrieve_knowledge', description: RETRIEVE_KNOWLEDGE_DESCRIPTION, inputShape: RETRIEVE_KNOWLEDGE_INPUT },
-  { name: 'ask_knowledge', description: ASK_KNOWLEDGE_DESCRIPTION, inputShape: ASK_KNOWLEDGE_INPUT },
-  { name: 'list_models', description: LIST_MODELS_DESCRIPTION },
-  { name: 'kb_stats', description: KB_STATS_DESCRIPTION, inputShape: KB_STATS_INPUT },
-  { name: 'diff_index', description: DIFF_INDEX_DESCRIPTION, inputShape: DIFF_INDEX_INPUT },
-  { name: 'add_document', description: ADD_DOCUMENT_DESCRIPTION, inputShape: ADD_DOCUMENT_INPUT, ingestGated: true },
-  { name: 'delete_document', description: DELETE_DOCUMENT_DESCRIPTION, inputShape: DELETE_DOCUMENT_INPUT, ingestGated: true },
-  { name: 'reindex_knowledge_base', description: REINDEX_KNOWLEDGE_BASE_DESCRIPTION, inputShape: REINDEX_KNOWLEDGE_BASE_INPUT, ingestGated: true },
+  { name: 'list_knowledge_bases', description: LIST_KNOWLEDGE_BASES_DESCRIPTION, annotations: READ_ONLY_ANNOTATIONS },
+  { name: 'retrieve_knowledge', description: RETRIEVE_KNOWLEDGE_DESCRIPTION, inputShape: RETRIEVE_KNOWLEDGE_INPUT, annotations: READ_ONLY_ANNOTATIONS },
+  { name: 'ask_knowledge', description: ASK_KNOWLEDGE_DESCRIPTION, inputShape: ASK_KNOWLEDGE_INPUT, annotations: READ_ONLY_ANNOTATIONS },
+  { name: 'list_models', description: LIST_MODELS_DESCRIPTION, annotations: READ_ONLY_ANNOTATIONS },
+  { name: 'kb_stats', description: KB_STATS_DESCRIPTION, inputShape: KB_STATS_INPUT, annotations: READ_ONLY_ANNOTATIONS },
+  { name: 'diff_index', description: DIFF_INDEX_DESCRIPTION, inputShape: DIFF_INDEX_INPUT, annotations: READ_ONLY_ANNOTATIONS },
+  // add_document writes a document: not read-only, and additive rather than
+  // destructive (it creates/overwrites a single path). Re-writing the same
+  // path+content leaves the KB in the same state, so it is idempotent.
+  {
+    name: 'add_document',
+    description: ADD_DOCUMENT_DESCRIPTION,
+    inputShape: ADD_DOCUMENT_INPUT,
+    ingestGated: true,
+    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true },
+  },
+  // delete_document removes a document: the one destructive write. Deleting the
+  // same path twice is not a stable no-op (the second call has nothing to
+  // remove), so it is not marked idempotent.
+  {
+    name: 'delete_document',
+    description: DELETE_DOCUMENT_DESCRIPTION,
+    inputShape: DELETE_DOCUMENT_INPUT,
+    ingestGated: true,
+    annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false },
+  },
+  // reindex_knowledge_base rebuilds the index from unchanged sources: not
+  // read-only, but additive (it does not delete source content) and idempotent
+  // (re-running over the same sources reproduces the same index).
+  {
+    name: 'reindex_knowledge_base',
+    description: REINDEX_KNOWLEDGE_BASE_DESCRIPTION,
+    inputShape: REINDEX_KNOWLEDGE_BASE_INPUT,
+    ingestGated: true,
+    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true },
+  },
 ];
+
+const ANNOTATIONS_BY_NAME = new Map(MCP_TOOL_SPECS.map((spec) => [spec.name, spec.annotations]));
+
+/**
+ * Look up the advisory `ToolAnnotations` for a registered tool. Throws if the
+ * name is unknown so a registration/spec drift fails loudly rather than
+ * silently registering a tool with no safety hints.
+ */
+export function toolAnnotations(name: string): ToolAnnotations {
+  const annotations = ANNOTATIONS_BY_NAME.get(name);
+  if (annotations === undefined) {
+    throw new Error(`No MCP tool annotations registered for tool "${name}"`);
+  }
+  return annotations;
+}


### PR DESCRIPTION
## Summary

Sets MCP `ToolAnnotations` (`readOnlyHint` / `destructiveHint` / `idempotentHint`) on all 9 registered tools so MCP clients can gate auto-approval and confirm destructive knowledge-base mutations. Previously a client could not distinguish `delete_document` from `list_models` — every tool registered with no annotations. These are advisory hints (defense-in-depth signaling), **not** server-side enforcement: the ingest gate remains the enforcement layer.

Closes #798

## Changes

- **`src/mcp-tool-specs.ts`** — add a per-tool `annotations: ToolAnnotations` field to the spec registry (the single source of truth) plus a `toolAnnotations(name)` lookup that throws on unknown names so spec/registration drift fails loudly.
- **`src/KnowledgeBaseServer.ts`** — restore the SDK's `tool(name, description, paramsSchema, annotations, cb)` overload inside `registerShapedTool` (the earlier signature loosening dropped it) and thread annotations through every registration. The zero-arg readers use the SDK's `(name, description, annotations, cb)` overload. The #795 `extra`-argument forwarding is preserved unchanged.
- **`src/KnowledgeBaseServer.test.ts`** — new focused test asserting each of the 9 tools registers with its expected annotation hints.

## Annotation values

| Tool | `readOnlyHint` | `destructiveHint` | `idempotentHint` |
| --- | --- | --- | --- |
| list_knowledge_bases, retrieve_knowledge, ask_knowledge, list_models, kb_stats, diff_index | `true` | — | — |
| add_document | `false` | `false` | `true` |
| delete_document | `false` | `true` | `false` |
| reindex_knowledge_base | `false` | `false` | `true` |

Rationale: the 6 readers mirror `!ingestGated`. The 3 ingest-gated writes are hand-reviewed because a single boolean can't distinguish a destructive delete from an idempotent add/reindex. `add_document` and `reindex_knowledge_base` are additive (they don't remove source content) and idempotent (re-running with the same inputs reproduces the same state); `delete_document` is the sole destructive write and isn't a stable no-op on repeat.

## Design choices the issue left open

- **`readOnlyHint` on readers only** — per the MCP spec, `destructiveHint`/`idempotentHint` are meaningful only when `readOnlyHint === false`, so readers carry just `readOnlyHint: true` (smallest complete hint). Alternative considered: also emitting explicit `destructiveHint: false` on readers — omitted as redundant.
- **`openWorldHint` omitted** — left to the SDK default rather than set. The KB is effectively a closed world (local files), so `openWorldHint: false` would be defensible, but the issue flagged it as a judgment call and it isn't required to satisfy the ask. Kept minimal; easy to add later if a client policy needs it.

## Verification

- `npm run build` ✅
- `npm run lint` ✅
- `npm run docs:check-mcp-tools` ✅ (no doc drift from the new field)
- `KnowledgeBaseServer.test.ts` (105 tests) ✅ including the new annotation test
- `mcp-tools-doc.test.ts` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)