### PR TITLE
test(chaos): cover search-time index corruption

### DIFF
--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1,0 +1,25 @@
+# Requirements
+
+### TS-CHAOS-001: Search-time index corruption degrades safely
+**Status:** Implemented
+**Priority:** Medium
+
+**Requirement:** The search path shall handle a corrupt or missing persisted
+index artifact at query time as a classified degradation or partial result,
+without an uncaught exception or process crash.
+
+**Rationale:** Read-path corruption is a distinct failure mode from ingest and
+save failures. The query-serving daemon needs deterministic coverage for its
+graceful-degradation contract.
+
+**Acceptance Criteria:**
+- [x] A truncated or garbage FAISS index produces a classified degradation or
+  partial result and never an uncaught throw.
+- [x] Torn lexical-index JSON produces a classified degradation or partial
+  result and never an uncaught throw.
+- [x] A missing or short metadata sidecar produces a classified degradation or
+  partial result and never an uncaught throw.
+- [x] The scenario runs deterministically through `npm run test:chaos`.
+
+**Linked Tests:** `tests/chaos/scenarios/search-faults.test.ts`
+**Dependencies:** Existing chaos fault harness and search degradation paths.

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1,25 +1,5 @@
 # Requirements
 
-### TS-CHAOS-001: Search-time index corruption degrades safely
-**Status:** Implemented
-**Priority:** Medium
-
-**Requirement:** The search path shall handle a corrupt or missing persisted
-index artifact at query time as a classified degradation or partial result,
-without an uncaught exception or process crash.
-
-**Rationale:** Read-path corruption is a distinct failure mode from ingest and
-save failures. The query-serving daemon needs deterministic coverage for its
-graceful-degradation contract.
-
-**Acceptance Criteria:**
-- [x] A truncated or garbage FAISS index produces a classified degradation or
-  partial result and never an uncaught throw.
-- [x] Torn lexical-index JSON produces a classified degradation or partial
-  result and never an uncaught throw.
-- [x] A missing or short metadata sidecar produces a classified degradation or
-  partial result and never an uncaught throw.
-- [x] The scenario runs deterministically through `npm run test:chaos`.
-
-**Linked Tests:** `tests/chaos/scenarios/search-faults.test.ts`
-**Dependencies:** Existing chaos fault harness and search degradation paths.
+The canonical requirements catalog is maintained in
+[`requirements/INDEX.md`](requirements/INDEX.md). Search-time index corruption
+is tracked by [TS-CHAOS-001](requirements/INDEX.md#ts-chaos-001-search-time-index-corruption-degrades-safely).

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -2,4 +2,4 @@
 
 The canonical requirements catalog is maintained in
 [`requirements/INDEX.md`](requirements/INDEX.md). Search-time index corruption
-is tracked by [TS-CHAOS-001](requirements/INDEX.md#ts-chaos-001-search-time-index-corruption-degrades-safely).
+is tracked by [NFR-SEARCH-834](requirements/INDEX.md#nfr-search-834-query-time-index-corruption-degrades-safely).

--- a/docs/requirements/INDEX.md
+++ b/docs/requirements/INDEX.md
@@ -254,6 +254,30 @@
 **Linked Tests:** TS-SEARCH-192
 **Dependencies:** RFC005
 
+### TS-CHAOS-001: Search-time index corruption degrades safely
+**Status:** Implemented
+**Priority:** Medium
+
+**Requirement:** The search path shall handle a corrupt or missing persisted
+index artifact at query time as a classified degradation or partial result,
+without an uncaught exception or process crash.
+
+**Rationale:** Read-path corruption is a distinct failure mode from ingest and
+save failures. The query-serving daemon needs deterministic coverage for its
+graceful-degradation contract.
+
+**Acceptance Criteria:**
+- [x] A truncated or garbage FAISS index produces a classified degradation or
+  partial result and never an uncaught throw.
+- [x] Torn lexical-index JSON produces a classified degradation or partial
+  result and never an uncaught throw.
+- [x] A missing or short metadata sidecar produces a classified degradation or
+  partial result and never an uncaught throw.
+- [x] The scenario runs deterministically through `npm run test:chaos`.
+
+**Linked Tests:** [TS-CHAOS-001](../../tests/chaos/scenarios/search-faults.test.ts)
+**Dependencies:** Existing chaos fault harness and search degradation paths.
+
 ## Relevance Gate (RFC 018)
 
 ### FR-GATE-EVAL-369: Gate Validation Harness

--- a/docs/requirements/INDEX.md
+++ b/docs/requirements/INDEX.md
@@ -254,7 +254,7 @@
 **Linked Tests:** TS-SEARCH-192
 **Dependencies:** RFC005
 
-### TS-CHAOS-001: Search-time index corruption degrades safely
+### NFR-SEARCH-834: Query-time index corruption degrades safely
 **Status:** Implemented
 **Priority:** Medium
 
@@ -275,7 +275,7 @@ graceful-degradation contract.
   partial result and never an uncaught throw.
 - [x] The scenario runs deterministically through `npm run test:chaos`.
 
-**Linked Tests:** [TS-CHAOS-001](../../tests/chaos/scenarios/search-faults.test.ts)
+**Linked Tests:** [TS-SEARCH-834](../../tests/chaos/scenarios/search-faults.test.ts)
 **Dependencies:** Existing chaos fault harness and search degradation paths.
 
 ## Relevance Gate (RFC 018)

--- a/docs/testing/INDEX.md
+++ b/docs/testing/INDEX.md
@@ -194,6 +194,14 @@ Keep this helper limited to temp directory scaffolding, file writes, path lookup
 - `computeStaleness` shall preserve global modified and new file counts for unscoped searches.
 - `formatFreshnessFooter` and JSON payload tests shall verify scoped fields remain distinct from global fields.
 
+### TS-SEARCH-834: Query-time index corruption degradation
+**Requirement:** NFR-SEARCH-834
+
+**Test Cases:**
+- `kb search` shall classify a corrupt active FAISS artifact as an indexing failure rather than throw an uncaught error.
+- The lexical retrieval leg shall classify torn per-KB lexical JSON as a per-KB failure and preserve partial-result semantics.
+- Dense retrieval shall return matching documents via post-filter overfetch when the metadata sidecar is missing or short.
+
 ## Relevance Gate (RFC 018)
 
 ### TS-LLM-465: Fake LLM Fixture

--- a/tests/chaos/README.md
+++ b/tests/chaos/README.md
@@ -19,7 +19,6 @@ fault's documented recovery contract:
 | embedding timeout | provider timeout during `embedDocuments` | ingest summary fails in `indexing`, the file is quarantined, and canonical classification maps to provider recovery |
 | malformed embedding response | provider returns the wrong vector count | ingest fails before persistence and quarantines the source file |
 | contextual-preface timeout storm | repeated LLM timeout | per-file circuit breaker stops after five chunk-level timeouts and records failed sidecar entries |
-
 | corrupt FAISS at search time | truncated active FAISS artifact | search returns a classified indexing failure rather than an uncaught throw |
 | torn lexical JSON at search time | truncated per-KB BM25 index | lexical retrieval records a classified per-KB failure and continues with partial results |
 | missing or short metadata sidecar | absent or truncated predicate-pushdown JSONL | dense retrieval falls back to post-filter overfetch and returns the matching document |

--- a/tests/chaos/README.md
+++ b/tests/chaos/README.md
@@ -1,7 +1,7 @@
-# Ingest Chaos Test Suite
+# Chaos Test Suite
 
-This suite exercises deterministic ingest fault classes that are too broad or
-too timing-sensitive for the default per-PR Jest run.
+This suite exercises deterministic ingest and search fault classes that are too
+broad or too timing-sensitive for the default per-PR Jest run.
 
 Run it locally with:
 
@@ -9,8 +9,8 @@ Run it locally with:
 npm run test:chaos
 ```
 
-The nightly workflow runs the suite on a small fixture KB and asserts that
-faults leave the dense index recoverable:
+The nightly workflow runs the suite on a small fixture KB and asserts each
+fault's documented recovery contract:
 
 | Scenario | Fault class | Recovery assertion |
 | --- | --- | --- |
@@ -19,6 +19,10 @@ faults leave the dense index recoverable:
 | embedding timeout | provider timeout during `embedDocuments` | ingest summary fails in `indexing`, the file is quarantined, and canonical classification maps to provider recovery |
 | malformed embedding response | provider returns the wrong vector count | ingest fails before persistence and quarantines the source file |
 | contextual-preface timeout storm | repeated LLM timeout | per-file circuit breaker stops after five chunk-level timeouts and records failed sidecar entries |
+
+| corrupt FAISS at search time | truncated active FAISS artifact | search returns a classified indexing failure rather than an uncaught throw |
+| torn lexical JSON at search time | truncated per-KB BM25 index | lexical retrieval records a classified per-KB failure and continues with partial results |
+| missing or short metadata sidecar | absent or truncated predicate-pushdown JSONL | dense retrieval falls back to post-filter overfetch and returns the matching document |
 
 Keep this suite opt-in. New scenarios should prefer deterministic injection
 points over wall-clock sleeps or real signals.

--- a/tests/chaos/scenarios/search-faults.test.ts
+++ b/tests/chaos/scenarios/search-faults.test.ts
@@ -244,7 +244,7 @@ describe('search chaos suite', () => {
 
       const timing: import('../../../src/FaissIndexManager.js').SimilaritySearchTiming = {};
       const results = await manager.similaritySearch(
-        'queue recovery',
+        'queue worker',
         1,
         2,
         workspace.kbName,

--- a/tests/chaos/scenarios/search-faults.test.ts
+++ b/tests/chaos/scenarios/search-faults.test.ts
@@ -1,0 +1,260 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import * as fsp from 'fs/promises';
+import * as path from 'path';
+import type { Document } from '@langchain/core/documents';
+import type { EmbeddingsInterface } from '@langchain/core/embeddings';
+import {
+  activeIndexSymlink,
+  createChaosWorkspace,
+  modelDir,
+  restoreChaosEnv,
+  saveChaosEnv,
+  writeFixtureNote,
+  type ChaosWorkspace,
+  type SavedEnv,
+} from '../fault-harness.js';
+
+class SearchFaultFaissStore {
+  public docstore = { _docs: new Map<string, Document>() };
+  public index = {
+    _n: 0,
+    ntotal: () => this.index._n,
+    getDimension: () => 2,
+  };
+
+  constructor(public embeddings: EmbeddingsInterface) {}
+
+  async addVectors(vectors: number[][], documents: Document[]): Promise<void> {
+    const expectedDimension = vectors[0]?.length ?? 0;
+    for (const vector of vectors) {
+      if (vector.length !== expectedDimension || vector.some((value) => !Number.isFinite(value))) {
+        throw new Error('fake FAISS received malformed vectors');
+      }
+    }
+    documents.forEach((document) => {
+      this.docstore._docs.set(`doc-${this.index._n}`, document);
+      this.index._n += 1;
+    });
+  }
+
+  async save(directory: string): Promise<void> {
+    await fsp.mkdir(directory, { recursive: true });
+    await fsp.writeFile(path.join(directory, 'faiss.index'), `vectors=${this.index._n}\n`, 'utf-8');
+    await fsp.writeFile(
+      path.join(directory, 'docstore.json'),
+      JSON.stringify(Array.from(this.docstore._docs.entries())),
+      'utf-8',
+    );
+  }
+
+  async similaritySearchWithScore(query: string, k: number): Promise<Array<[Document, number]>> {
+    const normalizedQuery = query.toLowerCase();
+    return Array.from(this.docstore._docs.values())
+      .map((document, ordinal): [Document, number] => {
+        const haystack = `${document.pageContent}\n${JSON.stringify(document.metadata ?? {})}`.toLowerCase();
+        return [document, haystack.includes(normalizedQuery) ? ordinal / 1000 : 1 + ordinal / 1000];
+      })
+      .sort((a, b) => a[1] - b[1])
+      .slice(0, k);
+  }
+
+  static async load(directory: string, embeddings: EmbeddingsInterface): Promise<SearchFaultFaissStore> {
+    const indexRaw = await fsp.readFile(path.join(directory, 'faiss.index'), 'utf-8');
+    const indexMatch = /^vectors=(\d+)\n$/.exec(indexRaw);
+    if (indexMatch === null) {
+      throw new Error('fake FAISS index is truncated or corrupt');
+    }
+
+    const entries = JSON.parse(await fsp.readFile(path.join(directory, 'docstore.json'), 'utf-8')) as unknown;
+    if (!Array.isArray(entries) || Number(indexMatch[1]) !== entries.length) {
+      throw new Error('fake FAISS index/docstore counts do not match');
+    }
+
+    const store = new SearchFaultFaissStore(embeddings);
+    for (const [id, document] of entries as Array<[string, Document]>) {
+      store.docstore._docs.set(id, document);
+    }
+    store.index._n = store.docstore._docs.size;
+    return store;
+  }
+}
+
+function vectorForText(text: string): number[] {
+  let hash = 0;
+  for (let i = 0; i < text.length; i += 1) {
+    hash = Math.imul(hash ^ text.charCodeAt(i), 16_777_619);
+  }
+  return [text.length, hash >>> 0];
+}
+
+jest.mock('@langchain/community/vectorstores/faiss', () => ({
+  __esModule: true,
+  FaissStore: SearchFaultFaissStore,
+}));
+
+jest.mock('@langchain/community/embeddings/hf', () => ({
+  __esModule: true,
+  HuggingFaceInferenceEmbeddings: class MockEmbedding {
+    async embedDocuments(texts: string[]): Promise<number[][]> {
+      return texts.map(vectorForText);
+    }
+
+    async embedQuery(text: string): Promise<number[]> {
+      return vectorForText(text);
+    }
+  },
+}));
+
+describe('search chaos suite', () => {
+  let workspace: ChaosWorkspace;
+  let savedEnv: SavedEnv;
+
+  beforeEach(async () => {
+    savedEnv = saveChaosEnv();
+    jest.resetModules();
+    workspace = await createChaosWorkspace();
+    process.env.KB_CONTEXTUAL_RETRIEVAL = 'off';
+  });
+
+  afterEach(async () => {
+    restoreChaosEnv(savedEnv);
+    await fsp.rm(workspace.tempDir, { recursive: true, force: true });
+  });
+
+  async function buildDenseIndex(): Promise<import('../../../src/FaissIndexManager.js').FaissIndexManager> {
+    const { FaissIndexManager } = await import('../../../src/FaissIndexManager.js');
+    const manager = new FaissIndexManager();
+    await manager.initialize();
+    await manager.updateIndex(workspace.kbName);
+    return manager;
+  }
+
+  async function buildLexicalIndex(): Promise<string> {
+    const { LexicalIndex, lexicalIndexFilePath } = await import('../../../src/lexical-index.js');
+    const index = await LexicalIndex.load(workspace.kbName, workspace.kbPath);
+    await index.refresh();
+    await index.save();
+    return lexicalIndexFilePath(workspace.kbName);
+  }
+
+  async function captureSearchOutput(
+    runSearch: (args: string[], deps: import('../../../src/cli-search.js').RunSearchDeps) => Promise<number>,
+    args: string[],
+    deps: import('../../../src/cli-search.js').RunSearchDeps,
+  ): Promise<{ code: number; stdout: string; stderr: string }> {
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const stdoutSpy = jest.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+      stdout.push(String(chunk));
+      return true;
+    });
+    const stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation((chunk) => {
+      stderr.push(String(chunk));
+      return true;
+    });
+
+    try {
+      const code = await runSearch(args, deps);
+      return { code, stdout: stdout.join(''), stderr: stderr.join('') };
+    } finally {
+      stdoutSpy.mockRestore();
+      stderrSpy.mockRestore();
+    }
+  }
+
+  it('classifies a corrupt FAISS artifact instead of throwing from the search command', async () => {
+    await writeFixtureNote(workspace);
+    await buildDenseIndex();
+
+    const activeVersion = await fsp.realpath(activeIndexSymlink(workspace));
+    await fsp.writeFile(path.join(activeVersion, 'faiss.index'), 'vectors=', 'utf-8');
+
+    const { FaissIndexManager } = await import('../../../src/FaissIndexManager.js');
+    const { createRunSearchDeps, runSearch } = await import('../../../src/cli-search.js');
+    const manager = new FaissIndexManager();
+    const deps = createRunSearchDeps({
+      bootstrapLayout: jest.fn(async () => {}),
+      resolveActiveModel: jest.fn(async () => 'huggingface__BAAI-bge-small-en-v1.5'),
+      loadManagerForModel: jest.fn(async () => manager),
+      loadWithJsonRetry: jest.fn(async () => {
+        await manager.initialize({ readOnly: true });
+      }),
+    });
+
+    const output = await captureSearchOutput(runSearch, [
+      'queue recovery',
+      '--format=json',
+      '--no-freshness',
+    ], deps);
+
+    expect(output.code).toBe(1);
+    expect(output.stderr).toContain('corrupt or unreadable');
+    expect(output.stderr).not.toContain('UnhandledPromiseRejection');
+    expect(JSON.parse(output.stdout)).toMatchObject({
+      error: {
+        code: 'INDEX_NOT_INITIALIZED',
+        category: 'indexing',
+      },
+    });
+  });
+
+  it('surfaces torn lexical JSON as a classified per-KB partial failure', async () => {
+    await writeFixtureNote(workspace);
+    const lexicalPath = await buildLexicalIndex();
+    const raw = await fsp.readFile(lexicalPath, 'utf-8');
+    await fsp.writeFile(lexicalPath, raw.slice(0, -2), 'utf-8');
+
+    const { runLexicalLeg } = await import('../../../src/hybrid-retrieval.js');
+    const { classifyKbSearchError } = await import('../../../src/search-errors-core.js');
+    const failures: Error[] = [];
+    const result = await runLexicalLeg({
+      kbs: [{ kbName: workspace.kbName, kbPath: workspace.kbPath }],
+      query: 'queue recovery',
+      fetchK: 10,
+      refresh: 'when-empty',
+      onError: (_kbName, error) => failures.push(error),
+    });
+
+    expect(result).toEqual({
+      hits: [],
+      refreshed: 0,
+      failed: 1,
+      failedKbs: [workspace.kbName],
+    });
+    expect(failures).toHaveLength(1);
+    expect(classifyKbSearchError(failures[0])).toMatchObject({
+      code: 'CORRUPT_INDEX',
+      category: 'indexing',
+    });
+  });
+
+  it.each(['missing', 'short'] as const)(
+    'falls back to dense post-filtering when the metadata sidecar is %s',
+    async (corruption) => {
+      await writeFixtureNote(workspace);
+      const manager = await buildDenseIndex();
+      const sidecarPath = path.join(modelDir(workspace), 'metadata-sidecar.jsonl');
+
+      if (corruption === 'missing') {
+        await fsp.rm(sidecarPath);
+      } else {
+        const header = (await fsp.readFile(sidecarPath, 'utf-8')).split('\n')[0];
+        await fsp.writeFile(sidecarPath, `${header}\n`, 'utf-8');
+      }
+
+      const timing: import('../../../src/FaissIndexManager.js').SimilaritySearchTiming = {};
+      const results = await manager.similaritySearch(
+        'queue recovery',
+        1,
+        2,
+        workspace.kbName,
+        { extensions: ['.md'] },
+        timing,
+      );
+
+      expect(results).toHaveLength(1);
+      expect(results[0].metadata.relativePath).toBe(`${workspace.kbName}/runbook.md`);
+      expect(timing.sidecar_fast_path).toBe('missing');
+    },
+  );
+});


### PR DESCRIPTION
## Summary

Add deterministic search-time chaos coverage for corrupt or truncated FAISS artifacts, torn lexical-index JSON, and missing or short metadata sidecars. The tests assert the existing classified degradation, per-KB partial failure, and dense post-filter fallback contracts without changing production code.

Fixes #834

## Testing

- [x] `npm test` passes (202 parallel suites / 2,649 tests; 11 serial suites / 440 tests)
- [ ] End-to-end verified for tool/transport changes (see `CLAUDE.md`) — N/A: this is test and documentation coverage only; no tool or transport changes.
- [ ] Benchmark run if performance-relevant: `BENCH_PROVIDER=stub npm run bench` — N/A: no performance-relevant implementation change.
- [x] <!-- kookr:check:tests --> Tests were added or updated for changed behavior; bug fixes include a regression test

## Documentation contract

- [ ] ~~<!-- kookr:check:readme --> `README.md` reflects user-visible CLI, MCP, installation, or configuration changes~~ — N/A: no user-visible CLI, MCP, installation, or configuration behavior changed.
- [x] <!-- kookr:check:docs --> Relevant operator, API, configuration, and retrieval documentation under `docs/` is consistent with the implementation
- [ ] ~~<!-- kookr:check:mbse --> RFCs are updated when this PR implements, supersedes, or changes an accepted design~~ — N/A: no accepted design or RFC is changed.

## Changelog

- [ ] ~~<!-- kookr:check:changelog --> `CHANGELOG.md` has an `Unreleased` entry for user-visible changes~~ — N/A: test and documentation coverage only; no user-visible behavior change.

## Retrieval and performance evidence

- [ ] ~~<!-- kookr:check:benchmarks --> Retrieval-quality or performance changes include the relevant benchmark/evaluation evidence, or this row is waived with a reason~~ — N/A: no retrieval algorithm or performance change.

## Follow-ups

- Full `npm run test:chaos` still has the pre-existing contextual-preface timeout assertion in `ingest-faults.test.ts` (expected 15 fetches, observed 24); the failure reproduces in isolation. The new search suite passes.

## Validation

- `npm run check:fast` — passed
- `npm run test:chaos -- --runTestsByPath tests/chaos/scenarios/search-faults.test.ts` — passed (4/4)
