### PR TITLE
fix(doctor): harden bug-report bundle permissions

### DIFF
--- a/docs/cli-json-contracts.md
+++ b/docs/cli-json-contracts.md
@@ -1355,7 +1355,9 @@ Stable KB symlink report fields:
 under `<dir>` (default: current directory). The bundle contains:
 
 - `manifest.json`: schema `kb.doctor.bug_report.v1`, created timestamp, file
-  list, bundle path, and aggregate redaction counts.
+  list, bundle path, intended POSIX modes (`0700` directory / `0600` files),
+  and aggregate redaction counts. The directory and files are created with
+  those private modes on POSIX hosts.
 - `doctor.json`: redacted aggregate doctor report.
 - `stats.json`: captured `kb stats --format=json` payload or failure metadata.
 - `logs-recent.json`: recent canonical log summaries when a log file is
@@ -1377,6 +1379,8 @@ prints the manifest shape:
   "bundle_dir": "/tmp/kb-bug-report-20260522T010203Z",
   "created_at": "2026-05-22T01:02:03.000Z",
   "files": ["README.md", "doctor.json", "manifest.json", "runtime.json"],
+  "intended_directory_mode": "0700",
+  "intended_file_mode": "0600",
   "redaction_summary": {
     "enabled": true,
     "total": 1,

--- a/src/cli-bug-report.test.ts
+++ b/src/cli-bug-report.test.ts
@@ -189,12 +189,44 @@ describe('doctor bug-report bundle', () => {
         'runtime.json',
         'stats.json',
       ]);
+      expect(result.intended_directory_mode).toBe('0700');
+      expect(result.intended_file_mode).toBe('0600');
       const runtime = await fsp.readFile(path.join(result.bundle_dir, 'runtime.json'), 'utf-8');
       expect(runtime).toContain('"name": "OPENAI_API_KEY"');
       expect(runtime).toContain('[REDACTED]');
       const bundleText = await readBundleText(result.bundle_dir, result.files);
       expect(bundleText).not.toContain('sk-proj-secretsecretsecretsecret');
       expect(bundleText).not.toContain('abcdefghijklmnop');
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  const itOnPosix = process.platform === 'win32' ? it.skip : it;
+
+  itOnPosix('creates the bundle directory 0700 and files 0600', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-bug-report-perms-'));
+    try {
+      const result = await createDoctorBugReportBundle({
+        outputParentDir: tempDir,
+        buildDoctorReport: async () => minimalDoctorReport(),
+        runStats: async () => 0,
+        runLogs: async () => 0,
+      });
+
+      expect(modeOf(await fsp.stat(result.bundle_dir))).toBe('0700');
+      for (const file of result.files) {
+        expect(modeOf(await fsp.stat(path.join(result.bundle_dir, file)))).toBe('0600');
+      }
+
+      const manifest = JSON.parse(
+        await fsp.readFile(path.join(result.bundle_dir, 'manifest.json'), 'utf-8'),
+      ) as {
+        intended_directory_mode: string;
+        intended_file_mode: string;
+      };
+      expect(manifest.intended_directory_mode).toBe('0700');
+      expect(manifest.intended_file_mode).toBe('0600');
     } finally {
       await fsp.rm(tempDir, { recursive: true, force: true });
     }
@@ -247,4 +279,8 @@ async function readBundleText(bundleDir: string, files: string[]): Promise<strin
     files.map((file) => fsp.readFile(path.join(bundleDir, file), 'utf-8')),
   );
   return contents.join('\n');
+}
+
+function modeOf(stats: { mode: number }): string {
+  return (stats.mode & 0o777).toString(8).padStart(4, '0');
 }

--- a/src/cli-bug-report.ts
+++ b/src/cli-bug-report.ts
@@ -18,6 +18,8 @@ import type { DoctorReport } from './cli-doctor.js';
 const BUG_REPORT_SCHEMA_VERSION = 'kb.doctor.bug_report.v1';
 const DEFAULT_LOG_LIMIT = 50;
 const COMMAND_STDERR_TAIL_BYTES = 16 * 1024;
