### PR TITLE
docs: restructure README and clarify docs for cold readers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,8 +20,8 @@ node build/index.js    # runs the server over stdio (clients launch it this way)
 - **MCP tool surface:** tools are registered in `KnowledgeBaseServer.registerTools()`. Current tools include `list_knowledge_bases`, `retrieve_knowledge`, `ask_knowledge`, `list_models`, `kb_stats`, `diff_index`, `add_document`, `delete_document`, and `reindex_knowledge_base`.
 - **CLI surface:** `src/cli.ts` is the `kb` dispatcher. Command-specific behavior lives in `src/cli-*.ts`; shared command-independent logic belongs in `*-core.ts` helpers.
 - **Embeddings:** `FaissIndexManager` is constructed for a concrete `(provider, modelName)` pair. Provider defaults come from `EMBEDDING_PROVIDER` plus provider-specific model env vars.
-- **Index layout:** `$FAISS_INDEX_PATH/active.txt` selects a model id. Each model stores metadata and versioned FAISS data under `$FAISS_INDEX_PATH/models/<model_id>/`; `active-model.ts` is the layout authority.
-- **Indexing strategy:** per-file SHA256 and chunk manifests in `<kb>/.index/` decide what to re-embed. Mutating refreshes use per-model write locks plus versioned atomic saves.
+- **Index layout:** `$FAISS_INDEX_PATH/active.txt` selects a model id. Each model stores metadata and versioned FAISS data under `$FAISS_INDEX_PATH/models/<model_id>/`. See `active-model.ts` — it decides and enforces this layout, so read it before changing any index path.
+- **Indexing strategy:** per-file SHA256 hashes and chunk manifests in `<kb>/.index/` let a refresh skip content that has not changed, so re-indexing costs embedding calls only for what moved. To stop concurrent writers from corrupting an index, mutating refreshes take a per-model write lock and save new index versions atomically.
 - **Logging:** `logger.ts` writes **only to stderr** (and optionally `LOG_FILE`). Writing to stdout corrupts the JSON-RPC stream — this is a landed bug, never reintroduce `console.log` inside the server process.
 
 ### Conventions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,8 +19,12 @@ strike the row through and add a one-line reason. A blank marked row fails CI.
 **Preflight the checklist locally before you open the PR.** The most common
 first-attempt CI failure is a PR body that was not built from
 [`.github/PULL_REQUEST_TEMPLATE.md`](./.github/PULL_REQUEST_TEMPLATE.md), so the
-`kookr:check:*` rows are absent. Draft your body into a file, then run the same
-verifier CI runs against it:
+`kookr:check:*` rows are absent. Those markers are read by *Kookr*, the
+maintainer's review-automation CLI, which the `PR checklist` workflow runs to
+verify each marked row against the actual diff. Kookr is not publicly
+distributed, so don't go looking for it — start from the template, keep the
+marker comments intact, and the workflow does the rest. Draft your body into a
+file, then run the same verifier CI runs against it:
 
 ```sh
 npm run pr-checklist -- pr-body.md          # verifies against origin/main
@@ -29,7 +33,9 @@ gh pr create --body-file pr-body.md         # only after it passes
 
 This catches a wrong-shape body in seconds instead of after a full CI cycle. CI
 remains authoritative; the preflight is a convenience that shells out to the
-Kookr CLI (set `KOOKR_BIN` if it is not on your `PATH`).
+Kookr CLI (set `KOOKR_BIN` if it is not on your `PATH`), so it is a no-op for
+contributors who don't have it — open the PR from the template and let CI check
+the rows.
 
 ## Reporting Bugs
 

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ Your client sees these tools (registered in `src/KnowledgeBaseServer.ts`):
 | Tool | What it's for |
 | --- | --- |
 | `list_knowledge_bases` | Discover which shelves exist, so the agent can scope a later search instead of guessing a name. |
-| `retrieve_knowledge` | The core semantic search — returns the passages most relevant to a query so an agent can ground its answer in your documents rather than in what the model already knows. Searches one knowledge base if `knowledge_base` is given, otherwise all of them. Returns at most 10 chunks by default, filtered by a similarity-score threshold of 2 (lower scores are closer matches); `threshold` loosens or tightens it. |
+| `retrieve_knowledge` | The core semantic search — returns the passages most relevant to a query so an agent can ground its answer in your documents rather than in what the model already knows. Searches one knowledge base if `knowledge_base` is given, otherwise all of them. Returns at most 10 chunks by default. `threshold` caps how far a match may be from the query (it is a *distance*, so lower is closer); the default of 2 is the far end of the scale and so rarely excludes anything on its own — lower it to make retrieval stricter, or see [relevance gating](#relevance-gating) for a stage designed to do that job properly. In hybrid mode the threshold is not applied at all, because both legs are over-fetched before fusion. |
 | `ask_knowledge` | Retrieve, then have a configured local or OpenAI-compatible LLM write an answer with citations — one call instead of retrieve-then-prompt. |
 | `list_models` | List the registered embedding models and which one is active. |
 | `kb_stats` | Read-only corpus, index, model, cache, and transport statistics — useful for a health check without touching the index. |
@@ -393,7 +393,7 @@ kb search "runbook rollback" --context-window=1
 
 | Operator | Use it when |
 | --- | --- |
-| `--diverse` | Your top results are near-duplicates from one file and you'd rather see coverage across sources. It reranks a bounded dense candidate pool for source-aware representative sampling. |
+| `--diverse` | Your top results are near-duplicates from one file and you'd rather see coverage across sources. It reranks a bounded pool of dense candidates to spread the results over more source files. |
 | `--anti-query="<text>"` | You want to push results away from a known-irrelevant neighbouring topic. Candidates close to the negative query are penalized, but only among candidates the positive query already supports. |
 | `--plus="<text>"` / `--minus="<text>"` | You want to nudge the query itself, adding positive and negative components to the query vector rather than filtering afterwards. |
 
@@ -448,9 +448,9 @@ kb ask "what changed in the daemonization notes?" --timing
 kb ask "what changed?" --kb=work --save-transcript --title="Ask - daemon changes" --yes
 ```
 
