### PR TITLE
fix(cache): evict rerank and decomposition disk caches as true LRU

### DIFF
--- a/docs/architecture/data-model.md
+++ b/docs/architecture/data-model.md
@@ -155,9 +155,10 @@ treated as misses; writes use a temporary file plus atomic rename.
 
 The disk tier is paired with a process-local LRU. Operators can bound the tiers
 with `KB_DECOMPOSE_CACHE_LRU_MAX` (default `256`, where `0` disables the memory
-tier) and `KB_DECOMPOSE_CACHE_DISK_MAX_BYTES` (default `67108864`). Oldest disk
-entries are removed when the byte budget is exceeded. The cache is an optional
-latency/cost optimization and does not change retrieval correctness.
+tier) and `KB_DECOMPOSE_CACHE_DISK_MAX_BYTES` (default `67108864`). When the
+byte budget is exceeded, least-recently-used disk entries are removed (reads
+refresh entry mtime). The cache is an optional latency/cost optimization and
+does not change retrieval correctness.
 ### Model sidecar files
 
 Each model directory can also contain:

--- a/src/decomposition-cache.test.ts
+++ b/src/decomposition-cache.test.ts
@@ -6,6 +6,7 @@ import * as path from 'path';
 import {
   DECOMPOSITION_CACHE_SCHEMA_VERSION,
   DiskTieredDecompositionCache,
+  defaultDecompositionCache,
   decompositionCacheKey,
   decompositionCacheRoot,
   isDecompositionCacheEnabled,
@@ -88,6 +89,45 @@ describe('DiskTieredDecompositionCache (#736)', () => {
     } finally {
       await fsp.rm(path.dirname(indexPath), { recursive: true, force: true });
     }
+  });
+
+  it('evicts the least-recently-read disk entry, not the oldest write (#894)', async () => {
+    const indexPath = await tempIndexPath('kb-decomposition-cache-true-lru-');
+    try {
+      const probe = new DiskTieredDecompositionCache({ indexPath, enabled: true });
+      probe.set('model', 'probe', ['probe result']);
+      const entryBytes = probe.diskSizeBytes();
+      await fsp.rm(decompositionCacheRoot(indexPath), { recursive: true, force: true });
+
+      const cache = new DiskTieredDecompositionCache({
+        indexPath,
+        enabled: true,
+        lruMax: 0,
+        diskMaxBytes: Math.floor(entryBytes * 2.5),
+      });
+      cache.set('model', 'q1', ['one']);
+      const q1Key = decompositionCacheKey('model', 'q1');
+      const q1File = path.join(decompositionCacheRoot(indexPath), q1Key.slice(0, 2), `${q1Key}.json`);
+      fs.utimesSync(q1File, new Date(1_000), new Date(1_000));
+      cache.set('model', 'q2', ['two']);
+      const q2Key = decompositionCacheKey('model', 'q2');
+      const q2File = path.join(decompositionCacheRoot(indexPath), q2Key.slice(0, 2), `${q2Key}.json`);
+      fs.utimesSync(q2File, new Date(2_000), new Date(2_000));
+
+      expect(cache.get('model', 'q1')).toEqual(['one']);
+      cache.set('model', 'q3', ['three']);
+
+      expect(cache.diskSizeBytes()).toBeLessThanOrEqual(Math.floor(entryBytes * 2.5));
+      expect(cache.get('model', 'q2')).toBeNull();
+      expect(cache.get('model', 'q1')).toEqual(['one']);
+      expect(cache.get('model', 'q3')).toEqual(['three']);
+    } finally {
+      await fsp.rm(path.dirname(indexPath), { recursive: true, force: true });
+    }
+  });
+
+  it('exports a process-global default cache instance (#894)', () => {
+    expect(defaultDecompositionCache).toBeInstanceOf(DiskTieredDecompositionCache);
   });
 
   it('rejects invalid or tampered records and removes them', async () => {

--- a/src/decomposition-cache.ts
+++ b/src/decomposition-cache.ts
@@ -186,6 +186,12 @@ export class DiskTieredDecompositionCache implements DecompositionCache {
       this.recordCorrupt(file);
       return null;
     }
+    // Best-effort LRU: touch mtime so the disk cap evicts least-recently-used.
+    try {
+      fs.utimesSync(file, new Date(), new Date());
+    } catch {
+      // a missing/locked file is fine to ignore
+    }
     return record.subqueries.slice();
   }
 
@@ -228,6 +234,11 @@ export class DiskTieredDecompositionCache implements DecompositionCache {
     }
   }
 }
