### PR TITLE
feat(config): suggest schema names for env var typos (#904)

### DIFF
--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -84,13 +84,17 @@ describe('config schema validation (FR-OBS-470)', () => {
     ]));
   });
 
-  it('does not suggest a schema name for an unrelated controlled variable', () => {
+  it.each([
+    'KB_CACHE_SIZE',
+    'OPENAI_BASE_URL',
+    'HUGGINGFACE_TIMEOUT',
+  ])('does not suggest a schema name for unrelated controlled variable %s', (name) => {
     const report = validateConfigEnv({
-      KB_COMPLETELY_UNRELATED_OPTION: 'enabled',
+      [name]: 'enabled',
     });
 
     const unknown = report.findings.find(
-      (finding) => finding.name === 'KB_COMPLETELY_UNRELATED_OPTION',
+      (finding) => finding.name === name,
     );
     expect(unknown).toEqual(expect.objectContaining({
       status: 'warn',

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -67,6 +67,38 @@ describe('config schema validation (FR-OBS-470)', () => {
     expect(report.findings.every((finding) => finding.source === '/tmp/bad.env')).toBe(true);
   });
 
+  it('suggests a nearby schema name for an unknown controlled variable', () => {
+    const report = validateConfigEnv({
+      KB_CHUNK_SIZ: '1000',
+    }, { source: '/tmp/typo.env' });
+
+    expect(report.status).toBe('warn');
+    expect(report.findings).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        name: 'KB_CHUNK_SIZ',
+        status: 'warn',
+        kind: 'unknown',
+        source: '/tmp/typo.env',
+        message: expect.stringContaining('Did you mean KB_CHUNK_SIZE?'),
+      }),
+    ]));
+  });
+
+  it('does not suggest a schema name for an unrelated controlled variable', () => {
+    const report = validateConfigEnv({
+      KB_COMPLETELY_UNRELATED_OPTION: 'enabled',
+    });
+
+    const unknown = report.findings.find(
+      (finding) => finding.name === 'KB_COMPLETELY_UNRELATED_OPTION',
+    );
+    expect(unknown).toEqual(expect.objectContaining({
+      status: 'warn',
+      kind: 'unknown',
+    }));
+    expect(unknown?.message).not.toContain('Did you mean');
+  });
+
   it('matches strict runtime parsers for reranker booleans and digit-only integers', () => {
     const report = validateConfigEnv({
       KB_RERANK: 'yes',

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -67,19 +67,23 @@ describe('config schema validation (FR-OBS-470)', () => {
     expect(report.findings.every((finding) => finding.source === '/tmp/bad.env')).toBe(true);
   });
 
-  it('suggests a nearby schema name for an unknown controlled variable', () => {
+  it.each([
+    ['KB_CHUNK_SIZ', 'KB_CHUNK_SIZE'],
+    ['KB_QUERY_CACHE_LURU_MAX', 'KB_QUERY_CACHE_LRU_MAX'],
+    ['KB_CHUNK_SIEZ', 'KB_CHUNK_SIZE'],
+  ])('suggests %s as a typo for %s', (name, expected) => {
     const report = validateConfigEnv({
-      KB_CHUNK_SIZ: '1000',
+      [name]: '1000',
     }, { source: '/tmp/typo.env' });
 
     expect(report.status).toBe('warn');
     expect(report.findings).toEqual(expect.arrayContaining([
       expect.objectContaining({
-        name: 'KB_CHUNK_SIZ',
+        name,
         status: 'warn',
         kind: 'unknown',
         source: '/tmp/typo.env',
-        message: expect.stringContaining('Did you mean KB_CHUNK_SIZE?'),
+        message: expect.stringContaining(`Did you mean ${expected}?`),
       }),
     ]));
   });
@@ -88,6 +92,8 @@ describe('config schema validation (FR-OBS-470)', () => {
     'KB_CACHE_SIZE',
     'OPENAI_BASE_URL',
     'HUGGINGFACE_TIMEOUT',
+    'MCP_HOST',
+    'KB_DAEMON_POST',
   ])('does not suggest a schema name for unrelated controlled variable %s', (name) => {
     const report = validateConfigEnv({
       [name]: 'enabled',

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -37,7 +37,7 @@ import {
   DEFAULT_DAEMON_HEALTH_TIMEOUT_MS,
   MAX_DAEMON_CLIENT_TIMEOUT_MS,
 } from '../daemon-client.js';
-import { closestSuggestion } from '../suggestion-core.js';
+import { closestSuggestion, levenshteinDistance } from '../suggestion-core.js';
 
 export type ConfigFindingStatus = 'ok' | 'warn' | 'error';
 export type ConfigValueKind =
@@ -313,7 +313,6 @@ export const CONFIG_SCHEMA: readonly ConfigSpec[] = [
 
 const SCHEMA_NAMES = CONFIG_SCHEMA.map((spec) => spec.name);
 const SCHEMA_BY_NAME = new Map(CONFIG_SCHEMA.map((spec) => [spec.name, spec]));
-const MAX_SCHEMA_NAME_SUGGESTION_DISTANCE = 2;
 
 export function validateConfigEnv(
   env: NodeJS.ProcessEnv | Record<string, string | undefined>,
@@ -622,11 +621,7 @@ function validateUnknownControlledVars(
     if (SCHEMA_BY_NAME.has(name)) continue;
     if (dynamicSpecForName(name) !== null) continue;
     if (!isControlledEnvName(name)) continue;
-    const nearest = closestSuggestion(name, SCHEMA_NAMES);
-    // Shared env-name prefixes make the generic length-based threshold too permissive.
-    const suggestion = nearest !== undefined && nearest.distance <= MAX_SCHEMA_NAME_SUGGESTION_DISTANCE
-      ? nearest.value
-      : undefined;
+    const suggestion = suggestSchemaName(name);
     findings.push(finding(
       name,
       'warn',
@@ -638,6 +633,39 @@ function validateUnknownControlledVars(
     ));
   }
   return findings;
+}
+
+function suggestSchemaName(name: string): string | undefined {
+  // Shared env-name prefixes make distance alone too permissive. Limit hints to
+  // typo shapes that do not guess between distinct configuration concepts.
+  const candidates = SCHEMA_NAMES.filter((candidate) => isLikelySchemaNameTypo(name, candidate));
+  const nearest = closestSuggestion(name, candidates);
+  if (nearest === undefined) return undefined;
+
+  const hasTie = candidates.some((candidate) => (
+    candidate !== nearest.value
+    && levenshteinDistance(name, candidate) === nearest.distance
+  ));
+  return hasTie ? undefined : nearest.value;
+}
+
+function isLikelySchemaNameTypo(input: string, candidate: string): boolean {
+  if (Math.abs(input.length - candidate.length) === 1) {
+    return levenshteinDistance(input, candidate) === 1;
+  }
+  if (input.length !== candidate.length) return false;
+
+  let firstMismatch = -1;
+  let secondMismatch = -1;
+  for (let i = 0; i < input.length; i++) {
+    if (input[i] === candidate[i]) continue;
+    if (firstMismatch === -1) firstMismatch = i;
+    else if (secondMismatch === -1) secondMismatch = i;
+    else return false;
+  }
+  return secondMismatch === firstMismatch + 1
+    && input[firstMismatch] === candidate[secondMismatch]
+    && input[secondMismatch] === candidate[firstMismatch];
 }
 
 function dynamicSpecForName(name: string): ConfigSpec | null {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -313,6 +313,7 @@ export const CONFIG_SCHEMA: readonly ConfigSpec[] = [
 
 const SCHEMA_NAMES = CONFIG_SCHEMA.map((spec) => spec.name);
 const SCHEMA_BY_NAME = new Map(CONFIG_SCHEMA.map((spec) => [spec.name, spec]));
+const MAX_SCHEMA_NAME_SUGGESTION_DISTANCE = 2;
 
 export function validateConfigEnv(
   env: NodeJS.ProcessEnv | Record<string, string | undefined>,
@@ -621,7 +622,11 @@ function validateUnknownControlledVars(
     if (SCHEMA_BY_NAME.has(name)) continue;
     if (dynamicSpecForName(name) !== null) continue;
     if (!isControlledEnvName(name)) continue;
-    const suggestion = closestSuggestion(name, SCHEMA_NAMES)?.value;
+    const nearest = closestSuggestion(name, SCHEMA_NAMES);
+    // Shared env-name prefixes make the generic length-based threshold too permissive.
+    const suggestion = nearest !== undefined && nearest.distance <= MAX_SCHEMA_NAME_SUGGESTION_DISTANCE
+      ? nearest.value
+      : undefined;
     findings.push(finding(
       name,
       'warn',

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -37,6 +37,7 @@ import {
   DEFAULT_DAEMON_HEALTH_TIMEOUT_MS,
   MAX_DAEMON_CLIENT_TIMEOUT_MS,
 } from '../daemon-client.js';
+import { closestSuggestion } from '../suggestion-core.js';
 
 export type ConfigFindingStatus = 'ok' | 'warn' | 'error';
 export type ConfigValueKind =
@@ -310,6 +311,7 @@ export const CONFIG_SCHEMA: readonly ConfigSpec[] = [
   { name: 'OTEL_SERVICE_NAME', kind: 'string', docDefault: 'knowledge-base-mcp-server', description: 'Standard OpenTelemetry service.name attached to exported traces when KB_OTEL_TRACES is enabled.' },
 ] as const;
 
+const SCHEMA_NAMES = CONFIG_SCHEMA.map((spec) => spec.name);
 const SCHEMA_BY_NAME = new Map(CONFIG_SCHEMA.map((spec) => [spec.name, spec]));
 
 export function validateConfigEnv(
@@ -619,13 +621,15 @@ function validateUnknownControlledVars(
     if (SCHEMA_BY_NAME.has(name)) continue;
     if (dynamicSpecForName(name) !== null) continue;
     if (!isControlledEnvName(name)) continue;
+    const suggestion = closestSuggestion(name, SCHEMA_NAMES)?.value;
     findings.push(finding(
       name,
       'warn',
       'unknown',
       source,
       '<set>',
-      'not in kb config schema; check spelling or add it to src/config/schema.ts',
+      'not in kb config schema; check spelling or add it to src/config/schema.ts' +
+        (suggestion === undefined ? '' : `. Did you mean ${suggestion}?`),
     ));
   }
   return findings;


### PR DESCRIPTION
## Summary

<!-- kookr:check:prose -->

`kb config validate` could tell operators that a configuration-related environment variable, such as a `KB_*` name, was unknown, but not which registered name they likely intended. It now appends the nearest config schema name for a unique one-character insertion or deletion, or for an adjacent transposition. Unrelated and ambiguous names keep the existing generic warning, so the hint does not guess when confidence is low.

Closes #904

### Design choice

The implementation reuses the existing deterministic `closestSuggestion` ranking, then applies a conservative typo-shape check. Generic length-based and fixed-distance thresholds were considered, but shared prefixes such as `HUGGINGFACE_` made both approaches overconfident and produced cross-setting suggestions. Limiting hints to a unique insertion, deletion, or adjacent transposition covers the issue examples while suppressing substitutions and tied matches that could refer to a different setting.

## Testing

- [x] `npm test` passes — 211 parallel suites (2,861 passed, 4 skipped) and 11 serial suites (458 passed, 2 skipped by configuration)
- [x] ~~End-to-end verified for tool/transport changes (see `CLAUDE.md`)~~ — not applicable: this changes config validation logic, not an MCP tool or transport path
- [x] ~~Benchmark run if performance-relevant: `BENCH_PROVIDER=stub npm run bench`~~ — not applicable: one bounded in-memory comparison runs only for unknown configuration-related environment variable names
- [x] <!-- kookr:check:tests --> Focused tests cover insertion, deletion, and transposition hints; five negative cases—including shared-prefix, cross-provider, substitution, and ambiguous names—emit no suggestion
- [x] `npm run build` and `npm run lint`
- [x] Reproduction: the focused schema suite failed on the missing suggestion before the implementation and passed all 25 tests afterward

## Documentation contract

- [x] ~~<!-- kookr:check:readme --> `README.md` reflects user-visible CLI, MCP, installation, or configuration changes~~ — no command, flag, or configuration contract changed; this only improves an existing validation warning
- [x] ~~<!-- kookr:check:docs --> Relevant operator, API, configuration, and retrieval documentation under `docs/` is consistent with the implementation~~ — no documented schema or validation contract changed; the exact diagnostic wording is not documented
- [x] ~~<!-- kookr:check:mbse --> RFCs are updated when this PR implements, supersedes, or changes an accepted design~~ — no accepted RFC or architecture-level system model is affected

## Changelog

- [x] ~~<!-- kookr:check:changelog --> `CHANGELOG.md` has an `Unreleased` entry for user-visible changes~~ — omitted per the issue unit instructions; acceptance does not require a release note

## Retrieval and performance evidence

- [x] ~~<!-- kookr:check:benchmarks --> Retrieval-quality or performance changes include the relevant benchmark/evaluation evidence, or this row is waived with a reason~~ — not applicable: retrieval behavior is unchanged

## Follow-ups

None.