-**Keeping a note out of LLM prompts.** A note whose frontmatter contains `kb_policy: { no_llm_context: true }` still appears in search results, but `kb ask` and MCP `ask_knowledge` drop it before calling the LLM and report the count under `context_packing.policy_filtered_chunks`. Contextual-preface ingest and relevance-gate judging exclude it too, while keeping the chunk as ordinary retrieval data.
+**Keeping a note out of LLM prompts.** A note whose frontmatter contains `kb_policy: { no_llm_context: true }` still appears in search results, but `kb ask` and MCP `ask_knowledge` drop it before calling the LLM and report the count under `context_packing.policy_filtered_chunks`. [Contextual-preface ingest](#contextual-prefaces-at-ingest) and [relevance-gate](#relevance-gating) judging exclude it too, while keeping the chunk as ordinary retrieval data.
 
-**Developing offline.** `KB_LLM_FAKE=on` routes `kb ask`, relevance-gate judging, and contextual-preface generation to a deterministic in-process fake LLM — no endpoint required. When a client needs a real OpenAI-compatible localhost endpoint instead, run `npm run dev:mockllm -- --port=18080`. Rules are customizable via `KB_LLM_FAKE_RULES`; see [docs/testing/fake-llm.md](docs/testing/fake-llm.md).
+**Developing offline.** `KB_LLM_FAKE=on` routes `kb ask`, [relevance-gate](#relevance-gating) judging, and [contextual-preface](#contextual-prefaces-at-ingest) generation to a deterministic in-process fake LLM — no endpoint required. When a client needs a real OpenAI-compatible localhost endpoint instead, run `npm run dev:mockllm -- --port=18080`. Rules are customizable via `KB_LLM_FAKE_RULES`; see [docs/testing/fake-llm.md](docs/testing/fake-llm.md).
 
 **Managing a warm model.** If you want `kb` to own the model process rather than reuse someone else's:
 
@@ -579,7 +579,7 @@ kb feedback promote --kb=work --query="rollback procedure" \
 
 See [`docs/operations/feedback-workflow.md`](docs/operations/feedback-workflow.md).
 
-**`kb eval` — run fixture-driven retrieval checks.** A case can set `query`, and optionally `kb`, `required_sources`, `forbidden_sources`, `expected_metadata`, `max_duplicate_groups`, `stale_policy`, and `gate`. Failing *ungated* cases print warnings and exit 0; failing *gated* cases exit 1, which is what makes this usable in CI.
+**`kb eval` — run fixture-driven retrieval checks.** A case can set `query`, and optionally `kb`, `required_sources`, `forbidden_sources`, `expected_metadata`, `max_duplicate_groups`, `stale_policy`, and `gate`. A case's `gate` field is unrelated to [relevance gating](#relevance-gating) — here it means "should failing this case break the build". Failing *ungated* cases print warnings and exit 0; failing *gated* cases exit 1, which is what makes this usable in CI.
 
 ```yaml
 gate: false
@@ -624,7 +624,7 @@ kb verify                          # slow integrity checks for persisted indexes
 
 **`kb serve`** runs the loopback daemon that clients passing `--daemon` use for warm reads, so a query doesn't pay model and index load time on every invocation. `kb serve [--host=127.0.0.1] [--port=17799] [--idle-timeout-ms=300000] [--warm]` brings it up; `--warm` (or `KB_DAEMON_PREWARM=on`) pre-loads the active model, FAISS index, and lexical indexes before reporting ready. `kb serve status [--json]` reports reachability, pid, idle timeout, supported commands, and prewarm state at `KB_DAEMON_URL` (default `http://127.0.0.1:17799`). SIGINT or SIGTERM stops it, and CLI commands fall back to direct in-process execution whenever the daemon is unreachable. See [`docs/operations/daemon-lifecycle.md`](docs/operations/daemon-lifecycle.md).
 
-**`kb reindex`** rebuilds the index. `--with-context` adds contextual prefaces (requires `KB_CONTEXTUAL_RETRIEVAL=on` and a `KB_LLM_ENDPOINT`). `kb reindex status` reads the durable run-state and per-source sidecar ledgers to report liveness, eligible indexed files, sidecar coverage, pending files, resolved and failed chunks, and failure codes. Note that `--kb=<name>` is only a guard and estimator hint — a rebuild always covers the entire single-index-per-model layout ([RFC 017 §5](docs/rfcs/017-contextual-retrieval.md)).
+**`kb reindex`** rebuilds the index. `--with-context` adds [contextual prefaces](#contextual-prefaces-at-ingest) (requires `KB_CONTEXTUAL_RETRIEVAL=on` and a `KB_LLM_ENDPOINT`). `kb reindex status` reads the durable run-state and per-source sidecar ledgers to report liveness, eligible indexed files, sidecar coverage, pending files, resolved and failed chunks, and failure codes. Note that `--kb=<name>` is only a guard and estimator hint — a rebuild always covers the entire single-index-per-model layout ([RFC 017 §5](docs/rfcs/017-contextual-retrieval.md)).
 
 **`kb logs`** reads the structured request log emitted under `KB_LOG_FORMAT=canonical` or `both`. `kb logs show --request-id=<id>` pulls every line of one retrieval; `--query-sha=<hash>` follows a recurring query; `kb logs recent --limit=<n>` shows the latest entries. `--format=json` emits a report envelope, `--format=csv|tsv|ndjson` flat event rows for downstream tooling.
 
@@ -632,7 +632,27 @@ kb verify                          # slow integrity checks for persisted indexes
 
 ## Tune retrieval quality
 
-Plain dense retrieval is the default and needs no configuration. Four further stages sit around it. Three are **off by default**, because each buys precision or safety at a cost you should choose deliberately; the fourth, the untrusted-content guard, is on. The complete flag matrix — defaults, per-call overrides, rollout status, validation commands — is in [docs/feature-flags.md](docs/feature-flags.md).
+Plain dense retrieval is the default and needs no configuration. Five further stages sit around it. Four are **off by default**, because each buys precision or safety at a cost you should choose deliberately; the fifth, the untrusted-content guard, is on. The complete flag matrix — defaults, per-call overrides, rollout status, validation commands — is in [docs/feature-flags.md](docs/feature-flags.md).
+
+### Contextual prefaces at ingest
+
+Chunking a note breaks it into ~1000-character pieces, and the embedding model sees each piece alone. So a chunk reading
+
+> "We pin it to CPU because the 24 GB card is already maxed by the gate model."
+
+carries none of what makes it findable: *which* service is pinned, *which* card, *which* model. Its vector lands near other passages about "pinning" rather than near the GPU-contention question an operator would actually type. The note is indexed and still effectively invisible.
+
+A **contextual preface** fixes this at ingest rather than at query time. Before a chunk is embedded, an LLM writes a short passage — roughly 50–100 tokens — describing where that chunk sits in its document, and the preface is prepended to the text that gets vectorized. The chunk now embeds as what it *is about*, not just what it literally says. Anthropic, who published the technique, measured a 49% reduction in top-5 retrieval failures on a code-and-prose benchmark.
+
+Two things worth knowing before you turn it on. The text returned to callers is unchanged — prefaces affect the vector, never what `retrieve_knowledge` or `kb search` hands back. And the cost is real: one LLM call per chunk at ingest time. Generated prefaces are cached in per-source sidecars, so a reindex only pays for chunks that actually changed.
+
+```bash
+KB_CONTEXTUAL_RETRIEVAL=on     # plus a KB_LLM_ENDPOINT to generate against
+kb reindex --with-context      # backfill existing shelves
+kb reindex status              # sidecar coverage, pending files, failures
+```
+
+Design and rollout details are in [RFC 017](docs/rfcs/017-contextual-retrieval.md).
 
 ### Cross-encoder reranking
 
@@ -651,7 +671,7 @@ Enable it with `KB_RERANK=on`, or per call with `kb search --rerank` / `kb ask -
 
 ### Relevance gating
 
-Retrieval always returns *something*: ask about a topic your notes don't cover and you still get the ten least-bad chunks. Fed to an LLM, those read as authoritative context and quietly corrupt the answer. Relevance gating adds a check between retrieval and use — a statistical score floor, then optionally an LLM judge — that drops chunks which don't actually match the task, and can return nothing at all rather than something wrong.
+Retrieval always returns *something*: ask about a topic your notes don't cover and you still get the ten least-bad chunks. The retrieval-time similarity threshold doesn't save you — it defaults to the far end of the distance scale and rarely excludes anything (see [`retrieve_knowledge`](#tools)). Fed to an LLM, those chunks read as authoritative context and quietly corrupt the answer. Relevance gating adds a check between retrieval and use — a statistical score floor, then optionally an LLM judge — that drops chunks which don't actually match the task, and can return nothing at all rather than something wrong.
 
 That is a real tradeoff: the gate can also discard genuinely relevant chunks, lowering recall to raise precision. That's why it is off unless you opt in.
 
@@ -772,7 +792,12 @@ kb doctor                    # human-readable report
 kb doctor --format=json      # machine-readable, for agent shells
 ```
 
-The full report covers active-model resolution, FAISS index version and mtime, the latest in-process index-update summary, per-KB stale counts, embedding-backend reachability (Ollama / HuggingFace / OpenAI), ask and relevance-gate LLM endpoint readiness, LLM call counters (calls, errors, p95 latency, reported token totals, bounded provider and coarse-model attribution, attempts and retries, workflow cache outcomes, answer impact, answer-cache counters), the CLI version, and local git state.
+The full report covers four areas:
+
+- **Retrieval readiness** — active-model resolution, FAISS index version and mtime, the latest in-process index-update summary, and per-KB stale counts.
+- **Backend reachability** — the embedding provider (Ollama / HuggingFace / OpenAI), plus the `kb ask` and relevance-gate LLM endpoints.
+- **LLM usage counters**, broken down by operation — calls, errors, p95 latency, reported token totals, attempts and retries, cache hit outcomes, and how often an answer actually changed as a result. Provider and model attribution is *bounded*: only the few most-used values are tracked by name, so a long tail of models can't grow the counter set without limit.
+- **Local install state** — the CLI version and local git state, which is what catches a global `kb` bin pointing at a stale checkout.
 
 It **exits non-zero when a required retrieval check fails** — unresolved active model, missing index, unreachable backend. LLM endpoint failures are only WARN rows, because search can be perfectly healthy while `kb ask` or the optional gate is not ready.
 

--- a/README.md
+++ b/README.md
@@ -632,7 +632,7 @@ kb verify                          # slow integrity checks for persisted indexes
 
 ## Tune retrieval quality
 
-Plain dense retrieval is the default and needs no configuration. Four optional stages sit around it, all **off by default** because each trades something away. The complete flag matrix — defaults, per-call overrides, rollout status, validation commands — is in [docs/feature-flags.md](docs/feature-flags.md).
+Plain dense retrieval is the default and needs no configuration. Four further stages sit around it. Three are **off by default**, because each buys precision or safety at a cost you should choose deliberately; the fourth, the untrusted-content guard, is on. The complete flag matrix — defaults, per-call overrides, rollout status, validation commands — is in [docs/feature-flags.md](docs/feature-flags.md).
 
 ### Cross-encoder reranking
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,14 @@
 [![License](https://img.shields.io/github/license/jeanibarz/knowledge-base-mcp-server)](./UNLICENSE)
 [![Node.js >= 20](https://img.shields.io/badge/node-%3E%3D20-brightgreen)](./package.json)
 
-This MCP server provides tools for listing and retrieving content from different knowledge bases.
+Point this server at a folder of markdown notes and it becomes searchable by meaning, not just by keyword — from your AI client, or from your shell.
+
+You keep your notes as ordinary files on your own disk. The server reads them, splits them into chunks, turns each chunk into a vector with an embedding model of your choosing (a local Ollama model, OpenAI, or HuggingFace), and stores those vectors in a local [FAISS](https://faiss.ai/) index. Run it with a local embedding model and a local LLM and your notes never leave the machine; point it at a hosted provider and only then do they cross the network. Two front doors sit on top of that index:
+
+- **An MCP server** that any [Model Context Protocol](https://modelcontextprotocol.io) client — Claude Desktop, Codex CLI, Cursor, Continue, Cline — can call to search your notes, ask questions answered from them, and (optionally) write new ones.
+- **A `kb` command-line tool** for the same corpus from a terminal or an agent's shell, plus the operational commands the MCP surface doesn't expose: indexing, diagnostics, evaluation, and note curation.
+
+Throughout the docs, a *knowledge base* (or *shelf*) is one subdirectory of your notes root — `work/`, `research/`, `personal/` — that you can search individually or together.
 
 ### Demo
 
@@ -19,441 +26,72 @@ Real output, no mock data: the capture drives the `kb` CLI against a small knowl
   <img width="380" height="200" src="https://glama.ai/mcp/servers/n0p6v0o0a4/badge" alt="Knowledge Base Server MCP server" />
 </a>
 
-## Setup Instructions
+## Contents
 
-These instructions assume you have Node.js (version 20 or higher) and npm installed on your system.
+| Section | Read it when |
+| --- | --- |
+| [Install](#install) | Getting the server or the `kb` CLI onto your machine. |
+| [Configure](#configure) | Choosing an embedding provider and laying out your notes. |
+| [Use the MCP server](#use-the-mcp-server) | Wiring an AI client to your knowledge bases. |
+| [Use the `kb` CLI](#use-the-kb-cli) | Searching, asking, writing, and curating from a shell. |
+| [Tune retrieval quality](#tune-retrieval-quality) | Turning on the optional reranking, gating, and safety stages. |
+| [Remote transport](#remote-transport-optional) | Serving MCP over HTTP or SSE instead of stdio. |
+| [Benchmarks](#benchmarks) | Measuring retrieval quality locally. |
+| [Troubleshooting](#troubleshooting) | Searches return nothing, or something looks stale. |
+| [Security](#security) | Understanding the trust boundaries before you point this at untrusted content. |
+| [Documentation map](#documentation-map) | Finding the deeper reference and runbooks under `docs/`. |
 
-### Install (one command)
+## Install
+
+All install paths need [Node.js](https://nodejs.org/) 20 or newer and npm.
+
+### As an MCP server (one command)
 
 ```bash
 npx -y @jeanibarz/knowledge-base-mcp-server@latest
 ```
 
-`npx` fetches the package from npm and launches the stdio server. Point your MCP client at `npx -y @jeanibarz/knowledge-base-mcp-server@latest` and configure the environment variables documented below. See [docs/clients.md](docs/clients.md) for copy-pasteable snippets (Claude Desktop, Codex CLI, Cursor, Continue, Cline).
+`npx` fetches the package from npm and launches the stdio server. Point your MCP client at that same command and set the environment variables described under [Configure](#configure). [docs/clients.md](docs/clients.md) has copy-pasteable config snippets for Claude Desktop, Codex CLI, Cursor, Continue, and Cline.
 
-> **Pin `@latest`, not the unversioned spec.** `npx -y @jeanibarz/knowledge-base-mcp-server` (no version) caches the resolved version in `~/.npm/_npx/` indefinitely — subsequent client launches reuse that cached version even after a new release ships. The `@latest` form hashes to a different cache key and re-resolves on every launch, so new fixes arrive on the next client restart instead of requiring a manual `~/.npm/_npx/` clear. See RFC 012 §2.4.
+> **Pin `@latest`, not the unversioned spec.** `npx -y @jeanibarz/knowledge-base-mcp-server` (no version) caches the resolved version in `~/.npm/_npx/` indefinitely — subsequent client launches reuse that cached version even after a new release ships. The `@latest` form hashes to a different cache key and re-resolves on every launch, so new fixes arrive on the next client restart instead of requiring a manual `~/.npm/_npx/` clear. See [RFC 012 §2.4](docs/rfcs/012-cli-distribution.md).
 
-### Install (CLI alongside the MCP server, RFC 012)
+### As a CLI (`kb`)
 
-For an interactive shell or AI-agent shell-tool flow, install globally and use the `kb` bin directly. The OS resolves the binary on every invocation, so `npm i -g …@latest` is picked up without restarting any AI client that has the MCP server loaded:
+Install globally to get the `kb` command in any shell — useful interactively, and useful as a tool an AI agent can shell out to:
 
 ```bash
 npm install -g @jeanibarz/knowledge-base-mcp-server@latest
-kb list                       # list available knowledge bases
-kb stats                      # read-only index/corpus stats
-kb search "your query"                       # read-only dense search
-kb search "your query" --timing              # include retrieval-stage timings
-kb search "your query" --format=compact      # one-line-per-hit operator table (#446)
-printf '{"query":"q1"}\n{"query":"q2"}\n' | kb search --batch-jsonl  # batched JSONL stdin (#440)
-kb search "query" --refresh                  # also re-scan KB files (write path)
-kb search "query" --explain-empty            # opt-in deep diagnostics when results are empty (#328)
-kb search "INDEX_NOT_INITIALIZED" --mode=lexical --refresh   # BM25 debug surface (#206 stage 1)
-kb search "retrieval benchmarks" --mode=lexical --lexical-unit=source  # source-level BM25
-kb search "INDEX_NOT_INITIALIZED" --mode=hybrid              # dense ⨁ BM25 fused via RRF (#206 stage 2)
-kb search "src/cli-search.ts" --mode=auto    # opt-in heuristic: hybrid for code/path/error-shaped queries
-kb search "runbook rollback" --context-window=1  # include adjacent chunks around dense hits
-kb search "agent evidence" --diverse --format=json           # source-aware representative sampling
-kb search "agent evidence" --anti-query="frontend styling"   # contrastive, positive-support constrained
-kb search "queue debt" --plus="slow loop" --minus="UI layout" --format=json
-kb open alpha/docs/deploy.md#L42-L78         # resolve a chunk id / kb:// URI / result path to its source file
-kb related alpha/docs/deploy.md#L42-L78      # find dense neighbors from an existing result chunk
-kb llm use-endpoint http://127.0.0.1:8080/v1/chat/completions --profile=local-research-agent
-kb ask "what changed in the daemonization notes?" --timing   # retrieval + local LLM answer with timings
-kb ask "why does src/cli.ts throw?" --mode=hybrid --rerank   # same dense|hybrid|lexical|auto modes + opt-in rerank as kb search
-kb ask "what changed?" --kb=work --save-transcript --title="Ask - daemon changes" --yes
-kb research plan "autonomous research agents and evals" --format=json
-kb research collect "autonomous research agents and evals" --run-dir runs/agents --format=json
-kb remember --suggest --kb=work --title="Quarterly plan"
-printf '# Quarterly plan\n\n...' | kb remember --kb=work --title="Quarterly plan" --stdin --yes
-printf '\nFollow-up note.\n' | kb remember --kb=work --append=quarterly-plan.md --stdin --yes
-kb import-url --kb=research https://example.com/article   # snapshot a URL into a provenance-tagged note
-kb superseded --kb=work       # read-only review for obsolete/contradicted notes
-kb tags --kb=work             # read-only: list frontmatter facet values (tags/status/type) with counts
-kb tags --facet=status --format=json  # discover the vocabulary for kb search --status filters
-kb tag work/runbooks/deploy.md --add=verified  # dry-run; add --yes to apply the tag change
-kb feedback add --kb=work --query="rollback procedure" --source=runbooks/deploy.md --verdict=relevant
-kb feedback promote --kb=work --query="rollback procedure" --fixture=docs/testing/feedback-fixture.yml --yes  # promote ledger entries into an eval fixture
-kb eval retrieval-eval.yml     # run fixture-driven retrieval checks
-kb eval-gate docs/testing/fixtures/rfc-018-gate-eval/queries.yml  # RFC 018 gate validation harness
-kb reindex --with-context     # rebuild the FAISS index with RFC 017 contextual prefaces
-kb reindex status --format=json  # ledger of recent / in-flight reindex passes (#417)
-kb logs show --request-id=<id>     # read canonical request logs by id (#397)
-kb logs recent --limit=20 --format=json  # most recent canonical log entries
-kb diagnose --request-id=<id> --repro-bundle=/tmp/kb-diag  # package redacted canonical log context
-kb serve                      # start the loopback CLI daemon (warm reads); add --warm to pre-load active indexes
-kb serve status               # daemon liveness + degraded-mode diagnostics (#420)
-kb config validate            # static env-var schema validation before startup
-kb doctor                     # availability snapshot (index, embedding backend, LLM)
-kb doctor --endpoints         # focused MCP/daemon/Ollama/LLM endpoint preflight
-kb doctor --locks             # write-lock owner and stale-lock diagnosis
-kb doctor --kb-symlinks       # inventory KB-root symlinks and escaping targets
-kb doctor --bug-report=/tmp   # write a redacted support bundle for issue reports
-kb --help                     # top-level command list
-kb help search                # per-command help (also: kb search --help)
-kb completion bash|zsh|fish   # generate a shell completion script (bash, zsh, or fish)
-kb cite alpha/docs/deploy.md  # export BibTeX or CSL-JSON from note frontmatter
-kb cache list                 # inspect local cache surfaces
-kb cache prune                # prune stale cache entries
-kb explain "rollback procedure" --kb=work  # verbose single-query retrieval trace for debugging
-kb verify                     # run slow integrity checks for persisted indexes and sidecars
-kb where "observability stack" # recommend the best KB and file for a given topic
-kb stale-check --kb=work      # scan markdown notes for path / URL references that no longer resolve
-kb promote alpha/docs/deploy.md  # review and update lifecycle frontmatter on a KB note
-kb quarantine list --kb=work  # inspect and manage per-file ingest quarantine entries
+kb list          # which knowledge bases can I see?
+kb doctor        # is retrieval actually healthy?
+kb search "your query"
 ```
 
-The `kb` bin shares the same env vars as the MCP server (`KNOWLEDGE_BASES_ROOT_DIR`, `FAISS_INDEX_PATH`, `EMBEDDING_PROVIDER`, `OLLAMA_*`, `OPENAI_*`, `HUGGINGFACE_*`). The consolidated operator matrix for retrieval flags, defaults, per-call overrides, rollout status, and validation commands lives in [docs/feature-flags.md](docs/feature-flags.md). `kb stats [--kb=<name>] [--format=md|json|csv|tsv|ndjson|openmetrics]` mirrors the MCP `kb_stats` payload for local shell use: per-KB file/chunk/byte counts, last indexed time, embedding model, index path, version context, filesystem enumeration failure diagnostics, process-lifetime chat-completion call/error/latency/token counters, bounded provider/coarse-model attribution, attempt/retry totals, workflow cache outcomes, answer impact, contextual-preface cache/failure counters (when RFC 017 ingest is enabled), and remote-transport request/auth/backoff counters (when the HTTP or SSE transport is active). It is read-only and does not refresh the index. `kb search` also defaults to read-only dense retrieval — it loads the existing FAISS index but does not re-scan KB files. Pass `--refresh` to re-index. Use `--mode=hybrid` for explicit dense+BM25 rank fusion, or `--mode=auto` to keep dense for prose queries while selecting hybrid for code, path, flag, error-code, and issue-reference shaped queries. Dense-only neighbor context flags (`--context-before`, `--context-after`, `--context-window`) attach adjacent chunks from the same source around each ranked semantic match; see [docs/search-neighbor-context.md](docs/search-neighbor-context.md) for examples, JSON shape, and tradeoffs. Exploration operators stay additive and read-only: `--diverse` reranks a bounded dense candidate pool for source-aware representative coverage; `--anti-query=<text>` penalizes candidates close to a negative query but only among positively supported candidates; `--plus=<text>` and `--minus=<text>` add vector-composition-style positive and negative query components. JSON output includes an `advanced_retrieval` explanation block with mode, constraints, query components, and per-result scoring signals. Add `--timing` to `kb search` or `kb ask` when you need per-stage elapsed milliseconds in either markdown or JSON output. `--format=compact` collapses each result to a single `score|kb|path:line` line for terse operator listings; `--batch-jsonl` reads `{"query":"…","kb":"…","k":N}` records from stdin and emits one JSON result envelope per line. Search output includes a freshness footer indicating whether the index is up-to-date relative to KB file mtimes.
+The OS resolves the binary on every invocation, so `npm i -g …@latest` takes effect immediately — no need to restart an AI client that already has the MCP server loaded. The `kb` bin reads the same environment variables as the MCP server. See [Use the `kb` CLI](#use-the-kb-cli) for the full command map.
 
-`kb config validate` also checks static cross-variable constraints before startup. In particular, `KB_CHUNK_OVERLAP` must be strictly less than `KB_CHUNK_SIZE`; `kb doctor` reports the same configuration finding and exits non-zero when the pair is invalid.
+### Via Smithery
 
-### Research evidence packets for agents
-
-`kb research` is a read-only workflow for agent shells that need a broad evidence pass before writing an answer, RFC, eval plan, or issue. It does not call an LLM, trigger local-research-agent, refresh indexes, or write KB notes.
-
-Run `plan` first to inspect the deterministic shelf/query plan, then run `collect` with a run directory:
-
-```bash
-kb research plan "synthesize an end-to-end approach for autonomous research agents and evals" --format=json
-kb research collect "synthesize an end-to-end approach for autonomous research agents and evals" \
-  --run-dir /tmp/kb-research-autonomous-agents-evals-20260521 \
-  --format=json
-```
-
-After `collect`, read the generated `evidence_packet.md` and synthesize manually. The run directory also contains `run.json`, `plan.json`, `ledger.json`, and `events.jsonl`; `ledger.json` stays lossless for audit/debug use, while `evidence_packet.md` is the human-scannable packet. The JSON contract and stable artifact fields are documented in [`docs/cli-json-contracts.md`](docs/cli-json-contracts.md#kb-research); a longer operator walk-through (when to use it, how to read the packet, downstream `kb ask` + `kb feedback` plumbing) lives in [`docs/operations/research-workflow.md`](docs/operations/research-workflow.md).
-
-For local day-two operations with Ollama, llama-server, n8n, systemd user
-units, remote MCP transports, or `kb serve`, see the
-[local service operations runbook](docs/operations/local-services.md). For
-active incidents, start with the symptom-keyed
-[incident response runbook](docs/operations/incident-response.md).
-
-RFC 018 relevance gating is off by default. Enable it per process with `KB_RELEVANCE_GATE=on`, or per CLI call with `kb search --gate`; bypass an enabled process with `--no-gate` or MCP `gate: "off"`. The judge uses `--task-context=<text>` / `--task-context-file=<path>` or MCP `task_context`, and reads `KB_GATE_LLM_ENDPOINT` / `KB_GATE_LLM_MODEL` (falling back to `KB_LLM_ENDPOINT` / `KB_LLM_MODEL`). Tuning env vars are `KB_GATE_SCORE_FLOOR` (default `0.95`), `KB_GATE_JUDGE_INPUT` (default `10`), `KB_GATE_LLM_TIMEOUT_MS` (default `8000`), and `KB_GATE_MIN_TASK_TOKENS` (default `8`). `KB_GATE_EMPTY_VERDICT` defaults to `off`; turn it on only when you are comfortable letting the gate return no retrieved context.
-
-**Cross-encoder reranking (RFC 019, off by default).** After the initial dense (or hybrid) retrieval stage, an optional cross-encoder reranking pass reorders the top-N candidates using a more precise model. It improves precision at a small latency cost. Enable it with `KB_RERANK=on`. Tuning env vars:
-
-| Env var | Description | Default |
-| --- | --- | --- |
-| `KB_RERANK` | Enable the cross-encoder reranking stage. | `off` |
-| `KB_RERANK_MODEL` | Cross-encoder model id used for reranking. | (built-in default) |
-| `KB_RERANK_TOP_N` | How many top candidates to feed into the reranker. | (built-in default) |
-| `KB_RERANK_SKIP_DOMAINS` | Comma-separated KB domain names to skip reranking for. | (none) |
-
-Note: `KB_RERANK_DEVICE` (e.g. `cuda`, `cpu`) and `KB_RERANK_DTYPE` (e.g. `fp32`) are optional Transformers.js / ONNX Runtime overrides for cross-encoder execution; set them in the shell when you need runtime-specific acceleration or dtype control. They are listed by `kb config show` and validated by `kb config validate`.
-
-`kb search --format=vimgrep` prints one quickfix-compatible line per result: `path:line:col:preview`. JSON results include a stable `chunk_id` such as `alpha/docs/deploy.md#L42-L78` when chunk metadata has a KB, path, and line range; chunks without line metadata fall back to `#chunk-N`. Set `KB_EDITOR_URI=vscode`, `cursor`, or `file` to add opt-in absolute-path `editor_uri` fields and markdown `Open` links. The default `KB_EDITOR_URI=none` omits local absolute paths. `kb open <chunk-id|kb://uri|kb-relative-path>` resolves any of those pointers back to the absolute source path, validated against the KB root; it is read-only and prints the path (add `--json` for the cited line range and an `editorUri`). `kb related <chunk-id|kb://uri>` retrieves an indexed seed chunk from that handle, runs dense search with the seed text, and excludes the seed chunk unless `--include-self` is passed.
-
-`kb remember` is a conservative CLI write path for agent shells. `--suggest` lists likely existing targets from note filenames/headings, does not read stdin or write notes, and may update a small `.index` heading cache. Creates and appends require both `--stdin` and `--yes`; create uses a slugified `.md` filename and refuses overwrites, while append accepts only existing KB-relative paths. Plain EOF appends and `kb capture --append` serialize per target and commit through a temp-file fsync plus atomic rename. `kb capture` redacts common credentials from captured stdout and the displayed command line by default; pass `--no-redact` only when raw output is required. Add `--refresh` to re-index the affected KB after a successful write. For the task-oriented workflow from collection through tagging, review, and promotion, see [`docs/authoring-knowledge.md`](docs/authoring-knowledge.md#6-curate-notes-through-their-lifecycle). For machine-readable command shapes, see [`docs/cli-json-contracts.md`](docs/cli-json-contracts.md).
-
-`kb import-url --kb=<name> <url>` snapshots a web page or PDF into one new KB note while preserving provenance. It fetches the URL over http(s), routes HTML and PDF responses through the same loaders the indexer uses, and writes a note whose YAML frontmatter records `source_url`, `fetched_at`, `content_sha256`, `content_type`, `http_status`, and `byte_count`. The fetch is guarded: only http/https schemes are allowed, redirects are followed manually and re-validated per hop (`--max-redirects`, default 5), responses are size-capped (`--max-bytes`, default 8 MiB) and time-bounded (`--timeout`, default 30000 ms), and private/loopback/link-local addresses are refused unless `--allow-local-network` is passed (SSRF guard). The note path defaults to a slug of the page title; pass `--note=<path.md>` to choose it, `--title` to override the title, and `--refresh` to re-index afterwards. It refuses to overwrite an existing note.
-
-`kb superseded --kb=<name>` is a read-only active-forgetting review. It scans markdown frontmatter for explicit contradiction, deprecated/dormant lifecycle status, stale verification dates, and low-confidence active notes, then uses the existing semantic index to add conservative newer-neighbor evidence when available. Use `--format=json` for agent workflows and `--include-clean` when you need a full inventory.
-
-`kb tag <kb>/<note> --add=<tag> [--remove=<tag>]` safely maintains one note's frontmatter tag array. The default is a dry-run; repeat `--add` or `--remove` for several tags and pass `--yes` to commit the change through the atomic writer and the KB's `.kb-policy.json` mutation policy. The note body is preserved byte-for-byte and malformed frontmatter is rejected before writing. Run `kb search --refresh` before expecting an existing index's tag filter to see the new value; `kb tags` reads note files directly.
-
-`kb feedback add --kb=<name> --query="<text>" --source=<kb-relative-path> --verdict=relevant|irrelevant|stale|misleading [--relevance=0..3] [--chunk-id=<id>]` appends a relevance judgment to the per-KB ledger (`<kb>/.index/relevance-feedback.jsonl`). `kb feedback list --kb=<name>` reviews recent entries, and `kb feedback promote --kb=<name> --query="<text>" --fixture=<path.yml> --yes` materialises every ledger row for a query into a retrieval-eval case so accumulated judgments become regression coverage. See [`docs/operations/feedback-workflow.md`](docs/operations/feedback-workflow.md).
-
-`kb eval-gate <fixture.yml>` runs the RFC 018 relevance-gate validation harness end-to-end against a labelled-queries fixture (Stage A statistical floor + optional Stage B LLM judge) and reports per-stage precision, recall, and false-empty rate. Use it when you change `KB_GATE_*` tuning or the judge prompt before promoting changes to production. See [`docs/operations/eval-gate-harness.md`](docs/operations/eval-gate-harness.md).
-
-`kb logs` is the canonical reader for the structured request log emitted under `KB_LOG_FORMAT=canonical` or `both`. Use `kb logs show --request-id=<id>` to pull every line of a specific retrieval, `kb logs show --query-sha=<hash>` to follow recurring queries, and `kb logs recent --limit=<n>` for the most recent entries. `--format=json` emits a report envelope; `--format=csv|tsv|ndjson` emits flat event rows for downstream tooling.
-
-`kb diagnose --request-id=<id> --repro-bundle=<dir>` packages the matching canonical events into a private redacted bundle. Canonical logs do not store raw query text; pass `--query`, `--query-file`, or `--stdin` to also replay `kb explain --repro-bundle` with model, KB scope, k, and threshold hints inferred from the log event.
-
-`kb serve` runs the loopback CLI daemon used by clients that pass `--daemon` for warm reads. The bare `kb serve [--host=127.0.0.1] [--port=17799] [--idle-timeout-ms=300000] [--warm]` brings it up; `--warm` or `KB_DAEMON_PREWARM=on` pre-loads the active model, FAISS index, and lexical indexes before readiness. `kb serve status [--json]` reports reachability, pid, idle timeout, supported commands, and prewarm state at the configured `KB_DAEMON_URL` (defaults to `http://127.0.0.1:17799`); SIGINT or SIGTERM stops it. CLI commands fall back to direct in-process execution when the daemon is unavailable. See [`docs/operations/daemon-lifecycle.md`](docs/operations/daemon-lifecycle.md).
-
-`kb reindex --with-context` rebuilds the FAISS index with RFC 017 contextual prefaces (requires `KB_CONTEXTUAL_RETRIEVAL=on` and an `KB_LLM_ENDPOINT`). `kb reindex status` reads the durable run-state and per-source sidecar ledgers and reports liveness, eligible indexed files, sidecar coverage, pending files, resolved/failed chunks, and failure codes. The `--kb=<name>` flag is a guard/estimator hint only — the rebuild always covers the entire single-index-per-model FAISS layout (see RFC 017 §5).
-
-Set `KB_INGEST_SECRET_SCAN=on` to scan chunks and frontmatter metadata for credential-shaped content before they are embedded. Hits are quarantined with reason `secret_detected`, skipped before FAISS writes, and can be inspected with `kb quarantine list --reason=secret_detected`; use `KB_SECRET_SCAN_BYPASS_KBS=trusted-kb,...` only for shelves that intentionally store credential examples. See [Ingest Secret Scan](docs/operations/secret-scan.md).
-
-Retrieved chunks are passed through the **untrusted-content guard** (`KB_INJECTION_GUARD`, default `tag`). The guard scans chunk text for prompt-injection signals — system-role markers, instruction-override phrases, Unicode bidi/zero-width/tag controls — and either annotates metadata (`tag`), fences the content with sentinel strings (`wrap`), or both (`both`). Set `KB_INJECTION_GUARD=off` only on shelves you fully control, or use `KB_INJECTION_GUARD_BYPASS_KBS=trusted-kb,...` to opt specific shelves out without weakening the global default.
-
-`kb eval <fixture.yml|json>` runs retrieval checks from fixtures. Each case can set `query`, optional `kb`, `required_sources`, `forbidden_sources`, `expected_metadata`, `max_duplicate_groups`, `stale_policy`, and `gate`. Failing ungated cases print warnings and exit 0; failing gated cases exit 1 for CI.
-
-```yaml
-gate: false
-cases:
-  - name: deployment runbook
-    query: rollback procedure
-    kb: work
-    gate: true
-    required_sources: [runbooks/deploy.md]
-    forbidden_sources: [archive/old-deploy.md]
-    expected_metadata:
-      frontmatter.status: approved
-    max_duplicate_groups: 1
-    stale_policy: fresh
-```
-
-The MCP server (`knowledge-base-mcp-server` bin) is unchanged and still works with all the configurations in [docs/clients.md](docs/clients.md). The CLI is additive.
-
-### Local retrieval benchmarks
-
-Use `npm run bench:beir` to run a local BEIR benchmark with credential-free
-lexical retrieval:
-
-```bash
-npm run bench:beir -- --dataset=scifact --split=test --mode=lexical --lexical-unit=source --output-dir=/tmp/kb-beir-scifact
-```
-
-The runner builds a temporary KB root, emits metrics JSON plus a TREC run file,
-and records reproduction metadata such as git SHA, command, dataset checksum,
-runtime versions, chunking config, and latency percentiles. These are local
-benchmark artifacts, not official BEIR leaderboard submissions; the current
-lexical source path is scored at document level and is also available in the
-CLI via `kb search --mode=lexical --lexical-unit=source`. See
-[benchmarks/README.md](benchmarks/README.md#beirscifact-local-retrieval-benchmark)
-for smoke-test commands and caveats, and
-[benchmarks/results/README.md](benchmarks/results/README.md) for the archived
-SciFact run.
-
-Optuna tuning is optional and only runs when explicitly invoked. A SciFact
-example that sweeps lexical chunking and writes a replayable best-config file:
-
-```bash
-npm run bench:tune -- \
-  --trials=12 \
-  --direction=maximize \
-  --metric=metrics.ndcgAt10 \
-  --study-name=scifact-lexical \
-  --best-config-out=/tmp/kb-scifact-lexical-best.json \
-  --param-int=KB_CHUNK_SIZE=256:1024:128 \
-  --param-int=KB_CHUNK_OVERLAP=0:128:32 \
-  -- npm run bench:beir -- --dataset=scifact --split=test --mode=lexical --max-queries=25 --output-dir=/tmp/kb-scifact-tune
-```
-
-Replay the best trial without importing Optuna:
-
-```bash
-npm run bench:tune -- --replay-config=/tmp/kb-scifact-lexical-best.json
-```
-
-### Local LLM answers (RFC 015)
-
-`kb ask` keeps retrieval deterministic and adds a local OpenAI-compatible chat step on top. It resolves the LLM endpoint from `--endpoint`, `KB_LLM_ENDPOINT`, `--llm-profile`, the active `kb llm` profile, then finally the local-research-agent default on `127.0.0.1:8080`.
-
-Notes can opt out of LLM prompt packing with this YAML frontmatter:
-`kb_policy: { no_llm_context: true }`. Search can still return the chunk, but
-`kb ask` and MCP `ask_knowledge` skip it before calling the LLM and report
-`context_packing.policy_filtered_chunks`. Contextual-preface ingest and
-relevance-gate judging also exclude it from their LLM prompts while preserving
-the chunk as retrieval data.
-
-For offline development, set `KB_LLM_FAKE=on` to route `kb ask`, RFC 018 relevance-gate judge calls, and RFC 017 contextual-preface generation to a deterministic in-process fake LLM. Use `npm run dev:mockllm -- --port=18080` when a client needs an OpenAI-compatible localhost endpoint instead. Rules can be customized with `KB_LLM_FAKE_RULES`; see [docs/testing/fake-llm.md](docs/testing/fake-llm.md).
-
-Add `--save-transcript --kb=<name> --yes` to persist the generated answer as a new markdown note in that KB. The saved record includes the question, answer, citations, source chunk ids, LLM endpoint/profile/model, retrieval model, and timing metadata when `--timing` is present. `--title=<title>` controls the note title and slug; existing transcript notes are never overwritten.
-
-```bash
-# Reuse an already-running local-research-agent llama-server.
-kb llm use-endpoint http://127.0.0.1:8080/v1/chat/completions --profile=local-research-agent
-kb llm status
-kb ask "Which notes discuss reboot recovery?" --kb=operating-environment
-kb ask "Which notes discuss reboot recovery?" --kb=operating-environment \
-  --save-transcript --title="Reboot recovery answer" --yes
-
-# Optional managed service for machines that want kb to own the warm model.
-kb llm install --profile=qwen --runner=llama-server \
-  --bin=/path/to/llama-server --model=/path/to/model.gguf --port=8091
-kb llm start --profile=qwen
-kb llm set-model --profile=qwen --model=/path/to/other-model.gguf --start
-kb llm uninstall --profile=qwen
-```
-
-External profiles are reuse-only: `kb llm stop`, `restart`, `uninstall`, and `reap` do not stop services owned by local-research-agent. Managed profiles are namespaced as `kb-llm@<profile>.service`, bind to `127.0.0.1`, and write leases under the user state directory so stale managed models can be reaped instead of staying loaded forever.
-
-### Comparing embedding models (RFC 013)
-
-The CLI can keep multiple embedding models side-by-side and query each by id. Useful for retrieval-quality A/B without losing the previous model:
-
-```bash
-# List registered models. The * marks the active one.
-kb models list
-
-# Add a second model — embeds your KB once under the new model.
-# For paid providers, prints an estimated cost and prompts before any HTTP traffic.
-kb models add ollama nomic-embed-text          # local, free
-kb models add openai text-embedding-3-small    # paid; estimate first
-kb models add huggingface BAAI/bge-small-en-v1.5
-kb models add ollama nomic-embed-text --index-type=sq8   # FAISS scalar quantization
-kb models add ollama nomic-embed-text --index-type=hnsw  # HNSW approximate search backend
-
-# Query a specific model without changing the default.
-kb search "your query" --model=openai__text-embedding-3-small
-
-# Side-by-side comparison: unified rank/score table over both models' top-k.
-kb compare "your query" ollama__nomic-embed-text-latest openai__text-embedding-3-small
-
-# Switch the default model.
-kb models set-active openai__text-embedding-3-small
-
-# Remove a model (refuses to remove the active one).
-kb models remove huggingface__BAAI-bge-small-en-v1.5
-```
-
-`<model_id>` is `<provider>__<filesystem-safe-slug>`, derived deterministically from `(provider, model_name)` as typed (e.g. `OLLAMA_MODEL=nomic-embed-text:latest` → `ollama__nomic-embed-text-latest`). On-disk layout: each model lives at `${FAISS_INDEX_PATH}/models/<id>/`. The active model is recorded in `${FAISS_INDEX_PATH}/active.txt` and overridable per-process via `KB_ACTIVE_MODEL`. `KB_INDEX_TYPE` or `kb models add --index-type=flat|sq8|hnsw` selects the per-model search index type; see [docs/operations/index-quantization.md](docs/operations/index-quantization.md). See [`docs/reference/embedding-models.md`](docs/reference/embedding-models.md) for the supported defaults, vector dimensions, task-prefix requirements, and reindex caveats; see [`docs/rfcs/013-multimodel-support.md`](docs/rfcs/013-multimodel-support.md) for the full design.
-
-**Migration from the legacy single-model layout** is automatic on first server (or `kb`) start: the existing single-model index is moved into `${FAISS_INDEX_PATH}/models/<derived_id>/` and `active.txt` is written. Cross-process starts coordinate the migration with `${FAISS_INDEX_PATH}/.kb-migration.lock`; MCP and CLI processes no longer rely on a long-lived single-instance PID advisory. Keep a backup of the previous `${FAISS_INDEX_PATH}` if you need rollback safety before upgrading from an older checkout.
-
-**MCP surface** — `retrieve_knowledge` gains an optional `model_name` argument; a new `list_models` tool returns the registered models; `kb_stats` reports the latest in-process `updateIndex` summary under `last_index_update` alongside the static index counts. Tools that don't pass `model_name` keep working unchanged (wire format is byte-equal to 0.2.x).
-
-### MCP error codes
-
-Tool errors are returned with `isError: true` and a JSON text payload so MCP clients can branch without substring matching:
-
-```json
-{
-  "error": {
-    "code": "PROVIDER_AUTH",
-    "message": "OPENAI_API_KEY environment variable is required when using OpenAI provider"
-  }
-}
-```
-
-| Code | Meaning | Typical client action |
-| --- | --- | --- |
-| `INDEX_NOT_INITIALIZED` | A search ran before a FAISS index was available. | Retry after initialization or trigger a refresh. |
-| `PROVIDER_UNAVAILABLE` | The embedding provider is temporarily unavailable. | Retry with backoff. |
-| `PROVIDER_TIMEOUT` | The embedding provider timed out. | Retry with backoff. |
-| `PROVIDER_AUTH` | Provider credentials are missing or invalid. | Ask the user to configure a valid API key. |
-| `KB_NOT_FOUND` | The requested knowledge base does not exist. | Prompt for one of the listed knowledge bases. |
-| `PERMISSION_DENIED` | The server cannot read or write a required local path. | Surface to the operator/admin. |
-| `CORRUPT_INDEX` | The persisted FAISS index is corrupt or unreadable. | Rebuild or recover the index. |
-| `VALIDATION` | A caller-supplied argument failed validation. | Fix the request before retrying. |
-| `INTERNAL` | An unclassified server error occurred. | Surface the message and logs for investigation. |
-
-### Install via Smithery
-
-To install Knowledge Base Server for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@jeanibarz/knowledge-base-mcp-server):
+To install for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@jeanibarz/knowledge-base-mcp-server):
 
 ```bash
 npx -y @smithery/cli install @jeanibarz/knowledge-base-mcp-server --client claude
 ```
 
-### Install from source
+### From source
 
-Use this path if you want to develop against the repo or pin an unreleased commit.
+Use this path to develop against the repo or to pin an unreleased commit.
 
-**Prerequisites**
+```bash
+git clone https://github.com/jeanibarz/knowledge-base-mcp-server.git
+cd knowledge-base-mcp-server
+npm install
+npm run build
+```
 
-*   [Node.js](https://nodejs.org/) (version 20 or higher)
-*   [npm](https://www.npmjs.com/) (Node Package Manager)
+Then set your environment variables (see [Configure](#configure)), create your knowledge base directories, and add `node build/index.js` to your MCP client config — see [docs/clients.md](docs/clients.md).
 
-1.  **Clone the repository:**
+### For local development
 
-    ```bash
-    git clone <repository_url>
-    cd knowledge-base-mcp-server
-    ```
-
-2.  **Install dependencies:**
-
-    ```bash
-    npm install
-    ```
-
-3.  **Configure environment variables:**
-
-    This server supports three production embedding providers: **Ollama** (recommended for reliability), **OpenAI** and **HuggingFace** (fallback option). A deterministic `EMBEDDING_PROVIDER=fake` backend also exists for tests and offline fixtures; it is not suitable for deployed retrieval quality.
-
-    ### Option 1: Ollama Configuration (Recommended)
-    
-    *   Set `EMBEDDING_PROVIDER=ollama` to use local Ollama embeddings
-    *   Install [Ollama](https://ollama.ai/) and pull an embedding model: `ollama pull dengcao/Qwen3-Embedding-0.6B:Q8_0`
-    *   Configure the following environment variables:
-        ```bash
-        EMBEDDING_PROVIDER=ollama
-        OLLAMA_BASE_URL=http://localhost:11434  # Default Ollama URL
-        OLLAMA_MODEL=dengcao/Qwen3-Embedding-0.6B:Q8_0          # Default embedding model
-        KNOWLEDGE_BASES_ROOT_DIR=$HOME/knowledge_bases
-        ```
-    *   **Minimum context window:** the embedding model must accept at least ~500 tokens of input. The default chunker emits ~1000-character chunks which commonly tokenize past 256 tokens, so models like `all-minilm` (256 ctx) will reject every request. Use `nomic-embed-text` (8192 ctx), `dengcao/Qwen3-Embedding-0.6B:Q8_0` (32K ctx), or any model with ≥512 ctx instead.
-
-    ### Option 2: OpenAI Configuration
-
-    *   Set `EMBEDDING_PROVIDER=openai` to use OpenAI API for embeddings
-    *   Configure the following environment variables:
-        ```bash
-        EMBEDDING_PROVIDER=openai
-        OPENAI_API_KEY=your_api_key_here
-        OPENAI_MODEL_NAME=text-embedding-3-small
-        KNOWLEDGE_BASES_ROOT_DIR=$HOME/knowledge_bases
-        ```
-    *   To target an OpenAI-compatible endpoint instead of the official API (self-hosted gateways, Volcengine Ark, OpenRouter, …), set `OPENAI_BASE_URL` to the endpoint's base URL including the API version path, e.g. `OPENAI_BASE_URL=https://ark.cn-beijing.volces.com/api/v3`. Unset keeps the default `https://api.openai.com/v1`. Azure OpenAI is reachable only through its `/openai/v1/` API-compatibility surface (`OPENAI_BASE_URL=https://<resource>.openai.azure.com/openai/v1`); classic Azure deployments need `api-key` auth, an `api-version` query parameter, and per-deployment paths, so a plain base URL cannot target them.
-    *   As of this release, the OpenAI default is `text-embedding-3-small` (up from `text-embedding-ada-002`). Both produce 1536-dim vectors, but the model name change will trigger a one-time FAISS index rebuild on the next query. Override with `OPENAI_MODEL_NAME=...` if you prefer the old default.
-
-    ### Option 3: HuggingFace Configuration (Fallback)
-    
-    *   Set `EMBEDDING_PROVIDER=huggingface` or leave unset (default)
-    *   Obtain a free API key from [HuggingFace](https://huggingface.co/)
-    *   Configure the following environment variables:
-        ```bash
-        EMBEDDING_PROVIDER=huggingface          # Optional, this is the default
-        HUGGINGFACE_API_KEY=your_api_key_here
-        HUGGINGFACE_MODEL_NAME=BAAI/bge-small-en-v1.5
-        HUGGINGFACE_PROVIDER=hf-inference       # Optional, router provider for serverless inference
-        KNOWLEDGE_BASES_ROOT_DIR=$HOME/knowledge_bases
-        ```
-    *   As of this release, the HuggingFace default is `BAAI/bge-small-en-v1.5` (up from `sentence-transformers/all-MiniLM-L6-v2`). Both produce 384-dim vectors, but the model name change will trigger a one-time FAISS index rebuild on the next query. Override with `HUGGINGFACE_MODEL_NAME=...` if you prefer the old default.
-    *   HuggingFace retired the legacy `api-inference.huggingface.co/models/...`
-        endpoint in 2025. Feature-extraction calls are now routed through the
-        Inference Providers router at
-        `https://router.huggingface.co/hf-inference/models/<model>/pipeline/feature-extraction`
-        by default. Set `HUGGINGFACE_PROVIDER` to choose a different supported
-        Inference Provider such as `together`, `replicate`, `fireworks-ai`,
-        `sambanova`, `nebius`, or `novita`. The existing
-        `HUGGINGFACE_API_KEY` value can be either a Hugging Face token or a
-        compatible provider key, depending on how the request is authenticated
-        upstream. To target a self-hosted or dedicated Inference Endpoint, set
-        `HUGGINGFACE_ENDPOINT_URL` to the full POST URL; explicit endpoint URLs
-        bypass router provider selection.
-
-    ### Additional Configuration
-    
-    *   The server supports the `FAISS_INDEX_PATH` environment variable to specify the path to the FAISS index. If not set, it will default to `$HOME/knowledge_bases/.faiss`. For a complete defaults and validation matrix across retrieval, ingest, diagnostics, and transport flags, see [docs/feature-flags.md](docs/feature-flags.md).
-    *   **Shared `FAISS_INDEX_PATH` coordination.** Multiple MCP/CLI processes may share a trusted `FAISS_INDEX_PATH`; mutating paths serialize through per-model write locks and versioned atomic saves. Keep the index directory trusted and local — do not mount it on a shared filesystem writable by untrusted peers. See [`docs/architecture/threat-model.md`](docs/architecture/threat-model.md) for the current concurrency posture.
-    *   Logging can be routed to a file by setting `LOG_FILE=/path/to/logs/knowledge-base.log`. Log verbosity defaults to `info` and can be adjusted with `LOG_LEVEL=debug|info|warn|error`.
-    *   **Mutation audit log (opt-in).** Set `KB_MUTATION_AUDIT_LOG=/path/to/kb-mutations.jsonl` to capture an append-only JSONL ledger of KB content writes. Each line records `surface` (`cli.kb-remember` / `cli.kb-capture` / `cli.kb-ask` / `mcp.add_document` / `mcp.delete_document`), `operation`, `kb`, `relative_path`, `timestamp`, `before_sha256`, `after_sha256`, `write_performed`, `refresh_requested`, `refresh_status`, and per-surface `decision_flags`. Note content is **not** stored; only hashes and metadata. The feature is best-effort — an audit write failure logs a `warn` to stderr but never aborts the primary mutation. KB names and paths are inherent to the records, so treat the audit log with the same sensitivity as the underlying KB directory.
-    *   **Tailor tool descriptions per deployment.** The model-facing MCP tool descriptions can be overridden before server start via `RETRIEVE_KNOWLEDGE_DESCRIPTION`, `ASK_KNOWLEDGE_DESCRIPTION`, `LIST_KNOWLEDGE_BASES_DESCRIPTION`, `LIST_MODELS_DESCRIPTION`, and `KB_STATS_DESCRIPTION`. Unset or empty falls back to the built-in defaults. Example:
-        ```bash
-        RETRIEVE_KNOWLEDGE_DESCRIPTION="Search engineering runbooks, RFCs, and postmortems."
-        ASK_KNOWLEDGE_DESCRIPTION="Answer from engineering runbooks with citations."
-        LIST_KNOWLEDGE_BASES_DESCRIPTION="List available engineering knowledge bases."
-        LIST_MODELS_DESCRIPTION="List embedding models registered for engineering retrieval."
-        KB_STATS_DESCRIPTION="Report engineering KB index and transport health."
-        ```
-    *   **Ingest filter overrides (RFC 011 M1).** The server embeds only files whose extension is in `{.md, .markdown, .txt, .rst, .html, .htm}` and excludes PDFs, workflow sidecars (`_seen.jsonl`, `_index.jsonl`), log / staging subtrees (`logs/`, `tmp/`, `_tmp/`), and OS turds (`.DS_Store`, `Thumbs.db`, `desktop.ini`). To extend the allowlist or add more exclusions:
-        ```bash
-        # Comma-separated extensions (case-insensitive; leading dot optional).
-        INGEST_EXTRA_EXTENSIONS=".json,.yaml"
-        # Comma-separated minimatch globs relative to the KB root.
-        INGEST_EXCLUDE_PATHS="drafts/**,scratch.md"
-        ```
-        Extensionless files (e.g. `README`, `LICENSE`, `Makefile`) and PDFs are **not** embedded by the default allowlist; use `INGEST_EXTRA_EXTENSIONS=".pdf"` only when PDF extraction is intentional. The base exclusions are authoritative: operators can add more but cannot remove the built-ins.
-    *   You can set these environment variables in your `.bashrc` or `.zshrc` file, or directly in the MCP settings.
-
-4.  **Build the server:**
-
-    ```bash
-    npm run build
-    ```
-
-5.  **Add the server to your MCP client:**
-
-    See [docs/clients.md](docs/clients.md) for copy-pasteable configuration snippets for Claude Desktop, Codex CLI, Cursor, Continue, and Cline.
-
-6.  **Create knowledge base directories:**
-
-    *   Create subdirectories within the `KNOWLEDGE_BASES_ROOT_DIR` for each knowledge base (e.g., `company`, `it_support`, `onboarding`).
-    *   Place text files (e.g., `.txt`, `.md`) containing the knowledge base content within these subdirectories.
-
-*   The server recursively reads ingestable files within the specified knowledge base subdirectories: the base allowlist is `.md`, `.markdown`, `.txt`, `.rst`, `.html`, and `.htm`, plus any extensions added with `INGEST_EXTRA_EXTENSIONS`.
-*   The server skips hidden files and directories (those starting with a `.`).
-*   For each file, the server calculates the SHA256 hash and stores it in a file with the same name in a hidden `.index` subdirectory. This hash is used to determine if the file has been modified since the last indexing.
-*   File content is split into chunks before indexing: `.md` files use `MarkdownTextSplitter` (heading-aware), and every other text file uses `RecursiveCharacterTextSplitter`. Both splitters share the same `chunkSize: 1000, chunkOverlap: 200` defaults, so a large `.txt`, `.rst`, or source file produces many chunks rather than a single embedding.
-*   The content of each chunk is then added to a FAISS index, which is used for similarity search.
-*   The FAISS index is automatically initialized when the server starts. It checks for changes in the knowledge base files and updates the index accordingly.
-
-### Install (local development, live `kb` from your checkout)
-
-Use this when you're actively developing on the repo and want your global `kb` and `knowledge-base-mcp-server` bins to always reflect the current state of `main` (or your feature branch) — without `npm publish` and without manual reinstalls after each `git pull`.
+Use this when you're actively developing on the repo and want your global `kb` and `knowledge-base-mcp-server` bins to always reflect the current state of your checkout — without `npm publish` and without a manual reinstall after every `git pull`.
 
 ```bash
 git clone https://github.com/jeanibarz/knowledge-base-mcp-server.git
@@ -461,106 +99,182 @@ cd knowledge-base-mcp-server
 npm run dev:setup
 ```
 
-`dev:setup` does three things, all idempotent:
+`dev:setup` does three idempotent things:
 
-1.  **`npm install` + `npm run build`** — first build, so the bins exist before linking.
-2.  **`npm link`** — symlinks `kb` and `knowledge-base-mcp-server` into the global node prefix (printed during setup so you can verify it lands where you expect). From then on, every `npm run build` overwrites `build/` in place and the global bins pick up the new code on the next invocation. **No re-link needed** after rebuilds.
-3.  **`git config core.hooksPath .githooks`** — points git at the tracked [`.githooks/`](./.githooks) directory so the `post-merge` and `post-rewrite` hooks fire after every `git pull` (merge or rebase) and `git merge`. The hook re-runs `npm install` if `package.json` changed and `npm run build` if any source changed. Skips quietly when nothing relevant moved. The hook order puts this **last**, so a failed install/build leaves the repo in its original state.
+1. **`npm install` + `npm run build`** — a first build, so the bins exist before linking.
+2. **`npm link`** — symlinks `kb` and `knowledge-base-mcp-server` into the global node prefix (the path is printed during setup so you can verify where it landed). From then on, each `npm run build` overwrites `build/` in place and the global bins pick up the new code on the next invocation. **No re-link needed.**
+3. **`git config core.hooksPath .githooks`** — points git at the tracked [`.githooks/`](./.githooks) directory so the `post-merge` and `post-rewrite` hooks fire after every `git pull` (merge or rebase) and `git merge`. Each hook re-runs `npm install` if `package.json` changed and `npm run build` if any source changed, and stays quiet when nothing relevant moved. It runs **last** in the hook order, so a failed install or build leaves the repo in its original state.
 
-After setup, the daily loop is just:
+The daily loop is then just `git pull` (the hook rebuilds) or `npm run build` after an edit; the global `kb` reflects the change on its next invocation.
 
-```bash
-git pull            # hook rebuilds automatically (merge or rebase)
-kb search "..."     # uses the freshly-built bin from this checkout
-```
+**Why `npm link` and not `npm install -g .`?** `npm link` is a symlink, so a rebuild is picked up for free. `npm install -g .` copies the build snapshot, so every change needs a re-install.
 
-Or, when editing locally:
+**Hook scope.** The hooks fire on `git pull` / `git merge` / `git pull --rebase`, not on `git checkout` between branches — run `npm run build` yourself after a branch switch. If a rebuild fails, the hook prints a warning and exits 0 so the pull itself isn't reported as failed.
 
-```bash
-# edit src/...
-npm run build       # global `kb` immediately reflects your change
-```
+Three development helpers run against throwaway state instead of your real knowledge bases and indexes:
 
-To smoke-check a fresh contributor shell without touching your real knowledge
-bases or FAISS indexes, run:
+| Command | What it does |
+| --- | --- |
+| `npm run dev:doctor` | Builds the checkout, creates a disposable scratch corpus, and verifies the CLI, the native FAISS dependency, `kb list`, lexical search, and — if the configured embedding provider is reachable — dense search. Use it to smoke-check a fresh contributor shell. |
+| `npm run dev:cli -- search "…" --kb=work` | Runs the TypeScript CLI entrypoint directly with source maps, so you get real stack traces without rebuilding or relinking. It prints the active `KNOWLEDGE_BASES_ROOT_DIR`, `FAISS_INDEX_PATH`, embedding provider, and model to stderr first, so you can confirm which KB and index the command would touch. |
+| `npm run dev:remote -- --transport=http\|sse` | Seeds a scratch KB, picks a free loopback port, generates an `MCP_AUTH_TOKEN`, prints curl examples, starts the TypeScript server against that scratch state, and removes it on exit. Add `--keep` to inspect the generated files, or `--print-env` to emit the environment and examples without starting the server. |
 
-```bash
-npm run dev:doctor
-```
-
-It builds the checkout, creates a disposable scratch corpus, verifies the local
-CLI and native FAISS dependency, runs `kb list`, runs lexical search, and
-attempts dense search when the configured embedding provider is reachable.
-
-For source-mapped CLI debugging without rebuilding or relinking, run the
-TypeScript CLI entrypoint directly:
-
-```bash
-npm run dev:cli -- --help
-npm run dev:cli -- search "rollback procedure" --kb=work --k=5
-```
-
-The wrapper prints the active `KNOWLEDGE_BASES_ROOT_DIR`, `FAISS_INDEX_PATH`,
-embedding provider, and embedding model to stderr before each invocation so
-you can confirm which KB and index a command would touch.
-
-For disposable HTTP/SSE transport debugging without touching your real KB or
-FAISS index, run:
-
-```bash
-npm run dev:remote -- --transport=http
-npm run dev:remote -- --transport=sse
-```
-
-`dev:remote` creates a seeded scratch KB, chooses a free loopback port,
-generates an `MCP_AUTH_TOKEN`, prints curl examples for the selected transport,
-starts the TypeScript server against the scratch state, and removes that state
-when the server exits. Add `--keep` to inspect the generated files afterward,
-or `--print-env` to emit the environment and examples without starting the
-server.
-
-**Switching back to the published npm release** (e.g. to compare behaviour):
+**Switching back to the published npm release** (to compare behaviour, say):
 
 ```bash
 npm unlink -g @jeanibarz/knowledge-base-mcp-server
 npm install -g @jeanibarz/knowledge-base-mcp-server@latest
 ```
 
-**Why `npm link` instead of `npm install -g .`?** `npm link` is a symlink, so `npm run build` is reflected without reinstalling. `npm install -g .` copies the build snapshot, so every change requires a re-install.
+## Configure
 
-**Hook scope.** The hooks trigger on `git pull` / `git merge` / `git pull --rebase`, not on `git checkout` between branches. Run `npm run build` manually after a branch switch if needed. If a rebuild fails, the hook prints a warning and exits 0 so the pull itself isn't reported as failed — fix the build, then run `npm run build` manually.
+Two settings matter before anything else: **where your notes live** and **which embedding model turns them into vectors**. Everything else has a working default.
 
-## Usage
+```bash
+KNOWLEDGE_BASES_ROOT_DIR=$HOME/knowledge_bases   # one subdirectory per knowledge base
+EMBEDDING_PROVIDER=ollama                        # ollama | openai | huggingface
+```
 
-> **Writing notes that retrieve well?** See [`docs/authoring-knowledge.md`](docs/authoring-knowledge.md) — a seven-section guide to chunk-friendly markdown, frontmatter taxonomy, content-boundary safety, KB organization, and the authoring lifecycle. For query-time neighbor windows around dense matches, see [`docs/search-neighbor-context.md`](docs/search-neighbor-context.md).
+Set these in your shell profile (`.bashrc`, `.zshrc`) or directly in your MCP client's config. Every recognised variable, with its default, accepted values, and validation constraints, is listed in [`docs/reference/configuration.md`](docs/reference/configuration.md); the operator-facing view of retrieval flags and rollout status is in [docs/feature-flags.md](docs/feature-flags.md). Copy [`.env.example`](./.env.example) to `.env` for local development.
 
-The MCP server exposes the current tool set registered by `src/KnowledgeBaseServer.ts`:
+Run `kb config validate` to check your configuration before startup. It catches cross-variable mistakes as well as bad individual values — for example, `KB_CHUNK_OVERLAP` must be strictly less than `KB_CHUNK_SIZE`. `kb doctor` reports the same finding and exits non-zero when the pair is invalid.
 
-*   `list_knowledge_bases`: Lists the available knowledge bases.
-*   `retrieve_knowledge`: Retrieves similar chunks from the knowledge base based on a query. Optionally, if a knowledge base is specified, only that one is searched; otherwise, all available knowledge bases are considered. By default, at most 10 document chunks are returned with a score below a threshold of 2. A different threshold can optionally be provided using the `threshold` parameter.
-*   `ask_knowledge`: Retrieves KB snippets and asks a configured local/OpenAI-compatible LLM to answer with citations.
-*   `list_models`: Lists registered embedding models and the active model.
-*   `kb_stats`: Returns read-only corpus, index, model, cache, and transport statistics.
-*   `diff_index`: Compares retrieval results across two persisted FAISS index versions.
-*   `add_document`: Writes a text document into a KB through the guarded MCP mutation path.
-*   `delete_document`: Deletes a KB-relative document through the guarded MCP mutation path.
-*   `reindex_knowledge_base`: Forces a global FAISS rebuild, optionally validating a named KB before the rebuild.
+### Pick an embedding provider
 
-> **Ingest gate (`KB_INGEST_ENABLED`).** The three write tools above — `add_document`, `delete_document`, and `reindex_knowledge_base` — are only registered when `KB_INGEST_ENABLED` is `on` (the default). Set `KB_INGEST_ENABLED=off` to remove all three from the MCP surface, leaving the server with a read-only tool set. This is useful for read-only deployments or shared environments where you want to prevent accidental writes.
+Three providers are supported for production use. A fourth, `EMBEDDING_PROVIDER=fake`, returns deterministic vectors for tests and offline fixtures — it is not suitable for real retrieval quality.
 
-You can use these tools through the MCP interface. The `kb` CLI covers the shell-oriented surfaces shown above.
+#### Ollama (recommended — local and free)
 
-The server also exposes MCP resources for clients that want to enumerate and read source documents directly. `resources/list` returns `kb://<knowledge-base>/<encoded-relative-path>` URIs for ingestable, non-quarantined files under `KNOWLEDGE_BASES_ROOT_DIR`, and `resources/read` returns the raw document content as text or, when `.pdf` is opted into ingest, a base64 PDF blob. See [`docs/mcp-resources.md`](docs/mcp-resources.md) for client-facing URI, MIME type, and percent-encoding details.
+Runs the embedding model on your own machine, so no note content is sent anywhere.
 
-The server advertises the standard MCP `logging` capability. HTTP and SSE
-clients can use `logging/setLevel` to select a minimum notification level per
-session; stdio accepts the request as a no-op. This does not change
-`KB_LOG_FORMAT` or `LOG_FILE`. See [`docs/mcp-logging.md`](docs/mcp-logging.md)
-for the transport-specific contract.
+```bash
+EMBEDDING_PROVIDER=ollama
+OLLAMA_BASE_URL=http://localhost:11434                   # default
+OLLAMA_MODEL=dengcao/Qwen3-Embedding-0.6B:Q8_0           # default
+KNOWLEDGE_BASES_ROOT_DIR=$HOME/knowledge_bases
+```
 
-The `retrieve_knowledge` tool performs a semantic search using a FAISS index. The index is automatically updated when the server starts or when a file in a knowledge base is modified.
+Install [Ollama](https://ollama.ai/) and pull the model first: `ollama pull dengcao/Qwen3-Embedding-0.6B:Q8_0`.
 
-The output of the `retrieve_knowledge` tool is a markdown formatted string with the following structure:
+> **Check the model's context window before you pick one.** The default chunker emits ~1000-character chunks, which commonly tokenize past 256 tokens, so a 256-token model such as `all-minilm` will reject *every* request. Use a model that accepts at least ~500 tokens: `nomic-embed-text` (8192), `dengcao/Qwen3-Embedding-0.6B:Q8_0` (32K), or anything with ≥512.
+
+#### OpenAI
+
+```bash
+EMBEDDING_PROVIDER=openai
+OPENAI_API_KEY=your_api_key_here
+OPENAI_MODEL_NAME=text-embedding-3-small
+KNOWLEDGE_BASES_ROOT_DIR=$HOME/knowledge_bases
+```
+
+To reach an OpenAI-*compatible* endpoint instead of the official API — a self-hosted gateway, Volcengine Ark, OpenRouter — set `OPENAI_BASE_URL` to that endpoint's base URL, including the API version path (`OPENAI_BASE_URL=https://ark.cn-beijing.volces.com/api/v3`). Leaving it unset keeps the default `https://api.openai.com/v1`. Azure OpenAI is reachable only through its `/openai/v1/` API-compatibility surface (`OPENAI_BASE_URL=https://<resource>.openai.azure.com/openai/v1`); classic Azure deployments need `api-key` auth, an `api-version` query parameter, and per-deployment paths, so a plain base URL cannot target them.
+
+> **Default model changed.** The OpenAI default is now `text-embedding-3-small`, up from `text-embedding-ada-002`. Both produce 1536-dimension vectors, but the *name* change triggers a one-time FAISS rebuild on the next query. Set `OPENAI_MODEL_NAME=text-embedding-ada-002` to keep the old default.
+
+#### HuggingFace (fallback, and the default if you set nothing)
+
+```bash
+EMBEDDING_PROVIDER=huggingface          # optional — this is the default
+HUGGINGFACE_API_KEY=your_api_key_here
+HUGGINGFACE_MODEL_NAME=BAAI/bge-small-en-v1.5
+HUGGINGFACE_PROVIDER=hf-inference       # optional router provider for serverless inference
+KNOWLEDGE_BASES_ROOT_DIR=$HOME/knowledge_bases
+```
+
+A free API key from [HuggingFace](https://huggingface.co/) is enough to start.
+
+HuggingFace retired the legacy `api-inference.huggingface.co/models/...` endpoint in 2025. Feature-extraction calls now route through the Inference Providers router at `https://router.huggingface.co/hf-inference/models/<model>/pipeline/feature-extraction`. Set `HUGGINGFACE_PROVIDER` to pick a different supported provider — `together`, `replicate`, `fireworks-ai`, `sambanova`, `nebius`, `novita`. `HUGGINGFACE_API_KEY` can hold either a Hugging Face token or a compatible provider key, depending on how the request is authenticated upstream. To target a self-hosted or dedicated Inference Endpoint, set `HUGGINGFACE_ENDPOINT_URL` to the full POST URL; an explicit endpoint URL bypasses router provider selection.
+
+> **Default model changed.** The HuggingFace default is now `BAAI/bge-small-en-v1.5`, up from `sentence-transformers/all-MiniLM-L6-v2`. Both produce 384-dimension vectors, but the name change triggers a one-time FAISS rebuild on the next query. Set `HUGGINGFACE_MODEL_NAME=sentence-transformers/all-MiniLM-L6-v2` to keep the old default.
+
+Supported defaults, vector dimensions, task-prefix requirements, and reindex caveats for every model are in [`docs/reference/embedding-models.md`](docs/reference/embedding-models.md).
+
+### Lay out your knowledge bases
+
+Create one subdirectory per knowledge base under `KNOWLEDGE_BASES_ROOT_DIR` — for example `company/`, `it_support/`, `onboarding/` — and drop your notes inside. Subdirectories nest freely; the server reads them recursively.
+
+```
+$HOME/knowledge_bases/
+├── work/
+│   └── runbooks/deploy.md
+├── research/
+│   └── papers/retrieval.md
+└── .faiss/              # index storage, created for you
+```
+
+**What gets indexed.** Only files whose extension is in the allowlist `.md`, `.markdown`, `.txt`, `.rst`, `.html`, `.htm`. Hidden files and directories (anything starting with `.`) are skipped, as are PDFs, workflow sidecars (`_seen.jsonl`, `_index.jsonl`), log and staging subtrees (`logs/`, `tmp/`, `_tmp/`), and OS clutter (`.DS_Store`, `Thumbs.db`, `desktop.ini`). Extensionless files such as `README`, `LICENSE`, or `Makefile` are **not** embedded.
+
+To widen or narrow that:
+
+```bash
+# Comma-separated extensions (case-insensitive; leading dot optional).
+INGEST_EXTRA_EXTENSIONS=".json,.yaml"
+# Comma-separated minimatch globs relative to the KB root.
+INGEST_EXCLUDE_PATHS="drafts/**,scratch.md"
+```
+
+Add `".pdf"` only when PDF extraction is intentional. The base exclusions are authoritative: you can add more, but you cannot remove the built-ins. The full loader/extension matrix is in [`docs/reference/loaders.md`](docs/reference/loaders.md).
+
+**How a file becomes searchable.** For each ingestable file the server computes a SHA256 hash and stores it in a hidden `.index/` subdirectory next to the file, so a later pass can tell whether the file changed since it was last indexed. Changed content is split into chunks — `.md` files with a heading-aware `MarkdownTextSplitter`, everything else with `RecursiveCharacterTextSplitter`, both at `chunkSize: 1000, chunkOverlap: 200`, so a large `.txt` or `.rst` file becomes many chunks rather than one blurry embedding. Each chunk is embedded and added to the FAISS index, which is initialized on server start and updated whenever the server notices changed files.
+
+Writing notes the server can retrieve well is its own topic: [`docs/authoring-knowledge.md`](docs/authoring-knowledge.md) covers chunk-friendly markdown, the frontmatter taxonomy, content-boundary safety, and the note lifecycle.
+
+### Index storage
+
+The FAISS index lives at `FAISS_INDEX_PATH`, defaulting to `$KNOWLEDGE_BASES_ROOT_DIR/.faiss`. Each embedding model gets its own subdirectory under it, so registering a second model never overwrites the first — see [Compare embedding models](#compare-embedding-models).
+
+**Sharing an index path across processes.** Several MCP and CLI processes may share one trusted `FAISS_INDEX_PATH`; writes serialize through per-model locks and versioned atomic saves. Keep the directory local and trusted — do not put it on a filesystem that untrusted peers can write to. See [Security](#security) and [`docs/architecture/threat-model.md`](docs/architecture/threat-model.md).
+
+### Logging and audit
+
+- `LOG_FILE=/path/to/logs/knowledge-base.log` mirrors structured logs to a file. Verbosity is `LOG_LEVEL=debug|info|warn|error`, defaulting to `info`. Logs never go to stdout, which carries the JSON-RPC stream.
+- `KB_MUTATION_AUDIT_LOG=/path/to/kb-mutations.jsonl` records an append-only ledger of every KB content write. Each line captures which surface performed it (`cli.kb-remember`, `cli.kb-capture`, `cli.kb-ask`, `mcp.add_document`, `mcp.delete_document`), the operation, the KB and relative path, a timestamp, `before_sha256` / `after_sha256`, whether the write and refresh happened, and per-surface decision flags. **Note content is never stored** — only hashes and metadata. Audit writes are best-effort: a failure logs a warning to stderr but never aborts the write it was recording. KB names and paths are inherent to the records, so treat the audit log as being as sensitive as the KB directory itself.
+
+### Tailor the MCP tool descriptions
+
+The descriptions your AI client sees for each tool can be overridden before server start, which is worth doing when a deployment serves one specific corpus and you want the model to reach for the right tool. Unset or empty falls back to the built-in defaults.
+
+```bash
+RETRIEVE_KNOWLEDGE_DESCRIPTION="Search engineering runbooks, RFCs, and postmortems."
+ASK_KNOWLEDGE_DESCRIPTION="Answer from engineering runbooks with citations."
+LIST_KNOWLEDGE_BASES_DESCRIPTION="List available engineering knowledge bases."
+LIST_MODELS_DESCRIPTION="List embedding models registered for engineering retrieval."
+KB_STATS_DESCRIPTION="Report engineering KB index and transport health."
+```
+
+## Use the MCP server
+
+### Tools
+
+Your client sees these tools (registered in `src/KnowledgeBaseServer.ts`):
+
+| Tool | What it's for |
+| --- | --- |
+| `list_knowledge_bases` | Discover which shelves exist, so the agent can scope a later search instead of guessing a name. |
+| `retrieve_knowledge` | The core semantic search — returns the passages most relevant to a query so an agent can ground its answer in your documents rather than in what the model already knows. Searches one knowledge base if `knowledge_base` is given, otherwise all of them. Returns at most 10 chunks by default, filtered by a similarity-score threshold of 2 (lower scores are closer matches); `threshold` loosens or tightens it. |
+| `ask_knowledge` | Retrieve, then have a configured local or OpenAI-compatible LLM write an answer with citations — one call instead of retrieve-then-prompt. |
+| `list_models` | List the registered embedding models and which one is active. |
+| `kb_stats` | Read-only corpus, index, model, cache, and transport statistics — useful for a health check without touching the index. |
+| `diff_index` | Compare retrieval results across two persisted index versions, to see what a rebuild actually changed. |
+| `add_document` | Write a text document into a KB through the guarded mutation path. |
+| `delete_document` | Delete a KB-relative document through the guarded mutation path. |
+| `reindex_knowledge_base` | Force a global rebuild, optionally validating a named KB first. |
+
+Exact input schemas, types, and bounds are generated from the shipped tool registry in [`docs/reference/mcp-tools.md`](docs/reference/mcp-tools.md).
+
+> **Turning off writes (`KB_INGEST_ENABLED`).** The last three tools — `add_document`, `delete_document`, `reindex_knowledge_base` — are only registered when `KB_INGEST_ENABLED` is `on`, which is the default. Set it to `off` to remove all three and leave a strictly read-only tool surface. Do this for shared or read-only deployments where an accidental agent write would be costly.
+
+### Resources
+
+Clients that want to enumerate and read source documents directly, rather than searching them, can use MCP resources. `resources/list` returns `kb://<knowledge-base>/<encoded-relative-path>` URIs for every ingestable, non-quarantined file under `KNOWLEDGE_BASES_ROOT_DIR`; `resources/read` returns the raw document as text, or as a base64 PDF blob when `.pdf` has been opted into ingest. See [`docs/mcp-resources.md`](docs/mcp-resources.md) for URI, MIME type, and percent-encoding details.
+
+### Logging
+
+The server advertises the standard MCP `logging` capability. HTTP and SSE clients can call `logging/setLevel` to pick a minimum notification level for their session; stdio accepts the request as a no-op. This is independent of `KB_LOG_FORMAT` and `LOG_FILE`. See [`docs/mcp-logging.md`](docs/mcp-logging.md).
+
+### What a result looks like
+
+`retrieve_knowledge` returns a markdown string, one block per match:
 
 ````markdown
 ## Semantic Search Results
@@ -592,96 +306,533 @@ The output of the `retrieve_knowledge` tool is a markdown formatted string with 
 > **Disclaimer:** The provided results might not all be relevant. Please cross-check the relevance of the information.
 ````
 
-Each result includes the content of the most similar chunk, the source file, and a similarity score.
-When chunk metadata includes line information, the markdown source header links a stable chunk handle such as `alpha/docs/deploy.md#L42-L78` to the matching `kb://alpha/docs/deploy.md#L42-L78` resource URI. Set `KB_EDITOR_URI=vscode`, `cursor`, or `file` before launching the server to also include editor-open links with local absolute paths.
+Each result carries the chunk content, its source file, and a similarity score. When chunk metadata includes line numbers, the source header links a stable chunk handle such as `alpha/docs/deploy.md#L42-L78` to the matching `kb://alpha/docs/deploy.md#L42-L78` resource URI. Set `KB_EDITOR_URI=vscode`, `cursor`, or `file` before launching the server to also emit editor-open links containing local absolute paths; the default `none` keeps absolute paths out of the response.
+
+### Error codes
+
+Tool errors come back with `isError: true` and a JSON text payload, so a client can branch on a stable code instead of matching substrings:
+
+```json
+{
+  "error": {
+    "code": "PROVIDER_AUTH",
+    "message": "OPENAI_API_KEY environment variable is required when using OpenAI provider"
+  }
+}
+```
+
+| Code | Meaning | Typical client action |
+| --- | --- | --- |
+| `INDEX_NOT_INITIALIZED` | A search ran before a FAISS index was available. | Retry after initialization or trigger a refresh. |
+| `PROVIDER_UNAVAILABLE` | The embedding provider is temporarily unavailable. | Retry with backoff. |
+| `PROVIDER_TIMEOUT` | The embedding provider timed out. | Retry with backoff. |
+| `PROVIDER_AUTH` | Provider credentials are missing or invalid. | Ask the user to configure a valid API key. |
+| `KB_NOT_FOUND` | The requested knowledge base does not exist. | Prompt for one of the listed knowledge bases. |
+| `PERMISSION_DENIED` | The server cannot read or write a required local path. | Surface to the operator/admin. |
+| `CORRUPT_INDEX` | The persisted FAISS index is corrupt or unreadable. | Rebuild or recover the index. |
+| `VALIDATION` | A caller-supplied argument failed validation. | Fix the request before retrying. |
+| `INTERNAL` | An unclassified server error occurred. | Surface the message and logs for investigation. |
+
+The complete taxonomy, including CLI-local codes, is generated into [`docs/reference/error-codes.md`](docs/reference/error-codes.md).
+
+## Use the `kb` CLI
+
+`kb` reads the same environment variables as the MCP server (`KNOWLEDGE_BASES_ROOT_DIR`, `FAISS_INDEX_PATH`, `EMBEDDING_PROVIDER`, `OLLAMA_*`, `OPENAI_*`, `HUGGINGFACE_*`), so once the server works, the CLI works. It exists for two audiences: a person at a terminal, and an AI agent that has a shell tool but no MCP connection.
+
+**Every command has a full generated reference in [`docs/reference/cli.md`](docs/reference/cli.md)** — the map below is for orientation, not completeness.
+
+### Command map
+
+| Task | Commands |
+| --- | --- |
+| **See what's there** | `kb list` · `kb stats` · `kb tags` · `kb where "<topic>"` |
+| **Search** | `kb search` · `kb open` · `kb related` · `kb explain` |
+| **Answer with an LLM** | `kb llm` · `kb ask` |
+| **Gather evidence** | `kb research plan` · `kb research collect` |
+| **Write and curate notes** | `kb remember` · `kb capture` · `kb import-url` · `kb tag` · `kb promote` · `kb superseded` · `kb stale-check` · `kb quarantine` · `kb cite` |
+| **Manage embedding models** | `kb models` · `kb compare` |
+| **Measure quality** | `kb feedback` · `kb eval` · `kb eval-gate` |
+| **Operate and diagnose** | `kb doctor` · `kb config validate` · `kb serve` · `kb reindex` · `kb logs` · `kb diagnose` · `kb cache` · `kb verify` |
+| **Shell integration** | `kb --help` · `kb help <command>` · `kb completion bash\|zsh\|fish` |
+
+### Search
+
+`kb search` is read-only by default: it loads the existing index but does not re-scan your files. Pass `--refresh` when you want it to notice edits first. Output ends with a freshness footer telling you whether the index is current relative to your files' modification times.
+
+```bash
+kb search "your query"                        # dense (semantic) search over all shelves
+kb search "your query" --kb=work --k=5        # scope to one shelf, cap results
+kb search "your query" --refresh              # re-scan KB files first (this writes)
+kb search "your query" --timing               # per-stage elapsed milliseconds
+kb search "your query" --explain-empty        # deep diagnostics when nothing comes back
+```
+
+**Choosing a retrieval mode.** Semantic ("dense") search finds passages that *mean* the same thing as your query, which is what you want for prose questions. It is weaker on exact tokens — a file path, a flag name, an error code — because those carry little meaning to an embedding model. `--mode` picks the strategy:
+
+| Mode | How it ranks | Reach for it when |
+| --- | --- | --- |
+| `dense` (default) | Vector similarity against the FAISS index. | You're asking a question in prose. |
+| `lexical` | BM25, the classic keyword/term-frequency ranking used by search engines. | You know the exact string — `INDEX_NOT_INITIALIZED`, `src/cli.ts`. |
+| `hybrid` | Runs both and merges the two ranked lists with RRF (Reciprocal Rank Fusion, which scores a result by its *position* in each list rather than by raw scores, so incomparable scales don't need normalizing). | You want exact-token recall without giving up semantic matches. |
+| `auto` | Heuristic: dense for prose, hybrid for queries shaped like code, paths, flags, error codes, or issue references. | You don't want to think about it. |
+
+```bash
+kb search "INDEX_NOT_INITIALIZED" --mode=lexical
+kb search "retrieval benchmarks" --mode=lexical --lexical-unit=source  # rank whole files, not chunks
+kb search "INDEX_NOT_INITIALIZED" --mode=hybrid
+kb search "src/cli-search.ts" --mode=auto
+```
+
+**Widening a match.** A chunk is roughly a thousand characters, so a good hit is often the middle of a longer thought. `--context-before`, `--context-after`, and `--context-window` attach the adjacent chunks from the same source to each dense match — more to read, but fewer follow-up queries. See [docs/search-neighbor-context.md](docs/search-neighbor-context.md) for the JSON shape and the tradeoffs.
+
+```bash
+kb search "runbook rollback" --context-window=1
+```
+
+**Steering the result set.** These operators are additive and read-only; each addresses a different way plain top-k disappoints you:
+
+| Operator | Use it when |
+| --- | --- |
+| `--diverse` | Your top results are near-duplicates from one file and you'd rather see coverage across sources. It reranks a bounded dense candidate pool for source-aware representative sampling. |
+| `--anti-query="<text>"` | You want to push results away from a known-irrelevant neighbouring topic. Candidates close to the negative query are penalized, but only among candidates the positive query already supports. |
+| `--plus="<text>"` / `--minus="<text>"` | You want to nudge the query itself, adding positive and negative components to the query vector rather than filtering afterwards. |
+
+```bash
+kb search "agent evidence" --diverse --format=json
+kb search "agent evidence" --anti-query="frontend styling"
+kb search "queue debt" --plus="slow loop" --minus="UI layout" --format=json
+```
+
+JSON output includes an `advanced_retrieval` block explaining the mode, constraints, query components, and per-result scoring signals, so you can see *why* a result ranked where it did.
+
+**Output formats.**
+
+| Flag | Shape |
+| --- | --- |
+| `--format=md` (default) | Human-readable markdown blocks. |
+| `--format=json` | Full envelope with scores, metadata, and the `advanced_retrieval` explanation. |
+| `--format=compact` | One `score\|kb\|path:line` line per hit, for terse operator listings. |
+| `--format=vimgrep` | One `path:line:col:preview` line per hit, for editor quickfix lists. |
+| `--batch-jsonl` | Reads `{"query":"…","kb":"…","k":N}` records from stdin and emits one JSON envelope per line. |
+
+```bash
+printf '{"query":"q1"}\n{"query":"q2"}\n' | kb search --batch-jsonl
+```
+
+**Following a result back to its source.** JSON results carry a stable `chunk_id` such as `alpha/docs/deploy.md#L42-L78` whenever the chunk has a KB, path, and line range; chunks without line metadata fall back to `#chunk-N`.
+
+```bash
+kb open alpha/docs/deploy.md#L42-L78     # resolve a chunk id, kb:// URI, or result path to a source file
+kb related alpha/docs/deploy.md#L42-L78  # find dense neighbors of an existing result chunk
+```
+
+`kb open` validates the path against the KB root and prints it; add `--json` for the cited line range and an `editorUri`. `kb related` fetches the indexed seed chunk behind the handle, searches with its text, and excludes the seed itself unless you pass `--include-self`.
+
+### Ask: answers from a local LLM
+
+`kb ask` keeps retrieval deterministic and adds a chat step on top: retrieve, then have an OpenAI-compatible LLM write an answer with citations. It accepts the same `--mode` values as `kb search`, plus `--rerank`.
+
+The endpoint is resolved in order: `--endpoint`, then `KB_LLM_ENDPOINT`, then `--llm-profile`, then the active `kb llm` profile, and finally the default local-research-agent address on `127.0.0.1:8080`. ([local-research-agent](https://github.com/jeanibarz/local-research-agent) is a separate project that runs a local `llama-server`; `kb` can reuse one you already have running, or manage its own — see below.)
+
+```bash
+kb llm use-endpoint http://127.0.0.1:8080/v1/chat/completions --profile=local-research-agent
+kb llm status
+kb ask "Which notes discuss reboot recovery?" --kb=operating-environment
+kb ask "why does src/cli.ts throw?" --mode=hybrid --rerank
+kb ask "what changed in the daemonization notes?" --timing
+```
+
+**Saving an answer as a note.** `--save-transcript --kb=<name> --yes` writes the answer into that KB as a new markdown note recording the question, answer, citations, source chunk ids, LLM endpoint/profile/model, retrieval model, and — with `--timing` — timing metadata. `--title=<title>` sets the note title and slug. Existing transcript notes are never overwritten.
+
+```bash
+kb ask "what changed?" --kb=work --save-transcript --title="Ask - daemon changes" --yes
+```
+
+**Keeping a note out of LLM prompts.** A note whose frontmatter contains `kb_policy: { no_llm_context: true }` still appears in search results, but `kb ask` and MCP `ask_knowledge` drop it before calling the LLM and report the count under `context_packing.policy_filtered_chunks`. Contextual-preface ingest and relevance-gate judging exclude it too, while keeping the chunk as ordinary retrieval data.
+
+**Developing offline.** `KB_LLM_FAKE=on` routes `kb ask`, relevance-gate judging, and contextual-preface generation to a deterministic in-process fake LLM — no endpoint required. When a client needs a real OpenAI-compatible localhost endpoint instead, run `npm run dev:mockllm -- --port=18080`. Rules are customizable via `KB_LLM_FAKE_RULES`; see [docs/testing/fake-llm.md](docs/testing/fake-llm.md).
+
+**Managing a warm model.** If you want `kb` to own the model process rather than reuse someone else's:
+
+```bash
+kb llm install --profile=qwen --runner=llama-server \
+  --bin=/path/to/llama-server --model=/path/to/model.gguf --port=8091
+kb llm start --profile=qwen
+kb llm set-model --profile=qwen --model=/path/to/other-model.gguf --start
+kb llm uninstall --profile=qwen
+```
+
+External profiles are reuse-only: `kb llm stop`, `restart`, `uninstall`, and `reap` never stop a service owned by local-research-agent. Managed profiles are namespaced as `kb-llm@<profile>.service`, bind to `127.0.0.1`, and write leases under the user state directory, so a stale managed model can be reaped instead of staying resident forever.
+
+### Gather evidence for a broad question
+
+`kb research` is a read-only workflow for agent shells that need a wide evidence pass before writing an answer, RFC, eval plan, or issue. It deliberately does *not* call an LLM, start a model, refresh indexes, or write notes — it only reads and organizes what retrieval already knows.
+
+Run `plan` first to inspect the deterministic shelf/query plan, then `collect` into a run directory:
+
+```bash
+kb research plan "synthesize an end-to-end approach for autonomous research agents and evals" --format=json
+kb research collect "synthesize an end-to-end approach for autonomous research agents and evals" \
+  --run-dir /tmp/kb-research-autonomous-agents-evals-20260521 \
+  --format=json
+```
+
+Then read the generated `evidence_packet.md` and synthesize yourself. The run directory also holds `run.json`, `plan.json`, `ledger.json`, and `events.jsonl`: `ledger.json` stays lossless for audit and debugging, while `evidence_packet.md` is the human-scannable view. The JSON contract and stable artifact fields are in [`docs/cli-json-contracts.md`](docs/cli-json-contracts.md#kb-research); a longer walk-through — when to use it, how to read the packet, and the downstream `kb ask` and `kb feedback` plumbing — is in [`docs/operations/research-workflow.md`](docs/operations/research-workflow.md).
+
+### Write and curate notes
+
+These commands let an agent shell contribute back to a knowledge base, conservatively. The full task-oriented workflow, from collection through tagging, review, and promotion, is in [`docs/authoring-knowledge.md`](docs/authoring-knowledge.md#6-curate-notes-through-their-lifecycle); machine-readable command shapes are in [`docs/cli-json-contracts.md`](docs/cli-json-contracts.md).
+
+**`kb remember` — create or append a note.** `--suggest` is the safe first step: it lists likely existing targets from note filenames and headings, reads no stdin, and writes no notes (it may refresh a small `.index` heading cache). Actually writing requires *both* `--stdin` and `--yes`. Creating uses a slugified `.md` filename and refuses to overwrite; appending accepts only an existing KB-relative path. Appends serialize per target and commit through a temp file, fsync, and atomic rename.
+
+```bash
+kb remember --suggest --kb=work --title="Quarterly plan"
+printf '# Quarterly plan\n\n...' | kb remember --kb=work --title="Quarterly plan" --stdin --yes
+printf '\nFollow-up note.\n' | kb remember --kb=work --append=quarterly-plan.md --stdin --yes
+```
+
+`kb capture` runs a command and appends its stdout to a note as a fenced block. It redacts common credential shapes from both the captured output and the displayed command line by default — pass `--no-redact` only when you truly need the raw text. Add `--refresh` to either command to re-index the affected KB after a successful write.
+
+**`kb import-url` — snapshot a web page or PDF as a note, with provenance.** It fetches over http(s), runs HTML and PDF responses through the same loaders the indexer uses, and writes one note whose YAML frontmatter records `source_url`, `fetched_at`, `content_sha256`, `content_type`, `http_status`, and `byte_count`.
+
+```bash
+kb import-url --kb=research https://example.com/article
+```
+
+The fetch is deliberately fenced in, because a URL is attacker-controlled input: only http and https schemes are allowed; redirects are followed manually and re-validated at every hop (`--max-redirects`, default 5); responses are size-capped (`--max-bytes`, default 8 MiB) and time-bounded (`--timeout`, default 30000 ms); and private, loopback, and link-local addresses are refused unless you pass `--allow-local-network` (an SSRF guard). The note path defaults to a slug of the page title — `--note=<path.md>` chooses it, `--title` overrides the title, `--refresh` re-indexes afterwards. It refuses to overwrite an existing note.
+
+**`kb tag` — maintain one note's frontmatter tags.** The default is a dry run; repeat `--add` or `--remove` for several tags and pass `--yes` to commit through the atomic writer and the KB's `.kb-policy.json` mutation policy. The note body is preserved byte-for-byte, and malformed frontmatter is rejected before anything is written.
+
+```bash
+kb tags --kb=work                       # list facet values (tags/status/type) with counts
+kb tags --facet=status --format=json    # discover the vocabulary for kb search --status filters
+kb tag work/runbooks/deploy.md --add=verified        # dry run
+kb tag work/runbooks/deploy.md --add=verified --yes  # commit
+```
+
+`kb tags` reads note files directly, but an existing *index* only learns a new tag value after `kb search --refresh`.
+
+**`kb superseded` — find notes that have gone stale.** A read-only "active forgetting" review: it scans frontmatter for explicit contradictions, deprecated or dormant lifecycle status, stale verification dates, and low-confidence active notes, then uses the semantic index to add conservative newer-neighbor evidence where it exists. `--format=json` suits agent workflows; `--include-clean` gives a full inventory.
+
+```bash
+kb superseded --kb=work
+kb promote alpha/docs/deploy.md   # review and update lifecycle frontmatter on one note
+kb stale-check --kb=work          # find path / URL references that no longer resolve
+kb quarantine list --kb=work      # inspect per-file ingest quarantine entries
+kb cite alpha/docs/deploy.md      # export BibTeX or CSL-JSON from note frontmatter
+```
+
+### Compare embedding models
+
+You can keep several embedding models side by side and query each by id — useful for an A/B on retrieval quality without throwing away the index you already trust.
+
+```bash
+# List registered models. The * marks the active one.
+kb models list
+
+# Add a second model — embeds your KB once under the new model.
+# For paid providers, prints an estimated cost and prompts before any HTTP traffic.
+kb models add ollama nomic-embed-text          # local, free
+kb models add openai text-embedding-3-small    # paid; estimate first
+kb models add huggingface BAAI/bge-small-en-v1.5
+kb models add ollama nomic-embed-text --index-type=sq8   # FAISS scalar quantization
+kb models add ollama nomic-embed-text --index-type=hnsw  # HNSW approximate search backend
+
+# Query a specific model without changing the default.
+kb search "your query" --model=openai__text-embedding-3-small
+
+# Side-by-side comparison: unified rank/score table over both models' top-k.
+kb compare "your query" ollama__nomic-embed-text-latest openai__text-embedding-3-small
+
+# Switch the default model.
+kb models set-active openai__text-embedding-3-small
+
+# Remove a model (refuses to remove the active one).
+kb models remove huggingface__BAAI-bge-small-en-v1.5
+```
+
+How a model id and its storage are derived:
+
+- **Id format** — `<provider>__<filesystem-safe-slug>`, computed deterministically from `(provider, model_name)` exactly as you typed it. `OLLAMA_MODEL=nomic-embed-text:latest` becomes `ollama__nomic-embed-text-latest`.
+- **On disk** — each model lives at `${FAISS_INDEX_PATH}/models/<id>/`.
+- **Active model** — recorded in `${FAISS_INDEX_PATH}/active.txt`; override per-process with `KB_ACTIVE_MODEL`.
+- **Index type** — `KB_INDEX_TYPE` or `kb models add --index-type=flat|sq8|hnsw`, explained in [docs/operations/index-quantization.md](docs/operations/index-quantization.md).
+
+See [`docs/reference/embedding-models.md`](docs/reference/embedding-models.md) for supported defaults, vector dimensions, task-prefix requirements, and reindex caveats, and [RFC 013](docs/rfcs/013-multimodel-support.md) for the design.
+
+> **Upgrading from the single-model layout.** Migration is automatic on the first server or `kb` start: the existing single-model index moves into `${FAISS_INDEX_PATH}/models/<derived_id>/` and `active.txt` is written. Concurrent starts coordinate through `${FAISS_INDEX_PATH}/.kb-migration.lock`. Keep a backup of the previous `${FAISS_INDEX_PATH}` if you want a rollback path. On the MCP side the change is additive: `retrieve_knowledge` gained an optional `model_name`, `list_models` is new, and `kb_stats` now reports the latest in-process `updateIndex` summary under `last_index_update`. Tools that don't pass `model_name` behave exactly as before — the wire format is byte-equal to 0.2.x.
+
+### Measure retrieval quality
+
+**`kb feedback` — record judgments, then turn them into tests.** Each judgment appends to a per-KB ledger at `<kb>/.index/relevance-feedback.jsonl`. `promote` materialises every ledger row for a query into a retrieval-eval case, so accumulated human judgment becomes regression coverage instead of evaporating.
+
+```bash
+kb feedback add --kb=work --query="rollback procedure" \
+  --source=runbooks/deploy.md --verdict=relevant   # also: irrelevant | stale | misleading
+kb feedback add --kb=work --query="rollback procedure" \
+  --source=runbooks/deploy.md --verdict=relevant \
+  --relevance=3 --chunk-id=work/runbooks/deploy.md#L42-L78   # graded 0..3, pinned to one chunk
+kb feedback list --kb=work
+kb feedback promote --kb=work --query="rollback procedure" \
+  --fixture=docs/testing/feedback-fixture.yml --yes
+```
+
+See [`docs/operations/feedback-workflow.md`](docs/operations/feedback-workflow.md).
+
+**`kb eval` — run fixture-driven retrieval checks.** A case can set `query`, and optionally `kb`, `required_sources`, `forbidden_sources`, `expected_metadata`, `max_duplicate_groups`, `stale_policy`, and `gate`. Failing *ungated* cases print warnings and exit 0; failing *gated* cases exit 1, which is what makes this usable in CI.
+
+```yaml
+gate: false
+cases:
+  - name: deployment runbook
+    query: rollback procedure
+    kb: work
+    gate: true
+    required_sources: [runbooks/deploy.md]
+    forbidden_sources: [archive/old-deploy.md]
+    expected_metadata:
+      frontmatter.status: approved
+    max_duplicate_groups: 1
+    stale_policy: fresh
+```
+
+**`kb eval-gate` — validate the relevance gate before you trust it.** Runs the gate end-to-end against a labelled-queries fixture (a statistical floor, plus an optional LLM judge) and reports per-stage precision, recall, and false-empty rate. Run it whenever you change `KB_GATE_*` tuning or the judge prompt.
+
+```bash
+kb eval retrieval-eval.yml
+kb eval-gate docs/testing/fixtures/rfc-018-gate-eval/queries.yml
+```
+
+See [`docs/operations/eval-gate-harness.md`](docs/operations/eval-gate-harness.md).
+
+### Operate and diagnose
+
+```bash
+kb doctor                          # availability snapshot: index, embedding backend, LLM
+kb config validate                 # static env-var schema validation before startup
+kb serve                           # loopback daemon for warm reads; --warm pre-loads indexes
+kb serve status                    # daemon liveness and degraded-mode diagnostics
+kb reindex --with-context          # rebuild the index with contextual prefaces
+kb reindex status --format=json    # ledger of recent and in-flight reindex passes
+kb logs show --request-id=<id>     # read canonical request logs by id
+kb logs recent --limit=20 --format=json
+kb diagnose --request-id=<id> --repro-bundle=/tmp/kb-diag
+kb cache list                      # inspect local cache surfaces
+kb cache prune                     # prune stale cache entries
+kb verify                          # slow integrity checks for persisted indexes and sidecars
+```
+
+**`kb serve`** runs the loopback daemon that clients passing `--daemon` use for warm reads, so a query doesn't pay model and index load time on every invocation. `kb serve [--host=127.0.0.1] [--port=17799] [--idle-timeout-ms=300000] [--warm]` brings it up; `--warm` (or `KB_DAEMON_PREWARM=on`) pre-loads the active model, FAISS index, and lexical indexes before reporting ready. `kb serve status [--json]` reports reachability, pid, idle timeout, supported commands, and prewarm state at `KB_DAEMON_URL` (default `http://127.0.0.1:17799`). SIGINT or SIGTERM stops it, and CLI commands fall back to direct in-process execution whenever the daemon is unreachable. See [`docs/operations/daemon-lifecycle.md`](docs/operations/daemon-lifecycle.md).
+
+**`kb reindex`** rebuilds the index. `--with-context` adds contextual prefaces (requires `KB_CONTEXTUAL_RETRIEVAL=on` and a `KB_LLM_ENDPOINT`). `kb reindex status` reads the durable run-state and per-source sidecar ledgers to report liveness, eligible indexed files, sidecar coverage, pending files, resolved and failed chunks, and failure codes. Note that `--kb=<name>` is only a guard and estimator hint — a rebuild always covers the entire single-index-per-model layout ([RFC 017 §5](docs/rfcs/017-contextual-retrieval.md)).
+
+**`kb logs`** reads the structured request log emitted under `KB_LOG_FORMAT=canonical` or `both`. `kb logs show --request-id=<id>` pulls every line of one retrieval; `--query-sha=<hash>` follows a recurring query; `kb logs recent --limit=<n>` shows the latest entries. `--format=json` emits a report envelope, `--format=csv|tsv|ndjson` flat event rows for downstream tooling.
+
+**`kb diagnose`** packages the canonical events for a request into a private redacted bundle for sharing on an issue. Canonical logs never store raw query text, so pass `--query`, `--query-file`, or `--stdin` if you also want it to replay `kb explain --repro-bundle` with the model, KB scope, k, and threshold hints inferred from the log event.
+
+## Tune retrieval quality
+
+Plain dense retrieval is the default and needs no configuration. Four optional stages sit around it, all **off by default** because each trades something away. The complete flag matrix — defaults, per-call overrides, rollout status, validation commands — is in [docs/feature-flags.md](docs/feature-flags.md).
+
+### Cross-encoder reranking
+
+Dense retrieval scores your query and each chunk *separately*, then compares the two vectors — fast, because chunk vectors are computed once at index time, but the model never sees the query and the chunk together. A **cross-encoder** does: it reads the pair jointly and scores the match directly, which is markedly more precise and far too slow to run over a whole corpus. Reranking gets both by using dense (or hybrid) retrieval to pick a shortlist, then re-ordering just that shortlist with the cross-encoder.
+
+Enable it with `KB_RERANK=on`, or per call with `kb search --rerank` / `kb ask --rerank`. You pay a small amount of latency per query.
+
+| Env var | Description | Default |
+| --- | --- | --- |
+| `KB_RERANK` | Enable the cross-encoder reranking stage. | `off` |
+| `KB_RERANK_MODEL` | Cross-encoder model id used for reranking. | (built-in default) |
+| `KB_RERANK_TOP_N` | How many top candidates to feed into the reranker. | (built-in default) |
+| `KB_RERANK_SKIP_DOMAINS` | Comma-separated KB domain names to skip reranking for. | (none) |
+
+`KB_RERANK_DEVICE` (`cuda`, `cpu`) and `KB_RERANK_DTYPE` (`fp32`, …) are optional Transformers.js / ONNX Runtime overrides for cross-encoder execution — set them when you need runtime-specific acceleration or dtype control. Both are listed by `kb config show` and validated by `kb config validate`. Design details are in [RFC 019](docs/rfcs/019-cross-encoder-reranker.md).
+
+### Relevance gating
+
+Retrieval always returns *something*: ask about a topic your notes don't cover and you still get the ten least-bad chunks. Fed to an LLM, those read as authoritative context and quietly corrupt the answer. Relevance gating adds a check between retrieval and use — a statistical score floor, then optionally an LLM judge — that drops chunks which don't actually match the task, and can return nothing at all rather than something wrong.
+
+That is a real tradeoff: the gate can also discard genuinely relevant chunks, lowering recall to raise precision. That's why it is off unless you opt in.
+
+```bash
+KB_RELEVANCE_GATE=on          # enable for a whole process
+kb search "…" --gate          # enable for one call
+kb search "…" --no-gate       # bypass in a process where it is enabled
+```
+
+The judge takes the task description from `--task-context=<text>` / `--task-context-file=<path>` (MCP: `task_context`) and reads `KB_GATE_LLM_ENDPOINT` / `KB_GATE_LLM_MODEL`, falling back to `KB_LLM_ENDPOINT` / `KB_LLM_MODEL`. MCP callers can pass `gate: "off"` to bypass.
+
+| Env var | Meaning | Default |
+| --- | --- | --- |
+| `KB_GATE_SCORE_FLOOR` | Statistical score floor a chunk must clear. | `0.95` |
+| `KB_GATE_JUDGE_INPUT` | How many surviving chunks reach the LLM judge. | `10` |
+| `KB_GATE_LLM_TIMEOUT_MS` | Judge call timeout. | `8000` |
+| `KB_GATE_MIN_TASK_TOKENS` | Minimum task-context length before judging runs at all. | `8` |
+| `KB_GATE_EMPTY_VERDICT` | Allow the gate to return *no* context. | `off` |
+
+Turn `KB_GATE_EMPTY_VERDICT` on only once you're comfortable with a caller receiving zero retrieved context. Validate any tuning change with `kb eval-gate` before relying on it; the design is in [RFC 018](docs/rfcs/018-context-relevance-gating.md).
+
+### Ingest-time secret scanning
+
+Notes captured from terminals and logs sometimes carry credentials. Set `KB_INGEST_SECRET_SCAN=on` to scan chunk text and frontmatter for credential-shaped content *before* it is embedded. Hits are quarantined with reason `secret_detected` and skipped before any FAISS write, so the secret never reaches the index.
+
+```bash
+kb quarantine list --reason=secret_detected
+```
+
+Use `KB_SECRET_SCAN_BYPASS_KBS=trusted-kb,...` only for shelves that intentionally store credential examples. See [Ingest secret scan](docs/operations/secret-scan.md).
+
+### Untrusted-content guard
+
+Anything you retrieve gets pasted into an LLM's context, so a note containing "ignore previous instructions" is an injection vector aimed at whatever agent asked the question. Every retrieved chunk therefore passes through the untrusted-content guard, which scans for prompt-injection signals — system-role markers, instruction-override phrasing, Unicode bidi / zero-width / tag control characters — and marks what it finds.
+
+Unlike the other three stages, this one is **on by default** (`KB_INJECTION_GUARD=tag`):
+
+| Value | Behaviour |
+| --- | --- |
+| `tag` (default) | Annotate the chunk's metadata with what was detected. |
+| `wrap` | Fence the content with sentinel strings so a downstream prompt can tell data from instructions. |
+| `both` | Both of the above. |
+| `off` | No scanning. |
+
+Set `off` only on shelves you fully control, or use `KB_INJECTION_GUARD_BYPASS_KBS=trusted-kb,...` to exempt specific shelves without weakening the global default.
 
 ## Remote transport (optional)
 
-By default the server speaks MCP over stdio — every supported client (Claude Desktop, Codex, Cursor, Continue, Cline) launches it as a child process. [RFC 008](./docs/rfcs/008-remote-transport.md) adds opt-in **SSE** and **streamable HTTP** transports for browser-based clients, Smithery remote mode, and shared deployments. Stdio is unchanged unless you set `MCP_TRANSPORT`.
+By default the server speaks MCP over stdio — every supported client (Claude Desktop, Codex, Cursor, Continue, Cline) launches it as a child process, which is the right shape for a single-user local tool. [RFC 008](./docs/rfcs/008-remote-transport.md) adds opt-in **SSE** and **streamable HTTP** transports for browser-based clients, Smithery remote mode, and shared deployments. Stdio behaviour is unchanged unless you set `MCP_TRANSPORT`.
 
 ```bash
-export MCP_TRANSPORT=http                         # stdio (default), sse, or http
+export MCP_TRANSPORT=http                            # stdio (default), sse, or http
 export MCP_AUTH_TOKEN="$(openssl rand -base64 32)"   # must be ≥32 characters; shorter tokens abort startup
-# Or set MCP_AUTH_TOKEN_FILE=/run/secrets/kb-mcp-token to read the token from a file; takes precedence over MCP_AUTH_TOKEN
-export MCP_ALLOWED_ORIGINS="http://localhost:5173"   # comma-separated; leave unset to deny all browser origins
-export MCP_PORT=8765                                  # default
-export MCP_BIND_ADDR=127.0.0.1                        # default — loopback only
-export MCP_AUTH_BACKOFF_THRESHOLD=5                   # failed bearer attempts before backoff; 0 disables
-export MCP_AUTH_BACKOFF_MS=30000                      # Retry-After window for auth backoff
+# Or MCP_AUTH_TOKEN_FILE=/run/secrets/kb-mcp-token to read the token from a file; takes precedence over MCP_AUTH_TOKEN
+export MCP_ALLOWED_ORIGINS="http://localhost:5173"   # comma-separated; unset denies all browser origins
+export MCP_PORT=8765                                 # default
+export MCP_BIND_ADDR=127.0.0.1                       # default — loopback only
+export MCP_AUTH_BACKOFF_THRESHOLD=5                  # failed bearer attempts before backoff; 0 disables
+export MCP_AUTH_BACKOFF_MS=30000                     # Retry-After window for auth backoff
 node build/index.js
 ```
 
-Endpoints exposed in this mode:
+Endpoints in this mode:
 
-- `GET /health` — unauthenticated liveness probe; returns `200 {"status":"ok"}` only. Per RFC 008 §6.8 it intentionally exposes no version, uptime, or filesystem fingerprint to anonymous callers.
-- `GET /ready` — authenticated readiness probe for operators and reverse proxies. Returns `200` when the active model resolves, the active index file is present, and the embedding backend answers a tiny smoke query; returns `503` with only failing check names otherwise.
-- `MCP_TRANSPORT=sse`: `GET /sse` opens the long-lived SSE stream and `POST /messages?sessionId=<uuid>` sends JSON-RPC messages for that session.
-- `MCP_TRANSPORT=http`: `POST /mcp` initializes and sends JSON-RPC messages using streamable HTTP. The server returns `Mcp-Session-Id` during initialization; clients must send it on subsequent `GET`, `POST`, and `DELETE /mcp` requests.
+| Endpoint | Auth | Purpose |
+| --- | --- | --- |
+| `GET /health` | none | Liveness probe. Returns `200 {"status":"ok"}` and nothing else — no version, uptime, or filesystem fingerprint for anonymous callers (RFC 008 §6.8). |
+| `GET /ready` | bearer | Readiness probe for operators and reverse proxies. `200` when the active model resolves, the active index file is present, and the embedding backend answers a tiny smoke query; otherwise `503` listing only the failing check names. |
+| `GET /sse` + `POST /messages?sessionId=<uuid>` | bearer | `MCP_TRANSPORT=sse`: long-lived stream, plus JSON-RPC messages for that session. |
+| `POST /mcp` | bearer | `MCP_TRANSPORT=http`: streamable HTTP. The server returns `Mcp-Session-Id` during initialization; clients must send it on subsequent `GET`, `POST`, and `DELETE /mcp` requests. |
 
-All non-health transport endpoints, including `/ready`, require `Authorization: Bearer <token>`.
-Set `MCP_AUTH_TOKEN_FILE` to read the bearer token from a mounted secret file;
-the file contents are trimmed, must still be at least 32 characters, and take
-precedence over `MCP_AUTH_TOKEN`.
-Repeated bearer failures from the same remote address enter a bounded in-memory
-backoff and return `Retry-After`; valid authentication clears the address state.
-When the server sits behind a reverse proxy, the key is the proxy socket address,
-not `X-Forwarded-For`, so configure proxy-side throttling for internet exposure.
+Every non-health endpoint, `/ready` included, requires `Authorization: Bearer <token>`. `MCP_AUTH_TOKEN_FILE` reads the token from a mounted secret file — contents are trimmed, must still be at least 32 characters, and take precedence over `MCP_AUTH_TOKEN`. Repeated bearer failures from one remote address enter a bounded in-memory backoff and receive `Retry-After`; a successful authentication clears that address's state. Behind a reverse proxy the backoff key is the proxy's socket address, not `X-Forwarded-For`, so configure throttling proxy-side for anything internet-facing.
 
-For a disposable remote playground during development, use `npm run dev:remote`
-from the local development section above.
+**Security defaults.** The server refuses to start in SSE or HTTP mode without `MCP_AUTH_TOKEN` or `MCP_AUTH_TOKEN_FILE`, binds to loopback only, and compares bearer tokens in constant time. To expose it off-host, set `MCP_BIND_ADDR=0.0.0.0` **and** terminate TLS in a reverse proxy — TLS is out of scope for this server.
 
-**Security defaults:** the server refuses to start in SSE or streamable HTTP mode without `MCP_AUTH_TOKEN_FILE` or `MCP_AUTH_TOKEN`, binds only to loopback, and uses a constant-time bearer comparison. Operators exposing the endpoint off-host should set `MCP_BIND_ADDR=0.0.0.0` *and* terminate TLS in a reverse proxy — TLS is out of scope for this server. Multiple MCP/CLI processes may share a `FAISS_INDEX_PATH`; mutating paths serialize through per-model locks and versioned atomic saves (see [`docs/architecture/threat-model.md`](./docs/architecture/threat-model.md)).
+For a disposable playground during development, use `npm run dev:remote` (see [For local development](#for-local-development)).
 
-## Troubleshooting & Logging
+## Benchmarks
 
-For a command-oriented runbook covering empty results, stale-index footers, linked-checkout/global-bin drift, missing active models, backend availability, and refresh lock contention, see [`docs/troubleshooting-local-kb.md`](docs/troubleshooting-local-kb.md). For operator incidents keyed by symptom, use [`docs/operations/incident-response.md`](docs/operations/incident-response.md).
-
-### KB availability smoke check
-
-When `kb search` (or the MCP `retrieve_knowledge` tool) is not returning results, run the read-only `kb doctor` command first — it is the canonical availability check for retrieval and also reports local LLM readiness for `kb ask`:
+`npm run bench:beir` runs a local [BEIR](https://github.com/beir-cellar/beir) retrieval benchmark with credential-free lexical retrieval, so you can measure a chunking or ranking change instead of guessing at it:
 
 ```bash
-kb doctor                # human-readable report
-kb doctor --format=json  # machine-readable for agent shells
-kb doctor --endpoints    # focused bind/connect endpoint preflight
-kb doctor --locks        # model write-lock owner/stale diagnosis
-kb doctor --kb-symlinks  # KB-root symlink inventory and target classification
-kb doctor --bug-report=/tmp  # redacted support bundle directory
+npm run bench:beir -- --dataset=scifact --split=test --mode=lexical --lexical-unit=source --output-dir=/tmp/kb-beir-scifact
 ```
 
-The report covers active-model resolution, FAISS index version + mtime, the latest in-process index-update summary, per-KB stale counts, embedding-backend reachability (Ollama / HuggingFace / OpenAI), ask and relevance-gate LLM endpoint readiness, LLM calls by operation including calls, errors, p95 latency, reported token totals, bounded provider/coarse-model attribution, attempts/retries, workflow cache outcomes, answer impact, and answer-cache counters, CLI version, and local git state. The command exits non-zero when any required retrieval check fails (active model unresolved, index missing, backend unreachable); LLM endpoint failures are WARN rows because search can remain healthy while `kb ask` or the optional relevance gate is not ready.
+The runner builds a temporary KB root and emits metrics JSON plus a TREC run file, along with reproduction metadata: git SHA, command, dataset checksum, runtime versions, chunking config, and latency percentiles. **These are local artifacts, not official BEIR leaderboard submissions** — the lexical source path is scored at document level, matching `kb search --mode=lexical --lexical-unit=source`. See [benchmarks/README.md](benchmarks/README.md#beirscifact-local-retrieval-benchmark) for smoke-test commands and caveats, and [benchmarks/results/README.md](benchmarks/results/README.md) for the archived SciFact run.
 
-Use `kb doctor --endpoints` when you only need configured local endpoint readiness before starting or wiring clients. It checks MCP bind address/port availability, configured `KB_DAEMON_URL` health, configured Ollama embedding reachability, configured `KB_LLM_ENDPOINT` or active LLM profile readiness, and the explicitly configured `KB_GATE_LLM_ENDPOINT` when `KB_RELEVANCE_GATE=on`. The gate row is skipped when the gate is disabled, its endpoint is unset, or the fake judge is active; the command does not load the full index health report.
+Optuna tuning is optional and runs only when you invoke it. This sweeps lexical chunking parameters and writes a replayable best-config file:
 
-Use `kb doctor --locks` when refresh or model writes report lock contention. It scans per-model `.kb-write.lock` paths, reports lock age, recorded owner PID/command for new locks, stale suspicion, and conservative next actions without deleting any lock file.
+```bash
+npm run bench:tune -- \
+  --trials=12 \
+  --direction=maximize \
+  --metric=metrics.ndcgAt10 \
+  --study-name=scifact-lexical \
+  --best-config-out=/tmp/kb-scifact-lexical-best.json \
+  --param-int=KB_CHUNK_SIZE=256:1024:128 \
+  --param-int=KB_CHUNK_OVERLAP=0:128:32 \
+  -- npm run bench:beir -- --dataset=scifact --split=test --mode=lexical --max-queries=25 --output-dir=/tmp/kb-scifact-tune
+```
 
-Use `kb doctor --kb-symlinks` when auditing KB content roots. It scans with `lstat`, does not follow symlink directories, and classifies symlink targets as inside-root, escaping, broken, or loop/error with capped examples.
+Replaying the best trial needs no Optuna install:
 
-Use `kb doctor --bug-report[=<dir>]` when opening an issue or handing diagnostics to another operator. It writes a timestamped directory containing redacted `doctor.json`, `stats.json`, recent canonical log summaries, runtime/env metadata, and a README. The bundle does not include note contents or raw API keys; KB names, paths, model names, and log metadata can still be sensitive.
+```bash
+npm run bench:tune -- --replay-config=/tmp/kb-scifact-lexical-best.json
+```
 
-### Distinguishing search failure modes
+## Troubleshooting
 
-`kb search` failures are classified into one of six categories so a user or agent can tell what to fix without reading stack traces. Each failure carries a stable `code`, a `category`, a human `message`, and a concrete `next_action`:
+Start with the command-oriented runbook in [`docs/troubleshooting-local-kb.md`](docs/troubleshooting-local-kb.md) — it covers empty results, stale-index footers, linked-checkout and global-bin drift, missing active models, backend availability, and refresh lock contention. For a live incident, [`docs/operations/incident-response.md`](docs/operations/incident-response.md) is keyed by symptom. For Ollama, llama-server, n8n, systemd user units, remote transports, or `kb serve`, see the [local service operations runbook](docs/operations/local-services.md).
+
+### Start with `kb doctor`
+
+When `kb search` (or the MCP `retrieve_knowledge` tool) returns nothing, run the read-only `kb doctor` first. It is the canonical availability check for retrieval and also reports local LLM readiness for `kb ask`.
+
+```bash
+kb doctor                    # human-readable report
+kb doctor --format=json      # machine-readable, for agent shells
+```
+
+The full report covers active-model resolution, FAISS index version and mtime, the latest in-process index-update summary, per-KB stale counts, embedding-backend reachability (Ollama / HuggingFace / OpenAI), ask and relevance-gate LLM endpoint readiness, LLM call counters (calls, errors, p95 latency, reported token totals, bounded provider and coarse-model attribution, attempts and retries, workflow cache outcomes, answer impact, answer-cache counters), the CLI version, and local git state.
+
+It **exits non-zero when a required retrieval check fails** — unresolved active model, missing index, unreachable backend. LLM endpoint failures are only WARN rows, because search can be perfectly healthy while `kb ask` or the optional gate is not ready.
+
+Four focused modes answer narrower questions without loading the full health report:
+
+| Command | Use when |
+| --- | --- |
+| `kb doctor --endpoints` | You only need to know whether the configured local endpoints are reachable before starting or wiring clients. Checks MCP bind address/port availability, `KB_DAEMON_URL` health, Ollama embedding reachability, `KB_LLM_ENDPOINT` or the active LLM profile, and `KB_GATE_LLM_ENDPOINT` when the gate is on. The gate row is skipped when the gate is disabled, its endpoint is unset, or the fake judge is active. |
+| `kb doctor --locks` | A refresh or model write reports lock contention. Scans per-model `.kb-write.lock` paths and reports lock age, the recorded owner PID and command for new locks, stale suspicion, and conservative next actions — it never deletes a lock file. |
+| `kb doctor --kb-symlinks` | You're auditing KB content roots. Scans with `lstat`, does not follow symlinked directories, and classifies targets as inside-root, escaping, broken, or loop/error, with capped examples. |
+| `kb doctor --bug-report=/tmp` | You're opening an issue or handing diagnostics to another operator. Writes a timestamped directory with redacted `doctor.json`, `stats.json`, recent canonical log summaries, runtime and environment metadata, and a README. It excludes note contents and raw API keys, but KB names, paths, model names, and log metadata can still be sensitive. |
+
+### Reading a search failure
+
+`kb search` failures are sorted into six categories so you — or an agent — can tell what to fix without reading a stack trace. Every failure carries a stable `code`, a `category`, a human `message`, and a concrete `next_action`.
 
 | Category | Typical codes | What to try |
 | --- | --- | --- |
 | `configuration` | `PROVIDER_AUTH`, `KB_NOT_FOUND`, `ACTIVE_MODEL_UNRESOLVED` | Set the missing API key, run `kb list` / `kb models list`, or `kb models set-active <id>`. |
 | `indexing` | `INDEX_NOT_INITIALIZED`, `CORRUPT_INDEX` | Build or rebuild the index with `kb search --refresh`. |
 | `provider` | `PROVIDER_UNAVAILABLE`, `PROVIDER_TIMEOUT` | Verify the embedding backend is reachable (`ollama serve`, provider status page). |
-| `permissions` | `PERMISSION_DENIED` | Grant write access to `$FAISS_INDEX_PATH` and per-KB `.index/`. |
+| `permissions` | `PERMISSION_DENIED` | Grant write access to `$FAISS_INDEX_PATH` and each KB's `.index/`. |
 | `input` | `VALIDATION` | Adjust the rejected field named in the message. |
 | `lock` | `REFRESH_LOCK_BUSY` | Retry shortly; only one `kb search --refresh` writer runs per model. |
 
-With `--format=md` the same fields render to stderr as `kb search: <message>` followed by `category:` and `next:` lines. With `--format=json` they render to stdout as `{"error":{"code","category","message","next_action",...}}` so an agent can branch on the category programmatically. When the cause is unclear, the `next_action` falls back to `kb doctor` which prints the exact health snapshot needed to diagnose.
-
-Exit codes mirror the CLI's existing convention — `2` for configuration and input problems the user can fix without retry, `1` for runtime / index / provider / permissions / lock problems.
+With `--format=md` these render to stderr as `kb search: <message>` followed by `category:` and `next:` lines. With `--format=json` they render to stdout as `{"error":{"code","category","message","next_action",...}}`, so an agent can branch on the category. When the cause is unclear, `next_action` falls back to `kb doctor`. Exit codes follow the CLI convention: **2** for configuration and input problems you can fix without retrying, **1** for runtime, index, provider, permission, and lock problems.
 
 ### Other tips
 
-- Set `LOG_FILE` to capture structured logs (JSON-RPC traffic continues to use stdout). This is especially helpful when diagnosing MCP handshake errors because all diagnostic messages are written to stderr and the optional log file.
-- Permission errors when creating or updating the FAISS index are surfaced with explicit messages in both the console and the log file. Verify that the process can write to `FAISS_INDEX_PATH` and the `.index` directories inside each knowledge base.
-- Run `npm test` to build the project, then run the parallel Jest project with `--maxWorkers=4` followed by the serial project with `--runInBand`; the suite covers logger fallback behaviour and FAISS permission handling.
+- Set `LOG_FILE` to capture structured logs. JSON-RPC traffic keeps using stdout, so this is especially useful for diagnosing MCP handshake errors — every diagnostic message goes to stderr and the optional log file.
+- Permission errors when creating or updating the index are surfaced explicitly in both the console and the log file. Check that the process can write to `FAISS_INDEX_PATH` and to the `.index/` directory inside each knowledge base.
+- `npm test` builds the project, runs the parallel Jest project with `--maxWorkers=4`, then the serial project with `--runInBand`. The suite covers logger fallback behaviour and FAISS permission handling.
 
 ## Security
 
-The server is designed to run as a **local tool**: one user, one machine, one trusted terminal. Two trust boundaries matter in practice. The `$FAISS_INDEX_PATH` directory is a **code-execution boundary** — `FaissStore.load` deserialises the docstore via `pickleparser`, so the directory must only contain files written by this server (no untrusted backups, no shared-write mounts). The `$KNOWLEDGE_BASES_ROOT_DIR` tree is a **content boundary** — its contents are embedded and returned verbatim to the MCP client, so markdown from untrusted sources is a prompt-injection risk for downstream agents. Multiple MCP/CLI processes may share a trusted `FAISS_INDEX_PATH`; writes are coordinated by per-model locks and atomic save. Full discussion, including provider-key handling and concurrency, is in [`docs/architecture/threat-model.md`](./docs/architecture/threat-model.md).
+This server is designed to run as a **local tool**: one user, one machine, one trusted terminal. Two trust boundaries matter in practice.
+
+**`$FAISS_INDEX_PATH` is a code-execution boundary.** `FaissStore.load` deserialises the docstore via `pickleparser`, so the directory must contain only files this server wrote — no untrusted backups, no shared-write mounts. Several MCP and CLI processes may share a *trusted* index path; writes coordinate through per-model locks and atomic saves.
+
+**`$KNOWLEDGE_BASES_ROOT_DIR` is a content boundary.** Its contents are embedded and returned verbatim to the MCP client, so markdown from an untrusted source is a prompt-injection risk for whatever agent consumes the result. The [untrusted-content guard](#untrusted-content-guard) mitigates this by default but does not eliminate it.
+
+The full discussion — provider-key handling, path validation, remote transport posture, and concurrency — is in [`docs/architecture/threat-model.md`](./docs/architecture/threat-model.md).
+
+## Documentation map
+
+[`docs/`](docs/README.md) has a full index. The most common destinations:
+
+| If you want to… | Read |
+| --- | --- |
+| Wire up a specific MCP client | [docs/clients.md](docs/clients.md) |
+| Write notes that retrieve well | [docs/authoring-knowledge.md](docs/authoring-knowledge.md) |
+| Look up any command, flag, env var, tool, metric, or error code | [docs/reference/](docs/reference/) — generated from source, so it never drifts |
+| See every retrieval flag with its default and rollout status | [docs/feature-flags.md](docs/feature-flags.md) |
+| Script against CLI JSON output | [docs/cli-json-contracts.md](docs/cli-json-contracts.md) |
+| Run or recover a deployment | [docs/operations/](docs/operations/README.md) |
+| Understand how the system is built | [docs/architecture/](docs/architecture/README.md) |
+| Understand why it's built that way | [docs/rfcs/](docs/rfcs/) and [docs/architecture/adr/](docs/architecture/adr/) |
+
+> **A note on "RFC NNN".** Non-trivial design decisions in this project are written up as numbered RFCs under [`docs/rfcs/`](docs/rfcs/) — they're this repo's own design-doc series, not IETF documents. When a section above cites one, it's pointing at the full rationale behind a feature, not at something you need to read to use it.
+
+## Contributing
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for the contribution workflow, and [CLAUDE.md](./CLAUDE.md) for the agent-facing guide to architecture, conventions, and verification steps.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,68 @@
+# Documentation
+
+Start at the repo [`README.md`](../README.md) if you're new — it covers install,
+configuration, and the day-one commands. This page routes you to everything
+deeper, grouped by what you're trying to do.
+
+## Set up and use
+
+| Doc | Read it when |
+| --- | --- |
+| [clients.md](clients.md) | Wiring a specific MCP client — Claude Desktop, Codex CLI, Cursor, Continue, Cline. |
+| [authoring-knowledge.md](authoring-knowledge.md) | Writing notes the server can actually retrieve: chunk-friendly markdown, frontmatter, content-boundary risk, the note lifecycle. |
+| [search-neighbor-context.md](search-neighbor-context.md) | Deciding whether to pull adjacent chunks in around each match. |
+| [llm-provider.md](llm-provider.md) | Pointing `kb ask` and the other chat-completion paths at a local or hosted LLM. |
+| [agent-task-lessons.md](agent-task-lessons.md) | Recording transferable lessons from an agent task with `kb remember --lesson`. |
+| [troubleshooting-local-kb.md](troubleshooting-local-kb.md) | Search returns nothing, the index looks stale, or `kb` seems to be running the wrong checkout. |
+
+## MCP surface
+
+| Doc | Read it when |
+| --- | --- |
+| [reference/mcp-tools.md](reference/mcp-tools.md) | You need a tool's exact input schema, types, and bounds. *(generated)* |
+| [mcp-resources.md](mcp-resources.md) | Your client wants to enumerate and read source documents directly, rather than search them. |
+| [mcp-prompts.md](mcp-prompts.md) | Your client wants reusable KB-backed prompt templates. |
+| [mcp-logging.md](mcp-logging.md) | You want per-session log levels over HTTP or SSE. |
+
+## Reference
+
+Everything under [`reference/`](reference/) is **generated from source** and gated
+in CI, so it cannot drift from the shipped behaviour. Don't hand-edit these
+files — change the source and regenerate.
+
+| Doc | Covers |
+| --- | --- |
+| [reference/cli.md](reference/cli.md) | Every `kb` command and flag. |
+| [reference/configuration.md](reference/configuration.md) | Every environment variable, with defaults and validation rules. |
+| [reference/mcp-tools.md](reference/mcp-tools.md) | Every MCP tool and its input schema. |
+| [reference/error-codes.md](reference/error-codes.md) | Every stable error code, with cause and remedy. |
+| [reference/embedding-models.md](reference/embedding-models.md) | Supported models, dimensions, task prefixes, reindex caveats. |
+| [reference/loaders.md](reference/loaders.md) | Which file types are ingested and how they're decoded. |
+| [reference/metrics.md](reference/metrics.md) | Every exported metric. |
+
+Two hand-maintained companions sit alongside them:
+
+- [feature-flags.md](feature-flags.md) — the operator-facing defaults matrix: what each retrieval, LLM, ingest, and diagnostic knob does, its rollout status, and how to validate a change.
+- [cli-json-contracts.md](cli-json-contracts.md) — stable JSON shapes for the agent-facing `kb` commands, for anyone scripting against the output.
+
+## Run it in production
+
+[`operations/`](operations/README.md) holds symptom- and task-keyed runbooks:
+daemon lifecycle, incident response, indexing throughput, index quantization,
+local service health, log reading, metrics export, query cache, the research and
+feedback workflows, secret scanning, and switching embedding models. Start at
+[operations/incident-response.md](operations/incident-response.md) during a live
+incident.
+
+## Understand and change the design
+
+| Folder | Perspective |
+| --- | --- |
+| [architecture/](architecture/README.md) | How the system works **today** — C4 views, sequence and state diagrams, data model, QA budgets, threat model. Every claim is anchored to a file and line on `main`. |
+| [architecture/adr/](architecture/adr/) | Decisions already made, including superseded ones, with the reasoning preserved. |
+| [rfcs/](rfcs/) | Where things are going. Numbered design docs for non-trivial changes; merging an RFC does not imply it is implemented. |
+| [requirements/INDEX.md](requirements/INDEX.md) | The canonical requirements catalog. |
+| [testing/INDEX.md](testing/INDEX.md) | Test strategy, retrieval-eval methodology, and the fake-LLM harness. |
+
+Benchmark harnesses and archived results live outside `docs/`, in
+[`benchmarks/`](../benchmarks/README.md).

--- a/docs/authoring-knowledge.md
+++ b/docs/authoring-knowledge.md
@@ -1,6 +1,6 @@
 # Authoring notes that retrieve well
 
-This is a short, opinionated guide for **KB authors** — the humans (and agents) who write the markdown the server retrieves. It is **not** a contributor guide for the repo (see [`CONTRIBUTING.md`](../CONTRIBUTING.md)) and **not** an agent runbook (see [`CLAUDE.md`](../CLAUDE.md)). Seven sections, one page; cap maintained on purpose.
+This is a short, opinionated guide for **KB authors** — the humans (and agents) who write the markdown the server retrieves. It is **not** a contributor guide for the repo (see [`CONTRIBUTING.md`](../CONTRIBUTING.md)) and **not** an agent runbook (see [`CLAUDE.md`](../CLAUDE.md)). It is deliberately kept to one page across seven short sections — if something isn't here, it is probably outside what an authoring guide should decide for you.
 
 The server pipeline is short:
 
@@ -62,6 +62,15 @@ kb_policy:
   sensitivity: internal
 ---
 ```
+
+Those keys fall into four groups, and only the last group changes what retrieval does:
+
+| Group | Keys | Who writes them, and what reads them |
+| --- | --- | --- |
+| **Provenance** | `arxiv_id`, `title`, `authors`, `published`, `ingested_at` | Written by ingest pipelines (or by you). Carried on every chunk so a calling agent can cite a result without re-parsing the note, but not filterable on their own. |
+| **Evaluation** | `judge_method`, `metrics_used`, `bias_handling`, `relevance_score` | Written by the LLM-as-judge pipeline that generated the note ([RFC 011 §5.4](rfcs/011-arxiv-backend.md)). Lifted generically, so they show up on any note that sets them. If you're writing notes by hand, ignore these. |
+| **Lifecycle** | `status`, `review_status`, `tier`, `confidence`, `last_verified_at`, `manual_edits`, `contradicted_by`, `promote_model` | The trust and staleness record for a note. `kb promote` writes `tier` (`working` \| `validated` \| `wisdom`), `review_status` (`approved` \| `needs-review`), `confidence`, and `last_verified_at`; `kb superseded` reads `status`, `review_status`, `contradicted_by`, `last_verified_at`, and `confidence` to decide whether a note has gone stale. See [§6](#6-curate-notes-through-their-lifecycle). `promote_model` and `manual_edits` are lifted for external workflows; no command in this repo currently reads them. |
+| **Retrieval behaviour** | `tags`, `kb_policy` | The only two that change what the server returns — see below. |
 
 Why it matters:
 

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -41,17 +41,20 @@ markdown/JSON output shape, and when wider windows dilute results.
 `KB_DENSE_DEGRADE_ON_PROVIDER_ERROR=on` is fail-open only for classified
 transient embedding-provider failures (`PROVIDER_UNAVAILABLE` and
 `PROVIDER_TIMEOUT`). It does not hide `PROVIDER_AUTH`, validation, active-model,
-or index configuration errors. A degraded MCP response is lexical-only, sets
-`structuredContent.degraded: true` with a bounded `degrade_reason`, emits the
-same fields in the canonical search event, and increments
-`kb_search_degraded_total{mode,reason}` when metrics export is enabled. Query
+or index configuration errors. A degraded MCP response falls back to lexical-only results. It sets
+`structuredContent.degraded: true` and a bounded `degrade_reason` on the
+response, and logs those same two fields in the canonical search event. When
+metrics export is enabled it also increments
+`kb_search_degraded_total{mode,reason}`. Query
 embedding cache hits still return through the normal dense/hybrid path because
 no provider call failed.
 
 ## Relevance Gate
 
-The RFC 018 gate is recall-negative by design, so it is disabled unless an
-operator opts in. With no task context it uses the statistical path only; with
+The RFC 018 gate is disabled unless an operator opts in, because it trades
+recall for precision: in suppressing chunks that don't match the task, it can
+also discard genuinely relevant ones. That is the right trade only when a
+wrong-but-confident answer costs more than a missing one. With no task context it uses the statistical path only; with
 task context it may call an LLM judge. Any judge failure degrades to retrieval
 rather than failing the query.
 

--- a/docs/mcp-prompts.md
+++ b/docs/mcp-prompts.md
@@ -51,8 +51,9 @@ than invent when the KB does not cover the request.
 
 The server advertises MCP `completion/complete` so clients can request argument
 suggestions. Prompt `knowledge_base_name` arguments complete from registered KB
-names. Model-style prompt arguments are completed from registered `model_id`
-values when a future prompt template declares one.
+names. None of the templates below take a model-style argument today; if one is
+added later, its values will complete from registered `model_id` values the
+same way `knowledge_base_name` does.
 
 ## Example: `prompts/get`
 

--- a/docs/search-neighbor-context.md
+++ b/docs/search-neighbor-context.md
@@ -1,18 +1,19 @@
 # Neighbor Context Search Windows
 
 `kb search` can include nearby chunks from the same source file around each
-dense semantic match:
+dense semantic match.
+
+Reach for this when the matching chunk is likely to be part of a longer note
+whose surrounding paragraphs carry the setup, commands, or caveats you need in
+order to act on the result — a rollback step is not much use without the
+preconditions above it. The ranked hit stays the semantic match; the neighbor
+chunks come back as extra context around that hit.
 
 ```bash
 kb search "rollback after failed deploy" --context-before=1 --context-after=2
 kb search "incident handoff checklist" --context-window=1
 kb search "rollback after failed deploy" --context-window=1 --format=json
 ```
-
-Use these flags when the matching chunk is likely to be part of a longer note
-whose surrounding paragraphs carry the setup, commands, or caveats needed to
-act on the result. The ranked hit stays the semantic match; the neighbor
-chunks are returned as extra context around that hit.
 
 ## Flag Behavior
 


### PR DESCRIPTION
## Summary

The README had grown past the point where a newcomer could use it. A cold reader got one thin sentence of what-and-why, then a demo, then a 70-line dump of every `kb` invocation — annotated with issue numbers meaningless outside this tracker — followed by a 600-word paragraph covering ten unrelated topics in one block. All of it filed under `## Setup Instructions`, which had quietly absorbed the entire feature reference: the five install paths ended up scattered across 430 lines with research packets, benchmarks, LLM answers, and model comparison wedged between them. There was no table of contents for 686 lines, and exactly one link into `docs/reference/`, leaving seven generated reference docs effectively undiscoverable.

This restructures the README around what a reader is trying to do — Install, Configure, Use the MCP server, Use the `kb` CLI, Tune retrieval quality, Remote transport, Benchmarks, Troubleshooting, Security, Documentation map — and adds the explanations that were missing rather than more identifiers: why you would reach for hybrid over dense retrieval, what BM25 and RRF are, what a cross-encoder buys and what it costs, what relevance gating trades away, and what `local-research-agent` is on first mention.

**No facts were dropped.** Every environment variable, `kb` command, CLI flag, npm script, and doc link from the previous README is still present — verified by extracting each set from both versions and diffing. The one place content was deliberately *not* reproduced is the command dump: the task-keyed command map now points at the generated `docs/reference/cli.md` as the authority instead of duplicating 39 commands the README could never keep in sync.

Alongside the README:

- **`docs/README.md` is new.** `docs/` had no index while `architecture/` and `operations/` both did, so browsing it on GitHub showed a flat list of 12 files and 6 folders. It routes by task and marks which references are generated.
- **`docs/authoring-knowledge.md`** gained a gloss for the frontmatter whitelist. Eighteen keys were shown as a YAML sample with only two explained — a reader could not tell what `tier: wisdom` meant, what values it accepts, or which fields actually affect retrieval. They are now grouped as provenance, evaluation, lifecycle, and retrieval-behaviour, with vocabularies and consuming commands named (verified against `src/frontmatter-lift.ts`, `src/cli-promote.ts`, and `src/cli-superseded.ts`).
- **`docs/feature-flags.md`** explains why the relevance gate ships off, instead of asserting it is "recall-negative by design" — the sentence that carried the whole rationale hinged on an undefined IR term. Also splits a five-fact sentence about degraded responses.
- **`docs/search-neighbor-context.md`** puts the "reach for this when" paragraph before the command examples.
- **`docs/mcp-prompts.md`** no longer describes completion behaviour for a prompt template that does not exist.
- **`CONTRIBUTING.md`** glosses Kookr. It gated PR merges under a tool name defined nowhere in the repo, with no link and no indication whether a contributor needs it — the doc now says what it is and that they don't.
- **`CLAUDE.md`** says *why* per-file hashing and per-model write locks exist, not just that they do.

Reviewed with `kookr-toolkit:clear-writing-reviewer` in four passes: three across the doc corpus to find the problems, one against the rewritten README to catch what the rewrite introduced.

Fixes # (no issue — proactive documentation audit)

## Testing

- [x] `npm test` passes — ran `npm run check:fast`, which is `npm run check` minus `test:coverage`; green, including build, lint, tests typecheck, 0 stale anchors across 155 anchors in 59 doc files, and all seven generated-doc drift gates
- [ ] ~~End-to-end verified for tool/transport changes (see `CLAUDE.md`)~~ — documentation only; no tool, transport, or runtime code is touched
- [ ] ~~Benchmark run if performance-relevant: `BENCH_PROVIDER=stub npm run bench`~~ — no performance-relevant change
- [ ] <!-- kookr:check:tests --> ~~Tests were added or updated for changed behavior; bug fixes include a regression test~~ — no behaviour changed; prose only. The generated-doc drift gates in `check:fast` are the mechanical check that applies here, and they pass

## Documentation contract

- [x] <!-- kookr:check:readme --> `README.md` reflects user-visible CLI, MCP, installation, or configuration changes
- [x] <!-- kookr:check:docs --> Relevant operator, API, configuration, and retrieval documentation under `docs/` is consistent with the implementation — every CLI flag, command, and env var used in the rewritten README was verified against the generated `docs/reference/cli.md`; the frontmatter groupings were verified against `src/frontmatter-lift.ts`, `src/cli-promote.ts`, and `src/cli-superseded.ts`
- [ ] <!-- kookr:check:mbse --> ~~RFCs are updated when this PR implements, supersedes, or changes an accepted design~~ — no design is implemented, superseded, or changed; RFC references were only turned into working links

## Changelog

- [ ] <!-- kookr:check:changelog --> ~~`CHANGELOG.md` has an `Unreleased` entry for user-visible changes~~ — the repo has no `CHANGELOG.md`

## Retrieval and performance evidence

- [ ] <!-- kookr:check:benchmarks --> ~~Retrieval-quality or performance changes include the relevant benchmark/evaluation evidence, or this row is waived with a reason~~ — waived: no retrieval or performance behaviour is changed

## Follow-ups

- #937 — 89 of 144 environment variables ship with an empty **Description** cell in the generated `docs/reference/configuration.md`. The gap is missing `description` fields in `CONFIG_SCHEMA` (`src/config/schema.ts`), so it cannot be fixed by editing the generated file, and writing ~89 accurate descriptions is a job that deserves its own reviewable PRs rather than riding along with a prose restructure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SNnw69aVxr26nbmD2xte4X
