### PR TITLE
fix(gate): bound process-global verdictCache with LRU

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -292,6 +292,10 @@ KB_GATE_TASK_CONTEXT_MODE=warn
 # Default: 600
 KB_GATE_TASK_CONTEXT_ARGV_MAX=600
 
+# Maximum relevance-gate verdict entries retained in the process LRU; 0 disables the memory cache.
+# Default: 256
+KB_GATE_VERDICT_CACHE_MAX=256
+
 # Reranking
 
 # Enables optional cross-encoder reranking.

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -75,6 +75,7 @@ both checks.
 | Gate empty verdict | `KB_GATE_EMPTY_VERDICT` | `off` | Gate terminal verdict | Implemented, opt-in after false-empty findings | none | `KB_GATE_EMPTY_VERDICT=on kb search "query" --gate --task-context="current task"` |
 | Gate judge endpoint | `KB_GATE_LLM_ENDPOINT` | falls back to `KB_LLM_ENDPOINT`; unset means statistical path/degrade | Gate stage B | Implemented | none | `KB_GATE_LLM_ENDPOINT=http://127.0.0.1:8080/v1/chat/completions kb search "query" --gate --task-context="current task"` |
 | Gate judge model | `KB_GATE_LLM_MODEL` | falls back to `KB_LLM_MODEL`; otherwise endpoint default | Gate stage B | Implemented | none | `KB_GATE_LLM_MODEL=<model> kb search "query" --gate --task-context="current task"` |
+| Gate verdict-cache LRU max | `KB_GATE_VERDICT_CACHE_MAX` | `256` | Process-global gate verdict LRU under long-lived `kb serve` | Implemented; `0` disables the memory cache | process lifetime | `KB_GATE_VERDICT_CACHE_MAX=512 kb serve` |
 
 ## Contextual Retrieval at Ingest
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -78,6 +78,7 @@ Run `npm run docs:generate-config-reference` after changing the schema.
 | <code>KB_GATE_LLM_MODEL</code> | <code>string</code> | _unset_ |  |  | kept as set |  |
 | <code>KB_GATE_TASK_CONTEXT_MODE</code> | <code>enum</code> | <code>warn</code> | <code>off</code>, <code>warn</code>, <code>strict</code> |  | uses default |  |
 | <code>KB_GATE_TASK_CONTEXT_ARGV_MAX</code> | <code>integer</code> | <code>600</code> |  | >= <code>1</code> | uses default |  |
