### PR TITLE
fix(otel): flush tracer provider on CLI and server exit

### DIFF
--- a/src/KnowledgeBaseServer.ts
+++ b/src/KnowledgeBaseServer.ts
@@ -142,7 +142,7 @@ import {
   type DenseDegradationReason,
 } from './search-core.js';
 import { parseRecencyFilterRange } from './search-filters.js';
-import { withSpan } from './otel-trace.js';
+import { shutdownOtel, withSpan } from './otel-trace.js';
 import {
   applyRelevanceGate,
   emitRelevanceGateDecision,
@@ -1953,6 +1953,13 @@ export class KnowledgeBaseServer {
       await this.mcp.close();
     } catch (err) {
       logger.warn(`Error closing root mcp: ${(err as Error).message}`);
+    }
+    // Flush pending OTLP spans before process exit (issue #879). Bounded so a
+    // dead collector cannot hang SIGINT/SIGTERM drain.
+    try {
+      await shutdownOtel();
+    } catch (err) {
+      logger.warn(`Error during OpenTelemetry shutdown: ${(err as Error).message}`);
     }
   }
 }

--- a/src/cli-serve.ts
+++ b/src/cli-serve.ts
@@ -247,6 +247,10 @@ export async function gracefulDrain(
     daemon.server.closeAllConnections?.();
   }
   await daemon.stop();
+  // OTEL flush is intentionally NOT here: force-exit is drainTimeoutMs+1s and
+  // shutdownOtel can take up to OTEL_SHUTDOWN_TIMEOUT_MS (2s). Flushing inside
+  // gracefulDrain races process.exit mid-export. `kb serve` returns to
+  // cli.ts which awaits shutdownOtel() after force-exit is cleared (issue #879).
 }
 
 /** Resolve to `true` once idle, or `false` if the bounded wait elapses first. */

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -55,6 +55,7 @@ import { emitCanonicalLog } from './canonical-log.js';
 import { buildDaemonSearchArgs, resolveSearchPager } from './cli-pager.js';
 import { exitCodeDocs, formatExitCodesHelp } from './cli-exit-codes.js';
 import { closestSuggestion } from './cli-shared.js';
+import { shutdownOtel } from './otel-trace.js';
 
 // ----- Subcommand registry --------------------------------------------------
 
