### PR TITLE
fix(freshness): count valid hash sidecars

### DIFF
--- a/src/cli-doctor.test.ts
+++ b/src/cli-doctor.test.ts
@@ -344,12 +344,17 @@ describe('kb doctor', () => {
       await fsp.mkdir(path.join(rootDir, 'beta', '.index'), { recursive: true });
       const alphaOld = path.join(rootDir, 'alpha', 'old.md');
       const alphaNewer = path.join(rootDir, 'alpha', 'newer.md');
+      const alphaNew = path.join(rootDir, 'alpha', 'new.md');
       const betaUnsided = path.join(rootDir, 'beta', 'unsidecarred.md');
       await fsp.writeFile(alphaOld, 'old');
       await fsp.writeFile(alphaNewer, 'newer');
+      await fsp.writeFile(alphaNew, 'new');
       await fsp.writeFile(betaUnsided, 'beta');
-      await fsp.writeFile(path.join(rootDir, 'alpha', '.index', 'old.md'), 'hash');
-      await fsp.writeFile(path.join(rootDir, 'alpha', '.index', 'newer.md'), 'hash');
+      await fsp.writeFile(path.join(rootDir, 'alpha', '.index', 'old.md'), 'a'.repeat(64));
+      await fsp.writeFile(path.join(rootDir, 'alpha', '.index', 'newer.md'), 'b'.repeat(64));
+      await fsp.writeFile(path.join(rootDir, 'alpha', '.index', 'old.md.chunks.json'), '{}');
+      await fsp.writeFile(path.join(rootDir, 'alpha', '.index', 'newer.md.chunks.json'), '{}');
+      await fsp.writeFile(path.join(rootDir, 'alpha', '.index', 'quarantine.jsonl'), '');
       await fsp.mkdir(extractionCacheDir, { recursive: true });
       const extractionCacheEntry = path.join(extractionCacheDir, `${'c'.repeat(64)}.txt`);
       await fsp.writeFile(extractionCacheEntry, 'cached extracted text');
@@ -371,6 +376,7 @@ describe('kb doctor', () => {
       await fsp.utimes(binaryPath, indexMs / 1000, indexMs / 1000);
       await fsp.utimes(alphaOld, oldMs / 1000, oldMs / 1000);
       await fsp.utimes(alphaNewer, newerMs / 1000, newerMs / 1000);
+      await fsp.utimes(alphaNew, oldMs / 1000, oldMs / 1000);
       await fsp.utimes(betaUnsided, oldMs / 1000, oldMs / 1000);
       await fsp.utimes(extractionCacheEntry, oldMs / 1000, oldMs / 1000);
       await fsp.mkdir(path.join(tempDir, 'build'), { recursive: true });
@@ -460,7 +466,7 @@ describe('kb doctor', () => {
         files_unchanged: 1,
       });
       expect(report.cli.symlinked_checkout_path).toBe(tempDir);
-      expect(report.stale_counts_by_kb.alpha).toEqual({ modified_files: 1, new_files: 0 });
+      expect(report.stale_counts_by_kb.alpha).toEqual({ modified_files: 1, new_files: 1 });
       expect(report.stale_counts_by_kb.beta).toEqual({ modified_files: 0, new_files: 1 });
       expect(report.quarantine_counts_by_kb).toEqual({ alpha: 0, beta: 0 });
       expect(report.incomplete_models).toEqual([]);
@@ -474,13 +480,14 @@ describe('kb doctor', () => {
       expect(markdown).toContain('Extracted-text cache:');
       expect(markdown).toContain(`path: ${extractionCacheDir}`);
       expect(markdown).toContain('entries: 1, bytes=21 B, exists=yes');
-      expect(markdown).toContain('alpha: 1 modified, 0 new');
+      expect(markdown).toContain('alpha: 1 modified, 1 new');
       expect(markdown).toContain('beta: 0 modified, 1 new');
       expect(markdown).toContain('Ingest quarantine by KB:\n  alpha: 0 quarantined\n  beta: 0 quarantined');
       expect(markdown).toContain('Incomplete model dirs:\n  (none)');
 
       const json = JSON.parse(JSON.stringify(report)) as typeof report;
       expect(json.stale_counts_by_kb.alpha.modified_files).toBe(1);
+      expect(json.stale_counts_by_kb.alpha.new_files).toBe(1);
       expect(json.quarantine_counts_by_kb.alpha).toBe(0);
       expect(json.last_index_update.saved).toBe(true);
     } finally {

--- a/src/cli-doctor.ts
+++ b/src/cli-doctor.ts
@@ -87,6 +87,7 @@ import {
   type ProviderCircuitSnapshot,
 } from './provider-breaker.js';
 import { countIngestQuarantine } from './ingest-quarantine.js';
+import { countHashSidecarFiles } from './freshness-manifest.js';
 import {
   inventoryExtractionCache,
   type ExtractionCacheInventory,
@@ -2287,7 +2288,7 @@ async function computeStaleCountsByKb(
         // Vanished between walk and stat; ignore in a read-only health check.
       }
     }
-    const sidecarCount = await countFiles(path.join(kbPath, '.index'));
+    const sidecarCount = await countHashSidecarFiles(kbPath, filePaths);
     const added = activeModelId === null || indexMtimeMs === null
       ? filePaths.length
       : Math.max(0, filePaths.length - sidecarCount);
@@ -2362,30 +2363,6 @@ async function computeAgeBudgetsByKb(
     };
   }
   return { byKb, configErrors };
-}
-
-async function countFiles(dir: string): Promise<number> {
-  let count = 0;
-  async function walk(target: string): Promise<void> {
-    let entries: Array<import('fs').Dirent>;
-    try {
-      entries = await fsp.readdir(target, { withFileTypes: true });
-    } catch (err) {
-      const code = (err as NodeJS.ErrnoException).code;
-      if (code === 'ENOENT' || code === 'ENOTDIR') return;
-      throw err;
-    }
-    for (const entry of entries) {
-      const child = path.join(target, entry.name);
-      if (entry.isDirectory()) {
-        await walk(child);
-      } else if (entry.isFile()) {
-        count += 1;
-      }
-    }
-  }
-  await walk(dir);
-  return count;
 }
 
 async function readRerankerHealth(): Promise<DoctorReport['reranker']> {

--- a/src/cli-search-staleness.test.ts
+++ b/src/cli-search-staleness.test.ts
@@ -62,7 +62,13 @@ describe('computeStaleness', () => {
       await fsp.writeFile(betaModified, '# Beta modified\n', 'utf-8');
 
       await fsp.mkdir(path.join(kbRoot, 'alpha', '.index'), { recursive: true });
-      await fsp.writeFile(path.join(kbRoot, 'alpha', '.index', 'fresh.hash'), 'hash', 'utf-8');
+      await fsp.writeFile(
+        path.join(kbRoot, 'alpha', '.index', 'fresh.md'),
+        'a'.repeat(64),
+        'utf-8',
+      );
+      await fsp.writeFile(path.join(kbRoot, 'alpha', '.index', 'fresh.md.chunks.json'), '{}', 'utf-8');
+      await fsp.writeFile(path.join(kbRoot, 'alpha', '.index', 'quarantine.jsonl'), '', 'utf-8');
 
       const beforeIndex = new Date('2026-05-03T15:00:00.000Z');
       const indexTime = new Date('2026-05-03T15:30:00.000Z');

--- a/src/freshness-manifest.test.ts
+++ b/src/freshness-manifest.test.ts
@@ -24,7 +24,7 @@ describe('freshness manifest', () => {
     const beforeIndex = new Date('2026-05-03T15:00:00.000Z');
     const afterIndex = new Date('2026-05-03T16:00:00.000Z');
 
-    const alphaFresh = path.join(kbRoot, 'alpha', 'fresh.md');
+    const alphaFresh = path.join(kbRoot, 'alpha', 'notes', 'fresh.md');
     const alphaModified = path.join(kbRoot, 'alpha', 'modified.md');
     const betaNew = path.join(kbRoot, 'beta', 'new.md');
     await fsp.mkdir(path.dirname(alphaFresh), { recursive: true });
@@ -36,7 +36,22 @@ describe('freshness manifest', () => {
     await fsp.utimes(alphaModified, afterIndex, afterIndex);
     await fsp.utimes(betaNew, beforeIndex, beforeIndex);
     await fsp.mkdir(path.join(kbRoot, 'alpha', '.index'), { recursive: true });
-    await fsp.writeFile(path.join(kbRoot, 'alpha', '.index', 'fresh.md'), 'hash', 'utf-8');
+    await fsp.mkdir(path.join(kbRoot, 'alpha', '.index', 'notes'), { recursive: true });
+    await fsp.writeFile(
+      path.join(kbRoot, 'alpha', '.index', 'notes', 'fresh.md'),
+      'a'.repeat(64),
+      'utf-8',
+    );
+    await fsp.writeFile(
+      path.join(kbRoot, 'alpha', '.index', 'notes', 'fresh.md.chunks.json'),
+      '{}',
+      'utf-8',
+    );
+    await fsp.writeFile(
+      path.join(kbRoot, 'alpha', '.index', 'quarantine.jsonl'),
+      '',
+      'utf-8',
+    );
 
     const manifest = await writeFreshnessManifest({
       modelId: 'huggingface__test',
@@ -65,6 +80,34 @@ describe('freshness manifest', () => {
     expect(manifest.filter.base_extensions).not.toContain('.pdf');
     await expect(fsp.stat(freshnessManifestPath(modelDir))).resolves.toMatchObject({
       isFile: expect.any(Function),
+    });
+  });
+
+  it('does not count same-named quarantine metadata as a hash sidecar', async () => {
+    const tempDir = await mkTempDir();
+    const kbPath = path.join(tempDir, 'kbs', 'alpha');
+    const modelDir = path.join(tempDir, '.faiss', 'models', 'huggingface__test');
+    const sourcePath = path.join(kbPath, 'quarantine.jsonl');
+    await fsp.mkdir(path.join(kbPath, '.index'), { recursive: true });
+    await fsp.writeFile(sourcePath, '{"document":true}\n', 'utf-8');
+    await fsp.writeFile(
+      path.join(kbPath, '.index', 'quarantine.jsonl'),
+      '{"schema_version":"ingest-quarantine.v1"}\n',
+      'utf-8',
+    );
+
+    const manifest = await writeFreshnessManifest({
+      modelId: 'huggingface__test',
+      modelDir,
+      kbRootDir: path.join(tempDir, 'kbs'),
+      indexMtimeMs: Date.now(),
+      filterConfig: { extraExtensions: ['.jsonl'], excludePaths: [] },
+    });
+
+    expect(manifest.kbs.alpha).toMatchObject({
+      file_count: 1,
+      sidecar_count: 0,
+      new_files: 1,
     });
   });
 

--- a/src/freshness-manifest.ts
+++ b/src/freshness-manifest.ts
@@ -1,4 +1,5 @@
 import * as crypto from 'crypto';
+import { constants as fsConstants } from 'fs';
 import * as fsp from 'fs/promises';
 import * as path from 'path';
 import {
@@ -14,6 +15,7 @@ import { writeFileAtomicDurable } from './file-utils.js';
 
 export const FRESHNESS_MANIFEST_SCHEMA_VERSION = 'kb.freshness-manifest.v1';
 export const FRESHNESS_MANIFEST_FILE = 'freshness.json';
+const SHA256_HEX_PATTERN = /^[0-9a-f]{64}$/;
 
 export interface FreshnessManifestFilterConfig {
   baseExtensions?: readonly string[];
@@ -101,7 +103,7 @@ export async function writeFreshnessManifest(
         // File vanished between enumeration and stat; ignore it.
       }
     }
-    const sidecarCount = await countSidecarFiles(path.join(kbPath, '.index'));
+    const sidecarCount = await countHashSidecarFiles(kbPath, filePaths);
     entries[kbName] = {
       file_count: filePaths.length,
       sidecar_count: sidecarCount,
@@ -162,20 +164,32 @@ export async function readFreshnessManifest(
   return parsed;
 }
 
-export async function countSidecarFiles(dir: string): Promise<number> {
-  let entries;
-  try {
-    entries = await fsp.readdir(dir, { withFileTypes: true });
-  } catch {
-    return 0;
-  }
+/** Count ingestable sources with an exact mirrored hash sidecar under `.index`. */
+export async function countHashSidecarFiles(
+  kbPath: string,
+  filePaths: readonly string[],
+): Promise<number> {
   let count = 0;
-  for (const entry of entries) {
-    const entryPath = path.join(dir, entry.name);
-    if (entry.isDirectory()) {
-      count += await countSidecarFiles(entryPath);
-    } else if (entry.isFile()) {
-      count += 1;
+  for (const filePath of filePaths) {
+    const relativePath = path.relative(kbPath, filePath);
+    const sidecarPath = path.join(kbPath, '.index', relativePath);
+    let handle: fsp.FileHandle | null = null;
+    try {
+      // Non-blocking open plus a bounded read keeps a FIFO or oversized
+      // same-named metadata file from hanging or inflating freshness scans.
+      handle = await fsp.open(sidecarPath, fsConstants.O_RDONLY | fsConstants.O_NONBLOCK);
+      const stat = await handle.stat();
+      if (!stat.isFile() || stat.size !== 64) continue;
+
+      const buffer = Buffer.alloc(64);
+      const { bytesRead } = await handle.read(buffer, 0, buffer.length, 0);
+      if (bytesRead === buffer.length && SHA256_HEX_PATTERN.test(buffer.toString('utf-8'))) {
+        count += 1;
+      }
+    } catch {
+      // Missing or unreadable hash sidecars do not represent indexed sources.
+    } finally {
+      await handle?.close().catch(() => undefined);
     }
   }
   return count;

--- a/src/search-core.ts
+++ b/src/search-core.ts
@@ -17,7 +17,7 @@ import type {
   FreshnessScanScope,
   FreshnessScanSource,
 } from './timing-core.js';
-import { readFreshnessManifest } from './freshness-manifest.js';
+import { countHashSidecarFiles, readFreshnessManifest } from './freshness-manifest.js';
 import {
   aggregateEnumerationDiagnostics,
   enumerateIngestableKbFiles,
@@ -268,32 +268,12 @@ async function countStaleness(
     });
     modifiedFiles += modifiedFlags.reduce((sum, value) => sum + value, 0);
 
-    const sidecarCount = await countSidecarFiles(path.join(kbPath, '.index'));
+    const sidecarCount = await countHashSidecarFiles(kbPath, filePaths);
     if (filePaths.length > sidecarCount) {
       newFiles += filePaths.length - sidecarCount;
     }
   }
   return { modifiedFiles, newFiles };
-}
-
-async function countSidecarFiles(dir: string): Promise<number> {
-  let entries;
-  try {
-    entries = await fsp.readdir(dir, { withFileTypes: true });
-  } catch {
-    return 0;
-  }
-  const childCounts = await mapBounded(entries, resolveFsConcurrency(), async (entry) => {
-    const entryPath = path.join(dir, entry.name);
-    if (entry.isDirectory()) {
-      return countSidecarFiles(entryPath);
-    }
-    if (entry.isFile()) {
-      return 1;
-    }
-    return 0;
-  });
-  return childCounts.reduce((sum, value) => sum + value, 0);
 }
 
 function emptyStaleness(indexMtime: string | null, scopedKb?: string): Staleness {


### PR DESCRIPTION
## Summary

Each indexed source produces multiple files under `.index`, but the freshness checks treated every one as evidence that another source had been indexed. Once chunk manifests or quarantine records existed, genuinely new source files could disappear from the reported count.

This change matches each ingestable source to its exact mirrored hash sidecar—the single per-source file that records its indexed content hash. Chunk manifests, quarantine records, and other `.index` metadata no longer hide new sources, and the persisted manifest, `kb doctor`, and the filesystem freshness fallback now agree.

<!-- kookr:check:prose -->

The shared classifier is used by freshness-manifest generation, `kb doctor`, and the filesystem-backed search freshness fallback. Regression fixtures cover indexed-plus-new files, nested mirrored paths, chunk manifests, quarantine metadata, and same-name metadata collisions.

## Testing

- [x] `npm test` passes — 3,312 passed, 6 skipped across the parallel and serial projects
- [x] <!-- kookr:check:tests --> Tests were added or updated for changed behavior; bug fixes include a regression test
- [x] Focused regression suites: 88 tests passed
- [x] `npm run build`, `npm run lint`, and `npm run typecheck:tests`
- [x] Live FIFO smoke test verified a non-regular sidecar returns promptly without being counted
- [x] ~~End-to-end verified for tool/transport changes (see `CLAUDE.md`)~~ — N/A: no tool or transport wiring changed
- [x] ~~Benchmark run if performance-relevant~~ — N/A: not performance-relevant

## Documentation contract

- [x] ~~<!-- kookr:check:readme --> `README.md` reflects user-visible CLI, MCP, installation, or configuration changes~~ — no public command, schema, installation, or configuration contract changed
- [x] ~~<!-- kookr:check:docs --> Relevant operator, API, configuration, and retrieval documentation under `docs/` is consistent with the implementation~~ — corrective counting fix; existing `new_files` semantics are unchanged
- [x] ~~<!-- kookr:check:mbse --> RFCs are updated when this PR implements, supersedes, or changes an accepted design~~ — no accepted design changed

## Changelog

- [x] ~~<!-- kookr:check:changelog --> `CHANGELOG.md` has an `Unreleased` entry for user-visible changes~~ — unit instruction: no changelog/release-note entry

## Retrieval and performance evidence

- [x] ~~<!-- kookr:check:benchmarks --> Retrieval-quality or performance changes include the relevant benchmark/evaluation evidence, or this row is waived with a reason~~ — N/A: no retrieval-quality or performance behavior changed

## Follow-ups

None.

Closes #897
