### PR TITLE
fix(cache): amortize disk cache size enforcement

### DIFF
--- a/docs/operations/query-cache.md
+++ b/docs/operations/query-cache.md
@@ -95,9 +95,12 @@ case. Because the query text is not written to disk, operators should use
 ## Disk-Budget Tuning
 
 `KB_QUERY_CACHE_DISK_MAX_MB` caps query-vector files per index path. The default
-is `64`. Budget enforcement happens after a successful cache write:
+is `64`. Budget enforcement happens after a successful cache write. The cache
+keeps a running total of vector bytes, initialized from one directory
+reconciliation and updated by write and eviction deltas. It periodically
+reconciles again, or reconciles immediately if accounting becomes unknown:
 
-1. The process lists `.f32` vector files under `cache/queries`.
+1. The process uses the running total unless a reconciliation is due.
 2. If total vector bytes exceed the budget, it deletes the oldest vector files
    by mtime.
 3. It also deletes the matching `.meta.json` sidecar for each pruned vector.

--- a/docs/operations/query-cache.md
+++ b/docs/operations/query-cache.md
@@ -21,7 +21,7 @@ Implementation anchors: `src/query-cache.ts::QueryEmbeddingCache`,
 | Task | Command or setting | Notes |
 | --- | --- | --- |
 | See per-request cache state | `kb search "query" --format=json --timing` | Inspect `query_cache` and `timing.query_cache*`. |
-| See runtime counters | `kb stats --format=json` | Inspect `.query_cache` for this process' hits, misses, bypasses, and corruptions; disk bytes are read from the cache directory. |
+| See runtime counters | `kb stats --format=json` | Inspect `.query_cache` for this process' hits, misses, bypasses, and corruptions; disk bytes use a running total initialized and periodically reconciled from the cache directory. |
 | Trace a request later | `KB_LOG_FORMAT=both LOG_FILE=/tmp/kb.log kb search "query"` | Read with `kb logs show --request-id=<id> --format=json`. |
 | Bypass one CLI search | `kb search "query" --no-cache` | Also supported by `kb related` and `kb compare`. |
 | Disable for a process | `KB_QUERY_CACHE=off kb search "query"` | Use for provider debugging or one-shot correctness probes. |

--- a/src/query-cache.test.ts
+++ b/src/query-cache.test.ts
@@ -1,12 +1,14 @@
-import { describe, expect, it } from '@jest/globals';
+import { describe, expect, it, jest } from '@jest/globals';
 import * as crypto from 'crypto';
 import * as fsp from 'fs/promises';
+import fspDefault from 'fs/promises';
 import * as os from 'os';
 import * as path from 'path';
 import {
   QueryEmbeddingCache,
   normalizeQueryForCache,
   queryCachePaths,
+  queryCacheDiskSizeBytes,
 } from './query-cache.js';
 import { isQueryCacheEnabled } from './config/cache.js';
 
