### PR TITLE
fix(slug): uniquify non-Latin titles for kb remember (#890)

### DIFF
--- a/src/cli-remember.test.ts
+++ b/src/cli-remember.test.ts
@@ -14,6 +14,7 @@ import {
 // ts-jest cannot transform). We exercise the parser end-to-end via the
 // child-process tests in cli.test.ts instead.
 import type { ScoredDocument } from './formatter.js';
+import { slugifyTitle } from './slug.js';
 
 const cliPath = path.join(process.cwd(), 'build', 'cli.js');
 
@@ -179,3 +180,78 @@ describe('kb remember write policy', () => {
     }
   });
 });
+
+describe('kb remember non-Latin titles (issue #890)', () => {
+  it('creates distinct files for two different non-Latin titles', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-cli-remember-non-latin-'));
+    try {
+      const rootDir = path.join(tempDir, 'kbs');
+      const faissDir = path.join(tempDir, '.faiss');
+      const kbDir = path.join(rootDir, 'project');
+      await fsp.mkdir(kbDir, { recursive: true });
+
+      const titleA = '第一个笔记';
+      const titleB = '第二个笔记';
+      const env = { KNOWLEDGE_BASES_ROOT_DIR: rootDir, FAISS_INDEX_PATH: faissDir };
+
+      const r1 = runCli(
+        ['remember', '--kb=project', `--title=${titleA}`, '--stdin', '--yes', '--no-check-similar'],
+        env,
+        '# 第一个\n\nbody a\n',
+      );
+      const r2 = runCli(
+        ['remember', '--kb=project', `--title=${titleB}`, '--stdin', '--yes', '--no-check-similar'],
+        env,
+        '# 第二个\n\nbody b\n',
+      );
+
+      expect(r1.code).toBe(0);
+      expect(r2.code).toBe(0);
+
+      const pathA = `${slugifyTitle(titleA)}.md`;
+      const pathB = `${slugifyTitle(titleB)}.md`;
+      expect(pathA).not.toBe(pathB);
+      expect(pathA).not.toBe('note.md');
+      expect(pathB).not.toBe('note.md');
+
+      await expect(fsp.readFile(path.join(kbDir, pathA), 'utf-8')).resolves.toContain('body a');
+      await expect(fsp.readFile(path.join(kbDir, pathB), 'utf-8')).resolves.toContain('body b');
+      await expect(fsp.stat(path.join(kbDir, 'note.md'))).rejects.toMatchObject({ code: 'ENOENT' });
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('still refuses to overwrite when the same non-Latin title is remembered twice', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-cli-remember-non-latin-dup-'));
+    try {
+      const rootDir = path.join(tempDir, 'kbs');
+      const faissDir = path.join(tempDir, '.faiss');
+      const kbDir = path.join(rootDir, 'project');
+      await fsp.mkdir(kbDir, { recursive: true });
+
+      const title = '同じタイトル';
+      const env = { KNOWLEDGE_BASES_ROOT_DIR: rootDir, FAISS_INDEX_PATH: faissDir };
+      const relativePath = `${slugifyTitle(title)}.md`;
+
+      const r1 = runCli(
+        ['remember', '--kb=project', `--title=${title}`, '--stdin', '--yes', '--no-check-similar'],
+        env,
+        '# once\n',
+      );
+      const r2 = runCli(
+        ['remember', '--kb=project', `--title=${title}`, '--stdin', '--yes', '--no-check-similar'],
+        env,
+        '# twice\n',
+      );
+
+      expect(r1.code).toBe(0);
+      expect(r2.code).toBe(1);
+      expect(r2.stderr).toContain(`refusing to overwrite existing note: ${relativePath}`);
+      await expect(fsp.readFile(path.join(kbDir, relativePath), 'utf-8')).resolves.toContain('# once');
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+});
+

--- a/src/slug.test.ts
+++ b/src/slug.test.ts
@@ -1,0 +1,73 @@
+import { createHash } from 'node:crypto';
+import { describe, expect, it } from '@jest/globals';
+import { slugifyTitle } from './slug.js';
+
+function expectedHash(title: string): string {
+  return createHash('sha256').update(title, 'utf8').digest('hex').slice(0, 8);
+}
+
+describe('slugifyTitle', () => {
+  it('slugifies Latin titles to kebab-case', () => {
+    expect(slugifyTitle('Hello, World!')).toBe('hello-world');
+    expect(slugifyTitle('Deploy runbook v2')).toBe('deploy-runbook-v2');
+  });
+
+  it('strips combining marks so accented Latin remains readable', () => {
+    expect(slugifyTitle('Café résumé')).toBe('cafe-resume');
+  });
+
+  it('honors maxLength for readable slugs', () => {
+    const long = 'a'.repeat(100);
+    expect(slugifyTitle(long, { maxLength: 12 })).toBe('a'.repeat(12));
+  });
+
+  it('honors a custom fallback prefix for non-Latin titles', () => {
+    const title = '知识库笔记';
+    expect(slugifyTitle(title, { fallback: 'ask-transcript' })).toBe(
+      `ask-transcript-${expectedHash(title)}`,
+    );
+  });
+
+  it('uses fallback-hash for empty / punctuation-only titles', () => {
+    expect(slugifyTitle('')).toBe(`note-${expectedHash('')}`);
+    expect(slugifyTitle('!!!')).toBe(`note-${expectedHash('!!!')}`);
+    expect(slugifyTitle('   ')).toBe(`note-${expectedHash('   ')}`);
+  });
+
+  it('gives distinct deterministic filenames to different non-Latin titles', () => {
+    const chineseA = '第一个笔记';
+    const chineseB = '第二个笔记';
+    const japanese = '日本語のノート';
+    const arabic = 'مذكرة عربية';
+    const cyrillic = 'Заметка';
+    const korean = '한국어 노트';
+
+    const slugA = slugifyTitle(chineseA);
+    const slugB = slugifyTitle(chineseB);
+    const slugJa = slugifyTitle(japanese);
+    const slugAr = slugifyTitle(arabic);
+    const slugRu = slugifyTitle(cyrillic);
+    const slugKo = slugifyTitle(korean);
+
+    expect(slugA).toBe(`note-${expectedHash(chineseA)}`);
+    expect(slugB).toBe(`note-${expectedHash(chineseB)}`);
+    expect(slugJa).toBe(`note-${expectedHash(japanese)}`);
+    expect(slugAr).toBe(`note-${expectedHash(arabic)}`);
+    expect(slugRu).toBe(`note-${expectedHash(cyrillic)}`);
+    expect(slugKo).toBe(`note-${expectedHash(korean)}`);
+
+    const all = [slugA, slugB, slugJa, slugAr, slugRu, slugKo];
+    expect(new Set(all).size).toBe(all.length);
+  });
+
+  it('is deterministic for the same non-Latin title', () => {
+    const title = '同じタイトル';
+    expect(slugifyTitle(title)).toBe(slugifyTitle(title));
+    expect(slugifyTitle(title)).toBe(`note-${expectedHash(title)}`);
+  });
+
+  it('keeps mixed Latin+script titles readable when any ASCII alnum remains', () => {
+    // Latin letters survive the filter; CJK is stripped — not empty-slug path.
+    expect(slugifyTitle('RFC 日本語 draft')).toBe('rfc-draft');
+  });
+});

--- a/src/slug.test.ts
+++ b/src/slug.test.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'node:crypto';
+import { createHash } from 'crypto';
 import { describe, expect, it } from '@jest/globals';
 import { slugifyTitle } from './slug.js';
 
@@ -62,8 +62,17 @@ describe('slugifyTitle', () => {
 
   it('is deterministic for the same non-Latin title', () => {
     const title = '同じタイトル';
-    expect(slugifyTitle(title)).toBe(slugifyTitle(title));
-    expect(slugifyTitle(title)).toBe(`note-${expectedHash(title)}`);
+    // Two independent calls must both match the independent hash oracle.
+    const once = slugifyTitle(title);
+    const twice = slugifyTitle(title);
+    expect(once).toBe(twice);
+    expect(once).toBe(`note-${expectedHash(title)}`);
+  });
+
+  it('does not apply maxLength to the empty-slug hash stem', () => {
+    const title = '中文';
+    // Truncating the fingerprint would raise collision risk; keep full stem.
+    expect(slugifyTitle(title, { maxLength: 4 })).toBe(`note-${expectedHash(title)}`);
   });
 
   it('keeps mixed Latin+script titles readable when any ASCII alnum remains', () => {

--- a/src/slug.ts
+++ b/src/slug.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'node:crypto';
+import { createHash } from 'crypto';
 
 export interface SlugifyTitleOptions {
   fallback?: string;

--- a/src/slug.ts
+++ b/src/slug.ts
@@ -1,8 +1,26 @@
+import { createHash } from 'node:crypto';
+
 export interface SlugifyTitleOptions {
   fallback?: string;
   maxLength?: number;
 }
 
+/** Short, stable fingerprint so empty Latin slugs still differ by title. */
+function shortTitleHash(title: string): string {
+  return createHash('sha256').update(title, 'utf8').digest('hex').slice(0, 8);
+}
+
+/**
+ * Derive a filesystem-safe filename stem from a note title.
+ *
+ * Latin / ASCII-friendly titles keep a readable kebab-case slug. Titles whose
+ * characters are all stripped by the `[a-z0-9]` filter (CJK, Arabic, Cyrillic,
+ * punctuation-only, empty) used to collapse to a shared fallback (`note`), so
+ * only the first `kb remember` / `kb ask --save-transcript` write could succeed.
+ * Those now use `${fallback}-<8-hex>` hashed from the original title so distinct
+ * titles get distinct, deterministic paths while exclusive-create (`wx`) still
+ * rejects a true same-title collision.
+ */
 export function slugifyTitle(title: string, options: SlugifyTitleOptions = {}): string {
   const maxLength = options.maxLength ?? 80;
   const fallback = options.fallback ?? 'note';
@@ -13,5 +31,8 @@ export function slugifyTitle(title: string, options: SlugifyTitleOptions = {}): 
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '')
     .replace(/-{2,}/g, '-');
-  return slug.length > 0 ? slug.slice(0, maxLength).replace(/-+$/g, '') : fallback;
+  if (slug.length > 0) {
+    return slug.slice(0, maxLength).replace(/-+$/g, '');
+  }
+  return `${fallback}-${shortTitleHash(title)}`;
 }


### PR DESCRIPTION
## Summary

Non-Latin script note titles (`kb remember`, `kb ask --save-transcript`) all collapsed to the bare fallback slug (`note` / `ask-transcript`) after `slugifyTitle` stripped every non-`[a-z0-9]` character. Exclusive create (`wx`) then blocked every save after the first with `refusing to overwrite existing note: note.md`.

**Fix:** when the Latin slug is empty, emit `${fallback}-<8-hex>` where the hex is a stable SHA-256 prefix of the original title. Distinct titles get distinct deterministic filenames; same title still collides and refuses overwrite.

**Design choice (issue offered hash vs `--path`):** chose the title-hash default only. It fixes the no-flag path for both `kb remember` and `kb ask --save-transcript` (shared `slugifyTitle`) without new CLI plumbing. A `--path` override remains a possible follow-up for operators who want human-readable stems.

Closes #890

## Testing

- [x] Focused tests: `npx jest --runTestsByPath src/slug.test.ts src/cli-remember.test.ts` (20 passed)
- [x] `npm run build` + `npm run typecheck:tests` pass
- [x] pre-push fast checks (lint + doc-drift) passed on push
- [ ] ~~End-to-end verified for tool/transport changes~~ — not a tool/transport change
- [ ] ~~Benchmark run~~ — not performance-relevant
- [x] <!-- kookr:check:tests --> Tests were added or updated for changed behavior; bug fixes include a regression test

## Documentation contract

- [ ] ~~<!-- kookr:check:readme --> `README.md` reflects user-visible CLI, MCP, installation, or configuration changes~~ — filename stem change for empty-slug titles only; no CLI/MCP/install/config surface
- [ ] ~~<!-- kookr:check:docs --> Relevant operator, API, configuration, and retrieval documentation under `docs/` is consistent with the implementation~~ — no operator docs describe empty-slug filename derivation
- [ ] ~~<!-- kookr:check:mbse --> RFCs are updated when this PR implements, supersedes, or changes an accepted design~~ — no RFC involved

## Changelog

- [ ] ~~<!-- kookr:check:changelog --> `CHANGELOG.md` has an `Unreleased` entry for user-visible changes~~ — unit task forbids changelog unless required for acceptance; acceptance is covered by tests + exclusive-create semantics

## Retrieval and performance evidence

- [ ] ~~<!-- kookr:check:benchmarks --> Retrieval-quality or performance changes include the relevant benchmark/evaluation evidence, or this row is waived with a reason~~ — not a retrieval/performance change

## Verification (before/after)

| Title | Old slug | New slug |
|-------|----------|----------|
| 第一个笔记 | `note` | `note-f14ffde1` |
| 第二个笔记 | `note` (collision) | `note-673d652c` |
| 日本語のノート | `note` | `note-f4f5d628` |
| Hello World | `hello-world` | `hello-world` (unchanged) |

CLI: two different CJK titles via `kb remember` create two files; same title twice still errors with `refusing to overwrite`.

## Pre-PR review

- Project type: npm
- Build/typecheck: passed
- Tests: passed (focused slug + cli-remember)
- Scope: clean (`src/slug.ts`, `src/slug.test.ts`, `src/cli-remember.test.ts`)
- Specialists: `SPECIALISTS=correctness,lint-like,test` (`DOCS_DRIFT=inactive`)
  - correctness: **APPROVE**
  - lint-like (conventions + deadcode): **APPROVE** / **APPROVE**
  - test: **APPROVE** (nits addressed: crypto import style, maxLength hash-path contract, non-tautological determinism)

## Follow-ups

None filed. Optional later: `--path` override on `kb remember` for fully custom stems.