### PR TITLE
feat(doctor): probe relevance-gate judge endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -641,9 +641,9 @@ kb doctor --kb-symlinks  # KB-root symlink inventory and target classification
 kb doctor --bug-report=/tmp  # redacted support bundle directory
 ```
 
-The report covers active-model resolution, FAISS index version + mtime, the latest in-process index-update summary, per-KB stale counts, embedding-backend reachability (Ollama / HuggingFace / OpenAI), local LLM endpoint readiness, CLI version, and local git state. The command exits non-zero when any required retrieval check fails (active model unresolved, index missing, backend unreachable); LLM endpoint failures are WARN rows because search can remain healthy while `kb ask` is not ready.
+The report covers active-model resolution, FAISS index version + mtime, the latest in-process index-update summary, per-KB stale counts, embedding-backend reachability (Ollama / HuggingFace / OpenAI), ask and relevance-gate LLM endpoint readiness, CLI version, and local git state. The command exits non-zero when any required retrieval check fails (active model unresolved, index missing, backend unreachable); LLM endpoint failures are WARN rows because search can remain healthy while `kb ask` or the optional relevance gate is not ready.
 
-Use `kb doctor --endpoints` when you only need configured local endpoint readiness before starting or wiring clients. It checks MCP bind address/port availability, configured `KB_DAEMON_URL` health, configured Ollama embedding reachability, and configured `KB_LLM_ENDPOINT` or active LLM profile readiness without loading the full index health report.
+Use `kb doctor --endpoints` when you only need configured local endpoint readiness before starting or wiring clients. It checks MCP bind address/port availability, configured `KB_DAEMON_URL` health, configured Ollama embedding reachability, configured `KB_LLM_ENDPOINT` or active LLM profile readiness, and the explicitly configured `KB_GATE_LLM_ENDPOINT` when `KB_RELEVANCE_GATE=on`. The gate row is skipped when the gate is disabled, its endpoint is unset, or the fake judge is active; the command does not load the full index health report.
 
 Use `kb doctor --locks` when refresh or model writes report lock contention. It scans per-model `.kb-write.lock` paths, reports lock age, recorded owner PID/command for new locks, stale suspicion, and conservative next actions without deleting any lock file.
 

--- a/docs/cli-json-contracts.md
+++ b/docs/cli-json-contracts.md
@@ -1051,6 +1051,15 @@ Report envelope:
     "detail": "ready; profile=local-research-agent; source=profile; ...",
     "next_action": null
   },
+  "gate_llm_endpoint": {
+    "name": "gate_llm_endpoint",
+    "kind": "http",
+    "status": "skipped",
+    "configured": false,
+    "target": null,
+    "source": "not_configured",
+    "detail": "KB_RELEVANCE_GATE is not enabled"
+  },
   "cli": {
     "version": "0.2.2",
     "package_root": "/path/to/package",
@@ -1094,6 +1103,12 @@ Stable fields:
   resolved profile/ownership when known. `health_ok` checks the derived
   `/health` URL and `chat_ok` checks an OpenAI-compatible chat completion.
   `next_action` is `null` when ready, otherwise a human-readable repair hint.
+- `gate_llm_endpoint`: explicitly configured relevance-gate judge readiness.
+  `status` is `ok`, `error`, or `skipped`; the row is skipped when the gate is
+  disabled, the explicit endpoint is unset, or the fake judge is active. A
+  configured but unhealthy gate is surfaced as a `warn` entry in `checks[]`
+  because retrieval remains fail-soft while the top-level row retains its
+  `error` status.
 - `cli`: `version`, `package_root`, `invoked_path`, and
   `symlinked_checkout_path`.
 - `git`: either `null` or an object with `branch`, `head`, `origin_main`, and
@@ -1112,6 +1127,9 @@ Stable fields:
   `failure_count` / `failures[]` entries with `phase: "enumeration"` and make
   the summary `status: "partial"` rather than silently treating skipped
   directories as absent.
+
+Source and test anchors: `src/cli-doctor.ts:1446-1776`,
+`src/cli-doctor.test.ts:717-1084`.
 
 Stdout/stderr and exit codes:
 
@@ -1296,14 +1314,18 @@ schema instead of the full report:
 ```
 
 Endpoint rows use `status: "ok" | "warn" | "error" | "skipped"`. The current
-row names are `mcp_bind`, `kb_daemon`, `embedding_ollama`, and
-`llm_endpoint`. Skipped rows mean the relevant endpoint is not configured in
-the current process environment/profile state. The command exits `1` only when
-the focused endpoint report has overall `status: "error"`.
+row names are `mcp_bind`, `kb_daemon`, `embedding_ollama`, `llm_endpoint`, and
+`gate_llm_endpoint`. The gate row is probed only when
+`KB_RELEVANCE_GATE=on` and `KB_GATE_LLM_ENDPOINT` is explicitly configured.
+Skipped rows mean the relevant endpoint is not configured, the gate is
+disabled, or the fake judge is active in the current process environment/profile
+state. The command exits `1` only when the focused endpoint report has overall
+`status: "error"`.
 
 Source and test anchors: `src/cli-doctor.ts:92-146`,
 `src/cli-doctor.ts:347-418`, `src/cli-doctor.ts:421-743`,
-`src/cli-doctor.ts:1365-1452`, `src/cli-doctor.test.ts:923-1120`,
+`src/cli-doctor.ts:711-731`, `src/cli-doctor.ts:972-1032`,
+`src/cli-doctor.test.ts:1425-1715`,
 `src/cli-json-contracts.test.ts:215-237`.
 
 ## `kb diagnose`

--- a/docs/operations/incident-response.md
+++ b/docs/operations/incident-response.md
@@ -304,7 +304,10 @@ kb logs recent --limit=50 --format=json \
                  and (.gate.degraded == true or .gate.degrade_reason != null))
         | {ts, request_id, process, cmd, tool, kb_scope, result_count, gate}'
 
