### PR TITLE
fix(mcp): fail closed on unparseable resource_read policy

### DIFF
--- a/src/mcp-resources.test.ts
+++ b/src/mcp-resources.test.ts
@@ -221,4 +221,83 @@ describe('readResource sensitivity policy', () => {
       else process.env.MCP_TRANSPORT = previousTransport;
     }
   });
+
+  it('fails closed on remote read when frontmatter YAML is malformed around a deny marker', async () => {
+    await fsp.mkdir(kbDir, { recursive: true });
+    await fsp.writeFile(path.join(kbDir, 'malformed-deny.md'), [
+      '---',
+      'kb_policy:',
+      '  resource_read: deny',
+      '  broken: [unclosed',
+      '---',
+      '# Secret body that must not leak',
+      '',
+      'classified payload',
+    ].join('\n'), 'utf-8');
+
+    await expect(readResource(buildResourceUri(kbName, 'malformed-deny.md'), { access: 'remote' }))
+      .rejects.toThrow(/resource blocked by kb_policy\.resource_read.*unreadable or malformed/);
+  });
+
+  it('fails closed when the frontmatter closing fence sits past the 8 KB scan window', async () => {
+    await fsp.mkdir(kbDir, { recursive: true });
+    // Opening fence + padding + policy + closing fence exceed FRONTMATTER_MAX_BYTES
+    // so the lenient parser would drop the policy; strict parse must fail closed.
+    const padding = `# ${'x'.repeat(9000)}\n`;
+    await fsp.writeFile(path.join(kbDir, 'oversized.md'), [
+      '---',
+      padding.trimEnd(),
+      'kb_policy:',
+      '  resource_read: deny',
+      '---',
+      '# Should not be readable remotely',
+    ].join('\n'), 'utf-8');
+
+    await expect(readResource(buildResourceUri(kbName, 'oversized.md'), { access: 'remote' }))
+      .rejects.toThrow(/resource blocked by kb_policy\.resource_read.*unreadable or malformed/);
+  });
+
+  it('fails closed on typo resource_read values instead of allowing', async () => {
+    await fsp.mkdir(kbDir, { recursive: true });
+    for (const [name, value] of [
+      ['typo-denied.md', 'denied'],
+      ['typo-private.md', 'private'],
+      ['typo-no.md', 'no'],
+    ] as const) {
+      await fsp.writeFile(path.join(kbDir, name), [
+        '---',
+        'kb_policy:',
+        `  resource_read: ${value}`,
+        '---',
+        '# Typo policy body',
+      ].join('\n'), 'utf-8');
+
+      await expect(readResource(buildResourceUri(kbName, name), { access: 'remote' }))
+        .rejects.toThrow(/resource blocked by kb_policy\.resource_read/);
+      await expect(readResource(buildResourceUri(kbName, name), { access: 'local' }))
+        .rejects.toThrow(/resource blocked by kb_policy\.resource_read/);
+    }
+  });
+
+  it('still allows local stdio reads of well-formed resource_read=allow notes', async () => {
+    await fsp.mkdir(kbDir, { recursive: true });
+    await fsp.writeFile(path.join(kbDir, 'allow.md'), [
+      '---',
+      'kb_policy:',
+      '  resource_read: allow',
+      '---',
+      '# Public',
+      '',
+      'open note body',
+    ].join('\n'), 'utf-8');
+
+    await expect(readResource(buildResourceUri(kbName, 'allow.md'), { access: 'local' }))
+      .resolves.toMatchObject({
+        contents: [{ text: expect.stringContaining('open note body') }],
+      });
+    await expect(readResource(buildResourceUri(kbName, 'allow.md'), { access: 'remote' }))
+      .resolves.toMatchObject({
+        contents: [{ text: expect.stringContaining('open note body') }],
+      });
+  });
 });

--- a/src/mcp-resources.ts
+++ b/src/mcp-resources.ts
@@ -23,7 +23,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { INGEST_EXCLUDE_PATHS, INGEST_EXTRA_EXTENSIONS } from './config/ingest.js';
 import { KNOWLEDGE_BASES_ROOT_DIR } from './config/paths.js';
 import { toError } from './error-utils.js';
-import { parseFrontmatter } from './frontmatter.js';
+import { parseFrontmatterStrict } from './frontmatter.js';
 import { filterIngestablePaths } from './ingest-filter.js';
 import { listIngestQuarantine } from './ingest-quarantine.js';
 import { resolveKbPath } from './kb-fs.js';
