### PR TITLE
fix(transport): count Host-header denials in runtime stats

### DIFF
--- a/src/KnowledgeBaseServer.test.ts
+++ b/src/KnowledgeBaseServer.test.ts
@@ -546,6 +546,7 @@ describe('KnowledgeBaseServer handlers', () => {
       },
       auth_failures: 1,
       origin_denials: 1,
+      host_denials: 0,
       last_error: {
         at: '2026-05-20T07:00:00.000Z',
         message: 'socket parse error',
@@ -595,6 +596,7 @@ describe('KnowledgeBaseServer handlers', () => {
         },
         auth_failures: 1,
         origin_denials: 0,
+        host_denials: 0,
         last_error: null,
       }),
     } as any;

--- a/src/cli-stats.test.ts
+++ b/src/cli-stats.test.ts
@@ -502,6 +502,7 @@ describe('kb stats CLI', () => {
       },
       auth_failures: 2,
       origin_denials: 1,
+      host_denials: 3,
       last_error: {
         at: '2026-05-20T07:00:00.000Z',
         message: 'client socket error',
@@ -519,6 +520,7 @@ describe('kb stats CLI', () => {
     expect(out).toContain('- Requests: total=12, in_flight=4, 1xx=0, 2xx=8, 3xx=0, 4xx=3, 5xx=1');
     expect(out).toContain('- Auth failures: 2');
     expect(out).toContain('- Origin denials: 1');
+    expect(out).toContain('- Host denials: 3');
     expect(out).toContain('- Last error: 2026-05-20T07:00:00.000Z client socket error');
   });
 

--- a/src/cli-stats.ts
+++ b/src/cli-stats.ts
@@ -417,6 +417,7 @@ export function formatRemoteTransportSection(payload: KbStatsPayload): string[] 
       `in_flight=${formatInteger(stats.in_flight_requests)}, ${bucketSummary}`,
     `- Auth failures: ${formatInteger(stats.auth_failures)}`,
     `- Origin denials: ${formatInteger(stats.origin_denials)}`,
+    `- Host denials: ${formatInteger(stats.host_denials)}`,
     `- Last error: ${lastError}`,
     '',
   ];

--- a/src/kb-stats.test.ts
+++ b/src/kb-stats.test.ts
@@ -670,6 +670,7 @@ describe('computeKbStats', () => {
         },
         auth_failures: 1,
         origin_denials: 1,
+        host_denials: 0,
         last_error: null,
       };
       const withTransport = await computeKbStats(makeManager({}) as any, {

--- a/src/prometheus-export.test.ts
+++ b/src/prometheus-export.test.ts
@@ -421,6 +421,7 @@ function samplePayload(): KbStatsPayload {
       },
       auth_failures: 1,
       origin_denials: 1,
+      host_denials: 0,
       last_error: null,
     },
   };

--- a/src/transport-runtime-stats.ts
+++ b/src/transport-runtime-stats.ts
@@ -17,6 +17,7 @@ export interface TransportRuntimeStatsSnapshot {
   response_status_buckets: Record<ResponseStatusBucket, number>;
   auth_failures: number;
   origin_denials: number;
+  host_denials: number;
   last_error: TransportRuntimeErrorSnapshot | null;
 }
 

--- a/src/transport/base-http-host.ts
+++ b/src/transport/base-http-host.ts
@@ -122,6 +122,7 @@ export abstract class BaseHttpHost<TTransport extends { close(): Promise<void> }
     emptyResponseStatusBuckets();
   private authFailures = 0;
   private originDenials = 0;
+  private hostDenials = 0;
   private lastError: TransportRuntimeErrorSnapshot | null = null;
   protected server?: http.Server;
   protected inFlight = 0;
@@ -217,6 +218,7 @@ export abstract class BaseHttpHost<TTransport extends { close(): Promise<void> }
       response_status_buckets: { ...this.responseStatusBuckets },
       auth_failures: this.authFailures,
       origin_denials: this.originDenials,
+      host_denials: this.hostDenials,
       last_error: this.lastError === null ? null : { ...this.lastError },
     };
   }