-kb doctor --format=json | jq '.llm_endpoint'
+kb doctor --format=json | jq '.llm_endpoint, .gate_llm_endpoint'
+kb doctor --endpoints --format=json \
+  | jq '.endpoints[]
+        | select(.name == "llm_endpoint" or .name == "gate_llm_endpoint")'
 kb llm status --format=json
 ```
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -458,7 +458,8 @@ Options:
                         (also included in the aggregate report).
   --endpoints           Check only configured local bind/connect endpoint
                         readiness (MCP bind target, KB_DAEMON_URL,
-                        Ollama embedding endpoint, and KB_LLM_ENDPOINT/profile).
+                        Ollama embedding endpoint, KB_LLM_ENDPOINT/profile, and
+                        the enabled relevance-gate KB_GATE_LLM_ENDPOINT).
   --locks               Check only FAISS/model write-lock paths, including
                         owner metadata when available and stale-lock guidance.
   --kb-symlinks         Inventory symlinks under KB roots without following

--- a/docs/requirements/INDEX.md
+++ b/docs/requirements/INDEX.md
@@ -79,6 +79,23 @@
 
 ## Observability
 
+### FR-OBS-835: Relevance-gate endpoint readiness
+**Status:** Implemented
+**Priority:** Medium
+
+**Requirement:** The system shall report the explicitly configured relevance-gate LLM endpoint in `kb doctor` and `kb doctor --endpoints` when the gate is enabled, and shall skip that entry when the gate is disabled or the endpoint is unset.
+**Rationale:** Operators need the doctor preflight to detect an unavailable judge endpoint before gated retrieval silently degrades, without treating an intentionally disabled or unconfigured gate as a failure.
+
+**Acceptance Criteria:**
+- [x] Given `KB_RELEVANCE_GATE=on` and `KB_GATE_LLM_ENDPOINT` set, when `kb doctor` or endpoint readiness runs, then it shall probe and report a distinct `gate_llm_endpoint` entry.
+- [x] Given a reachable gate endpoint, when endpoint readiness runs, then the gate entry shall be healthy.
+- [x] Given an unreachable or unhealthy gate endpoint, when endpoint readiness runs, then the gate entry shall report an error.
+- [x] Given the gate is disabled or `KB_GATE_LLM_ENDPOINT` is unset, when endpoint readiness runs, then the gate entry shall be skipped rather than failed.
+- [x] Given any gate configuration, when endpoint readiness runs, then the existing ask-endpoint entry shall retain its behavior.
+
+**Linked Tests:** TS-OBS-835
+**Dependencies:** FR-GATE-379
+
 ### FR-OBS-470: Config Schema Validation
 **Status:** Implemented
 **Priority:** High

--- a/docs/testing/INDEX.md
+++ b/docs/testing/INDEX.md
@@ -86,6 +86,15 @@ Keep this helper limited to temp directory scaffolding, file writes, path lookup
 
 ## Observability
 
+### TS-OBS-835: Relevance-gate endpoint readiness
+**Requirement:** FR-OBS-835
+
+**Test Cases:**
+- `buildDoctorReport` and `buildEndpointReadinessReport` shall probe and report a healthy `gate_llm_endpoint` when the gate is enabled with an explicit gate endpoint.
+- `buildDoctorReport` shall surface an unhealthy gate endpoint as a warning check while preserving the endpoint row's error status.
+- `buildEndpointReadinessReport` shall report an unhealthy `gate_llm_endpoint` without changing the ask-endpoint result when the gate probe fails.
+- `buildEndpointReadinessReport` shall skip the gate entry when the gate is disabled or its explicit endpoint is unset.
+
 ### TS-OBS-470: Config Schema Validation
 **Requirement:** FR-OBS-470
 

--- a/docs/troubleshooting-local-kb.md
+++ b/docs/troubleshooting-local-kb.md
@@ -17,9 +17,9 @@ kb doctor --kb-symlinks
 kb doctor --bug-report=/tmp
 ```
 
-`kb doctor` reports active-model resolution, index path and version, stale file counts, embedding backend health, local LLM endpoint readiness for `kb ask`, CLI package and symlink state, git drift for linked checkouts, and the latest index-update summary. Use it before deleting index files, changing client configuration, or debugging local LLM answers.
+`kb doctor` reports active-model resolution, index path and version, stale file counts, embedding backend health, ask and relevance-gate LLM endpoint readiness, CLI package and symlink state, git drift for linked checkouts, and the latest index-update summary. Use it before deleting index files, changing client configuration, or debugging local LLM answers.
 
-Use `kb doctor --endpoints` for the narrower port/URL preflight: MCP bind target availability, configured `KB_DAEMON_URL`, configured Ollama embedding endpoint, and configured `KB_LLM_ENDPOINT` or active LLM profile.
+Use `kb doctor --endpoints` for the narrower port/URL preflight: MCP bind target availability, configured `KB_DAEMON_URL`, configured Ollama embedding endpoint, configured `KB_LLM_ENDPOINT` or active LLM profile, and the explicitly configured `KB_GATE_LLM_ENDPOINT` when `KB_RELEVANCE_GATE=on`.
 
 Use `kb doctor --locks` for write-lock contention. It reports per-model lock path, age, recorded owner PID/command when available, whether that PID is still live, stale suspicion, and the next safe action. It never removes lock files.
 

--- a/src/cli-bug-report.test.ts
+++ b/src/cli-bug-report.test.ts
@@ -74,6 +74,15 @@ function minimalDoctorReport(): DoctorReport {
       detail: 'not configured',
       next_action: null,
     },
