### PR TITLE
feat(cli): suggest available knowledge bases for unknown --kb names

### DIFF
--- a/docs/requirements/INDEX.md
+++ b/docs/requirements/INDEX.md
@@ -209,6 +209,22 @@
 **Linked Tests:** TS-CLI-383
 **Dependencies:** RFC012
 
+### FR-CLI-832: Unknown Knowledge-Base Suggestions
+**Status:** Implemented
+**Priority:** High
+
+**Requirement:** The system shall explain an unknown knowledge-base name with a bounded list of available knowledge bases and, when sufficiently close, a nearest-name suggestion.
+**Rationale:** A mistyped `--kb` value currently forces users to run `kb list` separately and retry, unlike the CLI's existing command and flag typo guidance.
+
+**Acceptance Criteria:**
+- [x] Given an unknown `--kb` value, when `kb search` runs in dense mode, then stderr shall include the available knowledge-base list and a nearest-name suggestion when one passes the shared Levenshtein threshold.
+- [x] Given an unknown `--kb` value, when `kb search --mode=lexical` runs, then stderr shall include the same bounded list and suggestion behavior.
+- [x] Given many available knowledge bases, when an unknown name is reported, then the list shall remain bounded and ordered by closeness with deterministic tie-breaking.
+- [x] Given a valid knowledge-base name or a root that cannot be enumerated, then existing successful behavior and the original not-found diagnostic shall remain unchanged.
+
+**Linked Tests:** TS-CLI-832
+**Dependencies:** Existing `listKnowledgeBases` and Levenshtein typo-suggestion logic.
+
 ### FR-CLI-833: Safe Note Tag Mutation
 **Status:** Implemented
 **Priority:** Medium

--- a/docs/testing/INDEX.md
+++ b/docs/testing/INDEX.md
@@ -179,6 +179,14 @@ Keep this helper limited to temp directory scaffolding, file writes, path lookup
 - `tagNote` shall atomically apply a mutation and `kb tags` shall report the resulting tag set.
 - The CLI smoke matrix shall verify the built command's JSON dry-run output and argument-error path without an embedding backend.
 
+### TS-CLI-832: Unknown Knowledge-Base Suggestions
+**Requirement:** FR-CLI-832
+
+**Test Cases:**
+- `rankSuggestions` and `closestSuggestion` shall use the shared Levenshtein ranking with deterministic tie-breaking and support the documented typo example.
+- `resolveKnowledgeBaseDir` shall include a bounded, closeness-ordered available-KB list and nearest-name suggestion in `KB_NOT_FOUND` errors.
+- Lexical `kb search --kb=<unknown>` shall preserve its error prefix and include the same available-KB list and suggestion.
+
 ### TS-ASK-382: Cited Ask Transcript Records
 **Requirement:** FR-ASK-382
 

--- a/src/cli-search.test.ts
+++ b/src/cli-search.test.ts
@@ -1711,6 +1711,22 @@ describe('runSearch timing guard (#331)', () => {
     expect(out.stderr).toContain('Did you mean alpha?');
   });
 
