### PR TITLE
feat: derive serial Jest matches from one path list

### DIFF
--- a/docs/testing/INDEX.md
+++ b/docs/testing/INDEX.md
@@ -33,7 +33,7 @@ The serial project is the explicit escape hatch for suites with shared process, 
 - `tests/stress/**/*.test.ts` remains in the serial project because stress scenarios are process- and resource-sensitive even when skipped by default.
 - `src/e2e/**/*.test.ts` joins the serial project only when `KB_RUN_E2E=1`.
 
-New tests should stay in the parallel project unless they require one of those shared resources. Add a test to the serial project by listing its path in `jest.config.js` and documenting the reason in this section.
+New tests should stay in the parallel project unless they require one of those shared resources. Add a test to the serial project by listing its `<rootDir>/...` path once in `serialTestPathPatterns` in `jest.config.js` and documenting the reason in this section. The parallel project's ignore patterns and the serial project's `testMatch` are derived from that single list, so there is no second list to keep in sync.
 
 ## Test Corpus Builder
 

--- a/docs/testing/INDEX.md
+++ b/docs/testing/INDEX.md
@@ -33,7 +33,7 @@ The serial project is the explicit escape hatch for suites with shared process, 
 - `tests/stress/**/*.test.ts` remains in the serial project because stress scenarios are process- and resource-sensitive even when skipped by default.
 - `src/e2e/**/*.test.ts` joins the serial project only when `KB_RUN_E2E=1`.
 
-New tests should stay in the parallel project unless they require one of those shared resources. Add a test to the serial project by listing its `<rootDir>/...` path once in `serialTestPathPatterns` in `jest.config.js` and documenting the reason in this section. The parallel project's ignore patterns and the serial project's `testMatch` are derived from that single list, so there is no second list to keep in sync.
+New tests should stay in the parallel project unless they require one of those shared resources. Add a test to the serial project by listing its `<rootDir>/...` path once in `serialTestPathPatterns` in `jest.config.js` and documenting the reason in this section. Use a path without a trailing slash for one exact test file; use a directory path with a trailing slash (for example, `<rootDir>/tests/stress/`) for a recursive test directory. The parallel project's ignore patterns and the serial project's `testMatch` are derived from that single list, so there is no second list to keep in sync.
 
 ## Test Corpus Builder
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -17,6 +17,16 @@ const baseTestMatch = [
   '**/tests/stress/**/*.test.ts',
 ];
 
