### PR TITLE
fix(cli): resolve pagers through PATHEXT so --pager works on Windows

### DIFF
--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -157,7 +157,7 @@ but the model never sees the original character.
 | Frontmatter extras on wire | `FRONTMATTER_EXTRAS_WIRE_VISIBLE` | `false` | MCP and CLI JSON retrieval output | Implemented | none | `FRONTMATTER_EXTRAS_WIRE_VISIBLE=true kb search "query" --format=json` |
 | CLI timing | `--timing` | off | CLI search and ask; aggregate filter selectivity diagnostics for non-empty filtered dense search | Implemented | `--timing` | `kb search "query" --timing` |
 | Compact search output | `kb search --format=compact` | `md` | CLI search | Implemented | `--format=compact` | `kb search "query" --format=compact` |
-| Search pager | `KB_PAGER`, `kb search --pager` | off; `less -R` when enabled without a pager env | CLI search markdown/compact output on TTY stdout | Implemented, opt-in | `--pager`, `--no-pager` | `KB_PAGER='less -R' kb search "query" --pager --k=30` |
+| Search pager | `KB_PAGER`, `kb search --pager` | off; `less -R` when enabled without a pager env, falling back to `more` on Windows | CLI search markdown/compact output on TTY stdout | Implemented, opt-in | `--pager`, `--no-pager` | `KB_PAGER='less -R' kb search "query" --pager --k=30` |
 | Batch JSONL search input | `kb search --batch-jsonl` | off | CLI search | Implemented | `--batch-jsonl < queries.jsonl` | `printf '{"query":"q1"}\n{"query":"q2"}\n' \| kb search --batch-jsonl` |
 | Canonical log format | `KB_LOG_FORMAT` | `both` | Process logs | Implemented | none | `KB_LOG_FORMAT=canonical kb search "query"` |
 | Verbose MCP server tracing | `KB_LOG_VERBOSE` | unset | `KnowledgeBaseServer` lifecycle logs | Implemented, opt-in | none | `KB_LOG_VERBOSE=1 node build/index.js` |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1567,7 +1567,8 @@ Output:
                         For non-empty filtered dense searches, also surfaces
                         aggregate filter selectivity counters.
   --pager               Page markdown/compact output through KB_PAGER, PAGER,
-                        or less -R when stdout is a TTY.
+                        or less -R when stdout is a TTY. On Windows, falls back
+                        to more when less is not installed.
   --no-pager            Disable KB_PAGER for this search.
   --highlight=auto|always|never
                         Highlight query terms in markdown snippets with ANSI

--- a/src/cli-pager.test.ts
+++ b/src/cli-pager.test.ts
@@ -1,5 +1,8 @@
+import * as fsp from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
 import { Writable } from 'stream';
-import { describe, expect, it } from '@jest/globals';
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
 import {
   buildDaemonSearchArgs,
   resolveSearchPager,
@@ -22,6 +25,24 @@ class CaptureStream extends Writable {
     return Buffer.concat(this.chunks).toString('utf-8');
   }
 }