+  it('preserves the lexical not-found prefix when the KB root cannot be enumerated', async () => {
+    const deps: RunSearchDeps = {
+      bootstrapLayout: jest.fn(async () => {}),
+      resolveActiveModel: jest.fn(async () => 'ollama__nomic-embed-text-latest'),
+      loadManagerForModel: jest.fn(async () => ({} as FaissIndexManager)),
+      loadWithJsonRetry: jest.fn(async () => {}),
+      listLexicalKbs: jest.fn(async () => []),
+      listKnowledgeBases: jest.fn(async () => { throw new Error('readdir failed'); }),
+    };
+
+    const out = await captureSearchOutput(['query', '--mode=lexical', '--kb=alpah'], deps);
+
+    expect(out.code).toBe(2);
+    expect(out.stderr).toBe('kb search (lexical): KB not found: alpah\n');
+  });
+
   it('reports the enriched KB_NOT_FOUND diagnostic for an unknown dense scope', async () => {
     const { deps, manager } = makeDeps();
     const message =
@@ -1726,6 +1742,32 @@ describe('runSearch timing guard (#331)', () => {
 
     expect(out.code).toBe(2);
     expect(out.stderr).toContain(message);
+    expect(manager.similaritySearch).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unknown KB in a batch JSONL row before retrieval', async () => {
+    const { deps, manager } = makeDeps();
+    const resolveKnowledgeBaseDir = jest.fn(async () => {
+      throw new KBError('KB_NOT_FOUND', 'unknown KB with suggestions');
+    });
+    deps.resolveKnowledgeBaseDir = resolveKnowledgeBaseDir;
+
+    const out = await captureSearchOutput(
+      ['--batch-jsonl'],
+      deps,
+      '{"query":"query","kb":"alpah"}\n',
+    );
+
+    expect(out.code).toBe(2);
+    expect(JSON.parse(out.stdout)).toMatchObject({
+      line: 1,
+      ok: false,
+      kb: 'alpah',
+      error: {
+        code: 'KB_NOT_FOUND',
+        message: 'unknown KB with suggestions',
+      },
+    });
     expect(manager.similaritySearch).not.toHaveBeenCalled();
   });
 

--- a/src/cli-search.test.ts
+++ b/src/cli-search.test.ts
@@ -21,6 +21,7 @@ import {
   type ScoredDocument as EngineScoredDocument,
 } from './search-filters.js';
 import { KNOWLEDGE_BASES_ROOT_DIR } from './config/paths.js';
+import { KBError } from './errors.js';
 import { compactTimingPayload, type TimingPayload } from './timing-core.js';
 import type { ScoredDocument } from './formatter.js';
 import type { FaissIndexManager, SimilaritySearchTiming } from './FaissIndexManager.js';
@@ -1690,6 +1691,42 @@ describe('runSearch timing guard (#331)', () => {
     expect(out.stdout).toContain('> _Lexical status: 1 KB(s), 0 error(s), unit=chunk._');
     expect(out.stdout).not.toContain('## Semantic Search Results');
     expect(lexicalIndex.query).toHaveBeenCalledWith('query', 10, { unit: 'chunk' });
+  });
+
+  it('reports available KBs and the nearest suggestion for an unknown lexical scope', async () => {
+    const deps: RunSearchDeps = {
+      bootstrapLayout: jest.fn(async () => {}),
+      resolveActiveModel: jest.fn(async () => 'ollama__nomic-embed-text-latest'),
+      loadManagerForModel: jest.fn(async () => ({} as FaissIndexManager)),
+      loadWithJsonRetry: jest.fn(async () => {}),
+      listLexicalKbs: jest.fn(async () => []),
+      listKnowledgeBases: jest.fn(async () => ['alpha', 'beta', 'delta', 'gamma', 'theta', 'epsilon']),
+    };
+
+    const out = await captureSearchOutput(['query', '--mode=lexical', '--kb=alpah'], deps);
+
+    expect(out.code).toBe(2);
+    expect(out.stderr).toContain('kb search (lexical): KB not found: alpah');
+    expect(out.stderr).toContain('Available knowledge bases: alpha, beta, delta, gamma, theta.');
+    expect(out.stderr).toContain('Did you mean alpha?');
+  });
+
+  it('reports the enriched KB_NOT_FOUND diagnostic for an unknown dense scope', async () => {
+    const { deps, manager } = makeDeps();
+    const message =
+      `Knowledge base "alpah" not found under ${KNOWLEDGE_BASES_ROOT_DIR}.\n` +
+      'Available knowledge bases: alpha, beta, zeta, delta, gamma.\n' +
+      'Did you mean alpha?';
+    const resolveKnowledgeBaseDir = jest.fn(async () => {
+      throw new KBError('KB_NOT_FOUND', message);
+    });
+    deps.resolveKnowledgeBaseDir = resolveKnowledgeBaseDir;
+
+    const out = await captureSearchOutput(['query', '--kb=alpah'], deps);
+
+    expect(out.code).toBe(2);
+    expect(out.stderr).toContain(message);
+    expect(manager.similaritySearch).not.toHaveBeenCalled();
   });
 
   it('wires --lexical-unit=source through lexical search JSON output', async () => {

--- a/src/cli-search.ts
+++ b/src/cli-search.ts
@@ -562,9 +562,9 @@ export async function runSearch(
       }
     : null;
   const effectiveParsed: SearchArgs = { ...parsed, mode: effectiveMode };
-  if (effectiveMode === 'dense' && parsed.kb !== undefined && deps.resolveKnowledgeBaseDir !== undefined) {
+  if (effectiveMode === 'dense') {
     try {
-      await deps.resolveKnowledgeBaseDir(KNOWLEDGE_BASES_ROOT_DIR, parsed.kb);
+      await validateDenseKnowledgeBase(parsed.kb, deps);
     } catch (err) {
       return reportFailure(classifyKbSearchError(err), parsed.format);
     }
@@ -2084,6 +2084,26 @@ async function runBatchJsonlSearch(
       exitCode = Math.max(exitCode, 2);
       continue;
     }
+    try {
+      await validateDenseKnowledgeBase(row.kb, deps);
+    } catch (err) {
+      const failure = classifyKbSearchError(err);
+      writeBatchEnvelope({
+        schema_version: BATCH_JSONL_SCHEMA_VERSION,
+        line: lineNumber,
+        ok: false,
+        query,
+        kb: row.kb ?? null,
+        error: {
+          code: failure.code,
+          category: failure.category,
+          message: failure.message,
+          next_action: failure.next_action,
+        },
+      });
+      exitCode = Math.max(exitCode, exitCodeForFailure(failure));
+      continue;
+    }
     const taskContextCheck = inspectBatchTaskContext(row);
     for (const warning of taskContextCheck.warnings) {
       process.stderr.write(`kb search: ${warning}\n`);
@@ -2233,6 +2253,14 @@ async function runBatchJsonlSearch(
   }
 
   return exitCode;
+}
+
+async function validateDenseKnowledgeBase(
+  knowledgeBaseName: string | undefined,
+  deps: RunSearchDeps,
+): Promise<void> {
+  if (knowledgeBaseName === undefined || deps.resolveKnowledgeBaseDir === undefined) return;
+  await deps.resolveKnowledgeBaseDir(KNOWLEDGE_BASES_ROOT_DIR, knowledgeBaseName);
 }
 
 async function resolveBatchActiveModel(

--- a/src/cli-search.ts
+++ b/src/cli-search.ts
@@ -40,9 +40,15 @@ import {
 } from './formatter.js';
 import { runPicker } from './cli-search-picker.js';
 import { parseColorMode, resolveColorEnabled, type ColorMode } from './color.js';
-import { listKnowledgeBases } from './kb-fs.js';
+import { listKnowledgeBases, resolveKnowledgeBaseDir } from './kb-fs.js';
 import { withWriteLock } from './write-lock.js';
-import { extractVerbosity, loadManagerForModel, loadWithJsonRetry, type Verbosity } from './cli-shared.js';
+import {
+  extractVerbosity,
+  formatKnowledgeBaseSuggestions,
+  loadManagerForModel,
+  loadWithJsonRetry,
+  type Verbosity,
+} from './cli-shared.js';
 import {
   compactTimingPayload,
   elapsedMs,
@@ -405,6 +411,8 @@ export interface RunSearchDeps {
   writeOutput?: typeof writeMaybePagedOutput;
   computeStaleness?: typeof computeStaleness;
   listLexicalKbs?: typeof listLexicalKbs;
+  listKnowledgeBases?: typeof listKnowledgeBases;
+  resolveKnowledgeBaseDir?: typeof resolveKnowledgeBaseDir;
   loadLexicalIndex?: typeof LexicalIndex.load;
   runLexicalLeg?: typeof runLexicalLeg;
   onSearchTiming?: (record: {
@@ -422,6 +430,8 @@ const DEFAULT_RUN_SEARCH_DEPS: RunSearchDeps = {
   loadWithJsonRetry,
   computeStaleness,
   listLexicalKbs,
+  listKnowledgeBases,
+  resolveKnowledgeBaseDir,
   runLexicalLeg,
 };
 
@@ -552,6 +562,13 @@ export async function runSearch(
       }
     : null;
   const effectiveParsed: SearchArgs = { ...parsed, mode: effectiveMode };
+  if (effectiveMode === 'dense' && parsed.kb !== undefined && deps.resolveKnowledgeBaseDir !== undefined) {
+    try {
+      await deps.resolveKnowledgeBaseDir(KNOWLEDGE_BASES_ROOT_DIR, parsed.kb);
+    } catch (err) {
+      return reportFailure(classifyKbSearchError(err), parsed.format);
+    }
+  }
   if (hasNeighborContext(parsed) && effectiveMode !== 'dense') {
     process.stderr.write('kb search: neighbor context expansion is only supported with --mode=dense\n');
     return 2;
@@ -2564,6 +2581,14 @@ async function runLexicalSearch(
   }
   if (parsed.kb && kbs.length === 0) {
     process.stderr.write(`kb search (lexical): KB not found: ${parsed.kb}\n`);
+    try {
+      const available = await (deps.listKnowledgeBases ?? listKnowledgeBases)(KNOWLEDGE_BASES_ROOT_DIR);
+      const suggestions = formatKnowledgeBaseSuggestions(parsed.kb, available);
+      if (suggestions) process.stderr.write(`${suggestions}\n`);
+    } catch {
+      // Keep the original lexical not-found diagnostic when the root cannot
+      // be enumerated.
+    }
     return 2;
   }
 

--- a/src/cli-shared.test.ts
+++ b/src/cli-shared.test.ts
@@ -56,6 +56,12 @@ describe('knowledge-base typo suggestions (FR-CLI-832)', () => {
       'Did you mean alpha?',
     );
   });
+
+  it('omits the nearest-match line for distant candidates', () => {
+    const output = formatKnowledgeBaseSuggestions('zzzzzzzz', ['alpha', 'beta']);
+    expect(output).toContain('Available knowledge bases:');
+    expect(output).not.toContain('Did you mean');
+  });
 });
 
 describe('extractVerbosity (issue #739)', () => {

--- a/src/cli-shared.test.ts
+++ b/src/cli-shared.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from '@jest/globals';
 import {
+  closestSuggestion,
   createVerbosityPrinter,
   extractVerbosity,
+  formatKnowledgeBaseSuggestions,
+  rankSuggestions,
   renderRecords,
 } from './cli-shared.js';
 
@@ -28,6 +31,29 @@ describe('renderRecords', () => {
       { name: 'beta', count: 2 },
     ], 'ndjson')).toBe(
       '{"name":"alpha","count":1}\n{"name":"beta","count":2}\n',
+    );
+  });
+});
+
+describe('knowledge-base typo suggestions (FR-CLI-832)', () => {
+  it('ranks candidates by Levenshtein distance with deterministic tie-breaking', () => {
+    expect(rankSuggestions('alpah', ['beta', 'alpha', 'alps', 'alpha'])).toEqual([
+      { value: 'alps', distance: 2 },
+      { value: 'alpha', distance: 2 },
+      { value: 'beta', distance: 4 },
+    ]);
+  });
+
+  it('returns the nearest suggestion for a transposed typo', () => {
+    expect(closestSuggestion('alpah', ['alpha', 'beta'])).toEqual({ value: 'alpha', distance: 2 });
+  });
+
+  it('formats a bounded list and nearest-match line', () => {
+    expect(formatKnowledgeBaseSuggestions('alpah', [
+      'zeta', 'alpha', 'beta', 'gamma', 'delta', 'epsilon', 'theta',
+    ])).toBe(
+      'Available knowledge bases: alpha, beta, zeta, delta, gamma.\n' +
+      'Did you mean alpha?',
     );
   });
 });

--- a/src/cli-shared.test.ts
+++ b/src/cli-shared.test.ts
@@ -7,6 +7,7 @@ import {
   rankSuggestions,
   renderRecords,
 } from './cli-shared.js';
+import { levenshteinDistance as coreLevenshteinDistance } from './suggestion-core.js';
 
 describe('renderRecords', () => {
   it('quotes CSV fields using RFC-4180 escaping', () => {
@@ -46,6 +47,7 @@ describe('knowledge-base typo suggestions (FR-CLI-832)', () => {
 
   it('returns the nearest suggestion for a transposed typo', () => {
     expect(closestSuggestion('alpah', ['alpha', 'beta'])).toEqual({ value: 'alpha', distance: 2 });
+    expect(coreLevenshteinDistance('alpah', 'alpha')).toBe(2);
   });
 
   it('formats a bounded list and nearest-match line', () => {

--- a/src/cli-shared.ts
+++ b/src/cli-shared.ts
@@ -3,6 +3,16 @@ import { parseModelId, readStoredIndexType, readStoredModelName } from './active
 import type { EmbeddingProvider } from './model-id.js';
 import { logger } from './logger.js';
 
+export {
+  closestSuggestion,
+  formatKnowledgeBaseSuggestions,
+  levenshteinDistance,
+  rankSuggestions,
+  suggestionDistanceThreshold,
+  MAX_KNOWLEDGE_BASE_SUGGESTIONS,
+  type ClosestSuggestion,
+} from './suggestion-core.js';
+
 /**
  * RFC 013: load a FaissIndexManager for the given model_id. Resolves the
  * (provider, modelName) pair from the model's `model_name.txt` so the

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -53,6 +53,7 @@ import { daemonUrlFromEnv, tryRunDaemonCommand } from './daemon-client.js';
 import { emitCanonicalLog } from './canonical-log.js';
 import { buildDaemonSearchArgs, resolveSearchPager } from './cli-pager.js';
 import { exitCodeDocs, formatExitCodesHelp } from './cli-exit-codes.js';
+import { closestSuggestion } from './cli-shared.js';
 
 // ----- Subcommand registry --------------------------------------------------
 
@@ -194,11 +195,6 @@ function wantsHelp(args: readonly string[]): boolean {
   return args.some((a) => a === '--help' || a === '-h');
 }
 
-interface ClosestSuggestion {
-  value: string;
-  distance: number;
-}
-
 interface UnknownFlagSuggestion {
   raw: string;
   suggestion: string;
@@ -338,47 +334,6 @@ function flagNameFromArg(raw: string): string | null {
 
 function formatUnknownFlagMessage(command: string, unknown: UnknownFlagSuggestion): string {
   return `kb ${command}: unknown flag: ${unknown.raw}\nDid you mean ${unknown.suggestion}?\n`;
-}
-
-function closestSuggestion(input: string, candidates: readonly string[]): ClosestSuggestion | undefined {
-  let best: ClosestSuggestion | undefined;
-  for (const candidate of candidates) {
-    const distance = levenshteinDistance(input, candidate);
-    if (
-      best === undefined
-      || distance < best.distance
-      || (distance === best.distance && candidate.length < best.value.length)
-      || (distance === best.distance && candidate.length === best.value.length && candidate < best.value)
-    ) {
-      best = { value: candidate, distance };
-    }
-  }
-  if (best === undefined || best.distance > suggestionDistanceThreshold(input)) return undefined;
-  return best;
-}
-
-function suggestionDistanceThreshold(input: string): number {
-  return Math.max(1, Math.floor(input.length / 3));
-}
-
-function levenshteinDistance(a: string, b: string): number {
-  const rows = a.length + 1;
-  const cols = b.length + 1;
-  const dp = Array.from({ length: rows }, () => new Array<number>(cols).fill(0));
-  for (let i = 0; i < rows; i++) dp[i][0] = i;
-  for (let j = 0; j < cols; j++) dp[0][j] = j;
-
-  for (let i = 1; i < rows; i++) {
-    for (let j = 1; j < cols; j++) {
-      const substitutionCost = a[i - 1] === b[j - 1] ? 0 : 1;
-      dp[i][j] = Math.min(
-        dp[i - 1][j] + 1,
-        dp[i][j - 1] + 1,
-        dp[i - 1][j - 1] + substitutionCost,
-      );
-    }
-  }
-  return dp[a.length][b.length];
 }
 
 function parseHelpArgs(rest: readonly string[]): HelpArgs {

--- a/src/kb-fs.test.ts
+++ b/src/kb-fs.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, it } from '@jest/globals';
 import * as fsp from 'fs/promises';
 import * as os from 'os';
 import * as path from 'path';
-import { describeKnowledgeBase, extractKbDescription, listKnowledgeBases } from './kb-fs.js';
+import {
+  describeKnowledgeBase,
+  extractKbDescription,
+  listKnowledgeBases,
+  resolveKnowledgeBaseDir,
+} from './kb-fs.js';
 
 describe('listKnowledgeBases', () => {
   it('returns names of subdirectories, filtering dot-prefixed entries', async () => {
@@ -35,6 +40,31 @@ describe('listKnowledgeBases', () => {
     await expect(
       listKnowledgeBases('/nonexistent/path/that/should/not/exist'),
     ).rejects.toThrow();
+  });
+});
+
+describe('resolveKnowledgeBaseDir unknown-name diagnostics (FR-CLI-832)', () => {
+  it('includes the closest available KB and a bounded list in KB_NOT_FOUND', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-fs-suggest-'));
+    try {
+      for (const name of ['alpha', 'beta', 'delta', 'gamma', 'theta', 'epsilon', 'zeta']) {
+        await fsp.mkdir(path.join(tempDir, name));
+      }
+
+      try {
+        await resolveKnowledgeBaseDir(tempDir, 'alpah');
+        throw new Error('expected resolveKnowledgeBaseDir to reject');
+      } catch (err) {
+        expect(err).toMatchObject({ code: 'KB_NOT_FOUND' });
+        expect((err as Error).message).toBe(
+          `Knowledge base "alpah" not found under ${tempDir}.\n` +
+          'Available knowledge bases: alpha, beta, zeta, delta, gamma.\n' +
+          'Did you mean alpha?',
+        );
+      }
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/src/kb-fs.test.ts
+++ b/src/kb-fs.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from '@jest/globals';
 import * as fsp from 'fs/promises';
 import * as os from 'os';
 import * as path from 'path';
+import { KBError } from './errors.js';
 import {
   describeKnowledgeBase,
   extractKbDescription,
@@ -51,19 +52,28 @@ describe('resolveKnowledgeBaseDir unknown-name diagnostics (FR-CLI-832)', () => 
         await fsp.mkdir(path.join(tempDir, name));
       }
 
-      try {
-        await resolveKnowledgeBaseDir(tempDir, 'alpah');
-        throw new Error('expected resolveKnowledgeBaseDir to reject');
-      } catch (err) {
-        expect(err).toMatchObject({ code: 'KB_NOT_FOUND' });
-        expect((err as Error).message).toBe(
-          `Knowledge base "alpah" not found under ${tempDir}.\n` +
-          'Available knowledge bases: alpha, beta, zeta, delta, gamma.\n' +
-          'Did you mean alpha?',
-        );
-      }
+      const pending = resolveKnowledgeBaseDir(tempDir, 'alpah');
+      await expect(pending).rejects.toBeInstanceOf(KBError);
+      await expect(pending).rejects.toThrow(
+        `Knowledge base "alpah" not found under ${tempDir}.\n` +
+        'Available knowledge bases: alpha, beta, zeta, delta, gamma.\n' +
+        'Did you mean alpha?',
+      );
     } finally {
       await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves the original diagnostic when available KBs cannot be enumerated', async () => {
+    const rootDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-fs-file-root-'));
+    const rootFile = path.join(rootDir, 'root');
+    try {
+      await fsp.writeFile(rootFile, 'not a directory');
+      await expect(resolveKnowledgeBaseDir(rootFile, 'missing')).rejects.toThrow(
+        `Knowledge base "missing" not found under ${rootFile}.`,
+      );
+    } finally {
+      await fsp.rm(rootDir, { recursive: true, force: true });
     }
   });
 });

--- a/src/kb-fs.ts
+++ b/src/kb-fs.ts
@@ -13,6 +13,7 @@ import {
   type FilesystemEnumerationDiagnostics,
 } from './file-utils.js';
 import { filterIngestablePaths } from './ingest-filter.js';
+import { formatKnowledgeBaseSuggestions } from './suggestion-core.js';
 
 /**
  * Issue #160 step 3 — single home for "is this rel path safe to join
@@ -523,10 +524,7 @@ export async function resolveKnowledgeBaseDir(
     path.isAbsolute(knowledgeBaseName) ||
     hasPathSeparator(knowledgeBaseName)
   ) {
-    throw new KBError(
-      'KB_NOT_FOUND',
-      `Knowledge base "${knowledgeBaseName}" not found under ${rootDir}.`,
-    );
+    throw await knowledgeBaseNotFound(rootDir, knowledgeBaseName);
   }
 
   const rootReal = await realpathIfExists(rootDir);
@@ -541,18 +539,12 @@ export async function resolveKnowledgeBaseDir(
   } catch (error: unknown) {
     const code = (error as NodeJS.ErrnoException | undefined)?.code;
     if (code === 'ENOENT' || code === 'ENOTDIR') {
-      throw new KBError(
-        'KB_NOT_FOUND',
-        `Knowledge base "${knowledgeBaseName}" not found under ${rootDir}.`,
-      );
+      throw await knowledgeBaseNotFound(rootDir, knowledgeBaseName);
     }
     throw error;
   }
   if (!stat.isDirectory()) {
-    throw new KBError(
-      'KB_NOT_FOUND',
-      `Knowledge base "${knowledgeBaseName}" not found under ${rootDir}.`,
-    );
+    throw await knowledgeBaseNotFound(rootDir, knowledgeBaseName);
   }
 
   const kbReal = await fsp.realpath(kbDir);
@@ -563,4 +555,17 @@ export async function resolveKnowledgeBaseDir(
     );
   }
   return kbDir;
+}
+
+async function knowledgeBaseNotFound(rootDir: string, knowledgeBaseName: string): Promise<KBError> {
+  let available: string[] = [];
+  try {
+    available = await listKnowledgeBases(rootDir);
+  } catch {
+    // Preserve the original not-found diagnostic when the root cannot be
+    // enumerated (for example, a transient permission error).
+  }
+  const suggestions = formatKnowledgeBaseSuggestions(knowledgeBaseName, available);
+  const base = `Knowledge base "${knowledgeBaseName}" not found under ${rootDir}.`;
+  return new KBError('KB_NOT_FOUND', suggestions ? `${base}\n${suggestions}` : base);
 }

--- a/src/suggestion-core.ts
+++ b/src/suggestion-core.ts
@@ -1,0 +1,82 @@
+/** Shared typo-suggestion helpers used by the CLI and KB error diagnostics. */
+
+export interface ClosestSuggestion {
+  value: string;
+  distance: number;
+}
+
+export const MAX_KNOWLEDGE_BASE_SUGGESTIONS = 5;
+
+/**
+ * Rank candidate names with the same deterministic ordering used by CLI
+ * command and flag suggestions: distance first, then shorter names, then
+ * lexicographic order. Duplicate names are removed so filesystem oddities do
+ * not duplicate entries in an error message.
+ */
+export function rankSuggestions(
+  input: string,
+  candidates: readonly string[],
+): ClosestSuggestion[] {
+  return [...new Set(candidates)]
+    .map((value) => ({ value, distance: levenshteinDistance(input, value) }))
+    .sort((a, b) => (
+      a.distance - b.distance
+      || a.value.length - b.value.length
+      || (a.value < b.value ? -1 : a.value > b.value ? 1 : 0)
+    ));
+}
+
+export function closestSuggestion(
+  input: string,
+  candidates: readonly string[],
+): ClosestSuggestion | undefined {
+  const best = rankSuggestions(input, candidates)[0];
+  if (best === undefined || best.distance > suggestionDistanceThreshold(input)) return undefined;
+  return best;
+}
+
+/**
+ * Keep short transposition typos such as "alpah" → "alpha" actionable while
+ * retaining a bounded threshold for unrelated names.
+ */
+export function suggestionDistanceThreshold(input: string): number {
+  return Math.max(1, Math.ceil(input.length / 3));
+}
+
+export function levenshteinDistance(a: string, b: string): number {
+  const rows = a.length + 1;
+  const cols = b.length + 1;
+  const dp = Array.from({ length: rows }, () => new Array<number>(cols).fill(0));
+  for (let i = 0; i < rows; i++) dp[i][0] = i;
+  for (let j = 0; j < cols; j++) dp[0][j] = j;
+
+  for (let i = 1; i < rows; i++) {
+    for (let j = 1; j < cols; j++) {
+      const substitutionCost = a[i - 1] === b[j - 1] ? 0 : 1;
+      dp[i][j] = Math.min(
+        dp[i - 1][j] + 1,
+        dp[i][j - 1] + 1,
+        dp[i - 1][j - 1] + substitutionCost,
+      );
+    }
+  }
+  return dp[a.length][b.length];
+}
+
+export function formatKnowledgeBaseSuggestions(
+  input: string,
+  candidates: readonly string[],
+): string {
+  const ranked = rankSuggestions(input, candidates);
+  if (ranked.length === 0) return '';
+
+  const available = ranked
+    .slice(0, MAX_KNOWLEDGE_BASE_SUGGESTIONS)
+    .map(({ value }) => value)
+    .join(', ');
+  const suggestion = closestSuggestion(input, candidates);
+  return [
+    `Available knowledge bases: ${available}.`,
+    suggestion === undefined ? null : `Did you mean ${suggestion.value}?`,
+  ].filter((line): line is string => line !== null).join('\n');
+}


### PR DESCRIPTION
## Summary

Unknown `--kb` names now produce actionable diagnostics: a bounded list of nearby available knowledge bases and a nearest-name suggestion when the typo is close enough. The behavior is shared by dense search, lexical search, direct KB resolution errors, and batch JSONL rows.

Closes #832

## Testing

- [x] `npm test` passes (203 parallel suites: 2,675 passed, 4 skipped; 11 serial suites: 440 passed, 2 skipped; 3 snapshots)
- ~~[ ] End-to-end verified for tool/transport changes~~ (not applicable: this changes local CLI diagnostics only)
- ~~[ ] Benchmark run if performance-relevant: `BENCH_PROVIDER=stub npm run bench`~~ (waived: error-path formatting and directory enumeration do not change retrieval quality or hot-path performance)
- [x] <!-- kookr:check:tests --> Tests were added or updated for changed behavior, including dense, lexical, batch JSONL, bounded ordering, enumeration failure, and distant-typo fallback paths.

## Documentation contract

- [ ] ~~<!-- kookr:check:readme --> `README.md` reflects user-visible CLI, MCP, installation, or configuration changes~~ — not applicable: README does not document `KB_NOT_FOUND` error wording
- [x] <!-- kookr:check:docs --> `docs/requirements/INDEX.md` records FR-CLI-832 as implemented, and `docs/testing/INDEX.md` records TS-CLI-832 coverage.
- [x] <!-- kookr:check:mbse --> ~~RFCs are updated~~ (waived: this is a scoped CLI UX improvement and does not change an accepted architecture decision)

## Changelog

- [x] <!-- kookr:check:changelog --> ~~`CHANGELOG.md` has an `Unreleased` entry~~ (not applicable: this repository has no `CHANGELOG.md`)

## Retrieval and performance evidence

- [x] <!-- kookr:check:benchmarks --> ~~Retrieval-quality or performance changes include benchmark/evaluation evidence~~ (waived: the change runs only on unknown-KB error paths and adds no retrieval behavior)

## Verification

- Before: dense search with an unknown `--kb` could silently return an empty result; lexical search emitted only `KB not found: <name>`.
- After: dense and lexical search emit the available-KB list and nearest suggestion; batch JSONL rows return a structured `KB_NOT_FOUND` error before retrieval.
- `npm run build`
- `npm run lint`
- `npm run check:fast`
- `git diff --check`

## Pre-PR reviewer panel

```
SPECIALISTS=correctness,lint-like,test
DOCS_DRIFT=active
FORCE=no
COUNT=3
rationale:
  correctness: always — unconditional, independent cross-check
  lint-like: source changed; conventions + deadcode + docs-drift concerns active (docs/public API touched)
  test: non-test logic changed
```

Reviewer results: the correctness reviewer identified a batch JSONL validation gap, which was fixed in `95ec90e` with regression coverage. The test reviewer’s additional enumeration and distant-typo cases were also added. The lint-like reviewer found no dead code or documentation drift; its style suggestions were non-blocking.

## Follow-ups

None.
