### PR TITLE
fix(cache): preserve entries on transient read failures (#830)

### DIFF
--- a/docs/architecture/adr/0009-query-embedding-cache.md
+++ b/docs/architecture/adr/0009-query-embedding-cache.md
@@ -28,8 +28,10 @@ Tier 1 is an in-process LRU with `KB_QUERY_CACHE_LRU_MAX` defaulting to 256.
 Tier 2 stores vectors under
 `$FAISS_INDEX_PATH/cache/queries/<model_id>/<sha>.f32` with a
 `<sha>.meta.json` sidecar. Writes use a model-cache-directory lock plus
-tmp-and-rename so readers do not consume partial files. Corrupt or incomplete
-entries are unlinked and treated as misses.
+tmp-and-rename so readers do not consume partial files. Read I/O failures are
+treated as misses without deleting entries; entries that are successfully read
+but fail parsing, schema, checksum, or value validation are unlinked and
+treated as misses.
 
 Operators can bypass the cache with `KB_QUERY_CACHE=off`, `kb search
 --no-cache`, and `kb compare --no-cache`.

--- a/docs/architecture/data-model.md
+++ b/docs/architecture/data-model.md
@@ -137,9 +137,11 @@ The pre-RFC-014 layout is `models/<model_id>/faiss.index/{faiss.index,docstore.j
 `$FAISS_INDEX_PATH/cache/queries/<model_id>/` stores optional query-vector cache
 entries. Each query key is a SHA-256 over schema version, `model_id`, and the
 normalized query. The vector is stored as `<sha>.f32`; metadata is stored as
-`<sha>.meta.json`. The cache is a latency/cost optimization only: corrupt or
-incomplete entries are removed and treated as misses. Operators can disable it
-with `KB_QUERY_CACHE=off` or per-call CLI flags where supported.
+`<sha>.meta.json`. The cache is a latency/cost optimization only: read I/O
+failures are treated as misses without deleting entries, while entries that
+fail parsing, schema, checksum, or value validation are removed and treated as
+misses. Operators can disable it with `KB_QUERY_CACHE=off` or per-call CLI
+flags where supported.
 
 ### Query decomposition cache
 

--- a/docs/operations/query-cache.md
+++ b/docs/operations/query-cache.md
@@ -208,11 +208,14 @@ Values such as `off`, `false`, `0`, and `disabled` turn the cache off.
 **Corruption counters increase.**
 
 `kb stats --format=json` reports query-cache corruption count. A corrupt entry
-is deleted and treated as a miss, so the next successful request should rewrite
-it. Repeated corruption usually means a filesystem or permission problem under
-`$FAISS_INDEX_PATH/cache/queries`; capture `kb stats --format=json`,
-`kb doctor --format=json`, and the relevant canonical log line before filing a
-bug.
+that fails parsing or validation is deleted and treated as a miss, so the next
+successful request should rewrite it. A transient read I/O failure such as
+`EACCES` or `EIO` is instead a miss that is not counted as corruption: the
+entry is retained for a later retry. Repeated corruption usually means a
+filesystem or permission problem under `$FAISS_INDEX_PATH/cache/queries`;
+capture `kb stats
+--format=json`, `kb doctor --format=json`, and the relevant canonical log line
+before filing a bug.
 
 **Disk budget does not shrink immediately.**
 

--- a/docs/requirements/INDEX.md
+++ b/docs/requirements/INDEX.md
@@ -209,6 +209,22 @@
 **Linked Tests:** TS-SEARCH-374
 **Dependencies:** RFC019
 
+### NFR-CACHE-830: Conservative Disk Cache Read Failures
+**Status:** Implemented
+**Priority:** Medium
+
+**Requirement:** The disk-backed rerank-score, query-embedding, and answer caches shall treat read I/O failures as cache misses without evicting entries, while evicting entries that fail parsing, schema, checksum, or value validation.
+**Rationale:** Transient filesystem failures should not turn valid, expensive-to-recompute cache records into permanent misses.
+
+**Acceptance Criteria:**
+- [x] Given a cached entry and a transient read failure such as `EACCES` or `EIO`, when the cache is read, then it shall return a miss without evicting the entry or recording corruption.
+- [x] Given malformed JSON or a failed schema, checksum, or value validation, when the cache is read, then it shall record corruption and evict the entry.
+- [x] Given a missing entry, when the cache is read, then it shall return a miss without recording corruption.
+- [x] Given the existing cache test suites, when they run, then valid disk hits, eviction, and corruption handling shall remain green.
+
+**Linked Tests:** TS-CACHE-830
+**Dependencies:** Existing rerank-score, query-embedding, and answer cache storage paths.
+
 ### FR-CLI-383: Machine-Readable Help Manifest
 **Status:** Implemented
 **Priority:** Medium

--- a/src/ask-answer-cache.test.ts
+++ b/src/ask-answer-cache.test.ts
@@ -75,6 +75,10 @@ describe('answer cache key (#656)', () => {
 
 describe('AnswerCache storage (#656)', () => {
   let dir: string;
+  const itPosixNonRoot =
+    process.platform === 'win32' || (typeof process.getuid === 'function' && process.getuid() === 0)
+      ? it.skip
+      : it;
 
   beforeEach(async () => {
     dir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-answer-cache-'));
@@ -88,6 +92,7 @@ describe('AnswerCache storage (#656)', () => {
     const cache = new AnswerCache({ enabled: true, indexPath: dir });
     const key = computeAnswerCacheKey(baseKeyInput());
     expect(await cache.get(key)).toBeNull();
+    expect((await cache.stats()).corruptions).toBe(0);
     await cache.set(key, { answer: 'cached answer', model: 'qwen3' });
     expect(await cache.get(key)).toEqual({ answer: 'cached answer', model: 'qwen3' });
     const stats = await cache.stats();
@@ -124,6 +129,24 @@ describe('AnswerCache storage (#656)', () => {
     expect(await cache.get(key)).toBeNull();
     await expect(fsp.access(file)).rejects.toBeDefined();
     expect((await cache.stats()).corruptions).toBe(1);
+  });
+
+  itPosixNonRoot('TS-CACHE-830: treats transient disk read errors as misses without evicting the entry', async () => {
+    const cache = new AnswerCache({ enabled: true, indexPath: dir });
+    const key = computeAnswerCacheKey(baseKeyInput());
+    await cache.set(key, { answer: 'cached answer', model: 'qwen3' });
+    const file = path.join(answerCacheDir(dir), `${key}.json`);
+    const original = await fsp.readFile(file);
+    await fsp.chmod(file, 0o000);
+    try {
+      expect(await cache.get(key)).toBeNull();
+      expect((await cache.stats()).corruptions).toBe(0);
+    } finally {
+      if (await fsp.access(file).then(() => true).catch(() => false)) {
+        await fsp.chmod(file, 0o600);
+      }
+    }
+    expect(await fsp.readFile(file)).toEqual(original);
   });
 
   it('evicts oldest entries when over the disk cap', async () => {

--- a/src/ask-answer-cache.ts
+++ b/src/ask-answer-cache.ts
@@ -149,10 +149,8 @@ export class AnswerCache {
     let raw: string;
     try {
       raw = await fsp.readFile(file, 'utf-8');
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
-        await this.recordCorrupt(file);
-      }
+    } catch {
+      // A read failure may be transient; keep the entry for a later attempt.
       this.misses += 1;
       return null;
     }

--- a/src/query-cache.test.ts
+++ b/src/query-cache.test.ts
@@ -26,6 +26,11 @@ function sha256(buffer: Buffer): string {
 }
 
 describe('query embedding cache (#214)', () => {
+  const itPosixNonRoot =
+    process.platform === 'win32' || (typeof process.getuid === 'function' && process.getuid() === 0)
+      ? it.skip
+      : it;
+
   it('coalesces concurrent identical misses when single-flight is enabled', async () => {
     const indexPath = await tempIndexPath('kb-query-cache-single-flight-');
     try {
@@ -165,6 +170,7 @@ describe('query embedding cache (#214)', () => {
         },
       });
       expect(miss.status).toBe('miss');
+      expect((await first.stats()).corruptions).toBe(0);
       expect(miss.telemetry).toMatchObject({
         enabled: true,
         outcome: 'miss',
@@ -281,6 +287,82 @@ describe('query embedding cache (#214)', () => {
       const stats = await cache.stats();
       expect(stats.corruptions).toBe(1);
       expect(await fsp.readFile(paths.vectorPath)).toHaveLength(4);
+    } finally {
+      await fsp.rm(path.dirname(indexPath), { recursive: true, force: true });
+    }
+  });
+
+  itPosixNonRoot('TS-CACHE-830: treats transient metadata read errors as misses without evicting the entry', async () => {
+    const indexPath = await tempIndexPath('kb-query-cache-transient-read-');
+    try {
+      const cache = new QueryEmbeddingCache({ indexPath, lruMax: 8 });
+      await cache.getOrCompute({
+        modelId: 'fake__one',
+        query: 'transient',
+        embed: async () => [1, 2],
+      });
+      const paths = queryCachePaths({ indexPath, modelId: 'fake__one', query: 'transient' });
+      const originalMeta = await fsp.readFile(paths.metaPath);
+      const originalVector = await fsp.readFile(paths.vectorPath);
+      cache.clearMemory();
+      await fsp.chmod(paths.metaPath, 0o000);
+      try {
+        let embedCalls = 0;
+        await expect(cache.getOrCompute({
+          modelId: 'fake__one',
+          query: 'transient',
+          embed: async () => {
+            embedCalls += 1;
+            throw new Error('embedding unavailable');
+          },
+        })).rejects.toThrow('embedding unavailable');
+        expect(embedCalls).toBe(1);
+        expect((await cache.stats()).corruptions).toBe(0);
+      } finally {
+        if (await fsp.access(paths.metaPath).then(() => true).catch(() => false)) {
+          await fsp.chmod(paths.metaPath, 0o600);
+        }
+      }
+      expect(await fsp.readFile(paths.metaPath)).toEqual(originalMeta);
+      expect(await fsp.readFile(paths.vectorPath)).toEqual(originalVector);
+    } finally {
+      await fsp.rm(path.dirname(indexPath), { recursive: true, force: true });
+    }
+  });
+
+  itPosixNonRoot('TS-CACHE-830: treats transient vector read errors as misses without evicting the entry', async () => {
+    const indexPath = await tempIndexPath('kb-query-cache-transient-vector-read-');
+    try {
+      const cache = new QueryEmbeddingCache({ indexPath, lruMax: 8 });
+      await cache.getOrCompute({
+        modelId: 'fake__one',
+        query: 'transient vector',
+        embed: async () => [1, 2],
+      });
+      const paths = queryCachePaths({ indexPath, modelId: 'fake__one', query: 'transient vector' });
+      const originalMeta = await fsp.readFile(paths.metaPath);
+      const originalVector = await fsp.readFile(paths.vectorPath);
+      cache.clearMemory();
+      await fsp.chmod(paths.vectorPath, 0o000);
+      try {
+        let embedCalls = 0;
+        await expect(cache.getOrCompute({
+          modelId: 'fake__one',
+          query: 'transient vector',
+          embed: async () => {
+            embedCalls += 1;
+            throw new Error('embedding unavailable');
+          },
+        })).rejects.toThrow('embedding unavailable');
+        expect(embedCalls).toBe(1);
+        expect((await cache.stats()).corruptions).toBe(0);
+      } finally {
+        if (await fsp.access(paths.vectorPath).then(() => true).catch(() => false)) {
+          await fsp.chmod(paths.vectorPath, 0o600);
+        }
+      }
+      expect(await fsp.readFile(paths.metaPath)).toEqual(originalMeta);
+      expect(await fsp.readFile(paths.vectorPath)).toEqual(originalVector);
     } finally {
       await fsp.rm(path.dirname(indexPath), { recursive: true, force: true });
     }

--- a/src/query-cache.ts
+++ b/src/query-cache.ts
@@ -217,11 +217,16 @@ export class QueryEmbeddingCache {
 
   private async readDisk(paths: QueryCachePaths): Promise<number[] | null> {
     let meta: CacheMeta;
+    let raw: string;
     try {
-      const raw = await fsp.readFile(paths.metaPath, 'utf-8');
+      raw = await fsp.readFile(paths.metaPath, 'utf-8');
+    } catch {
+      // A read failure may be transient; keep the entry for a later attempt.
+      return null;
+    }
+    try {
       meta = JSON.parse(raw) as CacheMeta;
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null;
+    } catch {
       await this.recordCorrupt(paths);
       return null;
     }
@@ -238,9 +243,8 @@ export class QueryEmbeddingCache {
     let buffer: Buffer;
     try {
       buffer = await fsp.readFile(paths.vectorPath);
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null;
-      await this.recordCorrupt(paths);
+    } catch {
+      // A read failure may be transient; keep the entry for a later attempt.
       return null;
     }
     if (buffer.byteLength !== meta.dim * 4) {

--- a/src/rerank-cache-disk.test.ts
+++ b/src/rerank-cache-disk.test.ts
@@ -19,11 +19,17 @@ async function tempIndexPath(prefix: string): Promise<string> {
 const MODEL = 'Xenova/ms-marco-MiniLM-L-6-v2';
 
 describe('DiskTieredRerankScoreCache (#646)', () => {
+  const itPosixNonRoot =
+    process.platform === 'win32' || (typeof process.getuid === 'function' && process.getuid() === 0)
+      ? it.skip
+      : it;
+
   it('persists scores across cache instances via the disk tier', async () => {
     const indexPath = await tempIndexPath('kb-rerank-cache-roundtrip-');
     try {
       const first = new DiskTieredRerankScoreCache({ indexPath, enabled: true });
       expect(first.get(MODEL, 'how do rollbacks work', 'candidate body')).toBeNull();
+      expect(first.stats().corruptions).toBe(0);
       first.set(MODEL, 'how do rollbacks work', 'candidate body', 0.875);
 
       // A fresh instance has a cold L1 but must recover the score from disk.
@@ -114,6 +120,27 @@ describe('DiskTieredRerankScoreCache (#646)', () => {
       expect(cache.get(MODEL, 'broken', 'body')).toBeNull();
       expect(cache.stats().corruptions).toBe(1);
       expect(fs.existsSync(file)).toBe(false);
+    } finally {
+      await fsp.rm(path.dirname(indexPath), { recursive: true, force: true });
+    }
+  });
+
+  itPosixNonRoot('TS-CACHE-830: treats transient disk read errors as misses without evicting the entry', async () => {
+    const indexPath = await tempIndexPath('kb-rerank-cache-transient-read-');
+    try {
+      const cache = new DiskTieredRerankScoreCache({ indexPath, enabled: true, l1Max: 0 });
+      cache.set(MODEL, 'transient', 'body', 0.5);
+      const key = rerankScoreCacheKey(MODEL, 'transient', 'body');
+      const file = path.join(rerankScoreCacheRoot(indexPath), key.slice(0, 2), `${key}.json`);
+      const original = fs.readFileSync(file);
+      fs.chmodSync(file, 0o000);
+      try {
+        expect(cache.get(MODEL, 'transient', 'body')).toBeNull();
+        expect(cache.stats().corruptions).toBe(0);
+      } finally {
+        if (fs.existsSync(file)) fs.chmodSync(file, 0o600);
+      }
+      expect(fs.readFileSync(file)).toEqual(original);
     } finally {
       await fsp.rm(path.dirname(indexPath), { recursive: true, force: true });
     }

--- a/src/rerank-cache-disk.ts
+++ b/src/rerank-cache-disk.ts
@@ -176,9 +176,8 @@ export class DiskTieredRerankScoreCache implements RerankScoreCache {
     let raw: string;
     try {
       raw = fs.readFileSync(file, 'utf-8');
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null;
-      this.recordCorrupt(file);
+    } catch {
+      // A read failure may be transient; keep the entry for a later attempt.
       return null;
     }
     let record: RerankScoreRecord;


### PR DESCRIPTION
## Summary

Preserve disk-cache entries when a read fails at the filesystem I/O layer. Rerank-score, query-embedding, and ask-answer caches now treat those failures as misses, while still evicting entries that fail parsing, schema, checksum, or value validation.

Fixes #830

## Testing

- [x] `npm test` passes — parallel: 203 suites, 2,686 passed, 4 skipped, 3 snapshots; serial: 11 suites, 441 passed, 2 skipped
- ~~[ ] End-to-end verified for tool/transport changes~~ (not applicable: this changes cache read behavior and docs, without changing tool or transport protocols)
- ~~[ ] Benchmark run if performance-relevant: `BENCH_PROVIDER=stub npm run bench`~~ (waived: this is a cache-correctness fix and does not change retrieval quality or ranking)
- [x] <!-- kookr:check:tests --> Tests were added or updated for changed behavior; bug fixes include regression coverage for transient metadata/vector/file reads and ENOENT counters

## Documentation contract

- [ ] ~~<!-- kookr:check:readme --> `README.md` reflects user-visible CLI, MCP, installation, or configuration changes~~ (not applicable: no user-facing command, protocol, installation, or configuration contract changed)
- [x] <!-- kookr:check:docs --> Relevant operator, API, configuration, and retrieval documentation under `docs/` is consistent with the implementation
- [ ] ~~<!-- kookr:check:mbse --> RFCs are updated when this PR implements, supersedes, or changes an accepted design~~ (not applicable: this preserves the existing cache architecture and changes only failure classification)

## Changelog

- [ ] ~~<!-- kookr:check:changelog --> `CHANGELOG.md` has an `Unreleased` entry for user-visible changes~~ (not applicable: this repository has no `CHANGELOG.md`)

## Retrieval and performance evidence

- [ ] ~~<!-- kookr:check:benchmarks --> Retrieval-quality or performance changes include the relevant benchmark/evaluation evidence, or this row is waived with a reason~~ (waived: no retrieval-quality or ranking behavior changed)

## Root cause

All three disk-backed caches previously treated every non-ENOENT read error as corruption and immediately unlinked the entry. A transient `EACCES`, `EIO`, `EBUSY`, or similar filesystem failure could therefore destroy a valid, expensive-to-recompute record.

## Verification

The same permission-denied reproduction produced:

- Base `origin/main`: `{"miss":true,"corruptions":1,"entry_exists":false}`
- This branch: `{"miss":true,"corruptions":0,"entry_exists":true}`

Additional checks:

- [x] Focused cache suites — 43 passed
- [x] `npm run check:fast`
- [x] `npm run lint`
- [x] `git diff --check`

## Documentation and requirements

- [x] Added `NFR-CACHE-830` and `TS-CACHE-830` traceability
- [x] Updated query-cache ADR, data model, and operations runbook to distinguish I/O misses from validation corruption

## Pre-PR reviewer panel

```
SPECIALISTS=correctness,lint-like,test
DOCS_DRIFT=active
FORCE=no
COUNT=3
```

Final reviewer results: correctness found no findings; consolidated conventions/dead-code found no findings; test review confirmed direct public-API coverage of metadata and vector read failures.

## Follow-ups

None.