### PR TITLE
feat(cli): add `kb init` to create a knowledge base (#884)

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -9,7 +9,7 @@ surface. Run `npm run build && node scripts/gen-cli-reference.mjs` after
 changing a command or its help text, and commit the result. The
 `docs:check-cli` gate (part of `npm run check`) fails if this file drifts.
 
-The `kb` CLI exposes 39 commands.
+The `kb` CLI exposes 40 commands.
 
 ## Commands
 
@@ -31,6 +31,7 @@ The `kb` CLI exposes 39 commands.
 | [`kb explain`](#kb-explain) | Verbose single-query retrieval trace for debugging and bug reports. |
 | [`kb feedback`](#kb-feedback) | Record relevance judgments and promote them into eval fixtures. |
 | [`kb import-url`](#kb-import-url) | Snapshot a web page or PDF into a KB note with provenance frontmatter. |
+| [`kb init`](#kb-init) | Create a new, empty knowledge base. |
 | [`kb inspect`](#kb-inspect) | Show file-side ingest chunking diagnostics for one file. |
 | [`kb list`](#kb-list) | List available knowledge bases. |
 | [`kb llm`](#kb-llm) | Configure local LLM endpoints and managed warm model services. |
@@ -758,6 +759,46 @@ Examples:
   kb import-url --kb=research https://example.com/article
   kb import-url --kb=research https://example.com/paper.pdf --note=papers/x.md
   kb import-url --kb=work http://localhost:8080/doc --allow-local-network
+```
+
+## `kb init`
+
+Create a new, empty knowledge base.
+
+```text
+kb init — create a new, empty knowledge base
+
+Usage:
+  kb init <name> [--format=md|json]
+
+Creates a new knowledge-base directory named <name> under
+`KNOWLEDGE_BASES_ROOT_DIR` so that `kb remember`, `kb capture`, and the MCP
+`add_document` tool can immediately write into it. Until now the only way to
+start a fresh shelf was a manual `mkdir`; every write path throws
+`KB_NOT_FOUND` for a directory that does not exist yet.
+
+The shelf is left empty — no index is built and no files are added — so the
+first write behaves exactly as it would for any existing KB (least surprise).
+
+The name is validated with the same rules the read and write surfaces use to
+address a KB: it must not be empty, start with ".", contain a path separator
+(`/` or `\`), or be an absolute path. Re-running with a name that already
+exists errors instead of clobbering the existing shelf.
+
+Options:
+  --format=md|json      Output format (default: md). `md` prints the created
+                        directory path; `json` prints an object with
+                        `knowledge_base_name`, `path`, and `created`.
+  --help, -h            Show this help.
+
+Exit codes:
+  0   the knowledge base was created
+  1   a knowledge base with that name already exists (or another runtime error)
+  2   missing / extra arguments, or an unsafe name
+
+Examples:
+  kb init new-topic
+  kb init research --format=json
 ```
 
 ## `kb inspect`

--- a/src/cli-init.test.ts
+++ b/src/cli-init.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, it } from '@jest/globals';
+import { spawnSync } from 'child_process';
+import * as fsp from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { INIT_HELP, runInit } from './cli-init.js';
+import { KBError } from './errors.js';
+import {
+  KnowledgeBaseExistsError,
+  createKnowledgeBase,
+  resolveKbPath,
+  resolveKnowledgeBaseDir,
+} from './kb-fs.js';
+
+// ---------------------------------------------------------------------------
+// Unit tests for the createKnowledgeBase filesystem helper (issue #884).
+// These exercise the traversal-safe guards and the no-clobber contract
+// directly, without going through the built CLI.
+// ---------------------------------------------------------------------------
+
+async function withTempRoot<T>(fn: (root: string) => Promise<T>): Promise<T> {
+  const root = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-init-'));
+  try {
+    return await fn(root);
+  } finally {
+    await fsp.rm(root, { recursive: true, force: true });
+  }
+}
+
+describe('createKnowledgeBase', () => {
+  it('creates a directory that resolveKnowledgeBaseDir can then address', async () => {
+    await withTempRoot(async (root) => {
+      const kbDir = await createKnowledgeBase(root, 'new-topic');
+      expect(kbDir).toBe(path.join(root, 'new-topic'));
+      const stat = await fsp.stat(kbDir);
+      expect(stat.isDirectory()).toBe(true);
+      // The freshly created shelf is immediately resolvable by the read/write
+      // surfaces' shared resolver.
+      await expect(resolveKnowledgeBaseDir(root, 'new-topic')).resolves.toBe(kbDir);
+    });
+  });
+
+  it('leaves the new shelf empty (no auto-index, no README)', async () => {
+    await withTempRoot(async (root) => {
+      const kbDir = await createKnowledgeBase(root, 'empty-shelf');
+      expect(await fsp.readdir(kbDir)).toEqual([]);
+    });
+  });
+
+  it('makes the shelf writable via the may-not-exist path resolver', async () => {
+    await withTempRoot(async (root) => {
+      await createKnowledgeBase(root, 'writable');
+      // add_document / kb remember resolve write targets with mustExist:false;
+      // a brand-new file path inside the created shelf must resolve cleanly.
+      await expect(
+        resolveKbPath(root, 'writable', 'note.md', { mustExist: false }),
+      ).resolves.toBe(path.join(root, 'writable', 'note.md'));
+    });
+  });
+
+  it('creates the KB root on demand when it does not exist yet', async () => {
+    await withTempRoot(async (root) => {
+      const missingRoot = path.join(root, 'does-not-exist-yet');
+      const kbDir = await createKnowledgeBase(missingRoot, 'first');
+      expect(kbDir).toBe(path.join(missingRoot, 'first'));
+      expect((await fsp.stat(kbDir)).isDirectory()).toBe(true);
+    });
+  });
+
+  it('rejects an already-existing name with KnowledgeBaseExistsError (no clobber)', async () => {
+    await withTempRoot(async (root) => {
+      await createKnowledgeBase(root, 'dup');
+      await fsp.writeFile(path.join(root, 'dup', 'keep.md'), 'existing content');
+
+      await expect(createKnowledgeBase(root, 'dup')).rejects.toBeInstanceOf(
+        KnowledgeBaseExistsError,
+      );
+      // The pre-existing file must be untouched.
+      expect(await fsp.readFile(path.join(root, 'dup', 'keep.md'), 'utf-8')).toBe(
+        'existing content',
+      );
+    });
+  });
+
+  it('rejects a name colliding with an existing file', async () => {
+    await withTempRoot(async (root) => {
+      await fsp.writeFile(path.join(root, 'taken'), '');
+      await expect(createKnowledgeBase(root, 'taken')).rejects.toBeInstanceOf(
+        KnowledgeBaseExistsError,
+      );
+    });
+  });
+
+  it.each([
+    ['empty', ''],
+    ['dot-prefixed', '.hidden'],
+    ['forward-slash traversal', '../escape'],
+    ['nested path', 'a/b'],
+    ['backslash separator', 'a\\b'],
+    // On POSIX an absolute path always contains '/', so hasPathSeparator
+    // rejects it first; the path.isAbsolute guard is belt-and-suspenders.
+    ['absolute path', path.resolve(os.tmpdir(), 'abs')],
+    ['null byte', 'bad\0name'],
+  ])('rejects the unsafe name (%s) with a VALIDATION error', async (_label, name) => {
+    await withTempRoot(async (root) => {
+      const pending = createKnowledgeBase(root, name);
+      await expect(pending).rejects.toBeInstanceOf(KBError);
+      await expect(pending).rejects.toMatchObject({ code: 'VALIDATION' });
+      // Nothing unsafe should have been created under the root.
+      const entries = await fsp.readdir(root);
+      expect(entries).toEqual([]);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// End-to-end tests against the built CLI: verify command wiring, exit codes,
+// and that a created shelf is immediately writable by `kb remember`.
+// ---------------------------------------------------------------------------
+
+const cliPath = path.join(process.cwd(), 'build', 'cli.js');
+
+function runCli(
+  args: string[],
+  env: Record<string, string>,
+  input?: string,
+): { code: number; stdout: string; stderr: string } {
+  const result = spawnSync('node', [cliPath, ...args], {
+    env: { PATH: process.env.PATH ?? '', KB_LOG_FORMAT: 'text', ...env },
+    encoding: 'utf-8',
+    input,
+  });
+  if (result.error) throw result.error;
+  return { code: result.status ?? -1, stdout: result.stdout, stderr: result.stderr };
+}
+
+describe('kb init (CLI)', () => {
+  it('creates a shelf that kb remember can immediately write into', async () => {
+    await withTempRoot(async (root) => {
+      const env = { KNOWLEDGE_BASES_ROOT_DIR: root };
+
+      const init = runCli(['init', 'topic'], env);
+      expect(init.stderr).toBe('');
+      expect(init.code).toBe(0);
+      expect(init.stdout).toContain(path.join(root, 'topic'));
+
+      // The new shelf shows up in `kb list`.
+      const list = runCli(['list'], env);
+      expect(list.code).toBe(0);
+      expect(list.stdout.split('\n')).toContain('topic');
+
+      // ...and accepts a write straight away.
+      const remember = runCli(
+        ['remember', '--kb=topic', '--title=Hello', '--stdin', '--yes', '--no-check-similar'],
+        env,
+        '# Hello\n\nbody\n',
+      );
+      expect(remember.code).toBe(0);
+      expect((await fsp.stat(path.join(root, 'topic', 'hello.md'))).isFile()).toBe(true);
+    });
+  });
+
+  it('prints a JSON summary with --format=json', async () => {
+    await withTempRoot(async (root) => {
+      const init = runCli(['init', 'jsonkb', '--format=json'], { KNOWLEDGE_BASES_ROOT_DIR: root });
+      expect(init.code).toBe(0);
+      const payload = JSON.parse(init.stdout);
+      expect(payload).toEqual({
+        knowledge_base_name: 'jsonkb',
+        path: path.join(root, 'jsonkb'),
+        created: true,
+      });
+    });
+  });
+
+  it('errors clearly (exit 1) when the shelf already exists', async () => {
+    await withTempRoot(async (root) => {
+      const env = { KNOWLEDGE_BASES_ROOT_DIR: root };
+      expect(runCli(['init', 'dup'], env).code).toBe(0);
+      const again = runCli(['init', 'dup'], env);
+      expect(again.code).toBe(1);
+      expect(again.stderr).toContain('already exists');
+    });
+  });
+
+  it('rejects an unsafe (traversal) name with exit 2', async () => {
+    await withTempRoot(async (root) => {
+      const res = runCli(['init', '../escape'], { KNOWLEDGE_BASES_ROOT_DIR: root });
+      expect(res.code).toBe(2);
+      expect(res.stderr).toContain('Invalid knowledge base name');
+      // No directory escaped the root.
+      expect(await fsp.readdir(root)).toEqual([]);
+    });
+  });
+
+  it('exits 2 when no name is given', async () => {
+    await withTempRoot(async (root) => {
+      const res = runCli(['init'], { KNOWLEDGE_BASES_ROOT_DIR: root });
+      expect(res.code).toBe(2);
+      expect(res.stderr).toContain('missing <name>');
+    });
+  });
+
+  it('exits 2 for an invalid --format value', async () => {
+    await withTempRoot(async (root) => {
+      const res = runCli(['init', 'topic', '--format=xml'], { KNOWLEDGE_BASES_ROOT_DIR: root });
+      expect(res.code).toBe(2);
+      expect(res.stderr).toContain('invalid --format');
+      // The bad flag must be rejected before anything is created.
+      expect(await fsp.readdir(root)).toEqual([]);
+    });
+  });
+
+  it('exits 2 when a second positional argument is given', async () => {
+    await withTempRoot(async (root) => {
+      const res = runCli(['init', 'one', 'two'], { KNOWLEDGE_BASES_ROOT_DIR: root });
+      expect(res.code).toBe(2);
+      expect(res.stderr).toContain('unexpected argument');
+      expect(await fsp.readdir(root)).toEqual([]);
+    });
+  });
+});
+
+// In-process coverage of runInit's argv-parse branch (returns before any
+// filesystem mutation, so it is safe to call against the real root).
+describe('runInit (in-process)', () => {
+  it('help text advertises the command and usage', () => {
+    expect(INIT_HELP).toContain('kb init');
+    expect(INIT_HELP).toContain('Usage:');
+  });
+
+  it('returns exit 2 for an unknown flag', async () => {
+    await expect(runInit(['--nope'])).resolves.toBe(2);
+  });
+
+  it('returns exit 2 when no name is given', async () => {
+    await expect(runInit([])).resolves.toBe(2);
+  });
+});

--- a/src/cli-init.ts
+++ b/src/cli-init.ts
@@ -1,0 +1,107 @@
+import { KNOWLEDGE_BASES_ROOT_DIR } from './config/paths.js';
+import { KBError } from './errors.js';
+import { KnowledgeBaseExistsError, createKnowledgeBase } from './kb-fs.js';
+
+export const INIT_HELP = `kb init — create a new, empty knowledge base
+
+Usage:
+  kb init <name> [--format=md|json]
+
+Creates a new knowledge-base directory named <name> under
+\`KNOWLEDGE_BASES_ROOT_DIR\` so that \`kb remember\`, \`kb capture\`, and the MCP
+\`add_document\` tool can immediately write into it. Until now the only way to
+start a fresh shelf was a manual \`mkdir\`; every write path throws
+\`KB_NOT_FOUND\` for a directory that does not exist yet.
+
+The shelf is left empty — no index is built and no files are added — so the
+first write behaves exactly as it would for any existing KB (least surprise).
+
+The name is validated with the same rules the read and write surfaces use to
+address a KB: it must not be empty, start with ".", contain a path separator
+(\`/\` or \`\\\`), or be an absolute path. Re-running with a name that already
+exists errors instead of clobbering the existing shelf.
+
+Options:
+  --format=md|json      Output format (default: md). \`md\` prints the created
+                        directory path; \`json\` prints an object with
+                        \`knowledge_base_name\`, \`path\`, and \`created\`.
+  --help, -h            Show this help.
+
+Exit codes:
+  0   the knowledge base was created
+  1   a knowledge base with that name already exists (or another runtime error)
+  2   missing / extra arguments, or an unsafe name
+
+Examples:
+  kb init new-topic
+  kb init research --format=json
+`;
+
+interface InitArgs {
+  name: string;
+  format: 'md' | 'json';
+}
+
+function parseInitArgs(rest: string[]): InitArgs {
+  let name: string | undefined;
+  let format: 'md' | 'json' = 'md';
+  for (const arg of rest) {
+    if (arg.startsWith('--format=')) {
+      const value = arg.slice('--format='.length);
+      if (value !== 'md' && value !== 'json') {
+        throw new Error(`invalid --format value '${value}' (expected md or json)`);
+      }
+      format = value;
+      continue;
+    }
+    if (arg.startsWith('-')) {
+      throw new Error(`unknown option '${arg}'`);
+    }
+    if (name !== undefined) {
+      throw new Error(`unexpected argument '${arg}' (kb init takes a single <name>)`);
+    }
+    name = arg;
+  }
+  if (name === undefined || name === '') {
+    throw new Error('missing <name> (usage: kb init <name>)');
+  }
+  return { name, format };
+}
+
+export async function runInit(rest: string[] = []): Promise<number> {
+  let parsed: InitArgs;
+  try {
+    parsed = parseInitArgs(rest);
+  } catch (err) {
+    process.stderr.write(`kb init: ${(err as Error).message}\n`);
+    return 2;
+  }
+
+  let kbDir: string;
+  try {
+    kbDir = await createKnowledgeBase(KNOWLEDGE_BASES_ROOT_DIR, parsed.name);
+  } catch (err) {
+    if (err instanceof KnowledgeBaseExistsError) {
+      process.stderr.write(`kb init: ${err.message}\n`);
+      return 1;
+    }
+    if (err instanceof KBError && err.code === 'VALIDATION') {
+      // Unsafe / malformed name — an argument problem, not a runtime failure.
+      process.stderr.write(`kb init: ${err.message}\n`);
+      return 2;
+    }
+    process.stderr.write(`kb init: ${(err as Error).message}\n`);
+    return 1;
+  }
+
+  if (parsed.format === 'json') {
+    process.stdout.write(`${JSON.stringify({
+      knowledge_base_name: parsed.name,
+      path: kbDir,
+      created: true,
+    }, null, 2)}\n`);
+  } else {
+    process.stdout.write(`Created knowledge base "${parsed.name}" at ${kbDir}\n`);
+  }
+  return 0;
+}

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -219,6 +219,7 @@ describe('kb CLI — argv parsing and dispatch', () => {
     ]));
     const names = manifest.commands.map((command) => command.name);
     expect(names).toEqual([
+      'init',
       'list',
       'ls',
       'search',

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -27,6 +27,7 @@ import { EVAL_GATE_HELP, runEvalGate } from './cli-eval-gate.js';
 import { EXPLAIN_HELP, runExplain } from './cli-explain.js';
 import { FEEDBACK_HELP, runFeedback } from './cli-feedback.js';
 import { IMPORT_URL_HELP, runImportUrl } from './cli-import-url.js';
+import { INIT_HELP, runInit } from './cli-init.js';
 import { INSPECT_HELP, runInspect } from './cli-inspect.js';
 import { LIST_HELP, runList } from './cli-list.js';
 import { LS_HELP, runLs } from './cli-ls.js';
@@ -104,6 +105,7 @@ const NON_OPTION_HELP_SECTIONS = new Set([
 ]);
 
 const SUBCOMMANDS: readonly Subcommand[] = [
+  { name: 'init',         summary: 'Create a new, empty knowledge base.',                                     help: INIT_HELP,         handler: runInit },
   { name: 'list',         summary: 'List available knowledge bases.',                                         help: LIST_HELP,         handler: runList },
   { name: 'ls',           summary: 'List ingestable documents in one or all knowledge bases.',                help: LS_HELP,           handler: runLs },
   { name: 'search',       summary: 'Semantic search across one or all knowledge bases.',                     help: SEARCH_HELP,       handler: runSearch },

--- a/src/kb-fs.ts
+++ b/src/kb-fs.ts
@@ -557,6 +557,87 @@ export async function resolveKnowledgeBaseDir(
   return kbDir;
 }
 
+/**
+ * Thrown by `createKnowledgeBase` when a shelf with the requested name already
+ * exists. A dedicated type (rather than a `KBError` variant) lets the `kb init`
+ * CLI distinguish "the name is taken" (a state conflict) from "the name is
+ * unsafe" (an argument error) without string-matching on messages.
+ */
+export class KnowledgeBaseExistsError extends Error {
+  constructor(
+    readonly knowledgeBaseName: string,
+    readonly rootDir: string,
+  ) {
+    super(`Knowledge base "${knowledgeBaseName}" already exists under ${rootDir}.`);
+    this.name = 'KnowledgeBaseExistsError';
+  }
+}
+
+/**
+ * Create a new, empty knowledge-base directory under `rootDir` and return its
+ * absolute path. Companion to `resolveKnowledgeBaseDir`: it applies the same
+ * addressability guards (empty / dot-prefixed / null-byte / absolute /
+ * path-separator names are rejected) so a shelf created here is one the ingest
+ * and read surfaces can immediately address.
+ *
+ * The KB root is created if it does not exist yet, so bootstrapping the very
+ * first shelf on a fresh install works without a manual `mkdir`. The KB
+ * directory itself is created non-recursively so an existing name is reported
+ * as a `KnowledgeBaseExistsError` conflict instead of silently reusing whatever
+ * is already there. The new directory is left empty — no index, no README — for
+ * least surprise (the first write behaves exactly as it would for any KB).
+ */
+export async function createKnowledgeBase(
+  rootDir: string,
+  knowledgeBaseName: string,
+): Promise<string> {
+  if (
+    knowledgeBaseName.length === 0 ||
+    knowledgeBaseName.startsWith('.') ||
+    knowledgeBaseName.includes('\0') ||
+    path.isAbsolute(knowledgeBaseName) ||
+    hasPathSeparator(knowledgeBaseName)
+  ) {
+    throw new KBError(
+      'VALIDATION',
+      `Invalid knowledge base name ${JSON.stringify(knowledgeBaseName)}: names must not be empty, ` +
+        'start with ".", contain a path separator, or be an absolute path.',
+    );
+  }
+
+  // Create the root on demand so the first-ever shelf works without a manual
+  // mkdir; `{ recursive: true }` is a no-op when the root already exists.
+  await fsp.mkdir(rootDir, { recursive: true });
+
+  const kbDir = path.join(rootDir, knowledgeBaseName);
+  try {
+    // Non-recursive so an already-present name (directory OR file) surfaces as
+    // EEXIST rather than silently succeeding — never clobber an existing shelf.
+    await fsp.mkdir(kbDir);
+  } catch (error: unknown) {
+    if ((error as NodeJS.ErrnoException | undefined)?.code === 'EEXIST') {
+      throw new KnowledgeBaseExistsError(knowledgeBaseName, rootDir);
+    }
+    throw error;
+  }
+
+  // Defence in depth: confirm the freshly created directory resolves inside the
+  // KB root (mirrors resolveKnowledgeBaseDir's realpath guard).
+  const rootReal = await fsp.realpath(rootDir);
+  const kbReal = await fsp.realpath(kbDir);
+  if (!isInsideOrEqual(rootReal, kbReal)) {
+    // Only reachable via a post-mkdir TOCTOU symlink swap (the lexical guard
+    // above makes a safe name a direct child otherwise). Remove the directory
+    // we just created so a rejected init leaves nothing behind.
+    await fsp.rmdir(kbDir).catch(() => {});
+    throw new KBError(
+      'VALIDATION',
+      `Knowledge base "${knowledgeBaseName}" resolves outside ${rootDir}.`,
+    );
+  }
+  return kbDir;
+}
+
 async function knowledgeBaseNotFound(rootDir: string, knowledgeBaseName: string): Promise<KBError> {
   let available: string[] = [];
   try {


### PR DESCRIPTION
## Summary

There was no command to create a knowledge base. Every write path (`add_document`,
`kb remember`, `kb capture`, `kb import-url`) resolves through `resolveKnowledgeBaseDir`,
which throws `KB_NOT_FOUND` for a directory that does not yet exist — so the only
documented way to start a fresh shelf was a manual `mkdir`, and an MCP-only agent could
not bootstrap a topic at all.

This adds a `kb init <name>` subcommand that creates the KB directory under
`KNOWLEDGE_BASES_ROOT_DIR` and errors clearly (instead of clobbering) when the name is
taken.

**Changes**

- `src/kb-fs.ts` — new traversal-safe `createKnowledgeBase(rootDir, name)` helper plus a
  dedicated `KnowledgeBaseExistsError`. It applies the **same addressability guards** as
  `resolveKnowledgeBaseDir` (rejects empty, `.`-prefixed, null-byte, absolute, and
  separator-containing names), so every shelf it creates is immediately addressable by the
  read/write surfaces. The KB dir is created **non-recursively** so an existing name (dir
  or file) surfaces as `EEXIST` → `KnowledgeBaseExistsError` with no TOCTOU window — never
  clobbering existing content. The root is created on demand so the first-ever shelf works
  without a manual `mkdir`. A defence-in-depth realpath/inside-root check mirrors the
  resolver (and cleans up the just-created dir if it ever fires).
- `src/cli-init.ts` — new `runInit` / `INIT_HELP`. Exit codes: `0` created, `1` name
  already exists, `2` unsafe / missing / extra argument. Supports `--format=md|json`.
- `src/cli.ts` — registers `init` in the `SUBCOMMANDS` table.
- `docs/reference/cli.md` — regenerated (generated file; `docs:check-cli` gate).
- `src/cli.test.ts` — the command-manifest test asserts the exact ordered command list, so
  `init` is added there (required by adding a subcommand).

The new shelf is left **empty** (no index, no README) for least surprise — the first write
behaves exactly as it would for any existing KB.

**Design choices** (issue left these open):

- Placed `createKnowledgeBase` in `kb-fs.ts` rather than reusing `resolveKbPath` in a
  create-mode: `resolveKbPath` resolves paths *inside an existing KB*, so it cannot create
  the KB directory itself. The new helper reuses the identical name guards.
- Exit code `1` for "already exists" (a state conflict) vs `2` for unsafe/malformed
  arguments; kept distinct so scripts can branch. Alternative was folding both into `2`.
- The MCP `create_knowledge_base` tool is intentionally out of scope (per the issue — it
  touches the ingest-gate policy; separate follow-on).

Fixes #884

## Testing

- [x] `npm test` passes — `npm run check:fast` gate is green (build, lint, `typecheck:tests`, all `docs:check-*`); the new `src/cli-init.test.ts` (23 tests) passes, as do `src/cli.test.ts` and `src/kb-fs.test.ts`.
- [ ] ~~End-to-end verified for tool/transport changes (see `CLAUDE.md`)~~ — N/A: no MCP tool shape or transport behavior changed; this is a new CLI subcommand, exercised end-to-end against the built CLI (`init` → `list` → `remember`).
- [ ] ~~Benchmark run if performance-relevant: `BENCH_PROVIDER=stub npm run bench`~~ — N/A: no retrieval or performance-sensitive path is touched.
- [x] <!-- kookr:check:tests --> Tests were added or updated for changed behavior; bug fixes include a regression test. `src/cli-init.test.ts` covers the traversal/unsafe-name matrix (empty, `.`-prefix, `../`, nested, `\`, absolute, null byte), the no-clobber contract (verifying pre-existing content is untouched), the empty-shelf guarantee, root creation on demand, immediate writability via `kb remember`, JSON output, and every exit code.

## Documentation contract

- [ ] ~~<!-- kookr:check:readme --> `README.md` reflects user-visible CLI, MCP, installation, or configuration changes~~ — N/A: `README.md` is an overview and does not enumerate individual CLI subcommands; the canonical CLI reference under `docs/reference/cli.md` was regenerated to include `kb init` instead.
- [x] <!-- kookr:check:docs --> Relevant operator, API, configuration, and retrieval documentation under `docs/` is consistent with the implementation: `docs/reference/cli.md` is regenerated from the `SUBCOMMANDS` registry and now documents `kb init` (verified by the `docs:check-cli` gate).
- [ ] ~~<!-- kookr:check:mbse --> RFCs are updated when this PR implements, supersedes, or changes an accepted design~~ — N/A: this is a small additive CLI command; it implements no new accepted design and supersedes no RFC.

## Changelog

- [ ] ~~<!-- kookr:check:changelog --> `CHANGELOG.md` has an `Unreleased` entry for user-visible changes~~ — N/A: this repository has no `CHANGELOG.md` (removed in #263).

## Retrieval and performance evidence

- [ ] ~~<!-- kookr:check:benchmarks --> Retrieval-quality or performance changes include the relevant benchmark/evaluation evidence, or this row is waived with a reason~~ — N/A: no retrieval-quality or performance behavior changes; `kb init` only creates an empty directory.

## Follow-ups

- MCP `create_knowledge_base` tool (touches the ingest-gate policy) — deliberately deferred
  per the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
