### PR TITLE
feat(cli): add --format=json to kb compare and kb stale-check

### DIFF
--- a/docs/cli-json-contracts.md
+++ b/docs/cli-json-contracts.md
@@ -2415,3 +2415,143 @@ Stdout/stderr and exit codes:
 Source and test anchors: `src/cli-reindex.ts::runReindexStatusCli`,
 `src/reindex-progress.ts::computeReindexProgress`,
 `src/cli-reindex-status.test.ts`, `src/reindex-progress.test.ts`.
+
+## `kb compare`
+
+Invocation:
+
+```bash
+kb compare <query> <model_a> <model_b> [--k=<int>] [--kb=<name>] [--no-cache] --format=json
+```
+
+Success envelope:
+
+```json
+{
+  "schema_version": "kb.compare.v1",
+  "query": "rollback procedure",
+  "model_a": "ollama__nomic-embed-text",
+  "model_b": "openai__text-embedding-3-small",
+  "k": 10,
+  "knowledge_base": null,
+  "rows": [
+    {
+      "rank_a": 1,
+      "rank_b": 2,
+      "score_a": 0.12,
+      "score_b": 0.34,
+      "in_both": true,
+      "source": "work/runbooks/deploy.md"
+    },
+    {
+      "rank_a": 2,
+      "rank_b": null,
+      "score_a": 0.45,
+      "score_b": null,
+      "in_both": false,
+      "source": "work/runbooks/rollback.md"
+    }
+  ]
+}
+```
+
+Stable fields:
+
+- `schema_version`: currently `kb.compare.v1`.
+- `query`: the query string exactly as supplied.
+- `model_a` / `model_b`: resolved model ids used for each leg.
+- `k`: the per-model top-K limit used for both legs.
+- `knowledge_base`: the `--kb=<name>` scope, or `null` when searching all KBs.
+- `rows[]`: joined rank/score table, sorted by best rank in either column
+  (same ordering as the markdown table).
+- `rows[].rank_a` / `rank_b`: 1-based rank within that model's top-K, or
+  `null` when the hit is only present on the other model.
+- `rows[].score_a` / `score_b`: per-model L2 distance (not cross-comparable),
+  or `null` when the hit is missing from that leg.
+- `rows[].in_both`: `true` when the same join key (`source` + chunk index)
+  appears in both legs. Multi-chunk documents can produce multiple rows that
+  share a `source` path; chunk index is used for joining but is not emitted
+  as a separate field (matching the historical markdown table).
+- `rows[].source`: document source path from the hit metadata.
+
+Stdout/stderr and exit codes:
+
+- Success JSON is stdout with exit `0`.
+- Argument / model-resolution errors print `kb compare: ...` to stderr and
+  exit `2`.
+- Layout/index/search failures print `kb compare: ...` to stderr and exit `1`.
+- Without `--format=json`, the historical markdown table is unchanged.
+
+Source and test anchors: `src/cli-compare.ts`, `src/cli-compare.test.ts`.
+
+## `kb stale-check`
+
+Invocation:
+
+```bash
+kb stale-check [--kb=<name>] [--no-cache] [--quiet|-q] [--verbose|-v] --format=json
+```
+
+Success envelope:
+
+```json
+{
+  "schema_version": "kb.stale-check.v1",
+  "knowledge_bases": ["ops"],
+  "totals": {
+    "files_scanned": 12,
+    "references_checked": 40,
+    "stale_references": 2,
+    "files_with_stale": 1
+  },
+  "broken_references": [
+    {
+      "knowledge_base": "ops",
+      "path": "runbooks/deploy.md",
+      "line": 14,
+      "type": "tilde-path",
+      "value": "~/missing/path.md",
+      "status": "MISSING",
+      "detail": "parent dir missing"
+    },
+    {
+      "knowledge_base": "ops",
+      "path": "runbooks/deploy.md",
+      "line": 22,
+      "type": "url",
+      "value": "https://example.invalid/doc",
+      "status": "HTTP_ERROR",
+      "detail": "HTTP 404"
+    }
+  ]
+}
+```
+
+Stable fields:
+
+- `schema_version`: currently `kb.stale-check.v1`.
+- `knowledge_bases`: KB names included in the scan (sorted when unscoped).
+- `totals.files_scanned`, `totals.references_checked`,
+  `totals.stale_references`, `totals.files_with_stale`: integer counters
+  matching the markdown summary.
+- `broken_references[]`: one object per broken/error reference, in scan order.
+  Machine-readable status codes are `MISSING`, `HTTP_ERROR`, and `TIMEOUT`
+  (the same codes used in the markdown report).
+- Entry fields: `knowledge_base`, `path` (KB-relative), `line`, `type`
+  (`tilde-path` | `rel-path` | `url`), `value`, `status`, and optional
+  `detail` when a more specific reason is available.
+- Optional `references[]`: present only with `--verbose`; every checked
+  reference (including `OK` / `SKIPPED`), same entry shape as
+  `broken_references[]`.
+
+Stdout/stderr and exit codes:
+
+- Success JSON is stdout with exit `0` (including when `broken_references` is
+  empty).
+- Argument errors print `kb stale-check: ...` to stderr and exit `2`.
+- Runtime/KB failures print `kb stale-check: ...` to stderr and exit `1`.
+- `--quiet` only affects markdown output (drops the summary footer); JSON
+  always includes `totals`.
+- Without `--format=json`, the historical markdown report is unchanged.
+
+Source and test anchors: `src/cli-stale-check.ts`, `src/cli-stale-check.test.ts`.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -268,7 +268,7 @@ Side-by-side rank/score table for two embedding models.
 kb compare — side-by-side rank/score table for two embedding models
 
 Usage:
