### PR TITLE
perf(search): cache view-document probe instead of copying docstore per query

### DIFF
--- a/src/FaissIndexManager.test.ts
+++ b/src/FaissIndexManager.test.ts
@@ -3,6 +3,7 @@ import * as crypto from 'crypto';
 import * as os from 'os';
 import * as path from 'path';
 import { createMockEmbeddings } from './test-support/embeddings.js';
+import type { SearchIndexAdapter } from './search-index-adapter.js';
 
 // RFC 013 M1+M2: per-model layout. Default test config (huggingface +
 // BAAI/bge-small-en-v1.5) maps to this model_id slug.
@@ -3395,6 +3396,156 @@ describe('FaissIndexManager similaritySearch threshold filter', () => {
     const results = await manager.similaritySearch('query', 10, 10);
 
     expect(results.map((r) => r.score)).toEqual([0.1, 0.5]);
+  });
+});
+
+describe('FaissIndexManager #882 — hasViewDocuments probe caching', () => {
+  const originalEnv = {
+    KNOWLEDGE_BASES_ROOT_DIR: process.env.KNOWLEDGE_BASES_ROOT_DIR,
+    FAISS_INDEX_PATH: process.env.FAISS_INDEX_PATH,
+    EMBEDDING_PROVIDER: process.env.EMBEDDING_PROVIDER,
+    HUGGINGFACE_API_KEY: process.env.HUGGINGFACE_API_KEY,
+  };
+
+  beforeEach(() => {
+    similaritySearchMock.mockReset();
+    similaritySearchMock.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    const keys = Object.keys(originalEnv) as Array<keyof typeof originalEnv>;
+    for (const key of keys) {
+      const value = originalEnv[key];
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+    jest.restoreAllMocks();
+  });
+
+  // A metadata blob that satisfies `isRetrievalViewDocument` (RFC retrieval
+  // views bake this in at ingest; it is independent of `KB_RETRIEVAL_VIEWS`).
+  const viewMetadata = (): Record<string, unknown> => ({
+    retrieval_view: {
+      schema_version: 'kb.retrieval-view.v1',
+      kind: 'summary',
+      view_id: 'v1',
+      canonical_id: 'c1',
+      canonical_source: 's1',
+      canonical_chunk_index: 0,
+      text_hash: 'h1',
+    },
+  });
+
+  type RawDoc = { pageContent: string; metadata: Record<string, unknown> };
+
+  // Minimal object matching the FaissStore shape FaissStoreAdapter reads for
+  // search: a docstore `_docs` Map and an `index` with `ntotal`/`getDimension`.
+  function makeRawStore(docs: RawDoc[]): Record<string, unknown> {
+    const map = new Map<string, RawDoc>();
+    docs.forEach((doc, index) => map.set(`doc-${index}`, doc));
+    return {
+      embeddings: mockEmbeddings,
+      docstore: { _docs: map },
+      index: { ntotal: () => map.size, getDimension: () => 2 },
+      similaritySearchWithScore: (...args: unknown[]) => similaritySearchMock(...args),
+    };
+  }
+
+  async function makeManagerWithStore(store: Record<string, unknown>) {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-faiss-hasview-'));
+    const kbDir = path.join(tempDir, 'kb');
+    await fsp.mkdir(kbDir, { recursive: true });
+    process.env.KNOWLEDGE_BASES_ROOT_DIR = kbDir;
+    process.env.FAISS_INDEX_PATH = path.join(tempDir, '.faiss');
+    process.env.EMBEDDING_PROVIDER = 'huggingface';
+    process.env.HUGGINGFACE_API_KEY = 'test-key';
+
+    jest.resetModules();
+    const { FaissIndexManager } = await import('./FaissIndexManager.js');
+    const manager = new FaissIndexManager();
+    await manager.initialize();
+    await setLoadedFaissStore(manager, store);
+    return manager;
+  }
+
+  function loadedAdapter(manager: unknown): SearchIndexAdapter {
+    return (manager as { faissIndex: SearchIndexAdapter }).faissIndex;
+  }
+
+  it('computes the view-document probe without copying the docstore and caches it across dense queries', async () => {
+    const manager = await makeManagerWithStore(makeRawStore([{ pageContent: 'plain', metadata: {} }]));
+    const adapter = loadedAdapter(manager);
+    const docstoreSpy = jest.spyOn(adapter, 'docstoreDocuments');
+    const anySpy = jest.spyOn(adapter, 'anyDocument');
+
+    await manager.similaritySearch('q', 5);
+    await manager.similaritySearch('q', 5);
+
+    // Acceptance #882: no full-array docstore copy to compute hasViewDocuments.
+    expect(docstoreSpy).not.toHaveBeenCalled();
+    // The lazy probe runs exactly once, then the cache serves every later query.
+    expect(anySpy).toHaveBeenCalledTimes(1);
+    expect(anySpy.mock.results[0]?.value).toBe(false);
+  });
+
+  it('serves the cached probe regardless of per-query opts.retrievalViews (same adapter/ntotal)', async () => {
+    const manager = await makeManagerWithStore(makeRawStore([{ pageContent: 'plain', metadata: {} }]));
+    const anySpy = jest.spyOn(loadedAdapter(manager), 'anyDocument');
+
+    // The probe derives only from baked per-document metadata; the query-time
+    // view selection must not participate in the cache key. Varying it across
+    // calls on the same adapter/ntotal must NOT trigger a recompute — this
+    // guards against a future regression that keys the cache on opts.
+    await manager.similaritySearch('q', 5);
+    await manager.similaritySearch('q', 5, undefined, undefined, undefined, undefined, {
+      retrievalViews: ['summary'],
+    });
+
+    expect(anySpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('recomputes the probe after the docstore grows and reflects a non-empty view set', async () => {
+    const store = makeRawStore([{ pageContent: 'plain', metadata: {} }]);
+    const manager = await makeManagerWithStore(store);
+    const adapter = loadedAdapter(manager);
+    const anySpy = jest.spyOn(adapter, 'anyDocument');
+
+    await manager.similaritySearch('q', 5);
+    expect(anySpy).toHaveBeenCalledTimes(1);
+    expect(anySpy.mock.results[0]?.value).toBe(false);
+
+    // Append-only mutation (the only in-place docstore change): ntotal grows,
+    // so the cache key changes and the probe re-runs.
+    (store.docstore as { _docs: Map<string, RawDoc> })._docs.set('doc-1', {
+      pageContent: 'view',
+      metadata: viewMetadata(),
+    });
+
+    await manager.similaritySearch('q', 5);
+    expect(anySpy).toHaveBeenCalledTimes(2);
+    expect(anySpy.mock.results[1]?.value).toBe(true);
+  });
+
+  it('recomputes the probe when the loaded index is replaced with equal ntotal but different content', async () => {
+    const manager = await makeManagerWithStore(makeRawStore([{ pageContent: 'plain', metadata: {} }]));
+    const firstSpy = jest.spyOn(loadedAdapter(manager), 'anyDocument');
+
+    await manager.similaritySearch('q', 5);
+    expect(firstSpy).toHaveBeenCalledTimes(1);
+    expect(firstSpy.mock.results[0]?.value).toBe(false);
+
+    // Simulate a reload/version-load swapping in a new adapter (same ntotal,
+    // now containing a view document). Adapter identity keys the cache, so the
+    // probe must re-run even though the vector count is unchanged.
+    await setLoadedFaissStore(manager, makeRawStore([{ pageContent: 'view', metadata: viewMetadata() }]));
+    const secondSpy = jest.spyOn(loadedAdapter(manager), 'anyDocument');
+
+    await manager.similaritySearch('q', 5);
+    expect(secondSpy).toHaveBeenCalledTimes(1);
+    expect(secondSpy.mock.results[0]?.value).toBe(true);
   });
 });
 

--- a/src/FaissIndexManager.ts
+++ b/src/FaissIndexManager.ts
@@ -593,6 +593,17 @@ export class FaissIndexManager {
   private metadataSidecarCache: { sidecar: MetadataSidecar; loadedAt: number } | null = null;
   private metadataSidecarMissingLogged = false;
   private metadataSidecarAllowedForLoadedStore = true;
+  // Issue #882 — cache "does the loaded store contain any retrieval-view
+  // document?" so a dense/hybrid query does not copy and scan the entire
+  // docstore per call. The value is derived purely from per-document
+  // `retrieval_view` metadata baked at ingest, so it changes only when the
+  // docstore mutates. Keying on the adapter identity plus `totalVectors()`
+  // makes the cache self-invalidating: every content change either swaps in a
+  // new adapter (load/reload/version-load) or grows `ntotal` via
+  // `addEmbeddedDocuments` (the docstore is append-only — never mutated in
+  // place). `KB_RETRIEVAL_VIEWS` does not affect this predicate, so a config
+  // change cannot flip the value.
+  private hasViewDocumentsCache: { adapter: SearchIndexAdapter; ntotal: number; value: boolean } | null = null;
 
   /**
    * RFC 013 §4.9 file table — preferred form: `new FaissIndexManager({provider, modelName})`
@@ -2716,7 +2727,7 @@ export class FaissIndexManager {
       });
     };
     const ntotal = this.faissIndex.totalVectors();
-    const hasViewDocuments = this.getDocstoreDocuments().some(isRetrievalViewDocument);
+    const hasViewDocuments = this.hasRetrievalViewDocuments();
     const viewFetchMultiplier = opts.retrievalViews !== undefined && opts.retrievalViews.length > 0
       ? Math.max(4, opts.retrievalViews.length + 1)
       : (hasViewDocuments ? 4 : 1);
@@ -2971,6 +2982,30 @@ export class FaissIndexManager {
 
   private getDocstoreDocuments(): Document[] {
     return this.faissIndex?.docstoreDocuments() ?? [];
+  }
+
+  /**
+   * Issue #882 — "does the loaded store contain any retrieval-view document?"
+   * Retrieval views are opt-in and default off, so the honest answer is almost
+   * always `false`, yet the value is consulted on every dense/hybrid query to
+   * size the view-overfetch multiplier. Compute it via a non-allocating,
+   * short-circuiting docstore scan (`anyDocument`) and cache the boolean keyed
+   * on the adapter identity + `totalVectors()`; the append-only docstore means
+   * any change to the answer is captured by one of those two keys. This
+   * replaces the previous `getDocstoreDocuments().some(...)`, which copied and
+   * scanned the whole corpus per query.
+   */
+  private hasRetrievalViewDocuments(): boolean {
+    const adapter = this.faissIndex;
+    if (!adapter) return false;
+    const ntotal = adapter.totalVectors();
+    const cached = this.hasViewDocumentsCache;
+    if (cached !== null && cached.adapter === adapter && cached.ntotal === ntotal) {
+      return cached.value;
+    }
+    const value = adapter.anyDocument(isRetrievalViewDocument);
+    this.hasViewDocumentsCache = { adapter, ntotal, value };
+    return value;
   }
 
   /**

--- a/src/faiss-store-adapter.test.ts
+++ b/src/faiss-store-adapter.test.ts
@@ -49,6 +49,38 @@ describe('FaissStoreAdapter', () => {
     });
   });
 
+  // Copy-avoidance on the query hot path is asserted at the manager level
+  // (FaissIndexManager.test.ts — `docstoreDocuments` is never called); here we
+  // only pin `anyDocument`'s short-circuit-on-first-match contract.
+  it('short-circuits anyDocument on the first match (#882)', () => {
+    const docs = new Map([
+      ['a', { pageContent: 'a', metadata: { flag: false } }],
+      ['b', { pageContent: 'b', metadata: { flag: true } }],
+      ['c', { pageContent: 'c', metadata: { flag: true } }],
+    ]);
+    const adapter = adapterFor({ docstore: { _docs: docs } });
+
+    const seen: string[] = [];
+    const found = adapter.anyDocument((doc) => {
+      seen.push(doc.pageContent);
+      return doc.metadata?.flag === true;
+    });
+
+    expect(found).toBe(true);
+    // Insertion order 'a','b' — stops at the first match, never visiting 'c'.
+    expect(seen).toEqual(['a', 'b']);
+  });
+
+  it('returns false from anyDocument when no document matches (#882)', () => {
+    const docs = new Map([
+      ['a', { pageContent: 'a', metadata: {} }],
+      ['b', { pageContent: 'b', metadata: {} }],
+    ]);
+    const adapter = adapterFor({ docstore: { _docs: docs } });
+
+    expect(adapter.anyDocument((doc) => doc.metadata?.flag === true)).toBe(false);
+  });
+
   // RFC 017 §3 — `addDocumentsWithEmbeddings` no longer routes through
   // `FaissStore.addDocuments`; instead it embeds via the passed-in
   // `embeddings` (the IndexingEmbeddingDeduper at the production call

--- a/src/faiss-store-adapter.ts
+++ b/src/faiss-store-adapter.ts
@@ -302,6 +302,19 @@ export class FaissStoreAdapter implements SearchIndexAdapter {
   }
 
   /**
+   * Issue #882 — iterate the docstore Map's values and return on the first
+   * match. Unlike `docstoreDocuments().some(...)`, this never allocates the
+   * intermediate `Document[]`, so a "does any view document exist?" probe on a
+   * warm daemon is allocation-free and short-circuits.
+   */
+  anyDocument(predicate: (doc: Document) => boolean): boolean {
+    for (const doc of getDocstoreMap(this.store).values()) {
+      if (predicate(doc)) return true;
+    }
+    return false;
+  }
+
+  /**
    * Issue #283 — emit `[docstoreId, Document]` pairs in insertion order so
    * the metadata sidecar can persist a stable id keyed by exactly what the
    * langchain docstore uses internally.

--- a/src/hnsw-index-adapter.test.ts
+++ b/src/hnsw-index-adapter.test.ts
@@ -73,6 +73,27 @@ describe('HnswIndexAdapter', () => {
     expect(afterLoad[0][0].pageContent).toBe('beta');
   });
 
+  it('short-circuits anyDocument on the first match (#882)', async () => {
+    const adapter = await HnswIndexAdapter.fromEmbeddedDocuments({
+      documents: docs(),
+      vectors: [
+        [0, 0],
+        [10, 0],
+        [0, 10],
+      ],
+    }, config);
+
+    const seen: string[] = [];
+    const found = adapter.anyDocument((doc) => {
+      seen.push(doc.pageContent);
+      return doc.metadata?.knowledgeBase === 'kb-a';
+    });
+
+    expect(found).toBe(true);
+    expect(seen).toEqual(['alpha']);
+    expect(adapter.anyDocument((doc) => doc.metadata?.knowledgeBase === 'kb-missing')).toBe(false);
+  });
+
   it('rejects dimension mismatches before mutating the index', async () => {
     const adapter = await HnswIndexAdapter.fromEmbeddedDocuments({
       documents: [docs()[0]],

--- a/src/hnsw-index-adapter.ts
+++ b/src/hnsw-index-adapter.ts
@@ -213,6 +213,15 @@ export class HnswIndexAdapter implements SearchIndexAdapter {
     return [...this.documents];
   }
 
+  /**
+   * Issue #882 — scan the backing documents array and return on the first
+   * match, so a "does any view document exist?" probe short-circuits without
+   * copying the array via `docstoreDocuments()`.
+   */
+  anyDocument(predicate: (doc: Document) => boolean): boolean {
+    return this.documents.some(predicate);
+  }
+
   docstoreEntries(): Array<[string, Document]> {
     return this.documents.map((document, index) => [`doc-${index}`, document]);
   }

--- a/src/search-index-adapter.ts
+++ b/src/search-index-adapter.ts
@@ -18,6 +18,14 @@ export interface SearchIndexAdapter {
   totalVectors(): number;
   vectorDimension(): number;
   docstoreDocuments(): Document[];
+  /**
+   * Issue #882 — lazily scan docstore entries and short-circuit on the first
+   * match, without materializing a full `Document[]` copy. Callers that only
+   * need "does any document satisfy `predicate`?" must prefer this over
+   * `docstoreDocuments().some(...)` so a warm daemon does not allocate (and GC)
+   * a full corpus copy per query.
+   */
+  anyDocument(predicate: (doc: Document) => boolean): boolean;
   docstoreEntries(): Array<[string, Document]>;
   chunkCountsByKnowledgeBase(): Record<string, number>;
 }


### PR DESCRIPTION
## Summary

`similaritySearch` computed a single boolean — "does this store contain any
retrieval-view document?" — by materializing a **full `Document[]` copy of the
entire docstore** and running `.some(...)` over it on **every** dense/hybrid
query. Retrieval views are opt-in and default off, so on a warm `kb serve`
daemon this was an avoidable full-corpus allocation plus an O(n) scan per query
(GC churn + CPU exactly where latency matters), scaling with corpus size.

This caches the boolean and computes it without allocating a copy.

- **`search-index-adapter.ts`** — add `anyDocument(predicate)` to the adapter
  interface: a lazy, short-circuiting docstore scan that never materializes a
  `Document[]`.
- **`faiss-store-adapter.ts` / `hnsw-index-adapter.ts`** — implement
  `anyDocument` over the backing Map values / documents array.
- **`FaissIndexManager.ts`** — replace
  `getDocstoreDocuments().some(isRetrievalViewDocument)` in the hot path with a
  cached `hasRetrievalViewDocuments()` helper, keyed on **adapter identity +
  `totalVectors()`**.

`isRetrievalViewDocument` derives purely from per-document `retrieval_view`
metadata baked at ingest, so the answer changes only when the docstore mutates.
The docstore is append-only: every content change either swaps in a **new
adapter** (load / reload / version-load) or **grows `ntotal`** via
`addEmbeddedDocuments` — both captured by the cache key, so it self-invalidates
at exactly the points the old per-query recomputation would have observed a
change. `KB_RETRIEVAL_VIEWS` does not feed this predicate, so a config change
cannot flip the value (matching prior behavior). An independent fresh-context
reviewer traced every mutation site and confirmed no path flips the answer while
holding the same adapter and the same `ntotal`.

Fixes #882

## Testing

- [x] `npm test` passes
- [ ] ~~End-to-end verified for tool/transport changes (see `CLAUDE.md`)~~ — N/A: no tool handler or transport change; internal search hot-path refactor only.
- [ ] ~~Benchmark run if performance-relevant: `BENCH_PROVIDER=stub npm run bench`~~ — N/A: pure allocation/CPU reduction with behaviorally-identical results (tests assert equivalence); retrieval quality unchanged.
- [x] <!-- kookr:check:tests --> Tests were added or updated for changed behavior; bug fixes include a regression test

## Documentation contract

- [ ] ~~<!-- kookr:check:readme --> `README.md` reflects user-visible CLI, MCP, installation, or configuration changes~~ — N/A: no user-visible CLI/MCP/install/config change; internal optimization.
- [ ] ~~<!-- kookr:check:docs --> Relevant operator, API, configuration, and retrieval documentation under `docs/` is consistent with the implementation~~ — N/A: no operator/API/config/retrieval surface changed.
- [ ] ~~<!-- kookr:check:mbse --> RFCs are updated when this PR implements, supersedes, or changes an accepted design~~ — N/A: implements no accepted design; a self-contained perf fix.

## Changelog

- [ ] ~~<!-- kookr:check:changelog --> `CHANGELOG.md` has an `Unreleased` entry for user-visible changes~~ — N/A: internal performance optimization with no user-visible behavior or output change.

## Retrieval and performance evidence

- [ ] ~~<!-- kookr:check:benchmarks --> Retrieval-quality or performance changes include the relevant benchmark/evaluation evidence, or this row is waived with a reason~~ — Waived: removes a per-query full-docstore copy + O(n) scan on an internal opt-in-view probe and returns the identical boolean (unit tests assert behavioral equivalence and cache invalidation); it does not alter ranking, recall, or any retrieval output, so retrieval-quality benchmarks are unaffected.

## Follow-ups

None. One out-of-scope future-proofing note surfaced in review (a guard so a future in-place-deletion feature would fail loud rather than silently serving a stale cached probe); it is not actionable today because no in-place deletion path exists, so no issue was spun off.

Closes #882

🤖 Generated with [Claude Code](https://claude.com/claude-code)