@@ -670,9 +671,12 @@ function isMainModule(): boolean {
 }
 
 if (isMainModule()) {
-  void main(process.argv).then((code) => {
+  // Flush OTEL spans before exit so one-shot CLI commands (kb ask, etc.)
+  // actually export — BatchSpanProcessor otherwise drops them (issue #879).
+  void main(process.argv).then(async (code) => {
+    await shutdownOtel();
     process.exit(code);
-  }).catch((err) => {
+  }).catch(async (err) => {
     // Catastrophic top-level (transitive import failure, etc.). Emit a
     // hint about half-installed npm i -g (RFC §7 F11).
     const msg = (err as Error)?.message ?? String(err);
@@ -684,6 +688,7 @@ if (isMainModule()) {
     } else {
       process.stderr.write(`kb: fatal: ${msg}\n`);
     }
+    await shutdownOtel();
     process.exit(1);
   });
 }

--- a/src/otel-trace.test.ts
+++ b/src/otel-trace.test.ts
@@ -3,8 +3,11 @@ import { afterEach, describe, expect, it } from '@jest/globals';
 import {
   isOtelTracesEnabled,
   resetOtelForTesting,
+  setOtelProviderForTesting,
   setOtelTracerForTesting,
+  shutdownOtel,
   withSpan,
+  type MinimalTracerProvider,
   type OtelSpanLike,
   type OtelTracerLike,
 } from './otel-trace.js';
@@ -171,5 +174,111 @@ describe('withSpan', () => {
       expect(allValues).not.toContain(secretQuery);
       expect(spans[0].attributes).toEqual({ 'kb.k': 8, 'kb.result_count': 2 });
     });
+  });
+});
+
+/**
+ * Fake provider that records forceFlush / shutdown order for issue #879.
+ */
+function makeFakeProvider(opts?: {
+  /** forceFlush hangs forever (no timer — no open-handle risk). */
+  hangFlush?: boolean;
+  flushError?: Error;
+  shutdownError?: Error;
+}): {
+  provider: MinimalTracerProvider;
+  calls: string[];
+} {
+  const calls: string[] = [];
+  const provider: MinimalTracerProvider = {
+    register() { /* unused */ },
+    getTracer() {
+      throw new Error('getTracer not used in shutdown tests');
+    },
+    async forceFlush() {
+      calls.push('forceFlush:start');
+      if (opts?.hangFlush) {
+        // Never settles — exercises the timeout bound without leaving a timer.
+        await new Promise<void>(() => { /* hang */ });
+      }
+      if (opts?.flushError) throw opts.flushError;
+      calls.push('forceFlush:done');
+    },
+    async shutdown() {
+      calls.push('shutdown:start');
+      if (opts?.shutdownError) throw opts.shutdownError;
+      calls.push('shutdown:done');
+    },
+  };
+  return { provider, calls };
+}
+
+describe('shutdownOtel (issue #879)', () => {
+  afterEach(() => {
+    resetOtelForTesting();
+  });
+
+  it('is a no-op when no provider was installed', async () => {
+    await expect(shutdownOtel()).resolves.toBeUndefined();
+  });
+
+  it('awaits forceFlush then shutdown on the teardown path', async () => {
+    const { provider, calls } = makeFakeProvider();
+    setOtelProviderForTesting(provider);
+
+    await shutdownOtel(1000);
+
+    expect(calls).toEqual([
+      'forceFlush:start',
+      'forceFlush:done',
+      'shutdown:start',
+      'shutdown:done',
+    ]);
+  });
+
+  it('does not hang when forceFlush never resolves (timeout-bounded)', async () => {
+    const { provider, calls } = makeFakeProvider({ hangFlush: true });
+    setOtelProviderForTesting(provider);
+
+    const started = Date.now();
+    // Leave residual budget after the 50ms flush timeout so shutdown still runs.
+    await shutdownOtel(80);
+    const elapsed = Date.now() - started;
+
+    // Must return near the bound; allow some CI slack.
+    expect(elapsed).toBeLessThan(500);
+    expect(elapsed).toBeGreaterThanOrEqual(40);
+    expect(calls[0]).toBe('forceFlush:start');
+    // forceFlush did not complete before the deadline.
+    expect(calls).not.toContain('forceFlush:done');
+    // Teardown continues to shutdown with remaining budget.
+    expect(calls).toContain('shutdown:start');
+    expect(calls).toContain('shutdown:done');
+  });
+
+  it('swallows forceFlush errors and still attempts shutdown', async () => {
+    const { provider, calls } = makeFakeProvider({
+      flushError: new Error('collector unreachable'),
+    });
+    setOtelProviderForTesting(provider);
+
+    await expect(shutdownOtel(1000)).resolves.toBeUndefined();
+    expect(calls).toEqual([
+      'forceFlush:start',
+      'shutdown:start',
+      'shutdown:done',
+    ]);
+  });
+
+  it('is idempotent after a successful flush', async () => {
+    const { provider, calls } = makeFakeProvider();
+    setOtelProviderForTesting(provider);
+
+    await shutdownOtel(1000);
+    await shutdownOtel(1000);
+
+    // Second call must not re-invoke the provider.
+    expect(calls.filter((c) => c === 'forceFlush:start')).toHaveLength(1);
+    expect(calls.filter((c) => c === 'shutdown:start')).toHaveLength(1);
   });
 });

--- a/src/otel-trace.ts
+++ b/src/otel-trace.ts
@@ -64,6 +64,14 @@ const NOOP_SPAN_HANDLE: SpanHandle = { setAttribute() { /* no-op */ } };
 let cachedTracer: MinimalTracer | null | undefined;
 let initPromise: Promise<MinimalTracer | null> | null = null;
 let testTracer: MinimalTracer | null | undefined;
+// Retained so CLI/server teardown can forceFlush + shutdown (issue #879).
+// Without this handle BatchSpanProcessor drops every span on short-lived exit.
+let activeProvider: MinimalTracerProvider | null = null;
+// Serializes concurrent shutdownOtel() calls (SIGINT + SIGTERM races).
+let shutdownPromise: Promise<void> | null = null;
+
+/** Default bound so an unreachable OTLP collector cannot hang process exit. */
+export const OTEL_SHUTDOWN_TIMEOUT_MS = 2000;
 
 /** Whether `KB_OTEL_TRACES` opts the process into trace export. */
 export function isOtelTracesEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