-  kb compare <query> <model_a> <model_b> [--k=<int>] [--kb=<name>] [--no-cache]
+  kb compare <query> <model_a> <model_b> [--k=<int>] [--kb=<name>] [--no-cache] [--format=md|json]
 
 Runs the same query against two registered models' indexes and prints a
 joined table of `rank_a / rank_b / score_a / score_b / in_both / source`,
@@ -287,11 +287,14 @@ Options:
   --k=<int>             Top-K results per model (default: 10).
   --kb=<name>           Scope to one knowledge base. Omit to search ALL KBs.
   --no-cache            Bypass the query-embedding cache for both model legs.
+  --format=md|json      Output format (default: md). `json` emits a stable
+                        rank/score object documented in docs/cli-json-contracts.md.
   --help, -h            Show this help.
 
 Examples:
   kb compare "rollback procedure" ollama__nomic-embed-text openai__text-embedding-3-small
   kb compare "deploy" ollama__nomic-embed-text huggingface__bge-small-en --k=5 --kb=work
+  kb compare "deploy" ollama__nomic-embed-text huggingface__bge-small-en --format=json
 ```
 
 ## `kb completion`
@@ -1678,7 +1681,7 @@ Scan markdown notes for path / URL references that no longer resolve.
 kb stale-check — find broken references in markdown notes (read-only)
 
 Usage:
-  kb stale-check [--kb=<name>] [--no-cache] [--quiet|-q] [--verbose|-v]
+  kb stale-check [--kb=<name>] [--no-cache] [--quiet|-q] [--verbose|-v] [--format=md|json]
 
 Walks every `.md` / `.markdown` file under one or all KBs and extracts:
   - tilde-rooted absolute paths       (`~/foo/bar`)
@@ -1698,14 +1701,19 @@ Options:
                         every URL and overwrite cached entries.
   --quiet, -q           Suppress the summary footer, leaving only the
                         broken/error reference lines (empty when clean).
+                        No effect on `--format=json` (totals always included).
   --verbose, -v         Include OK references in the report (default:
                         only print broken/error references).
+  --format=md|json      Output format (default: md). `json` emits a stable
+                        broken-reference report documented in
+                        docs/cli-json-contracts.md.
   --help, -h            Show this help.
 
 Examples:
   kb stale-check
   kb stale-check --kb=work
   kb stale-check --no-cache --verbose
+  kb stale-check --format=json
 ```
 
 ## `kb stats`

