### PR TITLE
docs(readme): document kb ask --interactive REPL

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,6 +442,25 @@ kb ask "why does src/cli.ts throw?" --mode=hybrid --rerank
 kb ask "what changed in the daemonization notes?" --timing
 ```
 
+**Iterating in a REPL.** `--interactive` (`-i`) starts a multi-turn session instead of a one-shot answer: the first question retrieves evidence, and follow-ups reuse that same evidence — no re-retrieval — until you ask for a fresh scan. This is the ergonomic path for drilling into a topic, since each follow-up skips the retrieval round-trip. In-session commands:
+
+- `/sources` — show the citations behind the last answer.
+- `/kb <name>` — scope retrieval to a KB and re-retrieve; `/kb` with no argument shows the current scope.
+- `/refresh` — drop the cached evidence so the next question re-scans and re-retrieves.
+- `/save [title]` — persist the last exchange as a transcript note (needs a KB scoped via `--kb` or `/kb`).
+- `/reset` — clear cached evidence and conversation history.
+- `/help`, `/exit` (alias `/quit`).
+
+Interactive mode needs a TTY; when stdin is piped or redirected it falls back to a single one-shot answer (with a notice on stderr).
+
+```bash
+kb ask -i --kb=operating-environment
+# > Which notes discuss reboot recovery?         # first question retrieves evidence
+# > What do they say about the watchdog timer?   # follow-up reuses the same evidence
+# > /refresh                                      # drop cached evidence; next question re-retrieves
+# > /exit
+```
+
 **Saving an answer as a note.** `--save-transcript --kb=<name> --yes` writes the answer into that KB as a new markdown note recording the question, answer, citations, source chunk ids, LLM endpoint/profile/model, retrieval model, and — with `--timing` — timing metadata. `--title=<title>` sets the note title and slug. Existing transcript notes are never overwritten.
 
 ```bash


### PR DESCRIPTION
## Summary

The `kb ask --interactive` (`-i`) multi-turn REPL is a built, tested feature — the first question retrieves evidence, follow-ups reuse it, and `/refresh` re-retrieves — but the README's ask section only described one-shot Q&A. It was documented solely in the auto-generated CLI reference, so a user scanning the primary docs never discovered the evidence-reuse REPL (the ergonomic centerpiece for iterative RAG questioning) unless they happened to run `kb ask --help`.

This adds an **"Iterating in a REPL"** subsection to the README ask section with:
- A plain-language explanation of the evidence-reuse model (retrieve once, reuse across follow-ups until a rescan).
- A runnable `kb ask -i` example with inline comments showing the first-question retrieve, follow-up reuse, and `/refresh`.
- The in-session command surface as a bullet list: `/sources`, `/kb <name>` (and bare `/kb`), `/refresh`, `/save [title]`, `/reset`, `/help`, `/exit` (alias `/quit`).
- The TTY requirement and the non-TTY one-shot fallback (with its stderr notice).

**Design choice:** placed the new subsection in the restructured "Ask: answers from a local LLM" section, immediately after the basic examples and before "Saving an answer as a note", matching the existing bold-lead-in subsection style. Alternative — a standalone top-level section — was rejected as heavier than the issue's "one short paragraph + example" scope.

Fixes #885

## Testing

- [x] `npm test` passes — ran `npm run check:fast` (build, lint, typecheck:tests, and all doc-drift gates including `docs:check-anchors`); all green.
- [x] ~~End-to-end verified for tool/transport changes~~ — N/A: docs-only README change, no tool/transport behavior touched.
- [x] ~~Benchmark run if performance-relevant~~ — N/A: no retrieval or performance change.
- [x] <!-- kookr:check:tests --> ~~Tests were added or updated for changed behavior~~ — N/A: documentation-only change; no code behavior changed, so there is nothing to regression-test.

## Documentation contract

- [x] <!-- kookr:check:readme --> `README.md` reflects user-visible CLI changes — this PR documents the existing `kb ask --interactive` / `-i` REPL in the README ask section.
- [x] <!-- kookr:check:docs --> ~~Relevant operator, API, configuration, and retrieval documentation under `docs/` is consistent with the implementation~~ — N/A: the `kb ask --interactive` surface is already documented in the generated `docs/reference/cli.md`; this PR only closes the README gap and touches no `docs/` files.
- [x] <!-- kookr:check:mbse --> ~~RFCs are updated when this PR implements, supersedes, or changes an accepted design~~ — N/A: documentation-only change; no design implemented, superseded, or changed.

## Changelog

- [x] <!-- kookr:check:changelog --> ~~`CHANGELOG.md` has an `Unreleased` entry for user-visible changes~~ — N/A: no behavior change (documents an already-shipped feature); this is a docs-only edit with no user-visible functional change.

## Retrieval and performance evidence

- [x] <!-- kookr:check:benchmarks --> ~~Retrieval-quality or performance changes include the relevant benchmark/evaluation evidence~~ — N/A: docs-only change with no retrieval or performance impact.

## Follow-ups

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