@@ -88,13 +96,18 @@ async function lazyImport(specifier: string): Promise<any> {
 interface OtlpExporterModule {
   OTLPTraceExporter: new (config?: Record<string, unknown>) => object;
 }
+/** Minimal provider surface needed for export flush + clean shutdown. */
+export interface MinimalTracerProvider {
+  register(): void;
+  getTracer(name: string): MinimalTracer;
+  forceFlush(): Promise<void>;
+  shutdown(): Promise<void>;
+}
+
 // `@opentelemetry/sdk-trace-node` re-exports the span processors from
 // `@opentelemetry/sdk-trace-base`, so we only need the one optional package.
 interface SdkNodeModule {
-  NodeTracerProvider: new (config: Record<string, unknown>) => {
-    register(): void;
-    getTracer(name: string): MinimalTracer;
-  };
+  NodeTracerProvider: new (config: Record<string, unknown>) => MinimalTracerProvider;
   BatchSpanProcessor: new (exporter: object) => object;
 }
 interface ResourcesModule {
@@ -123,6 +136,9 @@ async function initTracerProvider(): Promise<MinimalTracer | null> {
     // Registers the global tracer + async-context manager so child spans nest
     // under the active parent span across `await` boundaries.
     provider.register();
+    // Keep the provider so teardown can forceFlush/shutdown (issue #879).
+    // Without this, BatchSpanProcessor never exports before short-lived exit.
+    activeProvider = provider;
     logger.info(`OpenTelemetry tracing enabled (service.name=${serviceName}, OTLP/HTTP exporter)`);
     return provider.getTracer(INSTRUMENTATION_SCOPE);
   } catch (err) {
@@ -132,6 +148,94 @@ async function initTracerProvider(): Promise<MinimalTracer | null> {
       + `Install the optional @opentelemetry/* packages to enable trace export. (${message})`,
     );
     return null;
+  }
+}
+
+/**
+ * Race `promise` against `timeoutMs`. Resolves with `'timeout'` if the bound
+ * elapses first; never leaves a dangling timer that keeps the event loop alive.
+ */
+function raceWithTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+): Promise<T | 'timeout'> {
+  if (timeoutMs <= 0) {
+    // Budget exhausted: abandon the work without attaching a race timer, but
+    // still attach a no-op catch so a late rejection is not unhandled.
+    void promise.catch(() => { /* abandoned after timeout budget */ });
+    return Promise.resolve('timeout');
+  }
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => resolve('timeout'), timeoutMs);
+    // Don't keep the process alive solely for the flush deadline.
+    timer.unref();
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (err: unknown) => {
+        clearTimeout(timer);
+        reject(err instanceof Error ? err : new Error(String(err)));
+      },
+    );
+  });
+}
+
+/**
+ * Flush pending spans and shut down the tracer provider (issue #879).
+ *
+ * Short-lived CLI processes exit before BatchSpanProcessor's scheduled export
+ * fires; without an explicit forceFlush every span is dropped. Bounded by
+ * `timeoutMs` so an unreachable OTLP collector cannot hang process exit.
+ *
+ * Safe to call when tracing was never enabled (no-op) and safe to call more
+ * than once (subsequent calls no-op after the first completes).
+ */
+export async function shutdownOtel(
+  timeoutMs: number = OTEL_SHUTDOWN_TIMEOUT_MS,
+): Promise<void> {
+  if (shutdownPromise) return shutdownPromise;
+  const provider = activeProvider;
+  if (provider === null) return;
+  // Drop the handle first so concurrent callers see a no-op while we drain.
+  activeProvider = null;
+  cachedTracer = null;
+  initPromise = null;
+
+  shutdownPromise = (async () => {
+    const deadline = Date.now() + Math.max(0, timeoutMs);
+    const remaining = (): number => Math.max(0, deadline - Date.now());
+
+    try {
+      const flushOutcome = await raceWithTimeout(provider.forceFlush(), remaining());
+      if (flushOutcome === 'timeout') {
+        logger.warn(
+          `OpenTelemetry forceFlush timed out after ${timeoutMs}ms; continuing shutdown`,
+        );
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      logger.warn(`OpenTelemetry forceFlush failed: ${message}`);
+    }
+
+    try {
+      const shutdownOutcome = await raceWithTimeout(provider.shutdown(), remaining());
+      if (shutdownOutcome === 'timeout') {
+        logger.warn(
+          `OpenTelemetry provider shutdown timed out after ${timeoutMs}ms`,
+        );
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      logger.warn(`OpenTelemetry provider shutdown failed: ${message}`);
+    }
+  })();
+
+  try {
+    await shutdownPromise;
+  } finally {
+    shutdownPromise = null;
   }
 }
 
@@ -197,11 +301,24 @@ export function setOtelTracerForTesting(tracer: MinimalTracer | null | undefined
   testTracer = tracer;
 }
 
+/**
+ * Test seam: install a provider so {@link shutdownOtel} can be exercised without
+ * booting the real SDK. Pass `null`/`undefined` to clear.
+ */
+export function setOtelProviderForTesting(
+  provider: MinimalTracerProvider | null | undefined,
+): void {
+  activeProvider = provider ?? null;
+  shutdownPromise = null;
+}
+
 /** Test seam: drop any cached tracer so the next call re-resolves from env. */
 export function resetOtelForTesting(): void {
   cachedTracer = undefined;
   initPromise = null;
   testTracer = undefined;
+  activeProvider = null;
+  shutdownPromise = null;
 }
 
 export type { MinimalSpan as OtelSpanLike, MinimalTracer as OtelTracerLike };


### PR DESCRIPTION
## Summary

When `KB_OTEL_TRACES=on`, the OpenTelemetry tracer provider was built with a `BatchSpanProcessor` but the provider handle was discarded and nothing ever called `forceFlush()` / `shutdown()`. Short-lived CLI commands (`kb ask`, etc.) exited before the batch export fired, so every span was silently dropped even though startup logged "OpenTelemetry tracing enabled."

This PR:
- Retains the provider handle in `otel-trace.ts`
- Adds timeout-bounded `shutdownOtel()` (`forceFlush` then `shutdown`, default 2s total budget)
- Awaits it on CLI process exit (`cli.ts`) and MCP server SIGINT/SIGTERM shutdown (`KnowledgeBaseServer`)
- For `kb serve`, flush runs via the shared CLI teardown *after* drain completes and the force-exit timer is cleared (avoids racing `process.exit` mid-export)

Closes #879

## Design choice

Daemon path: `shutdownOtel` is **not** called inside `gracefulDrain`. The SIGINT force-exit budget is `drainTimeoutMs + 1s`; putting a 2s OTEL flush inside drain could reintroduce silent span loss under load. Instead `runServe` returns to `cli.ts`, which always flushes before `process.exit`. MCP `index.js` does not go through `cli.ts`, so it still flushes inside `KnowledgeBaseServer.shutdown()`.

## Testing

- [x] `npm test` passes (full suite green before review fixes; focused `otel-trace` re-run after amend)
- [x] <!-- kookr:check:tests --> Tests were added or updated for changed behavior; bug fixes include a regression test
- [x] ~~End-to-end verified for tool/transport changes (see `CLAUDE.md`)~~ — not a tool/transport surface change; unit tests cover the flush lifecycle
- [x] ~~Benchmark run if performance-relevant~~ — N/A (teardown-only)

### Verification (issue #879)

**Before:** provider discarded; zero `forceFlush`/`shutdown` call sites; short-lived CLI spans never exported.

**After (unit):**
- `shutdownOtel` awaits `forceFlush` then `shutdown` in order
- hang-forever `forceFlush` returns near the timeout bound and still continues to shutdown
- flush errors are swallowed; shutdown still runs
- second call is a no-op

## Documentation contract

- [x] ~~<!-- kookr:check:readme --> `README.md` reflects user-visible CLI, MCP, installation, or configuration changes~~ — no user-facing config/CLI change; existing `KB_OTEL_TRACES` docs still accurate (export now actually works on one-shot exit)
- [x] ~~<!-- kookr:check:docs --> Relevant operator, API, configuration, and retrieval documentation under `docs/` is consistent with the implementation~~ — no docs claim about BatchSpanProcessor lifecycle to update
- [x] ~~<!-- kookr:check:mbse --> RFCs are updated when this PR implements, supersedes, or changes an accepted design~~ — N/A

## Changelog

- [x] ~~<!-- kookr:check:changelog --> `CHANGELOG.md` has an `Unreleased` entry for user-visible changes~~ — internal fix for opt-in tracing; no changelog required by unit constraints

## Retrieval and performance evidence

- [x] ~~<!-- kookr:check:benchmarks --> Retrieval-quality or performance changes include the relevant benchmark/evaluation evidence, or this row is waived with a reason~~ — N/A (no retrieval/perf change)

## Pre-PR review

- project type: npm
- type/build: passed
- tests: passed (`otel-trace` suite 24/24; full `npm test` green pre-amend)
- specialists: `SPECIALISTS=correctness,lint-like,test` / `DOCS_DRIFT=active`
  - correctness: REQUEST_CHANGES on daemon force-exit race → fixed (flush only in CLI teardown for serve)
  - test: APPROVE
  - conventions/deadcode/docs-drift: APPROVE
- scope guard: clean (5 expected files only)
- gate file: created

## Follow-ups

None.