--- a/src/cli-compare.test.ts
+++ b/src/cli-compare.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+  buildCompareReport,
+  buildCompareRows,
+  COMPARE_SCHEMA_VERSION,
+  formatCompareReport,
+  parseCompareArgs,
+  type CompareHit,
+} from './cli-compare.js';
+
+describe('parseCompareArgs', () => {
+  it('parses required positionals with defaults', () => {
+    expect(parseCompareArgs(['hello', 'model_a', 'model_b'])).toEqual({
+      query: 'hello',
+      modelA: 'model_a',
+      modelB: 'model_b',
+      k: 10,
+      kb: undefined,
+      noCache: false,
+      format: 'md',
+    });
+  });
+
+  it('parses --k, --kb, --no-cache, and --format=json', () => {
+    expect(parseCompareArgs([
+      'deploy',
+      'ollama__a',
+      'openai__b',
+      '--k=5',
+      '--kb=work',
+      '--no-cache',
+      '--format=json',
+    ])).toEqual({
+      query: 'deploy',
+      modelA: 'ollama__a',
+      modelB: 'openai__b',
+      k: 5,
+      kb: 'work',
+      noCache: true,
+      format: 'json',
+    });
+  });
+
+  it('rejects invalid --format', () => {
+    expect(() => parseCompareArgs(['q', 'a', 'b', '--format=csv'])).toThrow(
+      "invalid --format value 'csv' (expected md or json)",
+    );
+  });
+
+  it('rejects invalid --k', () => {
+    expect(() => parseCompareArgs(['q', 'a', 'b', '--k=0'])).toThrow('invalid --k');
+  });
+
+  it('rejects missing positionals', () => {
+    expect(() => parseCompareArgs(['only-one'])).toThrow('expected <query> <model_a> <model_b>');
+  });
+
+  it('rejects unknown flags', () => {
+    expect(() => parseCompareArgs(['q', 'a', 'b', '--zzz'])).toThrow('unknown flag');
+  });
+});
+
+describe('buildCompareRows / formatCompareReport', () => {
+  const hitsA: CompareHit[] = [
+    { source: 'work/a.md', chunkIndex: 0, score: 0.12 },
+    { source: 'work/b.md', chunkIndex: 1, score: 0.34 },
+  ];
+  const hitsB: CompareHit[] = [
+    { source: 'work/b.md', chunkIndex: 1, score: 0.21 },
+    { source: 'work/c.md', chunkIndex: 0, score: 0.55 },
+  ];
+
+  it('joins hits by source#chunkIndex and sorts by best rank', () => {
+    const rows = buildCompareRows(hitsA, hitsB);
+    expect(rows).toEqual([
+      {
+        rank_a: 1,
+        rank_b: null,
+        score_a: 0.12,
+        score_b: null,
+        in_both: false,
+        source: 'work/a.md',
+      },
+      {
+        rank_a: 2,
+        rank_b: 1,
+        score_a: 0.34,
+        score_b: 0.21,
+        in_both: true,
+        source: 'work/b.md',
+      },
+      {
+        rank_a: null,
+        rank_b: 2,
+        score_a: null,
+        score_b: 0.55,
+        in_both: false,
+        source: 'work/c.md',
+      },
+    ]);
+  });
+
+  it('markdown output keeps the historical table layout', () => {
+    const report = buildCompareReport({
+      query: 'deploy',
+      modelA: 'ollama__a',
+      modelB: 'openai__b',
+      k: 5,
+      kb: 'work',
+      hitsA,
+      hitsB,
+    });
+    const out = formatCompareReport(report, 'md');
+    expect(out).toContain('# kb compare');
+    expect(out).toContain('Query: deploy');
+    expect(out).toContain('Model A: ollama__a');
+    expect(out).toContain('Model B: openai__b');
+    expect(out).toContain('rank_a  rank_b  score_a  score_b  in_both  source');
+    expect(out).toContain('work/a.md');
+    expect(out).toContain('  yes  ');
+    expect(out).toContain('  no   ');
+    expect(out).toMatch(/—/);
+  });
+
+  it('json output emits a stable schema envelope with the same rank/score data', () => {
+    const report = buildCompareReport({
+      query: 'deploy',
+      modelA: 'ollama__a',
+      modelB: 'openai__b',
+      k: 5,
+      kb: 'work',
+      hitsA,
+      hitsB,
+    });
+    const out = formatCompareReport(report, 'json');
+    const parsed = JSON.parse(out) as typeof report;
+    expect(parsed).toEqual({
+      schema_version: COMPARE_SCHEMA_VERSION,
+      query: 'deploy',
+      model_a: 'ollama__a',
+      model_b: 'openai__b',
+      k: 5,
+      knowledge_base: 'work',
+      rows: [
+        {
+          rank_a: 1,
+          rank_b: null,
+          score_a: 0.12,
+          score_b: null,
+          in_both: false,
+          source: 'work/a.md',
+        },
+        {
+          rank_a: 2,
+          rank_b: 1,
+          score_a: 0.34,
+          score_b: 0.21,
+          in_both: true,
+          source: 'work/b.md',
+        },
+        {
+          rank_a: null,
+          rank_b: 2,
+          score_a: null,
+          score_b: 0.55,
+          in_both: false,
+          source: 'work/c.md',
+        },
+      ],
+    });
+    expect(out.endsWith('\n')).toBe(true);
+  });
+
+  it('json knowledge_base is null when --kb is omitted', () => {
+    const report = buildCompareReport({
+      query: 'q',
+      modelA: 'a',
+      modelB: 'b',
+      k: 10,
+      hitsA: [],
+      hitsB: [],
+    });
+    expect(report.knowledge_base).toBeNull();
+    expect(report.rows).toEqual([]);
+  });
+});

--- a/src/cli-compare.ts
+++ b/src/cli-compare.ts
@@ -5,10 +5,12 @@ import {
 } from './active-model.js';
 import { loadManagerForModel, loadWithJsonRetry } from './cli-shared.js';
 
+export const COMPARE_SCHEMA_VERSION = 'kb.compare.v1' as const;
+
 export const COMPARE_HELP = `kb compare — side-by-side rank/score table for two embedding models
 
 Usage:
-  kb compare <query> <model_a> <model_b> [--k=<int>] [--kb=<name>] [--no-cache]
+  kb compare <query> <model_a> <model_b> [--k=<int>] [--kb=<name>] [--no-cache] [--format=md|json]
 
 Runs the same query against two registered models' indexes and prints a
 joined table of \`rank_a / rank_b / score_a / score_b / in_both / source\`,
@@ -27,42 +29,211 @@ Options:
   --k=<int>             Top-K results per model (default: 10).
   --kb=<name>           Scope to one knowledge base. Omit to search ALL KBs.
   --no-cache            Bypass the query-embedding cache for both model legs.
+  --format=md|json      Output format (default: md). \`json\` emits a stable
+                        rank/score object documented in docs/cli-json-contracts.md.
   --help, -h            Show this help.
 
 Examples:
   kb compare "rollback procedure" ollama__nomic-embed-text openai__text-embedding-3-small
   kb compare "deploy" ollama__nomic-embed-text huggingface__bge-small-en --k=5 --kb=work
+  kb compare "deploy" ollama__nomic-embed-text huggingface__bge-small-en --format=json
 `;
 
