### PR TITLE
test(relevance-judge): cover parser fail-safes and no-loss invariant

### DIFF
--- a/src/__property-tests__/relevance-judge.property.test.ts
+++ b/src/__property-tests__/relevance-judge.property.test.ts
@@ -1,0 +1,278 @@
+// Property tests for relevance-judge fail-safes (issue #911).
+//
+// The parser's load-bearing safety invariant: *no candidate is ever lost*.
+// Whatever adversarial / partial / malformed JSON shape the model returns
+// (as long as `overall` is parseable so `normalizeJudgeResponse` does not
+// throw), every input candidate id appears exactly once in the output
+// verdict list, and every decision is either `keep` or `drop`.
+//
+// A second property pins the hallucinated-drop guard: when a verdict says
+// `drop` but the reason shares no content terms with the candidate, the
+// output decision must be `keep` with `downgraded: true`.
+
+import { describe, expect, it } from '@jest/globals';
+import * as fc from 'fast-check';
+import {
+  normalizeJudgeResponse,
+  type RelevanceJudgeCandidate,
+  type RelevanceJudgeDecision,
+  type RelevanceJudgeOverall,
+} from '../relevance-judge.js';
+
+const NUM_RUNS = process.env.KB_PROPERTY_DEEP === '1' ? 1000 : 100;
+
+const OVERALLS: RelevanceJudgeOverall[] = [
+  'relevant',
+  'partial',
+  'no-relevant-context',
+];
+
+// Content terms are drawn from a closed vocabulary so we can control whether
+// a drop-reason overlaps a candidate (for the downgrade property). Tokens are
+// ≥3 chars and not in the judge's stop-word set.
+const CONTENT_WORDS = [
+  'postgres',
+  'migration',
+  'worker',
+  'deploy',
+  'redis',
+  'cache',
+  'reload',
+  'embedding',
+  'huggingface',
+  'index',
+  'vector',
+  'document',
+] as const;
+
+const NON_OVERLAP_WORDS = [
+  'kubernetes',
+  'quantum',
+  'entanglement',
+  'spaceship',
+  'xylophone',
+  'jazz',
+] as const;
+
+const idArb = fc.stringMatching(/^c[a-z0-9]{2,8}$/);
+
+const contentArb = fc
+  .array(fc.constantFrom(...CONTENT_WORDS), { minLength: 3, maxLength: 8 })
+  .map((words) => words.join(' '));
+
+const candidateArb: fc.Arbitrary<RelevanceJudgeCandidate> = fc.record({
+  id: idArb,
+  content: contentArb,
+  metadata: fc.constant({ source: '/kb/fixture.md' }),
+});
+
+const candidatesArb = fc
+  .uniqueArray(candidateArb, {
+    minLength: 1,
+    maxLength: 6,
+    selector: (c) => c.id,
+  });
+
+const decisionArb = fc.constantFrom<RelevanceJudgeDecision | string>(
+  'keep',
+  'drop',
+  'KEEP',
+  'maybe',
+  '',
+);
+
+const reasonArb = fc.oneof(
+  fc.constantFrom(...CONTENT_WORDS).map((w) => `${w} related`),
+  fc.constantFrom(...NON_OVERLAP_WORDS).map((w) => `${w} unrelated`),
+  fc.constant(''),
+  fc.constant('no specific reason'),
+);
+
+/** Build a verdict-row arbitrary biased toward the given candidate ids. */
+function rawVerdictsFor(candidates: RelevanceJudgeCandidate[]) {
+  const knownIdArb = fc.constantFrom(...candidates.map((c) => c.id));
+  const wellFormed = fc.record({
+    id: fc.oneof(
+      // Prefer real candidate ids so keep/drop/duplicate paths fire often
+      { arbitrary: knownIdArb, weight: 4 },
+      { arbitrary: idArb, weight: 1 },
+    ),
+    decision: decisionArb,
+    reason: reasonArb,
+  });
+  // Missing fields / wrong types — parser must skip, not throw.
+  const junk = fc.constantFrom(
+    null,
+    42,
+    'not-an-object',
+    { decision: 'keep' },
+    { id: 123, decision: 'drop' },
+  );
+  return fc.array(fc.oneof(wellFormed, junk), { minLength: 0, maxLength: 12 });
+}
+
+function wrapPayload(
+  body: object,
+  wrapping: 'clean' | 'fenced' | 'fenced-json' | 'garbage',
+): string {
+  const json = JSON.stringify(body);
+  switch (wrapping) {
+    case 'fenced':
+      return `\`\`\`\n${json}\n\`\`\``;
+    case 'fenced-json':
+      return `\`\`\`json\n${json}\n\`\`\``;
+    case 'garbage':
+      return `Here is the answer:\n${json}\nThanks!`;
+    default:
+      return json;
+  }
+}
+
+const wrappingArb = fc.constantFrom(
+  'clean' as const,
+  'fenced' as const,
+  'fenced-json' as const,
+  'garbage' as const,
+);
+
+describe('normalizeJudgeResponse — no candidate is ever lost (issue #911)', () => {
+  it('returns exactly one verdict per input candidate for any parseable payload', () => {
+    fc.assert(
+      fc.property(
+        candidatesArb.chain((candidates) =>
+          fc.tuple(
+            fc.constant(candidates),
+            rawVerdictsFor(candidates),
+            fc.constantFrom(...OVERALLS),
+            wrappingArb,
+          ),
+        ),
+        ([candidates, rawVerdicts, overall, wrapping]) => {
+          // Inject an unknown id so the parser must ignore it without
+          // dropping real candidates.
+          const withUnknown = [
+            ...rawVerdicts,
+            { id: 'unknown-zz', decision: 'drop', reason: 'xylophone jazz' },
+          ];
+          const content = wrapPayload(
+            { overall, verdicts: withUnknown },
+            wrapping,
+          );
+
+          const result = normalizeJudgeResponse(
+            { content, model: 'prop-test' },
+            candidates,
+          );
+
+          const inputIds = candidates.map((c) => c.id).sort();
+          const outputIds = result.verdicts.map((v) => v.id).sort();
+          expect(outputIds).toEqual(inputIds);
+
+          for (const verdict of result.verdicts) {
+            expect(verdict.decision === 'keep' || verdict.decision === 'drop').toBe(true);
+            expect(typeof verdict.reason).toBe('string');
+            expect(verdict.reason.length).toBeGreaterThan(0);
+          }
+
+          expect(OVERALLS).toContain(result.overall);
+        },
+      ),
+      { numRuns: NUM_RUNS },
+    );
+  });
+
+  it('fills keep verdicts when the model omits the verdicts key entirely', () => {
+    fc.assert(
+      fc.property(candidatesArb, fc.constantFrom(...OVERALLS), wrappingArb, (
+        candidates,
+        overall,
+        wrapping,
+      ) => {
+        const content = wrapPayload({ overall }, wrapping);
+        const result = normalizeJudgeResponse(
+          { content, model: null },
+          candidates,
+        );
+        expect(result.verdicts).toHaveLength(candidates.length);
+        for (const verdict of result.verdicts) {
+          expect(verdict.decision).toBe('keep');
+          expect(verdict.reason).toBe('missing judge verdict');
+        }
+      }),
+      { numRuns: NUM_RUNS },
+    );
+  });
+});
+
+describe('normalizeJudgeResponse — hallucinated drop downgrade (issue #911)', () => {
+  it('downgrades drop when reason shares no content terms with the candidate', () => {
+    fc.assert(
+      fc.property(
+        candidatesArb,
+        fc.array(fc.constantFrom(...NON_OVERLAP_WORDS), {
+          minLength: 1,
+          maxLength: 4,
+        }),
+        (candidates, reasonWords) => {
+          // Reason built only from NON_OVERLAP_WORDS → no term can appear in
+          // candidate content (which uses CONTENT_WORDS exclusively).
+          const reason = reasonWords.join(' ');
+          const verdicts = candidates.map((c) => ({
+            id: c.id,
+            decision: 'drop' as const,
+            reason,
+          }));
+          const content = JSON.stringify({
+            overall: 'no-relevant-context',
+            verdicts,
+          });
+
+          const result = normalizeJudgeResponse(
+            { content, model: 'prop-test' },
+            candidates,
+          );
+
+          expect(result.verdicts).toHaveLength(candidates.length);
+          for (const verdict of result.verdicts) {
+            expect(verdict.decision).toBe('keep');
+            expect(verdict.downgraded).toBe(true);
+            expect(verdict.reason).toBe(reason);
+          }
+        },
+      ),
+      { numRuns: NUM_RUNS },
+    );
+  });
+
+  it('preserves drop when at least one reason term appears in the candidate', () => {
+    fc.assert(
+      fc.property(candidatesArb, (candidates) => {
+        // Build a reason that reuses the first content token of each candidate
+        // so the overlap check succeeds and the drop is legitimate.
+        const verdicts = candidates.map((c) => {
+          const firstTerm = c.content.split(/\s+/)[0] ?? 'postgres';
+          return {
+            id: c.id,
+            decision: 'drop' as const,
+            reason: `${firstTerm} only`,
+          };
+        });
+        const content = JSON.stringify({
+          overall: 'partial',
+          verdicts,
+        });
+
+        const result = normalizeJudgeResponse(
+          { content, model: 'prop-test' },
+          candidates,
+        );
+
+        for (const verdict of result.verdicts) {
+          expect(verdict.decision).toBe('drop');
+          expect(verdict.downgraded).toBeUndefined();
+        }
+      }),
+      { numRuns: NUM_RUNS },
+    );
+  });
+});