@@ -37,6 +37,7 @@ import {
   normalizeKbSensitivityPolicy,
   resolveResourceReadAccess,
   type KbResourceReadAccess,
+  type KbSensitivityPolicy,
 } from './sensitivity-policy.js';
 
 export interface ListResourcesOptions {
@@ -404,8 +405,20 @@ function assertResourceReadPolicy(input: {
   relativePath: string;
   access: KbResourceReadAccess;
 }): void {
-  const parsed = parseFrontmatter(input.text);
-  const policy = normalizeKbSensitivityPolicy(parsed.frontmatter.kb_policy);
+  // Mirror the LLM-egress boundary: parse strictly so malformed YAML, an
+  // oversized frontmatter block, or a missing closing fence cannot silently
+  // drop a resource_read deny/local_only control and fail open.
+  let policy: KbSensitivityPolicy | undefined;
+  try {
+    const parsed = parseFrontmatterStrict(input.text);
+    policy = normalizeKbSensitivityPolicy(parsed.frontmatter.kb_policy);
+  } catch {
+    throw new Error(
+      `resource blocked by kb_policy.resource_read: ${JSON.stringify(input.relativePath)} `
+      + '(resource frontmatter is unreadable or malformed)',
+    );
+  }
+
   const decision = decideResourceRead(policy, input.access);
   if (decision.allowed) return;
 

--- a/src/sensitivity-policy.test.ts
+++ b/src/sensitivity-policy.test.ts
@@ -1,0 +1,102 @@
+import {
+  decideResourceRead,
+  normalizeKbSensitivityPolicy,
+  resolveResourceReadAccess,
+} from './sensitivity-policy.js';
+
+describe('normalizeKbSensitivityPolicy — resource_read fail-closed', () => {
+  it('keeps recognized resource_read values', () => {
+    expect(normalizeKbSensitivityPolicy({ resource_read: 'allow' })).toEqual({
+      resource_read: 'allow',
+    });
+    expect(normalizeKbSensitivityPolicy({ resource_read: 'local_only' })).toEqual({
+      resource_read: 'local_only',
+    });
+    expect(normalizeKbSensitivityPolicy({ resource_read: 'deny' })).toEqual({
+      resource_read: 'deny',
+    });
+    expect(normalizeKbSensitivityPolicy({ resource_read: 'Local-Only' })).toEqual({
+      resource_read: 'local_only',
+    });
+  });
+
+  it('fails closed on typo and non-enum resource_read values', () => {
+    for (const value of ['denied', 'private', 'no', 'true', 'block', '']) {
+      expect(normalizeKbSensitivityPolicy({ resource_read: value })).toEqual({
+        resource_read: 'deny',
+      });
+    }
+    expect(normalizeKbSensitivityPolicy({ resource_read: 1 })).toEqual({
+      resource_read: 'deny',
+    });
+    expect(normalizeKbSensitivityPolicy({ resource_read: ['deny'] })).toEqual({
+      resource_read: 'deny',
+    });
+    expect(normalizeKbSensitivityPolicy({ resource_read: null })).toEqual({
+      resource_read: 'deny',
+    });
+  });
+
+  it('fails closed when kb_policy is not a mapping', () => {
+    expect(normalizeKbSensitivityPolicy(true)).toEqual({
+      no_llm_context: true,
+      resource_read: 'deny',
+    });
+    expect(normalizeKbSensitivityPolicy('deny')).toEqual({
+      no_llm_context: true,
+      resource_read: 'deny',
+    });
+    expect(normalizeKbSensitivityPolicy(['resource_read', 'deny'])).toEqual({
+      no_llm_context: true,
+      resource_read: 'deny',
+    });
+  });
+
+  it('leaves resource_read unset when the key is absent', () => {
+    expect(normalizeKbSensitivityPolicy({ no_llm_context: true })).toEqual({
+      no_llm_context: true,
+    });
+    expect(normalizeKbSensitivityPolicy({})).toBeUndefined();
+    expect(normalizeKbSensitivityPolicy(undefined)).toBeUndefined();
+  });
+});
+
+describe('decideResourceRead', () => {
+  it('allows when no resource_read policy is present', () => {
+    expect(decideResourceRead(undefined, 'remote')).toEqual({ allowed: true });
+    expect(decideResourceRead({}, 'remote')).toEqual({ allowed: true });
+    expect(decideResourceRead({ resource_read: 'allow' }, 'remote')).toEqual({
+      allowed: true,
+    });
+  });
+
+  it('denies deny for local and remote', () => {
+    expect(decideResourceRead({ resource_read: 'deny' }, 'local')).toEqual({
+      allowed: false,
+      reason: 'resource_read_deny',
+    });
+    expect(decideResourceRead({ resource_read: 'deny' }, 'remote')).toEqual({
+      allowed: false,
+      reason: 'resource_read_deny',
+    });
+  });
+
+  it('blocks local_only only for remote access', () => {
+    expect(decideResourceRead({ resource_read: 'local_only' }, 'local')).toEqual({
+      allowed: true,
+    });
+    expect(decideResourceRead({ resource_read: 'local_only' }, 'remote')).toEqual({
+      allowed: false,
+      reason: 'resource_read_local_only',
+    });
+  });
+});
+
+describe('resolveResourceReadAccess', () => {
+  it('treats http and sse as remote', () => {
+    expect(resolveResourceReadAccess({ MCP_TRANSPORT: 'http' } as NodeJS.ProcessEnv)).toBe('remote');
+    expect(resolveResourceReadAccess({ MCP_TRANSPORT: 'sse' } as NodeJS.ProcessEnv)).toBe('remote');
+    expect(resolveResourceReadAccess({} as NodeJS.ProcessEnv)).toBe('local');
+    expect(resolveResourceReadAccess({ MCP_TRANSPORT: 'stdio' } as NodeJS.ProcessEnv)).toBe('local');
+  });
+});

--- a/src/sensitivity-policy.ts
+++ b/src/sensitivity-policy.ts
@@ -54,9 +54,9 @@ export function normalizeKbSensitivityPolicy(
   }
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
     // An explicit non-mapping policy cannot be inspected safely. Preserve
-    // retrieval while preventing any LLM-boundary caller from treating it as
-    // a policy-free document.
-    return { no_llm_context: true };
+    // retrieval while preventing any LLM-boundary or resources/read caller
+    // from treating it as a policy-free document.
+    return { no_llm_context: true, resource_read: 'deny' };
   }
   const raw = value as Record<string, unknown>;
   const policy: KbSensitivityPolicy = {};
@@ -72,9 +72,14 @@ export function normalizeKbSensitivityPolicy(
     policy.no_llm_context = true;
   }
 
+  const hasResourceRead = Object.prototype.hasOwnProperty.call(raw, 'resource_read');
   const resourceRead = parseResourceReadPolicy(raw.resource_read);
   if (resourceRead !== undefined) {
     policy.resource_read = resourceRead;
+  } else if (hasResourceRead) {
+    // Typos and non-enum values (denied, private, no, …) must fail closed at
+    // the resources/read boundary rather than silently opening the gate.
+    policy.resource_read = 'deny';
   }
 
   if (typeof raw.sensitivity === 'string') {


### PR DESCRIPTION
## Summary

`resources/read` previously used the lenient frontmatter parser and treated
missing/unrecognized `kb_policy.resource_read` as allow. That meant a note
the author marked `deny` or `local_only` was still served to remote clients
when frontmatter YAML was malformed, the closing fence sat past the 8 KB
scan window, or the value was a typo (`denied`, `private`, `no`).

This change mirrors the existing LLM-egress fail-closed path:
- `assertResourceReadPolicy` parses with `parseFrontmatterStrict` and denies
  when frontmatter is unreadable or malformed.
- `normalizeKbSensitivityPolicy` treats present-but-unrecognized
  `resource_read` values (and non-mapping `kb_policy`) as `deny`.

Local stdio reads of well-formed `resource_read: allow` notes are unchanged.

Closes #880

## Testing

- [x] `npm test` passes
- [x] <!-- kookr:check:tests --> Tests were added or updated for changed behavior; bug fixes include a regression test
- [x] Focused coverage: unit tests in `src/sensitivity-policy.test.ts`; integration cases in `src/mcp-resources.test.ts` for malformed YAML, oversized frontmatter, typos, and well-formed allow
- [x] ~~End-to-end verified for tool/transport changes (see `CLAUDE.md`)~~ — policy gate is unit/integration covered via `readResource({ access })`; no transport wiring change
- [x] ~~Benchmark run if performance-relevant~~ — N/A: not performance-relevant

## Documentation contract

- [x] ~~<!-- kookr:check:readme --> `README.md` reflects user-visible CLI, MCP, installation, or configuration changes~~ — no public API/surface change; confidentiality gate hardening only
- [x] ~~<!-- kookr:check:docs --> Relevant operator, API, configuration, and retrieval documentation under `docs/` is consistent with the implementation~~ — `docs/mcp-resources.md` already documents allow/local_only/deny; fail-closed edge cases match the existing LLM-egress confidentiality model without a new author-facing contract
- [x] ~~<!-- kookr:check:mbse --> RFCs are updated when this PR implements, supersedes, or changes an accepted design~~ — no RFC change; corrective fix to existing control

## Changelog

- [x] ~~<!-- kookr:check:changelog --> `CHANGELOG.md` has an `Unreleased` entry for user-visible changes~~ — unit instruction: no changelog/release-note entry

## Retrieval and performance evidence

- [x] ~~<!-- kookr:check:benchmarks --> Retrieval-quality or performance changes include the relevant benchmark/evaluation evidence, or this row is waived with a reason~~ — N/A: not a retrieval-quality or performance change

## Follow-ups

None.
