### PR TITLE
feat: add global --quiet/--verbose verbosity flags across kb commands

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -86,6 +86,9 @@ Options:
                         commands: /sources, /kb <name>, /save, /refresh, /reset, /exit.
   --no-stream           Wait for the full answer before printing markdown output.
   --timing              Include elapsed milliseconds for retrieval and LLM stages.
+  --quiet, -q           Suppress the thinking spinner and the LLM/context
+                        footers, leaving only the answer and sources.
+  --verbose, -v         Surface extra diagnostics (equivalent to --timing).
   --stdin               Read question from stdin.
   --save-transcript     Save the question, answer, citations, and provenance
                         as a new markdown note. Requires --kb and --yes.
@@ -1158,6 +1161,9 @@ Options:
                         a reindex inside 06:00-10:30 UTC or when the
                         run is estimated to cross that window.
   --format=md|json      Output format for `status` (default: md).
+  --quiet, -q           Suppress the rebuild progress spinner, leaving only
+                        the summary and errors.
+  --verbose, -v         Reserved for extra diagnostics.
   --help, -h            Show this help.
 
 Exit codes:
@@ -1520,6 +1526,12 @@ Indexing:
                         100 MiB, prints a nonblocking refresh preflight to
                         stderr before embedding starts.
 
+Verbosity:
+  --quiet, -q           Suppress the freshness footer and refresh progress,
+                        leaving only results and errors (ideal for `| jq`).
+                        Combines with --format=json.
+  --verbose, -v         Surface extra diagnostics (equivalent to --timing).
+
 Input:
   --stdin               Read query from stdin (multi-line safe).
   -i, --interactive     Open an interactive results picker (TTY only; ignored
@@ -1570,6 +1582,9 @@ Options:
   --warm                    Pre-warm the active model, FAISS index, and
                             lexical indexes before the daemon reports ready.
   --json                    `kb serve status`: emit the daemon health JSON.
+  --quiet, -q               Suppress the "listening on" line (and the `status`
+                            "start one with" hint), leaving only errors.
+  --verbose, -v             Reserved for extra diagnostics.
   --help, -h                Show this help.
 
 Environment:
@@ -1603,7 +1618,7 @@ Scan markdown notes for path / URL references that no longer resolve.
 kb stale-check — find broken references in markdown notes (read-only)
 
 Usage:
-  kb stale-check [--kb=<name>] [--no-cache] [--verbose|-v]
+  kb stale-check [--kb=<name>] [--no-cache] [--quiet|-q] [--verbose|-v]
 
 Walks every `.md` / `.markdown` file under one or all KBs and extracts:
   - tilde-rooted absolute paths       (`~/foo/bar`)
@@ -1621,6 +1636,8 @@ Options:
   --kb=<name>           Scope to one knowledge base. Omit for all KBs.
   --no-cache            Bypass the URL cache for this run; freshly probe
                         every URL and overwrite cached entries.
+  --quiet, -q           Suppress the summary footer, leaving only the
+                        broken/error reference lines (empty when clean).
   --verbose, -v         Include OK references in the report (default:
                         only print broken/error references).
   --help, -h            Show this help.

--- a/src/cli-ask.test.ts
+++ b/src/cli-ask.test.ts
@@ -46,6 +46,7 @@ describe('parseAskArgs', () => {
       interactive: false,
       noStream: false,
       timing: true,
+      verbosity: 'normal',
       saveTranscript: true,
       title: 'Incident answer',
       yes: true,
@@ -1445,5 +1446,73 @@ describe('kb ask --interactive routing', () => {
       if (previousEndpoint === undefined) delete process.env.KB_LLM_ENDPOINT;
       else process.env.KB_LLM_ENDPOINT = previousEndpoint;
     }
+  });
+});
+
+describe('kb ask global verbosity (#739)', () => {
+  async function runAskMarkdown(extraArgs: string[]): Promise<string> {
+    const previousEndpoint = process.env.KB_LLM_ENDPOINT;
+    const stdout: string[] = [];
+    const stdoutSpy = jest.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+      stdout.push(String(chunk));
+      return true;
+    });
+    const stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    try {
+      process.env.KB_LLM_ENDPOINT = 'http://127.0.0.1:8080/v1/chat/completions';
+      const manager = {
+        modelDir: '/tmp/kb-ask-verbosity',
+        initialize: jest.fn(async () => {}),
+        updateIndex: jest.fn(async () => {}),
+        similaritySearch: jest.fn(async () => [
+          {
+            pageContent: 'Rollback is approved by the on-call lead.',
+            metadata: {
+              knowledgeBase: 'ops',
+              relativePath: 'rollback.md',
+              loc: { lines: { from: 1, to: 4 } },
+            },
+            score: 0.1,
+          },
+        ]),
+      };
+      const deps: RunAskDeps = {
+        bootstrapLayout: jest.fn(async () => {}),
+        resolveActiveModel: jest.fn(async () => 'ollama__nomic-embed-text-latest'),
+        loadManagerForModel: jest.fn(async () => manager as never),
+        loadWithJsonRetry: jest.fn(async () => {}),
+        withWriteLock: jest.fn(async <T>(_resource: string, action: () => Promise<T>) => action()) as RunAskDeps['withWriteLock'],
+        callChatCompletion: jest.fn(async () => ({
+          content: 'The on-call lead approves rollback.',
+          model: 'qwen3',
+          raw: {},
+        })),
+        createTranscriptNote: createAskTranscriptNote,
+        knowledgeBasesRootDir: '/tmp/kb-ask-verbosity-root',
+      };
+      const code = await runAsk(['Who approves rollback?', '--kb=ops', '--no-stream', ...extraArgs], deps);
+      expect(code).toBe(0);
+      return stdout.join('');
+    } finally {
+      stdoutSpy.mockRestore();
+      stderrSpy.mockRestore();
+      if (previousEndpoint === undefined) delete process.env.KB_LLM_ENDPOINT;
+      else process.env.KB_LLM_ENDPOINT = previousEndpoint;
+    }
+  }
+
+  it('prints the LLM/context footers in normal mode', async () => {
+    const out = await runAskMarkdown([]);
+    expect(out).toContain('The on-call lead approves rollback.');
+    expect(out).toContain('> _LLM:');
+    expect(out).toContain('> _Context:');
+  });
+
+  it('--quiet drops the LLM/context footers, keeping the answer and sources', async () => {
+    const out = await runAskMarkdown(['--quiet']);
+    expect(out).toContain('The on-call lead approves rollback.');
+    expect(out).toContain('## Sources');
+    expect(out).not.toContain('> _LLM:');
+    expect(out).not.toContain('> _Context:');
   });
 });