+
+/** Stands in for %SystemRoot%\\System32: `more.com` and nothing else. */
+let fakeSystem32: string;
+/** The same, plus a `less.exe` a user installed themselves. */
+let fakeSystem32WithLess: string;
+
+beforeAll(async () => {
+  fakeSystem32 = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-system32-'));
+  await fsp.writeFile(path.join(fakeSystem32, 'more.com'), '');
+  fakeSystem32WithLess = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-system32-less-'));
+  await fsp.writeFile(path.join(fakeSystem32WithLess, 'more.com'), '');
+  await fsp.writeFile(path.join(fakeSystem32WithLess, 'less.exe'), '');
+});
+
+afterAll(async () => {
+  await fsp.rm(fakeSystem32, { recursive: true, force: true });
+  await fsp.rm(fakeSystem32WithLess, { recursive: true, force: true });
+});
 
 describe('search pager resolution (#471)', () => {
   it('keeps pager disabled by default', async () => {
@@ -87,6 +108,132 @@ describe('search pager resolution (#471)', () => {
   });
 });
 
+describe('executable lookup on Windows (#934)', () => {
+  /**
+   * A PATH directory holding `winpager.exe` and a *directory* called `trap`.
+   * Windows resolves `winpager` to the .exe through PATHEXT, and must not
+   * mistake the directory for a command.
+   */
+  let binDir: string;
+
+  beforeAll(async () => {
+    binDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-pager-'));
+    await fsp.writeFile(path.join(binDir, 'winpager.exe'), '');
+    await fsp.mkdir(path.join(binDir, 'trap'));
+  });
+
+  afterAll(async () => {
+    await fsp.rm(binDir, { recursive: true, force: true });
+  });
+
+  it('resolves a bare command through PATHEXT', async () => {
+    await expect(resolveSearchPager({
+      flag: true,
+      format: 'md',
+      platform: 'win32',
+      env: { PATH: binDir, PATHEXT: '.COM;.EXE', KB_PAGER: 'winpager -R' },
+      stdoutIsTTY: true,
+    })).resolves.toEqual({ command: 'winpager', args: ['-R'] });
+  });
+
+  it('resolves an already-qualified command name', async () => {
+    await expect(resolveSearchPager({
+      flag: true,
+      format: 'md',
+      platform: 'win32',
+      env: { PATH: binDir, PATHEXT: '.COM;.EXE', KB_PAGER: 'winpager.exe' },
+      stdoutIsTTY: true,
+    })).resolves.toEqual({ command: 'winpager.exe', args: [] });
+  });
+
+  it('assumes cmd.exe defaults when PATHEXT is unset, and tolerates quoted PATH entries', async () => {
+    await expect(resolveSearchPager({
+      flag: true,
+      format: 'md',
+      platform: 'win32',
+      env: { PATH: `"${binDir}"`, KB_PAGER: 'winpager' },
+      stdoutIsTTY: true,
+    })).resolves.toEqual({ command: 'winpager', args: [] });
+  });
+
+  it('does not treat a same-named directory as a pager', async () => {
+    for (const platform of ['win32', 'linux'] as const) {
+      await expect(resolveSearchPager({
+        flag: true,
+        format: 'md',
+        platform,
+        env: { PATH: binDir, PATHEXT: '.COM;.EXE', KB_PAGER: 'trap' },
+        stdoutIsTTY: true,
+      })).resolves.toBeNull();
+    }
+  });
+
+  it('keeps PATHEXT off POSIX, where the extensionless name is the whole name', async () => {
+    await expect(resolveSearchPager({
+      flag: true,
+      format: 'md',
+      platform: 'linux',
+      env: { PATH: binDir, PATHEXT: '.COM;.EXE', KB_PAGER: 'winpager' },
+      stdoutIsTTY: true,
+    })).resolves.toBeNull();
+  });
+});
+
+describe('default pager selection (#934)', () => {
+  const NO_BIN = { PATH: '/definitely/not/a/real/bin' };
+
+  it('falls back to more on Windows when less is unavailable', async () => {
+    await expect(resolveSearchPager({
+      flag: true,
+      format: 'md',
+      platform: 'win32',
+      // Only `more` exists, and only as more.com -- the shape of a stock Windows box.
+      env: { PATH: fakeSystem32, PATHEXT: '.COM;.EXE' },
+      stdoutIsTTY: true,
+    })).resolves.toEqual({ command: 'more', args: [] });
+  });
+
+  it('prefers less -R over more when both are installed', async () => {
+    await expect(resolveSearchPager({
+      flag: true,
+      format: 'md',
+      platform: 'win32',
+      env: { PATH: fakeSystem32WithLess, PATHEXT: '.COM;.EXE' },
+      stdoutIsTTY: true,
+    })).resolves.toEqual({ command: 'less', args: ['-R'] });
+  });
+
+  it('never substitutes more for a pager the operator configured', async () => {
+    await expect(resolveSearchPager({
+      flag: true,
+      format: 'md',
+      platform: 'win32',
+      env: { PATH: fakeSystem32, PATHEXT: '.COM;.EXE', KB_PAGER: 'bat' },
+      stdoutIsTTY: true,
+    })).resolves.toBeNull();
+  });
+
+  it('does not reach for more on POSIX', async () => {
+    await expect(resolveSearchPager({
+      flag: true,
+      format: 'md',
+      platform: 'linux',
+      env: NO_BIN,
+      stdoutIsTTY: true,
+    })).resolves.toBeNull();
+  });
+
+  it('still honours --no-pager on Windows', async () => {
+    await expect(resolveSearchPager({
+      flag: false,
+      format: 'md',
+      platform: 'win32',
+      env: { PATH: fakeSystem32, PATHEXT: '.COM;.EXE' },
+      stdoutIsTTY: true,
+    })).resolves.toBeNull();
+  });
+});
+
 describe('writeMaybePagedOutput (#471)', () => {
   it('pipes output through the configured pager when enabled on a TTY', async () => {
     const stdout = new CaptureStream();
@@ -102,18 +249,54 @@ describe('writeMaybePagedOutput (#471)', () => {
     expect(stdout.text()).toBe('paged output\n');
   });
 
-  it('falls back to direct stdout when the pager command is not present', async () => {
+  it('falls back to direct stdout when the pager command is not present, and says so', async () => {
     const stdout = new CaptureStream();
+    const stderr = new CaptureStream();
     await writeMaybePagedOutput('direct output\n', {
       flag: true,
       format: 'md',
       env: { PATH: '/definitely/not/a/real/bin', PAGER: 'missing-kb-pager' },
       stdoutIsTTY: true,
       stdout,
+      stderr,
       capturePagerStdout: true,
     });
 
     expect(stdout.text()).toBe('direct output\n');
+    expect(stderr.text()).toContain('no pager found on PATH');
+    expect(stderr.text()).toContain('"missing-kb-pager"');
+  });
+
+  it('stays quiet when paging was never requested', async () => {
+    const stdout = new CaptureStream();
+    const stderr = new CaptureStream();
+    await writeMaybePagedOutput('direct output\n', {
+      flag: null,
+      format: 'md',
+      env: { PATH: '/definitely/not/a/real/bin' },
+      stdoutIsTTY: true,
+      stdout,
+      stderr,
+      capturePagerStdout: true,
+    });
+
+    expect(stdout.text()).toBe('direct output\n');
+    expect(stderr.text()).toBe('');
+  });
+
+  it('stays quiet when the operator disabled paging with cat', async () => {
+    const stderr = new CaptureStream();
+    await writeMaybePagedOutput('direct output\n', {
+      flag: true,
+      format: 'md',
+      env: { PATH: process.env.PATH, PAGER: 'cat' },
+      stdoutIsTTY: true,
+      stdout: new CaptureStream(),
+      stderr,
+      capturePagerStdout: true,
+    });
+
+    expect(stderr.text()).toBe('');
   });
 
   it('does not fail when the pager exits before consuming stdin', async () => {

--- a/src/cli-pager.ts
+++ b/src/cli-pager.ts
@@ -14,6 +14,8 @@ export interface SearchPagerOptions {
   stdout?: Writable;
   stderr?: Writable;
   capturePagerStdout?: boolean;
+  /** Overrides `process.platform`; lets the Windows lookup rules be tested anywhere. */
+  platform?: NodeJS.Platform;
 }
 
 export interface PagerResolution {
@@ -22,15 +24,36 @@ export interface PagerResolution {
 }
 
 const DEFAULT_PAGER = 'less -R';
+/**
+ * Windows rarely has `less`, but `%SystemRoot%\System32\more.com` ships with
+ * every install and System32 is always on PATH, so it is a dependency-free
+ * default of last resort. Only used when the operator configured no pager of
+ * their own -- an explicit KB_PAGER/PAGER is never silently substituted.
+ */
+const WINDOWS_FALLBACK_PAGER = 'more';
+/** What cmd.exe assumes when PATHEXT is unset. */
+const DEFAULT_PATHEXT = '.COM;.EXE;.BAT;.CMD';
 const DISABLED_PAGER_VALUES = new Set(['', '0', 'false', 'off', 'none', 'no']);
+
+interface PagerLookup {
+  pager: PagerResolution | null;
+  /**
+   * Pager command lines actually probed on PATH. Empty when paging was never
+   * eligible (structured format, no TTY, --no-pager, `cat`, ...), which is how
+   * callers tell "operator asked for a pager we could not find" -- worth a
+   * warning -- from "paging simply does not apply here".
+   */
+  tried: string[];
+}
 
 export async function writeMaybePagedOutput(
   output: string,
   options: SearchPagerOptions,
 ): Promise<void> {
   const stdout: Writable = options.stdout ?? process.stdout;
-  const pager = await resolveSearchPager(options);
+  const { pager, tried } = await lookupSearchPager(options);
   if (pager === null) {
+    if (tried.length > 0) warnPagerUnavailable(tried, options);
     writeChunk(stdout, output);
     return;
   }
@@ -41,31 +64,57 @@ export async function writeMaybePagedOutput(
   }
 }
 
+/** Silent probe: resolves the pager to use, or null to write output directly. */
 export async function resolveSearchPager(
   options: SearchPagerOptions,
 ): Promise<PagerResolution | null> {
-  if (options.format !== 'md' && options.format !== 'compact') return null;
-  if (options.flag === false) return null;
+  return (await lookupSearchPager(options)).pager;
+}
+
+async function lookupSearchPager(options: SearchPagerOptions): Promise<PagerLookup> {
+  const direct: PagerLookup = { pager: null, tried: [] };
+  if (options.format !== 'md' && options.format !== 'compact') return direct;
+  if (options.flag === false) return direct;
 
   const env = options.env ?? process.env;
+  const platform = options.platform ?? process.platform;
   const stdoutIsTTY = options.stdoutIsTTY ?? process.stdout.isTTY === true;
-  if (!stdoutIsTTY) return null;
-  if (env.TERM === 'dumb') return null;
-  if (env.NO_COLOR !== undefined && env.NO_COLOR !== '') return null;
+  if (!stdoutIsTTY) return direct;
+  if (env.TERM === 'dumb') return direct;
+  if (env.NO_COLOR !== undefined && env.NO_COLOR !== '') return direct;
 
   const kbPager = env.KB_PAGER;
   const envEnabled = kbPager !== undefined && kbPager.trim() !== '';
-  if (options.flag !== true && !envEnabled) return null;
+  if (options.flag !== true && !envEnabled) return direct;
 
-  const raw = (envEnabled ? kbPager : (env.PAGER && env.PAGER.trim() !== '' ? env.PAGER : DEFAULT_PAGER)) ?? DEFAULT_PAGER;
-  if (isPagerDisabledValue(raw)) return null;
+  const configured = envEnabled
+    ? kbPager
+    : (env.PAGER !== undefined && env.PAGER.trim() !== '' ? env.PAGER : undefined);
+  if (configured !== undefined && isPagerDisabledValue(configured)) return direct;
 
-  const argv = splitPagerCommand(raw);
-  if (argv.length === 0) return null;
-  const [command, ...args] = argv;
-  if (isCatPager(command)) return null;
-  if (!(await commandExists(command, env))) return null;
-  return { command, args };
+  const tried: string[] = [];
+  for (const candidate of pagerCandidates(configured, platform)) {
+    const argv = splitPagerCommand(candidate);
+    if (argv.length === 0) continue;
+    const [command, ...args] = argv;
+    // `cat` is the conventional way to say "never page"; not a missing binary.
+    if (isCatPager(command)) return direct;
+    tried.push(candidate);
+    if (await commandExists(command, env, platform)) return { pager: { command, args }, tried };
+  }
+  return { pager: null, tried };
+}
+
+/**
+ * The pager command lines to try, best first. An operator-configured pager is
+ * the only candidate -- we never quietly run something they did not ask for.
+ */
+function pagerCandidates(
+  configured: string | undefined,
+  platform: NodeJS.Platform,
+): string[] {
+  if (configured !== undefined) return [configured];
+  return platform === 'win32' ? [DEFAULT_PAGER, WINDOWS_FALLBACK_PAGER] : [DEFAULT_PAGER];
 }
 
 export function buildDaemonSearchArgs(args: readonly string[]): string[] {
@@ -165,23 +214,98 @@ function splitPagerCommand(commandLine: string): string[] {
   return out;
 }
 
-async function commandExists(command: string, env: NodeJS.ProcessEnv): Promise<boolean> {
-  if (command.includes(path.sep)) {
-    return isExecutable(command);
+async function commandExists(
+  command: string,
+  env: NodeJS.ProcessEnv,
+  platform: NodeJS.Platform,
+): Promise<boolean> {
+  if (containsPathSeparator(command, platform)) {
+    return anyExecutable(command, env, platform);
   }
-  const pathEnv = env.PATH ?? process.env.PATH ?? '';
-  for (const dir of pathEnv.split(path.delimiter)) {
-    if (dir === '') continue;
-    if (await isExecutable(path.join(dir, command))) return true;
+  // `Path` is the canonical spelling on Windows; process.env lookups there are
+  // case-insensitive, but an injected plain object is not.
+  const pathEnv = env.PATH ?? env.Path ?? process.env.PATH ?? '';
+  for (const dir of pathEnv.split(platform === 'win32' ? ';' : ':')) {
+    // cmd.exe tolerates quoted PATH entries; strip them before joining.
+    const trimmed = platform === 'win32' ? dir.replace(/^"(.*)"$/, '$1') : dir;
+    if (trimmed === '') continue;
+    if (await anyExecutable(path.join(trimmed, command), env, platform)) return true;
   }
   return false;
 }
 
-async function isExecutable(file: string): Promise<boolean> {
+async function anyExecutable(
+  base: string,
+  env: NodeJS.ProcessEnv,
+  platform: NodeJS.Platform,
+): Promise<boolean> {
+  for (const candidate of executableCandidates(base, env, platform)) {
+    if (await isExecutable(candidate, platform)) return true;
+  }
+  return false;
+}
+
+/**
+ * Filenames to probe for a command. On POSIX that is the name itself; on
+ * Windows a bare `less` on PATH is really `less.exe`, and which suffixes count
+ * is spelled out by PATHEXT. Probing only the extensionless name is why
+ * --pager and KB_PAGER were silent no-ops on Windows (#934). The bare name
+ * stays first so an already-qualified `less.exe` -- or an extensionless script
+ * under a POSIX-ish shell -- still matches.
+ */
+function executableCandidates(
+  base: string,
+  env: NodeJS.ProcessEnv,
+  platform: NodeJS.Platform,
+): string[] {
+  if (platform !== 'win32') return [base];
+  const raw = env.PATHEXT ?? process.env.PATHEXT ?? DEFAULT_PATHEXT;
+  const suffixes = raw
+    .split(';')
+    .map((ext) => ext.trim())
+    .filter((ext) => ext !== '')
+    .map((ext) => (ext.startsWith('.') ? ext : `.${ext}`));
+  // PATHEXT is spelled upper-case by convention while the files on disk are
+  // lower-case; that only lines up for free on a case-insensitive volume, so
+  // probe both spellings. Order is preserved, so .COM still beats .EXE.
+  const spellings = [...new Set(suffixes.flatMap((ext) => [ext, ext.toLowerCase()]))];
+  return [base, ...spellings.map((ext) => `${base}${ext}`)];
+}
+
+function containsPathSeparator(command: string, platform: NodeJS.Platform): boolean {
+  return platform === 'win32'
+    ? command.includes('\\') || command.includes('/')
+    : command.includes('/');
+}
+
+async function isExecutable(file: string, platform: NodeJS.Platform): Promise<boolean> {
+  try {
+    // stat, not access: a *directory* named `less` satisfies access(X_OK) on
+    // POSIX (search permission) and F_OK on Windows.
+    if (!(await fsp.stat(file)).isFile()) return false;
+  } catch {
+    return false;
+  }
+  // Windows has no POSIX execute bit; Node maps X_OK to a bare existence check
+  // there, so the extension match above is the real test.
+  if (platform === 'win32') return true;
   try {
     await fsp.access(file, fsConstants.X_OK);
     return true;
   } catch {
     return false;
   }
+}
+
+/**
+ * The operator explicitly asked for paging and we found nothing to page with.
+ * Saying so turns a flag that looks broken into one that is merely unsupported
+ * here -- the actual complaint behind #934.
+ */
+function warnPagerUnavailable(tried: readonly string[], options: SearchPagerOptions): void {
+  const stderr: Writable = options.stderr ?? process.stderr;
+  stderr.write(
+    `kb: no pager found on PATH (tried ${tried.map((c) => `"${c}"`).join(', ')}); `
+    + 'wrote output directly. Set KB_PAGER to choose one.\n',
+  );
 }

--- a/src/cli-search.ts
+++ b/src/cli-search.ts
@@ -293,7 +293,8 @@ Output:
                         For non-empty filtered dense searches, also surfaces
                         aggregate filter selectivity counters.
   --pager               Page markdown/compact output through KB_PAGER, PAGER,
-                        or less -R when stdout is a TTY.
+                        or less -R when stdout is a TTY. On Windows, falls back
+                        to more when less is not installed.
   --no-pager            Disable KB_PAGER for this search.
   --highlight=auto|always|never
                         Highlight query terms in markdown snippets with ANSI


### PR DESCRIPTION
## Summary

`kb search --pager` and `KB_PAGER` are silent no-ops on Windows. `commandExists` probes only the extensionless name:

```ts
if (await isExecutable(path.join(dir, command))) return true;   // src/cli-pager.ts:175
```

Windows resolves a bare command through `PATHEXT` — the file on `PATH` is `less.exe`. Nothing matches, so `resolveSearchPager` returns `null` at `:67` and output is written directly, with no warning, whatever the user has installed.

Reproduced against the pre-fix code (`less.exe` sitting on `PATH`, `PAGER='less -R'`):

```
PRE-FIX, less.exe present on PATH -> null   (null = silent no-op = the bug)
```

Three parts:

1. **Probe `PATH × PATHEXT` on Windows.** Honours an explicit `PATHEXT`, falls back to cmd.exe's `.COM;.EXE;.BAT;.CMD`. The bare name is still tried first, so an already-qualified `less.exe` keeps working. Both the `PATHEXT` spelling and its lower-case form are probed — `PATHEXT` is upper-case by convention while files on disk are not; free on a case-insensitive volume, needed on a case-sensitive one. This fixes **every** pager (`bat`, `moar`, `delta`, `more`, `less`), not just one.
2. **Default to `more` on Windows when `less` is absent.** `%SystemRoot%\System32` is always on `PATH` and always has `more.com`, so paging works out of the box with **no new dependency**. Only the *built-in default* falls back — a pager the operator set in `KB_PAGER`/`PAGER` is never substituted.
3. **Say something when paging was requested and nothing was found**, instead of silently writing direct. That silence is the actual complaint in #934 — the flag looks broken rather than unsupported.

Also switches the probe from `access(X_OK)` to `stat().isFile()`: a *directory* named `less` satisfied `access(X_OK)` on POSIX (search permission) and `F_OK` on Windows, where Node maps `X_OK` to a bare existence check. Pre-existing on POSIX too.

POSIX behaviour is unchanged: no `PATHEXT`, no `more` fallback, same `less -R` default.

### Behaviour after the fix

Simulated Windows environments against the built output:

```
stock Windows (only more.com in System32)      {"command":"more","args":[]}
user installed less.exe via scoop              {"command":"less","args":["-R"]}
KB_PAGER=less (bare name -> less.exe)          {"command":"less","args":["-R"]}
KB_PAGER=bat, not installed -> no substitute   null
--no-pager still wins                          null
linux, no less on PATH -> direct (no more)     null

kb: no pager found on PATH (tried "less -R", "more"); wrote output directly. Set KB_PAGER to choose one.
```

### Relationship to #935

#935 targets the same issue but does not fix it: it leaves `commandExists` untouched (so `bat`/`moar`/`delta`/`more` stay broken, and its own test asserts that), routes `less` on Windows to a third-party in-process pager *unconditionally* — shadowing a real `less.exe` the user installed — and adds four transitive single-maintainer npm dependencies, three of them under two months old and one with no published repository. The new code path is also unreachable from the test suite (`capturePagerStdout` is set only in tests, and the new tests stop at `resolveSearchPager`). This PR fixes the reported bug with no new dependencies. Credit to @dawsonhuang0 for the report and the precise diagnosis.

Fixes #934

## Testing

- [x] `npm test` passes — green in CI on Node 20 and 24. Locally `npx jest src/cli` gives 1057 passed / 1 failed; that one (`src/cli-search.test.ts:2606`, `"cmd":"rerank.stage"`) reproduces identically on clean `origin/main` and passes in CI, so it is a local environment artifact, not a regression.
- [x] End-to-end verified for tool/transport changes (see `CLAUDE.md`) — CLI-only change, no tool or transport surface touched; the built output was instead exercised directly against simulated Windows `PATH`/`PATHEXT` layouts, results above.
- [x] ~~Benchmark run if performance-relevant: `BENCH_PROVIDER=stub npm run bench`~~ — not performance-relevant: this changes which pager is selected, on a path that runs once per CLI invocation after retrieval has completed.
- [x] <!-- kookr:check:tests --> Tests were added or updated for changed behavior; bug fixes include a regression test

12 new tests across two suites, driving the Windows rules through an injectable `platform` seam (so they run on any host) plus real temp-dir `PATH` fixtures: PATHEXT resolution, already-qualified names, unset-PATHEXT defaults, quoted PATH entries, the directory false-positive on both platforms, `more` fallback, `less` preferred over `more`, no substitution of a configured pager, POSIX left alone, `--no-pager`, and the stderr notice firing exactly when paging was explicitly requested (and staying silent for `cat` and for unrequested paging).

## Documentation contract

- [x] <!-- kookr:check:readme --> ~~`README.md` reflects user-visible CLI, MCP, installation, or configuration changes~~ — `README.md` does not document the pager (`grep -i pager README.md` is empty); the feature is documented under `docs/`, which is updated below.
- [x] <!-- kookr:check:docs --> Relevant operator, API, configuration, and retrieval documentation under `docs/` is consistent with the implementation — `docs/reference/cli.md` and `docs/feature-flags.md` both now state the Windows `more` fallback, kept in sync with the `--pager` help text in `src/cli-search.ts`.
- [x] <!-- kookr:check:mbse --> ~~RFCs are updated when this PR implements, supersedes, or changes an accepted design~~ — no RFC covers pager selection; this is a bug fix to existing behaviour, not a design change.

## Changelog

- [x] <!-- kookr:check:changelog --> ~~`CHANGELOG.md` has an `Unreleased` entry for user-visible changes~~ — the repository has no `CHANGELOG.md`; release notes are derived from conventional-commit history, and the commit is a `fix(cli):`.

## Retrieval and performance evidence

- [x] <!-- kookr:check:benchmarks --> ~~Retrieval-quality or performance changes include the relevant benchmark/evaluation evidence~~ — waived: no retrieval or performance surface is touched. The change is confined to pager discovery in `src/cli-pager.ts`, which runs after results are rendered and does not affect ranking, recall, or search latency.

## Follow-ups

None. The `access(X_OK)` directory false-positive noticed on the POSIX path was fixed here rather than spun out, since it is the same three lines this PR already rewrites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RqnXX4Fv3X95YMUztFZNdn
