### PR TITLE
ci(e2e): run KB_RUN_E2E suite in CI and gate releases on it

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,43 @@
+name: E2E
+
+# Issue #883 — the spawn-the-binary suite under `src/e2e/` (MCP stdio client,
+# npm-pack tarball smoke, HTTP/SSE transport) is gated behind `KB_RUN_E2E=1` and
+# ran in zero pipelines. A broken `bin`, a file missing from the packed tarball
+# (the regression class of #82), a stdio-handshake break, or an HTTP/SSE
+# transport regression therefore shipped uncaught. This job runs the suite on
+# every PR and push so those regressions fail the build.
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    # The npm-pack smoke test borrows the checkout's installed node_modules
+    # (native faiss-node included), and each test spawns the built binary as a
+    # child process — allow generous wall-time versus the fast inner-loop suite.
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      # Match `test.yml`'s matrix: the tarball/handshake regressions this suite
+      # guards (native faiss-node ABI, ESM loader, undici/SSE fetch) are
+      # Node-version-sensitive, and the package ships `engines >=20`, so the
+      # min-supported runtime must be exercised, not just the newest.
+      matrix:
+        node: [20, 24]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          cache: npm
+          node-version: ${{ matrix.node }}
+      - run: npm ci
+      # The e2e suite spawns `build/index.js` / `build/cli.js` and `npm pack`s
+      # the `build/` tree; `test:serial` does not build, so build explicitly.
+      - run: npm run build
+      # `KB_RUN_E2E=1` drops the `src/e2e/` exclusion in `jest.config.js` and
+      # flips the `describe.skip` gate on, so the suite actually executes. It
+      # runs in the serial project (`--runInBand`) to avoid worker contention
+      # between binary-spawning tests.
+      - run: KB_RUN_E2E=1 npm run test:serial

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,10 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    # The e2e-inclusive test step spawns binary child processes; cap the job so
+    # a leaked child / open handle can't stall a tagged release toward the
+    # default 6h ceiling.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -21,7 +25,12 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build
-      - run: npm test
+      # Issue #883 — gate releases on the full suite INCLUDING the `src/e2e/`
+      # npm-pack tarball smoke and stdio-handshake tests. `KB_RUN_E2E=1` drops
+      # the `src/e2e/` exclusion so a broken `bin`, a file missing from the
+      # packed tarball, or a stdio-handshake break fails the release before
+      # `npm publish`.
+      - run: KB_RUN_E2E=1 npm test
       - run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

The spawn-the-binary suite under `src/e2e/` — the MCP stdio client harness (#222), the npm-pack tarball smoke test (#413), and the HTTP/SSE transport E2E (#548) — is gated behind `KB_RUN_E2E=1`, and **no workflow set that variable**. The suite ran in zero pipelines, including `release.yml`. So a broken `bin`, a file missing from the packed tarball (the regression class of #82), a stdio-handshake break, or an HTTP/SSE transport regression shipped uncaught — and the release smoke test built to gate releases did not actually gate them.

This PR:

- Adds **`.github/workflows/e2e.yml`** — builds, then runs `KB_RUN_E2E=1 npm run test:serial` on every PR and push to `main`, across the same Node `[20, 24]` matrix as `test.yml`. Runs in the serial project (`--runInBand`) to avoid worker contention between binary-spawning tests. `KB_RUN_E2E=1` both drops the `src/e2e/` exclusion in `jest.config.js` and flips the `describe.skip` gate on, so the suite actually executes.
- Edits **`release.yml`** — the pre-publish test step now runs `KB_RUN_E2E=1 npm test`, so the tarball smoke and stdio-handshake tests gate `npm publish`; adds a `timeout-minutes` cap so a leaked binary child process cannot stall a tagged release.

**Design choices** (the issue left these open): a dedicated `e2e.yml` job (over a leg in `test.yml`) keeps the fast inner loop fast and isolates the added CI minutes; the Node `[20, 24]` matrix exercises the min-supported runtime (`engines >=20`) because the regressions this suite guards — native faiss-node ABI, ESM loader, undici/SSE fetch — are Node-version-sensitive. **Not in scope:** making `e2e` a *required* status check that blocks PR merges is a branch-protection repo setting, not a workflow-file change.

Fixes #883

## Testing

- [x] `npm test` passes — `KB_RUN_E2E=1 npm run test:serial` → **480 passed** (incl. all 3 `src/e2e/` suites) on Node 24; the `src/e2e/` suite (14 tests) also verified green on Node 20.20.2. In CI on this PR, both `e2e (20)` and `e2e (24)` pass.
- [x] End-to-end verified for tool/transport changes (see `CLAUDE.md`) — this change **is** the E2E wiring: the stdio, npm-pack, and HTTP/SSE suites now execute in CI (green `e2e (20)`/`e2e (24)` checks).
- [x] ~~Benchmark run if performance-relevant: `BENCH_PROVIDER=stub npm run bench`~~ — N/A: CI-configuration change, not performance-relevant.
- [x] ~~<!-- kookr:check:tests --> Tests were added or updated for changed behavior; bug fixes include a regression test~~ — N/A: no product code changed. The change makes the existing `src/e2e/` suite execute in CI; its "test" is the suite itself, verified by the green `e2e (20)`/`e2e (24)` checks on this PR. There is no jest test to add for a workflow YAML file.

## Documentation contract

- [x] ~~<!-- kookr:check:readme --> `README.md` reflects user-visible CLI, MCP, installation, or configuration changes~~ — N/A: no user-visible CLI/MCP/install/config change; this is CI-only.
- [x] ~~<!-- kookr:check:docs --> Relevant operator, API, configuration, and retrieval documentation under `docs/` is consistent with the implementation~~ — N/A: no documented behavior changed. `CLAUDE.md` already documents `KB_RUN_E2E=1 npm test`; nothing to update.
- [x] ~~<!-- kookr:check:mbse --> RFCs are updated when this PR implements, supersedes, or changes an accepted design~~ — N/A: no RFC/accepted design is implemented, superseded, or changed; this only runs an existing suite in CI.

## Changelog

- [x] ~~<!-- kookr:check:changelog --> `CHANGELOG.md` has an `Unreleased` entry for user-visible changes~~ — N/A: this repository has no `CHANGELOG.md` (removed in #263), and the change is not user-visible.

## Retrieval and performance evidence

- [x] ~~<!-- kookr:check:benchmarks --> Retrieval-quality or performance changes include the relevant benchmark/evaluation evidence, or this row is waived with a reason~~ — N/A: no retrieval-quality or performance change; this is CI configuration only.

## Follow-ups

- Optionally add `e2e` as a required status check in branch protection if PR-merge blocking (not just release gating) is desired — a repo-settings change outside this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
