### PR TITLE
perf(serve): reuse warm store and cache corpus size for /metrics + stats

### DIFF
--- a/src/cli-serve.test.ts
+++ b/src/cli-serve.test.ts
@@ -6,12 +6,15 @@ import * as path from 'node:path';
 import {
   appendDaemonAdmissionMetrics,
   createDaemonCommandHandlers,
+  createWarmCorpusStatsHandler,
+  type DaemonCommandHandlers,
   formatStatsRunResultAsOpenMetrics,
   gracefulDrain,
   parseServeArgs,
   runServeStatus,
   startDaemonServer,
 } from './cli-serve.js';
+import type { RunStatsDeps } from './cli-stats.js';
 import {
   DaemonAdmissionGate,
   resolveDaemonAdmissionConfig,
@@ -21,7 +24,7 @@ import {
   DEFAULT_DAEMON_DRAIN_TIMEOUT_MS,
 } from './daemon-admission.js';
 import { fetchDaemonHealth, runDaemonCommand, type DaemonRunResult } from './daemon-client.js';
-import type { KbStatsPayload } from './kb-stats.js';
+import { CorpusSizeCache, type KbStatsPayload } from './kb-stats.js';
 import type { RunSearchDeps } from './cli-search.js';
 import type { LexicalIndex } from './lexical-index.js';
 import { searchLatencyMetrics } from './metrics.js';
@@ -221,6 +224,102 @@ describe('kb serve daemon', () => {
     await expect(handlers.search(['query'])).resolves.toMatchObject({ exitCode: 0 });
     expect(loadManagerForModel).toHaveBeenCalledTimes(1);
     expect(loadWithJsonRetry).toHaveBeenCalledTimes(2);
+  });
+
+  it('reuses the warm resident store across consecutive daemon stats scrapes (#878)', async () => {
+    const manager = { marker: 'manager', modelId: 'ollama__nomic' };
+    let denseMtimeMs = 1;
+    const denseIndexMetadataReader = jest.fn(async () => ({
+      path: '/faiss/index',
+      mtimeMs: denseMtimeMs,
+      size: 10,
+    }));
+    const resolveActiveModelImpl = jest.fn(async () => 'ollama__nomic');
+    // These are the *base* loaders the daemon wraps in its warm cache. A spy on
+    // them stands in for FaissStore.load — it must fire at most once across
+    // repeated scrapes with an unchanged index.
+    const loadManagerForModel = jest.fn(async () => manager as never);
+    const loadWithJsonRetry = jest.fn(async () => undefined);
+    const runStatsImpl = jest.fn(async (_args: string[], deps: RunStatsDeps = {} as RunStatsDeps) => {
+      const modelId = await deps.resolveActiveModel();
+      const loaded = await deps.loadManagerForModel(modelId);
+      await deps.loadWithJsonRetry(loaded);
+      return 0;
+    });
+    const handlers = createDaemonCommandHandlers({
+      denseIndexMetadataReader,
+      resolveActiveModelImpl,
+      loadManagerForModel,
+      loadWithJsonRetry,
+      runStatsImpl,
+    });
+
+    await expect(handlers.stats(['--format=json'])).resolves.toMatchObject({ exitCode: 0 });
+    await expect(handlers.stats(['--format=json'])).resolves.toMatchObject({ exitCode: 0 });
+
+    // AC1: two consecutive scrapes load the FAISS store at most once.
+    expect(loadManagerForModel).toHaveBeenCalledTimes(1);
+    expect(loadWithJsonRetry).toHaveBeenCalledTimes(1);
+    expect(runStatsImpl).toHaveBeenCalledTimes(2);
+    // The daemon threads its warm manager loaders + cached corpus enumeration
+    // into the stats deps (not the raw base spies, which it wraps).
+    expect(runStatsImpl).toHaveBeenCalledWith(
+      ['--format=json'],
+      expect.objectContaining({
+        loadManagerForModel: expect.any(Function),
+        loadWithJsonRetry: expect.any(Function),
+        computeKbStats: expect.any(Function),
+      }),
+      { preferDaemon: false },
+    );
+
+    // A reindex (dense-index mtime bumps) forces exactly one reload.
+    denseMtimeMs = 2;
+    await expect(handlers.stats(['--format=json'])).resolves.toMatchObject({ exitCode: 0 });
+    expect(loadManagerForModel).toHaveBeenCalledTimes(1);
+    expect(loadWithJsonRetry).toHaveBeenCalledTimes(2);
+  });
+
+  it('recomputes the corpus size only when the dense-index signature changes (#878)', async () => {
+    let denseMtimeMs = 1;
+    const readDenseIndexMetadata = jest.fn(async (_modelId: string) => ({
+      path: '/faiss/index',
+      mtimeMs: denseMtimeMs,
+      size: 10,
+    }));
+    // The seam the daemon injects to walk + stat the corpus. AC2 says two
+    // scrapes with an unchanged index must hit it at most once.
+    const corpusSizeLoader = jest.fn(async () => ({
+      sizes: { alpha: { file_count: 1, total_bytes_indexed: 11 } },
+      enumerationFailures: { failure_count: 0, failures: [] },
+    }));
+    const cache = new CorpusSizeCache();
+    // Stand in for the heavy computeKbStats body: invoke the injected corpus
+    // loader exactly as the real computeKbStats does, so the
+    // signature-to-recompute wiring is genuinely exercised end to end.
+    const computeKbStatsImpl: typeof import('./kb-stats.js').computeKbStats = async (_manager, opts) => {
+      await opts.computeCorpusSizes?.(['alpha']);
+      return {} as KbStatsPayload;
+    };
+    const handler = createWarmCorpusStatsHandler({
+      readDenseIndexMetadata,
+      cache,
+      corpusSizeLoader,
+      computeKbStatsImpl,
+    });
+    const manager = { modelId: 'ollama__nomic' } as never;
+    const opts = { serverVersion: 'x', startedAt: 0 };
+
+    await handler(manager, opts);
+    await handler(manager, opts);
+    // AC2: unchanged dense index → corpus walked once across two scrapes.
+    expect(corpusSizeLoader).toHaveBeenCalledTimes(1);
+    expect(corpusSizeLoader).toHaveBeenCalledWith(['alpha']);
+
+    denseMtimeMs = 2; // a reindex rewrites the index file
+    await handler(manager, opts);
+    // AC2: the changed dense-index signature forces exactly one recompute.
+    expect(corpusSizeLoader).toHaveBeenCalledTimes(2);
   });
 
   it('records successful daemon-served search timings through the search deps hook', async () => {
@@ -790,92 +889,96 @@ describe('appendDaemonAdmissionMetrics', () => {
   });
 });
 
+function sampleKbStatsPayload(): KbStatsPayload {
+  return {
+    knowledge_bases: {
+      alpha: {
+        file_count: 1,
+        chunk_count: 2,
+        total_bytes_indexed: 3,
+        last_updated_at: null,
+      },
+    },
+    quarantined: {},
+    filesystem: {
+      enumeration_failures: { failure_count: 0, failures: [] },
+    },
+    embedding: {
+      provider: 'huggingface',
+      model: 'BAAI/bge-small-en-v1.5',
+      dim: 384,
+    },
+    index_path: '/tmp/faiss',
+    last_index_update: {
+      status: 'never_run',
+      scope: null,
+      model_id: 'huggingface__BAAI-bge-small-en-v1.5',
+      started_at: null,
+      finished_at: null,
+      duration_ms: null,
+      files_scanned: 0,
+      files_changed: 0,
+      files_unchanged: 0,
+      files_skipped: 0,
+      chunks_attempted: 0,
+      chunks_added: 0,
+      index_mutated: false,
+      saved: false,
+      sidecars_written: false,
+      warning_count: 0,
+      warnings: [],
+      failure_count: 0,
+      failures: [],
+    },
+    server: {
+      version: '0.0.0-test',
+      uptime_ms: 1,
+    },
+    provider_calls: {},
+    search_latency: {
+      requests: {},
+      stages: {},
+      degraded: {},
+    },
+    query_cache: {
+      hits: 0,
+      misses: 0,
+      hit_ratio: 0,
+      l1_hits: 0,
+      disk_hits: 0,
+      bypasses: 0,
+      writes: 0,
+      corruptions: 0,
+      l1_size: 0,
+      disk_size_bytes: 0,
+    },
+    relevance_gate: {
+      gated_queries: 0,
+      verdict_injected: 0,
+      verdict_no_relevant_context: 0,
+      verdict_empty_index: 0,
+      low_confidence_rate: 0,
+      drop_rate_A1: 0,
+      drop_rate_A2: 0,
+      drop_rate_B: 0,
+      judge_degrade_rate: 0,
+      judge_window: {
+        size: 0,
+        degraded: 0,
+        rate: 0,
+        warn_threshold: 0.1,
+      },
+    },
+    write_locks: {
+      wait: {},
+      hold: {},
+    },
+  };
+}
+
 describe('kb serve metrics formatting', () => {
   it('formats the default kb stats daemon result as OpenMetrics text', () => {
-    const payload: KbStatsPayload = {
-      knowledge_bases: {
-        alpha: {
-          file_count: 1,
-          chunk_count: 2,
-          total_bytes_indexed: 3,
-          last_updated_at: null,
-        },
-      },
-      quarantined: {},
-      filesystem: {
-        enumeration_failures: { failure_count: 0, failures: [] },
-      },
-      embedding: {
-        provider: 'huggingface',
-        model: 'BAAI/bge-small-en-v1.5',
-        dim: 384,
-      },
-      index_path: '/tmp/faiss',
-      last_index_update: {
-        status: 'never_run',
-        scope: null,
-        model_id: 'huggingface__BAAI-bge-small-en-v1.5',
-        started_at: null,
-        finished_at: null,
-        duration_ms: null,
-        files_scanned: 0,
-        files_changed: 0,
-        files_unchanged: 0,
-        files_skipped: 0,
-        chunks_attempted: 0,
-        chunks_added: 0,
-        index_mutated: false,
-        saved: false,
-        sidecars_written: false,
-        warning_count: 0,
-        warnings: [],
-        failure_count: 0,
-        failures: [],
-      },
-      server: {
-        version: '0.0.0-test',
-        uptime_ms: 1,
-      },
-      provider_calls: {},
-      search_latency: {
-        requests: {},
-        stages: {},
-        degraded: {},
-      },
-      query_cache: {
-        hits: 0,
-        misses: 0,
-        hit_ratio: 0,
-        l1_hits: 0,
-        disk_hits: 0,
-        bypasses: 0,
-        writes: 0,
-        corruptions: 0,
-        l1_size: 0,
-        disk_size_bytes: 0,
-      },
-      relevance_gate: {
-        gated_queries: 0,
-        verdict_injected: 0,
-        verdict_no_relevant_context: 0,
-        verdict_empty_index: 0,
-        low_confidence_rate: 0,
-        drop_rate_A1: 0,
-        drop_rate_A2: 0,
-        drop_rate_B: 0,
-        judge_degrade_rate: 0,
-        judge_window: {
-          size: 0,
-          degraded: 0,
-          rate: 0,
-          warn_threshold: 0.1,
-        },
-      },
-      write_locks: {
-        wait: {},
-        hold: {},
-      },
-    };
+    const payload = sampleKbStatsPayload();
 
     const text = formatStatsRunResultAsOpenMetrics({
       exitCode: 0,
@@ -895,6 +998,41 @@ describe('kb serve metrics formatting', () => {
       stdout: '',
       stderr: 'stats unavailable\n',
     })).toThrow('stats unavailable');
+  });
+
+  it('serves /metrics from the warm daemon command handlers, not a throwaway store (#878)', async () => {
+    // Before #878, the default /metrics handler built a fresh
+    // createDaemonCommandHandlers() per scrape (reloading FAISS + re-walking the
+    // corpus each time). It must now reuse the daemon's warm `handlers`, so the
+    // injected stats spy is what answers each scrape.
+    const stats = jest.fn(async () => ({
+      exitCode: 0,
+      stdout: JSON.stringify(sampleKbStatsPayload()),
+      stderr: '',
+    }));
+    const handlers: DaemonCommandHandlers = {
+      search: jest.fn(async () => ({ exitCode: 0, stdout: '', stderr: '' })),
+      list: jest.fn(async () => ({ exitCode: 0, stdout: '', stderr: '' })),
+      stats,
+    };
+    const previousMetricsExport = process.env.KB_METRICS_EXPORT;
+    process.env.KB_METRICS_EXPORT = 'on';
+    const daemon = await startDaemonServer({ port: 0, idleTimeoutMs: 0, warm: false, handlers });
+    try {
+      const first = await request(daemon.url, { path: '/metrics' });
+      const second = await request(daemon.url, { path: '/metrics' });
+      expect(first.statusCode).toBe(200);
+      expect(second.statusCode).toBe(200);
+      expect(first.body).toContain('kb_knowledge_base_chunks{kb="alpha"} 2');
+      // The live admission gauges are still spliced in per scrape.
+      expect(first.body).toContain('kb_daemon_inflight');
+      expect(stats).toHaveBeenCalledTimes(2);
+      expect(stats).toHaveBeenNthCalledWith(1, ['--format=json']);
+    } finally {
+      await daemon.stop();
+      if (previousMetricsExport === undefined) delete process.env.KB_METRICS_EXPORT;
+      else process.env.KB_METRICS_EXPORT = previousMetricsExport;
+    }
   });
 });
 

--- a/src/cli-serve.ts
+++ b/src/cli-serve.ts
@@ -7,7 +7,7 @@ import { runList } from './cli-list.js';
 import { createRunSearchDeps, runSearch, type RunSearchDeps } from './cli-search.js';
 import { captureProcessOutput, extractVerbosity, type Verbosity } from './cli-shared.js';
 import { EXIT } from './cli-exit-codes.js';
-import { runStats } from './cli-stats.js';
+import { createRunStatsDeps, runStats, type RunStatsDeps } from './cli-stats.js';
 import {
   isMetricsExportEnabled,
   OPENMETRICS_CONTENT_TYPE,
@@ -36,7 +36,12 @@ import {
 } from './prometheus-export.js';
 import { searchLatencyMetrics, type SearchLatencyMode } from './metrics.js';
 import { searchStageDurationsFromTiming } from './timing-core.js';
-import type { KbStatsPayload } from './kb-stats.js';
+import {
+  computeKbStats,
+  CorpusSizeCache,
+  type ComputeCorpusSizes,
+  type KbStatsPayload,
+} from './kb-stats.js';
 import { LexicalIndexCache } from './lexical-index-cache.js';
 import type { LexicalIndex } from './lexical-index.js';
 import { KNOWLEDGE_BASES_ROOT_DIR } from './config/paths.js';
@@ -143,6 +148,12 @@ export interface DaemonCommandHandlerOptions {
   runSearchImpl?: typeof runSearch;
   runListImpl?: typeof runList;
   runStatsImpl?: typeof runStats;
+  /**
+   * Issue #878 — underlying corpus-size enumeration wrapped by the daemon's
+   * `CorpusSizeCache`. Tests inject a spy to assert consecutive scrapes walk
+   * the corpus at most once. Defaults to the real `computeCorpusSizes`.
+   */
+  corpusSizeLoader?: ComputeCorpusSizes;
 }
 
 interface DenseIndexMetadata {
@@ -390,7 +401,7 @@ export async function startDaemonServer(
   if (parsed.warm) {
     prewarmHealth = await runDaemonPrewarm(handlers);
   }
-  const baseMetricsHandler = options.metricsHandler ?? defaultMetricsHandler;
+  const baseMetricsHandler = options.metricsHandler ?? (() => defaultMetricsHandler(handlers));
   const admission = new DaemonAdmissionGate(
     options.admission ?? resolveDaemonAdmissionConfig(),
   );
@@ -659,6 +670,24 @@ export function createDaemonCommandHandlers(options: DaemonCommandHandlerOptions
   const runSearchImpl = options.runSearchImpl ?? runSearch;
   const runListImpl = options.runListImpl ?? runList;
   const runStatsImpl = options.runStatsImpl ?? runStats;
+  // Issue #878 — reuse the daemon's warm resident store for `stats`/`/metrics`
+  // instead of rebuilding a fresh FaissStore per scrape, and serve the
+  // corpus-size enumeration (file counts + total_bytes_indexed) from a cache
+  // keyed on the dense-index signature so a reindex refreshes it but repeated
+  // scrapes do not re-walk + re-stat ~10k files. Live runtime counters
+  // (search latency, admission gauges) are read fresh on every call.
+  const statsDeps = createRunStatsDeps({
+    resolveActiveModel: resolveActiveModelImpl,
+    loadManagerForModel,
+    loadWithJsonRetry,
+    computeKbStats: createWarmCorpusStatsHandler({
+      readDenseIndexMetadata,
+      cache: new CorpusSizeCache(),
+      // Undefined lets CorpusSizeCache.load fall back to the real
+      // computeCorpusSizes; tests inject a spy via options.corpusSizeLoader.
+      corpusSizeLoader: options.corpusSizeLoader,
+    }),
+  });
   return {
     search: async (args) => {
       const startedAt = Date.now();
@@ -673,7 +702,7 @@ export function createDaemonCommandHandlers(options: DaemonCommandHandlerOptions
       return result;
     },
     list: async (args) => captureProcessOutput(() => runListImpl(args)),
-    stats: async (args) => captureProcessOutput(() => runStatsImpl(args, undefined, { preferDaemon: false })),
+    stats: async (args) => captureProcessOutput(() => runStatsImpl(args, statsDeps, { preferDaemon: false })),
     prewarm: async () => {
       const activeModelId = await resolveActiveModelImpl();
       const manager = await loadManagerForModel(activeModelId);
@@ -948,8 +977,42 @@ export function appendDaemonAdmissionMetrics(
   return `${body}${lines.join('\n')}\n`;
 }
 
-async function defaultMetricsHandler(): Promise<string> {
-  const result = await createDaemonCommandHandlers().stats(['--format=json']);
+/**
+ * Issue #878 — wrap `computeKbStats` so the corpus-size enumeration (file
+ * counts + `total_bytes_indexed`) is served from `cache`, keyed on the
+ * manager's dense-index signature (index path + mtime + size). A reindex
+ * rewrites the index file, changing the signature and forcing a recompute;
+ * repeated scrapes between reindexes reuse the cached counts. Exported so the
+ * signature-to-recompute wiring is directly testable; the daemon binds it in
+ * `createDaemonCommandHandlers`.
+ */
+export function createWarmCorpusStatsHandler(deps: {
+  readDenseIndexMetadata: (modelId: string) => Promise<DenseIndexMetadata>;
+  cache: CorpusSizeCache;
+  corpusSizeLoader?: ComputeCorpusSizes;
+  computeKbStatsImpl?: typeof computeKbStats;
+}): RunStatsDeps['computeKbStats'] {
+  const computeKbStatsImpl = deps.computeKbStatsImpl ?? computeKbStats;
+  return async (manager, statsOptions) => {
+    const meta = await deps.readDenseIndexMetadata(manager.modelId);
+    const signature = JSON.stringify([meta.path, meta.mtimeMs, meta.size]);
+    return computeKbStatsImpl(manager, {
+      ...statsOptions,
+      computeCorpusSizes: (kbNames) =>
+        deps.cache.load(kbNames, signature, deps.corpusSizeLoader),
+    });
+  };
+}
+
+/**
+ * Issue #878 — build the default `/metrics` body from the daemon's *warm*
+ * command handlers so each scrape reuses the resident FaissStore and the
+ * corpus-size cache. Previously this spun up a throwaway
+ * `createDaemonCommandHandlers()` per request, forcing a full ~160 MB index
+ * reload + ~10k stat syscalls on every Prometheus scrape.
+ */
+async function defaultMetricsHandler(handlers: DaemonCommandHandlers): Promise<string> {
+  const result = await handlers.stats(['--format=json']);
   return formatStatsRunResultAsOpenMetrics(result);
 }
 

--- a/src/cli-stats.ts
+++ b/src/cli-stats.ts
@@ -97,6 +97,16 @@ const DEFAULT_DEPS: RunStatsDeps = {
   stderr: (text) => process.stderr.write(text),
 };
 
+/**
+ * Issue #878 — build `RunStatsDeps` from the defaults with selective overrides,
+ * mirroring `createRunSearchDeps`. `kb serve` overrides the manager loaders and
+ * `computeKbStats` so scrapes reuse its warm resident store and corpus-size
+ * cache instead of reconstructing a fresh `FaissStore` per request.
+ */
+export function createRunStatsDeps(overrides: Partial<RunStatsDeps> = {}): RunStatsDeps {
+  return { ...DEFAULT_DEPS, ...overrides };
+}
+
 export async function runStats(
   rest: string[],
   deps: RunStatsDeps = DEFAULT_DEPS,

--- a/src/kb-stats.test.ts
+++ b/src/kb-stats.test.ts
@@ -806,3 +806,118 @@ describe('enumerateIngestableKbFiles', () => {
     }
   });
 });
+
+// Issue #878 — the corpus-size enumeration (file counts + total_bytes_indexed)
+// is the expensive part of a stats call. `kb serve` serves it from a cache so
+// repeated /metrics scrapes do not re-walk + re-stat the whole corpus.
+describe('CorpusSizeCache (#878)', () => {
+  const emptyFailures = { failure_count: 0, failures: [] };
+  const result = (fileCount: number) => ({
+    sizes: { alpha: { file_count: fileCount, total_bytes_indexed: fileCount * 10 } },
+    enumerationFailures: emptyFailures,
+  });
+
+  it('computes once and reuses for the same signature and KB set', async () => {
+    const { CorpusSizeCache } = await import('./kb-stats.js');
+    const cache = new CorpusSizeCache();
+    const compute = jest.fn(async () => result(3));
+
+    const first = await cache.load(['alpha'], 'sig-1', compute);
+    const second = await cache.load(['alpha'], 'sig-1', compute);
+
+    expect(first).toBe(second);
+    expect(first.sizes.alpha.total_bytes_indexed).toBe(30);
+    expect(compute).toHaveBeenCalledTimes(1);
+    expect(compute).toHaveBeenCalledWith(['alpha']);
+  });
+
+  it('recomputes when the index signature changes (reindex)', async () => {
+    const { CorpusSizeCache } = await import('./kb-stats.js');
+    const cache = new CorpusSizeCache();
+    let count = 3;
+    const compute = jest.fn(async () => result(count));
+
+    await cache.load(['alpha'], 'sig-1', compute);
+    count = 7;
+    const after = await cache.load(['alpha'], 'sig-2', compute);
+
+    expect(after.sizes.alpha.file_count).toBe(7);
+    expect(compute).toHaveBeenCalledTimes(2);
+  });
+
+  it('recomputes when the requested KB set changes', async () => {
+    const { CorpusSizeCache } = await import('./kb-stats.js');
+    const cache = new CorpusSizeCache();
+    const compute = jest.fn(async () => result(3));
+
+    await cache.load(['alpha'], 'sig-1', compute);
+    await cache.load(['alpha', 'beta'], 'sig-1', compute);
+
+    expect(compute).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not confuse a KB named with a space for a two-KB set', async () => {
+    const { CorpusSizeCache } = await import('./kb-stats.js');
+    const cache = new CorpusSizeCache();
+    const compute = jest.fn(async () => result(3));
+
+    // The JSON key encodes array boundaries, so `["a b"]` and `["a","b"]`
+    // are distinct even though a naive space-joined key would collide.
+    await cache.load(['a b'], 'sig-1', compute);
+    await cache.load(['a', 'b'], 'sig-1', compute);
+
+    expect(compute).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('computeKbStats corpus-size seam (#878)', () => {
+  const originalRoot = process.env.KNOWLEDGE_BASES_ROOT_DIR;
+  const originalFaiss = process.env.FAISS_INDEX_PATH;
+
+  afterEach(() => {
+    if (originalRoot === undefined) delete process.env.KNOWLEDGE_BASES_ROOT_DIR;
+    else process.env.KNOWLEDGE_BASES_ROOT_DIR = originalRoot;
+    if (originalFaiss === undefined) delete process.env.FAISS_INDEX_PATH;
+    else process.env.FAISS_INDEX_PATH = originalFaiss;
+  });
+
+  it('serves file_count/total_bytes from the injected loader while keeping chunk_count live', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-stats-corpus-'));
+    await fsp.mkdir(path.join(tempDir, 'alpha'));
+    // Real on-disk bytes differ from the injected loader's numbers, so a match
+    // proves the seam is used instead of the uncached walk.
+    await fsp.writeFile(path.join(tempDir, 'alpha', 'one.md'), 'hello world');
+
+    const { computeKbStats } = await freshKbStats({
+      KNOWLEDGE_BASES_ROOT_DIR: tempDir,
+      FAISS_INDEX_PATH: path.join(tempDir, '.faiss'),
+    });
+
+    const computeCorpusSizes = jest.fn(async () => ({
+      sizes: { alpha: { file_count: 42, total_bytes_indexed: 4242 } },
+      enumerationFailures: {
+        failure_count: 1,
+        failures: [{ kbName: 'alpha', path: '/x', code: 'EACCES', message: 'denied' }],
+      },
+    }));
+
+    const manager = makeManager({ chunkCountsByKb: { alpha: 9 } });
+    const payload = await computeKbStats(manager as any, {
+      serverVersion: '9.9.9',
+      startedAt: Date.now(),
+      computeCorpusSizes,
+    });
+
+    expect(computeCorpusSizes).toHaveBeenCalledTimes(1);
+    expect(computeCorpusSizes).toHaveBeenCalledWith(['alpha']);
+    expect(payload.knowledge_bases.alpha).toMatchObject({
+      file_count: 42,
+      total_bytes_indexed: 4242,
+      chunk_count: 9, // live from the manager, never cached
+    });
+    // enumeration diagnostics also flow from the injected loader's result.
+    expect(payload.filesystem.enumeration_failures.failure_count).toBe(1);
+
+    await fsp.rm(tempDir, { recursive: true, force: true });
+  });
+});

--- a/src/kb-stats.ts
+++ b/src/kb-stats.ts
@@ -229,6 +229,107 @@ export interface ComputeKbStatsOptions {
   writeLockMetrics?: WriteLockMetrics;
   /** Process-local HTTP/SSE counters, supplied by KnowledgeBaseServer when active. */
   remoteTransportStats?: TransportRuntimeStatsSnapshot;
+  /**
+   * Issue #878 — seam for the corpus-size enumeration (per-KB file counts +
+   * `total_bytes_indexed`). Walking every ingestable file and `fs.stat`-ing it
+   * dominates the cost of a stats call, so `kb serve` injects a cached loader
+   * (see `CorpusSizeCache`) to avoid ~10k stat syscalls per `/metrics` scrape.
+   * Left undefined, the uncached {@link computeCorpusSizes} runs per call.
+   */
+  computeCorpusSizes?: ComputeCorpusSizes;
+}
+
+/** Per-KB corpus-size counts derived purely from the on-disk source tree. */
+export interface CorpusSizeRow {
+  file_count: number;
+  total_bytes_indexed: number;
+}
+
+/**
+ * Result of the corpus-size enumeration: per-KB file/byte counts plus the
+ * walk's enumeration diagnostics. Everything here depends only on the KB
+ * source files (not the loaded index), so it is safe to cache behind an
+ * index-mutation signature.
+ */
+export interface CorpusEnumerationResult {
+  sizes: Record<string, CorpusSizeRow>;
+  enumerationFailures: KbFilesystemEnumerationDiagnostics;
+}
+
+export type ComputeCorpusSizes = (
+  kbNames: readonly string[],
+) => Promise<CorpusEnumerationResult>;
+
+/**
+ * Issue #878 — walk each KB's ingestable files and sum their byte sizes.
+ * Applies the SAME ingest filter the indexer uses so `file_count` and
+ * `total_bytes_indexed` reflect what would actually be embedded — not the raw
+ * file walk (which still includes excluded extensions and excluded subtrees).
+ *
+ * This is the expensive part of `computeKbStats` (a full recursive walk plus
+ * one `fs.stat` per file). It reads only the source tree, so callers that scrape
+ * repeatedly (e.g. `kb serve` `/metrics`) can cache the result.
+ */
+export async function computeCorpusSizes(
+  kbNames: readonly string[],
+): Promise<CorpusEnumerationResult> {
+  const enumerations = await enumerateIngestableKbFiles(
+    KNOWLEDGE_BASES_ROOT_DIR,
+    kbNames,
+    {
+      extraExtensions: INGEST_EXTRA_EXTENSIONS,
+      excludePaths: INGEST_EXCLUDE_PATHS,
+    },
+  );
+  const enumerationFailures = aggregateEnumerationDiagnostics(enumerations);
+  const fsConcurrency = resolveFsConcurrency();
+  const sizes: Record<string, CorpusSizeRow> = {};
+  for (const { kbName, filePaths } of enumerations) {
+    const byteCounts = await mapBounded(filePaths, fsConcurrency, async (filePath) => {
+      try {
+        const st = await fsp.stat(filePath);
+        return st.size;
+      } catch (err) {
+        // Best-effort: a TOCTOU between the walker and stat (e.g. concurrent
+        // edit) shouldn't fail the whole stats call.
+        logger.debug(`kb_stats: could not stat ${filePath}: ${(err as Error).message}`);
+        return 0;
+      }
+    });
+    sizes[kbName] = {
+      file_count: filePaths.length,
+      total_bytes_indexed: byteCounts.reduce((sum, value) => sum + value, 0),
+    };
+  }
+  return { sizes, enumerationFailures };
+}
+
+/**
+ * Issue #878 — memoizes {@link computeCorpusSizes} behind a caller-supplied
+ * signature so a warm `kb serve` daemon does not re-walk + re-`stat` the whole
+ * corpus on every `/metrics` scrape. The signature is the daemon's dense-index
+ * metadata (path/mtime/size): a reindex changes the index file, which changes
+ * the signature and forces a recompute, satisfying "refresh on reindex". A
+ * stale byte total between reindexes is acceptable. The KB set is folded into
+ * the key so a `--kb`-scoped call never returns another scope's counts.
+ */
+export class CorpusSizeCache {
+  private entry: { key: string; result: CorpusEnumerationResult } | null = null;
+
+  async load(
+    kbNames: readonly string[],
+    signature: string,
+    compute: ComputeCorpusSizes = computeCorpusSizes,
+  ): Promise<CorpusEnumerationResult> {
+    // JSON encodes the array boundaries unambiguously, so a KB named
+    // "a b" can never collide with the set ["a", "b"].
+    const key = JSON.stringify([signature, [...kbNames]]);
+    const cached = this.entry;
+    if (cached !== null && cached.key === key) return cached.result;
+    const result = await compute(kbNames);
+    this.entry = { key, result };
+    return result;
+  }
 }
 
 /**
@@ -263,43 +364,26 @@ export async function computeKbStats(
 
   const indexStats = manager.getStats();
 
-  // Apply the SAME ingest filter the indexer uses, so file_count and
-  // total_bytes_indexed reflect what would actually be embedded — not the
-  // raw file walk (which still includes excluded extensions and excluded
-  // subtrees).
-  const enumerations = await enumerateIngestableKbFiles(
-    KNOWLEDGE_BASES_ROOT_DIR,
-    kbsToReport,
-    {
-      extraExtensions: INGEST_EXTRA_EXTENSIONS,
-      excludePaths: INGEST_EXCLUDE_PATHS,
-    },
-  );
+  // Corpus-size enumeration (per-KB file_count + total_bytes_indexed) — the
+  // expensive full walk + per-file stat. Injectable so `kb serve` can serve it
+  // from a cache (issue #878); left undefined it runs uncached per call.
+  const computeCorpusSizesImpl = options.computeCorpusSizes ?? computeCorpusSizes;
+  const { sizes: corpusSizes, enumerationFailures } = await computeCorpusSizesImpl(kbsToReport);
 
   const knowledge_bases: Record<string, KbStatsRow> = {};
   const quarantined: Record<string, number> = {};
-  const enumerationFailures = aggregateEnumerationDiagnostics(enumerations);
-  const fsConcurrency = resolveFsConcurrency();
-  for (const { kbName, kbPath, filePaths } of enumerations) {
-    const byteCounts = await mapBounded(filePaths, fsConcurrency, async (filePath) => {
-      try {
-        const st = await fsp.stat(filePath);
-        return st.size;
-      } catch (err) {
-        // Best-effort: a TOCTOU between the walker and stat (e.g. concurrent
-        // edit) shouldn't fail the whole stats call.
-        logger.debug(`kb_stats: could not stat ${filePath}: ${(err as Error).message}`);
-        return 0;
-      }
-    });
-    const totalBytes = byteCounts.reduce((sum, value) => sum + value, 0);
+  for (const kbName of kbsToReport) {
+    const kbPath = path.join(KNOWLEDGE_BASES_ROOT_DIR, kbName);
+    const size = corpusSizes[kbName] ?? { file_count: 0, total_bytes_indexed: 0 };
+    // last_updated_at, chunk_count, and quarantine reflect live index/disk
+    // state, so they stay uncached even when corpus sizes are served warm.
     const lastUpdatedAt = await maxMtimeIso(path.join(kbPath, '.index'));
     const chunkCount = indexStats.chunkCountsByKb[kbName] ?? 0;
     const contextualPreface = await computeContextualPrefaceBlock(kbName, chunkCount);
     knowledge_bases[kbName] = {
-      file_count: filePaths.length,
+      file_count: size.file_count,
       chunk_count: chunkCount,
-      total_bytes_indexed: totalBytes,
+      total_bytes_indexed: size.total_bytes_indexed,
       last_updated_at: lastUpdatedAt,
       contextual_preface: contextualPreface,
     };


### PR DESCRIPTION
## Summary

`kb serve` runs a background daemon that keeps the search index loaded in memory ("warm") so real queries don't have to reload it from disk. Two paths bypassed that warm state: the `/metrics` endpoint and the daemon's `stats` command each built a fresh set of handlers per call, which reloaded the ~160 MB FAISS index (the vector index) and its docstore (the sidecar file mapping index entries back to documents), then walked the filesystem — `stat`-ing all ~10k ingestable files — just to recompute one number, `total_bytes_indexed`. With Prometheus scraping every 15 s, that reload-and-walk competed with real searches for disk I/O and GC, and could run long enough to blow through the scrape timeout, leaving gaps in the metrics.

This change makes scrapes reuse the daemon's already-warm resident store and serves the expensive corpus-size enumeration from a cache, while keeping live runtime counters fresh on every scrape.

Closes #878

### Changes

- **Reuse the warm resident store on the stats/metrics path** (`src/cli-serve.ts`): the daemon `stats` handler now runs with deps that thread its warm `loadManagerForModel` / `loadWithJsonRetry` (the same cached loaders the search path already uses), instead of `undefined` deps that fall through to a fresh `FaissStore.load`. The default `/metrics` body is now built from the daemon's warm `handlers`, not a throwaway handler set.
- **Cache the corpus-size enumeration** (`src/kb-stats.ts`): the per-KB file-count + `total_bytes_indexed` walk is extracted into `computeCorpusSizes` behind a new `ComputeKbStatsOptions.computeCorpusSizes` seam. A new `CorpusSizeCache` memoizes it keyed on the **dense-index signature** (index path + mtime + size) plus the requested KB set. A reindex rewrites the index file, which changes the signature and forces a recompute; repeated scrapes between reindexes reuse the cached counts instead of re-walking + re-stat-ing the tree. The cache key is built with `JSON.stringify`, so a KB literally named `"a b"` can never collide with the two-KB set `["a","b"]`.
- **Wiring helper** (`src/cli-serve.ts`): the signature-to-recompute glue is factored into an exported `createWarmCorpusStatsHandler`, so a unit test can drive "same signature → walk once; changed signature → recompute" directly.
- **Live counters stay uncached**: only the corpus-size numbers are cached. `chunk_count` (from the loaded store), search-latency histograms, and the daemon admission gauges (`kb_daemon_inflight` / `kb_daemon_rejected_total`) are all computed fresh on every request.
- **`createRunStatsDeps` factory** (`src/cli-stats.ts`): lets the daemon override just the loaders it needs while leaving the rest of `RunStatsDeps` at their defaults — mirroring `createRunSearchDeps`. Non-daemon `runStats` callers are unchanged.

### Design notes

- **Why key on the dense-index signature** rather than a source-dir mtime or a TTL: the daemon is strictly read-only (it refuses `search --refresh`), so it detects corpus changes the same way the warm store already does — by observing the FAISS index file's mtime/size. Clean "refresh on reindex" with no extra walking. A stale byte total between reindexes is acceptable and consistent with the also-stale `chunk_count` for the same interval.
- **Scope of the staleness:** the daemon also answers the `kb stats` CLI (a CLI call with a running daemon reads the daemon's payload), so the "stale until reindex" `file_count` / `total_bytes_indexed` behavior applies to daemon-served `kb stats`, not only `/metrics`. Non-daemon `kb stats` is unchanged and still re-walks per call. Exported metric names, shapes, and semantics (`kb_knowledge_base_indexed_bytes` = "total bytes from ingestable files") are unchanged.

### Review

Reviewed before opening by parallel correctness, conventions/dead-code, and test-quality specialists plus a prose reviewer — no blocking findings. Applied from their feedback: a collision-safe JSON cache key, dropped an unused `CorpusSizeCache.invalidate()`, and extracted `createWarmCorpusStatsHandler` so the invalidate-on-reindex path is tested through the real wiring.

## Testing

- [x] `npm test` passes — full Jest suite green: parallel **2963 passed** (4 skipped), serial **466 passed** (2 skipped); `tsc` (build + tests configs) and `eslint src` clean.
- [ ] ~~End-to-end verified for tool/transport changes (see `CLAUDE.md`)~~ — N/A: no MCP tool or transport wire-path change; the change is internal to the `kb serve` daemon's `/metrics` + `stats` handlers.
- [ ] ~~Benchmark run if performance-relevant: `BENCH_PROVIDER=stub npm run bench`~~ — N/A: `npm run bench` measures retrieval/search latency, not the `/metrics` scrape path this PR optimizes.
- [x] <!-- kookr:check:tests --> Tests were added or updated for changed behavior; bug fixes include a regression test — added `CorpusSizeCache` unit tests, a `computeKbStats` corpus-seam test, a warm-store-reuse daemon test, a `createWarmCorpusStatsHandler` reindex-recompute test, and a `/metrics`-uses-warm-handlers test.

## Documentation contract

- [ ] <!-- kookr:check:readme --> ~~`README.md` reflects user-visible CLI, MCP, installation, or configuration changes~~ — N/A: no user-visible CLI, MCP, install, or config change.
- [ ] <!-- kookr:check:docs --> ~~Relevant operator, API, configuration, and retrieval documentation under `docs/` is consistent with the implementation~~ — N/A: no metric added/removed/renamed; `docs/reference/metrics.md` semantics for `kb_knowledge_base_indexed_bytes` remain accurate.
- [ ] <!-- kookr:check:mbse --> ~~RFCs are updated when this PR implements, supersedes, or changes an accepted design~~ — N/A: no RFC implemented, superseded, or changed.

## Changelog

- [ ] <!-- kookr:check:changelog --> ~~`CHANGELOG.md` has an `Unreleased` entry for user-visible changes~~ — N/A: internal daemon performance optimization; no user-visible CLI flag, MCP tool, or exported-metric change.

## Retrieval and performance evidence

- [ ] <!-- kookr:check:benchmarks --> ~~Retrieval-quality or performance changes include the relevant benchmark/evaluation evidence~~ — Waived: this optimizes `/metrics` scrape I/O (daemon-internal store reuse + corpus-size cache), not retrieval quality or search latency, which is what the benchmark harness exercises. Evidence is in unit tests asserting the FAISS store loads once and the corpus walk runs once across consecutive scrapes.

## Follow-ups

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