+const serialTestMatchFromPath = (pathPattern) => {
+  const relativePath = pathPattern
+    .replace(/^<rootDir>\//, '')
+    .replace(/\/$/, '');
+
+  return pathPattern.endsWith('/')
+    ? `**/${relativePath}/**/*.test.ts`
+    : `**/${relativePath}`;
+};
+
 const serialTestPathPatterns = [
   '<rootDir>/src/FaissIndexManager.test.ts',
   '<rootDir>/src/KnowledgeBaseServer.test.ts',
@@ -32,6 +42,8 @@ const serialTestPathPatterns = [
   '<rootDir>/tests/stress/',
   ...(e2eEnabled ? ['<rootDir>/src/e2e/'] : []),
 ];
+
+const serialTestMatch = serialTestPathPatterns.map(serialTestMatchFromPath);
 
 const baseConfig = {
   preset: 'ts-jest',
@@ -125,21 +137,7 @@ export default {
     {
       ...baseConfig,
       displayName: 'serial',
-      testMatch: [
-        '**/src/FaissIndexManager.test.ts',
-        '**/src/KnowledgeBaseServer.test.ts',
-        '**/src/cli-doctor.test.ts',
-        '**/src/docstore-cas.integration.test.ts',
-        '**/src/docstore-cas.test.ts',
-        '**/src/recursive-fs-watch.test.ts',
-        '**/src/reindex-runner.test.ts',
-        '**/src/transport/http.test.ts',
-        '**/src/transport/sse.test.ts',
-        '**/src/triggerWatcher.test.ts',
-        '**/src/write-lock.test.ts',
-        '**/tests/stress/**/*.test.ts',
-        ...(e2eEnabled ? ['**/src/e2e/**/*.test.ts'] : []),
-      ],
+      testMatch: serialTestMatch,
       testPathIgnorePatterns: [
         '/node_modules/',
         ...(e2eEnabled ? [] : ['<rootDir>/src/e2e/']),

--- a/src/jest-config.test.ts
+++ b/src/jest-config.test.ts
@@ -1,0 +1,31 @@
+import { execFileSync } from 'node:child_process';
+
+describe('Jest serial project configuration', () => {
+  it('keeps the existing serial test partition', () => {
+    const config = execFileSync(
+      process.execPath,
+      [
+        '--input-type=module',
+        '--eval',
+        "const { default: config } = await import('./jest.config.js'); console.log(JSON.stringify(config.projects.find(({ displayName }) => displayName === 'serial').testMatch));",
+      ],
+      { encoding: 'utf8' },
+    );
+
+    expect(JSON.parse(config)).toEqual([
+      '**/src/FaissIndexManager.test.ts',
+      '**/src/KnowledgeBaseServer.test.ts',
+      '**/src/cli-doctor.test.ts',
+      '**/src/docstore-cas.integration.test.ts',
+      '**/src/docstore-cas.test.ts',
+      '**/src/recursive-fs-watch.test.ts',
+      '**/src/reindex-runner.test.ts',
+      '**/src/transport/http.test.ts',
+      '**/src/transport/sse.test.ts',
+      '**/src/triggerWatcher.test.ts',
+      '**/src/write-lock.test.ts',
+      '**/tests/stress/**/*.test.ts',
+      ...(process.env.KB_RUN_E2E === '1' ? ['**/src/e2e/**/*.test.ts'] : []),
+    ]);
+  });
+});

--- a/src/jest-config.test.ts
+++ b/src/jest-config.test.ts
@@ -1,4 +1,7 @@
 import { execFileSync } from 'node:child_process';
+import * as path from 'node:path';
+
+const configRoot = path.resolve(__dirname, '..');
 
 describe('Jest serial project configuration', () => {
   it('keeps both projects aligned across E2E modes', () => {
@@ -41,6 +44,7 @@ describe('Jest serial project configuration', () => {
         ],
         {
           encoding: 'utf8',
+          cwd: configRoot,
           env: { ...process.env, KB_RUN_E2E: e2eEnabled ? '1' : '0' },
         },
       );

--- a/src/jest-config.test.ts
+++ b/src/jest-config.test.ts
@@ -57,6 +57,10 @@ describe('Jest serial project configuration', () => {
       ];
 
       expect(serial?.testMatch).toEqual(expectedSerialTestMatch);
+      expect(serial?.testPathIgnorePatterns).toEqual([
+        '/node_modules/',
+        ...(e2eEnabled ? [] : ['<rootDir>/src/e2e/']),
+      ]);
       expect(parallel?.testPathIgnorePatterns).toEqual([
         '/node_modules/',
         ...serialPathPatterns,

--- a/src/jest-config.test.ts
+++ b/src/jest-config.test.ts
@@ -1,18 +1,22 @@
 import { execFileSync } from 'node:child_process';
 
 describe('Jest serial project configuration', () => {
-  it('keeps the existing serial test partition', () => {
-    const config = execFileSync(
-      process.execPath,
-      [
-        '--input-type=module',
-        '--eval',
-        "const { default: config } = await import('./jest.config.js'); console.log(JSON.stringify(config.projects.find(({ displayName }) => displayName === 'serial').testMatch));",
-      ],
-      { encoding: 'utf8' },
-    );
-
-    expect(JSON.parse(config)).toEqual([
+  it('keeps both projects aligned across E2E modes', () => {
+    const serialPathPatterns = [
+      '<rootDir>/src/FaissIndexManager.test.ts',
+      '<rootDir>/src/KnowledgeBaseServer.test.ts',
+      '<rootDir>/src/cli-doctor.test.ts',
+      '<rootDir>/src/docstore-cas.integration.test.ts',
+      '<rootDir>/src/docstore-cas.test.ts',
+      '<rootDir>/src/recursive-fs-watch.test.ts',
+      '<rootDir>/src/reindex-runner.test.ts',
+      '<rootDir>/src/transport/http.test.ts',
+      '<rootDir>/src/transport/sse.test.ts',
+      '<rootDir>/src/triggerWatcher.test.ts',
+      '<rootDir>/src/write-lock.test.ts',
+      '<rootDir>/tests/stress/',
+    ];
+    const serialTestMatch = [
       '**/src/FaissIndexManager.test.ts',
       '**/src/KnowledgeBaseServer.test.ts',
       '**/src/cli-doctor.test.ts',
@@ -25,7 +29,39 @@ describe('Jest serial project configuration', () => {
       '**/src/triggerWatcher.test.ts',
       '**/src/write-lock.test.ts',
       '**/tests/stress/**/*.test.ts',
-      ...(process.env.KB_RUN_E2E === '1' ? ['**/src/e2e/**/*.test.ts'] : []),
-    ]);
+    ];
+
+    for (const e2eEnabled of [false, true]) {
+      const config = execFileSync(
+        process.execPath,
+        [
+          '--input-type=module',
+          '--eval',
+          "const { default: config } = await import('./jest.config.js'); console.log(JSON.stringify(config.projects.map(({ displayName, testMatch, testPathIgnorePatterns }) => ({ displayName, testMatch, testPathIgnorePatterns }))));",
+        ],
+        {
+          encoding: 'utf8',
+          env: { ...process.env, KB_RUN_E2E: e2eEnabled ? '1' : '0' },
+        },
+      );
+      const projects = JSON.parse(config) as Array<{
+        displayName: string;
+        testMatch: string[];
+        testPathIgnorePatterns: string[];
+      }>;
+      const parallel = projects.find(({ displayName }) => displayName === 'parallel');
+      const serial = projects.find(({ displayName }) => displayName === 'serial');
+      const expectedSerialTestMatch = [
+        ...serialTestMatch,
+        ...(e2eEnabled ? ['**/src/e2e/**/*.test.ts'] : []),
+      ];
+
+      expect(serial?.testMatch).toEqual(expectedSerialTestMatch);
+      expect(parallel?.testPathIgnorePatterns).toEqual([
+        '/node_modules/',
+        ...serialPathPatterns,
+        '<rootDir>/src/e2e/',
+      ]);
+    }
   });
 });


### PR DESCRIPTION
<!--
Work every checklist row carrying a `kookr:check:*` marker. The PR checklist
workflow verifies these rows against the merge-base diff with Kookr's pinned,
deterministic verifier:

- check a row when you performed it;
- strike the whole row through and add a one-line reason when it is not applicable;
- do not leave marked rows blank.
-->

## Summary

- Derive the serial Jest project's `testMatch` globs from `serialTestPathPatterns`, including recursive directory entries.
- Add regression coverage for both Jest projects and both `KB_RUN_E2E` modes, including their ignore lists.
- Document the single-edit workflow and trailing-slash directory convention in `docs/testing/INDEX.md`.

Fixes #836

## Testing

- [x] `npm test` passes (202 suites passed; 2,649 tests passed; 2 skipped)
- ~~[ ] End-to-end verified for tool/transport changes (see `CLAUDE.md`)~~ — Not applicable; this changes Jest test selection only.
- ~~[ ] Benchmark run if performance-relevant: `BENCH_PROVIDER=stub npm run bench`~~ — Not applicable; no runtime or performance behavior changed.
- [x] <!-- kookr:check:tests --> Tests were added or updated for changed behavior; bug fixes include a regression test

## Documentation contract

- [ ] ~~<!-- kookr:check:readme -->~~ `README.md` reflects user-visible CLI, MCP, installation, or configuration changes — Not applicable; no README-visible behavior changed.
- [x] <!-- kookr:check:docs --> Relevant operator, API, configuration, and retrieval documentation under `docs/` is consistent with the implementation
- [ ] ~~<!-- kookr:check:mbse -->~~ RFCs are updated when this PR implements, supersedes, or changes an accepted design — Not applicable; this is a local Jest configuration and contributor-guidance refactor.

## Changelog

- [ ] ~~<!-- kookr:check:changelog -->~~ `CHANGELOG.md` has an `Unreleased` entry for user-visible changes — Not applicable; no user-visible runtime change.

## Retrieval and performance evidence

- [ ] ~~<!-- kookr:check:benchmarks -->~~ Retrieval-quality or performance changes include the relevant benchmark/evaluation evidence, or this row is waived with a reason — Waived; this does not change retrieval quality or performance.

## Follow-ups

None.
