### PR TITLE
fix(redaction): scrub GCP/JWT/SSH/Azure/AWS-session secrets on egress

### DIFF
--- a/src/redaction.test.ts
+++ b/src/redaction.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from '@jest/globals';
-import { redactSecrets } from './redaction.js';
+import { redactSecrets, REDACTION_PLACEHOLDER } from './redaction.js';
+import { detectSecretsInText, type SecretFindingCategory } from './secret-scanner.js';
 
 describe('redactSecrets', () => {
   it('redacts common support-bundle secret shapes', () => {
@@ -18,4 +19,181 @@ describe('redactSecrets', () => {
     expect(result.text).toContain('https://[REDACTED]@example.com/path');
     expect(result.summary.total).toBeGreaterThanOrEqual(4);
   });
+
+  it('scrubs the five newly-covered egress secret categories', () => {
+    const gcpKey = `AIzaSy${'B'.repeat(33)}`; // AIza + 35 chars
+    const jwt =
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U';
+    const pemKey = [
+      '-----BEGIN OPENSSH PRIVATE KEY-----', // pragma: allowlist secret
+      'b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtz',
+      'c2gtZWQyNTUxOQAAACD7uJ0j9mFq3Lr8sVtWuZ1aBcDeFgHiJkLmNoPqRsTuA==',
+      '-----END OPENSSH PRIVATE KEY-----',
+    ].join('\n');
+    const azureKey = 'AccountKey=Xj7Kq2Wm9Rt4Yv6Bn1Zc3Pl5Sd8Fg0Hk2Lw4Qa6Ne8Ui0Op2==';
+    const awsSessionKey = 'ASIAIOSFODNN7EXAMPLE'; // ASIA session-key prefix
+
+    const result = redactSecrets(
+      [
+        `key: ${gcpKey}`,
+        `token: ${jwt}`,
+        pemKey,
+        `conn: ${azureKey}`,
+        `aws: ${awsSessionKey}`,
+      ].join('\n'),
+    );
+
+    expect(result.text).not.toContain(gcpKey);
+    expect(result.text).not.toContain(jwt);
+    expect(result.text).not.toContain('c2gtZWQyNTUxOQ'); // PEM key body
+    expect(result.text).not.toContain('Xj7Kq2Wm9Rt4Yv6Bn1Zc3Pl5Sd8Fg0Hk2Lw4Qa6Ne8Ui0Op2'); // Azure key value
+    expect(result.text).not.toContain(awsSessionKey);
+    // AccountKey= label is preserved; only the value is scrubbed.
+    expect(result.text).toContain(`AccountKey=${REDACTION_PLACEHOLDER}`);
+    // Each of the five secrets is replaced by a placeholder (not merely deleted).
+    expect(result.text).toContain(REDACTION_PLACEHOLDER);
+    expect(result.summary.total).toBeGreaterThanOrEqual(5);
+  });
+
+  it('redacts private-key blocks across PEM formats (PKCS#8, encrypted, truncated)', () => {
+    // The ingest scanner only keys on the `-----BEGIN-----` header, but egress
+    // must scrub the whole block. Cover the bare PKCS#8 header (no algorithm
+    // prefix), the encrypted variant, and a truncated block missing its END
+    // footer (as clipped in a log) — all previously slipped through.
+    const pkcs8Body = 'MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQ7uJ0j9mFq3Lr8s';
+    const encryptedBody = 'MIIFDjBABgkqhkiG9w0BBQ0wMzAbBgkqhkiG9w0BBQwwDgQItruncatedAESkey00';
+    const truncatedBody = 'b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQMoreKeyBodyBytes123456';
+
+    const pkcs8 = redactSecrets(`-----BEGIN PRIVATE KEY-----\n${pkcs8Body}\n-----END PRIVATE KEY-----`); // pragma: allowlist secret
+    expect(pkcs8.text).not.toContain(pkcs8Body);
+    expect(pkcs8.text).toContain(REDACTION_PLACEHOLDER);
+
+    const encrypted = redactSecrets(
+      `-----BEGIN ENCRYPTED PRIVATE KEY-----\n${encryptedBody}\n-----END ENCRYPTED PRIVATE KEY-----`, // pragma: allowlist secret
+    );
+    expect(encrypted.text).not.toContain(encryptedBody);
+
+    // Truncated: header present, END footer clipped. The body must not egress.
+    const truncated = redactSecrets(`-----BEGIN OPENSSH PRIVATE KEY-----\n${truncatedBody}`); // pragma: allowlist secret
+    expect(truncated.text).not.toContain(truncatedBody);
+  });
+
+  it('keeps the full three-segment JWT shape (does not over-redact bare base64)', () => {
+    // A lone `eyJ`-prefixed base64 token without the two trailing segments is not
+    // a JWT and must survive untouched, per the acceptance criteria.
+    const notAJwt = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9';
+    const result = redactSecrets(`value: ${notAJwt}`);
+    expect(result.text).toContain(notAJwt);
+  });
+
+  it('does not over-redact a bare high-entropy token with no keyword or shape', () => {
+    // Egress redaction intentionally does NOT mirror the ingest scanner's generic
+    // high-entropy heuristic (and its bare, un-prefixed `token` keyword): a lone
+    // random-looking string with no secret-field keyword and no recognizable
+    // provider shape is left intact so ordinary prompt content is not corrupted.
+    // This is the documented boundary behind the `high_entropy` non-mirrored case.
+    const bareToken = 'aB3xY9zK1mNpQ2rS4tU6vW8dE0fGhIjK';
+    const result = redactSecrets(`The build id is ${bareToken} for reference.`);
+    expect(result.text).toContain(bareToken);
+  });
+});
+
+/**
+ * Parity gate against the ingest secret scanner.
+ *
+ * Every category the ingest scanner (`detectSecretsInText`) recognizes must map
+ * to an entry here. Because the map is a `Record<SecretFindingCategory, …>`, any
+ * category added to or renamed in the scanner's union breaks compilation until
+ * it is accounted for — so the egress redactor and the ingest scanner cannot
+ * silently drift apart again.
+ *
+ * Each `mirrored: true` entry carries a canonical sample that the ingest scanner
+ * actually detects (asserted below) and that `redactSecrets` must scrub. A
+ * `mirrored: false` entry documents a category that is intentionally not
+ * mirrored on egress (currently only the generic high-entropy heuristic, which
+ * would over-redact arbitrary text in an LLM prompt).
+ */
+type ParityCase =
+  | { mirrored: true; sample: string; secret: string }
+  | { mirrored: false; reason: string };
+
+const CATEGORY_PARITY: Record<SecretFindingCategory, ParityCase> = {
+  aws_access_key: {
+    mirrored: true,
+    sample: 'ASIAIOSFODNN7EXAMPLE',
+    secret: 'ASIAIOSFODNN7EXAMPLE',
+  },
+  gcp_api_key: {
+    mirrored: true,
+    sample: `AIzaSy${'B'.repeat(33)}`,
+    secret: `AIzaSy${'B'.repeat(33)}`,
+  },
+  github_token: {
+    mirrored: true,
+    sample: `ghp_${'a'.repeat(36)}`,
+    secret: `ghp_${'a'.repeat(36)}`,
+  },
+  jwt: {
+    mirrored: true,
+    sample:
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U',
+    secret:
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U',
+  },
+  ssh_private_key: {
+    mirrored: true,
+    sample: [
+      '-----BEGIN RSA PRIVATE KEY-----', // pragma: allowlist secret
+      'MIIEpAIBAAKCAQEA7uJ0j9mFq3Lr8sVtWuZ1aBcDeFgHiJkLmNoPqRsTuVwXyZ012',
+      '-----END RSA PRIVATE KEY-----',
+    ].join('\n'),
+    secret: 'MIIEpAIBAAKCAQEA7uJ0j9mFq3Lr8sVtWuZ1aBcDeFgHiJkLmNoPqRsTuVwXyZ012',
+  },
+  bearer_token: {
+    mirrored: true,
+    sample: 'Bearer aB3xY9zK1mNpQ2rS4tU6vW8dE0fG',
+    secret: 'aB3xY9zK1mNpQ2rS4tU6vW8dE0fG',
+  },
+  azure_storage_key: {
+    mirrored: true,
+    sample: 'AccountKey=Xj7Kq2Wm9Rt4Yv6Bn1Zc3Pl5Sd8Fg0Hk2Lw4Qa6Ne8Ui0Op2==',
+    secret: 'Xj7Kq2Wm9Rt4Yv6Bn1Zc3Pl5Sd8Fg0Hk2Lw4Qa6Ne8Ui0Op2',
+  },
+  key_value_secret: {
+    // A bare secret field with a shapeless (non-provider) value: the value is
+    // scrubbed by the redactor's own `key_value_secret` pattern, not by a
+    // coincidental provider-token match — so this genuinely exercises key/value
+    // parity. (Only the generic un-prefixed `token` keyword and shapeless
+    // high-entropy values remain intentionally un-mirrored; see high_entropy.)
+    mirrored: true,
+    sample: 'password=Xq7-Rt2_Vn9.Kw4Zp',
+    secret: 'Xq7-Rt2_Vn9.Kw4Zp',
+  },
+  high_entropy: {
+    mirrored: false,
+    reason:
+      'Generic high-entropy heuristic: no fixed shape to mirror, and redacting arbitrary base64 would corrupt legitimate LLM-prompt content.',
+  },
+};
+
+describe('redactSecrets / secret-scanner parity', () => {
+  const mirrored = Object.entries(CATEGORY_PARITY).filter(
+    (entry): entry is [SecretFindingCategory, Extract<ParityCase, { mirrored: true }>] =>
+      entry[1].mirrored,
+  );
+
+  it.each(mirrored)(
+    'ingest scanner detects %s and redactSecrets scrubs it',
+    (category, parity) => {
+      // 1. The canonical sample is genuinely something the ingest scanner flags
+      //    for this category (guards against the scanner's pattern drifting).
+      const detected = detectSecretsInText(parity.sample).map((finding) => finding.category);
+      expect(detected).toContain(category);
+
+      // 2. The egress redactor scrubs that same secret material.
+      const { text } = redactSecrets(parity.sample);
+      expect(text).not.toContain(parity.secret);
+      expect(text).toContain(REDACTION_PLACEHOLDER);
+    },
+  );
 });

--- a/src/redaction.ts
+++ b/src/redaction.ts
@@ -57,7 +57,11 @@ export function redactSecrets(input: string): { text: string; summary: Redaction
   );
   apply(
     'key_value_secret',
-    /\b([A-Za-z_][A-Za-z0-9_]*(?:(?:api|access|refresh|auth|session)[_-]?token|api[_-]?key|client[_-]?secret|password|passwd|secret|cookie)[A-Za-z0-9_]*\s*[:=]\s*)(['"]?)(?!\[REDACTED\])([^\s'",}]+)(\2)/gi,
+    // The identifier prefix before the keyword is optional so that bare fields
+    // (`password=…`, `secret: …`, `token=…`), not just prefixed ones
+    // (`db_password=…`), are scrubbed — matching the shapes the ingest scanner
+    // flags. The leading `\b` still anchors the match to a word boundary.
+    /\b([A-Za-z0-9_]*(?:(?:api|access|refresh|auth|session)[_-]?token|api[_-]?key|client[_-]?secret|password|passwd|secret|cookie)[A-Za-z0-9_]*\s*[:=]\s*)(['"]?)(?!\[REDACTED\])([^\s'",}]+)(\2)/gi,
     (_match, prefix, quote, _value, suffix) => `${prefix}${quote}${REDACTION_PLACEHOLDER}${suffix}`,
   );
   apply(
@@ -65,9 +69,39 @@ export function redactSecrets(input: string): { text: string; summary: Redaction
     /\b(Bearer\s+)([A-Za-z0-9._~+/-]{12,})\b/g,
     (_match, prefix) => `${prefix}${REDACTION_PLACEHOLDER}`,
   );
+  // Multi-line private-key blocks (PEM / OpenSSH / PKCS#8). Redact the whole
+  // block rather than just the header line the ingest scanner keys on, so no key
+  // material survives. The algorithm-name prefix (`RSA `, `EC `, `OPENSSH `,
+  // `ENCRYPTED `, …) is optional, so bare PKCS#8 headers with no algorithm name
+  // are covered too. When the trailing `END` footer line is missing (a
+  // truncated key in a log or support bundle), fall back to redacting the header
+  // plus its trailing base64 body lines instead of letting them egress.
+  apply(
+    'ssh_private_key',
+    /-----BEGIN (?:[A-Z0-9]+ )*PRIVATE KEY-----(?:[\s\S]*?-----END (?:[A-Z0-9]+ )*PRIVATE KEY-----|(?:\r?\n[A-Za-z0-9+/=]{16,})+)/g,
+    () => REDACTION_PLACEHOLDER,
+  );
+  // JSON Web Tokens: match the full three-segment header.payload.signature shape
+  // (not just the `eyJ` header) to avoid over-redacting arbitrary base64 text.
+  apply(
+    'jwt',
+    /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/g,
+    () => REDACTION_PLACEHOLDER,
+  );
+  // Azure Storage connection-string secret. Keep the `AccountKey=` label and
+  // scrub only the base64 key value, mirroring the field-preserving style of the
+  // other secret-field patterns above.
+  apply(
+    'azure_storage_key',
+    /\b(AccountKey=)([A-Za-z0-9+/=]{40,})/gi,
+    (_match, prefix) => `${prefix}${REDACTION_PLACEHOLDER}`,
+  );
+  // Provider API tokens and cloud access-key IDs. The AWS branch mirrors the
+  // ingest scanner's full prefix set (including the ASIA/AGPA/AIDA/AROA session
+  // and role prefixes) and the GCP branch covers `AIza…` API keys.
   apply(
     'provider_token',
-    /\b(?:sk-(?:proj-)?[A-Za-z0-9_-]{20,}|gh[pousr]_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]{20,}|AKIA[0-9A-Z]{16}|xox[abprs]-[A-Za-z0-9-]{10,})\b/g,
+    /\b(?:sk-(?:proj-)?[A-Za-z0-9_-]{20,}|gh[pousr]_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]{20,}|(?:A3T[A-Z0-9]|AKIA|ASIA|AGPA|AIDA|AROA|AIPA|ANPA)[A-Z0-9]{16}|AIza[0-9A-Za-z_-]{35}|xox[abprs]-[A-Za-z0-9-]{10,})\b/g,
     () => REDACTION_PLACEHOLDER,
   );
 


### PR DESCRIPTION
## Summary

`redactSecrets` (`src/redaction.ts`) is the **outbound** scrubber run before every remote `kb ask` prompt and every relevance-judge message is sent to a remote LLM (`KB_ASK_REDACT_OUTBOUND`). Its pattern table recognized credential URLs, auth headers, Bearer tokens, secret fields and a fixed provider-token set (`sk-`/`gh_`/`github_pat_`/`AKIA`/`xox`) — but **missed five secret shapes the ingest-time scanner (`src/secret-scanner.ts`) already detects**, so a KB document holding one of them egressed verbatim even with outbound redaction on.

This closes that gap and adds a parity gate so the two modules cannot silently drift again.

Fixes #888

### What changed

Extended `redactSecrets`, mirroring `secret-scanner.ts`:
- **GCP API keys** (`AIza…`)
- **JWTs** — full three-segment `header.payload.signature` shape (not just the `eyJ` header, to avoid over-redacting arbitrary base64)
- **PEM / OpenSSH / PKCS#8 private-key blocks** (multiline, whole block)
- **Azure Storage** `AccountKey=…` (label preserved, value scrubbed)
- **AWS session/role access keys** (`ASIA`/`AGPA`/`AIDA`/`AROA`/… prefixes) — widened the AWS branch to the scanner's full prefix set

**Parity gate** (`src/redaction.test.ts`): a `Record<SecretFindingCategory, …>` keyed on the scanner's own category union. Adding or renaming a scanner category **breaks compilation** until a redaction sample is accounted for (`ts-jest` type-checks during `npm test`). Each mirrored category asserts the ingest scanner detects a canonical sample **and** `redactSecrets` scrubs it with a placeholder. `high_entropy` is explicitly *not* mirrored (a generic heuristic with no fixed shape; mirroring it would corrupt legitimate prompt text).

### Additional egress holes fixed (surfaced by pre-PR review while building the parity gate)

- **PKCS#8 / ENCRYPTED private keys** — the old SSH pattern required the literal word `PRIVATE` *twice*, so the modern-default PKCS#8 and encrypted key headers **never matched**. The algorithm-name prefix is now optional.
- **Truncated key blocks** (header present, footer clipped in a log/support bundle) leaked their body; a base64-body fallback now redacts them.
- **Bare secret fields** (`password=…`, `secret: …`) were skipped because the key/value pattern required a character *before* the keyword; that prefix is now optional. This matches shapes the ingest scanner flags.

### Deliberate scope choices / known residuals

- The generic un-prefixed `token` keyword and shapeless high-entropy values remain **intentionally un-mirrored** (same rationale as `high_entropy`): redacting them on egress would corrupt ordinary prompt content. Documented with a dedicated over-redaction test.
- `secret-scanner.ts` has the same twice-`PRIVATE` bug at **ingest** (it under-detects PKCS#8 keys). That's an ingest-side concern out of scope here; egress is now strictly stricter than ingest for private keys. Worth a follow-up issue.
- Left `secret-scanner.ts` untouched per the narrow write scope.

## Testing

- [x] `npm test` passes — **478 passed, 0 failed** (2 pre-existing skips)
- [x] End-to-end verified for tool/transport changes (see `CLAUDE.md`) — e2e (20)/(24) green on CI; no transport change
- [ ] ~~Benchmark run if performance-relevant: `BENCH_PROVIDER=stub npm run bench`~~ — N/A: no retrieval/performance-relevant change
- [x] <!-- kookr:check:tests --> Tests were added or updated for changed behavior; bug fixes include a regression test

## Documentation contract

- [ ] <!-- kookr:check:readme --> ~~`README.md` reflects user-visible CLI, MCP, installation, or configuration changes~~ — N/A: no user-visible CLI/MCP/install/config surface changed; only internal egress-redaction coverage broadened
- [ ] <!-- kookr:check:docs --> ~~Relevant operator, API, configuration, and retrieval documentation under `docs/` is consistent with the implementation~~ — N/A: the `KB_ASK_REDACT_OUTBOUND` contract ("scrub secrets via redactSecrets") is unchanged; no doc drift
- [ ] <!-- kookr:check:mbse --> ~~RFCs are updated when this PR implements, supersedes, or changes an accepted design~~ — N/A: no RFC/accepted design is affected

## Changelog

- [ ] <!-- kookr:check:changelog --> ~~`CHANGELOG.md` has an `Unreleased` entry for user-visible changes~~ — N/A: internal egress-redaction hardening with no user-facing CLI/MCP/API/config change; existing `KB_ASK_REDACT_OUTBOUND` behavior contract unchanged

## Retrieval and performance evidence

- [ ] <!-- kookr:check:benchmarks --> ~~Retrieval-quality or performance changes include the relevant benchmark/evaluation evidence~~ — waived: no retrieval-quality or performance change (regex-only edits to the redactor; no embedding/ranking path touched)

## Follow-ups

- The ingest scanner (`src/secret-scanner.ts`) shares the twice-`PRIVATE` PKCS#8 gap and does not detect bare `-----BEGIN PRIVATE KEY-----` / `ENCRYPTED PRIVATE KEY` blocks at ingest — worth a separate issue to bring ingest detection to parity with the now-stricter egress redactor.

Closes #888

🤖 Generated with [Claude Code](https://claude.com/claude-code)
