### PR TITLE
fix(llm): make health probe single-shot (#891)

### DIFF
--- a/src/llm-client.test.ts
+++ b/src/llm-client.test.ts
@@ -523,6 +523,26 @@ describe('llm-client', () => {
     expect(urls.some((u) => u.endsWith('/health'))).toBe(false);
   });
 
+  it('reports a rejected remote probe after a single chat attempt', async () => {
+    delete process.env.KB_LLM_FAKE;
+    process.env.KB_LLM_PROVIDER = 'openrouter';
+    process.env.KB_OPENROUTER_API_KEY = 'sk-or-test-key';
+    const fetchMock = jest.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+
+    const result = await probeLlmEndpoint(
+      'https://openrouter.ai/api/v1/chat/completions',
+      fetchMock as unknown as typeof fetch,
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({
+      provider: 'openrouter',
+      health_ok: true,
+      chat_ok: false,
+    });
+    expect(result.detail).toContain('chat failed: local LLM request failed: ECONNREFUSED');
+  });
+
   it('parses Retry-After as delta-seconds and HTTP-date', () => {
     expect(parseRetryAfterMs('5')).toBe(5000);
     expect(parseRetryAfterMs('')).toBeUndefined();

--- a/src/llm-client.ts
+++ b/src/llm-client.ts
@@ -677,6 +677,7 @@ export async function probeLlmEndpoint(
       ],
       temperature: 0,
       timeoutMs: options.chatTimeoutMs ?? 15_000,
+      retry: false,
     }, fetchImpl);
     return {
       endpoint: chatEndpoint,


### PR DESCRIPTION
<!-- kookr:check:prose -->

## Summary

`kb doctor` and `kb llm probe` are intended to give operators a quick status
check. When the LLM endpoint rejected a connection, the shared chat client
retried twice before reporting the failure, making the diagnostic slowest when
the endpoint was unavailable.

This change makes only the health probe single-shot. Normal chat-completion
calls retain their existing retry behavior.

Closes #891

## Changes

- Disable retries on the chat-completion request made by the LLM health probe.
- Add a regression test that rejects the request and verifies one fetch attempt
  and a `chat_ok: false` result.

## Testing

- [x] `npm test` passes (3,312 passed, 6 skipped)
- [x] `npm run check` passes
- [x] Focused: `npm run test:file -- src/llm-client.test.ts` (24 passed)
- [x] Regression evidence: before the fix, the new test observed three fetch
  attempts; after the fix, it observes exactly one
- [x] <!-- kookr:check:tests --> Tests were added or updated for changed behavior; bug fixes include a regression test
- [x] ~~End-to-end verified for tool/transport changes (see `CLAUDE.md`)~~ — no transport wiring changed; the probe path is covered directly with a rejecting fetch stub
- [x] ~~Benchmark run if performance-relevant: `BENCH_PROVIDER=stub npm run bench`~~ — the retrieval benchmark is unrelated; the regression test verifies the retry count directly

## Documentation contract

- [x] ~~<!-- kookr:check:readme --> `README.md` reflects user-visible CLI, MCP, installation, or configuration changes~~ — no CLI syntax, configuration, or output contract changed
- [x] ~~<!-- kookr:check:docs --> Relevant operator, API, configuration, and retrieval documentation under `docs/` is consistent with the implementation~~ — this is an internal latency fix with no documentation contract change
- [x] ~~<!-- kookr:check:mbse --> RFCs are updated when this PR implements, supersedes, or changes an accepted design~~ — no accepted design changed

## Changelog

- [x] ~~<!-- kookr:check:changelog --> `CHANGELOG.md` has an `Unreleased` entry for user-visible changes~~ — this focused internal latency fix does not require a changelog entry

## Retrieval and performance evidence

- [x] ~~<!-- kookr:check:benchmarks --> Retrieval-quality or performance changes include the relevant benchmark/evaluation evidence, or this row is waived with a reason~~ — no retrieval behavior changed; retry count is covered by the focused regression test

## Pre-PR review

- Project checks: build, lint, typecheck, full test suite, and repository check passed
- Specialist reviews: correctness, test quality, conventions, dead code, and documentation drift all passed
- Scope: two expected files only; no production call site outside the probe changed

## Follow-ups

None.