+    gate_llm_endpoint: {
+      name: 'gate_llm_endpoint',
+      kind: 'http',
+      status: 'skipped',
+      configured: false,
+      target: null,
+      source: 'not_configured',
+      detail: 'not configured',
+    },
     reranker: {
       enabled: false,
       model: 'reranker',

--- a/src/cli-doctor.test.ts
+++ b/src/cli-doctor.test.ts
@@ -21,6 +21,12 @@ const originalEnv = {
   REINDEX_TRIGGER_POLL_MS: process.env.REINDEX_TRIGGER_POLL_MS,
   KB_FS_WATCH: process.env.KB_FS_WATCH,
   KB_LLM_ENDPOINT: process.env.KB_LLM_ENDPOINT,
+  KB_LLM_PROVIDER: process.env.KB_LLM_PROVIDER,
+  KB_LLM_FAKE: process.env.KB_LLM_FAKE,
+  KB_RELEVANCE_GATE: process.env.KB_RELEVANCE_GATE,
+  KB_GATE_LLM_ENDPOINT: process.env.KB_GATE_LLM_ENDPOINT,
+  KB_GATE_LLM_MODEL: process.env.KB_GATE_LLM_MODEL,
+  KB_GATE_LLM_TIMEOUT_MS: process.env.KB_GATE_LLM_TIMEOUT_MS,
   KB_LLM_CONFIG_DIR: process.env.KB_LLM_CONFIG_DIR,
   KB_LLM_STATE_DIR: process.env.KB_LLM_STATE_DIR,
   KB_RERANK: process.env.KB_RERANK,
@@ -727,6 +733,8 @@ describe('kb doctor', () => {
         HUGGINGFACE_API_KEY: 'test-key',
         KB_LLM_CONFIG_DIR: llmConfigDir,
         KB_LLM_STATE_DIR: llmStateDir,
+        KB_RELEVANCE_GATE: 'off',
+        KB_GATE_LLM_ENDPOINT: '',
       });
       const { createExternalProfile, writeActiveProfile, writeProfile } = await import('./llm-profiles.js');
       const profile = await createExternalProfile(
@@ -769,11 +777,84 @@ describe('kb doctor', () => {
         status: 'ok',
         detail: expect.stringContaining('ready; profile=local-research-agent'),
       });
+      expect(report.gate_llm_endpoint).toMatchObject({
+        status: 'skipped',
+        configured: false,
+        source: 'not_configured',
+      });
       const markdown = formatDoctorMarkdown(report);
       expect(markdown).toContain('LLM endpoint:');
       expect(markdown).toContain('source: profile');
       expect(markdown).toContain('managed_by: local-research-agent');
       expect(markdown).toContain('chat_ok: yes');
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('includes relevance-gate readiness in the full doctor report', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-doctor-gate-full-report-'));
+    try {
+      const { rootDir, faissDir } = await seedDoctorBase(tempDir);
+      const llmConfigDir = path.join(tempDir, 'llm-config');
+      const llmStateDir = path.join(tempDir, 'llm-state');
+      const { buildDoctorReport, formatDoctorMarkdown } = await freshDoctor({
+        KNOWLEDGE_BASES_ROOT_DIR: rootDir,
+        FAISS_INDEX_PATH: faissDir,
+        EMBEDDING_PROVIDER: 'huggingface',
+        HUGGINGFACE_MODEL_NAME: MODEL_NAME,
+        HUGGINGFACE_API_KEY: 'test-key',
+        KB_LLM_CONFIG_DIR: llmConfigDir,
+        KB_LLM_STATE_DIR: llmStateDir,
+        KB_LLM_ENDPOINT: '',
+        KB_LLM_PROVIDER: 'local',
+        KB_LLM_FAKE: 'off',
+        KB_RELEVANCE_GATE: 'on',
+        KB_GATE_LLM_ENDPOINT: 'http://127.0.0.1:9090',
+        KB_GATE_LLM_MODEL: 'gate-model',
+        KB_GATE_LLM_TIMEOUT_MS: '100',
+      });
+      const probed: string[] = [];
+      const report = await buildDoctorReport({
+        backendHealthCheck: async () => ({ healthy: true, detail: 'backend ok' }),
+        packageRoot: tempDir,
+        invokedPath: null,
+        packageVersion: '9.9.9',
+        llmEndpointProbe: async (endpoint) => {
+          probed.push(endpoint);
+          const gate = endpoint.startsWith('http://127.0.0.1:9090/');
+          return {
+            endpoint,
+            health_url: endpoint.replace(/\/v1\/chat\/completions$/, '/health'),
+            health_ok: !gate,
+            chat_ok: !gate,
+            detail: gate
+              ? 'health failed: gate unavailable'
+              : 'health and chat completion succeeded',
+          };
+        },
+      });
+
+      expect(probed).toEqual([
+        'http://127.0.0.1:8080/v1/chat/completions',
+        'http://127.0.0.1:9090/v1/chat/completions',
+      ]);
+      expect(report.status).toBe('warn');
+      expect(report.gate_llm_endpoint).toMatchObject({
+        name: 'gate_llm_endpoint',
+        kind: 'http',
+        status: 'error',
+        configured: true,
+        target: 'http://127.0.0.1:9090/v1/chat/completions',
+        source: 'env',
+        detail: expect.stringContaining('gate unavailable'),
+      });
+      expect(report.checks).toContainEqual({
+        name: 'gate_llm_endpoint',
+        status: 'warn',
+        detail: expect.stringContaining('gate unavailable'),
+      });
+      expect(formatDoctorMarkdown(report)).toContain('Gate LLM endpoint:');
     } finally {
       await fsp.rm(tempDir, { recursive: true, force: true });
     }
@@ -798,6 +879,8 @@ describe('kb doctor', () => {
         HUGGINGFACE_API_KEY: 'test-key',
         KB_LLM_CONFIG_DIR: llmConfigDir,
         KB_LLM_STATE_DIR: llmStateDir,
+        KB_RELEVANCE_GATE: 'off',
+        KB_GATE_LLM_ENDPOINT: '',
       });
       const { createManagedProfile, writeActiveProfile, writeProfile } = await import('./llm-profiles.js');
       const modelPath = path.join(tempDir, 'model.gguf');
@@ -871,6 +954,8 @@ describe('kb doctor', () => {
         KB_LLM_CONFIG_DIR: llmConfigDir,
         KB_LLM_STATE_DIR: llmStateDir,
         KB_LLM_ENDPOINT: 'http://127.0.0.1:9999',
+        KB_RELEVANCE_GATE: 'off',
+        KB_GATE_LLM_ENDPOINT: '',
       });
       const { createExternalProfile, writeActiveProfile, writeProfile } = await import('./llm-profiles.js');
       const profile = await createExternalProfile('active-profile', 'http://127.0.0.1:8080');
@@ -913,6 +998,7 @@ describe('kb doctor', () => {
   it('uses the production LLM endpoint probe when no test probe is injected', async () => {
     const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-doctor-llm-default-probe-'));
     const oldFetch = global.fetch;
+    const timeoutSpy = jest.spyOn(global, 'setTimeout');
     try {
       const rootDir = path.join(tempDir, 'kbs');
       const faissDir = path.join(tempDir, '.faiss');
@@ -942,6 +1028,12 @@ describe('kb doctor', () => {
         KB_LLM_CONFIG_DIR: llmConfigDir,
         KB_LLM_STATE_DIR: llmStateDir,
         KB_LLM_ENDPOINT: '',
+        KB_LLM_PROVIDER: 'local',
+        KB_LLM_FAKE: 'off',
+        KB_RELEVANCE_GATE: 'on',
+        KB_GATE_LLM_ENDPOINT: 'http://127.0.0.1:9090',
+        KB_GATE_LLM_MODEL: 'gate-model',
+        KB_GATE_LLM_TIMEOUT_MS: '100',
       });
 
       const report = await buildDoctorReport({
@@ -962,6 +1054,19 @@ describe('kb doctor', () => {
         health_ok: true,
         chat_ok: true,
       });
+      expect(report.gate_llm_endpoint).toMatchObject({
+        status: 'ok',
+        configured: true,
+        target: 'http://127.0.0.1:9090/v1/chat/completions',
+      });
+      const calls = fetchMock.mock.calls as unknown as Array<[
+        string | URL | Request,
+        RequestInit | undefined,
+      ]>;
+      const gateChatCall = calls.find(([input]) => String(input) === 'http://127.0.0.1:9090/v1/chat/completions');
+      expect(gateChatCall).toBeDefined();
+      expect(JSON.parse(String(gateChatCall?.[1]?.body))).toMatchObject({ model: 'gate-model' });
+      expect(timeoutSpy).toHaveBeenCalledWith(expect.any(Function), 100);
       expect(fetchMock).toHaveBeenCalledWith(
         'http://127.0.0.1:8080/health',
         expect.objectContaining({ method: 'GET' }),
@@ -971,6 +1076,7 @@ describe('kb doctor', () => {
         expect.objectContaining({ method: 'POST' }),
       );
     } finally {
+      timeoutSpy.mockRestore();
       global.fetch = oldFetch;
       await fsp.rm(tempDir, { recursive: true, force: true });
     }
@@ -1253,6 +1359,8 @@ describe('kb doctor', () => {
         EMBEDDING_PROVIDER: 'ollama',
         OLLAMA_BASE_URL: 'http://127.0.0.1:11434',
         KB_LLM_ENDPOINT: 'http://127.0.0.1:8080',
+        KB_RELEVANCE_GATE: 'off',
+        KB_GATE_LLM_ENDPOINT: '',
         KB_LLM_CONFIG_DIR: path.join(tempDir, 'llm-config'),
         KB_LLM_STATE_DIR: path.join(tempDir, 'llm-state'),
       });
@@ -1298,6 +1406,11 @@ describe('kb doctor', () => {
           status: 'ok',
           target: 'http://127.0.0.1:8080/v1/chat/completions',
         }),
+        expect.objectContaining({
+          name: 'gate_llm_endpoint',
+          status: 'skipped',
+          configured: false,
+        }),
       ]);
       const markdown = formatEndpointReadinessMarkdown(report);
       expect(markdown).toContain('Endpoint readiness:');
@@ -1305,6 +1418,298 @@ describe('kb doctor', () => {
       expect(JSON.parse(JSON.stringify(report)).schema_version).toBe('kb.doctor.endpoints.v1');
     } finally {
       await closeServer(reserved).catch(() => undefined);
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('probes a configured gate endpoint and preserves ask endpoint behavior', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-doctor-gate-endpoint-'));
+    try {
+      const probed: string[] = [];
+      const probedModels: Array<string | undefined> = [];
+      const probedTimeouts: Array<number | undefined> = [];
+      let gateHealthOk = true;
+      let gateChatOk = true;
+      const { buildEndpointReadinessReport } = await freshDoctor({
+        MCP_TRANSPORT: 'stdio',
+        KB_DAEMON_URL: '',
+        EMBEDDING_PROVIDER: 'huggingface',
+        OLLAMA_BASE_URL: '',
+        KB_LLM_ENDPOINT: 'http://127.0.0.1:8080',
+        KB_LLM_PROVIDER: 'local',
+        KB_LLM_FAKE: 'off',
+        KB_RELEVANCE_GATE: 'on',
+        KB_GATE_LLM_ENDPOINT: 'http://127.0.0.1:9090',
+        KB_GATE_LLM_MODEL: 'gate-model',
+        KB_GATE_LLM_TIMEOUT_MS: '100',
+        KB_LLM_CONFIG_DIR: path.join(tempDir, 'llm-config'),
+        KB_LLM_STATE_DIR: path.join(tempDir, 'llm-state'),
+      });
+
+      const probe = async (
+        endpoint: string,
+        options?: { model?: string; chatTimeoutMs?: number },
+      ) => {
+        probed.push(endpoint);
+        probedModels.push(options?.model);
+        probedTimeouts.push(options?.chatTimeoutMs);
+        const gate = endpoint.startsWith('http://127.0.0.1:9090/');
+        return {
+          endpoint,
+          health_url: `${endpoint.replace(/\/v1\/chat\/completions$/, '')}/health`,
+          health_ok: !gate || gateHealthOk,
+          chat_ok: !gate || gateChatOk,
+          detail: gate && (!gateHealthOk || !gateChatOk)
+            ? 'health failed: gate unavailable'
+            : 'health and chat completion succeeded',
+        };
+      };
+
+      const healthyReport = await buildEndpointReadinessReport({ llmEndpointProbe: probe });
+
+      expect(healthyReport.status).toBe('ok');
+      expect(healthyReport.endpoints).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          name: 'llm_endpoint',
+          status: 'ok',
+          target: 'http://127.0.0.1:8080/v1/chat/completions',
+        }),
+        expect.objectContaining({
+          name: 'gate_llm_endpoint',
+          status: 'ok',
+          configured: true,
+          source: 'env',
+          target: 'http://127.0.0.1:9090/v1/chat/completions',
+        }),
+      ]));
+
+      gateHealthOk = false;
+      const unhealthyReport = await buildEndpointReadinessReport({ llmEndpointProbe: probe });
+
+      expect(unhealthyReport.status).toBe('error');
+      expect(probed).toEqual([
+        'http://127.0.0.1:8080/v1/chat/completions',
+        'http://127.0.0.1:9090/v1/chat/completions',
+        'http://127.0.0.1:8080/v1/chat/completions',
+        'http://127.0.0.1:9090/v1/chat/completions',
+      ]);
+      expect(probedModels).toEqual([undefined, 'gate-model', undefined, 'gate-model']);
+      expect(probedTimeouts).toEqual([undefined, 100, undefined, 100]);
+      expect(unhealthyReport.endpoints).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          name: 'llm_endpoint',
+          status: 'ok',
+          target: 'http://127.0.0.1:8080/v1/chat/completions',
+        }),
+        expect.objectContaining({
+          name: 'gate_llm_endpoint',
+          status: 'error',
+          configured: true,
+          source: 'env',
+          target: 'http://127.0.0.1:9090/v1/chat/completions',
+          detail: expect.stringContaining('gate unavailable'),
+        }),
+      ]));
+
+      gateHealthOk = true;
+      gateChatOk = false;
+      const chatUnhealthyReport = await buildEndpointReadinessReport({ llmEndpointProbe: probe });
+      expect(chatUnhealthyReport.status).toBe('error');
+      expect(chatUnhealthyReport.endpoints).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          name: 'gate_llm_endpoint',
+          status: 'error',
+          target: 'http://127.0.0.1:9090/v1/chat/completions',
+          detail: expect.stringContaining('gate unavailable'),
+        }),
+      ]));
+
+      const rejectedReport = await buildEndpointReadinessReport({
+        llmEndpointProbe: async (endpoint) => {
+          if (endpoint.startsWith('http://127.0.0.1:9090/')) {
+            throw new Error('connection reset');
+          }
+          return healthyLlmProbe(endpoint);
+        },
+      });
+
+      expect(rejectedReport.status).toBe('error');
+      expect(rejectedReport.endpoints).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          name: 'gate_llm_endpoint',
+          status: 'error',
+          configured: true,
+          target: 'http://127.0.0.1:9090/v1/chat/completions',
+          source: 'env',
+          detail: 'Gate LLM endpoint probe failed: connection reset',
+        }),
+      ]));
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('uses the default probe with the gate model and timeout', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-doctor-gate-endpoint-default-probe-'));
+    try {
+      const { buildEndpointReadinessReport } = await freshDoctor({
+        MCP_TRANSPORT: 'stdio',
+        KB_DAEMON_URL: '',
+        EMBEDDING_PROVIDER: 'huggingface',
+        OLLAMA_BASE_URL: '',
+        KB_LLM_ENDPOINT: '',
+        KB_LLM_PROVIDER: 'local',
+        KB_LLM_FAKE: 'off',
+        KB_RELEVANCE_GATE: 'on',
+        KB_GATE_LLM_ENDPOINT: 'http://127.0.0.1:9090',
+        KB_GATE_LLM_MODEL: 'gate-model',
+        KB_GATE_LLM_TIMEOUT_MS: '100',
+        KB_LLM_CONFIG_DIR: path.join(tempDir, 'llm-config'),
+        KB_LLM_STATE_DIR: path.join(tempDir, 'llm-state'),
+      });
+      const fetchMock = jest.fn(async (input: string | URL | Request, init?: RequestInit) => {
+        const url = String(input);
+        if (url.endsWith('/health')) {
+          expect(init?.method).toBe('GET');
+          return new Response('{"status":"ok"}', { status: 200 });
+        }
+        expect(init?.method).toBe('POST');
+        expect(JSON.parse(String(init?.body))).toMatchObject({ model: 'gate-model' });
+        return new Response(JSON.stringify({
+          choices: [{ message: { content: 'ok' } }],
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      });
+
+      const report = await buildEndpointReadinessReport({
+        fetchImpl: fetchMock as unknown as typeof fetch,
+      });
+
+      expect(report.status).toBe('ok');
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(report.endpoints).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          name: 'gate_llm_endpoint',
+          status: 'ok',
+          configured: true,
+          target: 'http://127.0.0.1:9090/v1/chat/completions',
+        }),
+      ]));
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it.each([
+    ['disabled', 'off', 'http://127.0.0.1:9090'],
+    ['unset', 'on', ''],
+  ])('skips the gate endpoint when the gate is %s', async (_caseName, gateSetting, endpoint) => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-doctor-gate-endpoint-skipped-'));
+    try {
+      const probe = jest.fn(healthyLlmProbe);
+      const { buildEndpointReadinessReport } = await freshDoctor({
+        MCP_TRANSPORT: 'stdio',
+        KB_DAEMON_URL: '',
+        EMBEDDING_PROVIDER: 'huggingface',
+        OLLAMA_BASE_URL: '',
+        KB_LLM_ENDPOINT: '',
+        KB_RELEVANCE_GATE: gateSetting,
+        KB_GATE_LLM_ENDPOINT: endpoint,
+        KB_LLM_CONFIG_DIR: path.join(tempDir, 'llm-config'),
+        KB_LLM_STATE_DIR: path.join(tempDir, 'llm-state'),
+      });
+
+      const report = await buildEndpointReadinessReport({ llmEndpointProbe: probe });
+
+      expect(report.status).toBe('ok');
+      expect(probe).not.toHaveBeenCalled();
+      expect(report.endpoints).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          name: 'llm_endpoint',
+          status: 'skipped',
+          configured: false,
+        }),
+        expect.objectContaining({
+          name: 'gate_llm_endpoint',
+          status: 'skipped',
+          configured: false,
+          source: 'not_configured',
+          target: null,
+        }),
+      ]));
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('skips an unset gate endpoint while retaining an explicitly configured ask endpoint', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-doctor-gate-endpoint-ask-configured-'));
+    try {
+      const probe = jest.fn(healthyLlmProbe);
+      const { buildEndpointReadinessReport } = await freshDoctor({
+        MCP_TRANSPORT: 'stdio',
+        KB_DAEMON_URL: '',
+        EMBEDDING_PROVIDER: 'huggingface',
+        OLLAMA_BASE_URL: '',
+        KB_LLM_ENDPOINT: 'http://127.0.0.1:8080',
+        KB_RELEVANCE_GATE: 'on',
+        KB_GATE_LLM_ENDPOINT: '',
+        KB_LLM_CONFIG_DIR: path.join(tempDir, 'llm-config'),
+        KB_LLM_STATE_DIR: path.join(tempDir, 'llm-state'),
+      });
+
+      const report = await buildEndpointReadinessReport({ llmEndpointProbe: probe });
+
+      expect(report.status).toBe('ok');
+      expect(probe).toHaveBeenCalledWith('http://127.0.0.1:8080/v1/chat/completions');
+      expect(report.endpoints).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          name: 'llm_endpoint',
+          status: 'ok',
+          target: 'http://127.0.0.1:8080/v1/chat/completions',
+        }),
+        expect.objectContaining({
+          name: 'gate_llm_endpoint',
+          status: 'skipped',
+          configured: false,
+          target: null,
+        }),
+      ]));
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('skips a configured gate endpoint when the fake judge is active', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-doctor-gate-endpoint-fake-'));
+    try {
+      const probe = jest.fn(healthyLlmProbe);
+      const { buildEndpointReadinessReport } = await freshDoctor({
+        MCP_TRANSPORT: 'stdio',
+        KB_DAEMON_URL: '',
+        EMBEDDING_PROVIDER: 'huggingface',
+        OLLAMA_BASE_URL: '',
+        KB_LLM_ENDPOINT: '',
+        KB_LLM_FAKE: 'on',
+        KB_RELEVANCE_GATE: 'on',
+        KB_GATE_LLM_ENDPOINT: 'http://127.0.0.1:9090',
+        KB_LLM_CONFIG_DIR: path.join(tempDir, 'llm-config'),
+        KB_LLM_STATE_DIR: path.join(tempDir, 'llm-state'),
+      });
+
+      const report = await buildEndpointReadinessReport({ llmEndpointProbe: probe });
+
+      expect(report.status).toBe('ok');
+      expect(probe).not.toHaveBeenCalled();
+      expect(report.endpoints).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          name: 'gate_llm_endpoint',
+          status: 'skipped',
+          configured: false,
+          target: null,
+          detail: 'KB_LLM_FAKE is enabled; the gate uses the in-process fake judge',
+        }),
+      ]));
+    } finally {
       await fsp.rm(tempDir, { recursive: true, force: true });
     }
   });
