### PR TITLE
fix(otel): correlate retrieve/ask traces with canonical request_id

### DIFF
--- a/src/KnowledgeBaseServer.test.ts
+++ b/src/KnowledgeBaseServer.test.ts
@@ -195,6 +195,40 @@ describe('KnowledgeBaseServer handlers', () => {
       .map((line) => JSON.parse(line));
   }
 
+  function makeFakeOtelTracer(): {
+    tracer: {
+      startActiveSpan<T>(name: string, fn: (span: {
+        setAttribute(key: string, value: unknown): unknown;
+        setStatus(): unknown;
+        recordException(): unknown;
+        end(): unknown;
+      }) => T): T;
+    };
+    spans: Array<{ name: string; attributes: Record<string, unknown> }>;
+  } {
+    const spans: Array<{ name: string; attributes: Record<string, unknown> }> = [];
+    const tracer = {
+      startActiveSpan<T>(name: string, fn: (span: {
+        setAttribute(key: string, value: unknown): unknown;
+        setStatus(): unknown;
+        recordException(): unknown;
+        end(): unknown;
+      }) => T): T {
+        const recorded = { name, attributes: {} as Record<string, unknown> };
+        spans.push(recorded);
+        return fn({
+          setAttribute(key, value) {
+            recorded.attributes[key] = value;
+          },
+          setStatus() { /* unused */ },
+          recordException() { /* unused */ },
+          end() { /* unused */ },
+        });
+      },
+    };
+    return { tracer, spans };
+  }
+
   // --- handleListKnowledgeBases ---------------------------------------------
 
   it('handleListKnowledgeBases returns filtered (dot-free) entries', async () => {
@@ -2170,6 +2204,38 @@ describe('KnowledgeBaseServer handlers', () => {
     }));
   });
 
