### PR TITLE
chore: gitignore per-run agent state and probe scratch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,17 @@ reports/mutation/
 # Local evolution chain controls
 STOP
 .chain-heartbeat
+
+# Per-run agent state (kookr issue targeting, ralph loop verdicts). Machine-local
+# and rewritten every run — the checked-in copy would always be someone else's stale target.
+.kookr-issue-state
+.kookr-target
+.kookr-target-title
+.kookr-target-title.json
+.ralph-verdict-*.json
+
+# Playwright MCP page snapshots (tool output, not project data)
+.playwright-mcp/
+
+# Ad-hoc logging-throughput probe output (synthetic payloads, ~7MB/run)
+probe-concurrent-*.jsonl


### PR DESCRIPTION
## Why

Four classes of untracked scratch have been accumulating in the working tree since May, cluttering `git status`. I checked each one: **none is referenced by any script, doc, or RFC**, and none belongs in version control.

| What | Files | Size | Age |
|---|---|---|---|
| Kookr issue-targeting state | `.kookr-target`, `.kookr-issue-state`, `.kookr-target-title{,.json}` | ~770 B | Jun 18 – Jul 2 |
| Ralph loop verdicts | `.ralph-verdict-*.json` (4) | ~900 B | May 11 |
| Playwright MCP snapshot | `.playwright-mcp/` | 24 KB | May 13 |
| Logging probe output | `probe-concurrent-*.jsonl` (6) | **6.9 MB** | Jun 4 |

Notes on each:

- **Kookr state** is rewritten every run to track which issue an agent loop is working. It is inherently machine-local — a checked-in copy would always be someone else's stale target. The files currently on disk point at long-finished targets (`742`, `695`, `#759`).
- **Ralph verdicts** are per-iteration loop records (`{"verdict":"progress","iteration":1,...}`) referencing PRs that merged two months ago.
- **`probe-concurrent-*.jsonl`** is the bulk of it: raw output from an ad-hoc `appendFileSync` vs `createWriteStream` throughput experiment. The `payload` field is synthetic filler (literally repeated `x`), so once the experiment concluded there is no information left in it.

This follows the convention already established in this file for agent/benchmark scratch (`STOP`, `.chain-heartbeat`, `.stryker-tmp/`, benchmark TREC files). These patterns are simply the ones that were missed.

## Verification

Confirmed each pattern matches its intended target via `git check-ignore -v`, and confirmed nothing tracked is caught:

```
IGNORED  .kookr-issue-state                <- .kookr-issue-state
IGNORED  .ralph-verdict-11723d34-6cb.json  <- .ralph-verdict-*.json
IGNORED  .playwright-mcp/page-...yml       <- .playwright-mcp/
IGNORED  probe-concurrent-appendFileSync-1024.jsonl  <- probe-concurrent-*.jsonl

OK (not ignored)  .kookr/playbooks/kb-reindex.md
OK (not ignored)  .kookr/pr-checklist.json
```

The `.kookr-*` patterns are dash-suffixed, so they do **not** match the tracked `.kookr/` **directory** (playbooks, `pr-checklist.json`) — that stays versioned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)