### PR TITLE
feat: hybrid/lexical modes and opt-in rerank for kb ask and ask_knowledge

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ kb open alpha/docs/deploy.md#L42-L78         # resolve a chunk id / kb:// URI / 
 kb related alpha/docs/deploy.md#L42-L78      # find dense neighbors from an existing result chunk
 kb llm use-endpoint http://127.0.0.1:8080/v1/chat/completions --profile=local-research-agent
 kb ask "what changed in the daemonization notes?" --timing   # retrieval + local LLM answer with timings
+kb ask "why does src/cli.ts throw?" --mode=hybrid --rerank   # same dense|hybrid|lexical|auto modes + opt-in rerank as kb search
 kb ask "what changed?" --kb=work --save-transcript --title="Ask - daemon changes" --yes
 kb research plan "autonomous research agents and evals" --format=json
 kb research collect "autonomous research agents and evals" --run-dir runs/agents --format=json

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -72,6 +72,17 @@ profile, or the local-research-agent default at 127.0.0.1:8080.
 Options:
   --kb=<name>           Scope retrieval to one knowledge base.
   --model=<id>          Override the active embedding model for retrieval.
+  --mode=dense|hybrid|lexical|auto
+                        Retrieval mode for the snippets fed to the LLM
+                        (default: auto). auto keeps dense for prose and
+                        upgrades code/error-token queries to hybrid; hybrid
+                        fuses dense + BM25 via RRF; lexical is BM25-only.
+  --rerank              Run the RFC 019 cross-encoder reranker for this call
+                        (hybrid retrieval only). Off by default.
+  --no-rerank           Bypass the reranker for this call.
+  --gate                Run the relevance gate for this call even when
+                        KB_RELEVANCE_GATE is off.
+  --no-gate             Bypass the relevance gate for this call.
   --k=<int>             Retrieval top-K (default 8).
   --context-budget-tokens=<int>
                         Approximate token budget for snippets sent to the LLM

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -68,6 +68,8 @@ Answers a question from retrieved knowledge-base context using the configured lo
 | `llm_profile` | string | no | — | Saved kb llm profile name to use for answer generation. |
 | `k` | integer | no | min 1; max 50 | Retrieval top-K before context packing. Default 8. |
 | `context_budget_tokens` | integer | no | min 64 | Approximate token budget for snippets sent to the LLM. Default 6000. |
+| `search_mode` | enum | no | one of: `dense`, `hybrid`, `lexical`, `auto` | Retrieval mode for the snippets fed to the answer LLM. "auto" (default) keeps dense for prose and upgrades code/error-token queries to hybrid; "dense" is FAISS-only; "hybrid" fuses FAISS + per-KB BM25 via Reciprocal Rank Fusion; "lexical" is BM25-only. See #206 + #732. |
+| `rerank` | enum | no | one of: `on`, `off` | Per-call RFC 019 cross-encoder reranker override for hybrid retrieval. Off by default; omit to use KB_RERANK. |
 | `task_context` | string | no | — | Optional task context passed to the answer prompt and relevance gate when enabled. |
 | `gate` | enum | no | one of: `on`, `off` | Per-call relevance gate override for retrieved snippets. Omit to keep the ask path ungated. |
 | `timing` | boolean | no | — | Include retrieval, packing, and LLM timing fields. Defaults to true for MCP. |

