### PR TITLE
docs: correct contributor test guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ node build/index.js    # runs the server over stdio (clients launch it this way)
 
 ### Verification beyond `npm test`
 
-The Jest suite is broad but still does **not** exercise every live MCP wire path or real embedding provider. For changes that touch tool handlers, embedding configuration, or transports, run the opt-in stdio E2E harness with `KB_RUN_E2E=1 npm test` (or `KB_RUN_E2E=1 jest src/e2e`). For HTTP/SSE changes, run `npm run dev:remote -- --transport=http` or `--transport=sse`.
+The Jest suite is broad but still does **not** exercise every live MCP wire path or real embedding provider. For changes that touch tool handlers, embedding configuration, or transports, run the opt-in stdio E2E harness with `KB_RUN_E2E=1 npm test`. The harness uses fake embeddings; embedding-provider or model changes also need a representative check against the configured real provider/API, and tool changes outside the harness need representative `tools/call` requests. For HTTP/SSE changes, run `npm run dev:remote -- --transport=http` or `--transport=sse`.
 
 If a bug or improvement surfaces during that E2E pass, record it as an issue (see below) — it will not be caught by `npm test` alone.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ Local-first knowledge-base MCP server and `kb` CLI backed by embedded FAISS inde
 ```bash
 npm install
 npm run build          # tsc → build/index.js (chmod +x, stdio-executable)
-npm test               # jest --runInBand — must stay green
+npm test               # build + test:parallel (--maxWorkers=4) + test:serial (--runInBand) — must stay green
 npm run dev            # nodemon src/index.ts for iteration
 node build/index.js    # runs the server over stdio (clients launch it this way)
 ```
@@ -32,12 +32,7 @@ node build/index.js    # runs the server over stdio (clients launch it this way)
 
 ### Verification beyond `npm test`
 
-The Jest suite is broad but still does **not** exercise every live MCP wire path or real embedding provider. For changes that touch tool handlers, embedding configuration, or transports, verify end-to-end by:
-
-1. Seeding a temp `KNOWLEDGE_BASES_ROOT_DIR` with a couple of markdown files.
-2. Spawning `build/index.js` over stdio from a tiny MCP client (the SDK exposes `Client` + `StdioClientTransport`) with `EMBEDDING_PROVIDER` plus the matching API key or local daemon set.
-3. Sending `tools/list` and representative `tools/call` requests for the changed tools.
-4. For HTTP/SSE changes, run `npm run dev:remote -- --transport=http` or `--transport=sse`.
+The Jest suite is broad but still does **not** exercise every live MCP wire path or real embedding provider. For changes that touch tool handlers, embedding configuration, or transports, run the opt-in stdio E2E harness with `KB_RUN_E2E=1 npm test` (or `KB_RUN_E2E=1 jest src/e2e`). For HTTP/SSE changes, run `npm run dev:remote -- --transport=http` or `--transport=sse`.
 
 If a bug or improvement surfaces during that E2E pass, record it as an issue (see below) — it will not be caught by `npm test` alone.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ node build/index.js    # runs the server over stdio (clients launch it this way)
 
 ### Verification beyond `npm test`
 
-The Jest suite is broad but still does **not** exercise every live MCP wire path or real embedding provider. For changes that touch tool handlers, embedding configuration, or transports, run the opt-in stdio E2E harness with `KB_RUN_E2E=1 npm test`. The harness uses fake embeddings; embedding-provider or model changes also need a representative check against the configured real provider/API, and tool changes outside the harness need representative `tools/call` requests. For HTTP/SSE changes, run `npm run dev:remote -- --transport=http` or `--transport=sse`.
+The Jest suite is broad but still does **not** exercise every live MCP wire path or real embedding provider. For changes that touch tool handlers, embedding configuration, or transports, run the opt-in E2E suites, including stdio coverage, with `KB_RUN_E2E=1 npm test`. The harness uses fake embeddings; embedding-provider or model changes also need a representative check against the configured real provider/API, and tool changes outside the harness need representative `tools/call` requests. For HTTP/SSE changes, run `npm run dev:remote -- --transport=http` or `--transport=sse`.
 
 If a bug or improvement surfaces during that E2E pass, record it as an issue (see below) — it will not be caught by `npm test` alone.
 


### PR DESCRIPTION
## Summary

Correct the contributor guidance in `CLAUDE.md` so it describes the current test pipeline and points to the existing opt-in E2E suites.

Fixes #837

## Testing

- [x] `npm test` passes — build + 201 parallel suites / 2,648 tests + 11 serial suites / 433 tests passed
~~- [ ] End-to-end verified for tool/transport changes (see `CLAUDE.md`)~~ — N/A: documentation-only change; the updated guidance preserves the required E2E path for future tool/transport changes.
~~- [ ] Benchmark run if performance-relevant: `BENCH_PROVIDER=stub npm run bench`~~ — N/A: documentation-only change.
~~- [ ] <!-- kookr:check:tests --> Tests were added or updated for changed behavior; bug fixes include a regression test~~ — N/A: documentation-only change; no runtime behavior changed.

## Documentation contract

~~- [ ] <!-- kookr:check:readme --> `README.md` reflects user-visible CLI, MCP, installation, or configuration changes~~ — N/A: this PR changes contributor guidance in `CLAUDE.md` only. The pre-existing README test-command mismatch is tracked in #838.
~~- [ ] <!-- kookr:check:docs --> Relevant operator, API, configuration, and retrieval documentation under `docs/` is consistent with the implementation~~ — N/A: no implementation or `docs/` claims changed.
~~- [ ] <!-- kookr:check:mbse --> RFCs are updated when this PR implements, supersedes, or changes an accepted design~~ — N/A: documentation correction does not implement or change an accepted design.

## Changelog

~~- [ ] <!-- kookr:check:changelog --> `CHANGELOG.md` has an `Unreleased` entry for user-visible changes~~ — N/A: contributor guidance correction does not change product behavior.

## Retrieval and performance evidence

~~- [ ] <!-- kookr:check:benchmarks --> Retrieval-quality or performance changes include the relevant benchmark/evaluation evidence, or this row is waived with a reason~~ — N/A: documentation-only change.

## Design choice

- Kept the fix limited to `CLAUDE.md`, as requested by #837, and reused the existing `KB_RUN_E2E=1 npm test` command rather than adding a new helper.
- Kept explicit real-provider and representative-tool checks because the opt-in suites use fake embeddings and do not exercise every MCP tool.

## Pre-PR review

```text
SPECIALISTS=correctness,lint-like,test
DOCS_DRIFT=active
FORCE=no
COUNT=3
rationale:
  correctness: always — unconditional, independent cross-check
  lint-like: source changed; conventions + deadcode + docs-drift concerns active (docs/public API touched)
  test: non-test logic changed
```

Review result: correctness, conventions, deadcode, and test checks found no remaining issues. The pre-existing README test-guidance mismatch is tracked in [#838](https://github.com/jeanibarz/knowledge-base-mcp-server/issues/838).

## Follow-ups

- #838 — align the README's stale `npm test` description with the current build/parallel/serial pipeline.

## Verification evidence

- `npm run lint` passed.
- `npm run docs:check-anchors` passed with 0 stale anchors.
- `npm run check:fast` and the repository pre-push hook passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)