### PR TITLE
fix(reindex): serialize manager lifecycle under model lock (#850)

### DIFF
--- a/src/reindex-runner.test.ts
+++ b/src/reindex-runner.test.ts
@@ -6,7 +6,7 @@
 // `updateIndex` call is mocked via the `runUpdateIndex` test seam, so
 // no real embedding provider or FAISS native code runs.
 
-import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import * as fsp from 'fs/promises';
 import * as os from 'os';
 import * as path from 'path';
@@ -434,6 +434,38 @@ describe('.reindex.run.json + PID liveness', () => {
 
     expect(result.outcome).toBe('completed');
     expect(lockedDuringUpdate).toBe(true);
+  });
+
+  it('initializes the default manager under the model write lock', async () => {
+    const { FaissIndexManager } = await import('./FaissIndexManager.js');
+    let lockedDuringInitialize = false;
+    const initialize = jest.spyOn(FaissIndexManager.prototype, 'initialize')
+      .mockImplementation(async function (this: { modelDir: string }) {
+        lockedDuringInitialize = await fsp
+          .stat(path.join(this.modelDir, '.kb-write.lock'))
+          .then(() => true)
+          .catch(() => false);
+      });
+    const updateIndex = jest.spyOn(FaissIndexManager.prototype, 'updateIndex')
+      .mockImplementation(async () => undefined);
+    const getLastIndexUpdateSummary = jest
+      .spyOn(FaissIndexManager.prototype, 'getLastIndexUpdateSummary')
+      .mockReturnValue(makeNeverRunSummary());
+
+    try {
+      const result = await runner.runReindex({
+        knowledgeBases: [],
+        force: true,
+        resolveKbs: async () => ['alpha'],
+      });
+
+      expect(result.outcome).toBe('completed');
+      expect(lockedDuringInitialize).toBe(true);
+    } finally {
+      initialize.mockRestore();
+      updateIndex.mockRestore();
+      getLastIndexUpdateSummary.mockRestore();
+    }
   });
 
   it('reports model lock contention as lock_held', async () => {

--- a/src/reindex-runner.test.ts
+++ b/src/reindex-runner.test.ts
@@ -10,6 +10,7 @@ import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
 import * as fsp from 'fs/promises';
 import * as os from 'os';
 import * as path from 'path';
+import * as properLockfile from 'proper-lockfile';
 
 type RunnerModule = typeof import('./reindex-runner.js');
 
@@ -433,6 +434,31 @@ describe('.reindex.run.json + PID liveness', () => {
 
     expect(result.outcome).toBe('completed');
     expect(lockedDuringUpdate).toBe(true);
+  });
+
+  it('reports model lock contention as lock_held', async () => {
+    const modelDir = path.join(tempDir, 'faiss', 'models', 'test-model');
+    const lockPath = path.join(modelDir, '.kb-write.lock');
+    await fsp.mkdir(modelDir, { recursive: true });
+    const release = await properLockfile.lock(modelDir, { lockfilePath: lockPath });
+    try {
+      const result = await runner.runReindex({
+        knowledgeBases: [],
+        force: true,
+        resolveKbs: async () => ['alpha'],
+        manager: {
+          modelDir,
+          updateIndex: async () => undefined,
+          getLastIndexUpdateSummary: () => makeNeverRunSummary(),
+        } as unknown as import('./FaissIndexManager.js').FaissIndexManager,
+      });
+
+      expect(result.outcome).toBe('lock_held');
+      expect(result.reason).toContain('Refresh lock is already held');
+    } finally {
+      await release();
+    }
+    await expect(fsp.access(runner.runStateFilePath())).rejects.toThrow();
   });
 
   it('writes the run-state file during a run and removes it on success', async () => {

--- a/src/reindex-runner.ts
+++ b/src/reindex-runner.ts
@@ -51,7 +51,7 @@ import { listKnowledgeBases } from './kb-fs.js';
 import { logger } from './logger.js';
 import { readLlmContextPolicy } from './sensitivity-policy.js';
 import { isPidAlive } from './process-liveness.js';
-import { withWriteLock } from './write-lock.js';
+import { WriteLockContentionError, withWriteLock } from './write-lock.js';
 
 export { isPidAlive } from './process-liveness.js';
 
@@ -554,20 +554,43 @@ export async function runReindex(options: ReindexOptions): Promise<ReindexResult
   try {
     if (options.runUpdateIndex) {
       // Test seam (or an injecting caller): bypass manager construction
-      // entirely. `createManagerForReindex()` calls `initialize()`, which
-      // resolves the embedding provider and throws when no provider key
-      // is configured (e.g. in CI) — even though the real `updateIndex`
-      // is being mocked here. The manager is only consumed by the
-      // non-seam path below, so construct it lazily there.
+      // and initialization entirely. A real manager resolves the embedding
+      // provider during `initialize()`, which throws when no provider key is
+      // configured (e.g. in CI) even when `updateIndex` is mocked here.
       summary = await options.runUpdateIndex({ force: shouldForceRebuild });
     } else {
-      const manager = options.manager ?? (await createManagerForReindex());
-      summary = await withWriteLock(manager.modelDir, () =>
-        runManagerUpdateIndex(manager, { force: shouldForceRebuild }),
-      );
+      const manager = options.manager ?? new FaissIndexManager();
+      summary = await withWriteLock(manager.modelDir, async () => {
+        // Initialization can recover a pending sidecar commit and repair the
+        // persisted index, so keep it under the same lock as updateIndex.
+        // The lock primitive is re-entrant for this async flow.
+        if (options.manager === undefined) await manager.initialize();
+        return runManagerUpdateIndex(manager, { force: shouldForceRebuild });
+      });
     }
   } catch (err) {
     await deleteRunState();
+    if (err instanceof WriteLockContentionError) {
+      emitCanonicalLog({
+        process: 'cli',
+        cmd: 'reindex.exit',
+        took_ms: Date.now() - startedAtMs,
+        result_count: 0,
+        k: kbs.length,
+        error: { code: 'REINDEX_LOCK_HELD', category: 'lock' },
+      });
+      return {
+        outcome: 'lock_held',
+        kbs_attempted: kbs.length,
+        total_chunks_estimate: totalChunks,
+        estimated_seconds: estimatedSeconds,
+        contextual_estimate: estimate,
+        took_ms: Date.now() - startedAtMs,
+        reason: err.message,
+        summary: null,
+        contextual: null,
+      };
+    }
     emitCanonicalLog({
       process: 'cli',
       cmd: 'reindex.exit',
@@ -620,12 +643,6 @@ export async function runReindex(options: ReindexOptions): Promise<ReindexResult
     summary,
     contextual: await summarizeContextualOutcome(kbs),
   };
-}
-
-async function createManagerForReindex(): Promise<FaissIndexManager> {
-  const manager = new FaissIndexManager();
-  await manager.initialize();
-  return manager;
 }
 
 async function runManagerUpdateIndex(


### PR DESCRIPTION
## Summary

Hold the per-model write lock across the default `FaissIndexManager` lifecycle, and report model-lock contention through the runner's existing `lock_held` outcome.

Fixes #850

## Testing

- [x] `npm test` passes (205 parallel suites / 2,771 tests; 11 serial suites / 456 tests)
- [ ] End-to-end verified for tool/transport changes (see `CLAUDE.md`) — N/A: this is an internal reindex/lock coordination fix
- [ ] Benchmark run if performance-relevant: `BENCH_PROVIDER=stub npm run bench` — N/A: no retrieval or performance behavior changed
- [x] <!-- kookr:check:tests --> Tests were added or updated for changed behavior; bug fixes include a regression test

## Documentation contract

- [ ] ~~<!-- kookr:check:readme --> `README.md` reflects user-visible CLI, MCP, installation, or configuration changes~~ — N/A: no user-facing CLI contract changed
- [ ] ~~<!-- kookr:check:docs --> Relevant operator, API, configuration, and retrieval documentation under `docs/` is consistent with the implementation~~ — N/A: no documented contract changed
- [ ] ~~<!-- kookr:check:mbse --> RFCs are updated when this PR implements, supersedes, or changes an accepted design~~ — N/A: this fixes an existing implementation gap without changing the accepted design

## Changelog

- [ ] ~~<!-- kookr:check:changelog --> `CHANGELOG.md` has an `Unreleased` entry for user-visible changes~~ — N/A: no user-visible release behavior changed

## Retrieval and performance evidence

- [ ] ~~<!-- kookr:check:benchmarks --> Retrieval-quality or performance changes include the relevant benchmark/evaluation evidence, or this row is waived with a reason~~ — N/A: this is a concurrency correctness fix

## Root cause

`kb reindex` initialized the manager before acquiring the model write lock, and lock acquisition failures were returned as generic failures. That left the initialization/recovery window unprotected and made contention indistinguishable from an internal error.

## Verification

- `npm run test:file -- src/reindex-runner.test.ts`: 29/29 passed
- `npm run build`: passed
- `npm run lint`: passed
- Pre-push fast CI-parity checks: passed
- The default-manager regression test observes the model lock during `initialize()`.
- The contention regression test returns `lock_held` and verifies run-state cleanup.

## Follow-ups

None.