@@ -214,6 +216,103 @@ describe('query embedding cache (#214)', () => {
       const meta = JSON.parse(await fsp.readFile(paths.metaPath, 'utf-8')) as { vector_sha256?: string };
       expect(meta.vector_sha256).toMatch(/^[0-9a-f]{64}$/);
       expect(meta.vector_sha256).toBe(sha256(await fsp.readFile(paths.vectorPath)));
+    } finally {
+      await fsp.rm(path.dirname(indexPath), { recursive: true, force: true });
+    }
+  });
+
+  it('does not rescan the disk tree for each hot-path miss write', async () => {
+    const indexPath = await tempIndexPath('kb-query-cache-amortized-');
+    const readdirSpy = jest.spyOn(fspDefault, 'readdir');
+    try {
+      await fsp.mkdir(path.join(indexPath, 'cache', 'queries', 'fake__one'), { recursive: true });
+      const cache = new QueryEmbeddingCache({ indexPath, lruMax: 0 });
+
+      await cache.getOrCompute({
+        modelId: 'fake__one',
+        query: 'first',
+        embed: async () => [1, 2],
+      });
+      const scansAfterFirstWrite = readdirSpy.mock.calls.length;
+
+      await cache.getOrCompute({
+        modelId: 'fake__one',
+        query: 'second',
+        embed: async () => [3, 4],
+      });
+
+      expect(readdirSpy.mock.calls.length).toBe(scansAfterFirstWrite);
+    } finally {
+      readdirSpy.mockRestore();
+      await fsp.rm(path.dirname(indexPath), { recursive: true, force: true });
+    }
+  });
+
+  it('keeps incremental byte accounting aligned with a ground-truth rescan', async () => {
+    const indexPath = await tempIndexPath('kb-query-cache-accounting-');
+    try {
+      const cache = new QueryEmbeddingCache({ indexPath, lruMax: 0 });
+      for (const [query, embedding] of [
+        ['first', [1, 2]],
+        ['second', [3, 4, 5]],
+        ['third', [6]],
+      ] as const) {
+        await cache.getOrCompute({
+          modelId: 'fake__one',
+          query,
+          embed: async () => Array.from(embedding),
+        });
+        expect((await cache.stats()).disk_size_bytes).toBe(await queryCacheDiskSizeBytes(indexPath));
+      }
+    } finally {
+      await fsp.rm(path.dirname(indexPath), { recursive: true, force: true });
+    }
+  });
+
+  it('enforces the disk byte cap while maintaining incremental accounting', async () => {
+    const indexPath = await tempIndexPath('kb-query-cache-evict-');
+    try {
+      const probe = new QueryEmbeddingCache({ indexPath, lruMax: 0 });
+      await probe.getOrCompute({
+        modelId: 'fake__one',
+        query: 'probe',
+        embed: async () => [0.1, 0.2, 0.3],
+      });
+      const entryBytes = await queryCacheDiskSizeBytes(indexPath);
+      expect(entryBytes).toBeGreaterThan(0);
+      await fsp.rm(path.join(indexPath, 'cache', 'queries'), { recursive: true, force: true });
+
+      const cache = new QueryEmbeddingCache({
+        indexPath,
+        lruMax: 0,
+        diskMaxBytes: Math.floor(entryBytes * 2.5),
+      });
+      for (const [query, embedding] of [
+        ['q1', [0.11, 0.12, 0.13]],
+        ['q2', [0.21, 0.22, 0.23]],
+        ['q3', [0.31, 0.32, 0.33]],
+      ] as const) {
+        await cache.getOrCompute({
+          modelId: 'fake__one',
+          query,
+          embed: async () => Array.from(embedding),
+        });
+        expect((await cache.stats()).disk_size_bytes).toBe(await queryCacheDiskSizeBytes(indexPath));
+      }
+
+      expect((await cache.stats()).disk_size_bytes).toBeLessThanOrEqual(Math.floor(entryBytes * 2.5));
+      await expect(cache.getOrCompute({
+        modelId: 'fake__one',
+        query: 'q1',
+        embed: async () => [9, 9, 9],
+      })).resolves.toMatchObject({ status: 'miss' });
+      await expect(cache.getOrCompute({
+        modelId: 'fake__one',
+        query: 'q3',
+        embed: async () => {
+          throw new Error('q3 should remain cached');
+        },
+      })).resolves.toMatchObject({ status: 'hit_disk' });
     } finally {
       await fsp.rm(path.dirname(indexPath), { recursive: true, force: true });
     }

--- a/src/query-cache.test.ts
+++ b/src/query-cache.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it, jest } from '@jest/globals';
 import * as crypto from 'crypto';
-import * as fsp from 'fs/promises';
-import fspDefault from 'fs/promises';
+import fsp from 'fs/promises';
 import * as os from 'os';
 import * as path from 'path';
 import {
@@ -223,7 +222,7 @@ describe('query embedding cache (#214)', () => {
 
   it('does not rescan the disk tree for each hot-path miss write', async () => {
     const indexPath = await tempIndexPath('kb-query-cache-amortized-');
-    const readdirSpy = jest.spyOn(fspDefault, 'readdir');
+    const readdirSpy = jest.spyOn(fsp, 'readdir');
     try {
       await fsp.mkdir(path.join(indexPath, 'cache', 'queries', 'fake__one'), { recursive: true });
       const cache = new QueryEmbeddingCache({ indexPath, lruMax: 0 });
@@ -301,6 +300,9 @@ describe('query embedding cache (#214)', () => {
       }
 
       expect((await cache.stats()).disk_size_bytes).toBeLessThanOrEqual(Math.floor(entryBytes * 2.5));
+      const q1Paths = queryCachePaths({ indexPath, modelId: 'fake__one', query: 'q1' });
+      await expect(fsp.access(q1Paths.vectorPath)).rejects.toThrow();
+      await expect(fsp.access(q1Paths.metaPath)).rejects.toThrow();
       await expect(cache.getOrCompute({
         modelId: 'fake__one',
         query: 'q1',

--- a/src/query-cache.ts
+++ b/src/query-cache.ts
@@ -107,6 +107,7 @@ export class QueryEmbeddingCache {
   private readonly singleFlight: boolean;
   private readonly l1: LruVectorCache;
   private readonly inFlight = new Map<string, Promise<number[]>>();
+  private diskWriteQueue: Promise<void> = Promise.resolve();
   private diskBytes: number | undefined;
   private diskSizeInitialization: Promise<void> | undefined;
   private writesSinceReconcile = 0;
@@ -190,11 +191,13 @@ export class QueryEmbeddingCache {
         const stableEmbedding = toFloat32Numbers(embedding);
         this.l1.set(paths.cacheKey, stableEmbedding);
         try {
-          await this.ensureDiskSize();
-          const write = await this.writeDisk(paths, stableEmbedding);
-          this.writes += 1;
-          this.applyDiskWrite(write);
-          await this.enforceDiskLimit();
+          await this.withDiskWriteQueue(async () => {
+            await this.ensureDiskSize();
+            const write = await this.writeDisk(paths, stableEmbedding);
+            this.writes += 1;
+            this.applyDiskWrite(write);
+            await this.enforceDiskLimit();
+          });
         } catch (err) {
           this.diskBytes = undefined;
           logger.warn(`query embedding cache write skipped for ${args.modelId}: ${(err as Error).message}`);
@@ -211,6 +214,7 @@ export class QueryEmbeddingCache {
   }
 
   async stats(): Promise<QueryCacheStats> {
+    await this.diskWriteQueue;
     await this.ensureDiskSize();
     const hits = this.hitsL1 + this.hitsDisk;
     const misses = this.misses;
@@ -340,12 +344,30 @@ export class QueryEmbeddingCache {
     files.sort((a, b) => a.mtimeMs - b.mtimeMs);
     for (const file of files) {
       if (total <= this.diskMaxBytes) break;
-      await fsp.unlink(file.path).catch(() => undefined);
+      const vectorRemoved = await fsp.unlink(file.path).then(
+        () => true,
+        (err: unknown) => (err as NodeJS.ErrnoException).code === 'ENOENT',
+      );
+      if (!vectorRemoved) continue;
       await fsp.unlink(file.path.replace(/\.f32$/, '.meta.json')).catch(() => undefined);
       total -= file.size;
     }
     this.diskBytes = total;
     this.writesSinceReconcile = 0;
+  }
+
+  private async withDiskWriteQueue<T>(operation: () => Promise<T>): Promise<T> {
+    const previous = this.diskWriteQueue;
+    let release!: () => void;
+    this.diskWriteQueue = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await previous;
+    try {
+      return await operation();
+    } finally {
+      release();
+    }
   }
 
   private applyDiskWrite(write: DiskWriteResult): void {

--- a/src/query-cache.ts
+++ b/src/query-cache.ts
@@ -16,6 +16,8 @@ import { isValidModelId } from './model-id.js';
 
 export const QUERY_CACHE_SCHEMA_VERSION = 'kb-query-cache.v1';
 
+const DISK_SIZE_RECONCILE_INTERVAL = 64;
+
 export type QueryCacheLookupStatus = 'hit_l1' | 'hit_disk' | 'miss' | 'bypass' | 'disabled';
 export type QueryCacheOutcome = 'memory_hit' | 'disk_hit' | 'miss' | 'bypass' | 'disabled';
 
@@ -61,6 +63,11 @@ interface CacheMeta {
   vector_sha256?: string;
 }
 
+interface DiskWriteResult {
+  previousSize: number;
+  size: number;
+}
+
 class LruVectorCache {
   private readonly values = new Map<string, number[]>();
   constructor(private readonly maxEntries: number) {}
@@ -100,6 +107,9 @@ export class QueryEmbeddingCache {
   private readonly singleFlight: boolean;
   private readonly l1: LruVectorCache;
   private readonly inFlight = new Map<string, Promise<number[]>>();
+  private diskBytes: number | undefined;
+  private diskSizeInitialization: Promise<void> | undefined;
+  private writesSinceReconcile = 0;
   private hitsL1 = 0;
   private hitsDisk = 0;
   private misses = 0;
@@ -180,10 +190,13 @@ export class QueryEmbeddingCache {
         const stableEmbedding = toFloat32Numbers(embedding);
         this.l1.set(paths.cacheKey, stableEmbedding);
         try {
-          await this.writeDisk(paths, stableEmbedding);
+          await this.ensureDiskSize();
+          const write = await this.writeDisk(paths, stableEmbedding);
           this.writes += 1;
+          this.applyDiskWrite(write);
           await this.enforceDiskLimit();
         } catch (err) {
+          this.diskBytes = undefined;
           logger.warn(`query embedding cache write skipped for ${args.modelId}: ${(err as Error).message}`);
         }
         return stableEmbedding;
@@ -198,6 +211,7 @@ export class QueryEmbeddingCache {
   }
 
   async stats(): Promise<QueryCacheStats> {
+    await this.ensureDiskSize();
     const hits = this.hitsL1 + this.hitsDisk;
     const misses = this.misses;
     const total = hits + misses;
@@ -211,7 +225,7 @@ export class QueryEmbeddingCache {
       writes: this.writes,
       corruptions: this.corruptions,
       l1_size: this.l1.size,
-      disk_size_bytes: await queryCacheDiskSizeBytes(this.indexPath),
+      disk_size_bytes: this.diskBytes ?? 0,
     };
   }
 
@@ -269,7 +283,7 @@ export class QueryEmbeddingCache {
     return out;
   }
 
-  private async writeDisk(paths: QueryCachePaths, embedding: readonly number[]): Promise<void> {
+  private async writeDisk(paths: QueryCachePaths, embedding: readonly number[]): Promise<DiskWriteResult> {
     await fsp.mkdir(paths.modelCacheDir, { recursive: true });
     const release = await properLockfile.lock(paths.modelCacheDir, {
       lockfilePath: path.join(paths.modelCacheDir, '.kb-query-cache.lock'),
@@ -279,6 +293,7 @@ export class QueryEmbeddingCache {
     const vectorTmp = `${paths.vectorPath}.${process.pid}.${Date.now()}.tmp`;
     const metaTmp = `${paths.metaPath}.${process.pid}.${Date.now()}.tmp`;
     try {
+      const previousSize = await fileSizeIfPresent(paths.vectorPath);
       const buffer = Buffer.allocUnsafe(embedding.length * 4);
       embedding.forEach((value, index) => buffer.writeFloatLE(value, index * 4));
       const meta: CacheMeta = {
@@ -292,6 +307,7 @@ export class QueryEmbeddingCache {
       await fsp.rename(vectorTmp, paths.vectorPath);
       await fsp.writeFile(metaTmp, `${JSON.stringify(meta, null, 2)}\n`, 'utf-8');
       await fsp.rename(metaTmp, paths.metaPath);
+      return { previousSize, size: buffer.byteLength };
     } finally {
       await Promise.all([
         fsp.unlink(vectorTmp).catch(() => undefined),
@@ -305,6 +321,7 @@ export class QueryEmbeddingCache {
 
   private async recordCorrupt(paths: QueryCachePaths): Promise<void> {
     this.corruptions += 1;
+    this.diskBytes = undefined;
     await Promise.all([
       fsp.unlink(paths.vectorPath).catch(() => undefined),
       fsp.unlink(paths.metaPath).catch(() => undefined),
@@ -313,16 +330,48 @@ export class QueryEmbeddingCache {
 
   private async enforceDiskLimit(): Promise<void> {
     if (this.diskMaxBytes <= 0) return;
-    const root = queryCacheRoot(this.indexPath);
-    const files = await listCacheVectorFiles(root);
+    if (this.diskBytes === undefined || this.writesSinceReconcile >= DISK_SIZE_RECONCILE_INTERVAL) {
+      await this.reconcileDiskSize();
+    }
+    if (this.diskBytes === undefined || this.diskBytes <= this.diskMaxBytes) return;
+
+    const files = await listCacheVectorFiles(queryCacheRoot(this.indexPath));
     let total = files.reduce((sum, file) => sum + file.size, 0);
-    if (total <= this.diskMaxBytes) return;
     files.sort((a, b) => a.mtimeMs - b.mtimeMs);
     for (const file of files) {
       if (total <= this.diskMaxBytes) break;
       await fsp.unlink(file.path).catch(() => undefined);
       await fsp.unlink(file.path.replace(/\.f32$/, '.meta.json')).catch(() => undefined);
       total -= file.size;
+    }
+    this.diskBytes = total;
+    this.writesSinceReconcile = 0;
+  }
+
+  private applyDiskWrite(write: DiskWriteResult): void {
+    if (this.diskBytes !== undefined) {
+      this.diskBytes += write.size - write.previousSize;
+    }
+    this.writesSinceReconcile += 1;
+  }
+
+  private async ensureDiskSize(): Promise<void> {
+    if (this.diskBytes !== undefined) return;
+    if (this.diskSizeInitialization === undefined) {
+      this.diskSizeInitialization = this.reconcileDiskSize().finally(() => {
+        this.diskSizeInitialization = undefined;
+      });
+    }
+    await this.diskSizeInitialization;
+  }
+
+  private async reconcileDiskSize(): Promise<void> {
+    try {
+      this.diskBytes = await queryCacheDiskSizeBytes(this.indexPath);
+      this.writesSinceReconcile = 0;
+    } catch (err) {
+      this.diskBytes = undefined;
+      logger.warn(`query embedding cache size reconciliation skipped: ${(err as Error).message}`);
     }
   }
 }
@@ -396,6 +445,15 @@ function sha256Buffer(buffer: Buffer): string {
 
 function isSha256Hex(value: string): boolean {
   return /^[0-9a-f]{64}$/.test(value);
+}
+
+async function fileSizeIfPresent(file: string): Promise<number> {
+  try {
+    return (await fsp.stat(file)).size;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return 0;
+    throw err;
+  }
 }
 
 async function listCacheVectorFiles(root: string): Promise<Array<{ path: string; size: number; mtimeMs: number }>> {

--- a/src/rerank-cache-disk.test.ts
+++ b/src/rerank-cache-disk.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from '@jest/globals';
+import { describe, expect, it, jest } from '@jest/globals';
 import * as fs from 'fs';
+import fsDefault from 'fs';
 import * as fsp from 'fs/promises';
 import * as os from 'os';
 import * as path from 'path';
@@ -17,6 +18,24 @@ async function tempIndexPath(prefix: string): Promise<string> {
 }
 
 const MODEL = 'Xenova/ms-marco-MiniLM-L-6-v2';
+
+function rescanRerankDiskSizeBytes(indexPath: string): number {
+  const root = rerankScoreCacheRoot(indexPath);
+  let total = 0;
+  const walk = (dir: string): void => {
+    if (!fs.existsSync(dir)) return;
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const child = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(child);
+      } else if (entry.isFile() && entry.name.endsWith('.json')) {
+        total += fs.statSync(child).size;
+      }
+    }
+  };
+  walk(root);
+  return total;
+}
 
 describe('DiskTieredRerankScoreCache (#646)', () => {
   const itPosixNonRoot =
@@ -77,6 +96,41 @@ describe('DiskTieredRerankScoreCache (#646)', () => {
     }
   });
 
+  it('does not rescan the disk tree for each hot-path write', () => {
+    const indexPath = path.join(os.tmpdir(), `kb-rerank-cache-amortized-${process.pid}`);
+    const readdirSpy = jest.spyOn(fsDefault, 'readdirSync');
+    try {
+      const cache = new DiskTieredRerankScoreCache({ indexPath, enabled: true });
+      const scansAfterConstruction = readdirSpy.mock.calls.length;
+
+      for (let index = 0; index < 40; index += 1) {
+        cache.set(MODEL, `query-${index}`, `candidate-${index}`, index / 100);
+      }
+
+      expect(readdirSpy.mock.calls.length).toBe(scansAfterConstruction);
+    } finally {
+      readdirSpy.mockRestore();
+      fs.rmSync(indexPath, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps incremental byte accounting aligned with a ground-truth rescan', async () => {
+    const indexPath = await tempIndexPath('kb-rerank-cache-accounting-');
+    try {
+      const cache = new DiskTieredRerankScoreCache({ indexPath, enabled: true });
+      cache.set(MODEL, 'q1', 'first', 0.11);
+      expect(cache.diskSizeBytes()).toBe(rescanRerankDiskSizeBytes(indexPath));
+
+      cache.set(MODEL, 'q2', 'second', 0.22);
+      expect(cache.diskSizeBytes()).toBe(rescanRerankDiskSizeBytes(indexPath));
+
+      cache.set(MODEL, 'q3', 'third', 0.33);
+      expect(cache.diskSizeBytes()).toBe(rescanRerankDiskSizeBytes(indexPath));
+    } finally {
+      await fsp.rm(path.dirname(indexPath), { recursive: true, force: true });
+    }
+  });
+
   it('enforces the disk size bound by evicting oldest entries', async () => {
     const indexPath = await tempIndexPath('kb-rerank-cache-evict-');
     try {
@@ -96,11 +150,14 @@ describe('DiskTieredRerankScoreCache (#646)', () => {
       });
 
       cache.set(MODEL, 'q1', 'first', 0.11);
+      expect(cache.diskSizeBytes()).toBe(rescanRerankDiskSizeBytes(indexPath));
       cache.set(MODEL, 'q2', 'second', 0.22);
+      expect(cache.diskSizeBytes()).toBe(rescanRerankDiskSizeBytes(indexPath));
       cache.set(MODEL, 'q3', 'third', 0.33);
 
       // Three entries exceed the ~2.5-entry bound, so the oldest (q1) is gone.
       expect(cache.diskSizeBytes()).toBeLessThanOrEqual(Math.floor(entryBytes * 2.5));
+      expect(cache.diskSizeBytes()).toBe(rescanRerankDiskSizeBytes(indexPath));
       expect(cache.get(MODEL, 'q1', 'first')).toBeNull();
       expect(cache.get(MODEL, 'q3', 'third')).toBe(0.33);
     } finally {

--- a/src/rerank-cache-disk.test.ts
+++ b/src/rerank-cache-disk.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it, jest } from '@jest/globals';
-import * as fs from 'fs';
-import fsDefault from 'fs';
-import * as fsp from 'fs/promises';
+import fs from 'fs';
+import fsp from 'fs/promises';
 import * as os from 'os';
 import * as path from 'path';
 import {
@@ -98,7 +97,7 @@ describe('DiskTieredRerankScoreCache (#646)', () => {
 
   it('does not rescan the disk tree for each hot-path write', () => {
     const indexPath = path.join(os.tmpdir(), `kb-rerank-cache-amortized-${process.pid}`);
-    const readdirSpy = jest.spyOn(fsDefault, 'readdirSync');
+    const readdirSpy = jest.spyOn(fs, 'readdirSync');
     try {
       const cache = new DiskTieredRerankScoreCache({ indexPath, enabled: true });
       const scansAfterConstruction = readdirSpy.mock.calls.length;
@@ -119,6 +118,9 @@ describe('DiskTieredRerankScoreCache (#646)', () => {
     try {
       const cache = new DiskTieredRerankScoreCache({ indexPath, enabled: true });
       cache.set(MODEL, 'q1', 'first', 0.11);
+      expect(cache.diskSizeBytes()).toBe(rescanRerankDiskSizeBytes(indexPath));
+
+      cache.set(MODEL, 'q1', 'first', 123456789.12345678);
       expect(cache.diskSizeBytes()).toBe(rescanRerankDiskSizeBytes(indexPath));
 
       cache.set(MODEL, 'q2', 'second', 0.22);

--- a/src/rerank-cache-disk.ts
+++ b/src/rerank-cache-disk.ts
@@ -24,6 +24,8 @@ export const RERANK_SCORE_CACHE_SCHEMA_VERSION = 'kb-rerank-score-cache.v1';
 
 export const DEFAULT_RERANK_CACHE_L1_MAX = 4096;
 
+const DISK_SIZE_RECONCILE_INTERVAL = 64;
+
 export interface DiskTieredRerankScoreCacheOptions {
   indexPath?: string;
   enabled?: boolean;
@@ -45,6 +47,11 @@ export interface RerankScoreCacheStats {
 interface RerankScoreRecord {
   schema_version: typeof RERANK_SCORE_CACHE_SCHEMA_VERSION;
   score: number;
+}
+
+interface DiskWriteResult {
+  previousSize: number;
+  size: number;
 }
 
 /**
@@ -84,6 +91,8 @@ export class DiskTieredRerankScoreCache implements RerankScoreCache {
   private readonly diskMaxBytes: number;
   private readonly l1Max: number;
   private readonly l1 = new Map<string, number>();
+  private diskBytes: number | undefined;
+  private writesSinceReconcile = 0;
   private l1Hits = 0;
   private diskHits = 0;
   private misses = 0;
@@ -95,6 +104,7 @@ export class DiskTieredRerankScoreCache implements RerankScoreCache {
     this.cacheRoot = rerankScoreCacheRoot(options.indexPath ?? FAISS_INDEX_PATH);
     this.diskMaxBytes = options.diskMaxBytes ?? KB_RERANK_CACHE_DISK_MAX_BYTES;
     this.l1Max = options.l1Max ?? DEFAULT_RERANK_CACHE_L1_MAX;
+    this.diskBytes = this.reconcileDiskSize();
   }
 
   get(modelId: string, query: string, candidateText: string): number | null {
@@ -124,10 +134,12 @@ export class DiskTieredRerankScoreCache implements RerankScoreCache {
     const key = rerankScoreCacheKey(modelId, query, candidateText);
     this.l1Set(key, score);
     try {
-      this.writeDisk(key, score);
+      const write = this.writeDisk(key, score);
       this.writes += 1;
+      this.applyDiskWrite(write);
       this.enforceDiskLimit();
     } catch (err) {
+      this.diskBytes = undefined;
       logger.warn(`rerank score cache write skipped: ${(err as Error).message}`);
     }
   }
@@ -150,7 +162,8 @@ export class DiskTieredRerankScoreCache implements RerankScoreCache {
   }
 
   diskSizeBytes(): number {
-    return listEntryFiles(this.cacheRoot).reduce((sum, file) => sum + file.size, 0);
+    if (this.diskBytes === undefined) this.diskBytes = this.reconcileDiskSize();
+    return this.diskBytes ?? 0;
   }
 
   private l1Set(key: string, value: number): void {
@@ -200,13 +213,15 @@ export class DiskTieredRerankScoreCache implements RerankScoreCache {
     return record.score;
   }
 
-  private writeDisk(key: string, score: number): void {
+  private writeDisk(key: string, score: number): DiskWriteResult {
     const file = this.entryPath(key);
+    const previousSize = fileSizeIfPresent(file);
     fs.mkdirSync(path.dirname(file), { recursive: true });
     const record: RerankScoreRecord = { schema_version: RERANK_SCORE_CACHE_SCHEMA_VERSION, score };
+    const serialized = `${JSON.stringify(record)}\n`;
     const tmp = `${file}.${process.pid}.tmp`;
     try {
-      fs.writeFileSync(tmp, `${JSON.stringify(record)}\n`, 'utf-8');
+      fs.writeFileSync(tmp, serialized, 'utf-8');
       fs.renameSync(tmp, file);
     } catch (err) {
       try {
@@ -216,12 +231,14 @@ export class DiskTieredRerankScoreCache implements RerankScoreCache {
       }
       throw err;
     }
+    return { previousSize, size: Buffer.byteLength(serialized, 'utf-8') };
   }
 
   private recordCorrupt(file: string): void {
     this.corruptions += 1;
     try {
       fs.unlinkSync(file);
+      this.diskBytes = undefined;
     } catch {
       // best-effort: a missing/locked corrupt file is fine to ignore
     }
@@ -229,9 +246,13 @@ export class DiskTieredRerankScoreCache implements RerankScoreCache {
 
   private enforceDiskLimit(): void {
     if (this.diskMaxBytes <= 0) return;
+    if (this.diskBytes === undefined || this.writesSinceReconcile >= DISK_SIZE_RECONCILE_INTERVAL) {
+      this.diskBytes = this.reconcileDiskSize();
+    }
+    if (this.diskBytes === undefined || this.diskBytes <= this.diskMaxBytes) return;
+
     const files = listEntryFiles(this.cacheRoot);
     let total = files.reduce((sum, file) => sum + file.size, 0);
-    if (total <= this.diskMaxBytes) return;
     // Evict oldest-first by mtime until back under the bound.
     files.sort((a, b) => a.mtimeMs - b.mtimeMs);
     for (const file of files) {
@@ -243,6 +264,35 @@ export class DiskTieredRerankScoreCache implements RerankScoreCache {
         // already gone or locked by another process — skip it
       }
     }
+    this.diskBytes = total;
+    this.writesSinceReconcile = 0;
+  }
+
+  private applyDiskWrite(write: DiskWriteResult): void {
+    if (this.diskBytes !== undefined) {
+      this.diskBytes += write.size - write.previousSize;
+    }
+    this.writesSinceReconcile += 1;
+  }
+
+  private reconcileDiskSize(): number | undefined {
+    try {
+      const total = listEntryFiles(this.cacheRoot).reduce((sum, file) => sum + file.size, 0);
+      this.writesSinceReconcile = 0;
+      return total;
+    } catch (err) {
+      logger.warn(`rerank score cache size reconciliation skipped: ${(err as Error).message}`);
+      return undefined;
+    }
+  }
+}
+
+function fileSizeIfPresent(file: string): number {
+  try {
+    return fs.statSync(file).size;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return 0;
+    throw err;
   }
 }
 

--- a/src/rerank-cache-disk.ts
+++ b/src/rerank-cache-disk.ts
@@ -236,9 +236,11 @@ export class DiskTieredRerankScoreCache implements RerankScoreCache {
 
   private recordCorrupt(file: string): void {
     this.corruptions += 1;
+    // The corrupt entry may have been removed or changed by another process;
+    // force a reconciliation before relying on the running total again.
+    this.diskBytes = undefined;
     try {
       fs.unlinkSync(file);
-      this.diskBytes = undefined;
     } catch {
       // best-effort: a missing/locked corrupt file is fine to ignore
     }


### PR DESCRIPTION
## Summary

Amortize disk-size enforcement for the rerank score cache and query embedding
cache. Each cache now maintains a running vector/entry-byte total, applies
write and eviction deltas, and reconciles periodically or when accounting is
unknown. This removes the recursive directory walk from every hot-path cache
write while preserving the existing byte caps and oldest-entry eviction order.

Root cause: `set()`/miss-write enforcement recalculated the entire cache tree
after every write, so reranking up to 40 candidates could synchronously rescan
all shard directories 40 times for one search.

Closes #828

## Verification

- Before: every successful write called the recursive cache-file listing from
  `enforceDiskLimit`, so the old implementation increased the `readdir` count
  for each write.
- After: the regression tests observe no additional recursive walk across 40
  rerank writes or successive query-cache miss writes; accounting tests match
  a ground-truth rescan after writes and eviction while cap behavior remains
  intact.

## Testing

- [x] `npm test` passes (203 parallel suites; 11 serial suites; 2 skipped)
- ~~[ ] End-to-end verified for tool/transport changes~~ (not applicable: this changes internal cache accounting only)
- [x] Benchmark run: `BENCH_PROVIDER=stub npm run bench` passes
- [x] <!-- kookr:check:tests --> Tests were added or updated for amortized walks, running byte accounting, and cap eviction in both caches.

## Documentation contract

- [ ] ~~<!-- kookr:check:readme --> `README.md` reflects user-visible CLI, MCP, installation, or configuration changes~~ — not applicable: no public command, tool, installation, or configuration contract changed
- [x] <!-- kookr:check:docs --> Query-cache disk-budget documentation now describes incremental accounting and reconciliation.
- [ ] ~~<!-- kookr:check:mbse --> RFCs are updated when this PR implements, supersedes, or changes an accepted design~~ — not applicable: scoped implementation of existing cache behavior; no accepted architecture decision changes

## Changelog

- [ ] ~~<!-- kookr:check:changelog --> `CHANGELOG.md` has an `Unreleased` entry for user-visible changes~~ — not applicable: this repository has no `CHANGELOG.md` and the change is internal

## Retrieval and performance evidence

- [ ] ~~<!-- kookr:check:benchmarks --> Retrieval-quality or performance changes include the relevant benchmark/evaluation evidence, or this row is waived with a reason~~ — waived: the stub benchmark passed locally, but no benchmark artifact is part of this cache-accounting diff

## Follow-ups

None.