@@ -1321,6 +1726,8 @@ describe('kb doctor', () => {
         EMBEDDING_PROVIDER: 'huggingface',
         OLLAMA_BASE_URL: '',
         KB_LLM_ENDPOINT: '',
+        KB_RELEVANCE_GATE: 'off',
+        KB_GATE_LLM_ENDPOINT: '',
         KB_LLM_CONFIG_DIR: path.join(os.tmpdir(), 'kb-doctor-endpoints-empty-config'),
         KB_LLM_STATE_DIR: path.join(os.tmpdir(), 'kb-doctor-endpoints-empty-state'),
       });
@@ -1349,6 +1756,11 @@ describe('kb doctor', () => {
         }),
         expect.objectContaining({
           name: 'llm_endpoint',
+          status: 'skipped',
+          configured: false,
+        }),
+        expect.objectContaining({
+          name: 'gate_llm_endpoint',
           status: 'skipped',
           configured: false,
         }),
@@ -1409,6 +1821,8 @@ describe('kb doctor', () => {
         EMBEDDING_PROVIDER: 'huggingface',
         OLLAMA_BASE_URL: '',
         KB_LLM_ENDPOINT: '',
+        KB_RELEVANCE_GATE: 'off',
+        KB_GATE_LLM_ENDPOINT: '',
         KB_LLM_CONFIG_DIR: path.join(tempDir, 'llm-config'),
         KB_LLM_STATE_DIR: path.join(tempDir, 'llm-state'),
       });