--- a/src/cli-ask.ts
+++ b/src/cli-ask.ts
@@ -15,7 +15,7 @@ import {
   formatKbAskFailureJson,
   formatKbAskFailureStderr,
 } from './search-errors-core.js';
-import { loadManagerForModel, loadWithJsonRetry } from './cli-shared.js';
+import { extractVerbosity, loadManagerForModel, loadWithJsonRetry, type Verbosity } from './cli-shared.js';
 import {
   formatTimingFooter,
   nowMs,
@@ -84,6 +84,9 @@ Options:
                         commands: /sources, /kb <name>, /save, /refresh, /reset, /exit.
   --no-stream           Wait for the full answer before printing markdown output.
   --timing              Include elapsed milliseconds for retrieval and LLM stages.
+  --quiet, -q           Suppress the thinking spinner and the LLM/context
+                        footers, leaving only the answer and sources.
+  --verbose, -v         Surface extra diagnostics (equivalent to --timing).
   --stdin               Read question from stdin.
   --save-transcript     Save the question, answer, citations, and provenance
                         as a new markdown note. Requires --kb and --yes.
@@ -106,6 +109,7 @@ export interface AskArgs {
   interactive: boolean;
   noStream: boolean;
   timing: boolean;
+  verbosity: Verbosity;
   saveTranscript: boolean;
   title?: string;
   yes: boolean;
@@ -166,6 +170,8 @@ export async function runAsk(rest: string[], deps: RunAskDeps = defaultRunAskDep
   if (args.stdin && args.question === null) {
     args.question = await readAllStdin();
   }
+  // Issue #739 — --verbose surfaces the same per-stage timing as --timing.
+  if (args.verbosity === 'verbose') args.timing = true;
 
   if (args.interactive) {
     const stdinIsTty = deps.stdinIsTty ?? (() => Boolean(process.stdin.isTTY));
@@ -198,7 +204,8 @@ export async function runAsk(rest: string[], deps: RunAskDeps = defaultRunAskDep
   // seconds. Show a stderr spinner while we wait; it self-suppresses for
   // JSON / piped / NO_COLOR output and is cleared before any answer prints.
   const progress = createTtyProgress({ label: 'kb ask: thinking', format: args.format });
-  progress.start();
+  // --quiet suppresses the spinner along with the other non-essential chatter.
+  if (args.verbosity !== 'quiet') progress.start();
   try {
     const streamMarkdown = args.format === 'md' && !args.noStream;
     result = await executeAsk({
@@ -315,13 +322,17 @@ export async function runAsk(rest: string[], deps: RunAskDeps = defaultRunAskDep
         process.stdout.write(`- ${kb}${c.path}${score}${chunk}\n`);
       }
     }
-    process.stdout.write(`\n> _LLM: ${result.llm.profile} (${result.llm.mode}) at ${result.llm.endpoint}; retrieval model: ${result.retrieval.embedding_model}._\n`);
-    const totalChunks = result.context_packing.included_chunks + result.context_packing.excluded_chunks;
-    process.stdout.write(`> _Context: ${result.context_packing.included_chunks}/${totalChunks} chunks, approx ${result.context_packing.estimated_tokens}/${result.context_packing.budget_tokens} tokens`);
-    if (result.context_packing.truncated_chunks > 0) {
-      process.stdout.write(`, ${result.context_packing.truncated_chunks} truncated`);
+    // Issue #739 — the LLM/context provenance footers are non-essential
+    // metadata; --quiet drops them so the answer + sources are all that print.
+    if (args.verbosity !== 'quiet') {
+      process.stdout.write(`\n> _LLM: ${result.llm.profile} (${result.llm.mode}) at ${result.llm.endpoint}; retrieval model: ${result.retrieval.embedding_model}._\n`);
+      const totalChunks = result.context_packing.included_chunks + result.context_packing.excluded_chunks;
+      process.stdout.write(`> _Context: ${result.context_packing.included_chunks}/${totalChunks} chunks, approx ${result.context_packing.estimated_tokens}/${result.context_packing.budget_tokens} tokens`);
+      if (result.context_packing.truncated_chunks > 0) {
+        process.stdout.write(`, ${result.context_packing.truncated_chunks} truncated`);
+      }
+      process.stdout.write('._\n');
     }
-    process.stdout.write('._\n');
     if (savedTranscript) {
       process.stdout.write(`> _Transcript saved: ${savedTranscript.knowledge_base}:${savedTranscript.path}._\n`);
     }
@@ -391,6 +402,9 @@ async function persistAskTranscript(
 }
 
 export function parseAskArgs(rest: string[]): AskArgs {
+  // Issue #739 — resolve the shared --quiet/--verbose flags before parsing the
+  // command-specific flags from what remains.
+  const { verbosity, rest: args } = extractVerbosity(rest);
   const out: AskArgs = {
     question: null,
     k: 8,
@@ -401,11 +415,12 @@ export function parseAskArgs(rest: string[]): AskArgs {
     interactive: false,
     noStream: false,
     timing: false,
+    verbosity,
     saveTranscript: false,
     yes: false,
   };
-  for (let i = 0; i < rest.length; i++) {
-    const raw = rest[i];
+  for (let i = 0; i < args.length; i++) {
+    const raw = args[i];
     if (raw === '--refresh') { out.refresh = true; continue; }
     if (raw === '--stdin') { out.stdin = true; continue; }
     if (raw === '--interactive' || raw === '-i') { out.interactive = true; continue; }
@@ -419,7 +434,7 @@ export function parseAskArgs(rest: string[]): AskArgs {
     if (raw.startsWith('--endpoint=')) { out.endpoint = raw.slice('--endpoint='.length); continue; }
     if (raw.startsWith('--title=')) { out.title = raw.slice('--title='.length); continue; }
     if (raw === '--title') {
-      const next = rest[i + 1];
+      const next = args[i + 1];
       if (next === undefined) throw new Error('--title requires a value');
       out.title = next;
       i++;

--- a/src/cli-reindex.ts
+++ b/src/cli-reindex.ts
@@ -20,6 +20,7 @@ import { assertSufficientDiskSpace } from './disk-preflight.js';
 import { KBError } from './errors.js';
 import { logger } from './logger.js';
 import { createTtyProgress } from './tty-progress.js';
+import { extractVerbosity } from './cli-shared.js';
 
 export const REINDEX_HELP = `kb reindex — rebuild FAISS indexes (RFC 017)
 
@@ -93,6 +94,9 @@ Options:
                         a reindex inside 06:00-10:30 UTC or when the
                         run is estimated to cross that window.
   --format=md|json      Output format for \`status\` (default: md).
+  --quiet, -q           Suppress the rebuild progress spinner, leaving only
+                        the summary and errors.
+  --verbose, -v         Reserved for extra diagnostics.
   --help, -h            Show this help.
 
 Exit codes:
@@ -140,15 +144,17 @@ function parseReindexArgs(rest: string[]): ReindexArgs {
 }
 
 export async function runReindexCli(rest: string[]): Promise<number> {
+  // Issue #739 — resolve the shared --quiet/--verbose flags before dispatching.
+  const { verbosity, rest: args } = extractVerbosity(rest);
   // `kb reindex status` is a separate read-only subcommand (#407) — it
   // does not run a rebuild and does not need `--with-context`.
-  if (rest[0] === 'status') {
-    return runReindexStatusCli(rest.slice(1));
+  if (args[0] === 'status') {
+    return runReindexStatusCli(args.slice(1));
   }
 
   let parsed: ReindexArgs;
   try {
-    parsed = parseReindexArgs(rest);
+    parsed = parseReindexArgs(args);
   } catch (err) {
     process.stderr.write(`kb reindex: ${(err as Error).message}\n`);
     return 2;
@@ -190,7 +196,9 @@ export async function runReindexCli(rest: string[]): Promise<number> {
   // the process is working, not hung. It self-suppresses on non-TTY / NO_COLOR
   // output and is cleared before the summary prints to stdout.
   const progress = createTtyProgress({ label: 'kb reindex: rebuilding index', format: 'md' });
-  progress.start();
+  // --quiet suppresses the spinner (routine progress), leaving only the summary
+  // and any errors.
+  if (verbosity !== 'quiet') progress.start();
   let result: ReindexResult;
   try {
     result = await runReindex({

--- a/src/cli-search.test.ts
+++ b/src/cli-search.test.ts
@@ -8,6 +8,7 @@ import {
   formatDenseSearchMarkdownOutput,
   formatRefreshProgressLine,
   parseSearchArgs,
+  refreshProgressWriter,
   runSearch,
   searchFiltersFromArgs,
   shouldUsePicker,
@@ -28,6 +29,30 @@ import type { ExplainEmptyDiagnostics, Staleness } from './search-core.js';
 import { setRerankerFactoryForTests } from './reranker.js';
 
 const MTIME = '2026-05-03T15:33:56.964Z';
+
+describe('refreshProgressWriter (#739)', () => {
+  it('--quiet swallows refresh progress lines', () => {
+    const stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    try {
+      refreshProgressWriter('quiet')('kb search refresh: embed...\n');
+      expect(stderrSpy).not.toHaveBeenCalled();
+    } finally {
+      stderrSpy.mockRestore();
+    }
+  });
+
+  it('normal/verbose write refresh progress to stderr', () => {
+    for (const level of ['normal', 'verbose'] as const) {
+      const stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+      try {
+        refreshProgressWriter(level)('line\n');
+        expect(stderrSpy).toHaveBeenCalledWith('line\n');
+      } finally {
+        stderrSpy.mockRestore();
+      }
+    }
+  });
+});
 
 describe('refresh progress output (#316)', () => {
   it('formats bounded embedding batches as concise stderr progress lines', () => {
@@ -741,6 +766,38 @@ describe('runSearch timing guard (#331)', () => {
       query: 'valid',
       result: { freshness_omitted: true },
     });
+  });
+
+  it('--quiet omits the freshness footer from markdown output (#739)', async () => {
+    const { deps } = makeDeps();
+    const out = await captureSearchOutput(['rollback', '--quiet'], deps);
+    expect(out.code).toBe(0);
+    expect(out.stdout).not.toContain('> _Index');
+  });
+
+  it('--quiet --format=json emits freshness_omitted with no staleness object (#739)', async () => {
+    const { deps } = makeDeps();
+    const out = await captureSearchOutput(['rollback', '--quiet', '--format=json'], deps);
+    expect(out.code).toBe(0);
+    const payload = JSON.parse(out.stdout) as { freshness_omitted?: boolean; staleness?: unknown };
+    expect(payload.freshness_omitted).toBe(true);
+    expect(payload.staleness).toBeUndefined();
+  });
+
+  it('--verbose turns on per-stage timing diagnostics (#739)', async () => {
+    const { deps } = makeDeps();
+    const verbose = await captureSearchOutput(
+      ['rollback', '--verbose', '--no-freshness', '--format=json'],
+      deps,
+    );
+    expect(verbose.code).toBe(0);
+    expect((JSON.parse(verbose.stdout) as { timing?: unknown }).timing).toBeDefined();
+
+    const normal = await captureSearchOutput(
+      ['rollback', '--no-freshness', '--format=json'],
+      deps,
+    );
+    expect((JSON.parse(normal.stdout) as { timing?: unknown }).timing).toBeUndefined();
   });
 
   it('invalidates cached freshness after a JSONL batch row refreshes the index', async () => {

--- a/src/cli-search.ts
+++ b/src/cli-search.ts
@@ -42,7 +42,7 @@ import { runPicker } from './cli-search-picker.js';
 import { parseColorMode, resolveColorEnabled, type ColorMode } from './color.js';
 import { listKnowledgeBases } from './kb-fs.js';
 import { withWriteLock } from './write-lock.js';
-import { loadManagerForModel, loadWithJsonRetry } from './cli-shared.js';
+import { extractVerbosity, loadManagerForModel, loadWithJsonRetry, type Verbosity } from './cli-shared.js';
 import {
   compactTimingPayload,
   elapsedMs,
@@ -308,6 +308,12 @@ Indexing:
                         100 MiB, prints a nonblocking refresh preflight to
                         stderr before embedding starts.
 
+Verbosity:
+  --quiet, -q           Suppress the freshness footer and refresh progress,
+                        leaving only results and errors (ideal for \`| jq\`).
+                        Combines with --format=json.
+  --verbose, -v         Surface extra diagnostics (equivalent to --timing).
+
 Input:
   --stdin               Read query from stdin (multi-line safe).
   -i, --interactive     Open an interactive results picker (TTY only; ignored
@@ -367,6 +373,7 @@ interface SearchArgs {
   batchJsonl: boolean;
   noCache: boolean;
   freshness: boolean;
+  verbosity: Verbosity;
   highlight: SearchHighlightMode;
   snippetLines?: number;
   color: ColorMode;
@@ -422,6 +429,33 @@ export function createRunSearchDeps(overrides: Partial<RunSearchDeps> = {}): Run
   return { ...DEFAULT_RUN_SEARCH_DEPS, ...overrides };
 }
 
+/**
+ * Issue #739 — fold the resolved verbosity level into the concrete output
+ * knobs `runSearch` already understands. `--quiet` reuses the existing
+ * `--no-freshness` lever (dropping the freshness footer / JSON staleness) and
+ * silences refresh progress; `--verbose` turns on the same per-stage timing
+ * diagnostics as `--timing`. An explicit `--timing`/`--no-freshness` a user
+ * also passed still holds — this only tightens the defaults.
+ */
+function applySearchVerbosity(parsed: SearchArgs): void {
+  if (parsed.verbosity === 'quiet') {
+    parsed.freshness = false;
+  } else if (parsed.verbosity === 'verbose') {
+    parsed.timing = true;
+  }
+}
+
+/**
+ * The stderr sink for refresh progress lines. `--quiet` swallows them (they are
+ * routine progress, not a result or error); every other level writes to stderr
+ * so stdout stays clean for the result.
+ */
+export function refreshProgressWriter(verbosity: Verbosity): (line: string) => void {
+  return verbosity === 'quiet'
+    ? () => {}
+    : (line) => { process.stderr.write(line); };
+}
+
 export async function runSearch(
   rest: string[],
   deps: RunSearchDeps = DEFAULT_RUN_SEARCH_DEPS,
@@ -435,6 +469,7 @@ export async function runSearch(
     process.stderr.write(`kb search: ${(err as Error).message}\n`);
     return 2;
   }
+  applySearchVerbosity(parsed);
 
   if (parsed.stdin && parsed.query === null) {
     if (parsed.batchJsonl) {
@@ -607,7 +642,7 @@ export async function runSearch(
         await manager.initialize();
         await withRetrievalViewsForIngest(parsed.retrievalViews, () =>
           manager.updateIndex(parsed.kb, {
-            onProgress: createRefreshProgressReporter(timing),
+            onProgress: createRefreshProgressReporter(timing, refreshProgressWriter(parsed.verbosity)),
             force: parsed.retrievalViews !== undefined,
           }),
         );
@@ -961,6 +996,9 @@ async function runAdvancedDenseSearch(input: {
 
 export function parseSearchArgs(rest: string[]): SearchArgs {
   let snippetExplicit = false;
+  // Issue #739 — resolve the shared --quiet/--verbose flags first, then parse
+  // the command-specific flags from what remains.
+  const { verbosity, rest: args } = extractVerbosity(rest);
   const out: SearchArgs = {
     query: null,
     k: 10,
@@ -976,6 +1014,7 @@ export function parseSearchArgs(rest: string[]): SearchArgs {
     batchJsonl: false,
     noCache: false,
     freshness: true,
+    verbosity,
     highlight: 'auto',
     color: 'auto',
     colorExplicit: false,
@@ -992,7 +1031,7 @@ export function parseSearchArgs(rest: string[]): SearchArgs {
     decomposeProvider: 'rule',
     decomposeBudget: {},
   };
-  for (const raw of rest) {
+  for (const raw of args) {
     if (raw === '--refresh') { out.refresh = true; continue; }
     if (raw === '--stdin')   { out.stdin = true; continue; }
     if (raw === '--group-by-source') { out.groupBySource = true; continue; }
@@ -2227,7 +2266,7 @@ async function loadBatchIndex(
         await printRefreshPreflightIfLarge(activeModelId, state.manager, row.kb, row.format);
         await state.manager.initialize();
         await state.manager.updateIndex(row.kb, {
-          onProgress: createRefreshProgressReporter(timing),
+          onProgress: createRefreshProgressReporter(timing, refreshProgressWriter(row.verbosity)),
         });
       });
       state.refreshedScopes.add(scopeKey);
@@ -2744,7 +2783,7 @@ async function runHybridSearch(
         await manager.initialize();
         await withRetrievalViewsForIngest(parsed.retrievalViews, () =>
           manager.updateIndex(parsed.kb, {
-            onProgress: createRefreshProgressReporter(timing),
+            onProgress: createRefreshProgressReporter(timing, refreshProgressWriter(parsed.verbosity)),
             force: parsed.retrievalViews !== undefined,
           }),
         );

--- a/src/cli-serve.test.ts
+++ b/src/cli-serve.test.ts
@@ -972,4 +972,30 @@ describe('kb serve status', () => {
     const result = await captureStatus(['--bogus']);
     expect(result.code).toBe(2);
   });
+
+  it('--quiet drops the "start one with" hint when unreachable (#739)', async () => {
+    const daemon = await startDaemonServer({ port: 0, idleTimeoutMs: 0 });
+    const url = daemon.url.href;
+    await daemon.stop();
+    process.env.KB_DAEMON_URL = url;
+
+    const chunks: string[] = [];
+    const originalWrite = process.stdout.write;
+    process.stdout.write = ((chunk: unknown, ...rest: unknown[]) => {
+      chunks.push(String(chunk));
+      const callback = rest.find((arg): arg is (err?: Error) => void => typeof arg === 'function');
+      if (callback) callback();
+      return true;
+    }) as typeof process.stdout.write;
+    let code: number;
+    try {
+      code = await runServeStatus([], 'quiet');
+    } finally {
+      process.stdout.write = originalWrite;
+    }
+    const stdout = chunks.join('');
+    expect(code).toBe(3);
+    expect(stdout).toContain(`no daemon reachable at ${url}`);
+    expect(stdout).not.toContain('start one with');
+  });
 });

--- a/src/cli-serve.ts
+++ b/src/cli-serve.ts
@@ -5,7 +5,7 @@ import * as path from 'node:path';
 import * as fsp from 'node:fs/promises';
 import { runList } from './cli-list.js';
 import { createRunSearchDeps, runSearch, type RunSearchDeps } from './cli-search.js';
-import { captureProcessOutput } from './cli-shared.js';
+import { captureProcessOutput, extractVerbosity, type Verbosity } from './cli-shared.js';
 import { EXIT } from './cli-exit-codes.js';
 import { runStats } from './cli-stats.js';
 import {
@@ -67,6 +67,9 @@ Options:
   --warm                    Pre-warm the active model, FAISS index, and
                             lexical indexes before the daemon reports ready.
   --json                    \`kb serve status\`: emit the daemon health JSON.
+  --quiet, -q               Suppress the "listening on" line (and the \`status\`
+                            "start one with" hint), leaving only errors.
+  --verbose, -v             Reserved for extra diagnostics.
   --help, -h                Show this help.
 
 Environment:
@@ -168,13 +171,15 @@ const DEFAULT_SERVE_ARGS: ServeArgs = {
 };
 
 export async function runServe(rest: string[]): Promise<number> {
-  if (rest[0] === 'status') {
-    return runServeStatus(rest.slice(1));
+  // Issue #739 — resolve the shared --quiet/--verbose flags before dispatching.
+  const { verbosity, rest: args } = extractVerbosity(rest);
+  if (args[0] === 'status') {
+    return runServeStatus(args.slice(1), verbosity);
   }
 
   let parsed: ServeArgs;
   try {
-    parsed = parseServeArgs(rest);
+    parsed = parseServeArgs(args);
   } catch (err) {
     process.stderr.write(`kb serve: ${(err as Error).message}\n`);
     return EXIT.USAGE;
@@ -188,7 +193,11 @@ export async function runServe(rest: string[]): Promise<number> {
     return EXIT.INTERNAL;
   }
 
-  process.stdout.write(`kb serve: listening on ${daemon.url.href}\n`);
+  // The "listening on" line is a non-essential status message; --quiet drops it
+  // so a scripted `kb serve &` starts silently.
+  if (verbosity !== 'quiet') {
+    process.stdout.write(`kb serve: listening on ${daemon.url.href}\n`);
+  }
   const drainTimeoutMs = resolveDaemonDrainTimeoutMs();
   let shuttingDown = false;
   const stop = () => {
@@ -265,7 +274,7 @@ function waitForInFlightDrain(
  * reachable, 2 bad argument/environment, 3 no daemon listening, 1 a daemon
  * answered with an unusable payload.
  */
-export async function runServeStatus(args: string[]): Promise<number> {
+export async function runServeStatus(args: string[], verbosity: Verbosity = 'normal'): Promise<number> {
   let json = false;
   for (const raw of args) {
     if (raw === '--json') {
@@ -298,7 +307,9 @@ export async function runServeStatus(args: string[]): Promise<number> {
       process.stdout.write(`${JSON.stringify({ reachable: false, url: url.href })}\n`);
     } else {
       process.stdout.write(`kb serve: no daemon reachable at ${url.href}\n`);
-      process.stdout.write('  start one with: kb serve\n');
+      // The "start one with" hint is a non-essential suggestion; --quiet omits
+      // it, leaving just the primary reachability line.
+      if (verbosity !== 'quiet') process.stdout.write('  start one with: kb serve\n');
     }
     return 3;
   }

--- a/src/cli-shared.test.ts
+++ b/src/cli-shared.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from '@jest/globals';
-import { renderRecords } from './cli-shared.js';
+import {
+  createVerbosityPrinter,
+  extractVerbosity,
+  renderRecords,
+} from './cli-shared.js';
 
 describe('renderRecords', () => {
   it('quotes CSV fields using RFC-4180 escaping', () => {
@@ -25,5 +29,64 @@ describe('renderRecords', () => {
     ], 'ndjson')).toBe(
       '{"name":"alpha","count":1}\n{"name":"beta","count":2}\n',
     );
+  });
+});
+
+describe('extractVerbosity (issue #739)', () => {
+  it('defaults to normal and leaves argv untouched', () => {
+    expect(extractVerbosity(['query', '--kb=ops'])).toEqual({
+      verbosity: 'normal',
+      rest: ['query', '--kb=ops'],
+    });
+  });
+
+  it('strips --quiet / -q and resolves quiet', () => {
+    expect(extractVerbosity(['a', '--quiet', 'b'])).toEqual({ verbosity: 'quiet', rest: ['a', 'b'] });
+    expect(extractVerbosity(['-q', 'a'])).toEqual({ verbosity: 'quiet', rest: ['a'] });
+  });
+
+  it('strips --verbose / -v and resolves verbose', () => {
+    expect(extractVerbosity(['a', '--verbose'])).toEqual({ verbosity: 'verbose', rest: ['a'] });
+    expect(extractVerbosity(['-v', 'a'])).toEqual({ verbosity: 'verbose', rest: ['a'] });
+  });
+
+  it('lets the last verbosity flag win when both appear', () => {
+    expect(extractVerbosity(['--verbose', '--quiet']).verbosity).toBe('quiet');
+    expect(extractVerbosity(['--quiet', '--verbose']).verbosity).toBe('verbose');
+  });
+});
+
+describe('createVerbosityPrinter (issue #739)', () => {
+  function capture(verbosity: Parameters<typeof createVerbosityPrinter>[0]): {
+    lines: string[];
+    printer: ReturnType<typeof createVerbosityPrinter>;
+  } {
+    const lines: string[] = [];
+    return { lines, printer: createVerbosityPrinter(verbosity, (text) => lines.push(text)) };
+  }
+
+  it('normal: writes info but not diag', () => {
+    const { lines, printer } = capture('normal');
+    printer.info('i\n');
+    printer.diag('d\n');
+    expect(lines).toEqual(['i\n']);
+    expect(printer.isQuiet).toBe(false);
+    expect(printer.isVerbose).toBe(false);
+  });
+
+  it('quiet: suppresses both info and diag', () => {
+    const { lines, printer } = capture('quiet');
+    printer.info('i\n');
+    printer.diag('d\n');
+    expect(lines).toEqual([]);
+    expect(printer.isQuiet).toBe(true);
+  });
+
+  it('verbose: writes both info and diag', () => {
+    const { lines, printer } = capture('verbose');
+    printer.info('i\n');
+    printer.diag('d\n');
+    expect(lines).toEqual(['i\n', 'd\n']);
+    expect(printer.isVerbose).toBe(true);
   });
 });

--- a/src/cli-shared.ts
+++ b/src/cli-shared.ts
@@ -59,6 +59,72 @@ export interface CapturedProcessOutput {
   stderr: string;
 }
 
+// -- Global verbosity (issue #739) -------------------------------------------
+//
+// A single shared mechanism so every migrated `kb` subcommand honors the same
+// `--quiet`/`--verbose` flags instead of each reinventing output-noise control.
+//   - `--quiet` / `-q`: strip non-essential chatter — progress spinners/lines,
+//     freshness footers, and informational status lines — leaving only the
+//     primary result and errors. This is what a `… | jq` pipeline wants, and it
+//     composes with `--format json`.
+//   - `--verbose` / `-v`: surface extra diagnostics (e.g. per-stage timing).
+// Errors and genuine warnings are NEVER routed through this mechanism, so a
+// degradation signal a user needs to see is not hidden by `--quiet`.
+
+export type Verbosity = 'quiet' | 'normal' | 'verbose';
+
+export interface ParsedVerbosity {
+  verbosity: Verbosity;
+  /** argv with the verbosity flags removed, ready for a command's own parser. */
+  rest: string[];
+}
+
+/**
+ * Strip `--quiet`/`-q` and `--verbose`/`-v` from argv and resolve one level.
+ * When both families appear the LAST occurrence wins, so `--verbose --quiet`
+ * ends quiet and `--quiet --verbose` ends verbose. The returned `rest` keeps
+ * every other token in order so a command's existing parser is unaffected.
+ */
+export function extractVerbosity(rest: readonly string[]): ParsedVerbosity {
+  let verbosity: Verbosity = 'normal';
+  const remaining: string[] = [];
+  for (const raw of rest) {
+    if (raw === '--quiet' || raw === '-q') { verbosity = 'quiet'; continue; }
+    if (raw === '--verbose' || raw === '-v') { verbosity = 'verbose'; continue; }
+    remaining.push(raw);
+  }
+  return { verbosity, rest: remaining };
+}
+
+export interface VerbosityPrinter {
+  readonly verbosity: Verbosity;
+  readonly isQuiet: boolean;
+  readonly isVerbose: boolean;
+  /** Non-essential status/progress line; written unless `--quiet`. */
+  info(text: string): void;
+  /** Extra diagnostic line; written only under `--verbose`. */
+  diag(text: string): void;
+}
+
+/**
+ * Build a printer for a resolved verbosity level. `info` is the sink for
+ * non-essential lines (suppressed by `--quiet`); `diag` is the sink for
+ * verbose-only diagnostics. Both default to stderr so stdout stays clean for
+ * the primary result. Callers pass complete lines including any trailing `\n`.
+ */
+export function createVerbosityPrinter(
+  verbosity: Verbosity,
+  write: (text: string) => void = (text) => { process.stderr.write(text); },
+): VerbosityPrinter {
+  return {
+    verbosity,
+    isQuiet: verbosity === 'quiet',
+    isVerbose: verbosity === 'verbose',
+    info(text) { if (verbosity !== 'quiet') write(text); },
+    diag(text) { if (verbosity === 'verbose') write(text); },
+  };
+}
+
 export type DelimitedOutputFormat = 'csv' | 'tsv' | 'ndjson';
 
 export interface RenderRecordsOptions {

--- a/src/cli-stale-check.test.ts
+++ b/src/cli-stale-check.test.ts
@@ -25,6 +25,12 @@ describe('parseStaleCheckArgs', () => {
     const a = parseStaleCheckArgs(['--no-cache', '--verbose']);
     expect(a.noCache).toBe(true);
     expect(a.verbose).toBe(true);
+    expect(a.quiet).toBe(false);
+  });
+  it('defers --quiet / -q to the shared verbosity mechanism (#739)', () => {
+    expect(parseStaleCheckArgs(['--quiet'])).toMatchObject({ quiet: true, verbose: false });
+    expect(parseStaleCheckArgs(['-q'])).toMatchObject({ quiet: true, verbose: false });
+    expect(parseStaleCheckArgs(['-v'])).toMatchObject({ quiet: false, verbose: true });
   });
 });
 
@@ -268,5 +274,32 @@ describe('formatReport', () => {
     expect(out).toContain('L7');
     expect(out).toContain('HTTP 404');
     expect(out).toContain('Summary: 2 stale reference(s) in 1 file(s)');
+  });
+
+  it('--quiet drops the summary footer, keeping only the stale-reference lines (#739)', () => {
+    const report = {
+      kbs: ['ops'],
+      files: [{
+        kb: 'ops',
+        relPath: 'a.md',
+        results: [
+          { type: 'tilde-path' as const, value: '~/x', line: 3, status: 'MISSING' as const, detail: 'gone' },
+        ],
+      }],
+      totals: { filesScanned: 1, referencesChecked: 1, staleReferences: 1, filesWithStale: 1 },
+    };
+    const out = formatReport(report, { quiet: true });
+    expect(out).toContain('ops/a.md');
+    expect(out).toContain('L3');
+    expect(out).not.toContain('Summary:');
+  });
+
+  it('--quiet emits nothing when there is no drift (#739)', () => {
+    const out = formatReport({
+      kbs: ['ops'],
+      files: [{ kb: 'ops', relPath: 'a.md', results: [] }],
+      totals: { filesScanned: 1, referencesChecked: 0, staleReferences: 0, filesWithStale: 0 },
+    }, { quiet: true });
+    expect(out).toBe('');
   });
 });

--- a/src/cli-stale-check.ts
+++ b/src/cli-stale-check.ts
@@ -17,11 +17,12 @@ import * as path from 'path';
 import * as os from 'os';
 import { KNOWLEDGE_BASES_ROOT_DIR } from './config/paths.js';
 import { listKnowledgeBases, resolveKnowledgeBaseDir } from './kb-fs.js';
+import { extractVerbosity } from './cli-shared.js';
 
 export const STALE_CHECK_HELP = `kb stale-check — find broken references in markdown notes (read-only)
 
 Usage:
-  kb stale-check [--kb=<name>] [--no-cache] [--verbose|-v]
+  kb stale-check [--kb=<name>] [--no-cache] [--quiet|-q] [--verbose|-v]
 
 Walks every \`.md\` / \`.markdown\` file under one or all KBs and extracts:
   - tilde-rooted absolute paths       (\`~/foo/bar\`)
@@ -39,6 +40,8 @@ Options:
   --kb=<name>           Scope to one knowledge base. Omit for all KBs.
   --no-cache            Bypass the URL cache for this run; freshly probe
                         every URL and overwrite cached entries.
+  --quiet, -q           Suppress the summary footer, leaving only the
+                        broken/error reference lines (empty when clean).
   --verbose, -v         Include OK references in the report (default:
                         only print broken/error references).
   --help, -h            Show this help.
@@ -117,7 +120,7 @@ export async function runStaleCheck(rest: string[]): Promise<number> {
       cachePath: parsed.noCache ? null : cachePath,
       verbose: parsed.verbose,
     });
-    process.stdout.write(formatReport(report));
+    process.stdout.write(formatReport(report, { quiet: parsed.quiet }));
     return 0;
   } catch (err) {
     process.stderr.write(`kb stale-check: ${(err as Error).message}\n`);
@@ -128,14 +131,25 @@ export async function runStaleCheck(rest: string[]): Promise<number> {
 interface ParsedArgs {
   kb?: string;
   noCache: boolean;
+  /** Include OK references in the report (shared --verbose / -v). */
   verbose: boolean;
+  /** Suppress the summary footer, leaving only broken references (--quiet / -q). */
+  quiet: boolean;
 }
 
 export function parseStaleCheckArgs(rest: string[]): ParsedArgs {
-  const out: ParsedArgs = { noCache: false, verbose: false };
-  for (const raw of rest) {
+  // Issue #739 — the historical per-command --verbose/-v now defers to the
+  // shared verbosity mechanism, which also adds --quiet/-q. `--verbose` keeps
+  // its original meaning here (include OK references); `--quiet` drops the
+  // summary footer so a script sees only the broken-reference lines.
+  const { verbosity, rest: args } = extractVerbosity(rest);
+  const out: ParsedArgs = {
+    noCache: false,
+    verbose: verbosity === 'verbose',
+    quiet: verbosity === 'quiet',
+  };
+  for (const raw of args) {
     if (raw === '--no-cache') { out.noCache = true; continue; }
-    if (raw === '--verbose' || raw === '-v') { out.verbose = true; continue; }
     if (raw.startsWith('--kb=')) {
       out.kb = raw.slice('--kb='.length);
       if (out.kb.length === 0) throw new Error('--kb=<name> requires a non-empty value');
@@ -500,7 +514,12 @@ function isStale(r: ReferenceResult): boolean {
   return r.status === 'MISSING' || r.status === 'HTTP_ERROR' || r.status === 'TIMEOUT';
 }
 
-export function formatReport(report: StaleCheckReport): string {
+export interface FormatReportOptions {
+  /** Issue #739 — drop the trailing summary footer, leaving only stale refs. */
+  quiet?: boolean;
+}
+
+export function formatReport(report: StaleCheckReport, options: FormatReportOptions = {}): string {
   const lines: string[] = [];
   for (const file of report.files) {
     const stale = file.results.filter(isStale);
@@ -509,6 +528,12 @@ export function formatReport(report: StaleCheckReport): string {
     for (const r of stale) {
       lines.push(`  L${r.line}  ${padCol(r.value, 50)}${formatStatus(r)}`);
     }
+  }
+
+  if (options.quiet) {
+    // Quiet output is just the broken-reference lines (empty when clean), so a
+    // pipeline can act on presence/absence of output without parsing a footer.
+    return lines.length === 0 ? '' : lines.join('\n') + '\n';
   }
 
   if (report.totals.staleReferences === 0) {


### PR DESCRIPTION
## Summary

Adds a shared verbosity mechanism so the high-traffic `kb` commands honor the same `--quiet`/`-q` and `--verbose`/`-v` flags instead of each reinventing output-noise control.

Closes #739

## What changed

- **`src/cli-shared.ts`** — new `extractVerbosity(argv)` (strips the flags, returns the remaining argv + a resolved `'quiet' | 'normal' | 'verbose'` level) and a small `createVerbosityPrinter(level)` helper (`info` = suppressed by `--quiet`, `diag` = shown only under `--verbose`, both default to stderr). This is the single source of truth the issue asked for.
- **search** — `--quiet` reuses the existing `--no-freshness` lever (no freshness footer in markdown, `freshness_omitted` in JSON) and silences refresh progress lines; `--verbose` turns on the same per-stage timing as `--timing`. stdout stays clean for `… | jq`, and `--quiet --format=json` is honored.
- **ask** — `--quiet` drops the "thinking" spinner and the `> _LLM:` / `> _Context:` provenance footers, leaving just the answer + sources; `--verbose` enables timing.
- **reindex** — `--quiet` suppresses the rebuild progress spinner.
- **serve** — `--quiet` drops the `listening on` line (and the `serve status` "start one with" hint).
- **stale-check** — its historical per-command `--verbose`/`-v` now **defers to the shared mechanism** (same "include OK references" meaning), and the new `--quiet` drops the summary footer so a script sees only the broken-reference lines.
- Regenerated `docs/reference/cli.md` (drift gate) and documented the flags in each command's help.

Errors and genuine warnings are **never** routed through this mechanism, so `--quiet` cannot hide a degradation signal.

## Design choices (not settled by the issue)

- **Precedence:** if both families appear, the **last flag wins** (`--verbose --quiet` → quiet). Simplest, predictable. Alternative considered: quiet-always-wins — rejected as less intuitive.
- **`--verbose` diagnostics = timing.** For search/ask this reuses the existing `--timing` surface rather than inventing a new diagnostics format. reindex/serve mark `--verbose` as reserved (no non-essential firehose to turn up yet) while still accepting the flag uniformly.
- **Global logger untouched.** `--quiet` suppresses each command's own non-essential output (footers, spinners, status lines) but does **not** reconfigure the process-wide `logger` (that `const`-level knob is env-driven via `LOG_LEVEL` and shared with the daemon/canonical logging — out of scope for a narrow change). The primary `| jq` use case is already satisfied because those library INFO lines go to **stderr** while the machine-readable result goes to **stdout**. Users who also want to mute library logs can set `LOG_LEVEL=warn`.

## Tests

- `cli-shared.test.ts` — `extractVerbosity` (defaults, stripping, `-q`/`-v` aliases, last-wins) and `createVerbosityPrinter` gating.
- `cli-search.test.ts` — `--quiet` omits the freshness footer (md) and emits `freshness_omitted` with no `staleness` (json); `--verbose` turns timing on; `refreshProgressWriter` swallows progress under quiet.
- `cli-ask.test.ts` — `--quiet` drops the LLM/context footers (answer + sources remain); normal mode still prints them.
- `cli-stale-check.test.ts` — `--quiet` drops the summary footer (and emits nothing when clean); parse maps shared `-q`/`-v`.
- `cli-serve.test.ts` — `--quiet` drops the `serve status` hint line.

`npm run build`, `npm run lint`, `docs:check-cli` (+ other docs gates), and the targeted suites above all pass locally.