### PR TITLE
fix(preface): key the sidecar on the configured model, not the response echo

### DIFF
--- a/src/contextual-preface.test.ts
+++ b/src/contextual-preface.test.ts
@@ -279,6 +279,62 @@ describe('resolveContextualPrefaces — LLM call + sidecar', () => {
     expect(sidecar.model).toBe('new-model');
   });
 
+  it('keys the sidecar on the configured model, not a versioned response echo', async () => {
+    // Providers may answer a request for `gpt-4o` with `gpt-4o-2024-08-06`.
+    // The sidecar must record the *configured* id, because that is what
+    // `sidecarModelMatchesCurrentProvider` compares against. Recording the echo
+    // would mismatch on every subsequent run and re-preface the whole corpus,
+    // forever.
+    setEnv('KB_LLM_MODEL', 'gpt-4o');
+    FETCH_MOCK.mockImplementation(async () => llmResponse('preface', 'gpt-4o-2024-08-06'));
+    const { resolveContextualPrefaces, sidecarPathFor } = await loadModule();
+    const args = {
+      source: path.join(tempDir, 'note.md'),
+      knowledgeBaseName: 'alpha',
+      documentHash: 'doc-hash-v1',
+      documentBody: 'body',
+      chunks: ['chunk-a'],
+    };
+
+    await resolveContextualPrefaces(args);
+    expect(FETCH_MOCK).toHaveBeenCalledTimes(1);
+
+    const sidecar = JSON.parse(
+      await fsp.readFile(sidecarPathFor(args.source, args.knowledgeBaseName), 'utf-8'),
+    ) as { model?: string };
+    expect(sidecar.model).toBe('gpt-4o');
+
+    // Same config, same content: the second run must be a cache hit.
+    FETCH_MOCK.mockClear();
+    await resolveContextualPrefaces(args);
+    expect(FETCH_MOCK).not.toHaveBeenCalled();
+  });
+
+  it('still records the response model when no model is configured', async () => {
+    // With no configured identifier the response model is the only stable one,
+    // so it stays authoritative (and must still round-trip as a cache hit).
+    setEnv('KB_LLM_MODEL', undefined);
+    FETCH_MOCK.mockImplementation(async () => llmResponse('preface', 'local-resolved'));
+    const { resolveContextualPrefaces, sidecarPathFor } = await loadModule();
+    const args = {
+      source: path.join(tempDir, 'note.md'),
+      knowledgeBaseName: 'alpha',
+      documentHash: 'doc-hash-v1',
+      documentBody: 'body',
+      chunks: ['chunk-a'],
+    };
+
+    await resolveContextualPrefaces(args);
+    const sidecar = JSON.parse(
+      await fsp.readFile(sidecarPathFor(args.source, args.knowledgeBaseName), 'utf-8'),
+    ) as { model?: string };
+    expect(sidecar.model).toBe('local-resolved');
+
+    FETCH_MOCK.mockClear();
+    await resolveContextualPrefaces(args);
+    expect(FETCH_MOCK).not.toHaveBeenCalled();
+  });
+
   it('invalidates the cache when documentHash changes', async () => {
     FETCH_MOCK.mockImplementation(async () => llmResponse('preface'));
     const { resolveContextualPrefaces } = await loadModule();

--- a/src/contextual-preface.ts
+++ b/src/contextual-preface.ts
@@ -169,7 +169,11 @@ export async function resolveContextualPrefaces(
   const nowMs = Date.now();
   const resolved: (string | null)[] = new Array(args.chunks.length);
   const newEntries: SidecarChunkEntry[] = new Array(args.chunks.length);
-  let modelSeen: string | null = resolveLlmProvider().model ?? existing?.model ?? null;
+  // The sidecar's `model` is a cache key, so it must record the same identifier
+  // `sidecarModelMatchesCurrentProvider` compares against — the *configured*
+  // model. See the guard on `result.model` below.
+  const configuredModel = resolveLlmProvider().model;
+  let modelSeen: string | null = configuredModel ?? existing?.model ?? null;
   let cacheHits = 0;
   let llmCalls = 0;
   let failures = 0;
@@ -272,7 +276,14 @@ export async function resolveContextualPrefaces(
         chunkText: args.chunks[i],
         isLlmContextAllowed: () => currentSourceAllowsLlm(args.source),
       });
-      if (result.model !== null) modelSeen = result.model;
+      // Only adopt the response model when nothing is configured. A provider may
+      // echo a normalized/versioned id (request `gpt-4o` -> response
+      // `gpt-4o-2024-08-06`); recording that while
+      // `sidecarModelMatchesCurrentProvider` compares against the configured
+      // `gpt-4o` would invalidate every sidecar on the next run and re-preface
+      // the whole corpus, on every run, forever. With no configured model the
+      // response is the only stable identifier, so it stays authoritative.
+      if (configuredModel === undefined && result.model !== null) modelSeen = result.model;
       newEntries[i] = {
         chunk_index: i,
         chunk_hash: chunkHash,


### PR DESCRIPTION
Fixes #865.

## The bug

#829 correctly added `model` to the preface sidecar's cache key. But the value **written** to the sidecar and the value **compared** against it come from two different sources:

| | source |
|---|---|
| **Written** | model from the API **response body** — `llm-client.ts:357-360` → `contextual-preface.ts:275` → persisted `:696` |
| **Compared** | the **configured** model — `sidecarModelMatchesCurrentProvider`, `contextual-preface.ts:744-745` |

When a provider echoes a normalized/versioned identifier, those never agree. Request `gpt-4o`, provider answers `gpt-4o-2024-08-06`:

```
run 1   miss -> LLM -> sidecar records "gpt-4o-2024-08-06"
run 2   configured "gpt-4o" != stored -> cacheValid false -> LLM again
run 3+  identical, forever
```

The cache **never hits**. Every reindex re-prefaces the entire corpus (~32.5k chunks in this KB) instead of only changed files — no error, no warning, just a permanently cold cache. On a paid remote provider that is ~32.5k LLM calls per nightly run, indefinitely.

**It does not fire today** because Ollama echoes the configured string verbatim (`qwen3:4b-instruct-2507-q4_K_M`), which is why all ~4,800 existing sidecars match. It becomes reachable the moment a version-stamping provider is configured — i.e. exactly the OpenRouter/DeepSeek migration path this repo is heading for.

## The fix

Keep the configured identifier as the cache key when one exists; adopt the response model only when nothing is configured — the local-placeholder case, where the response is the only stable identifier. This is the behavior `sidecarModelMatchesCurrentProvider`'s own doc comment already describes; the write path just wasn't honoring it.

```ts
const configuredModel = resolveLlmProvider().model;
...
if (configuredModel === undefined && result.model !== null) modelSeen = result.model;
```

## Why the existing test missed it

`contextual-preface.test.ts` → *"invalidates cached prefaces when the configured LLM model changes"* sets `KB_LLM_MODEL: 'new-model'` **and** stubs the mock to echo `'new-model'` back — so response always equals configured, and the mismatch is never exercised.

## Tests

Two added:

1. **`keys the sidecar on the configured model, not a versioned response echo`** — configures `gpt-4o`, mocks the response as `gpt-4o-2024-08-06`, asserts the sidecar records `gpt-4o` and that a second identical run is a **cache hit** (no further LLM call).
2. **`still records the response model when no model is configured`** — guards the local-placeholder path: the response model stays authoritative and still round-trips as a cache hit.

Verified test (1) genuinely fails on unfixed code (negative control — stashed the fix, kept the tests):

```
✕ keys the sidecar on the configured model, not a versioned response echo
  Expected: "gpt-4o"
  Received: "gpt-4o-2024-08-06"
```

Full suite green with the fix: **203 suites, 2728 passed, 4 skipped, 0 failures.** The pre-existing model test still passes (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)