--- a/src/relevance-judge.test.ts
+++ b/src/relevance-judge.test.ts
@@ -1,0 +1,372 @@
+// Unit tests for relevance-judge JSON parsing and fail-safes (issue #911).
+//
+// `relevance-gate.test.ts` stubs the judge endpoint and exercises gate
+// orchestration; this suite drives `normalizeJudgeResponse` with real /
+// adversarial payloads so the parser, drop→keep downgrade, and no-loss
+// guarantee are covered directly. Fixtures are synthetic — no provider
+// secrets, no live LLM calls.
+
+import { describe, expect, it } from '@jest/globals';
+import {
+  normalizeJudgeResponse,
+  RelevanceJudgeError,
+  type RelevanceJudgeCandidate,
+} from './relevance-judge.js';
+
+function candidate(
+  id: string,
+  content: string,
+  metadata: Record<string, unknown> = { source: '/kb/note.md' },
+): RelevanceJudgeCandidate {
+  return { id, content, metadata };
+}
+
+function response(content: string, model: string | null = 'test-judge') {
+  return { content, model };
+}
+
+const CAND_A = candidate(
+  'cand-a',
+  'Deploy the worker after the postgres migration completes successfully.',
+);
+const CAND_B = candidate(
+  'cand-b',
+  'Redis cache invalidation runs on every config reload.',
+);
+const CAND_C = candidate(
+  'cand-c',
+  'The embedding provider default is huggingface for local indexes.',
+);
+
+describe('normalizeJudgeResponse — JSON salvage', () => {
+  it('parses clean JSON with keep/drop verdicts', () => {
+    const content = JSON.stringify({
+      overall: 'partial',
+      verdicts: [
+        { id: 'cand-a', decision: 'keep', reason: 'covers postgres migration' },
+        { id: 'cand-b', decision: 'drop', reason: 'redis cache unrelated' },
+      ],
+    });
+
+    const result = normalizeJudgeResponse(response(content), [CAND_A, CAND_B]);
+
+    expect(result.overall).toBe('partial');
+    expect(result.model).toBe('test-judge');
+    expect(result.rawContent).toBe(content);
+    expect(result.verdicts).toEqual([
+      { id: 'cand-a', decision: 'keep', reason: 'covers postgres migration' },
+      // "redis" and "cache" both appear in cand-b content → legitimate drop
+      { id: 'cand-b', decision: 'drop', reason: 'redis cache unrelated' },
+    ]);
+  });
+
+  it('parses markdown-fenced JSON (```json … ```)', () => {
+    const payload = {
+      overall: 'relevant',
+      verdicts: [{ id: 'cand-a', decision: 'keep', reason: 'postgres migration steps' }],
+    };
+    const fenced = `\`\`\`json\n${JSON.stringify(payload)}\n\`\`\``;
+
+    const result = normalizeJudgeResponse(response(fenced), [CAND_A]);
+
+    expect(result.overall).toBe('relevant');
+    expect(result.verdicts).toEqual([
+      { id: 'cand-a', decision: 'keep', reason: 'postgres migration steps' },
+    ]);
+  });
+
+  it('parses plain markdown fence without language tag', () => {
+    const payload = {
+      overall: 'no-relevant-context',
+      verdicts: [{ id: 'cand-a', decision: 'drop', reason: 'postgres migration absent here' }],
+    };
+    // reason overlaps "postgres"/"migration" from cand-a → legitimate drop
+    const fenced = `\`\`\`\n${JSON.stringify(payload)}\n\`\`\``;
+
+    const result = normalizeJudgeResponse(response(fenced), [CAND_A]);
+
+    expect(result.overall).toBe('no-relevant-context');
+    expect(result.verdicts).toEqual([
+      { id: 'cand-a', decision: 'drop', reason: 'postgres migration absent here' },
+    ]);
+  });
+
+  it('salvages a JSON object wrapped in garbage prose', () => {
+    const payload = {
+      overall: 'partial',
+      verdicts: [{ id: 'cand-b', decision: 'keep', reason: 'redis cache reload' }],
+    };
+    const wrapped = `Sure, here is my judgment:\n${JSON.stringify(payload)}\nHope that helps!`;
+
+    const result = normalizeJudgeResponse(response(wrapped), [CAND_B]);
+
+    expect(result.overall).toBe('partial');
+    expect(result.verdicts).toEqual([
+      { id: 'cand-b', decision: 'keep', reason: 'redis cache reload' },
+    ]);
+  });
+
+  it('throws RelevanceJudgeError when content is not valid JSON and cannot be repaired', () => {
+    expect(() => normalizeJudgeResponse(response('not json at all'), [CAND_A])).toThrow(
+      RelevanceJudgeError,
+    );
+    expect(() => normalizeJudgeResponse(response('not json at all'), [CAND_A])).toThrow(
+      /not valid JSON/,
+    );
+  });
+
+  it('throws RelevanceJudgeError when extracted braces do not form valid JSON', () => {
+    // extractFirstJsonObject finds {…} but the slice is still unparseable
+    expect(() =>
+      normalizeJudgeResponse(response('prefix { overall: relevant, broken } suffix'), [CAND_A]),
+    ).toThrow(RelevanceJudgeError);
+    expect(() =>
+      normalizeJudgeResponse(response('prefix { overall: relevant, broken } suffix'), [CAND_A]),
+    ).toThrow(/repair failed/);
+  });
+
+  it('throws RelevanceJudgeError on malformed overall values', () => {
+    const badOveralls = ['', 'maybe', 'RELEVANT', 'no_relevant_context', 42, null, true];
+
+    for (const overall of badOveralls) {
+      const content = JSON.stringify({
+        overall,
+        verdicts: [{ id: 'cand-a', decision: 'keep', reason: 'ok' }],
+      });
+      expect(() => normalizeJudgeResponse(response(content), [CAND_A])).toThrow(
+        RelevanceJudgeError,
+      );
+      expect(() => normalizeJudgeResponse(response(content), [CAND_A])).toThrow(
+        /invalid overall verdict/,
+      );
+    }
+  });
+
+  it('throws when overall key is missing', () => {
+    const content = JSON.stringify({
+      verdicts: [{ id: 'cand-a', decision: 'keep', reason: 'ok' }],
+    });
+    expect(() => normalizeJudgeResponse(response(content), [CAND_A])).toThrow(
+      /invalid overall verdict/,
+    );
+  });
+});
+
+describe('normalizeJudgeResponse — drop→keep downgrade (hallucinated drop guard)', () => {
+  it('downgrades drop when reason has no lexical overlap with the candidate', () => {
+    // Reason talks about "kubernetes pods" — terms absent from cand-a content
+    const content = JSON.stringify({
+      overall: 'partial',
+      verdicts: [
+        { id: 'cand-a', decision: 'drop', reason: 'kubernetes pods unrelated' },
+      ],
+    });
+
+    const result = normalizeJudgeResponse(response(content), [CAND_A]);
+
+    expect(result.verdicts).toEqual([
+      {
+        id: 'cand-a',
+        decision: 'keep',
+        reason: 'kubernetes pods unrelated',
+        downgraded: true,
+      },
+    ]);
+  });
+
+  it('keeps a legitimate drop when reason terms appear in the candidate', () => {
+    // cand-b content: "Redis cache invalidation runs on every config reload."
+    const content = JSON.stringify({
+      overall: 'partial',
+      verdicts: [
+        { id: 'cand-b', decision: 'drop', reason: 'redis cache topic only' },
+      ],
+    });
+
+    const result = normalizeJudgeResponse(response(content), [CAND_B]);
+
+    expect(result.verdicts).toEqual([
+      { id: 'cand-b', decision: 'drop', reason: 'redis cache topic only' },
+    ]);
+    expect(result.verdicts[0].downgraded).toBeUndefined();
+  });
+
+  it('never downgrades an explicit keep', () => {
+    const content = JSON.stringify({
+      overall: 'relevant',
+      verdicts: [
+        { id: 'cand-a', decision: 'keep', reason: 'totally unrelated gibberish xyzzy' },
+      ],
+    });
+
+    const result = normalizeJudgeResponse(response(content), [CAND_A]);
+
+    expect(result.verdicts).toEqual([
+      { id: 'cand-a', decision: 'keep', reason: 'totally unrelated gibberish xyzzy' },
+    ]);
+    expect(result.verdicts[0].downgraded).toBeUndefined();
+  });
+
+  it('downgrades drop when reason only yields stop-words or short tokens', () => {
+    // "after with that" → all stop words; "to be" → tokens < 3 chars. Neither
+    // produces a content-term, so the hallucinated-drop guard must fire.
+    for (const reason of ['after with that', 'to be or of']) {
+      const content = JSON.stringify({
+        overall: 'partial',
+        verdicts: [{ id: 'cand-a', decision: 'drop', reason }],
+      });
+      const result = normalizeJudgeResponse(response(content), [CAND_A]);
+      expect(result.verdicts).toEqual([
+        { id: 'cand-a', decision: 'keep', reason, downgraded: true },
+      ]);
+    }
+  });
+});
+
+describe('normalizeJudgeResponse — no-loss invariant (missing verdicts)', () => {
+  it('re-adds candidates with no verdict as keep', () => {
+    const content = JSON.stringify({
+      overall: 'partial',
+      verdicts: [
+        { id: 'cand-a', decision: 'keep', reason: 'postgres migration' },
+        // cand-b and cand-c omitted
+      ],
+    });
+
+    const result = normalizeJudgeResponse(response(content), [CAND_A, CAND_B, CAND_C]);
+
+    expect(result.verdicts.map((v) => v.id).sort()).toEqual(
+      ['cand-a', 'cand-b', 'cand-c'].sort(),
+    );
+    expect(result.verdicts.find((v) => v.id === 'cand-b')).toEqual({
+      id: 'cand-b',
+      decision: 'keep',
+      reason: 'missing judge verdict',
+    });
+    expect(result.verdicts.find((v) => v.id === 'cand-c')).toEqual({
+      id: 'cand-c',
+      decision: 'keep',
+      reason: 'missing judge verdict',
+    });
+  });
+
+  it('fills every candidate when verdicts array is empty or missing', () => {
+    for (const body of [{ overall: 'relevant' }, { overall: 'relevant', verdicts: [] }]) {
+      const result = normalizeJudgeResponse(
+        response(JSON.stringify(body)),
+        [CAND_A, CAND_B],
+      );
+      expect(result.verdicts).toEqual([
+        { id: 'cand-a', decision: 'keep', reason: 'missing judge verdict' },
+        { id: 'cand-b', decision: 'keep', reason: 'missing judge verdict' },
+      ]);
+    }
+  });
+
+  it('ignores unknown ids, non-objects, and duplicate verdicts', () => {
+    const content = JSON.stringify({
+      overall: 'partial',
+      verdicts: [
+        null,
+        42,
+        'skip-me',
+        { id: 'unknown-id', decision: 'drop', reason: 'not a candidate' },
+        { decision: 'keep', reason: 'missing id field' },
+        { id: 'cand-a', decision: 'keep', reason: 'first keep' },
+        { id: 'cand-a', decision: 'drop', reason: 'duplicate ignored' },
+      ],
+    });
+
+    const result = normalizeJudgeResponse(response(content), [CAND_A, CAND_B]);
+
+    expect(result.verdicts).toEqual([
+      { id: 'cand-a', decision: 'keep', reason: 'first keep' },
+      { id: 'cand-b', decision: 'keep', reason: 'missing judge verdict' },
+    ]);
+  });
+
+  it('defaults non-drop decisions to keep and empty reasons to a placeholder', () => {
+    const content = JSON.stringify({
+      overall: 'relevant',
+      verdicts: [
+        { id: 'cand-a', decision: 'maybe', reason: '' },
+        { id: 'cand-b', decision: 'KEEP', reason: '   ' },
+        { id: 'cand-c', decision: 'drop' /* reason missing */ },
+      ],
+    });
+
+    const result = normalizeJudgeResponse(response(content), [CAND_A, CAND_B, CAND_C]);
+
+    // non-'drop' decisions become keep; empty/missing reason → 'no specific reason'
+    // drop with no overlapping reason (placeholder) is also downgraded to keep
+    expect(result.verdicts).toEqual([
+      { id: 'cand-a', decision: 'keep', reason: 'no specific reason' },
+      { id: 'cand-b', decision: 'keep', reason: 'no specific reason' },
+      {
+        id: 'cand-c',
+        decision: 'keep',
+        reason: 'no specific reason',
+        downgraded: true,
+      },
+    ]);
+  });
+});
+
+describe('normalizeJudgeResponse — tabulated payload matrix', () => {
+  it.each([
+    {
+      name: 'clean keep/drop',
+      content: JSON.stringify({
+        overall: 'partial',
+        verdicts: [
+          { id: 'cand-a', decision: 'keep', reason: 'postgres migration' },
+          { id: 'cand-b', decision: 'drop', reason: 'redis cache only' },
+        ],
+      }),
+      candidates: [CAND_A, CAND_B],
+      expectedOverall: 'partial' as const,
+      expected: [
+        { id: 'cand-a', decision: 'keep' as const, reason: 'postgres migration' },
+        { id: 'cand-b', decision: 'drop' as const, reason: 'redis cache only' },
+      ],
+    },
+    {
+      name: 'fenced JSON with hallucinated drop',
+      content: '```json\n'
+        + JSON.stringify({
+          overall: 'no-relevant-context',
+          verdicts: [
+            { id: 'cand-a', decision: 'drop', reason: 'quantum entanglement theory' },
+          ],
+        })
+        + '\n```',
+      candidates: [CAND_A],
+      expectedOverall: 'no-relevant-context' as const,
+      expected: [
+        {
+          id: 'cand-a',
+          decision: 'keep' as const,
+          reason: 'quantum entanglement theory',
+          downgraded: true,
+        },
+      ],
+    },
+    {
+      name: 'garbage-wrapped + missing sibling verdict',
+      content: `Here you go: ${JSON.stringify({
+        overall: 'relevant',
+        verdicts: [{ id: 'cand-a', decision: 'keep', reason: 'worker deploy' }],
+      })} // end`,
+      candidates: [CAND_A, CAND_B],
+      expectedOverall: 'relevant' as const,
+      expected: [
+        { id: 'cand-a', decision: 'keep' as const, reason: 'worker deploy' },
+        { id: 'cand-b', decision: 'keep' as const, reason: 'missing judge verdict' },
+      ],
+    },
+  ])('$name', ({ content, candidates, expectedOverall, expected }) => {
+    const result = normalizeJudgeResponse(response(content), candidates);
+    expect(result.overall).toBe(expectedOverall);
+    expect(result.verdicts).toEqual(expected);
+  });
+});


