### PR TITLE
fix(quarantine): skip malformed JSONL lines in manifest reader

### DIFF
--- a/src/ingest-quarantine.test.ts
+++ b/src/ingest-quarantine.test.ts
@@ -195,4 +195,67 @@ describe('ingest quarantine manifest', () => {
       await fsp.rm(tempDir, { recursive: true, force: true });
     }
   });
+
+  it('skips torn/malformed JSONL lines and still returns valid quarantine records', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-quarantine-torn-'));
+    try {
+      const kbPath = path.join(tempDir, 'kb');
+      await fsp.mkdir(kbPath, { recursive: true });
+      const q = await freshQuarantine(tempDir);
+
+      const good = await q.recordIngestFailure({
+        kbPath,
+        relativePath: 'good.md',
+        sourceHash: 'hash-good',
+        error: Object.assign(new Error('poison'), { code: 'EINVAL' }),
+        now: new Date('2026-05-12T10:00:00.000Z'),
+      });
+      const second = await q.recordIngestFailure({
+        kbPath,
+        relativePath: 'also-good.md',
+        sourceHash: 'hash-also',
+        error: Object.assign(new Error('still poison'), { code: 'EACCES' }),
+        now: new Date('2026-05-12T10:01:00.000Z'),
+      });
+
+      const manifestPath = path.join(kbPath, '.index', 'quarantine.jsonl');
+      // Compose a dirty manifest: valid rows + interior garbage + torn tail +
+      // schema-invalid-but-parseable JSON. Mimics crash/corruption without
+      // changing the writer.
+      const expected = [good, second].sort((a, b) => a.relative_path.localeCompare(b.relative_path));
+      await fsp.writeFile(
+        manifestPath,
+        [
+          JSON.stringify(good),
+          'this is not json at all',
+          JSON.stringify(second),
+          '{"schema_version":"ingest-quarant', // torn / truncated line
+          '{"schema_version":"wrong.v0","relative_path":"ignored.md"}',
+          '',
+        ].join('\n'),
+        'utf-8',
+      );
+
+      await expect(q.listIngestQuarantine(kbPath)).resolves.toEqual(expected);
+      await expect(q.listIngestQuarantine(kbPath, { useLock: false })).resolves.toEqual(expected);
+
+      // Hot-path consumer must not throw either.
+      await expect(q.shouldRetryIngest(kbPath, 'good.md', {
+        sourceHash: 'hash-good',
+        now: new Date('2026-05-12T10:00:30.000Z'),
+      })).resolves.toMatchObject({
+        retry: false,
+        reason: 'backoff_active',
+      });
+      await expect(q.shouldRetryIngest(kbPath, 'unrelated.md', {
+        sourceHash: 'x',
+        now: new Date('2026-05-12T10:00:00.000Z'),
+      })).resolves.toMatchObject({
+        retry: true,
+        reason: 'no_record',
+      });
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/ingest-quarantine.ts
+++ b/src/ingest-quarantine.ts
@@ -294,7 +294,18 @@ async function readManifestUnlocked(kbPath: string): Promise<IngestQuarantineRec
   const records: IngestQuarantineRecord[] = [];
   for (const line of raw.split(/\r?\n/)) {
     if (line.trim() === '') continue;
-    const parsed = JSON.parse(line) as Partial<IngestQuarantineRecord>;
+    let parsed: Partial<IngestQuarantineRecord>;
+    try {
+      parsed = JSON.parse(line) as Partial<IngestQuarantineRecord>;
+    } catch {
+      // A non-parseable line is almost always a torn write (crash mid-append)
+      // or other byte-level corruption. Skip rather than aborting the whole
+      // quarantine read — shouldRetryIngest consults this on the ingest hot
+      // path, so a single bad line used to brick reindex of the entire KB.
+      // Well-formed-but-schema-invalid lines still fall through to
+      // isManifestRecord below and are filtered without throwing.
+      continue;
+    }
     if (isManifestRecord(parsed)) records.push(parsed);
   }
   records.sort((a, b) => a.relative_path.localeCompare(b.relative_path));


### PR DESCRIPTION
## Summary

`readManifestUnlocked` called `JSON.parse` on each quarantine JSONL line with no try/catch. A single torn or corrupted line in `.index/quarantine.jsonl` threw out of the reader and aborted the entire reindex hot path via unguarded `shouldRetryIngest` call sites.

This mirrors the existing `feedback-ledger.ts` tolerant-read pattern: skip unparseable lines and keep valid records. Schema-invalid lines that still parse continue to be filtered by `isManifestRecord` without throwing (unchanged).

Closes #887

## Testing

- [x] Focused: `npm run test:file -- src/ingest-quarantine.test.ts` (6/6 pass)
- [x] `npm run build` passes
- [x] Pre-push fast checks (lint + doc-drift) passed
- [x] <!-- kookr:check:tests --> Tests were added or updated for changed behavior; bug fixes include a regression test
- [ ] ~~End-to-end verified for tool/transport changes (see `CLAUDE.md`)~~ — not a tool/transport change
- [ ] ~~Benchmark run if performance-relevant~~ — not performance-relevant

## Documentation contract

- [x] <!-- kookr:check:readme --> ~~`README.md` reflects user-visible CLI, MCP, installation, or configuration changes~~ — no user-visible surface change
- [x] <!-- kookr:check:docs --> ~~Relevant operator, API, configuration, and retrieval documentation under `docs/` is consistent with the implementation~~ — internal reader hardening only
- [x] <!-- kookr:check:mbse --> ~~RFCs are updated when this PR implements, supersedes, or changes an accepted design~~ — no RFC impact

## Changelog

- [x] <!-- kookr:check:changelog --> ~~`CHANGELOG.md` has an `Unreleased` entry for user-visible changes~~ — internal resilience fix, no user-facing API/CLI/MCP change

## Retrieval and performance evidence

- [x] <!-- kookr:check:benchmarks --> ~~Retrieval-quality or performance changes include the relevant benchmark/evaluation evidence~~ — waived: no retrieval or performance surface change

## Design choice

Counted malformed lines only in the sense of skipping them; the public quarantine API still returns `IngestQuarantineRecord[]` only (unlike feedback-ledger's `malformedLineCount`). Smallest fix that satisfies the acceptance criteria without expanding the public API.

## Follow-ups

None.

## Pre-PR review

Correctness / test / conventions specialists: **APPROVE** (nits only; fixture simplified per feedback).