--- a/src/cli-doctor.ts
+++ b/src/cli-doctor.ts
@@ -87,7 +87,12 @@ import {
   type ExtractionCacheInventory,
 } from './extraction-cache.js';
 import { inspectReindexTriggerFilesystem } from './triggerWatcher.js';
-import { deriveHealthUrl, probeLlmEndpoint, type LlmProbeResult } from './llm-client.js';
+import {
+  deriveHealthUrl,
+  probeLlmEndpoint,
+  type LlmProbeOptions,
+  type LlmProbeResult,
+} from './llm-client.js';
 import {
   createExternalProfile,
   readActiveProfileName,
@@ -95,6 +100,8 @@ import {
   resolveProfile,
   type LlmProfile,
 } from './llm-profiles.js';
+import { resolveRelevanceGateConfig } from './config/relevance-gate.js';
+import { isFakeLlmEnabled } from './llm-fake-stub.js';
 import { resolveRerankerConfig } from './config/reranker.js';
 import {
   backendForIndexType,
@@ -170,7 +177,8 @@ Options:
                         (also included in the aggregate report).
   --endpoints           Check only configured local bind/connect endpoint
                         readiness (MCP bind target, KB_DAEMON_URL,
-                        Ollama embedding endpoint, and KB_LLM_ENDPOINT/profile).
+                        Ollama embedding endpoint, KB_LLM_ENDPOINT/profile, and
+                        the enabled relevance-gate KB_GATE_LLM_ENDPOINT).
   --locks               Check only FAISS/model write-lock paths, including
                         owner metadata when available and stale-lock guidance.
   --kb-symlinks         Inventory symlinks under KB roots without following
@@ -214,7 +222,7 @@ export type EmbeddingCanaryHealthStatus = HealthStatus | 'not_recorded' | 'skipp
 type DoctorDaemonStatsPayload = Pick<KbStatsPayload, 'dense_search_latency'>;
 
 export interface EndpointReadinessEntry {
-  name: 'mcp_bind' | 'kb_daemon' | 'embedding_ollama' | 'llm_endpoint';
+  name: 'mcp_bind' | 'kb_daemon' | 'embedding_ollama' | 'llm_endpoint' | 'gate_llm_endpoint';
   kind: 'bind' | 'http';
   status: EndpointHealthStatus;
   configured: boolean;
@@ -409,6 +417,7 @@ export interface DoctorReport {
     detail: string;
     next_action: string | null;
   };
+  gate_llm_endpoint: EndpointReadinessEntry;
   reranker: {
     enabled: boolean;
     model: string;
@@ -533,7 +542,10 @@ export type BackendHealthCheck = (
   provider: string,
   modelName: string,
 ) => Promise<{ healthy: boolean; detail: string }>;
-export type LlmEndpointProbe = (endpoint: string) => Promise<LlmProbeResult>;
+export type LlmEndpointProbe = (
+  endpoint: string,
+  probeOptions?: LlmProbeOptions,
+) => Promise<LlmProbeResult>;
 
 export async function runDoctor(rest: string[]): Promise<number> {
   let parsed: DoctorArgs;
@@ -701,16 +713,18 @@ export async function buildEndpointReadinessReport(
   options: BuildEndpointReadinessReportOptions = {},
 ): Promise<EndpointReadinessReport> {
   const fetchImpl = options.fetchImpl ?? fetch;
+  const llmEndpointProbe: LlmEndpointProbe = (options.llmEndpointProbe
+    ?? ((endpoint, probeOptions) => probeLlmEndpoint(endpoint, fetchImpl, {
+      healthTimeoutMs: DOCTOR_LLM_HEALTH_TIMEOUT_MS,
+      chatTimeoutMs: DOCTOR_LLM_CHAT_TIMEOUT_MS,
+      ...probeOptions,
+    })));
   const entries: EndpointReadinessEntry[] = [];
   entries.push(await readMcpBindEndpointHealth());
   entries.push(await readKbDaemonEndpointHealth(fetchImpl));
   entries.push(await readOllamaEndpointHealth(fetchImpl));
-  entries.push(await readConfiguredLlmEndpointHealth(
-    options.llmEndpointProbe ?? ((endpoint) => probeLlmEndpoint(endpoint, fetchImpl, {
-      healthTimeoutMs: DOCTOR_LLM_HEALTH_TIMEOUT_MS,
-      chatTimeoutMs: DOCTOR_LLM_CHAT_TIMEOUT_MS,
-    })),
-  ));
+  entries.push(await readConfiguredLlmEndpointHealth(llmEndpointProbe));
+  entries.push(await readConfiguredGateLlmEndpointHealth(llmEndpointProbe));
   return {
     schema_version: 'kb.doctor.endpoints.v1',
     status: summarizeEndpointStatus(entries),
@@ -952,6 +966,71 @@ async function readConfiguredLlmEndpointHealth(
       target: target.profile.endpoint,
       source: target.source,
       detail: `LLM endpoint probe failed: ${(err as Error).message}`,
+    };
+  }
+}
+
+async function readConfiguredGateLlmEndpointHealth(
+  check: LlmEndpointProbe,
+): Promise<EndpointReadinessEntry> {
+  const gateConfig = resolveRelevanceGateConfig();
+  const gateEnabled = gateConfig.enabled;
+  const fakeLlmEnabled = isFakeLlmEnabled();
+  const endpoint = process.env.KB_GATE_LLM_ENDPOINT?.trim();
+  if (!gateEnabled || !endpoint || fakeLlmEnabled) {
+    return {
+      name: 'gate_llm_endpoint',
+      kind: 'http',
+      status: 'skipped',
+      configured: false,
+      target: null,
+      source: 'not_configured',
+      detail: fakeLlmEnabled
+        ? 'KB_LLM_FAKE is enabled; the gate uses the in-process fake judge'
+        : !gateEnabled
+          ? 'KB_RELEVANCE_GATE is not enabled'
+          : 'KB_GATE_LLM_ENDPOINT is not configured',
+    };
+  }
+
+  let profile: LlmProfile;
+  try {
+    profile = await createExternalProfile('gate', endpoint);
+  } catch (err) {
+    return {
+      name: 'gate_llm_endpoint',
+      kind: 'http',
+      status: 'error',
+      configured: true,
+      target: endpoint,
+      source: 'invalid',
+      detail: `KB_GATE_LLM_ENDPOINT configuration is invalid: ${(err as Error).message}`,
+    };
+  }
+
+  try {
+    const probe = await check(profile.endpoint, {
+      model: gateConfig.judgeModel,
+      chatTimeoutMs: gateConfig.judgeTimeoutMs,
+    });
+    return {
+      name: 'gate_llm_endpoint',
+      kind: 'http',
+      status: probe.health_ok && probe.chat_ok ? 'ok' : 'error',
+      configured: true,
+      target: probe.endpoint,
+      source: 'env',
+      detail: formatLlmEndpointDetail(profile, 'env', probe),
+    };
+  } catch (err) {
+    return {
+      name: 'gate_llm_endpoint',
+      kind: 'http',
+      status: 'error',
+      configured: true,
+      target: profile.endpoint,
+      source: 'env',
+      detail: `Gate LLM endpoint probe failed: ${(err as Error).message}`,
     };
   }
 }
@@ -1532,6 +1611,14 @@ export async function buildDoctorReport(
     status: llmEndpoint.status,
     detail: llmEndpoint.detail,
   });
+  const gateLlmEndpoint = await readConfiguredGateLlmEndpointHealth(
+    options.llmEndpointProbe ?? defaultLlmEndpointProbe,
+  );
+  checks.push({
+    name: 'gate_llm_endpoint',
+    status: gateLlmEndpoint.status === 'error' ? 'warn' : 'ok',
+    detail: gateLlmEndpoint.detail,
+  });
 
   const reranker = await readRerankerHealth();
   checks.push({
@@ -1676,6 +1763,7 @@ export async function buildDoctorReport(
     incomplete_models: incompleteModels,
     backend,
     llm_endpoint: llmEndpoint,
+    gate_llm_endpoint: gateLlmEndpoint,
     reranker,
     cli,
     git,
@@ -2414,10 +2502,14 @@ async function resolveDoctorLlmTarget(): Promise<{
   };
 }
 
-async function defaultLlmEndpointProbe(endpoint: string): Promise<LlmProbeResult> {
+async function defaultLlmEndpointProbe(
+  endpoint: string,
+  probeOptions?: LlmProbeOptions,
+): Promise<LlmProbeResult> {
   return probeLlmEndpoint(endpoint, fetch, {
     healthTimeoutMs: DOCTOR_LLM_HEALTH_TIMEOUT_MS,
     chatTimeoutMs: DOCTOR_LLM_CHAT_TIMEOUT_MS,
+    ...probeOptions,
   });
 }
 
@@ -2734,6 +2826,12 @@ export function formatDoctorMarkdown(report: DoctorReport): string {
   if (report.llm_endpoint.next_action !== null) {
     lines.push(`  next_action: ${report.llm_endpoint.next_action}`);
   }
+  lines.push('Gate LLM endpoint:');
+  lines.push(`  status: ${report.gate_llm_endpoint.status}`);
+  lines.push(`  configured: ${report.gate_llm_endpoint.configured ? 'yes' : 'no'}`);
+  lines.push(`  source: ${report.gate_llm_endpoint.source}`);
+  lines.push(`  endpoint: ${report.gate_llm_endpoint.target ?? '<unconfigured>'}`);
+  lines.push(`  detail: ${report.gate_llm_endpoint.detail}`);
   lines.push('Reranker:');
   lines.push(`  enabled: ${report.reranker.enabled ? 'yes' : 'no'}`);
   lines.push(`  model: ${report.reranker.model}`);

--- a/src/llm-client.test.ts
+++ b/src/llm-client.test.ts
@@ -470,7 +470,11 @@ describe('llm-client', () => {
     expect(LlmClientError).toBeDefined();
   });
 
-  it('probes health and chat completion', async () => {
+  it('probes health and chat completion with an explicit model', async () => {
+    process.env.KB_LLM_PROVIDER = 'local';
+    process.env.KB_LLM_FAKE = 'off';
+    const healthTimeoutSpy = jest.spyOn(AbortSignal, 'timeout');
+    const chatTimeoutSpy = jest.spyOn(global, 'setTimeout');
     const fetchMock = jest.fn(async (url: string) => {
       if (url.endsWith('/health')) {
         return new Response('{"status":"ok"}', { status: 200 });
@@ -480,9 +484,20 @@ describe('llm-client', () => {
       }), { status: 200, headers: { 'Content-Type': 'application/json' } });
     });
 
-    const result = await probeLlmEndpoint('http://127.0.0.1:8080', fetchMock as unknown as typeof fetch);
+    const result = await probeLlmEndpoint(
+      'http://127.0.0.1:8080',
+      fetchMock as unknown as typeof fetch,
+      { model: 'gate-model', healthTimeoutMs: 456, chatTimeoutMs: 123 },
+    );
+    expect(healthTimeoutSpy).toHaveBeenCalledWith(456);
+    expect(chatTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 123);
+    healthTimeoutSpy.mockRestore();
+    chatTimeoutSpy.mockRestore();
     expect(result.health_ok).toBe(true);
     expect(result.chat_ok).toBe(true);
+    const calls = fetchMock.mock.calls as unknown as Array<[string, RequestInit]>;
+    const chatRequest = calls.find(([url]) => !url.endsWith('/health'))!;
+    expect(JSON.parse(chatRequest[1].body as string)).toMatchObject({ model: 'gate-model' });
   });
 });
 

--- a/src/llm-client.ts
+++ b/src/llm-client.ts
@@ -48,6 +48,8 @@ export interface LlmProbeResult {
 }
 
 export interface LlmProbeOptions {
+  /** Model to use for the probe when the endpoint has a feature-specific model. */
+  model?: string;
   healthTimeoutMs?: number;
   chatTimeoutMs?: number;
 }
@@ -594,6 +596,7 @@ export async function probeLlmEndpoint(
   try {
     await callChatCompletion({
       endpoint: chatEndpoint,
+      model: options.model,
       messages: [
         { role: 'system', content: 'Reply with exactly: ok' },
         { role: 'user', content: 'health check' },


### PR DESCRIPTION
## Summary

- Add a distinct `gate_llm_endpoint` readiness row to both `kb doctor` and `kb doctor --endpoints` when the relevance gate has an explicit judge endpoint.
- Preserve skip behavior for disabled, unset, and fake-LLM modes; keep ask-endpoint probing independent while forwarding the gate model and timeout.
- Update the CLI JSON contract, operational guidance, requirements, tests, and troubleshooting documentation.

Fixes #835

## Testing

- [ ] `npm test` passes — attempted; the existing benchmark fixture fails under the ambient `/tmp/package.json` `type: module` setting because its generated CommonJS file uses `require`.
- [ ] End-to-end verified for tool/transport changes — not applicable; this is a local doctor-report change.
- [ ] Benchmark run if performance-relevant — not applicable; retrieval ranking and performance are unchanged.
- [x] <!-- kookr:check:tests --> Tests were added or updated for changed behavior; bug fixes include a regression test — 71 focused tests and 2 bug-report tests passed.

## Documentation contract

- [x] <!-- kookr:check:readme --> `README.md` reflects user-visible CLI, MCP, installation, or configuration changes.
- [x] <!-- kookr:check:docs --> Relevant operator, API, configuration, and retrieval documentation under `docs/` is consistent with the implementation.
- [ ] ~~<!-- kookr:check:mbse --> RFCs are updated when this PR implements, supersedes, or changes an accepted design.~~ — N/A: the existing doctor/gate design is implemented without changing an accepted RFC.

## Changelog

- [ ] ~~<!-- kookr:check:changelog --> `CHANGELOG.md` has an `Unreleased` entry for user-visible changes.~~ — N/A: this repository does not contain a `CHANGELOG.md`.

## Retrieval and performance evidence

- [ ] ~~<!-- kookr:check:benchmarks --> Retrieval-quality or performance changes include the relevant benchmark/evaluation evidence, or this row is waived with a reason.~~ — N/A: this change only adds readiness reporting and does not alter retrieval quality or performance.

## Follow-ups

- Add deeper signal-aware stalled-network timeout regression coverage in a follow-up test improvement; this PR verifies model/timeout forwarding and timer creation.
