### PR TITLE
feat(llm): surface resolved provider in probe

### DIFF
--- a/docs/cli-json-contracts.md
+++ b/docs/cli-json-contracts.md
@@ -103,6 +103,44 @@ Stdout/stderr and exit codes:
   exit `2`.
 - `kb help` without `--format=json` keeps the existing human-readable output.
 
+## `kb llm probe`
+
+Invocation:
+
+```bash
+kb llm probe [--endpoint=<url>]
+kb llm probe --expect-provider <provider> --expect-model <model>
+```
+
+Success or failed-probe payload:
+
+```json
+{
+  "endpoint": "http://127.0.0.1:11434/v1/chat/completions",
+  "health_url": "http://127.0.0.1:11434/health",
+  "provider": "local",
+  "model": "qwen3:4b-instruct-2507-q4_K_M",
+  "health_ok": false,
+  "chat_ok": true,
+  "detail": "chat completion succeeded; health HTTP 404"
+}
+```
+
+Stable fields are `endpoint`, `health_url`, `provider`, `model`,
+`health_ok`, `chat_ok`, and `detail`. `endpoint` and `health_url` are
+normalized URLs. `provider` is the resolved LLM provider (`local`,
+`openrouter`, or `fake` in test mode); `model` is the configured/requested
+model, or the response model when no model was configured. `health_ok` is a
+local health-route check and may be false for otherwise usable providers such
+as Ollama; `chat_ok` is the OpenAI-compatible completion check.
+
+Optional `warning` is present when the environment contains a likely provider
+configuration drift, such as an OpenRouter API key while the provider resolves
+to local. `--expect-provider` and `--expect-model` make the probe fail with
+exit `1` when the resolved identity does not match; each flag accepts either
+`--flag=value` or a space-separated value. Without expectations, exit `0`
+means the chat probe succeeded and exit `1` means it failed.
+
 ## `kb ls`
 
 Invocation:

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -822,7 +822,7 @@ kb llm — manage local LLM endpoints for kb ask
 
 Usage:
   kb llm status [--profile=<name>] [--format=md|json]
-  kb llm probe [--endpoint=<url>]
+  kb llm probe [--endpoint=<url>] [--expect-provider=<provider>] [--expect-model=<model>]
   kb llm use-endpoint <url> [--profile=<name>]
   kb llm install --profile=<name> --runner=llama-server --bin=<path> --model=<gguf-path> [--port=8091] [--ctx=32768] [--ngl=99] [--runner-arg=<arg>] [--start]
   kb llm start [--profile=<name>]
@@ -834,6 +834,11 @@ Usage:
 
 External profiles are reuse-only. Stop, restart, uninstall, and reap never
 touch external services such as local-research-agent's llama-server.
+
+kb llm probe accepts both --expect-provider=<provider> and
+--expect-provider <provider> (and the equivalent model flag). It exits 1
+when the chat probe fails or an expectation does not match the resolved
+provider/model.
 ```
 
 ## `kb logs`

--- a/src/cli-llm.test.ts
+++ b/src/cli-llm.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { runLlm } from './cli-llm.js';
+
+const ORIGINAL_ENV = { ...process.env };
+let stdout = '';
+let stderr = '';
+
+beforeEach(() => {
+  process.env = {
+    ...ORIGINAL_ENV,
+    KB_LLM_FAKE: 'on',
+    KB_LOG_FORMAT: 'text',
+  };
+  delete process.env.KB_LLM_PROVIDER;
+  delete process.env.KB_LLM_MODEL;
+  stdout = '';
+  stderr = '';
+  jest.spyOn(process.stdout, 'write').mockImplementation((chunk: string | Uint8Array) => {
+    stdout += chunk.toString();
+    return true;
+  });
+  jest.spyOn(process.stderr, 'write').mockImplementation((chunk: string | Uint8Array) => {
+    stderr += chunk.toString();
+    return true;
+  });
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+  process.env = { ...ORIGINAL_ENV };
+});
+
+describe('kb llm probe', () => {
+  it('reports the resolved fake provider/model and accepts space-delimited expectations', async () => {
+    await expect(runLlm([
+      'probe',
+      '--expect-provider', 'fake',
+      '--expect-model', 'kb-fake-llm',
+    ])).resolves.toBe(0);
+
+    expect(JSON.parse(stdout)).toMatchObject({
+      provider: 'fake',
+      model: 'kb-fake-llm',
+      chat_ok: true,
+    });
+  });
+
+  it('returns exit 1 and explains a resolved provider/model mismatch', async () => {
+    await expect(runLlm([
+      'probe',
+      '--expect-provider=openrouter',
+      '--expect-model=deepseek/deepseek-v4-flash',
+    ])).resolves.toBe(1);
+
+    const output = JSON.parse(stdout) as { detail: string };
+    expect(output.detail).toContain("expected provider 'openrouter', resolved 'fake'");
+    expect(output.detail).toContain("expected model 'deepseek/deepseek-v4-flash', resolved 'kb-fake-llm'");
+  });
+});

--- a/src/cli-llm.ts
+++ b/src/cli-llm.ts
@@ -24,7 +24,7 @@ export const LLM_HELP = `kb llm — manage local LLM endpoints for kb ask
 
 Usage:
   kb llm status [--profile=<name>] [--format=md|json]
