### PR TITLE
docs: align README test command guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -672,7 +672,7 @@ Exit codes mirror the CLI's existing convention — `2` for configuration and in
 
 - Set `LOG_FILE` to capture structured logs (JSON-RPC traffic continues to use stdout). This is especially helpful when diagnosing MCP handshake errors because all diagnostic messages are written to stderr and the optional log file.
 - Permission errors when creating or updating the FAISS index are surfaced with explicit messages in both the console and the log file. Verify that the process can write to `FAISS_INDEX_PATH` and the `.index` directories inside each knowledge base.
-- Run `npm test` to execute the Jest suite (serialised with `--runInBand`) that covers logger fallback behaviour and FAISS permission handling.
+- Run `npm test` to build the project, then run the parallel Jest project with `--maxWorkers=4` followed by the serial project with `--runInBand`; the suite covers logger fallback behaviour and FAISS permission handling.
 
 ## Security
 


### PR DESCRIPTION
## Summary

Correct the README's description of the `npm test` pipeline so contributors see the build, parallel Jest, and serial Jest stages.

Closes #838

## Testing

- [x] `npm test` passes — build + 201 parallel suites / 2,648 tests + 11 serial suites / 433 tests passed
~~- [ ] End-to-end verified for tool/transport changes (see `CLAUDE.md`)~~ — N/A: documentation-only change; no tool or transport behavior changed.
~~- [ ] Benchmark run if performance-relevant: `BENCH_PROVIDER=stub npm run bench`~~ — N/A: documentation-only change.
~~- [ ] <!-- kookr:check:tests --> Tests were added or updated for changed behavior; bug fixes include a regression test~~ — N/A: documentation-only change; no runtime behavior changed.

## Documentation contract

- [x] <!-- kookr:check:readme --> `README.md` reflects user-visible CLI, MCP, installation, or configuration changes — updated the contributor-facing `npm test` guidance.
~~- [ ] <!-- kookr:check:docs --> Relevant operator, API, configuration, and retrieval documentation under `docs/` is consistent with the implementation~~ — N/A: no implementation or `docs/` claims changed.
~~- [ ] <!-- kookr:check:mbse --> RFCs are updated when this PR implements, supersedes, or changes an accepted design~~ — N/A: documentation correction does not implement or change an accepted design.

## Changelog

~~- [ ] <!-- kookr:check:changelog --> `CHANGELOG.md` has an `Unreleased` entry for user-visible changes~~ — N/A: contributor guidance correction does not change product behavior.

## Retrieval and performance evidence

~~- [ ] <!-- kookr:check:benchmarks --> Retrieval-quality or performance changes include the relevant benchmark/evaluation evidence, or this row is waived with a reason~~ — N/A: documentation-only change.

## Pre-PR review

```text
SPECIALISTS=correctness,lint-like
DOCS_DRIFT=active
FORCE=no
COUNT=2
rationale:
  correctness: always — unconditional, independent cross-check
  lint-like: source changed; conventions + deadcode + docs-drift concerns active (docs/public API touched)
```

Reviewer specialists were skipped under the skill's trivial-change exception: this PR is a one-line documentation correction with no runtime behavior or test logic to review.

## Verification evidence

- `npm run check:fast` passed.
- `npm test` passed.
- Repository pre-push fast CI-parity checks passed.
- `git diff --check` passed with `README.md` as the only changed file.

## Follow-ups

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