+| <code>KB_GATE_VERDICT_CACHE_MAX</code> | <code>integer</code> | <code>256</code> |  | >= <code>0</code> | uses default | Maximum relevance-gate verdict entries retained in the process LRU; 0 disables the memory cache. |
 | <code>KB_RERANK</code> | <code>boolean</code> | <code>off</code> | <code>on</code>, <code>off</code>, <code>true</code>, <code>false</code>, <code>1</code>, <code>0</code> |  | uses default | Enables optional cross-encoder reranking. |
 | <code>KB_RERANK_MODEL</code> | <code>string</code> | <code>Xenova/ms-marco-MiniLM-L-6-v2</code> |  |  | kept as empty |  |
 | <code>KB_RERANK_TOP_N</code> | <code>integer</code> | <code>40</code> |  | >= <code>1</code>; <= <code>1000</code>; digits only | uses default |  |

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -230,6 +230,7 @@ export const CONFIG_SCHEMA: readonly ConfigSpec[] = [
   { name: 'KB_GATE_LLM_MODEL', kind: 'string' },
   { name: 'KB_GATE_TASK_CONTEXT_MODE', kind: 'enum', values: ['off', 'warn', 'strict'], default: 'warn' },
   { name: 'KB_GATE_TASK_CONTEXT_ARGV_MAX', kind: 'integer', default: '600', min: 1 },
+  { name: 'KB_GATE_VERDICT_CACHE_MAX', kind: 'integer', default: '256', min: 0, description: 'Maximum relevance-gate verdict entries retained in the process LRU; 0 disables the memory cache.' },
 
   { name: 'KB_RERANK', kind: 'boolean', default: 'off', description: 'Enables optional cross-encoder reranking.' },
   { name: 'KB_RERANK_MODEL', kind: 'string', default: DEFAULT_RERANK_MODEL },

--- a/src/relevance-gate.test.ts
+++ b/src/relevance-gate.test.ts
@@ -2,7 +2,14 @@ import * as fsp from 'fs/promises';
 import * as os from 'os';
 import * as path from 'path';
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
-import { applyRelevanceGate, emitRelevanceGateDecision } from './relevance-gate.js';
+import {
+  applyRelevanceGate,
+  emitRelevanceGateDecision,
+  resolveGateVerdictCacheMax,
+  DEFAULT_GATE_VERDICT_CACHE_MAX,
+  __getRelevanceGateVerdictCacheSizeForTests,
+  __resetRelevanceGateVerdictCacheForTests,
+} from './relevance-gate.js';
 import type { RelevanceGateConfig } from './config/relevance-gate.js';
 import { chunkIdFromMetadata } from './rrf.js';
 import { RelevanceGateMetrics, relevanceGateMetrics } from './relevance-gate-metrics.js';
@@ -90,6 +97,7 @@ function metricVerdict(overrides: Partial<RelevanceGateVerdict> = {}): Relevance
 describe('relevance gate', () => {
   beforeEach(() => {
     relevanceGateMetrics.reset();
+    __resetRelevanceGateVerdictCacheForTests();
   });
 
   it('bypasses by default when the feature flag is off', async () => {
@@ -319,6 +327,179 @@ describe('relevance gate', () => {
       cache_outcomes: { hit: 1, miss: 1 },
       answer_impact: { used: 2 },
     });
+  });
+
+  it('bounds the process-global verdict cache and evicts the oldest entry (#899)', async () => {
+    __resetRelevanceGateVerdictCacheForTests({ maxEntries: 2 });
+
+    const taskContext = 'please answer a deployment rollback question with precise operational context';
+    const makeInput = (query: string, source: string) => {
+      const rows = [candidate(source, 0, 0.2, 'deployment rollback')];
+      return {
+        query,
+        taskContext,
+        candidates: rows,
+        config: config({ emptyVerdictEnabled: true }),
+        fetchImpl: fakeFetchJson(
+          `{"overall":"relevant","verdicts":[{"id":"${source}#0","decision":"keep","reason":"rollback"}]}`,
+        ),
+      };
+    };
+
+    await applyRelevanceGate(makeInput('verdict-cache-a', '/kb/verdict-a.md'));
+    await applyRelevanceGate(makeInput('verdict-cache-b', '/kb/verdict-b.md'));
+    expect(__getRelevanceGateVerdictCacheSizeForTests()).toBe(2);
+
+    await applyRelevanceGate(makeInput('verdict-cache-c', '/kb/verdict-c.md'));
+    expect(__getRelevanceGateVerdictCacheSizeForTests()).toBe(2);
+
+    // B and C remain; oldest (A) was evicted. Check retained hits before re-inserting A.
+    const metricsB = new LlmCallMetrics();
+    await applyRelevanceGate({ ...makeInput('verdict-cache-b', '/kb/verdict-b.md'), llmMetrics: metricsB });
+    expect(metricsB.snapshot().gate).toMatchObject({
+      cache_outcomes: { hit: 1 },
+    });
+
+    const metricsC = new LlmCallMetrics();
+    await applyRelevanceGate({ ...makeInput('verdict-cache-c', '/kb/verdict-c.md'), llmMetrics: metricsC });
+    expect(metricsC.snapshot().gate).toMatchObject({
+      cache_outcomes: { hit: 1 },
+    });
+
+    const metricsA = new LlmCallMetrics();
+    await applyRelevanceGate({ ...makeInput('verdict-cache-a', '/kb/verdict-a.md'), llmMetrics: metricsA });
+    expect(metricsA.snapshot().gate).toMatchObject({
+      cache_outcomes: { miss: 1 },
+    });
+    // A re-insert still respects the cap (evicts an older retained entry).
+    expect(__getRelevanceGateVerdictCacheSizeForTests()).toBe(2);
+  });
+
+  it('promotes a re-accessed verdict so a newer insert evicts the colder entry (#899)', async () => {
+    __resetRelevanceGateVerdictCacheForTests({ maxEntries: 2 });
+    const taskContext = 'please answer a deployment rollback question with precise operational context';
+    const makeInput = (query: string, source: string) => {
+      const rows = [candidate(source, 0, 0.2, 'deployment rollback')];
+      return {
+        query,
+        taskContext,
+        candidates: rows,
+        config: config(),
+        fetchImpl: fakeFetchJson(
+          `{"overall":"relevant","verdicts":[{"id":"${source}#0","decision":"keep","reason":"rollback"}]}`,
+        ),
+      };
+    };
+
+    await applyRelevanceGate(makeInput('lru-promote-a', '/kb/lru-a.md'));
+    await applyRelevanceGate(makeInput('lru-promote-b', '/kb/lru-b.md'));
+    // Touch A so B is the colder (eviction) candidate.
+    await applyRelevanceGate(makeInput('lru-promote-a', '/kb/lru-a.md'));
+    await applyRelevanceGate(makeInput('lru-promote-c', '/kb/lru-c.md'));
+    expect(__getRelevanceGateVerdictCacheSizeForTests()).toBe(2);
+
+    const metricsA = new LlmCallMetrics();
+    await applyRelevanceGate({ ...makeInput('lru-promote-a', '/kb/lru-a.md'), llmMetrics: metricsA });
+    expect(metricsA.snapshot().gate).toMatchObject({ cache_outcomes: { hit: 1 } });
+
+    const metricsB = new LlmCallMetrics();
+    await applyRelevanceGate({ ...makeInput('lru-promote-b', '/kb/lru-b.md'), llmMetrics: metricsB });
+    expect(metricsB.snapshot().gate).toMatchObject({ cache_outcomes: { miss: 1 } });
+  });
+
+  it('disables the process verdict cache when maxEntries is 0 (#899)', async () => {
+    __resetRelevanceGateVerdictCacheForTests({ maxEntries: 0 });
+    const rows = [candidate('/kb/disabled-cache.md', 0, 0.2, 'deployment rollback')];
+    const fetchImpl = fakeFetchJson(
+      '{"overall":"relevant","verdicts":[{"id":"/kb/disabled-cache.md#0","decision":"keep","reason":"rollback"}]}',
+    );
+    const input = {
+      query: 'disabled verdict cache',
+      taskContext: 'please answer a deployment rollback question with precise operational context',
+      candidates: rows,
+      config: config(),
+      fetchImpl,
+    };
+
+    await applyRelevanceGate(input);
+    expect(__getRelevanceGateVerdictCacheSizeForTests()).toBe(0);
+
+    const llmMetrics = new LlmCallMetrics();
+    await applyRelevanceGate({ ...input, llmMetrics });
+    expect(__getRelevanceGateVerdictCacheSizeForTests()).toBe(0);
+    expect(llmMetrics.snapshot().gate).toMatchObject({
+      cache_outcomes: { miss: 1 },
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps a recently-set verdict as a hit while under the cap (#899)', async () => {
+    __resetRelevanceGateVerdictCacheForTests({ maxEntries: 4 });
+    const taskContext = 'please answer a deployment rollback question with precise operational context';
+    // Fill near capacity so the target hit is not an empty-cache special case.
+    for (const n of [1, 2, 3]) {
+      await applyRelevanceGate({
+        query: `filler verdict ${n}`,
+        taskContext,
+        candidates: [candidate(`/kb/filler-${n}.md`, 0, 0.2, 'deployment rollback')],
+        config: config(),
+        fetchImpl: fakeFetchJson(
+          `{"overall":"relevant","verdicts":[{"id":"/kb/filler-${n}.md#0","decision":"keep","reason":"rollback"}]}`,
+        ),
+      });
+    }
+
+    const rows = [candidate('/kb/recent-hit.md', 0, 0.2, 'deployment rollback')];
+    const fetchImpl = fakeFetchJson(
+      '{"overall":"relevant","verdicts":[{"id":"/kb/recent-hit.md#0","decision":"keep","reason":"rollback"}]}',
+    );
+    const input = {
+      query: 'recent verdict hit',
+      taskContext,
+      candidates: rows,
+      config: config(),
+      fetchImpl,
+    };
+
+    await applyRelevanceGate(input);
+    expect(__getRelevanceGateVerdictCacheSizeForTests()).toBe(4);
+
+    const llmMetrics = new LlmCallMetrics();
+    const second = await applyRelevanceGate({ ...input, llmMetrics });
+    expect(second.results).toEqual(rows);
+    expect(llmMetrics.snapshot().gate).toMatchObject({
+      cache_outcomes: { hit: 1 },
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('exposes a test-reset hook that clears the verdict cache (#899)', async () => {
+    const rows = [candidate('/kb/reset-hook.md', 0, 0.2, 'deployment rollback')];
+    await applyRelevanceGate({
+      query: 'reset-hook seed',
+      taskContext: 'please answer a deployment rollback question with precise operational context',
+      candidates: rows,
+      config: config(),
+      fetchImpl: fakeFetchJson(
+        '{"overall":"relevant","verdicts":[{"id":"/kb/reset-hook.md#0","decision":"keep","reason":"rollback"}]}',
+      ),
+    });
+    expect(__getRelevanceGateVerdictCacheSizeForTests()).toBe(1);
+
+    __resetRelevanceGateVerdictCacheForTests();
+    expect(__getRelevanceGateVerdictCacheSizeForTests()).toBe(0);
+  });
+
+  it('parses KB_GATE_VERDICT_CACHE_MAX with a sensible default (#899)', () => {
+    // Pass explicit raw strings so the default-parameter env read cannot flake.
+    expect(resolveGateVerdictCacheMax('')).toBe(DEFAULT_GATE_VERDICT_CACHE_MAX);
+    expect(resolveGateVerdictCacheMax('   ')).toBe(DEFAULT_GATE_VERDICT_CACHE_MAX);
+    expect(resolveGateVerdictCacheMax('512')).toBe(512);
+    expect(resolveGateVerdictCacheMax('2.9')).toBe(2);
+    expect(resolveGateVerdictCacheMax('0')).toBe(0);
+    expect(resolveGateVerdictCacheMax('-3')).toBe(DEFAULT_GATE_VERDICT_CACHE_MAX);
+    expect(resolveGateVerdictCacheMax('Infinity')).toBe(DEFAULT_GATE_VERDICT_CACHE_MAX);
+    expect(resolveGateVerdictCacheMax('not-a-number')).toBe(DEFAULT_GATE_VERDICT_CACHE_MAX);
   });
 
   it('degrades to A2 when the judge fails or returns malformed JSON', async () => {

--- a/src/relevance-gate.ts
+++ b/src/relevance-gate.ts
@@ -104,7 +104,92 @@ interface CachedGateDecision {
   observability: RelevanceGateObservability;
 }
 
-const verdictCache = new Map<string, CachedGateDecision>();
+/** Default process-LRU cap for gate verdicts under long-lived `kb serve` (#899). */
+export const DEFAULT_GATE_VERDICT_CACHE_MAX = 256;
+
+/**
+ * Maximum retained verdict-cache entries. Reads `KB_GATE_VERDICT_CACHE_MAX`;
+ * non-finite / negative values fall back to the default; `0` disables caching.
+ */
+export function resolveGateVerdictCacheMax(
+  raw: string | undefined = process.env.KB_GATE_VERDICT_CACHE_MAX,
+): number {
+  const parsed = raw === undefined || raw.trim() === '' ? NaN : Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) return DEFAULT_GATE_VERDICT_CACHE_MAX;
+  return Math.floor(parsed);
+}
+
+/**
+ * Bounded LRU over insertion order. Map keeps insertion order; get/set re-touch
+ * so recently used entries survive eviction under `kb serve`.
+ */
+class VerdictCacheLru {
+  private readonly values = new Map<string, CachedGateDecision>();
+  private maxEntries: number;
+
+  constructor(maxEntries: number = resolveGateVerdictCacheMax()) {
+    this.maxEntries = maxEntries;
+  }
+
+  get size(): number {
+    return this.values.size;
+  }
+
+  get(key: string): CachedGateDecision | undefined {
+    const value = this.values.get(key);
+    if (value === undefined) return undefined;
+    this.values.delete(key);
+    this.values.set(key, value);
+    return value;
+  }
+
+  set(key: string, value: CachedGateDecision): void {
+    if (this.maxEntries <= 0) return;
+    if (this.values.has(key)) this.values.delete(key);
+    this.values.set(key, value);
+    while (this.values.size > this.maxEntries) {
+      const oldest = this.values.keys().next().value as string | undefined;
+      if (oldest === undefined) break;
+      this.values.delete(oldest);
+    }
+  }
+
+  clear(): void {
+    this.values.clear();
+  }
+
+  setMaxEntries(maxEntries: number): void {
+    this.maxEntries = maxEntries;
+    if (this.maxEntries <= 0) {
+      this.values.clear();
+      return;
+    }
+    while (this.values.size > this.maxEntries) {
+      const oldest = this.values.keys().next().value as string | undefined;
+      if (oldest === undefined) break;
+      this.values.delete(oldest);
+    }
+  }
+}
+
+const verdictCache = new VerdictCacheLru();
+
+/** Clears the process-global verdict cache (and optionally retunes the cap) for tests. */
+export function __resetRelevanceGateVerdictCacheForTests(options?: {
+  maxEntries?: number;
+}): void {
+  if (options?.maxEntries !== undefined) {
+    verdictCache.setMaxEntries(options.maxEntries);
+  } else {
+    verdictCache.setMaxEntries(resolveGateVerdictCacheMax());
+  }
+  verdictCache.clear();
+}
+
+/** Process-global verdict-cache size; for tests only. */
+export function __getRelevanceGateVerdictCacheSizeForTests(): number {
+  return verdictCache.size;
+}
 
 export async function applyRelevanceGate<T extends RelevanceGateCandidate>(
   input: RelevanceGateInput<T>,


### PR DESCRIPTION
## Summary

Bound the process-global relevance-gate `verdictCache` so long-lived `kb serve` processes cannot retain unbounded gate verdicts.

- Wrap the module-scope map in an insertion-order LRU (default max **256**).
- Register `KB_GATE_VERDICT_CACHE_MAX` (schema + generated config reference / `.env.example`); `0` disables the memory tier.
- Export `__resetRelevanceGateVerdictCacheForTests` / size accessor for focused tests.
- Verdict **values** are unchanged — only retention is bounded.

Closes #899

## Design choice

Kept the env name `KB_GATE_VERDICT_CACHE_MAX` as specified by the issue (peers use `*_LRU_MAX`; the shorter name matches the acceptance text). Cap default matches other process LRUs (query/decompose: 256).

## Testing

- [x] `npm run test:file -- src/relevance-gate.test.ts` passes (37 tests)
- [x] `npm run lint` + `npm run typecheck:tests` + `npm run build` clean
- [x] `npm run config:check-env-usage` clean
- [x] `npm run docs:check-config-reference` + `docs:check-env-example` clean
- [x] <!-- kookr:check:tests --> Tests were added or updated for changed behavior; bug fixes include a regression test

### Verification

- Inserting more than the cap keeps size bounded and evicts the oldest entry.
- LRU recency promotion: re-accessing an entry protects it over a colder peer when a new key arrives.
- `maxEntries: 0` never retains entries (every lookup is a miss).
- Recently-set verdict hits while under the cap (including near-capacity fill).
- Test-reset export clears the process map.

## Documentation contract

- [x] ~~<!-- kookr:check:readme --> `README.md` reflects user-visible CLI, MCP, installation, or configuration changes~~ Not applicable — no CLI/MCP surface change; operator knobs live in the generated config reference and feature-flags catalog
- [x] <!-- kookr:check:docs --> Relevant operator, API, configuration, and retrieval documentation under `docs/` is consistent with the implementation
- [x] ~~<!-- kookr:check:mbse --> RFCs are updated when this PR implements, supersedes, or changes an accepted design~~ Not applicable — RFC 018 already called for a bounded LRU; this implements retention bounds only

## Changelog

- [x] ~~<!-- kookr:check:changelog --> `CHANGELOG.md` has an `Unreleased` entry for user-visible changes~~ Not applicable — repo has no `CHANGELOG.md`

## Retrieval and performance evidence

- [x] ~~<!-- kookr:check:benchmarks --> Retrieval-quality or performance changes include the relevant benchmark/evaluation evidence, or this row is waived with a reason~~ Waived — memory retention bound only; no retrieval scoring/ranking change

## Follow-ups

None.