-  kb llm probe [--endpoint=<url>]
+  kb llm probe [--endpoint=<url>] [--expect-provider=<provider>] [--expect-model=<model>]
   kb llm use-endpoint <url> [--profile=<name>]
   kb llm install --profile=<name> --runner=llama-server --bin=<path> --model=<gguf-path> [--port=8091] [--ctx=32768] [--ngl=99] [--runner-arg=<arg>] [--start]
   kb llm start [--profile=<name>]
@@ -36,6 +36,11 @@ Usage:
 
 External profiles are reuse-only. Stop, restart, uninstall, and reap never
 touch external services such as local-research-agent's llama-server.
+
+kb llm probe accepts both --expect-provider=<provider> and
+--expect-provider <provider> (and the equivalent model flag). It exits 1
+when the chat probe fails or an expectation does not match the resolved
+provider/model.
 `;
 
 export async function runLlm(rest: string[]): Promise<number> {
@@ -97,14 +102,57 @@ async function runStatus(rest: string[]): Promise<number> {
 
 async function runProbe(rest: string[]): Promise<number> {
   let endpoint = process.env.KB_LLM_ENDPOINT || 'http://127.0.0.1:8080/v1/chat/completions';
-  for (const raw of rest) {
-    if (raw.startsWith('--endpoint=')) { endpoint = raw.slice('--endpoint='.length); continue; }
+  let expectedProvider: string | undefined;
+  let expectedModel: string | undefined;
+  for (let index = 0; index < rest.length; index += 1) {
+    const raw = rest[index];
+    if (raw.startsWith('--endpoint=')) { endpoint = requireProbeOptionValue(raw.slice('--endpoint='.length), '--endpoint'); continue; }
+    if (raw === '--endpoint') {
+      endpoint = requireProbeOptionValue(rest[++index], '--endpoint');
+      continue;
+    }
+    if (raw.startsWith('--expect-provider=')) {
+      expectedProvider = requireProbeOptionValue(raw.slice('--expect-provider='.length), '--expect-provider');
+      continue;
+    }
+    if (raw === '--expect-provider') {
+      expectedProvider = requireProbeOptionValue(rest[++index], '--expect-provider');
+      continue;
+    }
+    if (raw.startsWith('--expect-model=')) {
+      expectedModel = requireProbeOptionValue(raw.slice('--expect-model='.length), '--expect-model');
+      continue;
+    }
+    if (raw === '--expect-model') {
+      expectedModel = requireProbeOptionValue(rest[++index], '--expect-model');
+      continue;
+    }
     if (raw.startsWith('--')) throw new Error(`unknown flag: ${raw}`);
     throw new Error(`unexpected argument: ${raw}`);
   }
   const result = await probeLlmEndpoint(endpoint);
-  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
-  return result.chat_ok ? 0 : 1;
+  const expectationFailures: string[] = [];
+  if (expectedProvider !== undefined && result.provider !== expectedProvider) {
+    expectationFailures.push(`expected provider '${expectedProvider}', resolved '${result.provider ?? 'unknown'}'`);
+  }
+  if (expectedModel !== undefined && result.model !== expectedModel) {
+    expectationFailures.push(`expected model '${expectedModel}', resolved '${result.model ?? 'unknown'}'`);
+  }
+  const output = expectationFailures.length === 0
+    ? result
+    : {
+      ...result,
+      detail: `${result.detail}; expectation failed: ${expectationFailures.join('; ')}`,
+    };
+  process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
+  return result.chat_ok && expectationFailures.length === 0 ? 0 : 1;
+}
+
+function requireProbeOptionValue(value: string | undefined, flag: string): string {
+  if (value === undefined || value.trim() === '' || value.startsWith('--')) {
+    throw new Error(`${flag} requires a value`);
+  }
+  return value;
 }
 
 async function runUseEndpoint(rest: string[]): Promise<number> {

--- a/src/config/llm-provider.ts
+++ b/src/config/llm-provider.ts
@@ -47,6 +47,8 @@ export interface LlmProviderResolution {
   model?: string;
   /** True when the active endpoint has no `/health` route (skip health probe). */
   remote: boolean;
+  /** Operator-facing hint for a likely OpenRouter provider configuration drift. */
+  warning?: string;
 }
 
 function firstNonEmpty(...values: (string | undefined)[]): string | undefined {
@@ -64,6 +66,10 @@ export function resolveLlmProvider(
   const appTitle = firstNonEmpty(env.KB_LLM_APP_TITLE) ?? KB_LLM_APP_TITLE_DEFAULT;
   const httpReferer = firstNonEmpty(env.KB_LLM_HTTP_REFERER);
   const configuredModel = firstNonEmpty(env.KB_LLM_MODEL);
+  const hasOpenRouterKey = firstNonEmpty(env.KB_OPENROUTER_API_KEY, env.OPENROUTER_API_KEY) !== undefined;
+  const warning = provider === 'local' && hasOpenRouterKey
+    ? 'OpenRouter API key is configured but KB_LLM_PROVIDER resolves to local; set KB_LLM_PROVIDER=openrouter to use OpenRouter.'
+    : undefined;
 
   if (provider === 'openrouter') {
     const apiKey = firstNonEmpty(env.KB_OPENROUTER_API_KEY, env.OPENROUTER_API_KEY);
@@ -83,5 +89,6 @@ export function resolveLlmProvider(
     ...(httpReferer !== undefined ? { httpReferer } : {}),
     ...(configuredModel !== undefined ? { model: configuredModel } : {}),
     remote: false,
+    ...(warning !== undefined ? { warning } : {}),
   };
 }

--- a/src/llm-client.test.ts
+++ b/src/llm-client.test.ts
@@ -513,6 +513,8 @@ describe('llm-client', () => {
     });
 
     const result = await probeLlmEndpoint('https://openrouter.ai/api/v1/chat/completions', fetchMock as unknown as typeof fetch);
+    expect(result.provider).toBe('openrouter');
+    expect(result.model).toBe('deepseek/deepseek-v4-flash');
     expect(result.health_ok).toBe(true);
     expect(result.chat_ok).toBe(true);
     expect(result.detail).toContain('health check skipped');
@@ -576,10 +578,33 @@ describe('llm-client', () => {
     chatTimeoutSpy.mockRestore();
     expect(result.health_ok).toBe(true);
     expect(result.chat_ok).toBe(true);
+    expect(result.provider).toBe('local');
+    expect(result.model).toBe('gate-model');
     const calls = fetchMock.mock.calls as unknown as Array<[string, RequestInit]>;
     const chatRequest = calls.find(([url]) => !url.endsWith('/health'))!;
     expect(JSON.parse(chatRequest[1].body as string)).toMatchObject({ model: 'gate-model' });
     expect(llmCallMetrics.snapshot()).toEqual({});
+  });
+
+  it('warns when an OpenRouter key is configured while the provider resolves local', async () => {
+    delete process.env.KB_LLM_FAKE;
+    delete process.env.KB_LLM_PROVIDER;
+    process.env.KB_OPENROUTER_API_KEY = 'sk-or-test-key';
+    delete process.env.OPENROUTER_API_KEY;
+    process.env.KB_LLM_MODEL = 'qwen3:4b-instruct-2507-q4_K_M';
+
+    const fetchMock = jest.fn(async (url: string) => {
+      if (url.endsWith('/health')) return new Response('{"status":"ok"}', { status: 200 });
+      return new Response(JSON.stringify({ choices: [{ message: { content: 'ok' } }] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+
+    const result = await probeLlmEndpoint('http://127.0.0.1:8080', fetchMock as unknown as typeof fetch);
+    expect(result.provider).toBe('local');
+    expect(result.model).toBe('qwen3:4b-instruct-2507-q4_K_M');
+    expect(result.warning).toContain('KB_LLM_PROVIDER resolves to local');
   });
 });
 

--- a/src/llm-client.ts
+++ b/src/llm-client.ts
@@ -1,5 +1,5 @@
 import { callFakeChatCompletion, isFakeLlmEnabled } from './llm-fake-stub.js';
-import { resolveLlmProvider } from './config/llm-provider.js';
+import { resolveLlmProvider, type LlmProviderKind } from './config/llm-provider.js';
 import {
   llmCallMetrics,
   normalizeLlmProvider,
@@ -65,6 +65,12 @@ export interface LlmProbeResult {
   health_ok: boolean;
   chat_ok: boolean;
   detail: string;
+  /** Provider selected for the probe; optional for injected legacy test probes. */
+  provider?: LlmProviderKind | 'fake';
+  /** Configured/requested model, or the response model when no model was configured. */
+  model?: string | null;
+  /** Present when the environment contains a likely provider-configuration drift. */
+  warning?: string;
 }
 
 export interface LlmProbeOptions {
@@ -632,10 +638,15 @@ export async function probeLlmEndpoint(
 ): Promise<LlmProbeResult> {
   const chatEndpoint = normalizeChatEndpoint(endpoint);
   const healthUrl = deriveHealthUrl(chatEndpoint);
+  const providerResolution = resolveLlmProvider();
+  const fake = isFakeLlmEnabled();
+  const provider: LlmProbeResult['provider'] = fake ? 'fake' : providerResolution.provider;
+  const configuredModel = options.model ?? providerResolution.model ?? null;
+  const warning = fake ? undefined : providerResolution.warning;
   // Hosted providers (OpenRouter) expose no `/health` route; a GET there 404s.
   // Skip the health probe for remote providers and judge readiness by the chat
   // call alone.
-  const remote = resolveLlmProvider().remote;
+  const remote = providerResolution.remote;
   let healthOk = false;
   let healthDetail = '';
   if (remote) {
@@ -656,7 +667,7 @@ export async function probeLlmEndpoint(
   }
 
   try {
-    await callChatCompletion({
+    const chat = await callChatCompletion({
       endpoint: chatEndpoint,
       model: options.model,
       operation: null,
@@ -675,6 +686,9 @@ export async function probeLlmEndpoint(
       detail: remote
         ? `chat completion succeeded; ${healthDetail}`
         : (healthOk ? 'health and chat completion succeeded' : `chat completion succeeded; ${healthDetail}`),
+      provider,
+      model: configuredModel ?? chat.model,
+      ...(warning !== undefined ? { warning } : {}),
     };
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
@@ -684,6 +698,9 @@ export async function probeLlmEndpoint(
       health_ok: healthOk,
       chat_ok: false,
       detail: `${healthDetail}; chat failed: ${msg}`,
+      provider,
+      model: configuredModel,
+      ...(warning !== undefined ? { warning } : {}),
     };
   }
 }


### PR DESCRIPTION
## Summary

Expose the provider and model resolved by `kb llm probe`, add optional provider/model assertions for preflight scripts, and warn when an OpenRouter key is present while the provider resolves to local.

Closes #861

## Testing

- [x] `npm test` passes — 206 parallel suites, 2,774 tests passed; 11 serial suites, 457 tests passed.
- ~~[ ] End-to-end verified for tool/transport changes (see `CLAUDE.md`)~~ — N/A: this changes the CLI probe and its LLM client, not MCP tools or transports.
- ~~[ ] Benchmark run if performance-relevant: `BENCH_PROVIDER=stub npm run bench`~~ — N/A: no retrieval or performance behavior changed.
- [x] <!-- kookr:check:tests --> Tests were added or updated for changed behavior; the probe identity and expectation paths have focused regression coverage.

## Documentation contract

~~- [ ] <!-- kookr:check:readme --> `README.md` reflects user-visible CLI, MCP, installation, or configuration changes~~ — N/A: the CLI reference and selected JSON contract are the relevant operator documentation.
- [x] <!-- kookr:check:docs --> Relevant operator, API, configuration, and retrieval documentation under `docs/` is consistent with the implementation.
~~- [ ] <!-- kookr:check:mbse --> RFCs are updated when this PR implements, supersedes, or changes an accepted design~~ — N/A: this is a small observability/CLI contract fix and does not change an accepted design.

## Changelog

~~- [ ] <!-- kookr:check:changelog --> `CHANGELOG.md` has an `Unreleased` entry for user-visible changes~~ — N/A: repository convention does not require a changelog entry for this focused CLI diagnostic fix.

## Retrieval and performance evidence

~~- [ ] <!-- kookr:check:benchmarks --> Retrieval-quality or performance changes include the relevant benchmark/evaluation evidence, or this row is waived with a reason~~ — N/A: no retrieval-quality or performance behavior changed.

## Follow-ups

None; the probe continues as a liveness check by default, while `--expect-provider` and `--expect-model` turn it into an intent check for runbooks and cron jobs.