-export async function runCompare(rest: string[]): Promise<number> {
-  // Parse: <query> <model_a> <model_b> [--k=<int>] [--kb=<name>]
+export interface CompareArgs {
+  query: string;
+  modelA: string;
+  modelB: string;
+  k: number;
+  kb?: string;
+  noCache: boolean;
+  format: 'md' | 'json';
+}
+
+export interface CompareHit {
+  source: string;
+  chunkIndex: number;
+  /** Present when the search hit carried a numeric score; omitted → markdown "—". */
+  score?: number;
+}
+
+export interface CompareRow {
+  rank_a: number | null;
+  rank_b: number | null;
+  score_a: number | null;
+  score_b: number | null;
+  in_both: boolean;
+  source: string;
+}
+
+export interface CompareReport {
+  schema_version: typeof COMPARE_SCHEMA_VERSION;
+  query: string;
+  model_a: string;
+  model_b: string;
+  k: number;
+  knowledge_base: string | null;
+  rows: CompareRow[];
+}
+
+export function parseCompareArgs(rest: string[]): CompareArgs {
   const positionals: string[] = [];
   let k = 10;
   let kb: string | undefined;
   let noCache = false;
+  let format: 'md' | 'json' = 'md';
+
   for (const raw of rest) {
     if (raw.startsWith('--k=')) {
       const n = Number(raw.slice('--k='.length));
       if (!Number.isInteger(n) || n <= 0) {
-        process.stderr.write(`kb compare: invalid --k: ${raw}\n`);
-        return 2;
+        throw new Error(`invalid --k: ${raw}`);
       }
       k = n;
       continue;
     }
-    if (raw.startsWith('--kb=')) { kb = raw.slice('--kb='.length); continue; }
-    if (raw === '--no-cache') { noCache = true; continue; }
+    if (raw.startsWith('--kb=')) {
+      kb = raw.slice('--kb='.length);
+      continue;
+    }
+    if (raw === '--no-cache') {
+      noCache = true;
+      continue;
+    }
+    if (raw.startsWith('--format=')) {
+      const value = raw.slice('--format='.length);
+      if (value !== 'md' && value !== 'json') {
+        throw new Error(`invalid --format value '${value}' (expected md or json)`);
+      }
+      format = value;
+      continue;
+    }
     if (raw.startsWith('--')) {
-      process.stderr.write(`kb compare: unknown flag: ${raw}\n`);
-      return 2;
+      throw new Error(`unknown flag: ${raw}`);
     }
     positionals.push(raw);
   }
+
   if (positionals.length !== 3) {
-    process.stderr.write('kb compare: expected <query> <model_a> <model_b>\n');
+    throw new Error('expected <query> <model_a> <model_b>');
+  }
+
+  const [query, modelA, modelB] = positionals;
+  return { query, modelA, modelB, k, kb, noCache, format };
+}
+
+/** Join two top-K hit lists into a rank/score table sorted by best rank. */
+export function buildCompareRows(hitsA: CompareHit[], hitsB: CompareHit[]): CompareRow[] {
+  interface MutableRow {
+    rank_a?: number;
+    rank_b?: number;
+    score_a?: number;
+    score_b?: number;
+    source: string;
+  }
+  const rows = new Map<string, MutableRow>();
+
+  hitsA.forEach((hit, i) => {
+    const key = `${hit.source}#${hit.chunkIndex}`;
+    rows.set(key, {
+      rank_a: i + 1,
+      ...(hit.score !== undefined ? { score_a: hit.score } : {}),
+      source: hit.source,
+    });
+  });
+  hitsB.forEach((hit, i) => {
+    const key = `${hit.source}#${hit.chunkIndex}`;
+    const existing = rows.get(key);
+    if (existing) {
+      existing.rank_b = i + 1;
+      if (hit.score !== undefined) existing.score_b = hit.score;
+    } else {
+      rows.set(key, {
+        rank_b: i + 1,
+        ...(hit.score !== undefined ? { score_b: hit.score } : {}),
+        source: hit.source,
+      });
+    }
+  });
+
+  const sorted = Array.from(rows.values());
+  sorted.sort((a, b) => {
+    const minA = Math.min(a.rank_a ?? Number.POSITIVE_INFINITY, a.rank_b ?? Number.POSITIVE_INFINITY);
+    const minB = Math.min(b.rank_a ?? Number.POSITIVE_INFINITY, b.rank_b ?? Number.POSITIVE_INFINITY);
+    return minA - minB;
+  });
+
+  return sorted.map((r) => ({
+    rank_a: r.rank_a ?? null,
+    rank_b: r.rank_b ?? null,
+    score_a: r.score_a ?? null,
+    score_b: r.score_b ?? null,
+    in_both: r.rank_a !== undefined && r.rank_b !== undefined,
+    source: r.source,
+  }));
+}
+
+export function buildCompareReport(input: {
+  query: string;
+  modelA: string;
+  modelB: string;
+  k: number;
+  kb?: string;
+  hitsA: CompareHit[];
+  hitsB: CompareHit[];
+}): CompareReport {
+  return {
+    schema_version: COMPARE_SCHEMA_VERSION,
+    query: input.query,
+    model_a: input.modelA,
+    model_b: input.modelB,
+    k: input.k,
+    knowledge_base: input.kb ?? null,
+    rows: buildCompareRows(input.hitsA, input.hitsB),
+  };
+}
+
+export function formatCompareReport(report: CompareReport, format: 'md' | 'json'): string {
+  if (format === 'json') {
+    return `${JSON.stringify(report, null, 2)}\n`;
+  }
+
+  const lines: string[] = [
+    '# kb compare',
+    '',
+    `Query: ${report.query}`,
+    `Model A: ${report.model_a}`,
+    `Model B: ${report.model_b}`,
+    '(Scores are per-model L2 distances; not directly comparable across models.)',
+    '',
+    'rank_a  rank_b  score_a  score_b  in_both  source',
+  ];
+  for (const r of report.rows) {
+    const ra = r.rank_a !== null ? String(r.rank_a).padStart(6) : '     —';
+    const rb = r.rank_b !== null ? String(r.rank_b).padStart(6) : '     —';
+    const sa = r.score_a !== null ? r.score_a.toFixed(2).padStart(7) : '      —';
+    const sb = r.score_b !== null ? r.score_b.toFixed(2).padStart(7) : '      —';
+    const both = r.in_both ? '  yes  ' : '  no   ';
+    lines.push(`${ra}  ${rb}  ${sa}  ${sb}  ${both}  ${r.source}`);
+  }
+  return `${lines.join('\n')}\n`;
+}
+
+function toCompareHit(doc: { score?: number; metadata?: { source?: string; chunkIndex?: number } }): CompareHit {
+  return {
+    source: doc.metadata?.source ?? 'unknown',
+    chunkIndex: doc.metadata?.chunkIndex ?? 0,
+    ...(typeof doc.score === 'number' && Number.isFinite(doc.score) ? { score: doc.score } : {}),
+  };
+}
+
+export async function runCompare(rest: string[]): Promise<number> {
+  let parsed: CompareArgs;
+  try {
+    parsed = parseCompareArgs(rest);
+  } catch (err) {
+    process.stderr.write(`kb compare: ${(err as Error).message}\n`);
     return 2;
   }
-  const [query, modelA, modelB] = positionals;
 
   try {
     await FaissIndexManager.bootstrapLayout();
@@ -74,8 +245,8 @@ export async function runCompare(rest: string[]): Promise<number> {
   let resolvedA: string;
   let resolvedB: string;
   try {
-    resolvedA = await resolveActiveModel({ explicitOverride: modelA });
-    resolvedB = await resolveActiveModel({ explicitOverride: modelB });
+    resolvedA = await resolveActiveModel({ explicitOverride: parsed.modelA });
+    resolvedB = await resolveActiveModel({ explicitOverride: parsed.modelB });
   } catch (err) {
     if (err instanceof ActiveModelResolutionError) {
       process.stderr.write(`kb compare: ${err.message}\n`);
@@ -85,72 +256,55 @@ export async function runCompare(rest: string[]): Promise<number> {
     return 1;
   }
   if (resolvedA === resolvedB) {
-    process.stderr.write(`kb compare: model_a and model_b resolve to the same id "${resolvedA}". Pick two different models.\n`);
+    process.stderr.write(
+      `kb compare: model_a and model_b resolve to the same id "${resolvedA}". Pick two different models.\n`,
+    );
     return 2;
   }
 
-  let resultsA;
-  let resultsB;
+  let hitsA: CompareHit[];
+  let hitsB: CompareHit[];
   try {
     const managerA = await loadManagerForModel(resolvedA);
     await loadWithJsonRetry(managerA);
-    resultsA = await managerA.similaritySearch(query, k, undefined, kb, undefined, undefined, { noCache });
+    const resultsA = await managerA.similaritySearch(
+      parsed.query,
+      parsed.k,
+      undefined,
+      parsed.kb,
+      undefined,
+      undefined,
+      { noCache: parsed.noCache },
+    );
 
     const managerB = await loadManagerForModel(resolvedB);
     await loadWithJsonRetry(managerB);
-    resultsB = await managerB.similaritySearch(query, k, undefined, kb, undefined, undefined, { noCache });
+    const resultsB = await managerB.similaritySearch(
+      parsed.query,
+      parsed.k,
+      undefined,
+      parsed.kb,
+      undefined,
+      undefined,
+      { noCache: parsed.noCache },
+    );
+
+    hitsA = resultsA.map(toCompareHit);
+    hitsB = resultsB.map(toCompareHit);
   } catch (err) {
     process.stderr.write(`kb compare: ${(err as Error).message}\n`);
     return 1;
   }
 
-  interface Row {
-    rank_a?: number;
-    rank_b?: number;
-    score_a?: number;
-    score_b?: number;
-    source: string;
-  }
-  const rows = new Map<string, Row>();
-  resultsA.forEach((doc: any, i: number) => {
-    const key = `${(doc.metadata?.source ?? 'unknown')}#${doc.metadata?.chunkIndex ?? 0}`;
-    rows.set(key, { rank_a: i + 1, score_a: doc.score, source: doc.metadata?.source ?? 'unknown' });
+  const report = buildCompareReport({
+    query: parsed.query,
+    modelA: resolvedA,
+    modelB: resolvedB,
+    k: parsed.k,
+    kb: parsed.kb,
+    hitsA,
+    hitsB,
   });
-  resultsB.forEach((doc: any, i: number) => {
-    const key = `${(doc.metadata?.source ?? 'unknown')}#${doc.metadata?.chunkIndex ?? 0}`;
-    const existing = rows.get(key);
-    if (existing) {
-      existing.rank_b = i + 1;
-      existing.score_b = doc.score;
-    } else {
-      rows.set(key, { rank_b: i + 1, score_b: doc.score, source: doc.metadata?.source ?? 'unknown' });
-    }
-  });
-
-  const sorted = Array.from(rows.entries()).map(([key, r]) => ({ key, ...r }));
-  sorted.sort((a, b) => {
-    const ra = a.rank_a ?? Number.POSITIVE_INFINITY;
-    const rb = a.rank_b ?? Number.POSITIVE_INFINITY;
-    const minA = Math.min(ra, rb);
-    const ra2 = b.rank_a ?? Number.POSITIVE_INFINITY;
-    const rb2 = b.rank_b ?? Number.POSITIVE_INFINITY;
-    const minB = Math.min(ra2, rb2);
-    return minA - minB;
-  });
-
-  process.stdout.write('# kb compare\n\n');
-  process.stdout.write(`Query: ${query}\n`);
-  process.stdout.write(`Model A: ${resolvedA}\n`);
-  process.stdout.write(`Model B: ${resolvedB}\n`);
-  process.stdout.write('(Scores are per-model L2 distances; not directly comparable across models.)\n\n');
-  process.stdout.write('rank_a  rank_b  score_a  score_b  in_both  source\n');
-  for (const r of sorted) {
-    const ra = r.rank_a !== undefined ? String(r.rank_a).padStart(6) : '     —';
-    const rb = r.rank_b !== undefined ? String(r.rank_b).padStart(6) : '     —';
-    const sa = r.score_a !== undefined ? r.score_a.toFixed(2).padStart(7) : '      —';
-    const sb = r.score_b !== undefined ? r.score_b.toFixed(2).padStart(7) : '      —';
-    const both = r.rank_a !== undefined && r.rank_b !== undefined ? '  yes  ' : '  no   ';
-    process.stdout.write(`${ra}  ${rb}  ${sa}  ${sb}  ${both}  ${r.source}\n`);
-  }
+  process.stdout.write(formatCompareReport(report, parsed.format));
   return 0;
 }

--- a/src/cli-stale-check.test.ts
+++ b/src/cli-stale-check.test.ts
@@ -8,6 +8,8 @@ import {
   formatReport,
   parseStaleCheckArgs,
   staleCheck,
+  STALE_CHECK_SCHEMA_VERSION,
+  toStaleCheckJsonReport,
   type UrlChecker,
 } from './cli-stale-check.js';
 
@@ -31,6 +33,16 @@ describe('parseStaleCheckArgs', () => {
     expect(parseStaleCheckArgs(['--quiet'])).toMatchObject({ quiet: true, verbose: false });
     expect(parseStaleCheckArgs(['-q'])).toMatchObject({ quiet: true, verbose: false });
     expect(parseStaleCheckArgs(['-v'])).toMatchObject({ quiet: false, verbose: true });
+  });
+  it('defaults format to md and accepts --format=json', () => {
+    expect(parseStaleCheckArgs([]).format).toBe('md');
+    expect(parseStaleCheckArgs(['--format=json']).format).toBe('json');
+    expect(parseStaleCheckArgs(['--format=md']).format).toBe('md');
+  });
+  it('rejects invalid --format', () => {
+    expect(() => parseStaleCheckArgs(['--format=csv'])).toThrow(
+      "invalid --format value 'csv' (expected md or json)",
+    );
   });
 });
 
@@ -301,5 +313,107 @@ describe('formatReport', () => {
       totals: { filesScanned: 1, referencesChecked: 0, staleReferences: 0, filesWithStale: 0 },
     }, { quiet: true });
     expect(out).toBe('');
+  });
+
+  it('--format=json emits a stable broken-reference envelope (#895)', () => {
+    const report = {
+      kbs: ['ops'],
+      files: [{
+        kb: 'ops',
+        relPath: 'a.md',
+        results: [
+          { type: 'tilde-path' as const, value: '~/x', line: 3, status: 'MISSING' as const, detail: 'gone' },
+          { type: 'url' as const, value: 'https://ok.example', line: 4, status: 'OK' as const },
+          { type: 'url' as const, value: 'https://e.invalid', line: 7, status: 'HTTP_ERROR' as const, detail: 'HTTP 404' },
+        ],
+      }],
+      totals: { filesScanned: 1, referencesChecked: 3, staleReferences: 2, filesWithStale: 1 },
+    };
+    const out = formatReport(report, { format: 'json' });
+    const parsed = JSON.parse(out);
+    expect(parsed).toEqual({
+      schema_version: STALE_CHECK_SCHEMA_VERSION,
+      knowledge_bases: ['ops'],
+      totals: {
+        files_scanned: 1,
+        references_checked: 3,
+        stale_references: 2,
+        files_with_stale: 1,
+      },
+      broken_references: [
+        {
+          knowledge_base: 'ops',
+          path: 'a.md',
+          line: 3,
+          type: 'tilde-path',
+          value: '~/x',
+          status: 'MISSING',
+          detail: 'gone',
+        },
+        {
+          knowledge_base: 'ops',
+          path: 'a.md',
+          line: 7,
+          type: 'url',
+          value: 'https://e.invalid',
+          status: 'HTTP_ERROR',
+          detail: 'HTTP 404',
+        },
+      ],
+    });
+    expect(parsed.references).toBeUndefined();
+    expect(out.endsWith('\n')).toBe(true);
+  });
+
+  it('--format=json --verbose also includes the full references array', () => {
+    const report = {
+      kbs: ['ops'],
+      files: [{
+        kb: 'ops',
+        relPath: 'a.md',
+        results: [
+          { type: 'url' as const, value: 'https://ok.example', line: 1, status: 'OK' as const },
+          { type: 'tilde-path' as const, value: '~/x', line: 2, status: 'MISSING' as const },
+        ],
+      }],
+      totals: { filesScanned: 1, referencesChecked: 2, staleReferences: 1, filesWithStale: 1 },
+    };
+    const parsed = toStaleCheckJsonReport(report, { verbose: true });
+    expect(parsed.broken_references).toHaveLength(1);
+    expect(parsed.references).toEqual([
+      {
+        knowledge_base: 'ops',
+        path: 'a.md',
+        line: 1,
+        type: 'url',
+        value: 'https://ok.example',
+        status: 'OK',
+      },
+      {
+        knowledge_base: 'ops',
+        path: 'a.md',
+        line: 2,
+        type: 'tilde-path',
+        value: '~/x',
+        status: 'MISSING',
+      },
+    ]);
+  });
+
+  it('default markdown output is unchanged when format is omitted', () => {
+    const report = {
+      kbs: ['ops'],
+      files: [{
+        kb: 'ops',
+        relPath: 'a.md',
+        results: [
+          { type: 'tilde-path' as const, value: '~/x', line: 3, status: 'MISSING' as const, detail: 'gone' },
+        ],
+      }],
+      totals: { filesScanned: 1, referencesChecked: 1, staleReferences: 1, filesWithStale: 1 },
+    };
+    expect(formatReport(report)).toBe(formatReport(report, { format: 'md' }));
+    expect(formatReport(report)).toContain('Summary:');
+    expect(formatReport(report)).not.toContain('schema_version');
   });
 });

--- a/src/cli-stale-check.ts
+++ b/src/cli-stale-check.ts
@@ -19,10 +19,12 @@ import { KNOWLEDGE_BASES_ROOT_DIR } from './config/paths.js';
 import { listKnowledgeBases, resolveKnowledgeBaseDir } from './kb-fs.js';
 import { extractVerbosity } from './cli-shared.js';
 
+export const STALE_CHECK_SCHEMA_VERSION = 'kb.stale-check.v1' as const;
+
 export const STALE_CHECK_HELP = `kb stale-check — find broken references in markdown notes (read-only)
 
 Usage:
-  kb stale-check [--kb=<name>] [--no-cache] [--quiet|-q] [--verbose|-v]
+  kb stale-check [--kb=<name>] [--no-cache] [--quiet|-q] [--verbose|-v] [--format=md|json]
 
 Walks every \`.md\` / \`.markdown\` file under one or all KBs and extracts:
   - tilde-rooted absolute paths       (\`~/foo/bar\`)
@@ -42,14 +44,19 @@ Options:
                         every URL and overwrite cached entries.
   --quiet, -q           Suppress the summary footer, leaving only the
                         broken/error reference lines (empty when clean).
+                        No effect on \`--format=json\` (totals always included).
   --verbose, -v         Include OK references in the report (default:
                         only print broken/error references).
+  --format=md|json      Output format (default: md). \`json\` emits a stable
+                        broken-reference report documented in
+                        docs/cli-json-contracts.md.
   --help, -h            Show this help.
 
 Examples:
   kb stale-check
   kb stale-check --kb=work
   kb stale-check --no-cache --verbose
+  kb stale-check --format=json
 `;
 
 export type ReferenceType = 'tilde-path' | 'rel-path' | 'url';
@@ -120,7 +127,11 @@ export async function runStaleCheck(rest: string[]): Promise<number> {
       cachePath: parsed.noCache ? null : cachePath,
       verbose: parsed.verbose,
     });