+  it('handleRetrieveKnowledge sets kb.request_id on the root span equal to the canonical line (#900)', async () => {
+    const tempDir = await setRetrieveEnv();
+    const logFile = path.join(tempDir, 'canonical-otel-retrieve.log');
+    process.env.LOG_FILE = logFile;
+    process.env.KB_LOG_FORMAT = 'canonical';
+    updateIndexMock.mockResolvedValue(undefined);
+    similaritySearchMock.mockResolvedValue([
+      { pageContent: 'Alpha content', metadata: { source: '/kb/a.md' }, score: 0.12 },
+    ]);
+
+    const server = await freshServer();
+    const otel = await import('./otel-trace.js');
+    const { tracer, spans } = makeFakeOtelTracer();
+    otel.setOtelTracerForTesting(tracer);
+    try {
+      const result = await server['handleRetrieveKnowledge']({
+        query: 'what is alpha',
+        knowledge_base_name: 'alpha',
+      });
+      expect(result.isError).toBeUndefined();
+
+      const events = await readCanonicalEvents(logFile);
+      const retrieveEvent = events.find((event) => event.tool === 'retrieve_knowledge');
+      const root = spans.find((span) => span.name === 'kb.retrieve_knowledge');
+      expect(typeof retrieveEvent?.request_id).toBe('string');
+      expect(retrieveEvent?.request_id).not.toBe('');
+      expect(root?.attributes['kb.request_id']).toBe(retrieveEvent?.request_id);
+    } finally {
+      otel.resetOtelForTesting();
+    }
+  });
+
   it('handleRetrieveKnowledge returns "_No similar results found._" when similaritySearch returns []', async () => {
     await setRetrieveEnv();
     updateIndexMock.mockResolvedValue(undefined);
@@ -2251,6 +2317,48 @@ describe('KnowledgeBaseServer handlers', () => {
       context_excluded_chunks: 0,
     });
     expect((result as any).structuredContent).toEqual(payload);
+  });
+
+  it('handleAskKnowledge sets kb.request_id on the root span equal to the canonical line (#900)', async () => {
+    const tempDir = await setRetrieveEnv();
+    const logFile = path.join(tempDir, 'canonical-otel-ask.log');
+    process.env.LOG_FILE = logFile;
+    process.env.KB_LOG_FORMAT = 'canonical';
+    process.env.KB_LLM_FAKE = 'on';
+    delete process.env.KB_LLM_ENDPOINT;
+    similaritySearchMock.mockResolvedValue([
+      {
+        pageContent: 'Rollback approval requires the release lead.',
+        metadata: {
+          knowledgeBase: 'ops',
+          relativePath: 'runbooks/rollback.md',
+          source: path.join(process.cwd(), 'package.json'),
+          loc: { lines: { from: 4, to: 8 } },
+        },
+        score: 0.1,
+      },
+    ]);
+
+    const server = await freshServer();
+    const otel = await import('./otel-trace.js');
+    const { tracer, spans } = makeFakeOtelTracer();
+    otel.setOtelTracerForTesting(tracer);
+    try {
+      const result = await server['handleAskKnowledge']({
+        query: 'Who approves rollback?',
+        knowledge_base_name: 'ops',
+      });
+      expect(result.isError).toBeUndefined();
+
+      const events = await readCanonicalEvents(logFile);
+      const askEvent = events.find((event) => event.tool === 'ask_knowledge');
+      const root = spans.find((span) => span.name === 'kb.ask');
+      expect(typeof askEvent?.request_id).toBe('string');
+      expect(askEvent?.request_id).not.toBe('');
+      expect(root?.attributes['kb.request_id']).toBe(askEvent?.request_id);
+    } finally {
+      otel.resetOtelForTesting();
+    }
   });
 
   it('handleRetrieveKnowledge forwards knowledge_base_name to updateIndex; passes undefined otherwise', async () => {

--- a/src/KnowledgeBaseServer.ts
+++ b/src/KnowledgeBaseServer.ts
@@ -121,6 +121,7 @@ import {
   classifyCanonicalError,
   canonicalGateStageRecord,
   canonicalRerankStageRecord,
+  createCanonicalRequestId,
   degradationSummaryFields,
   emitCanonicalLog,
   type CanonicalDegradedStage,
@@ -937,13 +938,19 @@ export class KnowledgeBaseServer {
     const gateOverride: RelevanceGateOverride = args.gate;
     const rerankOverride: RerankOverride = args.rerank;
     const neighborContext = resolveNeighborContextOptions(args);
+    // Mint before the span so the trace and the canonical log share one id
+    // (issue #900). withCanonicalTool would otherwise mint later, after the
+    // span is already open, leaving two unlinkable identifiers.
+    const requestId = createCanonicalRequestId();
 
     return withSpan('kb.retrieve_knowledge', {
       'kb.scope': knowledgeBaseName ?? null,
       'kb.search_mode': searchMode,
       'kb.k': 10,
+      'kb.request_id': requestId,
     }, () => this.withCanonicalTool({
       tool: 'retrieve_knowledge',
+      request_id: requestId,
       query,
       kb_scope: knowledgeBaseName ?? null,
       k: 10,
@@ -1231,8 +1238,12 @@ export class KnowledgeBaseServer {
     timing?: boolean;
   }, extra?: ToolExtra): Promise<CallToolResult> {
     const report = this.progressReporter(extra);
+    // Same mint-early pattern as retrieve_knowledge (issue #900): the kb.ask
+    // span opens inside executeAsk, so the id has to travel in as request_id.
+    const requestId = createCanonicalRequestId();
     return this.withCanonicalTool({
       tool: 'ask_knowledge',
+      request_id: requestId,
       query: args.query,
       kb_scope: args.knowledge_base_name ?? null,
       k: args.k ?? 8,
@@ -1250,6 +1261,7 @@ export class KnowledgeBaseServer {
           search_mode: args.search_mode,
           rerank: args.rerank,
           timing: args.timing ?? true,
+          request_id: requestId,
         }, {
           bootstrapLayout: FaissIndexManager.bootstrapLayout.bind(FaissIndexManager),
           resolveActiveModel,

--- a/src/ask-core.otel.test.ts
+++ b/src/ask-core.otel.test.ts
@@ -149,6 +149,24 @@ describe('executeAsk OpenTelemetry spans (#647)', () => {
     expect(spans.every((s) => s.ended)).toBe(true);
   });
 
+  it('copies a provided request id onto the root kb.ask span as kb.request_id (#900)', async () => {
+    const { tracer, spans } = makeFakeTracer();
+    setOtelTracerForTesting(tracer);
+
+    const requestId = 'req-otel-900-ask';
+    const cache = new AnswerCache({ enabled: false, indexPath: dir });
+    const call = jest.fn(async () => ({ content: 'an answer', model: 'qwen3', raw: {} }));
+    await executeAsk(
+      { ...askArgs('How did the deploy change?'), requestId },
+      makeDeps(cache, makeManager('The deploy switched models.'), call),
+      Date.now(),
+    );
+
+    const root = spans.find((s) => s.name === 'kb.ask');
+    expect(root?.attributes['kb.request_id']).toBe(requestId);
+    expect(spans.filter((s) => s.name !== 'kb.ask').every((s) => s.attributes['kb.request_id'] === undefined)).toBe(true);
+  });
+
   it('never puts the query text or chunk content in any span attribute', async () => {
     const { tracer, spans } = makeFakeTracer();
     setOtelTracerForTesting(tracer);

--- a/src/ask-core.ts
+++ b/src/ask-core.ts
@@ -116,6 +116,11 @@ export interface AskExecutionArgs {
   /** Per-call cross-encoder reranker override (hybrid only). Off by default. */
   rerank?: RerankOverride;
   onAnswerToken?: (token: string) => void | Promise<void>;
+  /**
+   * Canonical-log request id (#900). Copied onto the root `kb.ask` span as
+   * `kb.request_id` so a slow log line and its OTLP trace share one id.
+   */
+  requestId?: string;
 }
 
 export interface AskKnowledgeInput {
@@ -134,6 +139,8 @@ export interface AskKnowledgeInput {
   search_mode?: SearchMode;
   /** Per-call cross-encoder reranker override (hybrid only). Off by default. */
   rerank?: RerankOverride;
+  /** Internal: canonical request id for the root `kb.ask` span (#900). */
+  request_id?: string;
 }
 
 export interface AskCitation {
@@ -292,6 +299,7 @@ export async function askKnowledge(
     gate: input.gate,
     searchMode: input.search_mode,
     rerank: input.rerank,
+    ...(input.request_id !== undefined ? { requestId: input.request_id } : {}),
   }, deps, nowMs(), onProgress);
 }
 
@@ -757,6 +765,7 @@ export async function executeAsk(
   return withSpan('kb.ask', {
     'kb.scope': args.kb ?? null,
     'kb.k': args.k,
+    'kb.request_id': args.requestId,
   }, async () => {
     // Issue #795 — two coarse stage boundaries flank the two expensive halves
     // (retrieval, then LLM synthesis) so an MCP client sees progress on a call

--- a/src/otel-trace.ts
+++ b/src/otel-trace.ts
@@ -11,9 +11,11 @@
 // are honoured by the OTLP exporter / resource respectively.
 //
 // Redaction discipline (mirrors the canonical log, ADR 0007): span attributes
-// carry only the low-cardinality, non-sensitive facts already present in the
-// canonical log line (mode, kb scope, k, counts). Query text and chunk content
-// MUST NEVER be attached to a span.
+// carry only non-sensitive facts already present in the canonical log line
+// (mode, kb scope, k, counts, and the per-call join-key request_id). Query
+// text and chunk content MUST NEVER be attached to a span. `kb.request_id` on
+// the root retrieve/ask span is the join key with the canonical line
+// (issue #900) — unique per call, not a low-cardinality dimension.
 import { logger } from './logger.js';
 
 /** Env flag that opts the process into OTLP trace export. */
@@ -263,8 +265,9 @@ function spanHandle(span: MinimalSpan): SpanHandle {
  * Zero-cost when tracing is disabled: `fn` is invoked directly with a no-op
  * {@link SpanHandle} and no span machinery runs.
  *
- * Attribute discipline: pass only non-sensitive, low-cardinality values
- * (mode, kb, k, counts) — never query text or chunk content.
+ * Attribute discipline: pass only non-sensitive values already on the
+ * canonical log (mode, kb, k, counts, request_id) — never query text or
+ * chunk content. `request_id` is a per-call join key, not a metric dimension.
  */
 export async function withSpan<T>(
   name: string,


### PR DESCRIPTION
## Summary

<!-- kookr:check:prose -->
Operators diagnosing a slow retrieve or ask could not jump from the one
structured JSON log line we emit per tool call (the canonical log) to
the matching OpenTelemetry trace, or the other way. The log generated a
request id only after the outermost span for that call (the root span)
was already open, so the two records used different identifiers.

This change generates the id first, stamps it on the root span, and
passes the same value into the canonical log so both sides share one
join key. The span attribute is `kb.request_id`. The retrieve root span
is `kb.retrieve_knowledge`; the ask root span is `kb.ask`.

Fixes #900

## Testing

- [x] `npm test` passes
- [ ] ~~End-to-end verified for tool/transport changes (see `CLAUDE.md`)~~ — N/A: span-attribute join key only; no MCP tool or transport change.
- [ ] ~~Benchmark run if performance-relevant: `BENCH_PROVIDER=stub npm run bench`~~ — N/A: observability join key, not a retrieval-quality or throughput claim.
- [x] <!-- kookr:check:tests --> Tests were added or updated for changed behavior; bug fixes include a regression test

## Documentation contract

- [ ] ~~<!-- kookr:check:readme --> `README.md` reflects user-visible CLI, MCP, installation, or configuration changes~~ — N/A: no CLI/MCP/install/config surface change.
- [ ] ~~<!-- kookr:check:docs --> Relevant operator, API, configuration, and retrieval documentation under `docs/` is consistent with the implementation~~ — N/A: no docs list retrieve/ask span attributes; the join key is an internal OTEL attribute.
- [ ] ~~<!-- kookr:check:mbse --> RFCs are updated when this PR implements, supersedes, or changes an accepted design~~ — N/A: does not implement or change an accepted RFC.

## Changelog

- [ ] ~~<!-- kookr:check:changelog --> `CHANGELOG.md` has an `Unreleased` entry for user-visible changes~~ — N/A: repository has no `CHANGELOG.md`.

## Retrieval and performance evidence

- [ ] ~~<!-- kookr:check:benchmarks --> Retrieval-quality or performance changes include the relevant benchmark/evaluation evidence, or this row is waived with a reason~~ — N/A: observability join key; no retrieval-quality or performance behaviour is altered.

## Changes

- Retrieve mints the id in `handleRetrieveKnowledge` before opening the
  span, then passes it into `withCanonicalTool` so the log line reuses it.
- Ask is different: the span opens inside `executeAsk`, after the
  canonical-log wrapper, so the id is threaded through `askKnowledge` /
  `executeAsk` onto `kb.ask`.
- Tests install a fake tracer via `setOtelTracerForTesting` and assert
  the root span attribute equals the canonical line's `request_id`.

## Out of scope

The command-line `kb ask` still is not joined: it generates its canonical
log id after `executeAsk` returns (`runSubcommandWithCanonicalLog`).

## Verification

- `npx tsc -p tsconfig.tests.json --noEmit`
- `npx eslint src/KnowledgeBaseServer.ts src/ask-core.ts src/otel-trace.ts`
- Targeted: `src/ask-core.otel.test.ts` + `KnowledgeBaseServer.test.ts` #900 tests (6 passed)
- `npm run test:serial` (480 passed)
- `src/hybrid-retrieval.test.ts` (30 passed after clearing a leftover write lock from a prior hung run; not caused by this change)

## Follow-ups

CLI `kb ask` still mints its canonical id after `executeAsk` returns, so
CLI traces are not joined.

Closes #900