+const PRIVATE_DIR_MODE = 0o700;
+const PRIVATE_FILE_MODE = 0o600;
 
 export interface DoctorBugReportOptions {
   outputParentDir?: string;
@@ -35,6 +37,8 @@ export interface DoctorBugReportResult {
   bundle_dir: string;
   created_at: string;
   files: string[];
+  intended_directory_mode: '0700';
+  intended_file_mode: '0600';
   redaction_summary: RedactionSummary;
 }
 
@@ -61,21 +65,24 @@ export async function createDoctorBugReportBundle(
   const createdAt = now.toISOString();
   const parentDir = path.resolve(options.cwd ?? process.cwd(), options.outputParentDir ?? '.');
   const bundleDir = path.join(parentDir, `kb-bug-report-${formatBundleTimestamp(now)}`);
-  await fsp.mkdir(bundleDir, { recursive: false });
+  await fsp.mkdir(bundleDir, { recursive: false, mode: PRIVATE_DIR_MODE });
+  if (isPosixPermissionsSupported()) {
+    await fsp.chmod(bundleDir, PRIVATE_DIR_MODE);
+  }
 
   const written: WrittenFile[] = [];
   const writeJson = async (name: string, value: unknown): Promise<void> => {
     const redacted = redactJsonValue(value);
-    await fsp.writeFile(
-      path.join(bundleDir, name),
+    await writePrivateUtf8File(
+      bundleDir,
+      name,
       `${JSON.stringify(redacted.value, null, 2)}\n`,
-      'utf-8',
     );
     written.push({ name, redaction: redacted.redaction });
   };
   const writeText = async (name: string, text: string): Promise<void> => {
     const redacted = redactSecrets(text);
-    await fsp.writeFile(path.join(bundleDir, name), redacted.text, 'utf-8');
+    await writePrivateUtf8File(bundleDir, name, redacted.text);
     written.push({ name, redaction: redacted.summary });
   };
 
@@ -109,17 +116,35 @@ export async function createDoctorBugReportBundle(
     bundle_dir: bundleDir,
     created_at: createdAt,
     files: [],
+    intended_directory_mode: '0700',
+    intended_file_mode: '0600',
     redaction_summary: manifestRedaction,
   };
   await writeText('README.md', buildReadme(createdAt, options.command !== undefined));
   manifest.files = [...written.map((file) => file.name), 'manifest.json'].sort();
-  await fsp.writeFile(
-    path.join(bundleDir, 'manifest.json'),
+  await writePrivateUtf8File(
+    bundleDir,
+    'manifest.json',
     `${JSON.stringify(manifest, null, 2)}\n`,
-    'utf-8',
   );
 
   return manifest;
+}
+
+async function writePrivateUtf8File(
+  bundleDir: string,
+  relativePath: string,
+  body: string,
+): Promise<void> {
+  const filePath = path.join(bundleDir, relativePath);
+  await fsp.writeFile(filePath, body, { encoding: 'utf-8', mode: PRIVATE_FILE_MODE });
+  if (isPosixPermissionsSupported()) {
+    await fsp.chmod(filePath, PRIVATE_FILE_MODE);
+  }
+}
+
+function isPosixPermissionsSupported(): boolean {
+  return process.platform !== 'win32';
 }
 
 async function defaultBuildDoctorReport(): Promise<DoctorReport> {

--- a/src/cli-json-contracts.test.ts
+++ b/src/cli-json-contracts.test.ts
@@ -281,6 +281,8 @@ const docAssertions: Record<DocumentedCommand, (examples: unknown[]) => void> = 
       bundle_dir: expect.any(String),
       created_at: expect.any(String),
       files: expect.any(Array),
+      intended_directory_mode: '0700',
+      intended_file_mode: '0600',
       redaction_summary: expect.any(Object),
     });
     expect(record(examples[4])).toMatchObject({


### PR DESCRIPTION
## Summary

`kb doctor --bug-report` wrote its diagnostic bundle with default umask permissions (typically world-readable files). Sibling `kb explain --repro-bundle` / `kb diagnose --repro-bundle` already use private `0700`/`0600` modes; the doctor bundle never got that hardening.

This PR mirrors that pattern: create the bundle directory `0700`, write files `0600` (with defensive `chmod` on POSIX), and record `intended_directory_mode` / `intended_file_mode` on the manifest. JSON contract docs and tests updated accordingly.

Closes #898

## Design choice

- Intended modes are top-level manifest fields (as the issue requested), not nested under a `permissions` object like explain. Doctor bundles always create a fresh timestamped directory, so the explain/diagnose existing-dir force/unsafe logic is intentionally omitted.
- Optional CLI help parity note for `--bug-report` (docs/reference/cli.md / doctor help) left as a non-blocking follow-up to keep this unit narrow.

## Testing

- [x] `npm test` passes
- [x] <!-- kookr:check:tests --> Tests were added or updated for changed behavior; bug fixes include a regression test
- [x] Focused: `npm run test:file -- src/cli-bug-report.test.ts` (3/3 pass, including POSIX `0700`/`0600` assertions)
- [x] Runtime repro: created a bundle via `createDoctorBugReportBundle` and confirmed dir `0700` + all files `0600` + intended modes in result/manifest

## Documentation contract

- [x] ~~<!-- kookr:check:readme --> `README.md` reflects user-visible CLI, MCP, installation, or configuration changes~~ — no CLI flag/UX change; only private FS modes on existing bundle
- [x] <!-- kookr:check:docs --> Relevant operator, API, configuration, and retrieval documentation under `docs/` is consistent with the implementation (`docs/cli-json-contracts.md` updated)
- [x] ~~<!-- kookr:check:mbse --> RFCs are updated when this PR implements, supersedes, or changes an accepted design~~ — no RFC/design change

## Changelog

- [x] ~~<!-- kookr:check:changelog --> `CHANGELOG.md` has an `Unreleased` entry for user-visible changes~~ — unit constraints exclude changelog unless required for acceptance; security hardening is covered by the bug-report contract/tests

## Retrieval and performance evidence

- [x] ~~<!-- kookr:check:benchmarks --> Retrieval-quality or performance changes include the relevant benchmark/evaluation evidence, or this row is waived with a reason~~ — no retrieval/performance impact

## Pre-PR review

- Project: npm
- Build/tests: passed (`npm test`, focused bug-report suite green)
- Bug reproduction: verified post-fix modes are private on POSIX
- Scope: clean (cli-bug-report + tests + JSON contract docs/tests)
- Specialists (`select-specialists.sh`): `SPECIALISTS=correctness,lint-like,test` `DOCS_DRIFT=active`
  - correctness: **approve**
  - test: **approve**
  - lint-like (conventions/deadcode/docs-drift): **approve** / **approve** / **approve**

## Follow-ups

Optional: mention private modes in `kb doctor --bug-report` help / `docs/reference/cli.md` for parity with explain/diagnose (specialist nit; out of narrow scope).