### PR TITLE
test: strengthen redaction and secret-scanner mutation coverage

### DIFF
--- a/jest.stryker.config.cjs
+++ b/jest.stryker.config.cjs
@@ -27,6 +27,7 @@ module.exports = {
   testMatch: [
     '**/src/chunk-id.test.ts',
     '**/src/redaction.test.ts',
+    '**/src/secret-scanner.test.ts',
     '**/src/lexical-bm25.test.ts',
     '**/src/hybrid-retrieval.test.ts',
     '**/src/injection-guard.test.ts',

--- a/src/__property-tests__/redaction.property.test.ts
+++ b/src/__property-tests__/redaction.property.test.ts
@@ -1,0 +1,156 @@
+// Property tests for outbound secret redaction (issue #896).
+//
+// `redactSecrets` decides what leaves the process on every remote LLM call.
+// Example-based unit tests pin regex floors and capture groups; this suite
+// asserts behavioural invariants over a positive/negative corpus and random
+// benign padding, following the `__property-tests__` + fuzz precedent (#751):
+//
+//   1. Positive corpus — shaped secrets are replaced; the secret needle is gone.
+//   2. Negative corpus — git SHAs, credential-less URLs, short tokens, prose
+//      are unchanged.
+//   3. Benign purity — restricted-vocabulary prose is never redacted.
+//   4. Wrapping monotonicity — a redacted payload stays redacted when padded
+//      with benign text.
+//   5. Determinism and text-idempotence.
+//   6. maybeRedact(text, false) is identity.
+//   7. summary.total equals the sum of by_type counts.
+
+import { describe, expect, it } from '@jest/globals';
+import * as fc from 'fast-check';
+import {
+  REDACTION_PLACEHOLDER,
+  maybeRedact,
+  redactSecrets,
+} from '../redaction.js';
+import {
+  REDACTION_NEGATIVE_CORPUS,
+  REDACTION_POSITIVE_CORPUS,
+  type RedactionNegativeEntry,
+  type RedactionPositiveEntry,
+} from '../test-support/redaction-corpus.js';
+
+const NUM_RUNS = process.env.KB_PROPERTY_DEEP === '1' ? 1000 : 100;
+
+const benignWordArb = fc.constantFrom(
+  'the', 'quick', 'brown', 'deploy', 'restart', 'worker', 'after', 'migration',
+  'notes', 'summary', 'update', 'config', 'value', 'index', 'search', 'result',
+  'cache', 'model', 'embedding', 'chunk', 'document', 'vector',
+);
+const benignTextArb = fc
+  .array(benignWordArb, { minLength: 0, maxLength: 12 })
+  .map((words) => words.join(' '));
+
+const positiveArb: fc.Arbitrary<RedactionPositiveEntry> = fc.constantFrom(
+  ...REDACTION_POSITIVE_CORPUS,
+);
+const negativeArb: fc.Arbitrary<RedactionNegativeEntry> = fc.constantFrom(
+  ...REDACTION_NEGATIVE_CORPUS,
+);
+
+function typeTotal(byType: Record<string, number>): number {
+  return Object.values(byType).reduce((sum, count) => sum + count, 0);
+}
+
+describe('redaction — positive corpus (issue #896)', () => {
+  it('replaces every shaped secret and drops the secret needle', () => {
+    fc.assert(
+      fc.property(positiveArb, (entry) => {
+        const result = redactSecrets(entry.payload);
+        expect(result.text).toContain(REDACTION_PLACEHOLDER);
+        expect(result.text).toContain(entry.expectedSnippet);
+        expect(result.text).not.toContain(entry.secretNeedle);
+        expect(result.summary.by_type[entry.expectedType] ?? 0).toBeGreaterThanOrEqual(1);
+      }),
+      { numRuns: NUM_RUNS },
+    );
+  });
+});
+
+describe('redaction — negative corpus (issue #896)', () => {
+  it('leaves git SHAs, URLs, short tokens, and prose unchanged', () => {
+    fc.assert(
+      fc.property(negativeArb, (entry) => {
+        const result = redactSecrets(entry.payload);
+        expect(result.text).toBe(entry.payload);
+        expect(result.summary.total).toBe(0);
+      }),
+      { numRuns: NUM_RUNS },
+    );
+  });
+});
+
+describe('redaction — benign purity (issue #896)', () => {
+  it('never redacts text built from an innocuous vocabulary', () => {
+    fc.assert(
+      fc.property(benignTextArb, (text) => {
+        const result = redactSecrets(text);
+        expect(result.text).toBe(text);
+        expect(result.summary.total).toBe(0);
+        expect(result.summary.by_type).toEqual({});
+      }),
+      { numRuns: NUM_RUNS },
+    );
+  });
+});
+
+describe('redaction — wrapping monotonicity (issue #896)', () => {
+  it('still redacts a payload padded with benign text', () => {
+    fc.assert(
+      fc.property(positiveArb, benignTextArb, benignTextArb, (entry, pre, post) => {
+        // Newline padding preserves `^`/`m` header and dotenv anchors; a same-line
+        // prefix would legitimately hide `Cookie:` / `OPENAI_API_KEY=` line matches.
+        const padded = `${pre}\n${entry.payload}\n${post}`;
+        const result = redactSecrets(padded);
+        expect(result.text).toContain(REDACTION_PLACEHOLDER);
+        expect(result.text).not.toContain(entry.secretNeedle);
+        expect(result.summary.by_type[entry.expectedType] ?? 0).toBeGreaterThanOrEqual(1);
+      }),
+      { numRuns: NUM_RUNS },
+    );
+  });
+});
+
+describe('redaction — determinism, idempotence, identity (issue #896)', () => {
+  it('is a pure function of its input', () => {
+    fc.assert(
+      fc.property(positiveArb, negativeArb, benignTextArb, (pos, neg, benign) => {
+        const input = `${benign}\n${pos.payload}\n${neg.payload}`;
+        expect(redactSecrets(input)).toEqual(redactSecrets(input));
+      }),
+      { numRuns: NUM_RUNS },
+    );
+  });
+
+  it('is text-idempotent', () => {
+    fc.assert(
+      fc.property(positiveArb, negativeArb, (pos, neg) => {
+        const once = redactSecrets(`${pos.payload}\n${neg.payload}`);
+        const twice = redactSecrets(once.text);
+        expect(twice.text).toBe(once.text);
+      }),
+      { numRuns: NUM_RUNS },
+    );
+  });
+
+  it('maybeRedact(text, false) is identity', () => {
+    fc.assert(
+      fc.property(positiveArb, (entry) => {
+        const result = maybeRedact(entry.payload, false);
+        expect(result.text).toBe(entry.payload);
+        expect(result.summary.enabled).toBe(false);
+        expect(result.summary.total).toBe(0);
+      }),
+      { numRuns: NUM_RUNS },
+    );
+  });
+
+  it('summary.total equals the sum of by_type counts', () => {
+    fc.assert(
+      fc.property(positiveArb, negativeArb, benignTextArb, (pos, neg, benign) => {
+        const result = redactSecrets(`${benign}\n${pos.payload}\n${neg.payload}`);
+        expect(result.summary.total).toBe(typeTotal(result.summary.by_type));
+      }),
+      { numRuns: NUM_RUNS },
+    );
+  });
+});

--- a/src/__property-tests__/secret-scanner.property.test.ts
+++ b/src/__property-tests__/secret-scanner.property.test.ts
@@ -1,0 +1,159 @@
+// Property tests for the ingest secret scanner (issue #896).
+//
+// `detectSecretsInText` owns the secret-category taxonomy used to quarantine
+// files before embedding. Example-based unit tests pin entropy floors and
+// pattern alternatives; this suite asserts behavioural invariants over a
+// positive/negative corpus, following the `__property-tests__` + fuzz
+// precedent (#751):
+//
+//   1. Positive corpus — true secrets raise the expected category.
+//   2. Negative corpus — git SHAs, URLs, low-entropy repeats, short tokens,
+//      and mid-entropy mixed blobs stay clean.
+//   3. Benign purity — restricted-vocabulary prose is never flagged.
+//   4. Wrapping monotonicity — a flagged payload stays flagged when padded
+//      with benign text (whitespace-separated so `\b` anchors survive).
+//   5. Determinism and category-dedup under repetition.
+//   6. Findings never echo the matched payload.
+//   7. A disabled scan never throws.
+
+import { describe, expect, it } from '@jest/globals';
+import * as fc from 'fast-check';
+import {
+  IngestSecretDetectedError,
+  assertNoIngestSecrets,
+  detectSecretsInText,
+  type SecretFindingCategory,
+} from '../secret-scanner.js';
+import {
+  SECRET_SCANNER_NEGATIVE_CORPUS,
+  SECRET_SCANNER_POSITIVE_CORPUS,
+  type SecretScannerNegativeEntry,
+  type SecretScannerPositiveEntry,
+} from '../test-support/secret-scanner-corpus.js';
+
+const NUM_RUNS = process.env.KB_PROPERTY_DEEP === '1' ? 1000 : 100;
+
+const benignWordArb = fc.constantFrom(
+  'the', 'quick', 'brown', 'deploy', 'restart', 'worker', 'after', 'migration',
+  'notes', 'summary', 'update', 'config', 'value', 'index', 'search', 'result',
+  'cache', 'model', 'embedding', 'chunk', 'document', 'vector',
+);
+const benignTextArb = fc
+  .array(benignWordArb, { minLength: 0, maxLength: 12 })
+  .map((words) => words.join(' '));
+
+const positiveArb: fc.Arbitrary<SecretScannerPositiveEntry> = fc.constantFrom(
+  ...SECRET_SCANNER_POSITIVE_CORPUS,
+);
+const negativeArb: fc.Arbitrary<SecretScannerNegativeEntry> = fc.constantFrom(
+  ...SECRET_SCANNER_NEGATIVE_CORPUS,
+);
+
+function categories(text: string): SecretFindingCategory[] {
+  return detectSecretsInText(text).map((finding) => finding.category);
+}
+
+describe('secret-scanner — positive corpus (issue #896)', () => {
+  it('raises the expected category for every true secret', () => {
+    fc.assert(
+      fc.property(positiveArb, (entry) => {
+        expect(categories(entry.payload)).toContain(entry.expectedCategory);
+      }),
+      { numRuns: NUM_RUNS },
+    );
+  });
+});
+
+describe('secret-scanner — negative corpus (issue #896)', () => {
+  it('does not flag git SHAs, URLs, low-entropy blobs, or prose', () => {
+    fc.assert(
+      fc.property(negativeArb, (entry) => {
+        expect(detectSecretsInText(entry.payload)).toEqual([]);
+      }),
+      { numRuns: NUM_RUNS },
+    );
+  });
+});
+
+describe('secret-scanner — benign purity (issue #896)', () => {
+  it('never flags text built from an innocuous vocabulary', () => {
+    fc.assert(
+      fc.property(benignTextArb, (text) => {
+        expect(detectSecretsInText(text)).toEqual([]);
+      }),
+      { numRuns: NUM_RUNS },
+    );
+  });
+});
+
+describe('secret-scanner — wrapping monotonicity (issue #896)', () => {
+  it('keeps the expected category when a payload is padded with benign text', () => {
+    fc.assert(
+      fc.property(positiveArb, benignTextArb, benignTextArb, (entry, pre, post) => {
+        const padded = `${pre} ${entry.payload} ${post}`;
+        expect(new Set(categories(padded)).has(entry.expectedCategory)).toBe(true);
+      }),
+      { numRuns: NUM_RUNS },
+    );
+  });
+});
+
+describe('secret-scanner — determinism, dedup, payload hygiene (issue #896)', () => {
+  it('is a pure function of its input', () => {
+    fc.assert(
+      fc.property(positiveArb, negativeArb, (pos, neg) => {
+        const input = `${pos.payload}\n${neg.payload}`;
+        expect(detectSecretsInText(input)).toEqual(detectSecretsInText(input));
+      }),
+      { numRuns: NUM_RUNS },
+    );
+  });
+
+  it('emits each (category, location, chunkIndex) at most once', () => {
+    fc.assert(
+      fc.property(positiveArb, fc.integer({ min: 1, max: 4 }), (entry, times) => {
+        const findings = detectSecretsInText(entry.payload.repeat(times));
+        const keys = findings.map(
+          (finding) => `${finding.category}:${finding.location}:${finding.chunkIndex ?? 'none'}`,
+        );
+        expect(keys.length).toBe(new Set(keys).size);
+      }),
+      { numRuns: NUM_RUNS },
+    );
+  });
+
+  it('never echoes the matched payload on the finding or the thrown error', () => {
+    fc.assert(
+      fc.property(positiveArb, (entry) => {
+        for (const finding of detectSecretsInText(entry.payload)) {
+          expect(JSON.stringify(finding)).not.toContain(entry.payload);
+        }
+        try {
+          assertNoIngestSecrets([entry.payload], {
+            relativePath: 'alpha/secret.md',
+            knowledgeBaseName: 'alpha',
+            scanOptions: { enabled: true, bypassKnowledgeBases: [] },
+          });
+          throw new Error('expected scanner to throw');
+        } catch (error) {
+          expect(error).toBeInstanceOf(IngestSecretDetectedError);
+          expect((error as Error).message).not.toContain(entry.payload);
+        }
+      }),
+      { numRuns: NUM_RUNS },
+    );
+  });
+
+  it('does not throw when the scan is disabled', () => {
+    fc.assert(
+      fc.property(positiveArb, (entry) => {
+        expect(() => assertNoIngestSecrets([entry.payload], {
+          relativePath: 'alpha/secret.md',
+          knowledgeBaseName: 'alpha',
+          scanOptions: { enabled: false, bypassKnowledgeBases: [] },
+        })).not.toThrow();
+      }),
+      { numRuns: NUM_RUNS },
+    );
+  });
+});

--- a/src/injection-guard.ts
+++ b/src/injection-guard.ts
@@ -34,6 +34,7 @@ export interface GuardedChunk {
 
 const DEFAULT_WRAP_OPEN = '<untrusted-doc src="{source}">';
 const DEFAULT_WRAP_CLOSE = '</untrusted-doc>';
+// Stryker disable next-line Regex: `\v` → `\V` mutants are a syntax error under `/u` and abort the dry run.
 const WRAPPER_LINE_BREAK = /[\r\n\v\f\u0085\u2028\u2029]/u;
 const WRAPPER_CODEC_CANDIDATES = [
   0x2060, // word joiner

--- a/src/redaction.test.ts
+++ b/src/redaction.test.ts
@@ -1,6 +1,16 @@
 import { describe, expect, it } from '@jest/globals';
-import { redactSecrets, REDACTION_PLACEHOLDER } from './redaction.js';
+import {
+  REDACTION_PLACEHOLDER,
+  combineRedactionSummaries,
+  emptyRedactionSummary,
+  maybeRedact,
+  redactSecrets,
+} from './redaction.js';
 import { detectSecretsInText, type SecretFindingCategory } from './secret-scanner.js';
+import {
+  REDACTION_NEGATIVE_CORPUS,
+  REDACTION_POSITIVE_CORPUS,
+} from './test-support/redaction-corpus.js';
 
 describe('redactSecrets', () => {
   it('redacts common support-bundle secret shapes', () => {
@@ -18,100 +28,284 @@ describe('redactSecrets', () => {
     expect(result.text).toContain('"github_token":"[REDACTED]"');
     expect(result.text).toContain('https://[REDACTED]@example.com/path');
     expect(result.summary.total).toBeGreaterThanOrEqual(4);
+    expect(result.summary.enabled).toBe(true);
   });
 
-  it('scrubs the five newly-covered egress secret categories', () => {
-    const gcpKey = `AIzaSy${'B'.repeat(33)}`; // AIza + 35 chars
+  it.each(REDACTION_POSITIVE_CORPUS.map((entry) => [entry.name, entry] as const))(
+    'redacts positive corpus entry: %s',
+    (_name, entry) => {
+      const result = redactSecrets(entry.payload);
+      expect(result.text).toContain(entry.expectedSnippet);
+      expect(result.text).not.toContain(entry.secretNeedle);
+      expect(result.summary.by_type[entry.expectedType]).toBeGreaterThanOrEqual(1);
+      expect(result.summary.total).toBeGreaterThanOrEqual(1);
+    },
+  );
+
+  it.each(REDACTION_NEGATIVE_CORPUS.map((entry) => [entry.name, entry] as const))(
+    'leaves negative corpus entry unchanged: %s',
+    (_name, entry) => {
+      const result = redactSecrets(entry.payload);
+      expect(result.text).toBe(entry.payload);
+      expect(result.summary.total).toBe(0);
+      expect(result.summary.by_type).toEqual({});
+    },
+  );
+
+  it('leaves clean text untouched and records no zero-count types', () => {
+    const result = redactSecrets('hello world');
+    expect(result.text).toBe('hello world');
+    expect(result.summary).toEqual({ enabled: true, total: 0, by_type: {} });
+  });
+
+  it('preserves the URL scheme capture group and drops userinfo', () => {
+    const result = redactSecrets('mirror ftp://alice:s3cretpass@files.example.com/pkg');
+    expect(result.text).toBe('mirror ftp://[REDACTED]@files.example.com/pkg');
+    expect(result.summary.by_type).toEqual({ credential_url: 1 });
+  });
+
+  it('redacts HTTP(S) userinfo case-insensitively', () => {
+    const result = redactSecrets('HTTP://Alice:Pass@Example.com');
+    expect(result.text).toBe('HTTP://[REDACTED]@Example.com');
+    expect(result.summary.by_type).toEqual({ credential_url: 1 });
+  });
+
+  it('does not treat a user-only URL as credential userinfo', () => {
+    expect(redactSecrets('https://alice@example.com/repo').text).toBe('https://alice@example.com/repo');
+  });
+
+  it('redacts Authorization Bearer and Basic, but not Digest', () => {
+    expect(redactSecrets('Authorization: Bearer abcdefghijklmnop').text).toBe(
+      'Authorization: Bearer [REDACTED]',
+    );
+    expect(redactSecrets('authorization: basic dXNlcjpwYXNzd29yZA').text).toBe(
+      'authorization: basic [REDACTED]',
+    );
+    expect(redactSecrets('Authorization: Digest abcdefghijklmnop').text).toBe(
+      'Authorization: Digest abcdefghijklmnop',
+    );
+  });
+
+  it('redacts Cookie and Set-Cookie only at line start, including leading tabs', () => {
+    const multiline = ['notes', '\tSet-Cookie: session=abc; Path=/', 'Cookie: extra=1'].join('\n');
+    const result = redactSecrets(multiline);
+    expect(result.text).toBe(['notes', '\tSet-Cookie: [REDACTED]', 'Cookie: [REDACTED]'].join('\n'));
+    expect(result.summary.by_type.cookie_header).toBe(2);
+
+    // Mid-line `Cookie:` is not a header (the header pattern is line-anchored).
+    // `key_value_secret` may still scrub it; the header type must not fire.
+    expect(redactSecrets('see Cookie: session=abc').summary.by_type.cookie_header).toBeUndefined();
+  });
+
+  it('redacts JSON secret keys including prefix/suffix forms and spaced colons', () => {
+    expect(redactSecrets('{"prod_api_key_v2" : "visible-value"}').text).toBe(
+      '{"prod_api_key_v2" : "[REDACTED]"}',
+    );
+    expect(redactSecrets('{"client_secret":"visible-value"}').text).toBe(
+      '{"client_secret":"[REDACTED]"}',
+    );
+    expect(redactSecrets('{"session-token":"visible-value"}').text).toBe(
+      '{"session-token":"[REDACTED]"}',
+    );
+    expect(redactSecrets('{"username":"alice"}').text).toBe('{"username":"alice"}');
+  });
+
+  it('preserves dotenv quote capture groups and export/whitespace prefixes', () => {
+    expect(redactSecrets('  export FOO_SECRET="quoted-value"').text).toBe(
+      '  export FOO_SECRET="[REDACTED]"',
+    );
+    expect(redactSecrets("FOO_PASSWORD='quoted-value'").text).toBe("FOO_PASSWORD='[REDACTED]'");
+    expect(redactSecrets('FOO_ACCESS_TOKEN=unquoted').text).toBe('FOO_ACCESS_TOKEN=[REDACTED]');
+    expect(redactSecrets('notes\nCLIENT_SECRET=visible-value').text).toBe(
+      'notes\nCLIENT_SECRET=[REDACTED]',
+    );
+  });
+
+  it('skips already-redacted key-value secrets via the negative lookahead', () => {
+    const result = redactSecrets('see password=[REDACTED] trailing');
+    expect(result.text).toBe('see password=[REDACTED] trailing');
+    expect(result.summary.by_type.key_value_secret ?? 0).toBe(0);
+  });
+
+  it('redacts key-value secrets with colon or equals mid-line', () => {
+    expect(redactSecrets('config api_key: visible-value').text).toBe('config api_key: [REDACTED]');
+    expect(redactSecrets('config passwd="visible-value"').text).toBe('config passwd="[REDACTED]"');
+  });
+
+  it('enforces the Bearer token 12-character floor and is case-sensitive', () => {
+    expect(redactSecrets('use Bearer 12345678901 here').text).toBe('use Bearer 12345678901 here');
+    expect(redactSecrets('use Bearer 123456789012 here').text).toBe('use Bearer [REDACTED] here');
+    expect(redactSecrets('use bearer abcdefghijklmno here').text).toBe(
+      'use bearer abcdefghijklmno here',
+    );
+  });
+
+  it('enforces provider-token length floors and each alternative', () => {
+    expect(redactSecrets('sk-abcdefghijklmnopqrst').text).toBe('[REDACTED]');
+    expect(redactSecrets('sk-abcdefghijklmnopqrs').text).toBe('sk-abcdefghijklmnopqrs');
+    expect(redactSecrets('sk-proj-abcdefghijklmnopqrst').text).toBe('[REDACTED]');
+    expect(redactSecrets('gho_abcdefghijklmnopqrst').text).toBe('[REDACTED]');
+    expect(redactSecrets('ghu_abcdefghijklmnopqrst').text).toBe('[REDACTED]');
+    expect(redactSecrets('ghs_abcdefghijklmnopqrst').text).toBe('[REDACTED]');
+    expect(redactSecrets('ghr_abcdefghijklmnopqrst').text).toBe('[REDACTED]');
+    expect(redactSecrets('AKIA0123456789ABCDEF').text).toBe('[REDACTED]');
+    expect(redactSecrets('AKIA0123456789ABCDE').text).toBe('AKIA0123456789ABCDE');
+    expect(redactSecrets('xoxa-1234567890').text).toBe('[REDACTED]');
+    expect(redactSecrets('xoxp-1234567890').text).toBe('[REDACTED]');
+    expect(redactSecrets('xoxr-1234567890').text).toBe('[REDACTED]');
+    expect(redactSecrets('xoxs-1234567890').text).toBe('[REDACTED]');
+    expect(redactSecrets('ASIAIOSFODNN7EXAMPLE').text).toBe('[REDACTED]');
+    expect(redactSecrets('AGPAIOSFODNN7EXAMPLE').text).toBe('[REDACTED]');
+    expect(redactSecrets('AIDA' + 'IOSFODNN7EXAMPLE').text).toBe('[REDACTED]');
+    expect(redactSecrets('AROA' + 'IOSFODNN7EXAMPLE').text).toBe('[REDACTED]');
+    expect(redactSecrets('AIPA' + 'IOSFODNN7EXAMPLE').text).toBe('[REDACTED]');
+    expect(redactSecrets('ANPA' + 'IOSFODNN7EXAMPLE').text).toBe('[REDACTED]');
+    expect(redactSecrets('A3TA' + 'IOSFODNN7EXAMPLE').text).toBe('[REDACTED]');
+    expect(redactSecrets('AIzaSyD-1234567890abcdefghijklmnopqrstu').text).toBe('[REDACTED]');
+    expect(redactSecrets(`AIzaSy${'B'.repeat(32)}`).text).toContain(`AIzaSy${'B'.repeat(32)}`);
+    expect(redactSecrets('AccountKey=abcdefghijklmnopqrstuvwxyz012345').text).toContain(
+      'abcdefghijklmnopqrstuvwxyz012345',
+    );
+  });
+
+  it('redacts JWT triples, Azure account keys, and PEM private-key blocks', () => {
+    const jwt =
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.vJ8eQhVZl2w5uXqO78Fpm_4ZcYc8-Ma5zJ5PpQ';
+    expect(redactSecrets(`token ${jwt}`).text).toBe('token [REDACTED]');
+    expect(redactSecrets('AccountKey=abcDEF1234567890abcDEF1234567890abcDEF1234567890==').text).toBe(
+      'AccountKey=[REDACTED]',
+    );
+    const pem = [
+      '-----BEGIN RSA PRIVATE KEY-----',
+      'abcdefghijklmnopqrstuvwxyzABCDEF',
+      '-----END RSA PRIVATE KEY-----',
+    ].join('\n');
+    expect(redactSecrets(pem).text).toBe('[REDACTED]');
+    const truncated = '-----BEGIN PRIVATE KEY-----\nabcdefghijklmnopqrstuvwxyzABCDEF';
+    expect(redactSecrets(truncated).text).toBe('[REDACTED]');
+  });
+
+  it('replaces every match when a pattern is global', () => {
+    const result = redactSecrets('sk-abcdefghijklmnopqrst sk-abcdefghijklmnopqrst');
+    expect(result.text).toBe('[REDACTED] [REDACTED]');
+    expect(result.summary.by_type).toEqual({ provider_token: 2 });
+    expect(result.summary.total).toBe(2);
+  });
+
+  it('is text-idempotent even when a later pass can rematch a placeholder', () => {
+    const once = redactSecrets('Authorization: Bearer abcdefghijklmnop');
+    const twice = redactSecrets(once.text);
+    expect(twice.text).toBe(once.text);
+    expect(twice.text).toBe('Authorization: Bearer [REDACTED]');
+  });
+});
+
+describe('maybeRedact', () => {
+  const secret = 'OPENAI_API_KEY=not-a-provider-shape-value';
+
+  it('returns the original text and a disabled empty summary when off', () => {
+    expect(maybeRedact(secret, false)).toEqual({
+      text: secret,
+      summary: { enabled: false, total: 0, by_type: {} },
+    });
+  });
+
+  it('redacts when enabled', () => {
+    const result = maybeRedact(secret, true);
+    expect(result.text).toBe('OPENAI_API_KEY=[REDACTED]');
+    expect(result.summary.enabled).toBe(true);
+    expect(result.summary.total).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe('emptyRedactionSummary', () => {
+  it('records the enabled flag and never invents counts', () => {
+    expect(emptyRedactionSummary(true)).toEqual({ enabled: true, total: 0, by_type: {} });
+    expect(emptyRedactionSummary(false)).toEqual({ enabled: false, total: 0, by_type: {} });
+  });
+});
+
+describe('combineRedactionSummaries', () => {
+  it('returns a disabled empty summary when redaction is off', () => {
+    expect(
+      combineRedactionSummaries(false, {
+        enabled: true,
+        total: 4,
+        by_type: { provider_token: 4 },
+      }),
+    ).toEqual({ enabled: false, total: 0, by_type: {} });
+  });
+
+  it('sums overlapping type counts and ignores empty input', () => {
+    expect(combineRedactionSummaries(true)).toEqual({ enabled: true, total: 0, by_type: {} });
+    expect(
+      combineRedactionSummaries(
+        true,
+        { enabled: true, total: 2, by_type: { a: 1, b: 1 } },
+        { enabled: true, total: 3, by_type: { b: 2, c: 1 } },
+      ),
+    ).toEqual({ enabled: true, total: 5, by_type: { a: 1, b: 3, c: 1 } });
+  });
+});
+
+describe('redactSecrets — #952 egress categories retained', () => {
+  it('scrubs GCP, JWT, PEM, Azure, and AWS-session secrets', () => {
+    const gcpKey = `AIzaSy${'B'.repeat(33)}`;
     const jwt =
       'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U';
     const pemKey = [
-      '-----BEGIN OPENSSH PRIVATE KEY-----', // pragma: allowlist secret
+      '-----BEGIN OPENSSH PRIVATE KEY-----',
       'b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtz',
       'c2gtZWQyNTUxOQAAACD7uJ0j9mFq3Lr8sVtWuZ1aBcDeFgHiJkLmNoPqRsTuA==',
       '-----END OPENSSH PRIVATE KEY-----',
     ].join('\n');
     const azureKey = 'AccountKey=Xj7Kq2Wm9Rt4Yv6Bn1Zc3Pl5Sd8Fg0Hk2Lw4Qa6Ne8Ui0Op2==';
-    const awsSessionKey = 'ASIAIOSFODNN7EXAMPLE'; // ASIA session-key prefix
+    const awsSessionKey = 'ASIAIOSFODNN7EXAMPLE';
 
     const result = redactSecrets(
-      [
-        `key: ${gcpKey}`,
-        `token: ${jwt}`,
-        pemKey,
-        `conn: ${azureKey}`,
-        `aws: ${awsSessionKey}`,
-      ].join('\n'),
+      [`key: ${gcpKey}`, `token: ${jwt}`, pemKey, `conn: ${azureKey}`, `aws: ${awsSessionKey}`].join('\n'),
     );
 
     expect(result.text).not.toContain(gcpKey);
     expect(result.text).not.toContain(jwt);
-    expect(result.text).not.toContain('c2gtZWQyNTUxOQ'); // PEM key body
-    expect(result.text).not.toContain('Xj7Kq2Wm9Rt4Yv6Bn1Zc3Pl5Sd8Fg0Hk2Lw4Qa6Ne8Ui0Op2'); // Azure key value
+    expect(result.text).not.toContain('c2gtZWQyNTUxOQ');
+    expect(result.text).not.toContain('Xj7Kq2Wm9Rt4Yv6Bn1Zc3Pl5Sd8Fg0Hk2Lw4Qa6Ne8Ui0Op2');
     expect(result.text).not.toContain(awsSessionKey);
-    // AccountKey= label is preserved; only the value is scrubbed.
     expect(result.text).toContain(`AccountKey=${REDACTION_PLACEHOLDER}`);
-    // Each of the five secrets is replaced by a placeholder (not merely deleted).
-    expect(result.text).toContain(REDACTION_PLACEHOLDER);
     expect(result.summary.total).toBeGreaterThanOrEqual(5);
   });
 
-  it('redacts private-key blocks across PEM formats (PKCS#8, encrypted, truncated)', () => {
-    // The ingest scanner only keys on the `-----BEGIN-----` header, but egress
-    // must scrub the whole block. Cover the bare PKCS#8 header (no algorithm
-    // prefix), the encrypted variant, and a truncated block missing its END
-    // footer (as clipped in a log) — all previously slipped through.
+  it('redacts PKCS#8, encrypted, and truncated private-key blocks', () => {
     const pkcs8Body = 'MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQ7uJ0j9mFq3Lr8s';
     const encryptedBody = 'MIIFDjBABgkqhkiG9w0BBQ0wMzAbBgkqhkiG9w0BBQwwDgQItruncatedAESkey00';
     const truncatedBody = 'b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQMoreKeyBodyBytes123456';
 
-    const pkcs8 = redactSecrets(`-----BEGIN PRIVATE KEY-----\n${pkcs8Body}\n-----END PRIVATE KEY-----`); // pragma: allowlist secret
-    expect(pkcs8.text).not.toContain(pkcs8Body);
-    expect(pkcs8.text).toContain(REDACTION_PLACEHOLDER);
-
-    const encrypted = redactSecrets(
-      `-----BEGIN ENCRYPTED PRIVATE KEY-----\n${encryptedBody}\n-----END ENCRYPTED PRIVATE KEY-----`, // pragma: allowlist secret
-    );
-    expect(encrypted.text).not.toContain(encryptedBody);
-
-    // Truncated: header present, END footer clipped. The body must not egress.
-    const truncated = redactSecrets(`-----BEGIN OPENSSH PRIVATE KEY-----\n${truncatedBody}`); // pragma: allowlist secret
-    expect(truncated.text).not.toContain(truncatedBody);
+    expect(redactSecrets(`-----BEGIN PRIVATE KEY-----\n${pkcs8Body}\n-----END PRIVATE KEY-----`).text)
+      .not.toContain(pkcs8Body);
+    expect(redactSecrets(
+      `-----BEGIN ENCRYPTED PRIVATE KEY-----\n${encryptedBody}\n-----END ENCRYPTED PRIVATE KEY-----`,
+    ).text).not.toContain(encryptedBody);
+    expect(redactSecrets(`-----BEGIN OPENSSH PRIVATE KEY-----\n${truncatedBody}`).text)
+      .not.toContain(truncatedBody);
   });
 
-  it('keeps the full three-segment JWT shape (does not over-redact bare base64)', () => {
-    // A lone `eyJ`-prefixed base64 token without the two trailing segments is not
-    // a JWT and must survive untouched, per the acceptance criteria.
+  it('keeps a lone eyJ header (not a three-segment JWT)', () => {
     const notAJwt = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9';
-    const result = redactSecrets(`value: ${notAJwt}`);
-    expect(result.text).toContain(notAJwt);
+    expect(redactSecrets(`value: ${notAJwt}`).text).toContain(notAJwt);
   });
 
   it('does not over-redact a bare high-entropy token with no keyword or shape', () => {
-    // Egress redaction intentionally does NOT mirror the ingest scanner's generic
-    // high-entropy heuristic (and its bare, un-prefixed `token` keyword): a lone
-    // random-looking string with no secret-field keyword and no recognizable
-    // provider shape is left intact so ordinary prompt content is not corrupted.
-    // This is the documented boundary behind the `high_entropy` non-mirrored case.
     const bareToken = 'aB3xY9zK1mNpQ2rS4tU6vW8dE0fGhIjK';
-    const result = redactSecrets(`The build id is ${bareToken} for reference.`);
-    expect(result.text).toContain(bareToken);
+    expect(redactSecrets(`The build id is ${bareToken} for reference.`).text).toContain(bareToken);
   });
 });
 
 /**
- * Parity gate against the ingest secret scanner.
+ * Compile-time ingest↔egress parity gate (#952).
  *
- * Every category the ingest scanner (`detectSecretsInText`) recognizes must map
- * to an entry here. Because the map is a `Record<SecretFindingCategory, …>`, any
- * category added to or renamed in the scanner's union breaks compilation until
- * it is accounted for — so the egress redactor and the ingest scanner cannot
- * silently drift apart again.
- *
- * Each `mirrored: true` entry carries a canonical sample that the ingest scanner
- * actually detects (asserted below) and that `redactSecrets` must scrub. A
- * `mirrored: false` entry documents a category that is intentionally not
- * mirrored on egress (currently only the generic high-entropy heuristic, which
- * would over-redact arbitrary text in an LLM prompt).
+ * `Record<SecretFindingCategory, …>` fails typecheck if the scanner grows a
+ * category that has no redaction decision. `mirrored: false` documents the
+ * intentional high-entropy non-mirror.
  */
 type ParityCase =
   | { mirrored: true; sample: string; secret: string }
@@ -143,7 +337,7 @@ const CATEGORY_PARITY: Record<SecretFindingCategory, ParityCase> = {
   ssh_private_key: {
     mirrored: true,
     sample: [
-      '-----BEGIN RSA PRIVATE KEY-----', // pragma: allowlist secret
+      '-----BEGIN RSA PRIVATE KEY-----',
       'MIIEpAIBAAKCAQEA7uJ0j9mFq3Lr8sVtWuZ1aBcDeFgHiJkLmNoPqRsTuVwXyZ012',
       '-----END RSA PRIVATE KEY-----',
     ].join('\n'),
@@ -160,11 +354,6 @@ const CATEGORY_PARITY: Record<SecretFindingCategory, ParityCase> = {
     secret: 'Xj7Kq2Wm9Rt4Yv6Bn1Zc3Pl5Sd8Fg0Hk2Lw4Qa6Ne8Ui0Op2',
   },
   key_value_secret: {
-    // A bare secret field with a shapeless (non-provider) value: the value is
-    // scrubbed by the redactor's own `key_value_secret` pattern, not by a
-    // coincidental provider-token match — so this genuinely exercises key/value
-    // parity. (Only the generic un-prefixed `token` keyword and shapeless
-    // high-entropy values remain intentionally un-mirrored; see high_entropy.)
     mirrored: true,
     sample: 'password=Xq7-Rt2_Vn9.Kw4Zp',
     secret: 'Xq7-Rt2_Vn9.Kw4Zp',
@@ -185,12 +374,9 @@ describe('redactSecrets / secret-scanner parity', () => {
   it.each(mirrored)(
     'ingest scanner detects %s and redactSecrets scrubs it',
     (category, parity) => {
-      // 1. The canonical sample is genuinely something the ingest scanner flags
-      //    for this category (guards against the scanner's pattern drifting).
       const detected = detectSecretsInText(parity.sample).map((finding) => finding.category);
       expect(detected).toContain(category);
 
-      // 2. The egress redactor scrubs that same secret material.
       const { text } = redactSecrets(parity.sample);
       expect(text).not.toContain(parity.secret);
       expect(text).toContain(REDACTION_PLACEHOLDER);

--- a/src/redaction.test.ts
+++ b/src/redaction.test.ts
@@ -15,9 +15,9 @@ import {
 describe('redactSecrets', () => {
   it('redacts common support-bundle secret shapes', () => {
     const input = [
-      'OPENAI_API_KEY=sk-proj-abcdefghijklmnopqrstuvwxyz',
+      'OPENAI_API_KEY=sk-proj-abcdefghijklmnopqrstuvwxyz', // pragma: allowlist secret
       'Authorization: Bearer abcdefghijklmnop',
-      '{"github_token":"ghp_abcdefghijklmnopqrstuvwxyz"}',
+      '{"github_token":"ghp_abcdefghijklmnopqrstuvwxyz"}', // pragma: allowlist secret
       'https://user:password@example.com/path',
     ].join('\n');
 
@@ -141,52 +141,52 @@ describe('redactSecrets', () => {
   });
 
   it('enforces provider-token length floors and each alternative', () => {
-    expect(redactSecrets('sk-abcdefghijklmnopqrst').text).toBe('[REDACTED]');
-    expect(redactSecrets('sk-abcdefghijklmnopqrs').text).toBe('sk-abcdefghijklmnopqrs');
-    expect(redactSecrets('sk-proj-abcdefghijklmnopqrst').text).toBe('[REDACTED]');
-    expect(redactSecrets('gho_abcdefghijklmnopqrst').text).toBe('[REDACTED]');
-    expect(redactSecrets('ghu_abcdefghijklmnopqrst').text).toBe('[REDACTED]');
-    expect(redactSecrets('ghs_abcdefghijklmnopqrst').text).toBe('[REDACTED]');
-    expect(redactSecrets('ghr_abcdefghijklmnopqrst').text).toBe('[REDACTED]');
-    expect(redactSecrets('AKIA0123456789ABCDEF').text).toBe('[REDACTED]');
-    expect(redactSecrets('AKIA0123456789ABCDE').text).toBe('AKIA0123456789ABCDE');
-    expect(redactSecrets('xoxa-1234567890').text).toBe('[REDACTED]');
-    expect(redactSecrets('xoxp-1234567890').text).toBe('[REDACTED]');
-    expect(redactSecrets('xoxr-1234567890').text).toBe('[REDACTED]');
-    expect(redactSecrets('xoxs-1234567890').text).toBe('[REDACTED]');
-    expect(redactSecrets('ASIAIOSFODNN7EXAMPLE').text).toBe('[REDACTED]');
-    expect(redactSecrets('AGPAIOSFODNN7EXAMPLE').text).toBe('[REDACTED]');
-    expect(redactSecrets('AIDA' + 'IOSFODNN7EXAMPLE').text).toBe('[REDACTED]');
-    expect(redactSecrets('AROA' + 'IOSFODNN7EXAMPLE').text).toBe('[REDACTED]');
-    expect(redactSecrets('AIPA' + 'IOSFODNN7EXAMPLE').text).toBe('[REDACTED]');
-    expect(redactSecrets('ANPA' + 'IOSFODNN7EXAMPLE').text).toBe('[REDACTED]');
-    expect(redactSecrets('A3TA' + 'IOSFODNN7EXAMPLE').text).toBe('[REDACTED]');
-    expect(redactSecrets('AIzaSyD-1234567890abcdefghijklmnopqrstu').text).toBe('[REDACTED]');
-    expect(redactSecrets(`AIzaSy${'B'.repeat(32)}`).text).toContain(`AIzaSy${'B'.repeat(32)}`);
-    expect(redactSecrets('AccountKey=abcdefghijklmnopqrstuvwxyz012345').text).toContain(
+    expect(redactSecrets('sk-abcdefghijklmnopqrst').text).toBe('[REDACTED]'); // pragma: allowlist secret
+    expect(redactSecrets('sk-abcdefghijklmnopqrs').text).toBe('sk-abcdefghijklmnopqrs'); // pragma: allowlist secret
+    expect(redactSecrets('sk-proj-abcdefghijklmnopqrst').text).toBe('[REDACTED]'); // pragma: allowlist secret
+    expect(redactSecrets('gho_abcdefghijklmnopqrst').text).toBe('[REDACTED]'); // pragma: allowlist secret
+    expect(redactSecrets('ghu_abcdefghijklmnopqrst').text).toBe('[REDACTED]'); // pragma: allowlist secret
+    expect(redactSecrets('ghs_abcdefghijklmnopqrst').text).toBe('[REDACTED]'); // pragma: allowlist secret
+    expect(redactSecrets('ghr_abcdefghijklmnopqrst').text).toBe('[REDACTED]'); // pragma: allowlist secret
+    expect(redactSecrets('AKIA0123456789ABCDEF').text).toBe('[REDACTED]'); // pragma: allowlist secret
+    expect(redactSecrets('AKIA0123456789ABCDE').text).toBe('AKIA0123456789ABCDE'); // pragma: allowlist secret
+    expect(redactSecrets('xoxa-1234567890').text).toBe('[REDACTED]'); // pragma: allowlist secret
+    expect(redactSecrets('xoxp-1234567890').text).toBe('[REDACTED]'); // pragma: allowlist secret
+    expect(redactSecrets('xoxr-1234567890').text).toBe('[REDACTED]'); // pragma: allowlist secret
+    expect(redactSecrets('xoxs-1234567890').text).toBe('[REDACTED]'); // pragma: allowlist secret
+    expect(redactSecrets('ASIAIOSFODNN7EXAMPLE').text).toBe('[REDACTED]'); // pragma: allowlist secret
+    expect(redactSecrets('AGPAIOSFODNN7EXAMPLE').text).toBe('[REDACTED]'); // pragma: allowlist secret
+    expect(redactSecrets('AIDA' + 'IOSFODNN7EXAMPLE').text).toBe('[REDACTED]'); // pragma: allowlist secret
+    expect(redactSecrets('AROA' + 'IOSFODNN7EXAMPLE').text).toBe('[REDACTED]'); // pragma: allowlist secret
+    expect(redactSecrets('AIPA' + 'IOSFODNN7EXAMPLE').text).toBe('[REDACTED]'); // pragma: allowlist secret
+    expect(redactSecrets('ANPA' + 'IOSFODNN7EXAMPLE').text).toBe('[REDACTED]'); // pragma: allowlist secret
+    expect(redactSecrets('A3TA' + 'IOSFODNN7EXAMPLE').text).toBe('[REDACTED]'); // pragma: allowlist secret
+    expect(redactSecrets('AIzaSyD-1234567890abcdefghijklmnopqrstu').text).toBe('[REDACTED]'); // pragma: allowlist secret
+    expect(redactSecrets(`AIzaSy${'B'.repeat(32)}`).text).toContain(`AIzaSy${'B'.repeat(32)}`); // pragma: allowlist secret
+    expect(redactSecrets('AccountKey=abcdefghijklmnopqrstuvwxyz012345').text).toContain( // pragma: allowlist secret
       'abcdefghijklmnopqrstuvwxyz012345',
     );
   });
 
   it('redacts JWT triples, Azure account keys, and PEM private-key blocks', () => {
     const jwt =
-      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.vJ8eQhVZl2w5uXqO78Fpm_4ZcYc8-Ma5zJ5PpQ';
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.vJ8eQhVZl2w5uXqO78Fpm_4ZcYc8-Ma5zJ5PpQ'; // pragma: allowlist secret
     expect(redactSecrets(`token ${jwt}`).text).toBe('token [REDACTED]');
-    expect(redactSecrets('AccountKey=abcDEF1234567890abcDEF1234567890abcDEF1234567890==').text).toBe(
-      'AccountKey=[REDACTED]',
+    expect(redactSecrets('AccountKey=abcDEF1234567890abcDEF1234567890abcDEF1234567890==').text).toBe( // pragma: allowlist secret
+      'AccountKey=[REDACTED]', // pragma: allowlist secret
     );
     const pem = [
-      '-----BEGIN RSA PRIVATE KEY-----',
+      '-----BEGIN RSA PRIVATE KEY-----', // pragma: allowlist secret
       'abcdefghijklmnopqrstuvwxyzABCDEF',
       '-----END RSA PRIVATE KEY-----',
     ].join('\n');
     expect(redactSecrets(pem).text).toBe('[REDACTED]');
-    const truncated = '-----BEGIN PRIVATE KEY-----\nabcdefghijklmnopqrstuvwxyzABCDEF';
+    const truncated = '-----BEGIN PRIVATE KEY-----\nabcdefghijklmnopqrstuvwxyzABCDEF'; // pragma: allowlist secret
     expect(redactSecrets(truncated).text).toBe('[REDACTED]');
   });
 
   it('replaces every match when a pattern is global', () => {
-    const result = redactSecrets('sk-abcdefghijklmnopqrst sk-abcdefghijklmnopqrst');
+    const result = redactSecrets('sk-abcdefghijklmnopqrst sk-abcdefghijklmnopqrst'); // pragma: allowlist secret
     expect(result.text).toBe('[REDACTED] [REDACTED]');
     expect(result.summary.by_type).toEqual({ provider_token: 2 });
     expect(result.summary.total).toBe(2);
@@ -250,17 +250,17 @@ describe('combineRedactionSummaries', () => {
 
 describe('redactSecrets — #952 egress categories retained', () => {
   it('scrubs GCP, JWT, PEM, Azure, and AWS-session secrets', () => {
-    const gcpKey = `AIzaSy${'B'.repeat(33)}`;
+    const gcpKey = `AIzaSy${'B'.repeat(33)}`; // pragma: allowlist secret
     const jwt =
-      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U';
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U'; // pragma: allowlist secret
     const pemKey = [
-      '-----BEGIN OPENSSH PRIVATE KEY-----',
+      '-----BEGIN OPENSSH PRIVATE KEY-----', // pragma: allowlist secret
       'b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtz',
       'c2gtZWQyNTUxOQAAACD7uJ0j9mFq3Lr8sVtWuZ1aBcDeFgHiJkLmNoPqRsTuA==',
       '-----END OPENSSH PRIVATE KEY-----',
     ].join('\n');
-    const azureKey = 'AccountKey=Xj7Kq2Wm9Rt4Yv6Bn1Zc3Pl5Sd8Fg0Hk2Lw4Qa6Ne8Ui0Op2==';
-    const awsSessionKey = 'ASIAIOSFODNN7EXAMPLE';
+    const azureKey = 'AccountKey=Xj7Kq2Wm9Rt4Yv6Bn1Zc3Pl5Sd8Fg0Hk2Lw4Qa6Ne8Ui0Op2=='; // pragma: allowlist secret
+    const awsSessionKey = 'ASIAIOSFODNN7EXAMPLE'; // pragma: allowlist secret
 
     const result = redactSecrets(
       [`key: ${gcpKey}`, `token: ${jwt}`, pemKey, `conn: ${azureKey}`, `aws: ${awsSessionKey}`].join('\n'),
@@ -271,7 +271,7 @@ describe('redactSecrets — #952 egress categories retained', () => {
     expect(result.text).not.toContain('c2gtZWQyNTUxOQ');
     expect(result.text).not.toContain('Xj7Kq2Wm9Rt4Yv6Bn1Zc3Pl5Sd8Fg0Hk2Lw4Qa6Ne8Ui0Op2');
     expect(result.text).not.toContain(awsSessionKey);
-    expect(result.text).toContain(`AccountKey=${REDACTION_PLACEHOLDER}`);
+    expect(result.text).toContain(`AccountKey=${REDACTION_PLACEHOLDER}`); // pragma: allowlist secret
     expect(result.summary.total).toBeGreaterThanOrEqual(5);
   });
 
@@ -280,17 +280,17 @@ describe('redactSecrets — #952 egress categories retained', () => {
     const encryptedBody = 'MIIFDjBABgkqhkiG9w0BBQ0wMzAbBgkqhkiG9w0BBQwwDgQItruncatedAESkey00';
     const truncatedBody = 'b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQMoreKeyBodyBytes123456';
 
-    expect(redactSecrets(`-----BEGIN PRIVATE KEY-----\n${pkcs8Body}\n-----END PRIVATE KEY-----`).text)
+    expect(redactSecrets(`-----BEGIN PRIVATE KEY-----\n${pkcs8Body}\n-----END PRIVATE KEY-----`).text) // pragma: allowlist secret
       .not.toContain(pkcs8Body);
     expect(redactSecrets(
-      `-----BEGIN ENCRYPTED PRIVATE KEY-----\n${encryptedBody}\n-----END ENCRYPTED PRIVATE KEY-----`,
+      `-----BEGIN ENCRYPTED PRIVATE KEY-----\n${encryptedBody}\n-----END ENCRYPTED PRIVATE KEY-----`, // pragma: allowlist secret
     ).text).not.toContain(encryptedBody);
-    expect(redactSecrets(`-----BEGIN OPENSSH PRIVATE KEY-----\n${truncatedBody}`).text)
+    expect(redactSecrets(`-----BEGIN OPENSSH PRIVATE KEY-----\n${truncatedBody}`).text) // pragma: allowlist secret
       .not.toContain(truncatedBody);
   });
 
   it('keeps a lone eyJ header (not a three-segment JWT)', () => {
-    const notAJwt = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9';
+    const notAJwt = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9'; // pragma: allowlist secret
     expect(redactSecrets(`value: ${notAJwt}`).text).toContain(notAJwt);
   });
 
@@ -314,30 +314,30 @@ type ParityCase =
 const CATEGORY_PARITY: Record<SecretFindingCategory, ParityCase> = {
   aws_access_key: {
     mirrored: true,
-    sample: 'ASIAIOSFODNN7EXAMPLE',
-    secret: 'ASIAIOSFODNN7EXAMPLE',
+    sample: 'ASIAIOSFODNN7EXAMPLE', // pragma: allowlist secret
+    secret: 'ASIAIOSFODNN7EXAMPLE', // pragma: allowlist secret
   },
   gcp_api_key: {
     mirrored: true,
-    sample: `AIzaSy${'B'.repeat(33)}`,
-    secret: `AIzaSy${'B'.repeat(33)}`,
+    sample: `AIzaSy${'B'.repeat(33)}`, // pragma: allowlist secret
+    secret: `AIzaSy${'B'.repeat(33)}`, // pragma: allowlist secret
   },
   github_token: {
     mirrored: true,
-    sample: `ghp_${'a'.repeat(36)}`,
-    secret: `ghp_${'a'.repeat(36)}`,
+    sample: `ghp_${'a'.repeat(36)}`, // pragma: allowlist secret
+    secret: `ghp_${'a'.repeat(36)}`, // pragma: allowlist secret
   },
   jwt: {
     mirrored: true,
     sample:
-      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U',
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U', // pragma: allowlist secret
     secret:
-      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U',
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U', // pragma: allowlist secret
   },
   ssh_private_key: {
     mirrored: true,
     sample: [
-      '-----BEGIN RSA PRIVATE KEY-----',
+      '-----BEGIN RSA PRIVATE KEY-----', // pragma: allowlist secret
       'MIIEpAIBAAKCAQEA7uJ0j9mFq3Lr8sVtWuZ1aBcDeFgHiJkLmNoPqRsTuVwXyZ012',
       '-----END RSA PRIVATE KEY-----',
     ].join('\n'),
@@ -350,7 +350,7 @@ const CATEGORY_PARITY: Record<SecretFindingCategory, ParityCase> = {
   },
   azure_storage_key: {
     mirrored: true,
-    sample: 'AccountKey=Xj7Kq2Wm9Rt4Yv6Bn1Zc3Pl5Sd8Fg0Hk2Lw4Qa6Ne8Ui0Op2==',
+    sample: 'AccountKey=Xj7Kq2Wm9Rt4Yv6Bn1Zc3Pl5Sd8Fg0Hk2Lw4Qa6Ne8Ui0Op2==', // pragma: allowlist secret
     secret: 'Xj7Kq2Wm9Rt4Yv6Bn1Zc3Pl5Sd8Fg0Hk2Lw4Qa6Ne8Ui0Op2',
   },
   key_value_secret: {

--- a/src/secret-scanner.test.ts
+++ b/src/secret-scanner.test.ts
@@ -14,16 +14,16 @@ import {
 describe('ingest secret scanner', () => {
   it('detects curated credential shapes without returning matched payloads', () => {
     const cases = [
-      ['aws_access_key', 'export AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE'],
-      ['gcp_api_key', 'AIzaSyD-1234567890abcdefghijklmnopqrstu'],
-      ['github_token', 'ghp_1234567890abcdefghijklmnopqrstuvwxyzABCD'],
+      ['aws_access_key', 'export AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE'], // pragma: allowlist secret
+      ['gcp_api_key', 'AIzaSyD-1234567890abcdefghijklmnopqrstu'], // pragma: allowlist secret
+      ['github_token', 'ghp_1234567890abcdefghijklmnopqrstuvwxyzABCD'], // pragma: allowlist secret
       [
         'jwt',
-        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.vJ8eQhVZl2w5uXqO78Fpm_4ZcYc8-Ma5zJ5PpQ',
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.vJ8eQhVZl2w5uXqO78Fpm_4ZcYc8-Ma5zJ5PpQ', // pragma: allowlist secret
       ],
-      ['ssh_private_key', '-----BEGIN OPENSSH PRIVATE KEY-----'],
+      ['ssh_private_key', '-----BEGIN OPENSSH PRIVATE KEY-----'], // pragma: allowlist secret
       ['bearer_token', 'Authorization: Bearer abcDEF1234567890abcDEF1234567890'],
-      ['azure_storage_key', 'AccountKey=abcDEF1234567890abcDEF1234567890abcDEF1234567890=='],
+      ['azure_storage_key', 'AccountKey=abcDEF1234567890abcDEF1234567890abcDEF1234567890=='], // pragma: allowlist secret
       ['key_value_secret', 'password=abcDEF1234567890!'],
     ] as const;
 
@@ -80,7 +80,7 @@ describe('ingest secret scanner', () => {
   it('can report frontmatter findings without inventing chunk indexes', () => {
     try {
       assertNoIngestSecrets(
-        [{ content: '{"api_key":"AKIA1234567890ABCDEF"}', location: 'frontmatter' }],
+        [{ content: '{"api_key":"AKIA1234567890ABCDEF"}', location: 'frontmatter' }], // pragma: allowlist secret
         {
           relativePath: 'alpha/secret.md',
           knowledgeBaseName: 'alpha',
@@ -114,13 +114,13 @@ describe('ingest secret scanner', () => {
   );
 
   it('detects every AWS access-key prefix and rejects a 15-character remainder', () => {
-    const prefixes = ['A3TA', 'AKIA', 'ASIA', 'AGPA', 'AIDA', 'AROA', 'AIPA', 'ANPA'] as const;
+    const prefixes = ['A3TA', 'AKIA', 'ASIA', 'AGPA', 'AIDA', 'AROA', 'AIPA', 'ANPA'] as const; // pragma: allowlist secret
     for (const prefix of prefixes) {
       expect(detectSecretsInText(`${prefix}IOSFODNN7EXAMPLE`)).toEqual(expect.arrayContaining([
         expect.objectContaining({ category: 'aws_access_key' }),
       ]));
     }
-    expect(detectSecretsInText('AKIAIOSFODNN7EXAMPL')).toEqual([]);
+    expect(detectSecretsInText('AKIAIOSFODNN7EXAMPL')).toEqual([]); // pragma: allowlist secret
   });
 
   it('detects every SSH private-key BEGIN variant', () => {
@@ -128,21 +128,21 @@ describe('ingest secret scanner', () => {
       // The ingest regex is `(?:OPENSSH|RSA|DSA|EC|PRIVATE) PRIVATE KEY`, so the
       // `PRIVATE` alternative is `BEGIN PRIVATE PRIVATE KEY`, not PKCS#8
       // `BEGIN PRIVATE KEY`. Egress redaction covers the latter separately.
-      expect(detectSecretsInText(`-----BEGIN ${kind} PRIVATE KEY-----`)).toEqual(
+      expect(detectSecretsInText(`-----BEGIN ${kind} PRIVATE KEY-----`)).toEqual( // pragma: allowlist secret
         expect.arrayContaining([expect.objectContaining({ category: 'ssh_private_key' })]),
       );
     }
-    expect(detectSecretsInText('-----BEGIN PRIVATE KEY-----')).toEqual([]);
+    expect(detectSecretsInText('-----BEGIN PRIVATE KEY-----')).toEqual([]); // pragma: allowlist secret
   });
 
-  it('detects gh[opsu]_ tokens of 36+ and ignores a ghr_ token as github_token', () => {
+  it('detects gh[opsu]_ tokens of 36+ and ignores a ghr_ token as github_token', () => { // pragma: allowlist secret
     const body = '1234567890abcdefghijklmnopqrstuvwxyzABCD';
-    for (const prefix of ['ghp_', 'gho_', 'ghu_', 'ghs_'] as const) {
+    for (const prefix of ['ghp_', 'gho_', 'ghu_', 'ghs_'] as const) { // pragma: allowlist secret
       expect(detectSecretsInText(`${prefix}${body}`)).toEqual(expect.arrayContaining([
         expect.objectContaining({ category: 'github_token' }),
       ]));
     }
-    const ghrFindings = detectSecretsInText(`ghr_${body}`);
+    const ghrFindings = detectSecretsInText(`ghr_${body}`); // pragma: allowlist secret
     expect(ghrFindings.some((finding) => finding.category === 'github_token')).toBe(false);
   });
 
@@ -170,7 +170,7 @@ describe('ingest secret scanner', () => {
   });
 
   it('resets global regex lastIndex so a second scan of the same text still matches', () => {
-    const text = 'AKIAIOSFODNN7EXAMPLE';
+    const text = 'AKIAIOSFODNN7EXAMPLE'; // pragma: allowlist secret
     expect(detectSecretsInText(text)).toEqual(expect.arrayContaining([
       expect.objectContaining({ category: 'aws_access_key' }),
     ]));

--- a/src/secret-scanner.test.ts
+++ b/src/secret-scanner.test.ts
@@ -3,6 +3,13 @@ import {
   assertNoIngestSecrets,
   detectSecretsInText,
 } from './secret-scanner.js';
+import {
+  HIGH_ENTROPY_STANDALONE,
+  MID_ENTROPY_KEY_VALUE,
+  MID_ENTROPY_STANDALONE,
+  SECRET_SCANNER_NEGATIVE_CORPUS,
+  SECRET_SCANNER_POSITIVE_CORPUS,
+} from './test-support/secret-scanner-corpus.js';
 
 describe('ingest secret scanner', () => {
   it('detects curated credential shapes without returning matched payloads', () => {
@@ -87,6 +94,127 @@ describe('ingest secret scanner', () => {
       expect(secretError.categories).toEqual(['aws_access_key']);
       expect(secretError.chunkIndexes).toEqual([]);
       expect(secretError.locations).toEqual(['frontmatter']);
+    }
+  });
+
+  it.each(SECRET_SCANNER_POSITIVE_CORPUS.map((entry) => [entry.name, entry] as const))(
+    'flags positive corpus entry: %s',
+    (_name, entry) => {
+      expect(detectSecretsInText(entry.payload)).toEqual(expect.arrayContaining([
+        expect.objectContaining({ category: entry.expectedCategory, chunkIndex: 0 }),
+      ]));
+    },
+  );
+
+  it.each(SECRET_SCANNER_NEGATIVE_CORPUS.map((entry) => [entry.name, entry] as const))(
+    'does not flag negative corpus entry: %s',
+    (_name, entry) => {
+      expect(detectSecretsInText(entry.payload)).toEqual([]);
+    },
+  );
+
+  it('detects every AWS access-key prefix and rejects a 15-character remainder', () => {
+    const prefixes = ['A3TA', 'AKIA', 'ASIA', 'AGPA', 'AIDA', 'AROA', 'AIPA', 'ANPA'] as const;
+    for (const prefix of prefixes) {
+      expect(detectSecretsInText(`${prefix}IOSFODNN7EXAMPLE`)).toEqual(expect.arrayContaining([
+        expect.objectContaining({ category: 'aws_access_key' }),
+      ]));
+    }
+    expect(detectSecretsInText('AKIAIOSFODNN7EXAMPL')).toEqual([]);
+  });
+
+  it('detects every SSH private-key BEGIN variant', () => {
+    for (const kind of ['OPENSSH', 'RSA', 'DSA', 'EC', 'PRIVATE'] as const) {
+      // The ingest regex is `(?:OPENSSH|RSA|DSA|EC|PRIVATE) PRIVATE KEY`, so the
+      // `PRIVATE` alternative is `BEGIN PRIVATE PRIVATE KEY`, not PKCS#8
+      // `BEGIN PRIVATE KEY`. Egress redaction covers the latter separately.
+      expect(detectSecretsInText(`-----BEGIN ${kind} PRIVATE KEY-----`)).toEqual(
+        expect.arrayContaining([expect.objectContaining({ category: 'ssh_private_key' })]),
+      );
+    }
+    expect(detectSecretsInText('-----BEGIN PRIVATE KEY-----')).toEqual([]);
+  });
+
+  it('detects gh[opsu]_ tokens of 36+ and ignores a ghr_ token as github_token', () => {
+    const body = '1234567890abcdefghijklmnopqrstuvwxyzABCD';
+    for (const prefix of ['ghp_', 'gho_', 'ghu_', 'ghs_'] as const) {
+      expect(detectSecretsInText(`${prefix}${body}`)).toEqual(expect.arrayContaining([
+        expect.objectContaining({ category: 'github_token' }),
+      ]));
+    }
+    const ghrFindings = detectSecretsInText(`ghr_${body}`);
+    expect(ghrFindings.some((finding) => finding.category === 'github_token')).toBe(false);
+  });
+
+  it('skips shaped secrets whose captured value is below the 3.5 entropy floor', () => {
+    expect(detectSecretsInText('password=aaaaaaaaaaaa')).toEqual([]);
+    expect(detectSecretsInText('Bearer aaaaaaaaaaaaaaaaaaaaa')).toEqual([]);
+    expect(detectSecretsInText(`password=${MID_ENTROPY_KEY_VALUE}`)).toEqual(expect.arrayContaining([
+      expect.objectContaining({ category: 'key_value_secret' }),
+    ]));
+  });
+
+  it('applies the 4.2 standalone entropy floor and charset/length gates', () => {
+    expect(detectSecretsInText(HIGH_ENTROPY_STANDALONE)).toEqual(expect.arrayContaining([
+      expect.objectContaining({ category: 'high_entropy' }),
+    ]));
+    expect(detectSecretsInText(MID_ENTROPY_STANDALONE)).toEqual([]);
+    expect(detectSecretsInText('Aa0.Aa0.Aa0.Aa0.Aa0.Aa0.Aa0.Aa0.Aa0.Aa0x')).toEqual([]);
+    expect(detectSecretsInText('abcdefghijklmnopqrstuvwxyz0123456789abc')).toEqual([]);
+  });
+
+  it('does not treat hex-only 40+ tokens or missing charset classes as standalone secrets', () => {
+    expect(detectSecretsInText('a1b2c3d4e5f6789012345678901234567890abcd')).toEqual([]);
+    expect(detectSecretsInText('ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ABCD')).toEqual([]);
+    expect(detectSecretsInText('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMN')).toEqual([]);
+  });
+
+  it('resets global regex lastIndex so a second scan of the same text still matches', () => {
+    const text = 'AKIAIOSFODNN7EXAMPLE';
+    expect(detectSecretsInText(text)).toEqual(expect.arrayContaining([
+      expect.objectContaining({ category: 'aws_access_key' }),
+    ]));
+    expect(detectSecretsInText(text)).toEqual(expect.arrayContaining([
+      expect.objectContaining({ category: 'aws_access_key' }),
+    ]));
+  });
+
+  it('preserves an explicit chunkIndex on structured inputs', () => {
+    try {
+      assertNoIngestSecrets(
+        [{ content: 'password=Abcdefghijk1', chunkIndex: 3, location: 'chunk' }],
+        {
+          relativePath: 'alpha/secret.md',
+          knowledgeBaseName: 'alpha',
+          scanOptions: { enabled: true, bypassKnowledgeBases: [] },
+        },
+      );
+      throw new Error('expected scanner to throw');
+    } catch (error) {
+      expect(error).toBeInstanceOf(IngestSecretDetectedError);
+      expect((error as IngestSecretDetectedError).chunkIndexes).toEqual([3]);
+    }
+  });
+
+  it('sorts mixed chunk and frontmatter locations without inventing indexes', () => {
+    try {
+      assertNoIngestSecrets(
+        [
+          { content: 'password=Abcdefghijk1', location: 'frontmatter' },
+          'Bearer abcDEF1234567890abcDEF1234567890',
+        ],
+        {
+          relativePath: 'alpha/secret.md',
+          knowledgeBaseName: 'alpha',
+          scanOptions: { enabled: true, bypassKnowledgeBases: [] },
+        },
+      );
+      throw new Error('expected scanner to throw');
+    } catch (error) {
+      expect(error).toBeInstanceOf(IngestSecretDetectedError);
+      const secretError = error as IngestSecretDetectedError;
+      expect(secretError.locations).toEqual(['chunk', 'frontmatter']);
+      expect(secretError.chunkIndexes).toEqual([1]);
     }
   });
 });

--- a/src/test-support/redaction-corpus.ts
+++ b/src/test-support/redaction-corpus.ts
@@ -1,0 +1,156 @@
+// Curated positive/negative corpus for outbound secret redaction (issue #896).
+//
+// `redactSecrets` (src/redaction.ts) is the scrubber on every remote-LLM
+// prompt. Each positive entry is a shaped secret that must be replaced with
+// `[REDACTED]`; each negative entry is high-entropy or secret-shaped-looking
+// text that must survive unchanged (git SHAs, credential-less URLs, short
+// tokens, ordinary prose). Consumed by both `redaction.test.ts` and
+// `__property-tests__/redaction.property.test.ts`.
+//
+// This file lives under `src/test-support/` (excluded from `tsconfig` build)
+// so the fixture strings never ship in `build/`. Values are fake and sized
+// to the production regexes; they are not live credentials.
+
+export interface RedactionPositiveEntry {
+  readonly name: string;
+  readonly payload: string;
+  /** `by_type` key `redactSecrets` must record for this isolated payload. */
+  readonly expectedType: string;
+  /** Substring of the secret that must not appear in the redacted text. */
+  readonly secretNeedle: string;
+  /** Substring that must appear after redaction. */
+  readonly expectedSnippet: string;
+}
+
+export interface RedactionNegativeEntry {
+  readonly name: string;
+  readonly payload: string;
+}
+
+export const REDACTION_POSITIVE_CORPUS: readonly RedactionPositiveEntry[] = [
+  {
+    name: 'credential-url',
+    payload: 'clone https://alice:s3cretpass@example.com/repo.git',
+    expectedType: 'credential_url',
+    secretNeedle: 'alice:s3cretpass',
+    expectedSnippet: 'https://[REDACTED]@example.com/repo.git',
+  },
+  {
+    name: 'authorization-basic',
+    payload: 'Authorization: Basic dXNlcjpwYXNzd29yZA',
+    expectedType: 'authorization_header',
+    secretNeedle: 'dXNlcjpwYXNzd29yZA',
+    expectedSnippet: 'Authorization: Basic [REDACTED]',
+  },
+  {
+    name: 'cookie-header',
+    payload: 'Cookie: sessionid=abc123def456',
+    expectedType: 'cookie_header',
+    secretNeedle: 'sessionid=abc123def456',
+    expectedSnippet: 'Cookie: [REDACTED]',
+  },
+  {
+    name: 'json-api-key',
+    payload: '{"api_key":"not-a-provider-shape"}',
+    expectedType: 'json_secret',
+    secretNeedle: 'not-a-provider-shape',
+    expectedSnippet: '"api_key":"[REDACTED]"',
+  },
+  {
+    name: 'dotenv-api-key',
+    payload: 'OPENAI_API_KEY=not-a-provider-shape-value',
+    expectedType: 'dotenv_secret',
+    secretNeedle: 'not-a-provider-shape-value',
+    expectedSnippet: 'OPENAI_API_KEY=[REDACTED]',
+  },
+  {
+    name: 'key-value-password',
+    payload: 'see password=not-a-provider-shape',
+    expectedType: 'key_value_secret',
+    secretNeedle: 'not-a-provider-shape',
+    expectedSnippet: 'password=[REDACTED]',
+  },
+  {
+    name: 'bare-bearer',
+    payload: 'use Bearer abcdefghijklmno for this',
+    expectedType: 'bearer_token',
+    secretNeedle: 'abcdefghijklmno',
+    expectedSnippet: 'Bearer [REDACTED]',
+  },
+  {
+    name: 'openai-sk',
+    payload: 'sk-abcdefghijklmnopqrstuvwxyz',
+    expectedType: 'provider_token',
+    secretNeedle: 'sk-abcdefghijklmnopqrstuvwxyz',
+    expectedSnippet: '[REDACTED]',
+  },
+  {
+    name: 'github-pat',
+    payload: 'github_pat_abcdefghijklmnopqrstuvwxyz',
+    expectedType: 'provider_token',
+    secretNeedle: 'github_pat_abcdefghijklmnopqrstuvwxyz',
+    expectedSnippet: '[REDACTED]',
+  },
+  {
+    name: 'aws-akia',
+    payload: 'AKIAIOSFODNN7EXAMPLE',
+    expectedType: 'provider_token',
+    secretNeedle: 'AKIAIOSFODNN7EXAMPLE',
+    expectedSnippet: '[REDACTED]',
+  },
+  {
+    name: 'slack-xoxb',
+    payload: 'xoxb-1234567890-token',
+    expectedType: 'provider_token',
+    secretNeedle: 'xoxb-1234567890-token',
+    expectedSnippet: '[REDACTED]',
+  },
+  {
+    name: 'jwt',
+    payload:
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.vJ8eQhVZl2w5uXqO78Fpm_4ZcYc8-Ma5zJ5PpQ',
+    expectedType: 'jwt',
+    secretNeedle:
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.vJ8eQhVZl2w5uXqO78Fpm_4ZcYc8-Ma5zJ5PpQ',
+    expectedSnippet: '[REDACTED]',
+  },
+  {
+    name: 'ssh-private-key',
+    payload: '-----BEGIN OPENSSH PRIVATE KEY-----\nabcdefghijklmnopqrstuvwxyzABCDEF\n-----END OPENSSH PRIVATE KEY-----',
+    expectedType: 'ssh_private_key',
+    secretNeedle: 'abcdefghijklmnopqrstuvwxyzABCDEF',
+    expectedSnippet: '[REDACTED]',
+  },
+  {
+    name: 'azure-account-key',
+    payload: 'AccountKey=abcDEF1234567890abcDEF1234567890abcDEF1234567890==',
+    expectedType: 'azure_storage_key',
+    secretNeedle: 'abcDEF1234567890abcDEF1234567890abcDEF1234567890==',
+    expectedSnippet: 'AccountKey=[REDACTED]',
+  },
+  {
+    name: 'gcp-api-key',
+    payload: 'AIzaSyD-1234567890abcdefghijklmnopqrstu',
+    expectedType: 'provider_token',
+    secretNeedle: 'AIzaSyD-1234567890abcdefghijklmnopqrstu',
+    expectedSnippet: '[REDACTED]',
+  },
+];
+
+export const REDACTION_NEGATIVE_CORPUS: readonly RedactionNegativeEntry[] = [
+  { name: 'git-sha-40', payload: 'commit a1b2c3d4e5f6789012345678901234567890abcd landed' },
+  { name: 'https-url', payload: 'see https://example.com/abcdefghijklmnopqrstuvwxyz0123456789' },
+  { name: 'ordinary-prose', payload: 'Deployment notes: restart the worker after migration.' },
+  { name: 'short-bearer', payload: 'use Bearer 12345678901 here' },
+  { name: 'short-sk', payload: 'sk-shorttokenvalue' },
+  { name: 'json-username', payload: '{"username":"alice","count":3}' },
+  { name: 'plain-assignment', payload: 'FOO=bar' },
+  { name: 'password-in-prose', payload: 'the password is documented in the runbook' },
+  { name: 'digest-auth', payload: 'Authorization: Digest abcdefghijklmnop' },
+  // Generic high-entropy blob: redaction matches shaped secrets only, not entropy.
+  { name: 'high-entropy-blob', payload: 'Aa0.Bb1.Cc2.Dd3.Ee4.Ff5.Gg6.Hh7.Ii8.Jj9k' },
+  // Lone `eyJ` header without payload.signature is not a JWT.
+  { name: 'bare-eyj-header', payload: 'value: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9' },
+  { name: 'short-gcp-key', payload: `AIzaSy${'B'.repeat(32)}` },
+  { name: 'short-azure-key', payload: 'AccountKey=abcdefghijklmnopqrstuvwxyz012345' },
+];

--- a/src/test-support/redaction-corpus.ts
+++ b/src/test-support/redaction-corpus.ts
@@ -79,60 +79,60 @@ export const REDACTION_POSITIVE_CORPUS: readonly RedactionPositiveEntry[] = [
   },
   {
     name: 'openai-sk',
-    payload: 'sk-abcdefghijklmnopqrstuvwxyz',
+    payload: 'sk-abcdefghijklmnopqrstuvwxyz', // pragma: allowlist secret
     expectedType: 'provider_token',
-    secretNeedle: 'sk-abcdefghijklmnopqrstuvwxyz',
+    secretNeedle: 'sk-abcdefghijklmnopqrstuvwxyz', // pragma: allowlist secret
     expectedSnippet: '[REDACTED]',
   },
   {
     name: 'github-pat',
-    payload: 'github_pat_abcdefghijklmnopqrstuvwxyz',
+    payload: 'github_pat_abcdefghijklmnopqrstuvwxyz', // pragma: allowlist secret
     expectedType: 'provider_token',
-    secretNeedle: 'github_pat_abcdefghijklmnopqrstuvwxyz',
+    secretNeedle: 'github_pat_abcdefghijklmnopqrstuvwxyz', // pragma: allowlist secret
     expectedSnippet: '[REDACTED]',
   },
   {
     name: 'aws-akia',
-    payload: 'AKIAIOSFODNN7EXAMPLE',
+    payload: 'AKIAIOSFODNN7EXAMPLE', // pragma: allowlist secret
     expectedType: 'provider_token',
-    secretNeedle: 'AKIAIOSFODNN7EXAMPLE',
+    secretNeedle: 'AKIAIOSFODNN7EXAMPLE', // pragma: allowlist secret
     expectedSnippet: '[REDACTED]',
   },
   {
     name: 'slack-xoxb',
-    payload: 'xoxb-1234567890-token',
+    payload: 'xoxb-1234567890-token', // pragma: allowlist secret
     expectedType: 'provider_token',
-    secretNeedle: 'xoxb-1234567890-token',
+    secretNeedle: 'xoxb-1234567890-token', // pragma: allowlist secret
     expectedSnippet: '[REDACTED]',
   },
   {
     name: 'jwt',
     payload:
-      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.vJ8eQhVZl2w5uXqO78Fpm_4ZcYc8-Ma5zJ5PpQ',
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.vJ8eQhVZl2w5uXqO78Fpm_4ZcYc8-Ma5zJ5PpQ', // pragma: allowlist secret
     expectedType: 'jwt',
     secretNeedle:
-      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.vJ8eQhVZl2w5uXqO78Fpm_4ZcYc8-Ma5zJ5PpQ',
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.vJ8eQhVZl2w5uXqO78Fpm_4ZcYc8-Ma5zJ5PpQ', // pragma: allowlist secret
     expectedSnippet: '[REDACTED]',
   },
   {
     name: 'ssh-private-key',
-    payload: '-----BEGIN OPENSSH PRIVATE KEY-----\nabcdefghijklmnopqrstuvwxyzABCDEF\n-----END OPENSSH PRIVATE KEY-----',
+    payload: '-----BEGIN OPENSSH PRIVATE KEY-----\nabcdefghijklmnopqrstuvwxyzABCDEF\n-----END OPENSSH PRIVATE KEY-----', // pragma: allowlist secret
     expectedType: 'ssh_private_key',
     secretNeedle: 'abcdefghijklmnopqrstuvwxyzABCDEF',
     expectedSnippet: '[REDACTED]',
   },
   {
     name: 'azure-account-key',
-    payload: 'AccountKey=abcDEF1234567890abcDEF1234567890abcDEF1234567890==',
+    payload: 'AccountKey=abcDEF1234567890abcDEF1234567890abcDEF1234567890==', // pragma: allowlist secret
     expectedType: 'azure_storage_key',
     secretNeedle: 'abcDEF1234567890abcDEF1234567890abcDEF1234567890==',
-    expectedSnippet: 'AccountKey=[REDACTED]',
+    expectedSnippet: 'AccountKey=[REDACTED]', // pragma: allowlist secret
   },
   {
     name: 'gcp-api-key',
-    payload: 'AIzaSyD-1234567890abcdefghijklmnopqrstu',
+    payload: 'AIzaSyD-1234567890abcdefghijklmnopqrstu', // pragma: allowlist secret
     expectedType: 'provider_token',
-    secretNeedle: 'AIzaSyD-1234567890abcdefghijklmnopqrstu',
+    secretNeedle: 'AIzaSyD-1234567890abcdefghijklmnopqrstu', // pragma: allowlist secret
     expectedSnippet: '[REDACTED]',
   },
 ];
@@ -142,7 +142,7 @@ export const REDACTION_NEGATIVE_CORPUS: readonly RedactionNegativeEntry[] = [
   { name: 'https-url', payload: 'see https://example.com/abcdefghijklmnopqrstuvwxyz0123456789' },
   { name: 'ordinary-prose', payload: 'Deployment notes: restart the worker after migration.' },
   { name: 'short-bearer', payload: 'use Bearer 12345678901 here' },
-  { name: 'short-sk', payload: 'sk-shorttokenvalue' },
+  { name: 'short-sk', payload: 'sk-shorttokenvalue' }, // pragma: allowlist secret
   { name: 'json-username', payload: '{"username":"alice","count":3}' },
   { name: 'plain-assignment', payload: 'FOO=bar' },
   { name: 'password-in-prose', payload: 'the password is documented in the runbook' },
@@ -150,7 +150,7 @@ export const REDACTION_NEGATIVE_CORPUS: readonly RedactionNegativeEntry[] = [
   // Generic high-entropy blob: redaction matches shaped secrets only, not entropy.
   { name: 'high-entropy-blob', payload: 'Aa0.Bb1.Cc2.Dd3.Ee4.Ff5.Gg6.Hh7.Ii8.Jj9k' },
   // Lone `eyJ` header without payload.signature is not a JWT.
-  { name: 'bare-eyj-header', payload: 'value: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9' },
-  { name: 'short-gcp-key', payload: `AIzaSy${'B'.repeat(32)}` },
-  { name: 'short-azure-key', payload: 'AccountKey=abcdefghijklmnopqrstuvwxyz012345' },
+  { name: 'bare-eyj-header', payload: 'value: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9' }, // pragma: allowlist secret
+  { name: 'short-gcp-key', payload: `AIzaSy${'B'.repeat(32)}` }, // pragma: allowlist secret
+  { name: 'short-azure-key', payload: 'AccountKey=abcdefghijklmnopqrstuvwxyz012345' }, // pragma: allowlist secret
 ];

--- a/src/test-support/secret-scanner-corpus.ts
+++ b/src/test-support/secret-scanner-corpus.ts
@@ -1,0 +1,97 @@
+// Curated positive/negative corpus for the ingest secret scanner (issue #896).
+//
+// `detectSecretsInText` (src/secret-scanner.ts) classifies secret-like
+// content before embedding. Positive entries must raise the named category;
+// negative entries are high-entropy non-secrets (git SHAs, URLs, low-entropy
+// repeats, short tokens, ordinary prose) that must stay clean. Consumed by
+// both `secret-scanner.test.ts` and `__property-tests__/secret-scanner.property.test.ts`.
+//
+// This file lives under `src/test-support/` (excluded from `tsconfig` build)
+// so the fixture strings never ship in `build/`. Values are fake and sized
+// to the production regexes and entropy floors (3.5 for shaped secrets with
+// `entropyCheck`, 4.2 for standalone high-entropy tokens).
+
+import type { SecretFindingCategory } from '../secret-scanner.js';
+
+export interface SecretScannerPositiveEntry {
+  readonly name: string;
+  readonly payload: string;
+  readonly expectedCategory: SecretFindingCategory;
+}
+
+export interface SecretScannerNegativeEntry {
+  readonly name: string;
+  readonly payload: string;
+}
+
+/** 40-char mixed token, Shannon entropy ~4.61 — above the 4.2 standalone floor. */
+export const HIGH_ENTROPY_STANDALONE = 'Aa0.Bb1.Cc2.Dd3.Ee4.Ff5.Gg6.Hh7.Ii8.Jj9k';
+
+/** 40-char mixed token, Shannon entropy ~3.97 — between 3.5 and 4.2. */
+export const MID_ENTROPY_STANDALONE = 'ABCDefgh0123._~+ABCDefgh0123._~+ABCDefgh';
+
+/** 12-char value, Shannon entropy ~3.59 — above the 3.5 shaped-secret floor. */
+export const MID_ENTROPY_KEY_VALUE = 'Abcdefghijk1';
+
+export const SECRET_SCANNER_POSITIVE_CORPUS: readonly SecretScannerPositiveEntry[] = [
+  {
+    name: 'aws-access-key',
+    payload: 'export AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE',
+    expectedCategory: 'aws_access_key',
+  },
+  {
+    name: 'gcp-api-key',
+    payload: 'AIzaSyD-1234567890abcdefghijklmnopqrstu',
+    expectedCategory: 'gcp_api_key',
+  },
+  {
+    name: 'github-token',
+    payload: 'ghp_1234567890abcdefghijklmnopqrstuvwxyzABCD',
+    expectedCategory: 'github_token',
+  },
+  {
+    name: 'jwt',
+    payload:
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.vJ8eQhVZl2w5uXqO78Fpm_4ZcYc8-Ma5zJ5PpQ',
+    expectedCategory: 'jwt',
+  },
+  {
+    name: 'ssh-private-key',
+    payload: '-----BEGIN OPENSSH PRIVATE KEY-----',
+    expectedCategory: 'ssh_private_key',
+  },
+  {
+    name: 'bearer-token',
+    payload: 'Authorization: Bearer abcDEF1234567890abcDEF1234567890',
+    expectedCategory: 'bearer_token',
+  },
+  {
+    name: 'azure-storage-key',
+    payload: 'AccountKey=abcDEF1234567890abcDEF1234567890abcDEF1234567890==',
+    expectedCategory: 'azure_storage_key',
+  },
+  {
+    name: 'key-value-secret',
+    payload: `password=${MID_ENTROPY_KEY_VALUE}`,
+    expectedCategory: 'key_value_secret',
+  },
+  {
+    name: 'high-entropy-standalone',
+    payload: HIGH_ENTROPY_STANDALONE,
+    expectedCategory: 'high_entropy',
+  },
+];
+
+export const SECRET_SCANNER_NEGATIVE_CORPUS: readonly SecretScannerNegativeEntry[] = [
+  { name: 'git-sha-40', payload: 'a1b2c3d4e5f6789012345678901234567890abcd' },
+  { name: 'sha256-hex', payload: 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855' },
+  { name: 'https-url', payload: 'https://example.com/abcdefghijklmnopqrstuvwxyz0123456789' },
+  { name: 'ordinary-prose', payload: 'Deployment notes: restart the worker after migration.' },
+  { name: 'low-entropy-password', payload: 'password=aaaaaaaaaaaa' },
+  { name: 'short-password', payload: 'password=short' },
+  { name: 'low-entropy-bearer', payload: 'Bearer aaaaaaaaaaaaaaaaaaaaa' },
+  { name: 'repeated-char-40', payload: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' },
+  { name: 'mid-entropy-standalone', payload: MID_ENTROPY_STANDALONE },
+  { name: 'uuid', payload: '550e8400-e29b-41d4-a716-446655440000' },
+  { name: 'all-lowercase-40', payload: 'abcdefghijklmnopqrstuvwxyz0123456789abcd' },
+];

--- a/src/test-support/secret-scanner-corpus.ts
+++ b/src/test-support/secret-scanner-corpus.ts
@@ -36,28 +36,28 @@ export const MID_ENTROPY_KEY_VALUE = 'Abcdefghijk1';
 export const SECRET_SCANNER_POSITIVE_CORPUS: readonly SecretScannerPositiveEntry[] = [
   {
     name: 'aws-access-key',
-    payload: 'export AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE',
+    payload: 'export AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE', // pragma: allowlist secret
     expectedCategory: 'aws_access_key',
   },
   {
     name: 'gcp-api-key',
-    payload: 'AIzaSyD-1234567890abcdefghijklmnopqrstu',
+    payload: 'AIzaSyD-1234567890abcdefghijklmnopqrstu', // pragma: allowlist secret
     expectedCategory: 'gcp_api_key',
   },
   {
     name: 'github-token',
-    payload: 'ghp_1234567890abcdefghijklmnopqrstuvwxyzABCD',
+    payload: 'ghp_1234567890abcdefghijklmnopqrstuvwxyzABCD', // pragma: allowlist secret
     expectedCategory: 'github_token',
   },
   {
     name: 'jwt',
     payload:
-      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.vJ8eQhVZl2w5uXqO78Fpm_4ZcYc8-Ma5zJ5PpQ',
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.vJ8eQhVZl2w5uXqO78Fpm_4ZcYc8-Ma5zJ5PpQ', // pragma: allowlist secret
     expectedCategory: 'jwt',
   },
   {
     name: 'ssh-private-key',
-    payload: '-----BEGIN OPENSSH PRIVATE KEY-----',
+    payload: '-----BEGIN OPENSSH PRIVATE KEY-----', // pragma: allowlist secret
     expectedCategory: 'ssh_private_key',
   },
   {
@@ -67,7 +67,7 @@ export const SECRET_SCANNER_POSITIVE_CORPUS: readonly SecretScannerPositiveEntry
   },
   {
     name: 'azure-storage-key',
-    payload: 'AccountKey=abcDEF1234567890abcDEF1234567890abcDEF1234567890==',
+    payload: 'AccountKey=abcDEF1234567890abcDEF1234567890abcDEF1234567890==', // pragma: allowlist secret
     expectedCategory: 'azure_storage_key',
   },
   {

--- a/stryker.conf.json
+++ b/stryker.conf.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./node_modules/@stryker-mutator/core/schema/stryker-schema.json",
-  "_comment": "Issue #651 — mutation testing scoped to a curated set of pure, high-value core modules that have focused unit tests. Run via `npm run test:mutation`; nightly/manual in CI only (mutation runs are slow). Issue #751 added the security-critical injection-guard detector to the scope, ratcheting `break` 45 -> 50 as the intent invites. Baseline re-measured 2026-07-03 (~3m33s, concurrency 2): combined 54.68% — chunk-id 54.94%, hybrid-retrieval 82.80%, lexical-bm25 48.78%, redaction 20.37%, injection-guard 67.70%. Only `injection-guard.test.ts` (the deterministic, example/corpus-based unit test) is in the Stryker `testMatch` (jest.stryker.config.cjs); the fast-check property suite is deliberately excluded so the gate stays deterministic — its random seeds would jitter the mutant verdicts. `thresholds.break` sits a few points under the combined baseline so the gate catches regressions without flaking on run-to-run jitter; ratchet it upward as the suite improves.",
+  "_comment": "Issue #651 — mutation testing scoped to a curated set of pure, high-value core modules that have focused unit tests. Run via `npm run test:mutation`; nightly/manual in CI only (mutation runs are slow). Issue #751 added the security-critical injection-guard detector to the scope, ratcheting `break` 45 -> 50. Issue #896 added secret-scanner and strengthened redaction tests, ratcheting `break` 50 -> 64. Baseline re-measured 2026-09-10 (~41m, concurrency 2): combined 68.97% — chunk-id 54.94%, hybrid-retrieval 93.15%, lexical-bm25 50.00%, redaction 69.95%, secret-scanner 80.84%, injection-guard 69.72%. Only the deterministic unit tests are in the Stryker `testMatch` (jest.stryker.config.cjs); the fast-check property suites are deliberately excluded so the gate stays deterministic — their random seeds would jitter the mutant verdicts. `thresholds.break` sits a few points under the combined baseline so the gate catches regressions without flaking on run-to-run jitter; ratchet it upward as the suite improves.",
   "packageManager": "npm",
   "testRunner": "jest",
   "jest": {
@@ -12,6 +12,7 @@
   "mutate": [
     "src/chunk-id.ts",
     "src/redaction.ts",
+    "src/secret-scanner.ts",
     "src/lexical-bm25.ts",
     "src/hybrid-retrieval.ts",
     "src/injection-guard.ts"
@@ -25,6 +26,6 @@
   "thresholds": {
     "high": 80,
     "low": 50,
-    "break": 50
+    "break": 64
   }
 }


### PR DESCRIPTION
<!-- kookr:check:prose -->

## Summary

The outbound scrubber that strips credentials from remote LLM prompts, and the ingest scanner that quarantines secret-like files before embedding, were the weakest spots in this repo's mutation tests (Stryker: small edits that should make tests fail). Redaction sat at 20% with a single 21-line test; the scanner was not in the mutation gate at all. A broken regex or an off-by-one entropy floor (minimum randomness treated as secret-like) could have shipped without any test noticing.

This PR adds focused unit tests and property tests for both modules, puts the scanner into the mutation scope, and raises the fail-the-run *break* threshold only after measuring that the combined score actually went up.

*Mutation testing* (Stryker) is an automated pass that edits production code in small ways; if the existing tests still pass, they did not pin that behavior. The *break* threshold is the combined score below which `npm run test:mutation` fails.

Fixes #896

## Testing

- [x] `npm test` passes
- [ ] ~~End-to-end verified for tool/transport changes (see `CLAUDE.md`)~~ — N/A: no tool or transport change
- [ ] ~~Benchmark run if performance-relevant: `BENCH_PROVIDER=stub npm run bench`~~ — N/A: no retrieval/performance-relevant change
- [x] <!-- kookr:check:tests --> Tests were added or updated for changed behavior; bug fixes include a regression test

## Documentation contract

- [ ] <!-- kookr:check:readme --> ~~`README.md` reflects user-visible CLI, MCP, installation, or configuration changes~~ — N/A: test and mutation-gate tooling only; no user-visible CLI/MCP/install/config change
- [ ] <!-- kookr:check:docs --> ~~Relevant operator, API, configuration, and retrieval documentation under `docs/` is consistent with the implementation~~ — N/A: no operator/API/config/retrieval behavior change
- [ ] <!-- kookr:check:mbse --> ~~RFCs are updated when this PR implements, supersedes, or changes an accepted design~~ — N/A: no RFC or accepted design is affected

## Changelog

- [ ] <!-- kookr:check:changelog --> ~~`CHANGELOG.md` has an `Unreleased` entry for user-visible changes~~ — N/A: test/tooling only; no user-facing CLI/MCP/API/config change

## Retrieval and performance evidence

- [ ] <!-- kookr:check:benchmarks --> ~~Retrieval-quality or performance changes include the relevant benchmark/evaluation evidence~~ — waived: no retrieval-quality or performance change

## Changes

- Expand `src/redaction.test.ts` and `src/secret-scanner.test.ts` with boundary, entropy, capture-group, and flag (`g`/`i`/`m`) cases, plus a shared positive/negative corpus under `src/test-support/` (true secrets vs git SHAs, URLs, low-entropy blobs, ordinary prose).
- Keep the #952 ingest↔egress parity gate (`Record<SecretFindingCategory, …>`), the three-segment JWT negative, and the PKCS#8 / encrypted / truncated PEM cases.
- Add `src/__property-tests__/redaction.property.test.ts` and `src/__property-tests__/secret-scanner.property.test.ts` (fast-check). These are excluded from Stryker's `testMatch` so random seeds cannot jitter mutant verdicts — same split as the injection-guard work in #751 / PR #779.
- Add `src/secret-scanner.ts` to `stryker.conf.json` `mutate` and `src/secret-scanner.test.ts` to `jest.stryker.config.cjs`.
- One production comment: disable Regex mutants on `WRAPPER_LINE_BREAK` in `src/injection-guard.ts`. Since #930 that unicode `\v` class is mutated to `\V`, which is a syntax error under the `/u` flag and aborts the Stryker dry run on current Node. Without this, `npm run test:mutation` cannot complete.
- Re-measured 2026-09-10 (~41m, concurrency 2): combined **54.68% → 68.97%** (redaction **20.37% → 69.95%**, secret-scanner **80.84%** new). Ratchet `thresholds.break` **50 → 64** (about five points under the new baseline, matching the previous margin).

## Scope notes

- Did not change `redaction.ts` or `secret-scanner.ts` production logic.
- `jest.stryker.config.cjs` is required so Stryker actually runs the scanner's unit tests. The two corpus files follow the #751 `src/test-support/` pattern so unit and property suites share one source of truth.

## Verification

- `npm test` — green (214 parallel suites + 11 serial).
- Focused: 110 tests in the four new/expanded files, all passing.
- `npm run test:mutation` — combined 68.97 ≥ break 64. Per-file: chunk-id 54.94%, hybrid-retrieval 93.15%, lexical-bm25 50.00%, redaction 69.95%, secret-scanner 80.84%, injection-guard 69.72%.

## Follow-ups

None.

Closes #896


<!-- retrigger anti-drift with current body -->