--- a/src/KnowledgeBaseServer.ts
+++ b/src/KnowledgeBaseServer.ts
@@ -1215,6 +1215,8 @@ export class KnowledgeBaseServer {
     context_budget_tokens?: number;
     task_context?: string;
     gate?: 'on' | 'off';
+    search_mode?: 'dense' | 'hybrid' | 'lexical' | 'auto';
+    rerank?: 'on' | 'off';
     timing?: boolean;
   }, extra?: ToolExtra): Promise<CallToolResult> {
     const report = this.progressReporter(extra);
@@ -1234,6 +1236,8 @@ export class KnowledgeBaseServer {
           context_budget_tokens: args.context_budget_tokens,
           task_context: args.task_context,
           gate: args.gate,
+          search_mode: args.search_mode,
+          rerank: args.rerank,
           timing: args.timing ?? true,
         }, {
           bootstrapLayout: FaissIndexManager.bootstrapLayout.bind(FaissIndexManager),

--- a/src/__fixtures__/mcp-tool-schemas.json
+++ b/src/__fixtures__/mcp-tool-schemas.json
@@ -45,6 +45,22 @@
         "type": "integer",
         "minimum": 64
       },
+      "search_mode": {
+        "type": "string",
+        "enum": [
+          "dense",
+          "hybrid",
+          "lexical",
+          "auto"
+        ]
+      },
+      "rerank": {
+        "type": "string",
+        "enum": [
+          "on",
+          "off"
+        ]
+      },
       "task_context": {
         "type": "string"
       },

--- a/src/ask-core.hybrid.test.ts
+++ b/src/ask-core.hybrid.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it, jest, beforeEach, afterEach } from '@jest/globals';
+
+import {
+  executeAsk,
+  type AskExecutionArgs,
+  type RunAskCoreDeps,
+} from './ask-core.js';
+import { AnswerCache } from './ask-answer-cache.js';
+import { hybridFetchK } from './hybrid-retrieval.js';
+import { setRerankerFactoryForTests } from './reranker.js';
+
+interface Doc {
+  pageContent: string;
+  metadata: Record<string, unknown>;
+  score: number;
+}
+
+function denseDoc(source: string, content: string, score: number): Doc {
+  return { pageContent: content, metadata: { knowledgeBase: 'ops', relativePath: source, source, chunkIndex: 0 }, score };
+}
+
+function makeManager(denseResults: Doc[]): { similaritySearch: jest.Mock } & Record<string, unknown> {
+  return {
+    modelDir: '/tmp/kb-ask-hybrid-model',
+    initialize: jest.fn(async () => {}),
+    updateIndex: jest.fn(async () => {}),
+    similaritySearch: jest.fn(async () => denseResults),
+  };
+}
+
+interface HybridDepsOverrides {
+  manager: ReturnType<typeof makeManager>;
+  lexicalHits?: Doc[];
+  listLexicalKbs?: jest.Mock;
+  runLexicalLeg?: jest.Mock;
+  callChatCompletion?: jest.Mock;
+}
+
+function makeDeps(overrides: HybridDepsOverrides): RunAskCoreDeps {
+  const listLexicalKbs = overrides.listLexicalKbs
+    ?? jest.fn(async () => [{ kbName: 'ops', kbPath: '/tmp/ops' }]);
+  const runLexicalLeg = overrides.runLexicalLeg
+    ?? jest.fn(async () => ({ hits: overrides.lexicalHits ?? [], refreshed: 0, failed: 0 }));
+  const callChatCompletion = overrides.callChatCompletion
+    ?? jest.fn(async () => ({ content: 'grounded answer', model: 'qwen3', raw: {} }));
+  return {
+    bootstrapLayout: jest.fn(async () => {}),
+    resolveActiveModel: jest.fn(async () => 'ollama__nomic-embed-text-latest') as RunAskCoreDeps['resolveActiveModel'],
+    loadManagerForModel: jest.fn(async () => overrides.manager as never),
+    loadReadOnlyIndex: jest.fn(async () => {}),
+    withWriteLock: (jest.fn(async <T>(_resource: string, action: () => Promise<T>) => action())) as RunAskCoreDeps['withWriteLock'],
+    callChatCompletion: callChatCompletion as unknown as RunAskCoreDeps['callChatCompletion'],
+    answerCache: new AnswerCache({ enabled: false, indexPath: '/tmp/kb-ask-hybrid-cache' }),
+    listLexicalKbs: listLexicalKbs as unknown as RunAskCoreDeps['listLexicalKbs'],
+    runLexicalLeg: runLexicalLeg as unknown as RunAskCoreDeps['runLexicalLeg'],
+  };
+}
+
+function askArgs(question: string, overrides: Partial<AskExecutionArgs> = {}): AskExecutionArgs {
+  return {
+    question,
+    kb: 'ops',
+    k: 8,
+    contextBudgetTokens: 6000,
+    refresh: false,
+    timing: true,
+    ...overrides,
+  };
+}
+
+describe('ask retrieval modes (#732)', () => {
+  const prevEndpoint = process.env.KB_LLM_ENDPOINT;
+  const prevRerank = process.env.KB_RERANK;
+
+  beforeEach(() => {
+    process.env.KB_LLM_ENDPOINT = 'http://127.0.0.1:8080/v1/chat/completions';
+    delete process.env.KB_RERANK;
+  });
+
+  afterEach(() => {
+    if (prevEndpoint === undefined) delete process.env.KB_LLM_ENDPOINT;
+    else process.env.KB_LLM_ENDPOINT = prevEndpoint;
+    if (prevRerank === undefined) delete process.env.KB_RERANK;
+    else process.env.KB_RERANK = prevRerank;
+  });
+
+  it('mode=hybrid reaches the hybrid retrieval leg (dense over-fetch + lexical fusion)', async () => {
+    const manager = makeManager([denseDoc('runbooks/a.md', 'Dense hit about rollback.', 0.1)]);
+    const listLexicalKbs = jest.fn(async () => [{ kbName: 'ops', kbPath: '/tmp/ops' }]);
+    const runLexicalLeg = jest.fn(async () => ({
+      hits: [denseDoc('runbooks/b.md', 'Lexical hit about rollback.', 3.2)],
+      refreshed: 0,
+      failed: 0,
+    }));
+    const deps = makeDeps({ manager, listLexicalKbs, runLexicalLeg });
+
+    const result = await executeAsk(askArgs('What changed?', { searchMode: 'hybrid' }), deps, Date.now());
+
+    expect(result.retrieval.search_mode).toBe('hybrid');
+    // Dense leg over-fetches with an unbounded threshold to give RRF room.
+    expect(manager.similaritySearch).toHaveBeenCalledWith(
+      'What changed?',
+      hybridFetchK(8),
+      Number.POSITIVE_INFINITY,
+      'ops',
+      undefined,
+      expect.anything(),
+    );
+    expect(listLexicalKbs).toHaveBeenCalledWith('ops');
+    expect(runLexicalLeg).toHaveBeenCalledTimes(1);
+    // Both legs' chunks are fused into the cited evidence.
+    const citedPaths = result.citations.map((c) => c.path).sort();
+    expect(citedPaths).toEqual(['runbooks/a.md', 'runbooks/b.md']);
+  });
+
+  it('mode=lexical runs the BM25 leg only (no dense FAISS search)', async () => {
+    const manager = makeManager([]);
+    const runLexicalLeg = jest.fn(async () => ({
+      hits: [denseDoc('runbooks/only.md', 'Lexical-only hit.', 4.0)],
+      refreshed: 0,
+      failed: 0,
+    }));
+    const deps = makeDeps({ manager, runLexicalLeg });
+
+    const result = await executeAsk(askArgs('INDEX_NOT_INITIALIZED', { searchMode: 'lexical' }), deps, Date.now());
+
+    expect(result.retrieval.search_mode).toBe('lexical');
+    expect(manager.similaritySearch).not.toHaveBeenCalled();
+    expect(runLexicalLeg).toHaveBeenCalledTimes(1);
+    expect(result.citations.map((c) => c.path)).toEqual(['runbooks/only.md']);
+  });
+
+  it('default mode stays dense for a prose query (backward compatible)', async () => {
+    const manager = makeManager([denseDoc('runbooks/a.md', 'Dense answer.', 0.1)]);
+    const listLexicalKbs = jest.fn(async () => [{ kbName: 'ops', kbPath: '/tmp/ops' }]);
+    const runLexicalLeg = jest.fn(async () => ({ hits: [], refreshed: 0, failed: 0 }));
+    const deps = makeDeps({ manager, listLexicalKbs, runLexicalLeg });
+
+    const result = await executeAsk(askArgs('What changed during the deploy?'), deps, Date.now());
+
+    expect(result.retrieval.search_mode).toBe('dense');
+    // Dense signature: bounded top-k, no threshold, no lexical leg.
+    expect(manager.similaritySearch).toHaveBeenCalledWith(
+      'What changed during the deploy?',
+      8,
+      undefined,
+      'ops',
+      undefined,
+      expect.anything(),
+    );
+    expect(listLexicalKbs).not.toHaveBeenCalled();
+    expect(runLexicalLeg).not.toHaveBeenCalled();
+  });
+
+  it('default mode=auto upgrades a code/error-token query to hybrid', async () => {
+    const manager = makeManager([denseDoc('src/foo.md', 'Dense hit.', 0.1)]);
+    const runLexicalLeg = jest.fn(async () => ({
+      hits: [denseDoc('src/bar.md', 'Lexical hit.', 2.0)],
+      refreshed: 0,
+      failed: 0,
+    }));
+    const deps = makeDeps({ manager, runLexicalLeg });
+
+    const result = await executeAsk(askArgs('why does src/foo.ts throw TypeError?'), deps, Date.now());
+
+    expect(result.retrieval.search_mode).toBe('hybrid');
+    expect(runLexicalLeg).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('ask reranking is opt-in (#732)', () => {
+  const prevEndpoint = process.env.KB_LLM_ENDPOINT;
+  const prevRerank = process.env.KB_RERANK;
+  let restoreReranker: (() => void) | null = null;
+  let rerankSpy: jest.Mock<(query: string, candidates: string[]) => Promise<number[]>>;
+
+  beforeEach(() => {
+    process.env.KB_LLM_ENDPOINT = 'http://127.0.0.1:8080/v1/chat/completions';
+    delete process.env.KB_RERANK;
+    rerankSpy = jest.fn<(query: string, candidates: string[]) => Promise<number[]>>(
+      async (_query, candidates) => candidates.map((_c, index) => candidates.length - index),
+    );
+    restoreReranker = setRerankerFactoryForTests(async () => ({
+      id: 'test-cross-encoder',
+      rerank: rerankSpy,
+    }));
+  });
+
+  afterEach(() => {
+    restoreReranker?.();
+    restoreReranker = null;
+    if (prevEndpoint === undefined) delete process.env.KB_LLM_ENDPOINT;
+    else process.env.KB_LLM_ENDPOINT = prevEndpoint;
+    if (prevRerank === undefined) delete process.env.KB_RERANK;
+    else process.env.KB_RERANK = prevRerank;
+  });
+
+  it('does not rerank hybrid retrieval by default', async () => {
+    const manager = makeManager([denseDoc('runbooks/a.md', 'Dense hit.', 0.1)]);
+    const deps = makeDeps({
+      manager,
+      runLexicalLeg: jest.fn(async () => ({
+        hits: [denseDoc('runbooks/b.md', 'Lexical hit.', 2.0)],
+        refreshed: 0,
+        failed: 0,
+      })),
+    });
+
+    await executeAsk(askArgs('What changed?', { searchMode: 'hybrid' }), deps, Date.now());
+
+    expect(rerankSpy).not.toHaveBeenCalled();
+  });
+
+  it('reranks hybrid retrieval when rerank=on is requested', async () => {
+    const manager = makeManager([denseDoc('runbooks/a.md', 'Dense hit.', 0.1)]);
+    const deps = makeDeps({
+      manager,
+      runLexicalLeg: jest.fn(async () => ({
+        hits: [denseDoc('runbooks/b.md', 'Lexical hit.', 2.0)],
+        refreshed: 0,
+        failed: 0,
+      })),
+    });
+
+    const result = await executeAsk(
+      askArgs('What changed?', { searchMode: 'hybrid', rerank: 'on' }),
+      deps,
+      Date.now(),
+    );
+
+    expect(rerankSpy).toHaveBeenCalledTimes(1);
+    expect(result.retrieval.rerank).toBe('on');
+  });
+});

--- a/src/ask-core.ts
+++ b/src/ask-core.ts
@@ -36,6 +36,23 @@ import {
 } from './relevance-gate.js';
 import { chunkIdFromMetadata } from './rrf.js';
 import {
+  fuseHybridResultsWithDiagnostics,
+  hybridFetchK,
+  listLexicalKbs,
+  runLexicalLeg,
+  type HybridChunk,
+} from './hybrid-retrieval.js';
+import {
+  applyRerankerIfEnabled,
+  resolveRerankerConfig,
+  type RerankOverride,
+} from './reranker.js';
+import {
+  resolveAutoSearchMode,
+  type EffectiveSearchMode,
+  type SearchMode,
+} from './search-core.js';
+import {
   classifyKbAskError,
   classifyKbSearchError,
   exitCodeForFailure,
@@ -55,6 +72,16 @@ import { withSpan } from './otel-trace.js';
 
 export const DEFAULT_ASK_CONTEXT_BUDGET_TOKENS = 6000;
 export const MIN_ASK_CONTEXT_BUDGET_TOKENS = 64;
+/**
+ * Issue #732 — the ask path now supports the same `dense|hybrid|lexical|auto`
+ * retrieval modes as `kb search` / `retrieve_knowledge`. It defaults to `auto`
+ * (a safe quality win: prose queries stay dense, code/error-token queries
+ * upgrade to hybrid) while reranking stays opt-in — cross-encoder reranking is
+ * not universally beneficial, so it is off unless the caller asks for it.
+ */
+export const DEFAULT_ASK_SEARCH_MODE: SearchMode = 'auto';
+
+export type { SearchMode, RerankOverride };
 const APPROX_CHARS_PER_TOKEN = 4;
 const ASK_SNIPPET_SEPARATOR = '\n\n---\n\n';
 const ASK_TEMPERATURE = 0.2;
@@ -73,6 +100,10 @@ export interface AskExecutionArgs {
   timing: boolean;
   taskContext?: string;
   gate?: RelevanceGateOverride;
+  /** Retrieval mode. Defaults to {@link DEFAULT_ASK_SEARCH_MODE} ('auto'). */
+  searchMode?: SearchMode;
+  /** Per-call cross-encoder reranker override (hybrid only). Off by default. */
+  rerank?: RerankOverride;
   onAnswerToken?: (token: string) => void | Promise<void>;
 }
 
@@ -88,6 +119,10 @@ export interface AskKnowledgeInput {
   timing?: boolean;
   task_context?: string;
   gate?: RelevanceGateOverride;
+  /** Retrieval mode. Defaults to {@link DEFAULT_ASK_SEARCH_MODE} ('auto'). */
+  search_mode?: SearchMode;
+  /** Per-call cross-encoder reranker override (hybrid only). Off by default. */
+  rerank?: RerankOverride;
 }
 
 export interface AskCitation {
@@ -112,8 +147,11 @@ export interface AskRetrievalPayload {
   context_budget_tokens: number;
   refreshed: boolean;
   knowledge_base: string | null;
+  /** Effective retrieval mode used (auto resolves to dense/hybrid). #732 */
+  search_mode: EffectiveSearchMode;
   task_context_provided?: boolean;
   gate?: RelevanceGateOverride;
+  rerank?: RerankOverride;
 }
 
 export interface AskPackedChunkPayload {
@@ -176,6 +214,10 @@ export interface RunAskCoreDeps {
   callChatCompletion: (options: ChatCompletionOptions) => Promise<ChatCompletionResult>;
   /** Optional answer-cache override (#656). Defaults to the env-configured singleton. */
   answerCache?: AnswerCache;
+  /** Lexical-leg KB enumeration for hybrid/lexical modes (#732). Injectable for tests. */
+  listLexicalKbs?: typeof listLexicalKbs;
+  /** Lexical-leg BM25 runner for hybrid/lexical modes (#732). Injectable for tests. */
+  runLexicalLeg?: typeof runLexicalLeg;
 }
 
 interface LlmTarget {
@@ -229,6 +271,8 @@ export async function askKnowledge(
     timing: input.timing ?? false,
     taskContext: input.task_context,
     gate: input.gate,
+    searchMode: input.search_mode,
+    rerank: input.rerank,
   }, deps, nowMs(), onProgress);
 }
 
@@ -237,6 +281,8 @@ export interface AskEvidence {
   activeModelId: string;
   /** Retrieved + sensitivity-hydrated + gated documents, reusable across turns. */
   results: SearchResultDocument[];
+  /** Effective retrieval mode used to gather the evidence (auto → dense/hybrid). */
+  searchMode: EffectiveSearchMode;
 }
 
 /**
@@ -250,14 +296,25 @@ export async function retrieveAskEvidence(
   deps: RunAskCoreDeps,
   timing: TimingPayload | null = null,
 ): Promise<AskEvidence> {
+  // #732 — resolve the requested mode before opening the span so the
+  // `kb.search_mode` attribute records the effective mode ('auto' resolves to
+  // dense for prose and hybrid for code/error-token queries).
+  const requestedMode: SearchMode = args.searchMode ?? DEFAULT_ASK_SEARCH_MODE;
+  const effectiveMode: EffectiveSearchMode = requestedMode === 'auto'
+    ? resolveAutoSearchMode(args.question).mode
+    : requestedMode;
   return withSpan('kb.ask.retrieve', {
     'kb.scope': args.kb ?? null,
     'kb.k': args.k,
-    'kb.search_mode': 'dense',
+    'kb.search_mode': effectiveMode,
     'kb.refresh': args.refresh,
   }, async (retrieveSpan) => {
     let activeModelId: string;
-    let results;
+    let results: SearchResultDocument[];
+    // Gate identity maps: dense distances feed the relevance judge, lexical hit
+    // ids let it credit BM25-only matches. Populated per mode below.
+    let denseDistanceById = new Map<string, number>();
+    let lexicalHitIds: Set<string> | undefined;
     try {
       let startedAt = nowMs();
       await deps.bootstrapLayout();
@@ -279,33 +336,49 @@ export async function retrieveAskEvidence(
         await deps.loadReadOnlyIndex(manager);
       }
       if (timing) timing.index_load_ms = elapsedMs(startedAt);
+
+      const retrievalStartedAt = nowMs();
       const denseTiming: SimilaritySearchTiming = {};
-      startedAt = nowMs();
-      // `kb.ask.dense` covers the embedding of the query plus the FAISS
-      // nearest-neighbour search (both happen inside similaritySearch).
-      results = await withSpan('kb.ask.dense', {
-        'kb.k': args.k,
-        'kb.scope': args.kb ?? null,
-      }, () => manager.similaritySearch(
-        args.question,
-        args.k,
-        undefined,
-        args.kb,
-        undefined,
-        timing ? denseTiming : undefined,
-      ));
+      if (effectiveMode === 'dense') {
+        // `kb.ask.dense` covers the embedding of the query plus the FAISS
+        // nearest-neighbour search (both happen inside similaritySearch).
+        results = await withSpan('kb.ask.dense', {
+          'kb.k': args.k,
+          'kb.scope': args.kb ?? null,
+        }, () => manager.similaritySearch(
+          args.question,
+          args.k,
+          undefined,
+          args.kb,
+          undefined,
+          timing ? denseTiming : undefined,
+        ));
+        for (const result of results) {
+          denseDistanceById.set(chunkIdFromMetadata(result.metadata as Record<string, unknown>), result.score);
+        }
+        if (timing) mergeAskDenseTiming(timing, denseTiming);
+      } else {
+        const hybrid = await retrieveHybridOrLexical({
+          manager,
+          args,
+          effectiveMode,
+          deps,
+          denseTiming,
+          timing,
+        });
+        results = hybrid.results;
+        denseDistanceById = hybrid.denseDistanceById;
+        lexicalHitIds = hybrid.lexicalHitIds;
+      }
+
       results = await hydrateSensitivityPoliciesFromSource(results);
       if (args.gate !== undefined || args.taskContext !== undefined) {
-        const denseDistanceById = new Map<string, number>();
         const policyExcluded = results.filter((result) =>
           excludesLlmContext(result.metadata as Record<string, unknown>),
         );
         let gateCandidates = results.filter((result) =>
           !excludesLlmContext(result.metadata as Record<string, unknown>),
         );
-        for (const result of gateCandidates) {
-          denseDistanceById.set(chunkIdFromMetadata(result.metadata as Record<string, unknown>), result.score);
-        }
         const gate = await withSpan('kb.ask.gate', {
           'kb.candidates_in': gateCandidates.length,
         }, async (gateSpan) => {
@@ -314,6 +387,7 @@ export async function retrieveAskEvidence(
             taskContext: args.taskContext,
             candidates: gateCandidates,
             denseDistanceById,
+            ...(lexicalHitIds !== undefined ? { lexicalHitIds } : {}),
             gateOverride: args.gate,
             process: 'mcp',
           });
@@ -327,24 +401,115 @@ export async function retrieveAskEvidence(
           process: 'mcp',
           query: args.question,
           kbScope: args.kb ?? null,
-          searchMode: 'dense',
+          searchMode: effectiveMode,
           verdict: gate.verdict,
           taskContext: args.taskContext,
           observability: gate.observability,
         });
       }
-      if (timing) {
-        timing.retrieval_ms = elapsedMs(startedAt);
-        mergeAskDenseTiming(timing, denseTiming);
-      }
+      if (timing) timing.retrieval_ms = elapsedMs(retrievalStartedAt);
     } catch (err) {
       const failure = classifyKbSearchError(err);
       throw new AskExecutionError(failure.message, exitCodeForFailure(failure), failure);
     }
 
     retrieveSpan.setAttribute('kb.result_count', results.length);
-    return { activeModelId, results };
+    return { activeModelId, results, searchMode: effectiveMode };
   });
+}
+
+interface HybridOrLexicalRetrieval {
+  results: SearchResultDocument[];
+  denseDistanceById: Map<string, number>;
+  lexicalHitIds: Set<string>;
+}
+
+/**
+ * #732 — hybrid/lexical retrieval leg for the ask path, mirroring
+ * `retrieve_knowledge`. Hybrid over-fetches a dense FAISS pool and a per-KB
+ * BM25 pool, fuses them with Reciprocal Rank Fusion, then applies the opt-in
+ * cross-encoder reranker. Lexical runs the BM25 leg alone. The lexical index is
+ * auto-refreshed on first use per KB (`when-empty`); `--refresh` forces it.
+ */
+async function retrieveHybridOrLexical(input: {
+  manager: FaissIndexManager;
+  args: AskExecutionArgs;
+  effectiveMode: Exclude<EffectiveSearchMode, 'dense'>;
+  deps: RunAskCoreDeps;
+  denseTiming: SimilaritySearchTiming;
+  timing: TimingPayload | null;
+}): Promise<HybridOrLexicalRetrieval> {
+  const { manager, args, effectiveMode, deps, denseTiming, timing } = input;
+  const fetchK = hybridFetchK(args.k);
+  const kbs = await (deps.listLexicalKbs ?? listLexicalKbs)(args.kb);
+
+  const runLexical = () => withSpan('kb.ask.lexical', {
+    'kb.k': fetchK,
+    'kb.kb_count': kbs.length,
+  }, () => (deps.runLexicalLeg ?? runLexicalLeg)({
+    kbs,
+    query: args.question,
+    fetchK,
+    refresh: args.refresh ? 'always' : 'when-empty',
+    onError: (kbName, err) => {
+      logger.warn(`kb ask (${effectiveMode} lexical leg): ${kbName} — ${err.message}`);
+    },
+  }));
+
+  if (effectiveMode === 'lexical') {
+    const lexical = await runLexical();
+    const hits = lexical.hits.slice(0, args.k);
+    const lexicalHitIds = new Set(hits.map((hit) => chunkIdFromMetadata(hit.metadata)));
+    return { results: hits as unknown as SearchResultDocument[], denseDistanceById: new Map(), lexicalHitIds };
+  }
+
+  // Hybrid: dense + lexical legs in parallel, then RRF + opt-in rerank.
+  const densePromise = withSpan('kb.ask.dense', {
+    'kb.k': fetchK,
+    'kb.scope': args.kb ?? null,
+  }, () => manager.similaritySearch(
+    args.question,
+    fetchK,
+    Number.POSITIVE_INFINITY,
+    args.kb,
+    undefined,
+    timing ? denseTiming : undefined,
+  )).then((rs) => rs.map((r): HybridChunk => ({
+    pageContent: r.pageContent,
+    metadata: r.metadata,
+    score: r.score,
+  })));
+  const [denseResults, lexical] = await Promise.all([densePromise, runLexical()]);
+  if (timing) mergeAskDenseTiming(timing, denseTiming);
+
+  const rerankConfig = resolveRerankerConfig(process.env, args.rerank, args.kb ?? null);
+  const fusion = fuseHybridResultsWithDiagnostics({
+    denseResults,
+    lexicalResults: lexical.hits,
+    k: rerankConfig.enabled ? Math.max(args.k, rerankConfig.topN) : args.k,
+  });
+  const rerankResult = await withSpan('kb.ask.rerank', {
+    'kb.candidates_in': fusion.results.length,
+    'kb.rerank_enabled': rerankConfig.enabled,
+  }, () => applyRerankerIfEnabled({
+    query: args.question,
+    results: fusion.results,
+    k: args.k,
+    override: args.rerank,
+    config: rerankConfig,
+    process: 'mcp',
+    searchMode: 'hybrid',
+    kbScope: args.kb ?? null,
+  }));
+  if (timing && rerankResult.candidatesIn > 0) {
+    timing.rerank_ms = rerankResult.tookMs;
+    if (rerankResult.degraded) timing.rerank_degraded = true;
+  }
+  return {
+    results: rerankResult.results as unknown as SearchResultDocument[],
+    denseDistanceById: fusion.denseDistanceById,
+    lexicalHitIds: fusion.lexicalHitIds,
+  };
 }
 
 /**
@@ -360,7 +525,7 @@ export async function answerWithEvidence(
   totalStartedAt: number,
   timing: TimingPayload | null = null,
 ): Promise<AskKnowledgeResult> {
-  const { activeModelId, results } = evidence;
+  const { activeModelId, results, searchMode } = evidence;
 
   let target: LlmTarget;
   try {
@@ -507,8 +672,10 @@ export async function answerWithEvidence(
       context_budget_tokens: args.contextBudgetTokens,
       refreshed: args.refresh,
       knowledge_base: args.kb ?? null,
+      search_mode: searchMode,
       ...(args.taskContext !== undefined ? { task_context_provided: args.taskContext.trim() !== '' } : {}),
       ...(args.gate !== undefined ? { gate: args.gate } : {}),
+      ...(args.rerank !== undefined ? { rerank: args.rerank } : {}),
     },
     context_packing: packedContext.payload,
     redaction: outboundSummary,

--- a/src/cli-ask.test.ts
+++ b/src/cli-ask.test.ts
@@ -61,6 +61,30 @@ describe('parseAskArgs', () => {
     expect(() => parseAskArgs(['q', 'extra'])).toThrow(/unexpected argument/);
   });
 
+  it('parses retrieval-mode, rerank, and gate overrides (#732)', () => {
+    expect(parseAskArgs(['q', '--mode=hybrid', '--rerank', '--gate'])).toMatchObject({
+      mode: 'hybrid',
+      rerank: 'on',
+      gate: 'on',
+    });
+    expect(parseAskArgs(['q', '--mode=lexical', '--no-rerank', '--no-gate'])).toMatchObject({
+      mode: 'lexical',
+      rerank: 'off',
+      gate: 'off',
+    });
+  });
+
+  it('rejects an invalid --mode', () => {
+    expect(() => parseAskArgs(['q', '--mode=fuzzy'])).toThrow(/invalid --mode/);
+  });
+
+  it('leaves mode, rerank, and gate unset by default', () => {
+    const parsed = parseAskArgs(['q']);
+    expect(parsed.mode).toBeUndefined();
+    expect(parsed.rerank).toBeUndefined();
+    expect(parsed.gate).toBeUndefined();
+  });
+
   it('parses --no-stream for markdown output', () => {
     expect(parseAskArgs(['what changed?', '--no-stream'])).toMatchObject({
       question: 'what changed?',
@@ -230,6 +254,7 @@ describe('ask transcript records', () => {
         context_budget_tokens: DEFAULT_ASK_CONTEXT_BUDGET_TOKENS,
         refreshed: false,
         knowledge_base: 'ops',
+        search_mode: 'dense',
       },
       timing: { retrieval_ms: 12, llm_total_ms: 34, total_ms: 56 },
     });

--- a/src/cli-ask.ts
+++ b/src/cli-ask.ts
@@ -42,6 +42,8 @@ import {
   type AskLlmPayload,
   type AskRetrievalPayload,
   type RunAskCoreDeps,
+  type RerankOverride,
+  type SearchMode,
 } from './ask-core.js';
 import {
   runAskRepl,
@@ -70,6 +72,17 @@ profile, or the local-research-agent default at 127.0.0.1:8080.
 Options:
   --kb=<name>           Scope retrieval to one knowledge base.
   --model=<id>          Override the active embedding model for retrieval.
+  --mode=dense|hybrid|lexical|auto
+                        Retrieval mode for the snippets fed to the LLM
+                        (default: auto). auto keeps dense for prose and
+                        upgrades code/error-token queries to hybrid; hybrid
+                        fuses dense + BM25 via RRF; lexical is BM25-only.
+  --rerank              Run the RFC 019 cross-encoder reranker for this call
+                        (hybrid retrieval only). Off by default.
+  --no-rerank           Bypass the reranker for this call.
+  --gate                Run the relevance gate for this call even when
+                        KB_RELEVANCE_GATE is off.
+  --no-gate             Bypass the relevance gate for this call.
   --k=<int>             Retrieval top-K (default 8).
   --context-budget-tokens=<int>
                         Approximate token budget for snippets sent to the LLM
@@ -115,6 +128,8 @@ export interface AskArgs {
   yes: boolean;
   taskContext?: string;
   gate?: RelevanceGateOverride;
+  mode?: SearchMode;
+  rerank?: RerankOverride;
 }
 
 interface AskTranscriptRecord {
@@ -211,6 +226,7 @@ export async function runAsk(rest: string[], deps: RunAskDeps = defaultRunAskDep
     result = await executeAsk({
       ...args,
       question: args.question,
+      ...(args.mode !== undefined ? { searchMode: args.mode } : {}),
       ...(streamMarkdown
         ? {
             onAnswerToken: (token: string) => {
@@ -369,6 +385,8 @@ function toAskBaseArgs(args: AskArgs): AskExecutionArgs {
     timing: false,
     ...(args.taskContext !== undefined ? { taskContext: args.taskContext } : {}),
     ...(args.gate !== undefined ? { gate: args.gate } : {}),
+    ...(args.mode !== undefined ? { searchMode: args.mode } : {}),
+    ...(args.rerank !== undefined ? { rerank: args.rerank } : {}),
   };
 }
 
@@ -428,6 +446,17 @@ export function parseAskArgs(rest: string[]): AskArgs {
     if (raw === '--timing') { out.timing = true; continue; }
     if (raw === '--save-transcript') { out.saveTranscript = true; continue; }
     if (raw === '--yes') { out.yes = true; continue; }
+    if (raw === '--rerank') { out.rerank = 'on'; continue; }
+    if (raw === '--no-rerank') { out.rerank = 'off'; continue; }
+    if (raw === '--gate') { out.gate = 'on'; continue; }
+    if (raw === '--no-gate') { out.gate = 'off'; continue; }
+    if (raw.startsWith('--mode=')) {
+      const v = raw.slice('--mode='.length);
+      if (v !== 'dense' && v !== 'hybrid' && v !== 'lexical' && v !== 'auto') {
+        throw new Error(`invalid --mode: ${raw} (expected 'dense', 'hybrid', 'lexical', or 'auto')`);
+      }
+      out.mode = v; continue;
+    }
     if (raw.startsWith('--kb=')) { out.kb = raw.slice('--kb='.length); continue; }
     if (raw.startsWith('--model=')) { out.model = raw.slice('--model='.length); continue; }
     if (raw.startsWith('--llm-profile=')) { out.llmProfile = raw.slice('--llm-profile='.length); continue; }

--- a/src/mcp-tool-specs.ts
+++ b/src/mcp-tool-specs.ts
@@ -99,6 +99,11 @@ export const ASK_KNOWLEDGE_INPUT = {
   llm_profile: z.string().optional().describe('Saved kb llm profile name to use for answer generation.'),
   k: z.number().int().min(1).max(50).optional().describe('Retrieval top-K before context packing. Default 8.'),
   context_budget_tokens: z.number().int().min(64).optional().describe('Approximate token budget for snippets sent to the LLM. Default 6000.'),
+  // #732 — bring the search-mode + opt-in rerank surface of retrieve_knowledge
+  // to the ask path. Defaults to 'auto' (prose stays dense, code/error-token
+  // queries upgrade to hybrid); reranking stays opt-in.
+  search_mode: z.enum(['dense', 'hybrid', 'lexical', 'auto']).optional().describe('Retrieval mode for the snippets fed to the answer LLM. "auto" (default) keeps dense for prose and upgrades code/error-token queries to hybrid; "dense" is FAISS-only; "hybrid" fuses FAISS + per-KB BM25 via Reciprocal Rank Fusion; "lexical" is BM25-only. See #206 + #732.'),
+  rerank: z.enum(['on', 'off']).optional().describe('Per-call RFC 019 cross-encoder reranker override for hybrid retrieval. Off by default; omit to use KB_RERANK.'),
   task_context: z.string().optional().describe('Optional task context passed to the answer prompt and relevance gate when enabled.'),
   gate: z.enum(['on', 'off']).optional().describe('Per-call relevance gate override for retrieved snippets. Omit to keep the ask path ungated.'),
   timing: z.boolean().optional().describe('Include retrieval, packing, and LLM timing fields. Defaults to true for MCP.'),


### PR DESCRIPTION
## Summary

The ask path was locked to dense-only retrieval (`searchMode: 'dense'` hardcoded, `kb.search_mode: 'dense'` on the canonical/OTEL surface). This brings it to parity with `kb search` / `retrieve_knowledge`: a `dense|hybrid|lexical|auto` search mode and an **opt-in** cross-encoder reranker are threaded through both `kb ask` (CLI) and `ask_knowledge` (MCP), and the effective mode is recorded on the OTEL `kb.search_mode` span, the relevance-gate decision, and the result's retrieval payload instead of the fixed `'dense'`.

Closes #732

## What changed

- **`src/ask-core.ts`** — `retrieveAskEvidence` resolves the requested mode (default `auto`) to an effective mode and branches: `dense` (existing FAISS path, unchanged), `hybrid` (dense over-fetch + per-KB BM25, fused via RRF, then opt-in rerank), and `lexical` (BM25-only). Reuses `hybrid-retrieval.ts` and `reranker.ts`. The gate receives the fused `denseDistanceById` + `lexicalHitIds` in hybrid mode.
- **`src/mcp-tool-specs.ts`** — `ASK_KNOWLEDGE_INPUT` gains `search_mode` and `rerank`, mirroring `retrieve_knowledge`.
- **`src/cli-ask.ts`** — new `--mode=dense|hybrid|lexical|auto`, `--rerank`/`--no-rerank`, `--gate`/`--no-gate` flags.
- **`src/KnowledgeBaseServer.ts`** — forwards the two new args from the `ask_knowledge` handler (required for the MCP surface to honor them).
- Regenerated `docs/reference/mcp-tools.md` and `docs/reference/cli.md`; added a `kb ask` example to `README.md`.

## Behavioral note (default change)

The ask path now defaults to **`auto`** instead of dense. Per the issue's KB grounding this is a safe quality win: `auto` keeps **prose** queries on dense (backward-compatible for the common case) and only upgrades **code/error-token-shaped** queries to hybrid. **Reranking stays OFF by default** and is opt-in via `--rerank` / `rerank: "on"` / `KB_RERANK`.

### Design choices the issue left open

- **`auto` vs `hybrid` default** → chose `auto`: prose stays dense so callers passing nothing keep dense retrieval, while code/error queries get the hybrid win. `hybrid` would have flipped every caller.
- **Exposing `gate`** → added `--gate`/`--no-gate` to the CLI (the `gate` field already existed in the MCP input/core but had no CLI surface); default stays ungated.
- **`lexical`/`auto` in the MCP enum** → exposed the full four-value enum on `ask_knowledge` since the ask core implements all four.

## Testing

- [x] `npm test` passes — targeted ask + KnowledgeBaseServer suites, `npm run build`, and `npm run lint` pass locally; full suite runs in CI.
- [x] End-to-end verified for tool/transport changes (see `CLAUDE.md`) — exercised each mode (dense/hybrid/lexical/auto) and the opt-in reranker through `executeAsk`/`ask_knowledge` in `ask-core.hybrid.test.ts`, plus the CLI flag parsing.
- [ ] ~~Benchmark run if performance-relevant: `BENCH_PROVIDER=stub npm run bench`~~ — wiring change only; routes ask through the already-benchmarked hybrid/rerank machinery, no ranking-algorithm change.
- [x] <!-- kookr:check:tests --> Tests were added or updated for changed behavior; bug fixes include a regression test — `src/ask-core.hybrid.test.ts` (mode routing + opt-in rerank) and new `src/cli-ask.test.ts` flag-parsing cases.

## Documentation contract

- [x] <!-- kookr:check:readme --> `README.md` reflects user-visible CLI, MCP, installation, or configuration changes — added a `kb ask --mode=hybrid --rerank` example noting parity with `kb search`.
- [x] <!-- kookr:check:docs --> Relevant operator, API, configuration, and retrieval documentation under `docs/` is consistent with the implementation — regenerated `docs/reference/mcp-tools.md` and `docs/reference/cli.md` from the tool/help sources.
- [ ] ~~<!-- kookr:check:mbse --> RFCs are updated when this PR implements, supersedes, or changes an accepted design~~ — no accepted RFC changes; this implements a repository-idea issue by reusing the existing hybrid (#206/ADR 0006) and reranker (RFC 019) mechanisms.

## Changelog

- [ ] ~~<!-- kookr:check:changelog --> `CHANGELOG.md` has an `Unreleased` entry for user-visible changes~~ — this repository has no `CHANGELOG.md`; user-visible changes are tracked via Conventional Commits and the regenerated `docs/reference/*` drift-gated docs.

## Retrieval and performance evidence

- [ ] ~~<!-- kookr:check:benchmarks --> Retrieval-quality or performance changes include the relevant benchmark/evaluation evidence, or this row is waived with a reason~~ — waived: no new ranking algorithm; the ask path now reuses the hybrid RRF + cross-encoder reranker that already carry benchmark coverage for `kb search` / `retrieve_knowledge`.

## Follow-ups

None.
