### PR TITLE
fix(watch): index files in subdirectories created after the daemon starts

### DIFF
--- a/src/recursive-fs-watch.test.ts
+++ b/src/recursive-fs-watch.test.ts
@@ -275,6 +275,202 @@ describe('RecursiveKbWatcher (RFC 007 §6.6 / issue #212)', () => {
     expect(onChange).toHaveBeenCalledTimes(1);
     expect(onChange).toHaveBeenCalledWith(KB);
   });
+
+  describe('per-directory discovery of subdirs created after start (issue #893)', () => {
+    it('indexes a file already present when a new subdirectory is first observed', async () => {
+      // mkdir-then-immediate-write: the file exists before the new
+      // watcher is attached, so listing at discovery time is what
+      // surfaces it. The test hook drives discovery without waiting
+      // on inotify.
+      const onChange = jest.fn().mockResolvedValue(undefined);
+      const watcher = makeWatcher({ onChange, debounceMs: 25 });
+      await watcher.start();
+      const watchedAtStart = watcher.watchedDirectoryCount(KB);
+
+      const topic = path.join(tempDir, KB, 'topic');
+      await fsp.mkdir(topic);
+      await fsp.writeFile(path.join(topic, 'note.md'), 'hello');
+      await watcher.handlePossibleNewDirectory(KB, 'topic');
+
+      expect(watcher.watchedDirectoryCount(KB)).toBe(watchedAtStart + 1);
+      await drain(80);
+      await watcher.stop();
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledWith(KB);
+    });
+
+    it('indexes a file already present in a nested subdirectory of a newly observed dir', async () => {
+      const onChange = jest.fn().mockResolvedValue(undefined);
+      const watcher = makeWatcher({ onChange, debounceMs: 25 });
+      await watcher.start();
+      const watchedAtStart = watcher.watchedDirectoryCount(KB);
+
+      await fsp.mkdir(path.join(tempDir, KB, 'topic/nested'), { recursive: true });
+      await fsp.writeFile(path.join(tempDir, KB, 'topic/nested/note.md'), 'hello');
+      await watcher.handlePossibleNewDirectory(KB, 'topic');
+
+      expect(watcher.watchedDirectoryCount(KB)).toBe(watchedAtStart + 2);
+      await drain(80);
+      await watcher.stop();
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledWith(KB);
+    });
+
+    it('does not attach a second watcher to a directory that already has one', async () => {
+      const onChange = jest.fn().mockResolvedValue(undefined);
+      const watcher = makeWatcher({ onChange, debounceMs: 25 });
+      await watcher.start();
+      const watchedAtStart = watcher.watchedDirectoryCount(KB);
+
+      await fsp.mkdir(path.join(tempDir, KB, 'topic'));
+      await Promise.all([
+        watcher.handlePossibleNewDirectory(KB, 'topic'),
+        watcher.handlePossibleNewDirectory(KB, 'topic'),
+      ]);
+
+      expect(watcher.watchedDirectoryCount(KB)).toBe(watchedAtStart + 1);
+      await drain(80);
+      await watcher.stop();
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('does not follow a symlink to a directory outside the KB', async () => {
+      const onChange = jest.fn().mockResolvedValue(undefined);
+      const watcher = makeWatcher({ onChange, debounceMs: 25 });
+      await watcher.start();
+      const watchedAtStart = watcher.watchedDirectoryCount(KB);
+
+      const outside = await fsp.mkdtemp(path.join(os.tmpdir(), 'kb-fs-watch-outside-'));
+      try {
+        await fsp.writeFile(path.join(outside, 'secret.md'), 'nope');
+        await fsp.symlink(outside, path.join(tempDir, KB, 'alias'));
+        await watcher.handlePossibleNewDirectory(KB, 'alias');
+        expect(watcher.watchedDirectoryCount(KB)).toBe(watchedAtStart);
+        await drain(80);
+        await watcher.stop();
+        expect(onChange).not.toHaveBeenCalled();
+      } finally {
+        await fsp.rm(outside, { recursive: true, force: true });
+      }
+    });
+
+    it('re-attaches after a watched subdirectory is removed and created again', async () => {
+      const onChange = jest.fn().mockResolvedValue(undefined);
+      const watcher = makeWatcher({ onChange, debounceMs: 25 });
+      await watcher.start();
+      const watchedAtStart = watcher.watchedDirectoryCount(KB);
+      const topic = path.join(tempDir, KB, 'topic');
+
+      await fsp.mkdir(topic);
+      await watcher.handlePossibleNewDirectory(KB, 'topic');
+      expect(watcher.watchedDirectoryCount(KB)).toBe(watchedAtStart + 1);
+
+      await fsp.rm(topic, { recursive: true, force: true });
+      await watcher.handlePossibleNewDirectory(KB, 'topic');
+      expect(watcher.watchedDirectoryCount(KB)).toBe(watchedAtStart);
+
+      await fsp.mkdir(topic);
+      await fsp.writeFile(path.join(topic, 'note.md'), 'hello');
+      await watcher.handlePossibleNewDirectory(KB, 'topic');
+      expect(watcher.watchedDirectoryCount(KB)).toBe(watchedAtStart + 1);
+      await drain(80);
+      await watcher.stop();
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledWith(KB);
+    });
+
+    it('does not attach a watcher to a dot-prefixed directory', async () => {
+      const onChange = jest.fn().mockResolvedValue(undefined);
+      const watcher = makeWatcher({ onChange, debounceMs: 25 });
+      await watcher.start();
+      const watchedAtStart = watcher.watchedDirectoryCount(KB);
+
+      await fsp.mkdir(path.join(tempDir, KB, '.index'));
+      await fsp.writeFile(path.join(tempDir, KB, '.index', 'sidecar.md'), 'nope');
+      await watcher.handlePossibleNewDirectory(KB, '.index');
+
+      expect(watcher.watchedDirectoryCount(KB)).toBe(watchedAtStart);
+      await drain(80);
+      await watcher.stop();
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('indexes a file written after a newly observed subdirectory is already being watched', async () => {
+      const onChange = jest.fn().mockResolvedValue(undefined);
+      const watcher = makeWatcher({ onChange, debounceMs: 50 });
+      await watcher.start();
+      const watchedAtStart = watcher.watchedDirectoryCount(KB);
+
+      const topic = path.join(tempDir, KB, 'topic');
+      await fsp.mkdir(topic);
+      await watcher.handlePossibleNewDirectory(KB, 'topic');
+      expect(watcher.watchedDirectoryCount(KB)).toBe(watchedAtStart + 1);
+      await drain(40);
+      expect(onChange).not.toHaveBeenCalled();
+
+      await fsp.writeFile(path.join(topic, 'note.md'), 'hello');
+      await drain(250);
+      await watcher.stop();
+
+      if (onChange.mock.calls.length === 0) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          'recursive-fs-watch later-write new-subdir test: fs.watch backend delivered no events; ' +
+            'skipping count assertion (this can happen on NFS/FUSE filesystems).',
+        );
+        return;
+      }
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledWith(KB);
+    });
+
+    it('does not fire onChange for a non-ingestable file in a newly observed directory', async () => {
+      const onChange = jest.fn().mockResolvedValue(undefined);
+      const watcher = makeWatcher({ onChange, debounceMs: 25 });
+      await watcher.start();
+
+      const topic = path.join(tempDir, KB, 'topic');
+      await fsp.mkdir(topic);
+      await fsp.writeFile(path.join(topic, 'shot.png'), 'nope');
+      await watcher.handlePossibleNewDirectory(KB, 'topic');
+      await drain(80);
+      await watcher.stop();
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('end-to-end: mkdir then write into the new subdir is indexed without a restart', async () => {
+      const onChange = jest.fn().mockResolvedValue(undefined);
+      const watcher = makeWatcher({ onChange, debounceMs: 50 });
+      await watcher.start();
+      const watchedAtStart = watcher.watchedDirectoryCount(KB);
+
+      // Control write in an already-watched directory. If this does
+      // not fire, the backend is not delivering events (NFS/FUSE) and
+      // the subdir case cannot be judged. If it does fire, a missing
+      // new-subdir discovery is a real failure — not a skip.
+      await fsp.writeFile(path.join(tempDir, KB, 'probe.md'), 'probe');
+      await drain(250);
+      if (onChange.mock.calls.length === 0) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          'recursive-fs-watch e2e new-subdir test: fs.watch backend delivered no events; ' +
+            'skipping count assertion (this can happen on NFS/FUSE filesystems).',
+        );
+        await watcher.stop();
+        return;
+      }
+      onChange.mockClear();
+
+      const topic = path.join(tempDir, KB, 'topic');
+      await fsp.mkdir(topic);
+      await fsp.writeFile(path.join(topic, 'note.md'), 'hello');
+      await drain(300);
+      expect(watcher.watchedDirectoryCount(KB)).toBe(watchedAtStart + 1);
+      await watcher.stop();
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledWith(KB);
+    });
+  });
 });
 
 describe('enumerateDirectories', () => {

--- a/src/recursive-fs-watch.test.ts
+++ b/src/recursive-fs-watch.test.ts
@@ -416,6 +416,27 @@ describe('RecursiveKbWatcher (RFC 007 §6.6 / issue #212)', () => {
       }
     });
 
+    it('preserves watching when the registered KB root is a symlink', async () => {
+      const onChange = jest.fn().mockResolvedValue(undefined);
+      const watcher = makeWatcher({ onChange });
+      const root = path.join(tempDir, KB);
+      const actual = path.join(tempDir, 'actual-notes');
+      await fsp.rename(root, actual);
+      await fsp.symlink(actual, root, 'dir');
+      try {
+        await watcher.start();
+        expect(watcher.watchedDirectoryCount(KB)).toBe(1);
+        await fsp.mkdir(path.join(actual, 'topic'));
+        await fsp.writeFile(path.join(actual, 'topic', 'note.md'), 'hello');
+        await watcher.handlePossibleNewDirectory(KB, 'topic');
+        expect(watcher.watchedDirectoryCount(KB)).toBe(2);
+        await drain(80);
+        expect(onChange).toHaveBeenCalledWith(KB);
+      } finally {
+        await watcher.stop();
+      }
+    });
+
     it('re-attaches after a watched subdirectory is removed and created again', async () => {
       const onChange = jest.fn().mockResolvedValue(undefined);
       const watcher = makeWatcher({ onChange, debounceMs: 25 });

--- a/src/recursive-fs-watch.test.ts
+++ b/src/recursive-fs-watch.test.ts
@@ -1,3 +1,4 @@
+import fs from 'fs';
 import * as fsp from 'fs/promises';
 import * as os from 'os';
 import * as path from 'path';
@@ -332,6 +333,67 @@ describe('RecursiveKbWatcher (RFC 007 §6.6 / issue #212)', () => {
       await drain(80);
       await watcher.stop();
       expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('discovers nested files created just before their parent watch attaches', async () => {
+      const onChange = jest.fn().mockResolvedValue(undefined);
+      const watcher = makeWatcher({ onChange });
+      const topic = path.join(tempDir, KB, 'topic');
+      const originalWatch = fs.watch;
+      const watchSpy = jest.spyOn(fs, 'watch').mockImplementation((dir) => {
+        if (dir === topic) {
+          fs.mkdirSync(path.join(topic, 'nested'));
+          fs.writeFileSync(path.join(topic, 'nested', 'note.md'), 'hello');
+        }
+        // Suppress kernel callbacks: only the discovery listing can find the
+        // nested directory created at the enumeration/subscription boundary.
+        return originalWatch(dir, () => undefined);
+      });
+      try {
+        await watcher.start();
+        await fsp.mkdir(topic);
+        await watcher.handlePossibleNewDirectory(KB, 'topic');
+        expect(watcher.watchedDirectoryCount(KB)).toBe(3);
+        await drain(80);
+        expect(onChange).toHaveBeenCalledWith(KB);
+      } finally {
+        await watcher.stop();
+        watchSpy.mockRestore();
+      }
+    });
+
+    it('replaces the old inode watch when a directory is recreated before discovery', async () => {
+      const onChange = jest.fn().mockResolvedValue(undefined);
+      const watcher = makeWatcher({ onChange });
+      const topic = path.join(tempDir, KB, 'topic');
+      const originalWatch = fs.watch;
+      const watchSpy = jest.spyOn(fs, 'watch').mockImplementation((dir) =>
+        originalWatch(dir, () => undefined),
+      );
+      try {
+        await watcher.start();
+        await fsp.mkdir(path.join(topic, 'nested'), { recursive: true });
+        await watcher.handlePossibleNewDirectory(KB, 'topic');
+        const originalHandle = watchSpy.mock.results[1].value as fs.FSWatcher;
+        const closeSpy = jest.spyOn(originalHandle, 'close');
+        const nestedHandle = watchSpy.mock.results[2].value as fs.FSWatcher;
+        const nestedCloseSpy = jest.spyOn(nestedHandle, 'close');
+        // Renaming retains the old inode, making replacement identity
+        // deterministic while no discovery observes an absent topic path.
+        await fsp.rename(topic, path.join(tempDir, KB, '.old-topic'));
+        await fsp.mkdir(topic);
+        await fsp.writeFile(path.join(topic, 'note.md'), 'replacement');
+        await watcher.handlePossibleNewDirectory(KB, 'topic');
+        expect(watchSpy).toHaveBeenCalledTimes(4);
+        expect(closeSpy).toHaveBeenCalledTimes(1);
+        expect(nestedCloseSpy).toHaveBeenCalledTimes(1);
+        expect(watcher.watchedDirectoryCount(KB)).toBe(2);
+        await drain(80);
+        expect(onChange).toHaveBeenCalledWith(KB);
+      } finally {
+        await watcher.stop();
+        watchSpy.mockRestore();
+      }
     });
 
     it('does not follow a symlink to a directory outside the KB', async () => {

--- a/src/recursive-fs-watch.ts
+++ b/src/recursive-fs-watch.ts
@@ -87,8 +87,8 @@ interface PerKbState {
   kbName: string;
   kbPath: string;
   watchers: fs.FSWatcher[];
-  /** Absolute paths that already have a per-directory watcher. */
-  watchedDirs: Set<string>;
+  /** Directory identity prevents a replacement path retaining an old inode's watch. */
+  directoryWatches: Map<string, { watcher: fs.FSWatcher; dev: number; ino: number }>;
   debounceTimers: Map<string, NodeJS.Timeout>;
   inFlight: Promise<void> | null;
   pending: boolean;
@@ -130,7 +130,7 @@ export class RecursiveKbWatcher {
         kbName: target.kbName,
         kbPath: target.kbPath,
         watchers: [],
-        watchedDirs: new Set(),
+        directoryWatches: new Map(),
         debounceTimers: new Map(),
         inFlight: null,
         pending: false,
@@ -181,7 +181,7 @@ export class RecursiveKbWatcher {
         }
       }
       state.watchers = [];
-      state.watchedDirs.clear();
+      state.directoryWatches.clear();
     }
     const drains = Array.from(this.states.values())
       .map((state) => state.inFlight)
@@ -226,7 +226,7 @@ export class RecursiveKbWatcher {
   watchedDirectoryCount(kbName: string): number {
     const state = this.states.get(kbName);
     if (state === undefined) return 0;
-    return state.watchedDirs.size;
+    return state.directoryWatches.size;
   }
 
   private useRecursive(): boolean {
@@ -256,22 +256,21 @@ export class RecursiveKbWatcher {
   }
 
   private async attachPerDirectory(state: PerKbState): Promise<void> {
-    const dirs = await enumerateDirectories(state.kbPath);
-    for (const dir of dirs) {
-      this.watchDirectory(state, dir);
-    }
+    await this.discoverNewDirectory(state, state.kbPath, false);
   }
 
   /**
    * Attach one non-recursive `fs.watch` to `dir` if this KB does not
-   * already have one. Claim the path before `fs.watch` so a re-entrant
-   * discovery (parent event + nested walk) cannot open a second handle.
+   * already have one for the same inode. There is no await between checking
+   * the identity and registering the handle, so concurrent discovery cannot
+   * attach a duplicate. Returns whether a new watch needs its contents scanned.
    */
-  private watchDirectory(state: PerKbState, dir: string): void {
-    if (this.stopped) return;
+  private watchDirectory(state: PerKbState, dir: string, st: fs.Stats): boolean {
+    if (this.stopped) return false;
     const absDir = path.resolve(dir);
-    if (state.watchedDirs.has(absDir)) return;
-    state.watchedDirs.add(absDir);
+    const existing = state.directoryWatches.get(absDir);
+    if (existing?.dev === st.dev && existing.ino === st.ino) return false;
+    this.closeDirectoryTree(state, absDir);
     try {
       const watcher = fs.watch(dir, (_event, filename) => {
         void this.onPerDirectoryFsEvent(state, dir, filename);
@@ -279,20 +278,41 @@ export class RecursiveKbWatcher {
       watcher.on('error', (err) => {
         // Deleted-dir / dead-inode errors leave a stale claim that
         // would block re-attach if the same path is created again.
-        state.watchedDirs.delete(absDir);
+        // A late error from a replaced handle must not drop the new watch.
+        if (state.directoryWatches.get(absDir)?.watcher === watcher) {
+          this.closeDirectoryWatch(state, absDir);
+        }
         logger.warn(
           `RecursiveKbWatcher: error on ${dir} (${state.kbName}): ${err.message}`,
         );
       });
       state.watchers.push(watcher);
+      state.directoryWatches.set(absDir, { watcher, dev: st.dev, ino: st.ino });
+      return true;
     } catch (err) {
       // A subdir that disappeared between enumerate and attach, or an
       // inotify slot exhaustion on this one dir, is not a hard error —
       // drop the claim so a later event can retry.
-      state.watchedDirs.delete(absDir);
       logger.debug(
         `RecursiveKbWatcher: skip ${dir} (${state.kbName}): ${(err as Error).message}`,
       );
+      return false;
+    }
+  }
+
+  private closeDirectoryWatch(state: PerKbState, absDir: string): void {
+    const existing = state.directoryWatches.get(absDir);
+    if (!existing) return;
+    state.directoryWatches.delete(absDir);
+    state.watchers = state.watchers.filter((watcher) => watcher !== existing.watcher);
+    existing.watcher.close();
+  }
+
+  private closeDirectoryTree(state: PerKbState, absDir: string): void {
+    for (const dir of state.directoryWatches.keys()) {
+      if (dir === absDir || dir.startsWith(absDir + path.sep)) {
+        this.closeDirectoryWatch(state, dir);
+      }
     }
   }
 
@@ -326,11 +346,15 @@ export class RecursiveKbWatcher {
    * what closes the mkdir-then-immediate-write race: a file written
    * before the new watcher is attached never generates its own event.
    */
-  private async discoverNewDirectory(state: PerKbState, absPath: string): Promise<void> {
+  private async discoverNewDirectory(
+    state: PerKbState,
+    absPath: string,
+    emitExisting = true,
+  ): Promise<void> {
     if (this.stopped || this.useRecursive()) return;
 
     const relFromKb = path.relative(state.kbPath, absPath);
-    if (relFromKb === '' || relFromKb.startsWith('..')) return;
+    if (relFromKb.startsWith('..')) return;
     // Same skip as `enumerateDirectories`: `.index/` and `.git/` are
     // indexer / vcs sidecars, never corpus.
     if (relFromKb.split(path.sep).some((segment) => segment.startsWith('.'))) return;
@@ -342,29 +366,25 @@ export class RecursiveKbWatcher {
       // not pull us into the target tree. Startup enumeration uses
       // dirent.isDirectory(), which likewise does not follow links.
       st = await fsp.lstat(absPath);
-    } catch {
+    } catch (err) {
       // Path vanished (typical: rmdir of a previously watched dir).
-      // Drop the claim so a later mkdir of the same name can attach.
-      state.watchedDirs.delete(resolved);
+      // Close the handle too; otherwise repeated replacements leak watches.
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+        this.closeDirectoryTree(state, resolved);
+      }
       return;
     }
-    if (!st.isDirectory()) return;
-    if (state.watchedDirs.has(resolved)) return;
-
-    const dirs = await enumerateDirectories(absPath);
-    if (this.stopped) return;
-
-    for (const dir of dirs) {
-      const wasNew = !state.watchedDirs.has(path.resolve(dir));
-      this.watchDirectory(state, dir);
-      if (wasNew) {
-        await this.emitExistingFiles(state, dir);
-        if (this.stopped) return;
-      }
+    if (!st.isDirectory()) {
+      this.closeDirectoryTree(state, resolved);
+      return;
     }
+    if (!this.watchDirectory(state, absPath, st)) return;
+    // Subscribe before listing. Children created before subscription are in
+    // the listing; children created afterward also produce a parent event.
+    await this.scanDirectory(state, absPath, emitExisting);
   }
 
-  private async emitExistingFiles(state: PerKbState, dir: string): Promise<void> {
+  private async scanDirectory(state: PerKbState, dir: string, emitExisting: boolean): Promise<void> {
     if (this.stopped) return;
     let entries: fs.Dirent[];
     try {
@@ -378,8 +398,12 @@ export class RecursiveKbWatcher {
     for (const entry of entries) {
       if (this.stopped) return;
       if (entry.name.startsWith('.')) continue;
-      if (entry.isDirectory()) continue;
       const absPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        await this.discoverNewDirectory(state, absPath, emitExisting);
+        continue;
+      }
+      if (!emitExisting) continue;
       const relFromKb = path.relative(state.kbPath, absPath);
       if (relFromKb === '' || relFromKb.startsWith('..')) continue;
       this.onRawFsEvent(state, relFromKb);

--- a/src/recursive-fs-watch.ts
+++ b/src/recursive-fs-watch.ts
@@ -362,10 +362,10 @@ export class RecursiveKbWatcher {
     const resolved = path.resolve(absPath);
     let st: fs.Stats;
     try {
-      // lstat, not stat: a symlink whose name sits inside the KB must
-      // not pull us into the target tree. Startup enumeration uses
-      // dirent.isDirectory(), which likewise does not follow links.
-      st = await fsp.lstat(absPath);
+      // Registered KB roots may themselves be symlinks, as supported by
+      // the indexer and original startup walk. Only discovered descendants
+      // use lstat, so links inside the corpus cannot pull us into other trees.
+      st = relFromKb === '' ? await fsp.stat(absPath) : await fsp.lstat(absPath);
     } catch (err) {
       // Path vanished (typical: rmdir of a previously watched dir).
       // Close the handle too; otherwise repeated replacements leak watches.

--- a/src/recursive-fs-watch.ts
+++ b/src/recursive-fs-watch.ts
@@ -13,8 +13,10 @@
 //   1. Per registered KB, attach a recursive `fs.watch(kbPath,
 //      {recursive: true})` on macOS / Windows. On Linux + WSL fall back
 //      to a non-recursive watch on each subdirectory enumerated at
-//      startup (`getFilesRecursively` already supplies the subdir set
-//      we need; we re-walk it here to harvest the directory list).
+//      startup, then attach more watches when new subdirectories appear
+//      after start (issue #893). Native recursive mode already delivers
+//      those events; per-directory `fs.watch` does not follow children
+//      created later, so we must discover them ourselves.
 //   2. Filter events through the same dotfile + extension allowlist +
 //      `INGEST_EXCLUDE_PATHS` rules the indexer uses. Anything the
 //      walker would skip is dropped on the watcher path too.
@@ -85,6 +87,8 @@ interface PerKbState {
   kbName: string;
   kbPath: string;
   watchers: fs.FSWatcher[];
+  /** Absolute paths that already have a per-directory watcher. */
+  watchedDirs: Set<string>;
   debounceTimers: Map<string, NodeJS.Timeout>;
   inFlight: Promise<void> | null;
   pending: boolean;
@@ -126,6 +130,7 @@ export class RecursiveKbWatcher {
         kbName: target.kbName,
         kbPath: target.kbPath,
         watchers: [],
+        watchedDirs: new Set(),
         debounceTimers: new Map(),
         inFlight: null,
         pending: false,
@@ -176,6 +181,7 @@ export class RecursiveKbWatcher {
         }
       }
       state.watchers = [];
+      state.watchedDirs.clear();
     }
     const drains = Array.from(this.states.values())
       .map((state) => state.inFlight)
@@ -195,6 +201,32 @@ export class RecursiveKbWatcher {
     const state = this.states.get(kbName);
     if (state === undefined) return;
     this.onRawFsEvent(state, eventTarget);
+  }
+
+  /**
+   * Test hook — run the per-directory "new subdirectory" discovery
+   * path without waiting on a real `fs.watch` event. Covers the
+   * mkdir-then-immediate-write race and duplicate-attach guard
+   * without depending on inotify timing.
+   */
+  async handlePossibleNewDirectory(kbName: string, eventTarget: string): Promise<void> {
+    const state = this.states.get(kbName);
+    if (state === undefined) return;
+    const relativePath = eventTarget.split(path.sep).join('/');
+    const absPath = path.join(state.kbPath, relativePath);
+    // Same shape as a real per-directory `fs.watch` callback: `filename`
+    // is one path segment relative to the already-watched parent.
+    await this.onPerDirectoryFsEvent(state, path.dirname(absPath), path.basename(absPath));
+  }
+
+  /**
+   * Test hook — number of per-directory `fs.watch` handles currently
+   * attached for a KB. Recursive mode never populates this set.
+   */
+  watchedDirectoryCount(kbName: string): number {
+    const state = this.states.get(kbName);
+    if (state === undefined) return 0;
+    return state.watchedDirs.size;
   }
 
   private useRecursive(): boolean {
@@ -226,30 +258,131 @@ export class RecursiveKbWatcher {
   private async attachPerDirectory(state: PerKbState): Promise<void> {
     const dirs = await enumerateDirectories(state.kbPath);
     for (const dir of dirs) {
-      try {
-        const watcher = fs.watch(dir, (_event, filename) => {
-          if (filename === null) return;
-          // `filename` is relative to the watched directory; rebuild a
-          // KB-root-relative path so the ingest filter sees the same
-          // shape it would from the recursive mode.
-          const absPath = path.join(dir, filename.toString());
-          const relFromKb = path.relative(state.kbPath, absPath);
-          if (relFromKb === '' || relFromKb.startsWith('..')) return;
-          this.onRawFsEvent(state, relFromKb);
-        });
-        watcher.on('error', (err) => {
-          logger.warn(
-            `RecursiveKbWatcher: error on ${dir} (${state.kbName}): ${err.message}`,
-          );
-        });
-        state.watchers.push(watcher);
-      } catch (err) {
-        // A subdir that disappeared between enumerate and attach is
-        // not a hard error — skip it.
-        logger.debug(
-          `RecursiveKbWatcher: skip ${dir} (${state.kbName}): ${(err as Error).message}`,
+      this.watchDirectory(state, dir);
+    }
+  }
+
+  /**
+   * Attach one non-recursive `fs.watch` to `dir` if this KB does not
+   * already have one. Claim the path before `fs.watch` so a re-entrant
+   * discovery (parent event + nested walk) cannot open a second handle.
+   */
+  private watchDirectory(state: PerKbState, dir: string): void {
+    if (this.stopped) return;
+    const absDir = path.resolve(dir);
+    if (state.watchedDirs.has(absDir)) return;
+    state.watchedDirs.add(absDir);
+    try {
+      const watcher = fs.watch(dir, (_event, filename) => {
+        void this.onPerDirectoryFsEvent(state, dir, filename);
+      });
+      watcher.on('error', (err) => {
+        // Deleted-dir / dead-inode errors leave a stale claim that
+        // would block re-attach if the same path is created again.
+        state.watchedDirs.delete(absDir);
+        logger.warn(
+          `RecursiveKbWatcher: error on ${dir} (${state.kbName}): ${err.message}`,
         );
+      });
+      state.watchers.push(watcher);
+    } catch (err) {
+      // A subdir that disappeared between enumerate and attach, or an
+      // inotify slot exhaustion on this one dir, is not a hard error —
+      // drop the claim so a later event can retry.
+      state.watchedDirs.delete(absDir);
+      logger.debug(
+        `RecursiveKbWatcher: skip ${dir} (${state.kbName}): ${(err as Error).message}`,
+      );
+    }
+  }
+
+  private onPerDirectoryFsEvent(
+    state: PerKbState,
+    dir: string,
+    filename: string | Buffer | null,
+  ): Promise<void> {
+    if (filename === null || filename.toString() === '') return Promise.resolve();
+    // `filename` is relative to the watched directory; rebuild a
+    // KB-root-relative path so the ingest filter sees the same
+    // shape it would from the recursive mode.
+    const absPath = path.join(dir, filename.toString());
+    const relFromKb = path.relative(state.kbPath, absPath);
+    if (relFromKb === '' || relFromKb.startsWith('..')) return Promise.resolve();
+    this.onRawFsEvent(state, relFromKb);
+    // Directory-creation events fail the ingest allowlist (no
+    // extension), so discovery lives here rather than in
+    // `onRawFsEvent`. Recursive mode never calls this method.
+    return this.discoverNewDirectory(state, absPath).catch((err) => {
+      logger.debug(
+        `RecursiveKbWatcher: discover ${absPath} (${state.kbName}): ${(err as Error).message}`,
+      );
+    });
+  }
+
+  /**
+   * When a per-directory event names a newly created subdirectory,
+   * attach watchers to it (and any directories already nested inside)
+   * and emit events for files already present. The listing step is
+   * what closes the mkdir-then-immediate-write race: a file written
+   * before the new watcher is attached never generates its own event.
+   */
+  private async discoverNewDirectory(state: PerKbState, absPath: string): Promise<void> {
+    if (this.stopped || this.useRecursive()) return;
+
+    const relFromKb = path.relative(state.kbPath, absPath);
+    if (relFromKb === '' || relFromKb.startsWith('..')) return;
+    // Same skip as `enumerateDirectories`: `.index/` and `.git/` are
+    // indexer / vcs sidecars, never corpus.
+    if (relFromKb.split(path.sep).some((segment) => segment.startsWith('.'))) return;
+
+    const resolved = path.resolve(absPath);
+    let st: fs.Stats;
+    try {
+      // lstat, not stat: a symlink whose name sits inside the KB must
+      // not pull us into the target tree. Startup enumeration uses
+      // dirent.isDirectory(), which likewise does not follow links.
+      st = await fsp.lstat(absPath);
+    } catch {
+      // Path vanished (typical: rmdir of a previously watched dir).
+      // Drop the claim so a later mkdir of the same name can attach.
+      state.watchedDirs.delete(resolved);
+      return;
+    }
+    if (!st.isDirectory()) return;
+    if (state.watchedDirs.has(resolved)) return;
+
+    const dirs = await enumerateDirectories(absPath);
+    if (this.stopped) return;
+
+    for (const dir of dirs) {
+      const wasNew = !state.watchedDirs.has(path.resolve(dir));
+      this.watchDirectory(state, dir);
+      if (wasNew) {
+        await this.emitExistingFiles(state, dir);
+        if (this.stopped) return;
       }
+    }
+  }
+
+  private async emitExistingFiles(state: PerKbState, dir: string): Promise<void> {
+    if (this.stopped) return;
+    let entries: fs.Dirent[];
+    try {
+      entries = await fsp.readdir(dir, { withFileTypes: true });
+    } catch (err) {
+      logger.debug(
+        `RecursiveKbWatcher: list ${dir} (${state.kbName}): ${(err as Error).message}`,
+      );
+      return;
+    }
+    for (const entry of entries) {
+      if (this.stopped) return;
+      if (entry.name.startsWith('.')) continue;
+      if (entry.isDirectory()) continue;
+      const absPath = path.join(dir, entry.name);
+      const relFromKb = path.relative(state.kbPath, absPath);
+      if (relFromKb === '' || relFromKb.startsWith('..')) continue;
+      this.onRawFsEvent(state, relFromKb);
     }
   }
 
@@ -262,7 +395,10 @@ export class RecursiveKbWatcher {
     if (relativePath === '' || relativePath === '.') return;
 
     // Reuse the indexer's exact filter set: dotfile / `_seen.jsonl` /
-    // `logs/` / extension allowlist / operator excludes. The watcher
+    // `logs/` / extension allowlist / operator excludes. Directory
+    // creation is not handled here — a new dir has no ingestible
+    // extension, and attaching extra watches from this shared path
+    // would change recursive (macOS/Windows) behavior. The watcher
     // synthesises an "absolute" path under `state.kbPath` so the
     // filter's `path.relative(kbRoot, ...)` strips it back to the same
     // shape it would see for a walker-discovered file.


### PR DESCRIPTION
## Summary

On Linux and WSL, the knowledge-base file watcher only attached to
directories that existed when it started. A subdirectory created later
never got a watcher, so files written into it were silently never
indexed until a restart. This change notices those new folders, starts
watching them, and treats files already inside as a change so a
mkdir-then-immediate-write is not missed. macOS and Windows already
handle this via native recursive watching and are unchanged.

<!-- kookr:check:prose -->

Fixes #893

## Changes

- Each directory watch attaches before its contents are listed. Newly found child directories are watched and scanned recursively, so nested mkdir-then-write operations cannot fall into an enumeration gap.
- Directory watches track device/inode identity. Replacing a directory closes its old watcher and descendant handles, then watches the replacement even if discovery never observed the path missing.
- Files already present when a new directory is discovered trigger the existing filtered, debounced update path. Concurrent discovery keeps one watcher per directory.
- Registered KB roots may still be symlinks. Symlinks discovered inside a KB are not followed. Native recursive watching on macOS/Windows is unchanged.

## Design notes

Watch-before-list discovery closes the timing gap without polling. Device/inode identity distinguishes a recreated path from the directory previously watched. Only explicitly registered roots follow symlinks; discovered descendants use `lstat` to preserve the existing traversal boundary.

## Testing

- [x] `npm test` passes — 225 suites, 3,602 tests passed; 6 tests skipped. The watcher suite passes all 24 tests, including deterministic discovery/replacement regressions and symlinked roots. Build, lint, test typecheck, and repository fast checks also passed.
- [ ] ~~End-to-end verified for tool/transport changes (see `CLAUDE.md`)~~ — N/A: watcher-only bugfix; no MCP tool or transport change.
- [ ] ~~Benchmark run if performance-relevant: `BENCH_PROVIDER=stub npm run bench`~~ — N/A: no retrieval or performance-path change.
- [x] <!-- kookr:check:tests --> Tests were added or updated for changed behavior; bug fixes include a regression test

## Documentation contract

- [ ] ~~<!-- kookr:check:readme --> `README.md` reflects user-visible CLI, MCP, installation, or configuration changes~~ — N/A: no CLI/MCP/install/config surface change; `KB_FS_WATCH` already documented.
- [ ] ~~<!-- kookr:check:docs --> Relevant operator, API, configuration, and retrieval documentation under `docs/` is consistent with the implementation~~ — N/A: internal watcher attach path; no operator/API/config/retrieval doc change.
- [ ] ~~<!-- kookr:check:mbse --> RFCs are updated when this PR implements, supersedes, or changes an accepted design~~ — N/A: corrective bugfix of the existing per-directory strategy; no accepted RFC/design changed.

## Changelog

- [ ] ~~<!-- kookr:check:changelog --> `CHANGELOG.md` has an `Unreleased` entry for user-visible changes~~ — N/A: repository has no `CHANGELOG.md`.

## Retrieval and performance evidence

- [ ] ~~<!-- kookr:check:benchmarks --> Retrieval-quality or performance changes include the relevant benchmark/evaluation evidence, or this row is waived with a reason~~ — N/A: filesystem-watch attach bugfix; no retrieval-quality or performance behaviour is altered.

## Follow-ups

None.

Closes #893

