### PR TITLE
chore: add local PR anti-drift checklist preflight (#826)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,21 @@ The marked rows in the PR template are verified against the actual diff by the
 `PR checklist` workflow. Check a marked row only when it is true; otherwise
 strike the row through and add a one-line reason. A blank marked row fails CI.
 
+**Preflight the checklist locally before you open the PR.** The most common
+first-attempt CI failure is a PR body that was not built from
+[`.github/PULL_REQUEST_TEMPLATE.md`](./.github/PULL_REQUEST_TEMPLATE.md), so the
+`kookr:check:*` rows are absent. Draft your body into a file, then run the same
+verifier CI runs against it:
+
+```sh
+npm run pr-checklist -- pr-body.md          # verifies against origin/main
+gh pr create --body-file pr-body.md         # only after it passes
+```
+
+This catches a wrong-shape body in seconds instead of after a full CI cycle. CI
+remains authoritative; the preflight is a convenience that shells out to the
+Kookr CLI (set `KOOKR_BIN` if it is not on your `PATH`).
+
 ## Reporting Bugs
 
 Please use the [Bug Report issue template](./.github/ISSUE_TEMPLATE/bug_report.yml) and include:

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "check:fast": "npm run build && npm run lint && npm run docs:check-anchors && npm run docs:check-config-reference && npm run docs:check-env-example && npm run config:check-env-usage && npm run docs:check-cli && npm run docs:check-mcp-tools && npm run docs:check-embedding-models && npm run docs:check-metrics-reference && npm run docs:check-error-codes && npm run docs:check-loaders",
     "lint": "eslint src",
     "lint:commit-message": "commitlint",
+    "pr-checklist": "node scripts/pr-checklist.mjs",
     "lint:fix": "eslint src --fix",
     "bench": "npm run build && tsc -p tsconfig.bench.json && node build/benchmarks/run.js",
     "bench:beir": "npm run build && tsc -p tsconfig.bench.json && node build/benchmarks/beir/run.js",

--- a/scripts/pr-checklist.mjs
+++ b/scripts/pr-checklist.mjs
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+// Local preflight for the required "Anti-drift checklist" CI check.
+//
+// Runs the SAME verifier the `PR checklist` workflow runs
+// (`.github/workflows/pr-checklist.yml` -> `kookr pr-checklist verify`) against
+// a drafted PR-body file and the merge-base diff, BEFORE you run
+// `gh pr create --body-file <file>`. This catches the most common first-attempt
+// failure — a PR body that was not built from `.github/PULL_REQUEST_TEMPLATE.md`
+// (so the `kookr:check:*` rows are absent) — without spending a full CI cycle.
+//
+// Usage:
+//   npm run pr-checklist -- <body-file> [--base <ref>] [--json]
+//
+// Exit codes mirror the verifier: 0 pass, 2 verification failure, non-zero on
+// usage/tooling problems. CI remains authoritative — this is a convenience
+// gate, and the pinned engine in CI is the source of truth if the two disagree.
+
+import { execFileSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+const KOOKR_BIN = process.env.KOOKR_BIN ?? 'kookr';
+const DEFAULT_BASE = 'origin/main';
+
+function usage() {
+  return [
+    'usage: npm run pr-checklist -- <body-file> [--base <ref>] [--json]',
+    '',
+    'Verifies a drafted PR-body file against the merge-base diff using the same',
+    'verifier the "Anti-drift checklist" CI check runs, so you can self-check',
+    'before `gh pr create --body-file <file>`.',
+    '',
+    'Draft the body from .github/PULL_REQUEST_TEMPLATE.md, work each',
+    '`kookr:check:*` row, then run this preflight.',
+  ].join('\n');
+}
+
+function parseArgs(argv) {
+  const opts = { body: undefined, base: DEFAULT_BASE, json: false };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--base') {
+      opts.base = argv[i + 1];
+      i += 1;
+    } else if (arg === '--json') {
+      opts.json = true;
+    } else if (arg === '-h' || arg === '--help') {
+      opts.help = true;
+    } else if (arg.startsWith('-')) {
+      throw new Error(`unknown option: ${arg}`);
+    } else if (opts.body === undefined) {
+      opts.body = arg;
+    } else {
+      throw new Error(`unexpected extra argument: ${arg}`);
+    }
+  }
+  return opts;
+}
+
+function main() {
+  let opts;
+  try {
+    opts = parseArgs(process.argv.slice(2));
+  } catch (err) {
+    process.stderr.write(`${err.message}\n\n${usage()}\n`);
+    process.exit(64); // usage
+  }
+
+  if (opts.help) {
+    process.stdout.write(`${usage()}\n`);
+    process.exit(0);
+  }
+
+  if (!opts.body) {
+    process.stderr.write(`error: a PR-body file is required.\n\n${usage()}\n`);
+    process.exit(64);
+  }
+
+  const bodyPath = path.resolve(opts.body);
+  if (!fs.existsSync(bodyPath)) {
+    process.stderr.write(`error: body file not found: ${opts.body}\n`);
+    process.exit(64);
+  }
+
+  if (!opts.base) {
+    process.stderr.write('error: --base requires a ref argument.\n');
+    process.exit(64);
+  }
+
+  // Best-effort refresh of the base so the merge-base diff matches what CI sees.
+  // Mirrors the workflow's `git fetch origin <base_ref>` step. Non-fatal: an
+  // offline run still verifies against whatever base commit is already local.
+  const baseBranch = opts.base.startsWith('origin/') ? opts.base.slice('origin/'.length) : opts.base;
+  try {
+    execFileSync('git', ['fetch', '--no-tags', '--quiet', 'origin', baseBranch], { stdio: 'ignore' });
+  } catch {
+    process.stderr.write(`[pr-checklist] warning: could not fetch origin/${baseBranch}; verifying against the local base.\n`);
+  }
+
+  const verifyArgs = ['pr-checklist', 'verify', '--pr-body', bodyPath, '--base', opts.base];
+  if (opts.json) verifyArgs.push('--json');
+
+  try {
+    execFileSync(KOOKR_BIN, verifyArgs, { stdio: 'inherit' });
+    process.exit(0);
+  } catch (err) {
+    if (err && err.code === 'ENOENT') {
+      process.stderr.write(
+        [
+          `error: \`${KOOKR_BIN}\` was not found on PATH.`,
+          '',
+          'This preflight shells out to the Kookr CLI, which also powers the',
+          '"Anti-drift checklist" CI check. Install/link it, or set KOOKR_BIN to',
+          'its path. CI still enforces the check regardless, so you can also just',
+          'push and let CI verify.',
+        ].join('\n') + '\n',
+      );
+      process.exit(69); // unavailable
+    }
+    // Propagate the verifier's own exit code (2 = verification failure).
+    const code = typeof err?.status === 'number' ? err.status : 1;
+    process.exit(code);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary

Adds a local preflight for the required **Anti-drift checklist** CI check so the
first PR attempt passes instead of burning a full CI matrix run to discover a
wrong-shaped body.

The check (added in #820) runs `kookr pr-checklist verify` against the PR body +
merge-base diff. A body not built from `.github/PULL_REQUEST_TEMPLATE.md` fails
because the six `kookr:check:*` rows are absent — but nothing surfaces that
locally, so the failure only appears after `gh pr create`, then needs a body
rewrite and another full CI cycle. This is especially costly for agent-authored
PRs that write a custom narrative body.

The attestation rows describe the **PR body**, which does not exist at `git push`
time, so a git pre-push hook is the wrong layer. The right shift-left point is a
command run against the drafted body file *before* `gh pr create --body-file`.
This PR adds exactly that, reusing the same verifier CI runs (zero logic drift):

- `scripts/pr-checklist.mjs` + `npm run pr-checklist -- <body-file>` — best-effort
  fetches the base, then runs `kookr pr-checklist verify --pr-body <file> --base
  origin/main` and propagates its exit code (0 pass / 2 fail).
- `CONTRIBUTING.md` documents the preflight step before `gh pr create`.

Additive and CI-authoritative: the CI check is unchanged (not weakened), and the
preflight is a convenience that mirrors it locally. Dogfooded — this PR's body was
drafted from the template and passed `npm run pr-checklist` before it was opened.

Fixes #826

## Testing

- [ ] `npm test` passes
- [ ] End-to-end verified for tool/transport changes (see `CLAUDE.md`)
- [ ] Benchmark run if performance-relevant: `BENCH_PROVIDER=stub npm run bench`
- [ ] <!-- kookr:check:tests --> ~~Tests were added or updated for changed behavior; bug fixes include a regression test~~ — N/A: dev-only preflight wrapper under `scripts/` plus docs; no runtime `src/` behavior. Verified manually (help; missing file; raw template → fail rc=2; filled body → pass rc=0).

## Documentation contract

- [ ] <!-- kookr:check:readme --> ~~`README.md` reflects user-visible CLI, MCP, installation, or configuration changes~~ — N/A: contributor tooling, documented in `CONTRIBUTING.md`, not the user-facing `README.md`.
- [ ] <!-- kookr:check:docs --> ~~Relevant operator, API, configuration, and retrieval documentation under `docs/` is consistent with the implementation~~ — N/A: no operator/API/config/retrieval behavior under `docs/` changed.
- [ ] <!-- kookr:check:mbse --> ~~RFCs are updated when this PR implements, supersedes, or changes an accepted design~~ — N/A: no accepted design/RFC is implemented or changed.

## Changelog

- [ ] <!-- kookr:check:changelog --> ~~`CHANGELOG.md` has an `Unreleased` entry for user-visible changes~~ — N/A: repo has no `CHANGELOG.md`; this is contributor tooling, not a user-visible runtime change.

## Retrieval and performance evidence

- [ ] <!-- kookr:check:benchmarks --> ~~Retrieval-quality or performance changes include the relevant benchmark/evaluation evidence, or this row is waived with a reason~~ — N/A: no retrieval-quality or performance change.

## Follow-ups

- Optional: read `KOOKR_ENGINE_REF`/`TSX_VERSION` from the workflow and run the pinned engine via `npx tsx` so a contributor without the `kookr` CLI on `PATH` gets a fully drift-proof, zero-install preflight. Deferred to keep this change minimal.
- Optional complement (from #826): make the fast checklist job a required gate that expensive jobs depend on, to also cut waste when a first attempt still fails.
