### PR TITLE
docs(kookr): correct the playbook's model-switch warning

### DIFF
--- a/.kookr/playbooks/kb-reindex.md
+++ b/.kookr/playbooks/kb-reindex.md
@@ -167,16 +167,21 @@ Two lines routinely get misread as regressions:
 ## Changing the preface model — read first
 
 **Do not switch the preface model (e.g. to OpenRouter/DeepSeek) as part of this
-nightly job.** The preface cache does not include `model` in its validity check
-(`src/contextual-preface.ts:163-171`), despite a header comment claiming it does.
-Consequence: whichever model wrote a preface owns that chunk **permanently**. A
-model switch would convert only the chunks of files that happen to be stale that
-night and silently leave every unchanged file on the old model — a mixed-model
-corpus with no signal that it happened.
+nightly job.**
 
-That is tracked as **issue #860**. A real model migration requires #860 fixed (or
-a `GENERATOR_VERSION` bump), followed by a deliberate full re-preface of ~32.5k
-chunks. That is a scheduled migration, not a nightly incremental.
+The switch itself is *safe*: `model` is part of the sidecar cache key
+(`sidecarModelMatchesCurrentProvider`, `src/contextual-preface.ts`), so changing
+`KB_LLM_MODEL` correctly invalidates every preface written by the old model
+instead of silently keeping it. There is no mixed-model-corpus hazard.
+
+That is precisely why it must not run *here*. Invalidating every sidecar means
+re-prefacing the **entire corpus** (~32.5k chunks), not just the night's changed
+files — a multi-hour job at the nightly concurrency, which will collide with the
+research-agent window and be refused by the guard (or, worse, run right up to it).
+
+A model migration is a deliberate, scheduled operation: change the config, run the
+full re-preface out of band, confirm coverage with `kb stats`, and only then
+resume the nightly cadence.
 
 ## Success criteria
 


### PR DESCRIPTION
## What was wrong

The **"Changing the preface model — read first"** section I added in #862 was wrong on arrival. It claimed:

> The preface cache does not include `model` in its validity check (`src/contextual-preface.ts:163-171`), despite a header comment claiming it does. Consequence: whichever model wrote a preface owns that chunk **permanently**.

That was true of the code I read — but I read a checkout that was **77 commits behind `origin/main`**. #829 had already added `model` to the cache key via `sidecarModelMatchesCurrentProvider`. The cited line numbers no longer resolve, and **the mixed-model-corpus hazard does not exist.**

My mistake: I diagnosed from a stale checkout without re-reading against `origin/main` before writing it down. (The bug *was* live in the binary being run — `build/` was compiled from that stale tree — but the repository was already fixed.)

## What replaces it

The **conclusion is unchanged** — don't switch the preface model from the nightly job — but the reason is now the opposite of what the old text said:

Because the cache key **works**, changing `KB_LLM_MODEL` invalidates *every* sidecar and re-prefaces the **entire corpus** (~32.5k chunks), not just the night's changed files. That is a multi-hour job at the nightly concurrency, which will collide with the research-agent window. So a model migration is a deliberate, scheduled, out-of-band operation — not something the incremental job should ever trigger.

## Notes

- Drops the now-resolved **#860** reference.
- The **#861** reference (making `kb llm probe` report the resolved provider) is retained — I re-verified against the current build that the probe still emits only `endpoint`/`health_ok`/`chat_ok`, with no provider or model field. Still open, still needed.
- **#865** / #866 track a separate, still-live defect in the *same* cache key: the sidecar stores the API **response** model but compares against the **configured** model, so a version-stamping provider would re-preface the whole corpus on every run. That one is real and unfixed on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)