### PR TITLE
fix: protect pending sidecar recovery from live writers (#851)

### DIFF
--- a/docs/architecture/data-model.md
+++ b/docs/architecture/data-model.md
@@ -78,12 +78,13 @@ The path structure mirrors the source tree under `<kb>/`: a file at `<kb>/a/b/c.
 
 | Field | Type | Meaning |
 | --- | --- | --- |
-| `schema_version` | `kb.pending-sidecar-commit.v1` | Parser guard. |
+| `schema_version` | `kb.pending-sidecar-commit.v1` or `kb.pending-sidecar-commit.v2` | Parser guard; writers use v2 and readers retain v1 compatibility. |
+| `owner` | `{pid, hostname, started_at}` (v2) | Identifies the writer that owns an in-progress save; absent on legacy v1 manifests. |
 | `phase` | `save-started` or `save-complete` | Whether the FAISS save has been confirmed. |
 | `pending_hash_writes` | array of `{path, hash}` | Absolute hash sidecar paths plus source sha256. |
 | `pending_chunk_manifest_writes` | array of `{path, manifest}` | Absolute chunk-manifest sidecar paths plus manifest JSON. |
 
-Normal completion removes the manifest after all sidecars are durable. On startup, `save-complete` rolls forward by writing the sidecars and removing the manifest. `save-started` is intentionally conservative: recovery purges the persisted store and stale sidecars so the next update rebuilds instead of risking duplicate vectors or hashes for missing vectors.
+Normal completion removes the manifest after all sidecars are durable. On startup, recovery runs under the model write lock. `save-complete` rolls forward by writing the sidecars and removing the manifest. A v2 `save-started` manifest with a live owner on the same host is left intact while that writer finishes; ownerless, malformed, dead, or foreign-host manifests are treated conservatively and purge the persisted store and stale sidecars so the next update rebuilds instead of risking duplicate vectors or hashes for missing vectors.
 
 ### Model registry
 

--- a/docs/architecture/state-index.md
+++ b/docs/architecture/state-index.md
@@ -24,7 +24,8 @@ stateDiagram-v2
   Initializing --> Failed: provider/config/load failure
 
   Recovering --> Loaded: save-complete manifest rolls sidecars forward
-  Recovering --> Empty: save-started manifest purges ambiguous store
+  Recovering --> Loaded: live same-host owner preserves store while writer finishes
+  Recovering --> Empty: ownerless/dead/foreign save-started manifest purges ambiguous store
 
   Empty --> Building: updateIndex() finds ingestable chunks
   Loaded --> Updating: updateIndex() finds append-safe changed chunks
@@ -51,7 +52,9 @@ stateDiagram-v2
 | `Constructed -> Initializing` | `initialize()` creates the embedding client and model directory as needed. | `src/FaissIndexManager.ts` |
 | `Initializing -> Loaded` | `loadFaissStoreAtomic` loads `index -> index.vN/` or legacy `faiss.index/`. | `src/faiss-store-layout.ts` |
 | `Initializing -> Empty` | No persisted store exists for the model. | `src/FaissIndexManager.ts` |
-| `Initializing -> Recovering` | Pending sidecar commit manifest exists. | `src/pending-sidecar-commit.ts` |
+| `Initializing -> Recovering` | Pending sidecar commit manifest exists; recovery takes the model write lock. | `src/pending-sidecar-commit.ts`, `src/FaissIndexManager.ts` |
+| `Recovering -> Loaded` | A live v2 owner on the same host still owns a `save-started` manifest, so recovery leaves the store and manifest intact. | `src/pending-sidecar-commit.ts`, `src/FaissIndexManager.ts` |
+| `Recovering -> Empty` | A legacy/ownerless, malformed, dead, or foreign-host `save-started` manifest is ambiguous, so recovery purges the store and stale sidecars. | `src/FaissIndexManager.ts` |
 | `Empty -> Building` | First refresh finds chunks for a model with no loaded index. | `src/FaissIndexManager.ts` |
 | `Loaded -> Updating` | Changed files can be appended without deleting stale vectors. | `src/file-ingest.ts`, `src/FaissIndexManager.ts` |
 | `Loaded -> Rebuilding` | Force reindex, stale freshness manifest, missing chunk manifest, or chunk drift that cannot be append-only. | `src/FaissIndexManager.ts`, `src/freshness-manifest.ts` |

--- a/src/FaissIndexManager.test.ts
+++ b/src/FaissIndexManager.test.ts
@@ -891,10 +891,18 @@ describe('FaissIndexManager permission handling', () => {
     const manifest = JSON.parse(
       await fsp.readFile(pendingManifestPathIn(process.env.FAISS_INDEX_PATH!), 'utf-8'),
     ) as {
+      schema_version: string;
+      owner: { pid: number; hostname: string; started_at: string };
       phase: string;
       pending_hash_writes: Array<{ path: string; hash: string }>;
       pending_chunk_manifest_writes: Array<{ path: string; manifest: { source_sha256: string } }>;
     };
+    expect(manifest.schema_version).toBe('kb.pending-sidecar-commit.v2');
+    expect(manifest.owner).toMatchObject({
+      pid: process.pid,
+      hostname: os.hostname(),
+      started_at: expect.any(String),
+    });
     expect(manifest.phase).toBe('save-complete');
     expect(manifest.pending_hash_writes).toEqual([{ path: sidecarPath, hash: sourceHash }]);
     expect(manifest.pending_chunk_manifest_writes).toEqual([
@@ -943,6 +951,161 @@ describe('FaissIndexManager permission handling', () => {
     await expect(fsp.stat(path.join(defaultKb, '.index')))
       .rejects.toMatchObject({ code: 'ENOENT' });
     await expect(fsp.stat(pendingManifestPathIn(faissDir)))
+      .rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('leaves a save-started manifest intact while its same-host owner is alive', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-faiss-pending-live-owner-'));
+    const kbDir = path.join(tempDir, 'kb');
+    const defaultKb = path.join(kbDir, 'default');
+    await fsp.mkdir(path.join(defaultKb, '.index'), { recursive: true });
+    const sidecarPath = path.join(defaultKb, '.index', 'doc.md');
+    await fsp.writeFile(sidecarPath, 'b'.repeat(64));
+
+    const faissDir = path.join(tempDir, '.faiss');
+    process.env.KNOWLEDGE_BASES_ROOT_DIR = kbDir;
+    process.env.FAISS_INDEX_PATH = faissDir;
+    process.env.EMBEDDING_PROVIDER = 'huggingface';
+    process.env.HUGGINGFACE_API_KEY = 'test-key';
+
+    await seedVersionedIndex(faissDir);
+    await fsp.writeFile(
+      pendingManifestPathIn(faissDir),
+      JSON.stringify({
+        schema_version: 'kb.pending-sidecar-commit.v2',
+        owner: {
+          pid: process.pid,
+          hostname: os.hostname(),
+          started_at: new Date().toISOString(),
+        },
+        phase: 'save-started',
+        pending_hash_writes: [{ path: sidecarPath, hash: 'c'.repeat(64) }],
+        pending_chunk_manifest_writes: [],
+      }),
+      'utf-8',
+    );
+
+    jest.resetModules();
+    const { FaissIndexManager } = await import('./FaissIndexManager.js');
+    const manager = new FaissIndexManager();
+    await manager.initialize();
+
+    await expect(fsp.stat(path.join(modelDirIn(faissDir), 'index'))).resolves.toBeTruthy();
+    await expect(fsp.stat(versionedIndexPathIn(faissDir))).resolves.toBeTruthy();
+    await expect(fsp.readFile(sidecarPath, 'utf-8')).resolves.toBe('b'.repeat(64));
+    await expect(fsp.stat(pendingManifestPathIn(faissDir))).resolves.toBeTruthy();
+    expect(loadMock).toHaveBeenCalledWith(versionedIndexPathIn(faissDir), expect.anything());
+  });
+
+  it('purges a save-started manifest owned by a foreign host', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-faiss-pending-foreign-owner-'));
+    const kbDir = path.join(tempDir, 'kb');
+    const defaultKb = path.join(kbDir, 'default');
+    await fsp.mkdir(path.join(defaultKb, '.index'), { recursive: true });
+    const sidecarPath = path.join(defaultKb, '.index', 'doc.md');
+    await fsp.writeFile(sidecarPath, 'b'.repeat(64));
+
+    const faissDir = path.join(tempDir, '.faiss');
+    process.env.KNOWLEDGE_BASES_ROOT_DIR = kbDir;
+    process.env.FAISS_INDEX_PATH = faissDir;
+    process.env.EMBEDDING_PROVIDER = 'huggingface';
+    process.env.HUGGINGFACE_API_KEY = 'test-key';
+
+    await seedVersionedIndex(faissDir);
+    await fsp.writeFile(
+      pendingManifestPathIn(faissDir),
+      JSON.stringify({
+        schema_version: 'kb.pending-sidecar-commit.v2',
+        owner: {
+          pid: process.pid,
+          hostname: `${os.hostname()}-foreign`,
+          started_at: new Date().toISOString(),
+        },
+        phase: 'save-started',
+        pending_hash_writes: [{ path: sidecarPath, hash: 'c'.repeat(64) }],
+        pending_chunk_manifest_writes: [],
+      }),
+      'utf-8',
+    );
+
+    jest.resetModules();
+    const { FaissIndexManager } = await import('./FaissIndexManager.js');
+    const manager = new FaissIndexManager();
+    await manager.initialize();
+
+    await expect(fsp.stat(path.join(modelDirIn(faissDir), 'index')))
+      .rejects.toMatchObject({ code: 'ENOENT' });
+    await expect(fsp.stat(versionedIndexPathIn(faissDir)))
+      .rejects.toMatchObject({ code: 'ENOENT' });
+    await expect(fsp.stat(path.join(defaultKb, '.index')))
+      .rejects.toMatchObject({ code: 'ENOENT' });
+    await expect(fsp.stat(pendingManifestPathIn(faissDir)))
+      .rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('waits for a slow writer before initializing another manager (#851)', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-faiss-pending-slow-save-'));
+    const kbDir = path.join(tempDir, 'kb');
+    const defaultKb = path.join(kbDir, 'default');
+    await fsp.mkdir(defaultKb, { recursive: true });
+    const docPath = path.join(defaultKb, 'doc.md');
+    await fsp.writeFile(docPath, '# Title\n\nInitial content.');
+
+    process.env.KNOWLEDGE_BASES_ROOT_DIR = kbDir;
+    process.env.FAISS_INDEX_PATH = path.join(tempDir, '.faiss');
+    process.env.EMBEDDING_PROVIDER = 'huggingface';
+    process.env.HUGGINGFACE_API_KEY = 'test-key';
+
+    jest.resetModules();
+    const { FaissIndexManager } = await import('./FaissIndexManager.js');
+    const { withWriteLock } = await import('./write-lock.js');
+    const writer = new FaissIndexManager();
+    await writer.initialize();
+    await withWriteLock(writer.modelDir, () => writer.updateIndex());
+
+    await fsp.writeFile(docPath, '# Title\n\nUpdated content while saving.');
+    let resolveSaveStarted!: () => void;
+    const saveStarted = new Promise<void>((resolve) => {
+      resolveSaveStarted = resolve;
+    });
+    let releaseSave!: () => void;
+    const saveReleased = new Promise<void>((resolve) => {
+      releaseSave = resolve;
+    });
+    saveMock.mockImplementation(async () => {
+      resolveSaveStarted();
+      await saveReleased;
+    });
+
+    const writerUpdate = withWriteLock(writer.modelDir, () => writer.updateIndex());
+    await saveStarted;
+
+    const pendingManifest = JSON.parse(
+      await fsp.readFile(pendingManifestPathIn(process.env.FAISS_INDEX_PATH!), 'utf-8'),
+    ) as { phase: string; owner: { pid: number; hostname: string } };
+    expect(pendingManifest).toMatchObject({
+      phase: 'save-started',
+      owner: { pid: process.pid, hostname: os.hostname() },
+    });
+
+    const reader = new FaissIndexManager();
+    let writerReleased = false;
+    let loadedBeforeWriterRelease = false;
+    loadMock.mockImplementation(() => {
+      loadedBeforeWriterRelease ||= !writerReleased;
+    });
+    const readerInitialization = reader.initialize();
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(loadedBeforeWriterRelease).toBe(false);
+
+    writerReleased = true;
+    releaseSave();
+    await writerUpdate;
+    await readerInitialization;
+
+    await expect(fsp.readFile(path.join(defaultKb, '.index', 'doc.md'), 'utf-8'))
+      .resolves.toBe(sha256Hex('# Title\n\nUpdated content while saving.'));
+    await expect(fsp.stat(pendingManifestPathIn(process.env.FAISS_INDEX_PATH!)))
       .rejects.toMatchObject({ code: 'ENOENT' });
   });
 

--- a/src/FaissIndexManager.ts
+++ b/src/FaissIndexManager.ts
@@ -5,7 +5,7 @@ import type { EmbeddingsInterface } from '@langchain/core/embeddings';
 import { Document } from "@langchain/core/documents";
 import { emitCanonicalLog, type CanonicalProcess } from './canonical-log.js';
 import { createEmbeddingsClient, type EmbeddingsClient } from './embedding-provider.js';
-import { handleFsOperationError, toError } from './error-utils.js';
+import { handleFsOperationError, isPermissionError, toError } from './error-utils.js';
 import { calculateSHA256, pathExists } from './file-utils.js';
 import {
   buildChunkManifest,
@@ -71,6 +71,8 @@ import {
 } from './freshness-manifest.js';
 import {
   clearPendingSidecarCommitManifest,
+  createPendingSidecarCommitOwner,
+  isPendingSidecarCommitOwnerAlive,
   readPendingSidecarCommitManifest,
   writePendingSidecarCommitManifest,
 } from './pending-sidecar-commit.js';
@@ -97,7 +99,7 @@ import {
   type MetadataSidecarRow,
 } from './metadata-sidecar.js';
 import { queryEmbeddingCache, type QueryCacheLookupStatus, type QueryCacheTelemetry } from './query-cache.js';
-import { withSidecarLock } from './write-lock.js';
+import { withSidecarLock, withWriteLock } from './write-lock.js';
 import { FaissStoreAdapter, type EmbeddedDocumentsBatch } from './faiss-store-adapter.js';
 import { HnswIndexAdapter } from './hnsw-index-adapter.js';
 import type { SearchIndexAdapter } from './search-index-adapter.js';
@@ -746,7 +748,14 @@ export class FaissIndexManager {
         }
       }
       if (!readOnly) {
-        await this.recoverPendingSidecarCommit();
+        try {
+          await withWriteLock(this.modelDir, () => this.recoverPendingSidecarCommit());
+        } catch (error) {
+          if (isPermissionError(error)) {
+            handleFsOperationError('acquire the FAISS model write lock in', this.modelDir, error);
+          }
+          throw error;
+        }
       }
       // RFC 013: no model-switch wipe at initialize time. Each model has its
       // own dir; a different provider+model goes to a different `models/<id>/`.
@@ -996,6 +1005,14 @@ export class FaissIndexManager {
     if (pending === null) return;
 
     if (pending.phase === 'save-started') {
+      if (pending.owner !== undefined && isPendingSidecarCommitOwnerAlive(pending.owner)) {
+        logger.warn(
+          `Pending sidecar commit for model ${this.modelId} is still owned by ` +
+            `a live writer on ${pending.owner.hostname} (pid=${pending.owner.pid}); ` +
+            `leaving the manifest and persisted store intact until that writer finishes.`,
+        );
+        return;
+      }
       logger.warn(
         `Pending sidecar commit for model ${this.modelId} was interrupted before ` +
           `the FAISS save was confirmed. Removing the persisted store and stale ` +
@@ -2435,6 +2452,9 @@ export class FaissIndexManager {
         const shouldPersistPendingSidecarCommit =
           indexMutated &&
           (pendingHashWrites.length > 0 || pendingChunkManifestWrites.length > 0);
+        const pendingSidecarCommitOwner = shouldPersistPendingSidecarCommit
+          ? createPendingSidecarCommitOwner()
+          : undefined;
         if (indexMutated) {
           let faissStoreCommitted = false;
           try {
@@ -2452,18 +2472,25 @@ export class FaissIndexManager {
                 phase: 'save-started',
                 pendingHashWrites,
                 pendingChunkManifestWrites,
+                owner: pendingSidecarCommitOwner,
               });
             }
             await this.atomicSave({
               onCommitted: shouldPersistPendingSidecarCommit
                 ? async () => {
-                    faissStoreCommitted = true;
+                    // The save-started marker remains ambiguous until the
+                    // save-complete marker is durable. If this write fails
+                    // after the symlink swap, the finally block must clear
+                    // the live-owner marker instead of leaving recovery to
+                    // mistake a failed save for an active writer.
                     await writePendingSidecarCommitManifest({
                       modelDir: this.modelDir,
                       phase: 'save-complete',
                       pendingHashWrites,
                       pendingChunkManifestWrites,
+                      owner: pendingSidecarCommitOwner,
                     });
+                    faissStoreCommitted = true;
                   }
                 : undefined,
             });

--- a/src/pending-sidecar-commit.ts
+++ b/src/pending-sidecar-commit.ts
@@ -1,4 +1,5 @@
 import * as fsp from 'fs/promises';
+import * as os from 'os';
 import * as path from 'path';
 import {
   isChunkManifest,
@@ -6,14 +7,26 @@ import {
   type PendingChunkManifestWrite,
   type PendingSidecarWrite,
 } from './file-ingest.js';
+import { isPidAlive } from './process-liveness.js';
 
 export const PENDING_SIDECAR_COMMIT_FILENAME = 'pending-manifest.json';
-export const PENDING_SIDECAR_COMMIT_SCHEMA_VERSION = 'kb.pending-sidecar-commit.v1';
+export const PENDING_SIDECAR_COMMIT_LEGACY_SCHEMA_VERSION = 'kb.pending-sidecar-commit.v1';
+export const PENDING_SIDECAR_COMMIT_SCHEMA_VERSION = 'kb.pending-sidecar-commit.v2';
 
 export type PendingSidecarCommitPhase = 'save-started' | 'save-complete';
 
+export interface PendingSidecarCommitOwner {
+  pid: number;
+  hostname: string;
+  started_at: string;
+}
+
 export interface PendingSidecarCommitManifest {
-  schema_version: typeof PENDING_SIDECAR_COMMIT_SCHEMA_VERSION;
+  schema_version:
+    | typeof PENDING_SIDECAR_COMMIT_LEGACY_SCHEMA_VERSION
+    | typeof PENDING_SIDECAR_COMMIT_SCHEMA_VERSION;
+  /** Absent on v1 manifests written by older builds. */
+  owner?: PendingSidecarCommitOwner;
   phase: PendingSidecarCommitPhase;
   pending_hash_writes: PendingSidecarWrite[];
   pending_chunk_manifest_writes: PendingChunkManifestWrite[];
@@ -54,6 +67,18 @@ function parsePhase(value: unknown): PendingSidecarCommitPhase | null {
   return null;
 }
 
+function parseOwner(value: unknown): PendingSidecarCommitOwner | null {
+  if (!isRecord(value)) return null;
+  if (!Number.isInteger(value.pid) || (value.pid as number) <= 0) return null;
+  if (typeof value.hostname !== 'string' || value.hostname.length === 0) return null;
+  if (typeof value.started_at !== 'string' || value.started_at.length === 0) return null;
+  return {
+    pid: value.pid as number,
+    hostname: value.hostname,
+    started_at: value.started_at,
+  };
+}
+
 export function pendingSidecarCommitManifestPath(modelDir: string): string {
   return path.join(modelDir, PENDING_SIDECAR_COMMIT_FILENAME);
 }
@@ -78,7 +103,9 @@ export async function readPendingSidecarCommitManifest(
     return null;
   }
   if (!isRecord(parsed)) return null;
-  if (parsed.schema_version !== PENDING_SIDECAR_COMMIT_SCHEMA_VERSION) return null;
+  const isLegacySchema = parsed.schema_version === PENDING_SIDECAR_COMMIT_LEGACY_SCHEMA_VERSION;
+  const isCurrentSchema = parsed.schema_version === PENDING_SIDECAR_COMMIT_SCHEMA_VERSION;
+  if (!isLegacySchema && !isCurrentSchema) return null;
   const phase = parsePhase(parsed.phase);
   if (phase === null) return null;
   if (!Array.isArray(parsed.pending_hash_writes)) return null;
@@ -94,12 +121,31 @@ export async function readPendingSidecarCommitManifest(
     return null;
   }
 
+  const owner = isCurrentSchema ? parseOwner(parsed.owner) ?? undefined : undefined;
+  const schemaVersion = isLegacySchema
+    ? PENDING_SIDECAR_COMMIT_LEGACY_SCHEMA_VERSION
+    : PENDING_SIDECAR_COMMIT_SCHEMA_VERSION;
   return {
-    schema_version: PENDING_SIDECAR_COMMIT_SCHEMA_VERSION,
+    schema_version: schemaVersion,
+    ...(owner === undefined ? {} : { owner }),
     phase,
     pending_hash_writes: pendingHashWrites as PendingSidecarWrite[],
     pending_chunk_manifest_writes: pendingChunkManifestWrites as PendingChunkManifestWrite[],
   };
+}
+
+export function createPendingSidecarCommitOwner(): PendingSidecarCommitOwner {
+  return {
+    pid: process.pid,
+    hostname: os.hostname(),
+    started_at: new Date().toISOString(),
+  };
+}
+
+export function isPendingSidecarCommitOwnerAlive(
+  owner: PendingSidecarCommitOwner,
+): boolean {
+  return owner.hostname === os.hostname() && isPidAlive(owner.pid);
 }
 
 export async function writePendingSidecarCommitManifest(options: {
@@ -107,12 +153,14 @@ export async function writePendingSidecarCommitManifest(options: {
   phase: PendingSidecarCommitPhase;
   pendingHashWrites: ReadonlyArray<PendingSidecarWrite>;
   pendingChunkManifestWrites: ReadonlyArray<PendingChunkManifestWrite>;
+  owner?: PendingSidecarCommitOwner;
 }): Promise<void> {
   const {
     modelDir,
     phase,
     pendingHashWrites,
     pendingChunkManifestWrites,
+    owner = createPendingSidecarCommitOwner(),
   } = options;
   await fsp.mkdir(modelDir, { recursive: true });
   const manifestPath = pendingSidecarCommitManifestPath(modelDir);
@@ -122,6 +170,7 @@ export async function writePendingSidecarCommitManifest(options: {
   );
   const payload: PendingSidecarCommitManifest = {
     schema_version: PENDING_SIDECAR_COMMIT_SCHEMA_VERSION,
+    owner,
     phase,
     pending_hash_writes: pendingHashWrites.map((entry) => ({ ...entry })),
     pending_chunk_manifest_writes: pendingChunkManifestWrites.map((entry) => ({

--- a/src/process-liveness.test.ts
+++ b/src/process-liveness.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from '@jest/globals';
+import { isPidAlive } from './process-liveness.js';
+
+describe('isPidAlive', () => {
+  it('recognizes the current process as alive', () => {
+    expect(isPidAlive(process.pid)).toBe(true);
+  });
+
+  it('rejects invalid and definitely absent process ids', () => {
+    expect(isPidAlive(0)).toBe(false);
+    expect(isPidAlive(-1)).toBe(false);
+    expect(isPidAlive(4_294_967_295)).toBe(false);
+  });
+});

--- a/src/process-liveness.ts
+++ b/src/process-liveness.ts
@@ -1,0 +1,17 @@
+/**
+ * Returns whether a process id currently refers to a live process.
+ *
+ * `process.kill(pid, 0)` probes liveness without delivering a signal. An
+ * EPERM result still means that the process exists, even when this process
+ * cannot signal it.
+ */
+export function isPidAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    return code === 'EPERM';
+  }
+}

--- a/src/reindex-runner.test.ts
+++ b/src/reindex-runner.test.ts
@@ -410,6 +410,31 @@ describe('cache-aware reindex estimate (#408)', () => {
 // ---------------------------------------------------------------------------
 
 describe('.reindex.run.json + PID liveness', () => {
+  it('holds the model write lock while updating the manager', async () => {
+    const modelDir = path.join(tempDir, 'faiss', 'models', 'test-model');
+    let lockedDuringUpdate = false;
+    const manager = {
+      modelDir,
+      updateIndex: async () => {
+        lockedDuringUpdate = await fsp
+          .stat(path.join(modelDir, '.kb-write.lock'))
+          .then(() => true)
+          .catch(() => false);
+      },
+      getLastIndexUpdateSummary: () => makeNeverRunSummary(),
+    } as unknown as import('./FaissIndexManager.js').FaissIndexManager;
+
+    const result = await runner.runReindex({
+      knowledgeBases: [],
+      force: true,
+      resolveKbs: async () => ['alpha'],
+      manager,
+    });
+
+    expect(result.outcome).toBe('completed');
+    expect(lockedDuringUpdate).toBe(true);
+  });
+
   it('writes the run-state file during a run and removes it on success', async () => {
     let stateAtMidRun: unknown = null;
     const result = await runner.runReindex({

--- a/src/reindex-runner.ts
+++ b/src/reindex-runner.ts
@@ -23,12 +23,10 @@
 //     only while the contextual-preface estimate still has cold chunks.
 //  6. Delete `.reindex.run.json` on success or failure.
 //
-// What this file does NOT do:
-//  - Acquire the per-model write lock directly. `updateIndex` already
-//    acquires `withWriteLock(modelDir, ...)` internally per RFC 013.
-//    M0b's pre-flight check via `.reindex.run.json` is the *cooperative*
-//    coordination signal for the trigger watcher; the strict
-//    serialization remains the same lock the watcher already respects.
+// The manager initialization and update are both serialized under the
+// per-model write lock. The `.reindex.run.json` file remains the
+// *cooperative* coordination signal for the trigger watcher, while the lock
+// is the strict serialization boundary for every writer.
 
 import * as fsp from 'fs/promises';
 import * as path from 'path';
@@ -52,6 +50,10 @@ import { writeFileAtomicDurable } from './file-utils.js';
 import { listKnowledgeBases } from './kb-fs.js';
 import { logger } from './logger.js';
 import { readLlmContextPolicy } from './sensitivity-policy.js';
+import { isPidAlive } from './process-liveness.js';
+import { withWriteLock } from './write-lock.js';
+
+export { isPidAlive } from './process-liveness.js';
 
 // RFC 017 §5 step 1 — cold-case per-chunk cost upper bound. Used by the
 // self-runtime estimator. Tuned to 8s based on cold KV-cache miss
@@ -247,22 +249,6 @@ async function deleteRunState(): Promise<void> {
     if (code !== 'ENOENT' && code !== 'ENOTDIR') {
       logger.warn(`RFC 017 M0b: failed to remove run-state file: ${(err as Error).message}`);
     }
-  }
-}
-
-export function isPidAlive(pid: number): boolean {
-  if (!Number.isInteger(pid) || pid <= 0) return false;
-  try {
-    // `process.kill(pid, 0)` does not deliver a signal — it returns
-    // normally if the PID exists and the caller may signal it, throws
-    // ESRCH if absent.
-    process.kill(pid, 0);
-    return true;
-  } catch (err) {
-    const code = (err as NodeJS.ErrnoException).code;
-    // EPERM means the process exists but we don't have permission to
-    // signal it (e.g. owned by another user). Still alive.
-    return code === 'EPERM';
   }
 }
 
@@ -576,7 +562,9 @@ export async function runReindex(options: ReindexOptions): Promise<ReindexResult
       summary = await options.runUpdateIndex({ force: shouldForceRebuild });
     } else {
       const manager = options.manager ?? (await createManagerForReindex());
-      summary = await runManagerUpdateIndex(manager, { force: shouldForceRebuild });
+      summary = await withWriteLock(manager.modelDir, () =>
+        runManagerUpdateIndex(manager, { force: shouldForceRebuild }),
+      );
     }
   } catch (err) {
     await deleteRunState();

--- a/src/write-lock.test.ts
+++ b/src/write-lock.test.ts
@@ -85,6 +85,28 @@ describe('withWriteLock', () => {
     expect(events).toEqual(['slow:start', 'slow:end', 'fast:start', 'fast:end']);
   });
 
+  it('allows nested acquisition for a resource held by the same async flow', async () => {
+    jest.resetModules();
+    const { withWriteLock, writeLockOwnerPathFor, writeLockPathFor } = await import('./write-lock.js');
+    const events: string[] = [];
+
+    await withWriteLock(tempDir, async () => {
+      events.push('outer:start');
+      await withWriteLock(tempDir, async () => {
+        await expect(fsp.stat(writeLockPathFor(tempDir))).resolves.toBeTruthy();
+        const owner = JSON.parse(
+          await fsp.readFile(writeLockOwnerPathFor(tempDir), 'utf-8'),
+        ) as { pid: number };
+        expect(owner.pid).toBe(process.pid);
+        events.push('inner');
+      });
+      await expect(fsp.stat(writeLockPathFor(tempDir))).resolves.toBeTruthy();
+      events.push('outer:end');
+    });
+
+    expect(events).toEqual(['outer:start', 'inner', 'outer:end']);
+  });
+
   it('releases the lock even if fn throws', async () => {
     jest.resetModules();
     const { withWriteLock } = await import('./write-lock.js');

--- a/src/write-lock.ts
+++ b/src/write-lock.ts
@@ -12,6 +12,7 @@
 // concurrent operations on different models.
 
 import * as fsp from 'fs/promises';
+import { AsyncLocalStorage } from 'node:async_hooks';
 import * as os from 'os';
 import * as path from 'path';
 import * as properLockfile from 'proper-lockfile';
@@ -36,6 +37,11 @@ const WRITE_LOCK_OPTS_BASE: Omit<properLockfile.LockOptions, 'lockfilePath'> = {
   // RFC 012 §4.8.3 slow-path behavior.
   retries: { retries: 5, factor: 1.5, minTimeout: 100, maxTimeout: 1000 },
 };
+
+// Callers commonly initialize a manager inside the write-lock callback that
+// will immediately update it. Recovery now also uses this lock, so track
+// locks held by the current async flow and make that nesting re-entrant.
+const heldWriteLocks = new AsyncLocalStorage<ReadonlySet<string>>();
 
 export const WRITE_LOCK_OWNER_SCHEMA_VERSION = 'kb.write-lock-owner.v1';
 
@@ -89,6 +95,10 @@ function isLockContentionError(err: unknown): boolean {
  * Throws if the lock can't be acquired within the retry budget.
  */
 export async function withWriteLock<T>(resource: string, fn: () => Promise<T>): Promise<T> {
+  const resourceKey = path.resolve(resource);
+  const currentLocks = heldWriteLocks.getStore();
+  if (currentLocks?.has(resourceKey)) return fn();
+
   // proper-lockfile requires the locked resource path to exist; mkdir-p
   // handles both first-run and subdirectory cases (M1+M2's per-model dirs).
   await fsp.mkdir(resource, { recursive: true });
@@ -116,33 +126,37 @@ export async function withWriteLock<T>(resource: string, fn: () => Promise<T>): 
   const waitMs = performanceNow() - waitStart;
   await writeLockOwnerMetadata(ownerPath);
   const holdStart = performanceNow();
-  let holdMs = 0;
-  let canonicalError: CanonicalError | undefined;
-  try {
-    return await fn();
-  } catch (err) {
-    canonicalError = classifyCanonicalError(err);
-    throw err;
-  } finally {
-    holdMs = performanceNow() - holdStart;
-    writeLockMetrics.record({ resourceKind, waitMs, holdMs });
-    emitWriteLockTiming({
-      resourceKind,
-      waitMs,
-      holdMs,
-      error: canonicalError,
-    });
+  const nextLocks = new Set(currentLocks ?? []);
+  nextLocks.add(resourceKey);
+  return heldWriteLocks.run(nextLocks, async () => {
+    let holdMs = 0;
+    let canonicalError: CanonicalError | undefined;
     try {
-      await fsp.rm(ownerPath, { force: true });
+      return await fn();
     } catch (err) {
-      logger.warn(`Error removing write lock owner metadata: ${(err as Error).message}`);
+      canonicalError = classifyCanonicalError(err);
+      throw err;
+    } finally {
+      holdMs = performanceNow() - holdStart;
+      writeLockMetrics.record({ resourceKind, waitMs, holdMs });
+      emitWriteLockTiming({
+        resourceKind,
+        waitMs,
+        holdMs,
+        error: canonicalError,
+      });
+      try {
+        await fsp.rm(ownerPath, { force: true });
+      } catch (err) {
+        logger.warn(`Error removing write lock owner metadata: ${(err as Error).message}`);
+      }
+      try {
+        await release();
+      } catch (err) {
+        logger.warn(`Error releasing write lock: ${(err as Error).message}`);
+      }
     }
-    try {
-      await release();
-    } catch (err) {
-      logger.warn(`Error releasing write lock: ${(err as Error).message}`);
-    }
-  }
+  });
 }
 
 /**


### PR DESCRIPTION
## Summary

Add owner-aware pending-sidecar recovery and lock all recovery/reindex writes so a second initializer cannot purge a live writer's FAISS index or sidecars.

Fixes #851

## Testing

- [x] `npm test` passes
- ~~[ ] End-to-end verified for tool/transport changes (see `CLAUDE.md`)~~ — Not applicable; this changes internal index recovery and locking only.
- ~~[ ] Benchmark run if performance-relevant: `BENCH_PROVIDER=stub npm run bench`~~ — Not applicable; no retrieval or performance behavior changed.
- [x] <!-- kookr:check:tests --> Tests were added or updated for changed behavior; bug fixes include a regression test

## Documentation contract

- [ ] ~~<!-- kookr:check:readme --> `README.md` reflects user-visible CLI, MCP, installation, or configuration changes~~ — N/A: no user-facing interface or configuration changed.
- [x] <!-- kookr:check:docs --> Relevant operator, API, configuration, and retrieval documentation under `docs/` is consistent with the implementation
- [ ] ~~<!-- kookr:check:mbse --> RFCs are updated when this PR implements, supersedes, or changes an accepted design~~ — N/A: this issue fixes the existing pending-sidecar recovery design and updates its architecture documentation.

## Changelog

- [ ] ~~<!-- kookr:check:changelog --> `CHANGELOG.md` has an `Unreleased` entry for user-visible changes~~ — N/A: no user-visible behavior or configuration changed.

## Retrieval and performance evidence

- [ ] ~~<!-- kookr:check:benchmarks --> Retrieval-quality or performance changes include the relevant benchmark/evaluation evidence, or this row is waived with a reason~~ — N/A: no retrieval-quality or performance change.

## Follow-ups

None.