-    process.stdout.write(formatReport(report, { quiet: parsed.quiet }));
+    process.stdout.write(formatReport(report, {
+      quiet: parsed.quiet,
+      format: parsed.format,
+      verbose: parsed.verbose,
+    }));
     return 0;
   } catch (err) {
     process.stderr.write(`kb stale-check: ${(err as Error).message}\n`);
@@ -128,13 +139,14 @@ export async function runStaleCheck(rest: string[]): Promise<number> {
   }
 }
 
-interface ParsedArgs {
+export interface ParsedArgs {
   kb?: string;
   noCache: boolean;
   /** Include OK references in the report (shared --verbose / -v). */
   verbose: boolean;
   /** Suppress the summary footer, leaving only broken references (--quiet / -q). */
   quiet: boolean;
+  format: 'md' | 'json';
 }
 
 export function parseStaleCheckArgs(rest: string[]): ParsedArgs {
@@ -147,12 +159,21 @@ export function parseStaleCheckArgs(rest: string[]): ParsedArgs {
     noCache: false,
     verbose: verbosity === 'verbose',
     quiet: verbosity === 'quiet',
+    format: 'md',
   };
   for (const raw of args) {
     if (raw === '--no-cache') { out.noCache = true; continue; }
     if (raw.startsWith('--kb=')) {
       out.kb = raw.slice('--kb='.length);
       if (out.kb.length === 0) throw new Error('--kb=<name> requires a non-empty value');
+      continue;
+    }
+    if (raw.startsWith('--format=')) {
+      const value = raw.slice('--format='.length);
+      if (value !== 'md' && value !== 'json') {
+        throw new Error(`invalid --format value '${value}' (expected md or json)`);
+      }
+      out.format = value;
       continue;
     }
     if (raw.startsWith('--')) throw new Error(`unknown flag: ${raw}`);
@@ -514,12 +535,93 @@ function isStale(r: ReferenceResult): boolean {
   return r.status === 'MISSING' || r.status === 'HTTP_ERROR' || r.status === 'TIMEOUT';
 }
 
+export interface BrokenReferenceEntry {
+  knowledge_base: string;
+  path: string;
+  line: number;
+  type: ReferenceType;
+  value: string;
+  /** Machine-readable status code: MISSING | HTTP_ERROR | TIMEOUT (or OK when verbose). */
+  status: ReferenceStatus;
+  detail?: string;
+}
+
+export interface StaleCheckJsonReport {
+  schema_version: typeof STALE_CHECK_SCHEMA_VERSION;
+  knowledge_bases: string[];
+  totals: {
+    files_scanned: number;
+    references_checked: number;
+    stale_references: number;
+    files_with_stale: number;
+  };
+  /** Broken/error references only — the machine-readable counterpart of the md report body. */
+  broken_references: BrokenReferenceEntry[];
+  /**
+   * Present only with `--verbose`: every checked reference (OK + broken), in
+   * scan order. Absent in the default JSON shape so scripts can rely on
+   * `broken_references` alone.
+   */
+  references?: BrokenReferenceEntry[];
+}
+
 export interface FormatReportOptions {
   /** Issue #739 — drop the trailing summary footer, leaving only stale refs. */
   quiet?: boolean;
+  format?: 'md' | 'json';
+  /** When true (and format=json), also emit the full `references` array. */
+  verbose?: boolean;
+}
+
+export function toStaleCheckJsonReport(
+  report: StaleCheckReport,
+  options: { verbose?: boolean } = {},
+): StaleCheckJsonReport {
+  const broken_references: BrokenReferenceEntry[] = [];
+  const references: BrokenReferenceEntry[] = [];
+
+  for (const file of report.files) {
+    for (const r of file.results) {
+      const entry: BrokenReferenceEntry = {
+        knowledge_base: file.kb,
+        path: file.relPath,
+        line: r.line,
+        type: r.type,
+        value: r.value,
+        status: r.status,
+        ...(r.detail !== undefined ? { detail: r.detail } : {}),
+      };
+      if (options.verbose) {
+        references.push(entry);
+      }
+      if (isStale(r)) {
+        broken_references.push(entry);
+      }
+    }
+  }
+
+  const payload: StaleCheckJsonReport = {
+    schema_version: STALE_CHECK_SCHEMA_VERSION,
+    knowledge_bases: report.kbs,
+    totals: {
+      files_scanned: report.totals.filesScanned,
+      references_checked: report.totals.referencesChecked,
+      stale_references: report.totals.staleReferences,
+      files_with_stale: report.totals.filesWithStale,
+    },
+    broken_references,
+  };
+  if (options.verbose) {
+    payload.references = references;
+  }
+  return payload;
 }
 
 export function formatReport(report: StaleCheckReport, options: FormatReportOptions = {}): string {
+  if (options.format === 'json') {
+    return `${JSON.stringify(toStaleCheckJsonReport(report, { verbose: options.verbose }), null, 2)}\n`;
+  }
+
   const lines: string[] = [];
   for (const file of report.files) {
     const stale = file.results.filter(isStale);


### PR DESCRIPTION
## Summary

Add `--format=md|json` to the two remaining read-only CLI commands that lacked machine-readable output:

- **`kb compare`** — stable `kb.compare.v1` envelope with joined rank/score rows (same data and ordering as the markdown table).
- **`kb stale-check`** — stable `kb.stale-check.v1` envelope with `broken_references[]` entries carrying machine-readable status codes (`MISSING` / `HTTP_ERROR` / `TIMEOUT`), plus optional full `references[]` under `--verbose`.

Default markdown output is unchanged when `--format` is omitted. Shapes are documented in `docs/cli-json-contracts.md`; help text and generated `docs/reference/cli.md` are updated.

### Design notes

- JSON envelopes use `schema_version` (snake_case) to match newer contracts (`inspect`, `logs`, `related`) rather than the older camelCase `schemaVersion` on `kb ls`.
- Rank/score `null` fields stand in for markdown `—` when a hit is only present on one model.
- `--quiet` remains markdown-only (footer suppression); JSON always includes `totals`.

Closes #895

## Testing

- [x] `npm test` passes
- [x] End-to-end verified for tool/transport changes (see `CLAUDE.md`) — N/A: CLI format-only; no MCP/tool/transport surface
- [x] Benchmark run if performance-relevant: `BENCH_PROVIDER=stub npm run bench` — N/A: not performance-relevant
- [x] <!-- kookr:check:tests --> Tests were added or updated for changed behavior; bug fixes include a regression test

## Documentation contract

- [x] ~~<!-- kookr:check:readme --> `README.md` reflects user-visible CLI, MCP, installation, or configuration changes~~ — waived: unit forbids README edits; contracts live in `docs/cli-json-contracts.md` + command help + generated `docs/reference/cli.md`
- [x] <!-- kookr:check:docs --> Relevant operator, API, configuration, and retrieval documentation under `docs/` is consistent with the implementation
- [x] ~~<!-- kookr:check:mbse --> RFCs are updated when this PR implements, supersedes, or changes an accepted design~~ — no RFC impact; additive CLI flag

## Changelog

- [x] ~~<!-- kookr:check:changelog --> `CHANGELOG.md` has an `Unreleased` entry for user-visible changes~~ — waived per unit instructions (no changelog unless required for acceptance)

## Retrieval and performance evidence

- [x] ~~<!-- kookr:check:benchmarks --> Retrieval-quality or performance changes include the relevant benchmark/evaluation evidence, or this row is waived with a reason~~ — N/A: output-format only

## Follow-ups

None.