### PR TITLE
fix(gate): preserve lexical-only hybrid hits

### DIFF
--- a/docs/requirements/INDEX.md
+++ b/docs/requirements/INDEX.md
@@ -467,6 +467,21 @@ graceful-degradation contract.
 **Linked Tests:** TS-GATE-379
 **Dependencies:** RFC018
 
+### FR-GATE-852: Hybrid lexical-only relevance scoring
+**Status:** Implemented
+**Priority:** High
+
+**Requirement:** The relevance gate shall apply dense-distance Stage A thresholds only to candidates with a recorded dense distance and shall preserve lexical-only candidates as independent lexical evidence in hybrid retrieval.
+**Rationale:** Lexical-only hybrid candidates have no L2 distance. Treating their fused-array position as an L2 distance creates a false knee and removes exact-token matches from gated results.
+
+**Acceptance Criteria:**
+- [x] Given hybrid candidates with a partial dense-distance map, when A2 computes its distribution knee, then lexical-only candidates shall not participate in the dense-distance distribution and shall remain eligible for the result set.
+- [x] Given a hybrid candidate without a dense distance, when A1 applies the dense score floor, then the candidate shall be explicitly handled as lexical-only evidence rather than being silently scored by a non-distance value.
+- [x] Given the RFC 018 gate evaluation fixture, when the mixed-scale fix is evaluated, then it shall produce no regression in the existing gate quality checks.
+
+**Linked Tests:** TS-GATE-852 (`src/relevance-gate.test.ts`)
+**Dependencies:** FR-GATE-379
+
 ### FR-GATE-422: Untrusted Task-Context Policy
 **Status:** Implemented
 **Priority:** High

--- a/docs/rfcs/018-context-relevance-gating.md
+++ b/docs/rfcs/018-context-relevance-gating.md
@@ -122,6 +122,8 @@ The statistical relevance decision when there is no usable task context. Reuses 
 
 **Input-contract caveat (round-1/2 finding).** `computeAutoThreshold` was designed for a raw FAISS top-K list; the gate feeds it a post-A1 survivor list that may be small or flat. M0a pins and unit-tests A2 on survivor lists of size 1, 2, 3 and flat distributions: size 1 → keep it; flat → keep all. **A2 alone never empties the set.**
 
+In hybrid mode, `denseDistanceById` is intentionally partial: lexical-only candidates have no L2 distance. A2 computes its knee only from candidates with recorded dense distances and preserves rows absent from that map; it never substitutes a fused-array position for a dense distance.
+
 ### 5. Stage B — LLM relevance judge
 
 Runs when `task_context` is present and above the minimum-signal threshold. **One batched LLM call** sees the task context, the query, and the surviving candidates (up to `KB_GATE_JUDGE_INPUT` = 10; if more survive A1, the lowest-ranked overflow is **kept un-judged**, never silently dropped — recorded with `stage: "B-input-overflow"`, consistent with bias-toward-keep). It returns JSON:
@@ -270,7 +272,7 @@ This RFC delivers the kb-mcp-server mechanism; the Kookr-side hook is cross-repo
 | Stale `task_context` | none in-band — server cannot detect it | §11 freshness contract makes the hook responsible; documented silent-false-drop source. |
 | Degenerate / adversarial `task_context` | token count; ADR 0010 injection-guard over `task_context` + structural delimiting in the judge prompt | degenerate → statistical path; injected instructions inside delimited data regions are treated as data. |
 | Judge latency exceeds budget | `judge_degrade_rate` in `kb stats` + WARN alarm at 10% | default raised to 8000 ms; a persistently high rate is alarmed, not silent — `on` is then effectively the statistical path and the operator is told. |
-| Hybrid mode, candidates lack a dense leg | absent from `denseDistanceById` | A1 passes them; the BM25 floor + A2/B decide; the lexical leg is the §6 independent witness. |
+| Hybrid mode, candidates lack a dense leg | absent from `denseDistanceById` | A1 passes them and A2 excludes them from the dense-distance knee; Stage B may still judge them; the lexical leg is the §6 independent witness. |
 | `denseDistanceById` missing an expected dense-leg distance | gate asserts finite distance for dense-contributed ids | throws at the gate boundary (programmer error) rather than silently disabling A1. |
 | `computeAutoThreshold` fed a tiny/flat survivor list | — | M0a pins and tests A2 for sizes 1/2/3 and flat; A2 alone never empties the set. |
 | Gate-internal exception | caught at the gate boundary | degrade to passing the raw retrieval set through, `verdict: bypassed`, error logged. Retrieval never breaks. |