@@ -433,6 +435,7 @@ export abstract class BaseHttpHost<TTransport extends { close(): Promise<void> }
     //     or no bind host derived). /health short-circuited earlier and stays
     //     reachable by infra probes with arbitrary Host headers.
     if (this.hostAllowList.size > 0 && !this.isAllowedHost(req.headers.host)) {
+      this.hostDenials += 1;
       respond(res, 403, 'Host not allowed');
       finalize(403);
       return;

--- a/src/transport/http.test.ts
+++ b/src/transport/http.test.ts
@@ -328,6 +328,7 @@ describe('StreamableHttpHost — endpoints', () => {
       requests_total: 0,
       auth_failures: 0,
       origin_denials: 0,
+      host_denials: 0,
       last_error: null,
     });
 
@@ -364,6 +365,7 @@ describe('StreamableHttpHost — endpoints', () => {
     expect(stats.response_status_buckets['4xx']).toBeGreaterThanOrEqual(2);
     expect(stats.auth_failures).toBe(1);
     expect(stats.origin_denials).toBe(1);
+    expect(stats.host_denials).toBe(0);
     expect(stats.last_error?.message).toEqual(expect.any(String));
   });
 
@@ -615,6 +617,7 @@ describe('StreamableHttpHost — endpoints', () => {
   it('rejects a forged Host header with 403 when the allow-list is active', async () => {
     const started = await startHost({ allowedHosts: [`127.0.0.1:1`, 'localhost'] });
     stop = started.stop;
+    expect(started.host.getRuntimeStats().host_denials).toBe(0);
     const res = await request(started.port, {
       method: 'POST',
       path: '/mcp',
@@ -625,6 +628,7 @@ describe('StreamableHttpHost — endpoints', () => {
     });
     expect(res.statusCode).toBe(403);
     expect(res.body).toBe('Host not allowed');
+    expect(started.host.getRuntimeStats().host_denials).toBe(1);
   });
 
   it('accepts a request whose Host is on the allow-list', async () => {
@@ -638,6 +642,7 @@ describe('StreamableHttpHost — endpoints', () => {
       headers: { Host: 'TRUSTED.example' },
     });
     expect(res.statusCode).toBe(401);
+    expect(started.host.getRuntimeStats().host_denials).toBe(0);
   });
 
   it('rejects a request with no Host header when the allow-list is active', async () => {

--- a/src/transport/sse.test.ts
+++ b/src/transport/sse.test.ts
@@ -366,6 +366,7 @@ describe('SseHost — endpoints', () => {
   it('rejects a forged Host header on /sse when the allow-list is active', async () => {
     const started = await startHost({ allowedHosts: ['trusted.example'] });
     stop = started.stop;
+    expect(started.host.getRuntimeStats().host_denials).toBe(0);
     const res = await request(started.port, {
       method: 'GET',
       path: '/sse',
@@ -376,6 +377,21 @@ describe('SseHost — endpoints', () => {
     });
     expect(res.statusCode).toBe(403);
     expect(res.body).toBe('Host not allowed');
+    expect(started.host.getRuntimeStats().host_denials).toBe(1);
+  });
+
+  it('does not bump host_denials for an allowed Host on /sse', async () => {
+    const started = await startHost({ allowedHosts: ['trusted.example'] });
+    stop = started.stop;
+    // Use openSseStream — request() would hang waiting for SSE body end.
+    const stream = await openSseStream(started.port, {
+      Host: 'trusted.example',
+      Authorization: `Bearer ${VALID_TOKEN}`,
+    });
+    expect(stream.statusCode).toBe(200);
+    expect(started.host.getRuntimeStats().host_denials).toBe(0);
+    stream.close();
+    await waitFor(() => started.host.sessionCount === 0);
   });
 
   it('exposes process-lifetime SSE transport counters', async () => {
@@ -415,6 +431,7 @@ describe('SseHost — endpoints', () => {
     expect(stats.response_status_buckets['4xx']).toBe(2);
     expect(stats.auth_failures).toBe(1);
     expect(stats.origin_denials).toBe(1);
+    expect(stats.host_denials).toBe(0);
   });
 
   it('serves authenticated OpenMetrics text at GET /metrics when enabled', async () => {


### PR DESCRIPTION
## Summary

DNS-rebinding Host-header rejections (`403 Host not allowed`, #750) returned without incrementing any transport counter, so operators watching `kb stats` could not tell whether the rebinding defense ever fired (or whether `MCP_ALLOWED_HOSTS` was misconfigured). This adds a `host_denials` counter symmetric with the existing `origin_denials` path.

- Increment `hostDenials` on the Host allow-list rejection in `BaseHttpHost`
- Export `host_denials` via `TransportRuntimeStatsSnapshot` / `getRuntimeStats()`
- Render `Host denials` in the `kb stats` Remote Transport markdown section
- Cover disallowed vs allowed Host in HTTP and SSE suites; update fixtures for the new required field

**Out of scope (per issue):** Prometheus `/metrics` export of `host_denials` remains a separate follow-up.

Closes #909

## Testing

- [x] `npm test` passes
- [x] <!-- kookr:check:tests --> Tests were added or updated for changed behavior; bug fixes include a regression test
- [x] Focused: HTTP/SSE Host denial counter assertions; process-lifetime counters leave `host_denials` at 0 when only origin/auth paths fire
- [x] ~~End-to-end verified for tool/transport changes (see `CLAUDE.md`)~~ Counter-only change on existing Host gate; covered by unit/integration transport tests
- [x] ~~Benchmark run if performance-relevant: `BENCH_PROVIDER=stub npm run bench`~~ Not performance-relevant

## Documentation contract

- [x] ~~<!-- kookr:check:readme --> `README.md` reflects user-visible CLI, MCP, installation, or configuration changes~~ Not applicable — no install/CLI surface change beyond an extra stats line under an existing section
- [x] ~~<!-- kookr:check:docs --> Relevant operator, API, configuration, and retrieval documentation under `docs/` is consistent with the implementation~~ Not applicable — `/metrics` OpenMetrics docs intentionally not updated (follow-up); `kb stats` markdown is code-driven
- [x] ~~<!-- kookr:check:mbse --> RFCs are updated when this PR implements, supersedes, or changes an accepted design~~ Not applicable — no RFC change

## Changelog

- [x] ~~<!-- kookr:check:changelog --> `CHANGELOG.md` has an `Unreleased` entry for user-visible changes~~ Not applicable — small operator-visibility counter; unit brief asked not to add changelog unless required; repo has no CHANGELOG.md on this path

## Retrieval and performance evidence

- [x] ~~<!-- kookr:check:benchmarks --> Retrieval-quality or performance changes include the relevant benchmark/evaluation evidence, or this row is waived with a reason~~ Waived — counter-only observability; no retrieval scoring/ranking change

## Design choice

Picked the smallest symmetry with `origin_denials`: private camelCase counter, snake_case snapshot field, markdown line next to Origin denials. Did not wire OpenMetrics (explicit non-goal in #909).

## Follow-ups

- Export `host_denials` on `/metrics` (Prometheus) as a sibling of `kb_remote_transport_origin_denials_total` — called out in the issue as a separate larger follow-up.