+
+// Process-wide default so long-lived daemons (`kb serve`) share one warm L1
+// across searches instead of building a cold cache per query. One-shot `kb
+// search` processes still start and exit with a single cache instance.
+export const defaultDecompositionCache = new DiskTieredDecompositionCache();
 
 function isValidIdentity(modelId: string, query: string): boolean {
   return modelId.trim() !== '' && normalizeDecompositionQuery(query) !== '';

--- a/src/query-decomposition.test.ts
+++ b/src/query-decomposition.test.ts
@@ -9,6 +9,10 @@ import {
   queryDecompositionTraceToJson,
   runQueryDecomposition,
 } from './query-decomposition.js';
+import {
+  defaultDecompositionCache,
+  DiskTieredDecompositionCache,
+} from './decomposition-cache.js';
 import type { DecompositionCache } from './decomposition-cache.js';
 import type { HybridChunk } from './hybrid-retrieval.js';
 
@@ -62,6 +66,65 @@ describe('LLM query decomposition cache (#736)', () => {
     expect(get).toHaveBeenNthCalledWith(1, 'model-a', 'Multi   hop query');
     expect(set).toHaveBeenCalledWith('model-a', 'Multi   hop query', ['hop one', 'hop two']);
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('shares the process-global cache across default decomposers (#894)', async () => {
+    const fetchMock = jest.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify({
+      choices: [{ message: { content: '{"subqueries":["cached hop"]}' } }],
+      model: 'model-a',
+    }), { status: 200, headers: { 'content-type': 'application/json' } }));
+    const get = jest.spyOn(defaultDecompositionCache, 'get')
+      .mockReturnValueOnce(null)
+      .mockReturnValueOnce(['cached hop']);
+    const set = jest.spyOn(defaultDecompositionCache, 'set').mockImplementation(() => undefined);
+
+    const first = createLocalLlmQueryDecomposer(undefined, {
+      endpoint: 'http://llm.test',
+      model: 'model-a',
+    });
+    const second = createLocalLlmQueryDecomposer(undefined, {
+      endpoint: 'http://llm.test',
+      model: 'model-a',
+    });
+
+    await expect(first.decompose('shared query')).resolves.toEqual(['cached hop']);
+    await expect(second.decompose('shared query')).resolves.toEqual(['cached hop']);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(get).toHaveBeenCalledTimes(2);
+    expect(set).toHaveBeenCalledTimes(1);
+    expect(get.mock.instances[0]).toBe(defaultDecompositionCache);
+    expect(get.mock.instances[1]).toBe(defaultDecompositionCache);
+  });
+
+  it('records L1 hits across decomposers that share one cache (#894)', async () => {
+    const indexPath = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-decomposition-shared-l1-'));
+    try {
+      const fetchMock = jest.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify({
+        choices: [{ message: { content: '{"subqueries":["hop one","hop two"]}' } }],
+        model: 'model-a',
+      }), { status: 200, headers: { 'content-type': 'application/json' } }));
+      const cache = new DiskTieredDecompositionCache({
+        indexPath,
+        enabled: true,
+      });
+      const first = createLocalLlmQueryDecomposer(undefined, {
+        endpoint: 'http://llm.test',
+        model: 'model-a',
+        cache,
+      });
+      const second = createLocalLlmQueryDecomposer(undefined, {
+        endpoint: 'http://llm.test',
+        model: 'model-a',
+        cache,
+      });
+
+      await expect(first.decompose('Multi hop query')).resolves.toEqual(['hop one', 'hop two']);
+      await expect(second.decompose('multi hop query')).resolves.toEqual(['hop one', 'hop two']);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(cache.stats()).toMatchObject({ writes: 1, l1_hits: 1, disk_hits: 0, misses: 1 });
+    } finally {
+      await fsp.rm(indexPath, { recursive: true, force: true });
+    }
   });
 
   it('never caches provider failures, invalid responses, or offline fallback results', async () => {

--- a/src/query-decomposition.ts
+++ b/src/query-decomposition.ts
@@ -1,7 +1,7 @@
 import { callChatCompletion } from './llm-client.js';
 import type { HybridChunk } from './hybrid-retrieval.js';
 import { chunkIdFromMetadata } from './rrf.js';
-import { DiskTieredDecompositionCache } from './decomposition-cache.js';
+import { defaultDecompositionCache } from './decomposition-cache.js';
 import type { DecompositionCache } from './decomposition-cache.js';
 import { resolveLlmProvider } from './config/llm-provider.js';
 import { readLlmContextPolicy } from './sensitivity-policy.js';
@@ -178,7 +178,7 @@ export function createLocalLlmQueryDecomposer(
   fallback: QueryDecompositionProvider = createRuleBasedQueryDecomposer(),
   options: LocalLlmQueryDecomposerOptions = {},
 ): QueryDecompositionProvider {
-  const cache = options.cache ?? new DiskTieredDecompositionCache();
+  const cache = options.cache ?? defaultDecompositionCache;
   return {
     name: 'local-llm',
     async decompose(query) {

--- a/src/rerank-cache-disk.test.ts
+++ b/src/rerank-cache-disk.test.ts
@@ -167,6 +167,43 @@ describe('DiskTieredRerankScoreCache (#646)', () => {
     }
   });
 
+  it('evicts the least-recently-read disk entry, not the oldest write (#894)', async () => {
+    const indexPath = await tempIndexPath('kb-rerank-cache-true-lru-');
+    try {
+      const probe = new DiskTieredRerankScoreCache({ indexPath, enabled: true });
+      probe.set(MODEL, 'probe', 'probe-body', 0.1);
+      const entryBytes = probe.diskSizeBytes();
+      await fsp.rm(rerankScoreCacheRoot(indexPath), { recursive: true, force: true });
+
+      const cache = new DiskTieredRerankScoreCache({
+        indexPath,
+        enabled: true,
+        l1Max: 0,
+        diskMaxBytes: Math.floor(entryBytes * 2.5),
+      });
+
+      cache.set(MODEL, 'q1', 'first', 0.11);
+      const q1Key = rerankScoreCacheKey(MODEL, 'q1', 'first');
+      const q1File = path.join(rerankScoreCacheRoot(indexPath), q1Key.slice(0, 2), `${q1Key}.json`);
+      fs.utimesSync(q1File, new Date(1_000), new Date(1_000));
+      cache.set(MODEL, 'q2', 'second', 0.22);
+      const q2Key = rerankScoreCacheKey(MODEL, 'q2', 'second');
+      const q2File = path.join(rerankScoreCacheRoot(indexPath), q2Key.slice(0, 2), `${q2Key}.json`);
+      fs.utimesSync(q2File, new Date(2_000), new Date(2_000));
+
+      // A hit must bump q1 ahead of q2 so the next overflow evicts q2.
+      expect(cache.get(MODEL, 'q1', 'first')).toBe(0.11);
+      cache.set(MODEL, 'q3', 'third', 0.33);
+
+      expect(cache.diskSizeBytes()).toBeLessThanOrEqual(Math.floor(entryBytes * 2.5));
+      expect(cache.get(MODEL, 'q2', 'second')).toBeNull();
+      expect(cache.get(MODEL, 'q1', 'first')).toBe(0.11);
+      expect(cache.get(MODEL, 'q3', 'third')).toBe(0.33);
+    } finally {
+      await fsp.rm(path.dirname(indexPath), { recursive: true, force: true });
+    }
+  });
+
   it('treats a corrupt disk entry as a miss and removes it', async () => {
     const indexPath = await tempIndexPath('kb-rerank-cache-corrupt-');
     try {

--- a/src/rerank-cache-disk.ts
+++ b/src/rerank-cache-disk.ts
@@ -210,6 +210,12 @@ export class DiskTieredRerankScoreCache implements RerankScoreCache {
       this.recordCorrupt(file);
       return null;
     }
+    // Best-effort LRU: touch mtime so the disk cap evicts least-recently-used.
+    try {
+      fs.utimesSync(file, new Date(), new Date());
+    } catch {
+      // a missing/locked file is fine to ignore
+    }
     return record.score;
   }
 


### PR DESCRIPTION
## Summary

<!-- kookr:check:prose -->

The rerank cache (saved scores used to re-order search hits) and the query-decomposition cache (saved splits of a question into sub-queries) both claimed to drop least-recently-used files when the on-disk size limit was full. A cache hit never updated the file's modification time, so a frequently reused entry looked as old as one nobody had read since it was written, and got deleted first. This change updates that timestamp on every successful disk hit, so eviction drops the entry that has actually gone unused.

The decomposition cache's in-memory layer (the fast RAM copy of recent splits) was also rebuilt for every search. Long-lived `kb serve` processes now share one process-wide cache so a hit in one search is still a hit in the next. One-shot `kb search` is unchanged: it still starts and exits with a single cache instance.

Call sites did not need edits. `kb search` already builds a decomposer without passing a cache, so it picks up the shared default. The rerank cache already had a process-wide singleton (`globalRerankScoreCache`); only its disk-hit timestamp needed fixing. The timestamp touch matches the existing answer-cache idiom in `src/ask-answer-cache.ts`.

L1 hits do not touch disk mtime. That keeps the in-memory path free of a syscall; disk LRU is true for cold-L1 / disk-tier hits, which is the path that matters under a full cap after restart or with the memory tier disabled.

Fixes #894

## Testing

- [x] `npm test` passes <!-- typecheck, build, 212 parallel suites + 478 serial tests -->
- [ ] ~~End-to-end verified for tool/transport changes (see `CLAUDE.md`)~~ — N/A: cache eviction and decomposer default-cache wiring only; no MCP tool or transport change.
- [ ] ~~Benchmark run if performance-relevant: `BENCH_PROVIDER=stub npm run bench`~~ — N/A: eviction-order correctness, not a retrieval-quality or throughput claim.
- [x] <!-- kookr:check:tests --> Tests were added or updated for changed behavior; bug fixes include a regression test

## Documentation contract

- [ ] ~~<!-- kookr:check:readme --> `README.md` reflects user-visible CLI, MCP, installation, or configuration changes~~ — N/A: no CLI/MCP/install/config surface change.
- [x] <!-- kookr:check:docs --> Relevant operator, API, configuration, and retrieval documentation under `docs/` is consistent with the implementation <!-- docs/architecture/data-model.md now says the disk sweep drops least-recently-used entries (reads refresh mtime) -->
- [ ] ~~<!-- kookr:check:mbse --> RFCs are updated when this PR implements, supersedes, or changes an accepted design~~ — N/A: corrective cache-eviction fix; no accepted RFC or design is superseded.

## Changelog

- [ ] ~~<!-- kookr:check:changelog --> `CHANGELOG.md` has an `Unreleased` entry for user-visible changes~~ — N/A: repository has no `CHANGELOG.md`.

## Retrieval and performance evidence

- [ ] ~~<!-- kookr:check:benchmarks --> Retrieval-quality or performance changes include the relevant benchmark/evaluation evidence, or this row is waived with a reason~~ — N/A: cache-correctness change; eviction order is covered by unit tests, not a benchmark.

## Follow-ups

None.