--- a/docs/testing/INDEX.md
+++ b/docs/testing/INDEX.md
@@ -327,6 +327,14 @@ Keep this helper limited to temp directory scaffolding, file writes, path lookup
 - Judge failures (timeout, non-JSON, bad model id) shall degrade to retrieval rather than failing the search.
 - `KB_GATE_EMPTY_VERDICT=on` shall let the gate return an empty set; the default `off` shall fall back to the pre-gate top-k.
 
+### TS-GATE-852: Hybrid Lexical-Only Relevance Scoring
+**Requirement:** FR-GATE-852
+
+**Test Cases:**
+- `applyRelevanceGate` shall keep lexical-only hybrid candidates outside the dense-distance A2 knee when the dense-distance map is partial.
+- `applyRelevanceGate` shall apply the dense A1 score floor to recorded dense distances while preserving candidates that have only lexical evidence.
+- The endpoint-unset and Stage-B-degraded paths shall preserve lexical-only candidates while applying the knee only to candidates with dense distances.
+
 ### TS-GATE-422: Untrusted Task-Context Policy
 **Requirement:** FR-GATE-422
 

--- a/src/relevance-gate.test.ts
+++ b/src/relevance-gate.test.ts
@@ -160,6 +160,7 @@ describe('relevance gate', () => {
 
     const result = await applyRelevanceGate({
       query: 'hybrid lexical-only knee',
+      taskContext: 'please answer an exact identifier question with precise operational context',
       candidates: rows,
       denseDistanceById: new Map([
         [idOf(denseNear), 0.1],
@@ -170,6 +171,31 @@ describe('relevance gate', () => {
     });
 
     expect(result.results).toEqual(rows);
+    expect(result.verdict.dropped).toEqual([]);
+  });
+
+  it('keeps lexical-only hybrid candidates out of A2 after Stage B degradation', async () => {
+    const denseNear = candidate('/kb/dense-near-degraded.md', 0, 0.1, 'near dense result');
+    const lexicalOnly = candidate('/kb/lexical-only-degraded.md', 0, 0.2, 'exact identifier match');
+    const denseFar = candidate('/kb/dense-far-degraded.md', 0, 0.2, 'far dense result');
+    const rows = [denseNear, lexicalOnly, denseFar];
+
+    const result = await applyRelevanceGate({
+      query: 'hybrid lexical-only judge degradation',
+      taskContext: 'please answer an exact identifier question with precise operational context',
+      candidates: rows,
+      denseDistanceById: new Map([
+        [idOf(denseNear), 0.1],
+        [idOf(denseFar), 0.2],
+      ]),
+      lexicalHitIds: new Set([idOf(lexicalOnly)]),
+      config: config({ scoreFloor: 2 }),
+      fetchImpl: fakeFetchJson('not-json'),
+    });
+
+    expect(result.results).toEqual(rows);
+    expect(result.verdict.judge.status).toBe('failed');
+    expect(result.verdict.judge.reason).toContain('degraded to A2');
     expect(result.verdict.dropped).toEqual([]);
   });
 

--- a/src/relevance-gate.test.ts
+++ b/src/relevance-gate.test.ts
@@ -152,6 +152,47 @@ describe('relevance gate', () => {
     expect(result.results).toEqual(knee.slice(0, 2));
   });
 
+  it('keeps lexical-only hybrid candidates out of the dense A2 knee', async () => {
+    const denseNear = candidate('/kb/dense-near.md', 0, 0.1, 'near dense result');
+    const lexicalOnly = candidate('/kb/lexical-only.md', 0, 0.2, 'exact identifier match');
+    const denseFar = candidate('/kb/dense-far.md', 0, 0.2, 'far dense result');
+    const rows = [denseNear, lexicalOnly, denseFar];
+
+    const result = await applyRelevanceGate({
+      query: 'hybrid lexical-only knee',
+      candidates: rows,
+      denseDistanceById: new Map([
+        [idOf(denseNear), 0.1],
+        [idOf(denseFar), 0.2],
+      ]),
+      lexicalHitIds: new Set([idOf(lexicalOnly)]),
+      config: config({ judgeEndpoint: undefined, scoreFloor: 2 }),
+    });
+
+    expect(result.results).toEqual(rows);
+    expect(result.verdict.dropped).toEqual([]);
+  });
+
+  it('keeps lexical-only hybrid candidates outside the dense A1 score floor', async () => {
+    const denseFar = candidate('/kb/dense-far-a1.md', 0, 1.2, 'far dense result');
+    const lexicalOnly = candidate('/kb/lexical-only-a1.md', 0, 0.1, 'exact identifier match');
+
+    const result = await applyRelevanceGate({
+      query: 'hybrid lexical-only score floor',
+      candidates: [denseFar, lexicalOnly],
+      denseDistanceById: new Map([[idOf(denseFar), 1.2]]),
+      lexicalHitIds: new Set([idOf(lexicalOnly)]),
+      config: config({ judgeEndpoint: undefined, scoreFloor: 0.95 }),
+    });
+
+    expect(result.results).toEqual([lexicalOnly]);
+    expect(result.verdict.dropped).toEqual([{
+      id: idOf(denseFar),
+      stage: 'A1-score-floor',
+      reason: 'dense distance 1.2000 > floor 0.95',
+    }]);
+  });
+
   it('keeps the empty verdict disabled by default from the M0 handoff', async () => {
     const rows = [candidate('/kb/a.md', 0, 0.2, 'deployment rollback')];
     const result = await applyRelevanceGate({

--- a/src/relevance-gate.test.ts
+++ b/src/relevance-gate.test.ts
@@ -155,8 +155,9 @@ describe('relevance gate', () => {
   it('keeps lexical-only hybrid candidates out of the dense A2 knee', async () => {
     const denseNear = candidate('/kb/dense-near.md', 0, 0.1, 'near dense result');
     const lexicalOnly = candidate('/kb/lexical-only.md', 0, 0.2, 'exact identifier match');
-    const denseFar = candidate('/kb/dense-far.md', 0, 0.2, 'far dense result');
-    const rows = [denseNear, lexicalOnly, denseFar];
+    const denseMiddle = candidate('/kb/dense-middle.md', 0, 0.2, 'middle dense result');
+    const denseFar = candidate('/kb/dense-far.md', 0, 1.2, 'far dense result');
+    const rows = [denseNear, lexicalOnly, denseMiddle, denseFar];
 
     const result = await applyRelevanceGate({
       query: 'hybrid lexical-only knee',
@@ -164,21 +165,31 @@ describe('relevance gate', () => {
       candidates: rows,
       denseDistanceById: new Map([
         [idOf(denseNear), 0.1],
-        [idOf(denseFar), 0.2],
+        [idOf(denseMiddle), 0.2],
+        [idOf(denseFar), 1.2],
       ]),
       lexicalHitIds: new Set([idOf(lexicalOnly)]),
       config: config({ judgeEndpoint: undefined, scoreFloor: 2 }),
     });
 
-    expect(result.results).toEqual(rows);
-    expect(result.verdict.dropped).toEqual([]);
+    expect(result.results).toEqual([denseNear, lexicalOnly, denseMiddle]);
+    expect(result.verdict.judge).toEqual({
+      status: 'failed',
+      reason: 'KB_GATE_LLM_ENDPOINT unset; degraded to A2',
+    });
+    expect(result.verdict.dropped).toEqual([{
+      id: idOf(denseFar),
+      stage: 'A2-distribution-knee',
+      reason: 'after score-distribution knee',
+    }]);
   });
 
   it('keeps lexical-only hybrid candidates out of A2 after Stage B degradation', async () => {
     const denseNear = candidate('/kb/dense-near-degraded.md', 0, 0.1, 'near dense result');
     const lexicalOnly = candidate('/kb/lexical-only-degraded.md', 0, 0.2, 'exact identifier match');
-    const denseFar = candidate('/kb/dense-far-degraded.md', 0, 0.2, 'far dense result');
-    const rows = [denseNear, lexicalOnly, denseFar];
+    const denseMiddle = candidate('/kb/dense-middle-degraded.md', 0, 0.2, 'middle dense result');
+    const denseFar = candidate('/kb/dense-far-degraded.md', 0, 1.2, 'far dense result');
+    const rows = [denseNear, lexicalOnly, denseMiddle, denseFar];
 
     const result = await applyRelevanceGate({
       query: 'hybrid lexical-only judge degradation',
@@ -186,17 +197,22 @@ describe('relevance gate', () => {
       candidates: rows,
       denseDistanceById: new Map([
         [idOf(denseNear), 0.1],
-        [idOf(denseFar), 0.2],
+        [idOf(denseMiddle), 0.2],
+        [idOf(denseFar), 1.2],
       ]),
       lexicalHitIds: new Set([idOf(lexicalOnly)]),
       config: config({ scoreFloor: 2 }),
       fetchImpl: fakeFetchJson('not-json'),
     });
 
-    expect(result.results).toEqual(rows);
+    expect(result.results).toEqual([denseNear, lexicalOnly, denseMiddle]);
     expect(result.verdict.judge.status).toBe('failed');
     expect(result.verdict.judge.reason).toContain('degraded to A2');
-    expect(result.verdict.dropped).toEqual([]);
+    expect(result.verdict.dropped).toEqual([{
+      id: idOf(denseFar),
+      stage: 'A2-distribution-knee',
+      reason: 'after score-distribution knee',
+    }]);
   });
 
   it('keeps lexical-only hybrid candidates outside the dense A1 score floor', async () => {

--- a/src/relevance-gate.ts
+++ b/src/relevance-gate.ts
@@ -215,7 +215,7 @@ export async function applyRelevanceGate<T extends RelevanceGateCandidate>(
       dropped,
       lexicalHitIds,
     );
-    survivors = applyA2(afterA1, dropped, effectiveInput.denseDistanceById, lexicalHitIds);
+    survivors = applyA2(afterA1, dropped, effectiveInput.denseDistanceById);
     judge = { status: 'skipped', reason: 'task_context absent or too short' };
   } else if (config.judgeEndpoint === undefined) {
     afterA1 = applyA1(
@@ -225,7 +225,7 @@ export async function applyRelevanceGate<T extends RelevanceGateCandidate>(
       dropped,
       lexicalHitIds,
     );
-    survivors = applyA2(afterA1, dropped, effectiveInput.denseDistanceById, lexicalHitIds);
+    survivors = applyA2(afterA1, dropped, effectiveInput.denseDistanceById);
     judge = { status: 'failed', reason: 'KB_GATE_LLM_ENDPOINT unset; degraded to A2' };
   } else {
     // Re-read immediately before the LLM path starts. The synchronous
@@ -263,7 +263,7 @@ export async function applyRelevanceGate<T extends RelevanceGateCandidate>(
       judgePromptHash = judged.judgePromptHash;
       shuffledOrder = judged.shuffledOrder;
       if (judged.degraded) {
-        survivors = applyA2(afterA1, dropped, effectiveInput.denseDistanceById, lexicalHitIds);
+        survivors = applyA2(afterA1, dropped, effectiveInput.denseDistanceById);
       }
     }
   }
@@ -408,18 +408,12 @@ function applyA2<T extends RelevanceGateCandidate>(
   rows: CandidateRow<T>[],
   dropped: DropRecord[],
   denseDistanceById?: ReadonlyMap<string, number>,
-  lexicalHitIds: ReadonlySet<string> = new Set(),
 ): CandidateRow<T>[] {
   if (rows.length <= 1) return rows;
 
-  const lexicalOnlyIds = new Set(
-    rows
-      .filter((row) => isLexicalOnlyRow(row, denseDistanceById, lexicalHitIds))
-      .map((row) => row.id),
-  );
   const scoredRows = denseDistanceById === undefined
     ? rows
-    : rows.filter((row) => denseDistanceById.has(row.id) && !lexicalOnlyIds.has(row.id));
+    : rows.filter((row) => denseDistanceById.has(row.id));
 
   // A2's knee detector is defined over L2 distances. In hybrid mode, rows
   // without a dense distance are lexical-only (or otherwise unscored) and

--- a/src/relevance-gate.ts
+++ b/src/relevance-gate.ts
@@ -208,12 +208,24 @@ export async function applyRelevanceGate<T extends RelevanceGateCandidate>(
     survivors = [];
     judge = { status: 'skipped', reason: 'all candidates excluded by no_llm_context policy' };
   } else if (!hasTaskSignal(taskContext, config.minTaskContextTokens)) {
-    afterA1 = applyA1(gateRows, effectiveInput.denseDistanceById, config.scoreFloor, dropped);
-    survivors = applyA2(afterA1, dropped, effectiveInput.denseDistanceById);
+    afterA1 = applyA1(
+      gateRows,
+      effectiveInput.denseDistanceById,
+      config.scoreFloor,
+      dropped,
+      lexicalHitIds,
+    );
+    survivors = applyA2(afterA1, dropped, effectiveInput.denseDistanceById, lexicalHitIds);
     judge = { status: 'skipped', reason: 'task_context absent or too short' };
   } else if (config.judgeEndpoint === undefined) {
-    afterA1 = applyA1(gateRows, effectiveInput.denseDistanceById, config.scoreFloor, dropped);
-    survivors = applyA2(afterA1, dropped, effectiveInput.denseDistanceById);
+    afterA1 = applyA1(
+      gateRows,
+      effectiveInput.denseDistanceById,
+      config.scoreFloor,
+      dropped,
+      lexicalHitIds,
+    );
+    survivors = applyA2(afterA1, dropped, effectiveInput.denseDistanceById, lexicalHitIds);
     judge = { status: 'failed', reason: 'KB_GATE_LLM_ENDPOINT unset; degraded to A2' };
   } else {
     // Re-read immediately before the LLM path starts. The synchronous
@@ -222,7 +234,13 @@ export async function applyRelevanceGate<T extends RelevanceGateCandidate>(
     effectiveInput.candidates = await hydrateSensitivityPoliciesFromSource(effectiveInput.candidates);
     ({ rows, policyExcludedRows, gateRows, lexicalHitIds } = partitionCandidates(effectiveInput));
     cacheKey = buildCacheKey(effectiveInput, config, lexicalHitIds);
-    afterA1 = applyA1(gateRows, effectiveInput.denseDistanceById, config.scoreFloor, dropped);
+    afterA1 = applyA1(
+      gateRows,
+      effectiveInput.denseDistanceById,
+      config.scoreFloor,
+      dropped,
+      lexicalHitIds,
+    );
     if (gateRows.length === 0) {
       survivors = [];
       judge = { status: 'skipped', reason: 'all candidates excluded by no_llm_context policy' };
@@ -245,7 +263,7 @@ export async function applyRelevanceGate<T extends RelevanceGateCandidate>(
       judgePromptHash = judged.judgePromptHash;
       shuffledOrder = judged.shuffledOrder;
       if (judged.degraded) {
-        survivors = applyA2(afterA1, dropped, effectiveInput.denseDistanceById);
+        survivors = applyA2(afterA1, dropped, effectiveInput.denseDistanceById, lexicalHitIds);
       }
     }
   }
@@ -348,10 +366,17 @@ function applyA1<T extends RelevanceGateCandidate>(
   denseDistanceById: ReadonlyMap<string, number> | undefined,
   scoreFloor: number,
   dropped: DropRecord[],
+  lexicalHitIds: ReadonlySet<string>,
 ): CandidateRow<T>[] {
   const survivors: CandidateRow<T>[] = [];
   const stageDrops: DropRecord[] = [];
   for (const row of rows) {
+    if (isLexicalOnlyRow(row, denseDistanceById, lexicalHitIds)) {
+      // A lexical-only hit has no L2 distance. Keep it as independent lexical
+      // evidence instead of silently treating its fused rank as a distance.
+      survivors.push(row);
+      continue;
+    }
     const distance = denseDistanceById?.get(row.id);
     if (distance === undefined) {
       survivors.push(row);
@@ -383,16 +408,32 @@ function applyA2<T extends RelevanceGateCandidate>(
   rows: CandidateRow<T>[],
   dropped: DropRecord[],
   denseDistanceById?: ReadonlyMap<string, number>,
+  lexicalHitIds: ReadonlySet<string> = new Set(),
 ): CandidateRow<T>[] {
   if (rows.length <= 1) return rows;
-  const scored = rows.map((row) => ({
+
+  const lexicalOnlyIds = new Set(
+    rows
+      .filter((row) => isLexicalOnlyRow(row, denseDistanceById, lexicalHitIds))
+      .map((row) => row.id),
+  );
+  const scoredRows = denseDistanceById === undefined
+    ? rows
+    : rows.filter((row) => denseDistanceById.has(row.id) && !lexicalOnlyIds.has(row.id));
+
+  // A2's knee detector is defined over L2 distances. In hybrid mode, rows
+  // without a dense distance are lexical-only (or otherwise unscored) and
+  // must not distort that distribution with their fused-array position.
+  if (scoredRows.length <= 1) return rows;
+
+  const scored = scoredRows.map((row) => ({
     row,
     score:
       denseDistanceById === undefined
         ? typeof row.result.score === 'number'
           ? row.result.score
           : row.originalIndex
-        : denseDistanceById.get(row.id) ?? row.originalIndex,
+        : denseDistanceById.get(row.id)!,
   }));
   scored.sort((a, b) => a.score - b.score);
   const decision = computeAutoThreshold(scored.map((entry) => entry.score));
@@ -406,7 +447,20 @@ function applyA2<T extends RelevanceGateCandidate>(
       });
     }
   }
-  return rows.filter((row) => keepIds.has(row.id));
+  if (denseDistanceById === undefined) {
+    return rows.filter((row) => keepIds.has(row.id));
+  }
+  return rows.filter((row) => !denseDistanceById.has(row.id) || keepIds.has(row.id));
+}
+
+function isLexicalOnlyRow<T extends RelevanceGateCandidate>(
+  row: CandidateRow<T>,
+  denseDistanceById: ReadonlyMap<string, number> | undefined,
+  lexicalHitIds: ReadonlySet<string>,
+): boolean {
+  return denseDistanceById !== undefined
+    && lexicalHitIds.has(row.id)
+    && !denseDistanceById.has(row.id);
 }
 
 async function applyStageB<T extends RelevanceGateCandidate>(input: {


### PR DESCRIPTION
<!--
Work every checklist row carrying a `kookr:check:*` marker. Checked rows
record completed work; struck rows record a concrete N/A reason.
-->

## Summary

- Preserve hybrid lexical-only candidates as independent evidence through Stage A1 and A2.
- Compute the A2 knee only from candidates with recorded dense L2 distances; never use fused-array position as a distance.
- Add regression coverage for endpoint-unset, Stage-B-degraded, and A1 score-floor paths.
- Document FR-GATE-852 / TS-GATE-852 and update RFC 018 failure-mode guidance.

Fixes #852

## Testing

- [x] `npm test` passes — 204/204 parallel suites and 11 serial suites passed.
- ~~[ ] End-to-end verified for tool/transport changes (see `CLAUDE.md`).~~ — N/A: internal relevance-gate behavior; no tool or transport surface changed.
- [x] Benchmark/evaluation evidence — `kb eval-gate docs/testing/fixtures/rfc-018-gate-eval/queries.yml --dry-run --format=json` completed all 15 simulation cases; the existing fixture baseline remains `directional_pass: false`.
- [x] <!-- kookr:check:tests --> Tests were added or updated for changed behavior; bug fixes include a regression test. Focused gate suite: 31 passed.

## Documentation contract

- [ ] ~~<!-- kookr:check:readme --> `README.md` reflects user-visible CLI, MCP, installation, or configuration changes~~ — N/A: no CLI, MCP, installation, or configuration surface changed.
- [x] <!-- kookr:check:docs --> Relevant retrieval documentation under `docs/` is consistent with the implementation; requirements, testing catalog, and RFC 018 were updated.
- [x] <!-- kookr:check:mbse --> RFCs are updated when this PR implements, supersedes, or changes an accepted design; RFC 018 now records the partial dense-distance contract.

## Changelog

- [ ] ~~<!-- kookr:check:changelog --> `CHANGELOG.md` has an `Unreleased` entry for user-visible changes~~ — N/A: this repository has no `CHANGELOG.md`; the behavior contract is recorded in the requirements catalog and RFC 018.

## Retrieval and performance evidence

- [ ] ~~<!-- kookr:check:benchmarks --> Retrieval-quality or performance changes include the relevant benchmark/evaluation evidence, or this row is waived with a reason~~ — N/A: no benchmark fixture or benchmark code changed; the existing 15-case RFC 018 eval-gate simulation was run and its baseline is recorded above.

## Follow-ups

None.