### PR DESCRIPTION
## Summary

`normalizeJudgeResponse` is the relevance-gate's untrusted-LLM JSON parsing layer. It enforces two safety invariants:

1. **Hallucinated-drop guard** — a `drop` whose reason does not lexically overlap the candidate is silently downgraded to `keep` (`downgraded: true`).
2. **No-loss fill-in** — candidates with no verdict are re-added as `keep` with reason `missing judge verdict`.

`relevance-gate.test.ts` stubs the judge endpoint and never drives the parser with real/adversarial payloads. This PR adds focused unit + property coverage for the parse/repair chain and those fail-safes.

Closes #911

## What was added

- `src/relevance-judge.test.ts` — tabulated unit cases for:
  - clean JSON, markdown-fenced JSON (`` ```json `` and plain fence)
  - garbage-wrapped JSON salvage
  - malformed / missing `overall` → `RelevanceJudgeError`
  - drop→keep downgrade (incl. stop-word / short-token reasons)
  - legitimate drop preserved when reason overlaps content
  - missing / empty / junk / duplicate verdicts → keep fill-in
- `src/__property-tests__/relevance-judge.property.test.ts` — fast-check properties:
  - no candidate is ever lost under adversarial verdict payloads + wrapping variants
  - omitted `verdicts` key always fills keep
  - non-overlapping drop reasons always downgrade; overlapping ones preserve drop

## Design choices

- **Tests only** — no production changes. Stryker `mutate` scope / `mutation-axes.md` left as a follow-up (issue noted the run may be slow and unit+property is the initial scope).
- Drive `normalizeJudgeResponse` directly (exported, pure) rather than `judgeRelevance` end-to-end, so fixtures stay deterministic with no live LLM and no policy/fs setup.

## Testing

- [x] `npm test` passes (full parallel + serial suite)
- [x] Focused: `jest --testPathPattern=relevance-judge` → 23 passed
- [x] <!-- kookr:check:tests --> Tests were added for changed behavior (parser fail-safes)

## Documentation contract

- [x] <!-- kookr:check:readme --> ~~README.md~~ N/A — test-only, no user-visible surface
- [x] <!-- kookr:check:docs --> ~~docs/~~ N/A — no operator/API/config change
- [x] <!-- kookr:check:mbse --> ~~RFCs~~ N/A — no design change

## Changelog

- [x] <!-- kookr:check:changelog --> ~~CHANGELOG.md~~ N/A — internal test coverage only

## Retrieval and performance evidence

- [x] <!-- kookr:check:benchmarks --> ~~benchmarks~~ N/A — no retrieval/perf change

## Follow-ups

- Optional: add `src/relevance-judge.ts` to Stryker `mutate` scope + note in `mutation-axes.md` (deferred per issue risk note).

## Pre-PR review

Specialists (test / correctness / conventions) all **APPROVE** with nits only; property arb biased toward known candidate ids after review feedback.