### PR TITLE
feat(transport): cap concurrent HTTP/SSE sessions (#905)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -472,6 +472,10 @@ MCP_PORT=8765
 # Default: 127.0.0.1
 MCP_BIND_ADDR=127.0.0.1
 
+# Maximum concurrent HTTP/SSE sessions, including initialization. Zero or unset is unbounded. New sessions at capacity receive HTTP 503 with Retry-After: 1; existing sessions remain usable.
+# Default: 0
+MCP_MAX_SESSIONS=0
+
 # Bearer token required for HTTP/SSE transports.
 # Secret: leave empty until configured locally.
 MCP_AUTH_TOKEN=

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -213,6 +213,7 @@ but the model never sees the original character.
 | Feature | Env var or flag | Default | Surfaces | Status | Per-call override | Validation command |
 |---|---|---:|---|---|---|---|
 | MCP transport | `MCP_TRANSPORT` | stdio | MCP server | Implemented | none | `MCP_TRANSPORT=http MCP_AUTH_TOKEN=<32+ chars> node build/index.js` |
+| Concurrent session cap | `MCP_MAX_SESSIONS` | `0` (unbounded) | HTTP/SSE MCP server | Implemented, opt-in | none | `MCP_TRANSPORT=http MCP_AUTH_TOKEN=<32+ chars> MCP_MAX_SESSIONS=2 node build/index.js`; a third concurrent session receives HTTP 503 with `Retry-After: 1` |
 | HTTP/SSE auth token | `MCP_AUTH_TOKEN` | required for non-stdio transports unless `MCP_AUTH_TOKEN_FILE` is set | MCP server | Implemented | none | `MCP_TRANSPORT=http MCP_AUTH_TOKEN=<32+ chars> node build/index.js` |
 | HTTP/SSE auth token file | `MCP_AUTH_TOKEN_FILE` | unset | MCP server | Implemented | none | `MCP_TRANSPORT=http MCP_AUTH_TOKEN_FILE=/run/secrets/kb-mcp-token node build/index.js` |
 | Allowed browser origins | `MCP_ALLOWED_ORIGINS` | deny browser origins | HTTP/SSE MCP server | Implemented | none | `MCP_TRANSPORT=http MCP_AUTH_TOKEN=<32+ chars> MCP_ALLOWED_ORIGINS=http://localhost:5173 node build/index.js` |

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -123,6 +123,7 @@ Run `npm run docs:generate-config-reference` after changing the schema.
 | <code>MCP_TRANSPORT</code> | <code>enum</code> | <code>stdio</code> | <code>stdio</code>, <code>sse</code>, <code>http</code> |  | uses default | MCP server transport. |
 | <code>MCP_PORT</code> | <code>integer</code> | <code>8765</code> |  | >= <code>1</code>; <= <code>65535</code> | uses default |  |
 | <code>MCP_BIND_ADDR</code> | <code>string</code> | <code>127.0.0.1</code> |  |  | kept as empty |  |
+| <code>MCP_MAX_SESSIONS</code> | <code>integer</code> | <code>0</code> |  | >= <code>0</code> | uses default | Maximum concurrent HTTP/SSE sessions, including initialization. Zero or unset is unbounded. New sessions at capacity receive HTTP 503 with Retry-After: 1; existing sessions remain usable. |
 | <code>MCP_AUTH_TOKEN</code> | <code>secret</code> | _unset_ |  | redacted in reports | kept as set | Bearer token required for HTTP/SSE transports. |
 | <code>MCP_AUTH_TOKEN_FILE</code> | <code>path</code> | _unset_ |  |  | uses default | Path to a file containing the bearer token for HTTP/SSE transports; takes precedence over MCP_AUTH_TOKEN. |
 | <code>MCP_ALLOWED_ORIGINS</code> | <code>csv</code> | _unset_ | comma-separated strings |  | uses default |  |

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -289,6 +289,7 @@ export const CONFIG_SCHEMA: readonly ConfigSpec[] = [
   { name: 'MCP_TRANSPORT', kind: 'enum', values: ['stdio', 'sse', 'http'], default: 'stdio', description: 'MCP server transport.' },
   { name: 'MCP_PORT', kind: 'integer', default: '8765', min: 1, max: 65535 },
   { name: 'MCP_BIND_ADDR', kind: 'string', default: '127.0.0.1' },
+  { name: 'MCP_MAX_SESSIONS', kind: 'integer', default: '0', min: 0, description: 'Maximum concurrent HTTP/SSE sessions, including initialization. Zero or unset is unbounded. New sessions at capacity receive HTTP 503 with Retry-After: 1; existing sessions remain usable.' },
   { name: 'MCP_AUTH_TOKEN', kind: 'secret', secret: true, description: 'Bearer token required for HTTP/SSE transports.' },
   { name: 'MCP_AUTH_TOKEN_FILE', kind: 'path', description: 'Path to a file containing the bearer token for HTTP/SSE transports; takes precedence over MCP_AUTH_TOKEN.' },
   { name: 'MCP_ALLOWED_ORIGINS', kind: 'csv' },

--- a/src/transport-config.test.ts
+++ b/src/transport-config.test.ts
@@ -10,6 +10,20 @@ import {
   parseAllowedHosts,
 } from './transport-config.js';
 
+describe('loadTransportConfig — maxSessions', () => {
+  it.each([undefined, '', '0'])('keeps %s unbounded', (raw) => {
+    expect(loadTransportConfig({ MCP_MAX_SESSIONS: raw }).maxSessions).toBe(0);
+  });
+
+  it('loads a positive session cap', () => {
+    expect(loadTransportConfig({ MCP_MAX_SESSIONS: '2' }).maxSessions).toBe(2);
+  });
+
+  it.each(['-1', '1.5', 'NaN', 'Infinity', 'many'])('rejects invalid cap %s', (raw) => {
+    expect(() => loadTransportConfig({ MCP_MAX_SESSIONS: raw })).toThrow('MCP_MAX_SESSIONS');
+  });
+});
+
 describe('defaultAllowedHosts', () => {
   it('includes host:port and bare host plus loopback aliases for a loopback bind', () => {
     const hosts = defaultAllowedHosts('127.0.0.1', 8765);

--- a/src/transport-config.ts
+++ b/src/transport-config.ts
@@ -39,6 +39,8 @@ export interface TransportConfig {
    */
   allowedHosts?: string[];
   authBackoff?: AuthBackoffConfig;
+  /** Maximum live or initializing remote sessions; zero/unset is unbounded. */
+  maxSessions?: number;
 }
 
 export class TransportConfigError extends Error {
@@ -252,6 +254,7 @@ export function loadTransportConfig(env: NodeJS.ProcessEnv = process.env): Trans
   const authToken = resolveAuthToken(env);
   const allowedOrigins = parseAllowedOrigins(env.MCP_ALLOWED_ORIGINS);
   const allowedHosts = parseAllowedHosts(env.MCP_ALLOWED_HOSTS, bindAddr, port);
+  const maxSessions = parseNonNegativeInteger('MCP_MAX_SESSIONS', env.MCP_MAX_SESSIONS, 0);
   const authBackoff = {
     failureThreshold: parseNonNegativeInteger(
       'MCP_AUTH_BACKOFF_THRESHOLD',
@@ -286,5 +289,5 @@ export function loadTransportConfig(env: NodeJS.ProcessEnv = process.env): Trans
     }
   }
 
-  return { transport, port, bindAddr, authToken, allowedOrigins, allowedHosts, authBackoff };
+  return { transport, port, bindAddr, authToken, allowedOrigins, allowedHosts, authBackoff, maxSessions };
 }

--- a/src/transport/base-http-host.ts
+++ b/src/transport/base-http-host.ts
@@ -118,6 +118,7 @@ export abstract class BaseHttpHost<TTransport extends { close(): Promise<void> }
   private readonly authFailureStates = new Map<string, AuthFailureState>();
   private sessionsOpened = 0;
   private sessionsClosed = 0;
+  private initializingSessions = 0;
   private requestsTotal = 0;
   private readonly responseStatusBuckets: Record<ResponseStatusBucket, number> =
     emptyResponseStatusBuckets();
@@ -798,6 +799,22 @@ export abstract class BaseHttpHost<TTransport extends { close(): Promise<void> }
       this.sessionsOpened += 1;
     }
     this.sessions.set(sessionId, entry);
+  }
+
+  /** Reserve before any asynchronous initialization so concurrent opens cannot oversubscribe. */
+  protected reserveSessionSlot(): (() => void) | null {
+    const maxSessions = this.options.config.maxSessions ?? 0;
+    if (maxSessions > 0 && this.sessions.size + this.initializingSessions >= maxSessions) {
+      return null;
+    }
+    this.initializingSessions += 1;
+    let released = false;
+    return () => {
+      if (!released) {
+        released = true;
+        this.initializingSessions -= 1;
+      }
+    };
   }
 
   protected unregisterSession(sessionId: string): BaseSessionEntry<TTransport> | undefined {

--- a/src/transport/http.test.ts
+++ b/src/transport/http.test.ts
@@ -776,7 +776,7 @@ describe('StreamableHttpHost — session capacity', () => {
       await pending;
       await connect(transport);
     });
-    const factory = jest.fn(() => server);
+    const factory = jest.fn(freshFactory()).mockImplementationOnce(() => server);
     const started = await startHost({ maxSessions: 1, createMcpServer: factory });
     stop = started.stop;
     const first = initialize(started.port);

--- a/src/transport/http.test.ts
+++ b/src/transport/http.test.ts
@@ -36,6 +36,8 @@ async function startHost(opts: {
   allowedOrigins?: string[];
   allowedHosts?: string[];
   authBackoff?: AuthBackoffConfig;
+  maxSessions?: number;
+  createMcpServer?: () => McpServer;
   metricsExporter?: () => Promise<string>;
   readinessProbe?: () => Promise<ReadinessPayload>;
 }): Promise<{ host: StreamableHttpHost; port: number; stop: () => Promise<void> }> {
@@ -48,8 +50,9 @@ async function startHost(opts: {
       allowedOrigins: opts.allowedOrigins ?? [],
       allowedHosts: opts.allowedHosts,
       authBackoff: opts.authBackoff,
+      maxSessions: opts.maxSessions,
     },
-    createMcpServer: freshFactory(),
+    createMcpServer: opts.createMcpServer ?? freshFactory(),
     metricsExporter: opts.metricsExporter,
     readinessProbe: opts.readinessProbe,
   });
@@ -718,3 +721,101 @@ describe('StreamableHttpHost — endpoints', () => {
 
 const UUID_REGEX =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+
+describe('StreamableHttpHost — session capacity', () => {
+  let stop: (() => Promise<void>) | undefined;
+  afterEach(async () => { await stop?.(); });
+
+  const initialize = (port: number, headers: Record<string, string> = {}) => request(port, {
+    method: 'POST', path: '/mcp',
+    headers: {
+      Authorization: `Bearer ${VALID_TOKEN}`,
+      'Content-Type': 'application/json',
+      Accept: 'application/json, text/event-stream',
+      ...headers,
+    },
+    body: JSON.stringify({
+      jsonrpc: '2.0', id: 1, method: 'initialize',
+      params: { protocolVersion: '2025-03-26', capabilities: {}, clientInfo: { name: 'cap-test', version: '1' } },
+    }),
+  });
+
+  it('refuses excess sessions, keeps existing sessions usable, and frees capacity on DELETE', async () => {
+    const factory = jest.fn(freshFactory());
+    const started = await startHost({ maxSessions: 1, createMcpServer: factory });
+    stop = started.stop;
+    const { client, transport } = await connectClient(started.port);
+    try {
+      const refused = await initialize(started.port);
+      expect(refused.statusCode).toBe(503);
+      expect(refused.headers['retry-after']).toBe('1');
+      expect(JSON.parse(refused.body).error.message).toContain('capacity');
+      expect(factory).toHaveBeenCalledTimes(1);
+      expect(started.host.getRuntimeStats().current_sessions).toBe(1);
+      expect(await client.callTool({ name: 'echo', arguments: { text: 'still usable' } }))
+        .toMatchObject({ content: [{ type: 'text', text: 'still usable' }] });
+      await transport.terminateSession();
+      await waitFor(() => started.host.sessionCount === 0);
+      expect((await initialize(started.port)).statusCode).toBe(200);
+      expect(started.host.sessionCount).toBe(1);
+    } finally {
+      await client.close();
+    }
+  });
+
+  it('reserves a slot while asynchronous initialization is still pending', async () => {
+    let resume!: () => void;
+    const pending = new Promise<void>((resolve) => { resume = resolve; });
+    let entered!: () => void;
+    const connecting = new Promise<void>((resolve) => { entered = resolve; });
+    const server = freshFactory()();
+    const connect = server.connect.bind(server);
+    jest.spyOn(server, 'connect').mockImplementation(async (transport) => {
+      entered();
+      await pending;
+      await connect(transport);
+    });
+    const factory = jest.fn(() => server);
+    const started = await startHost({ maxSessions: 1, createMcpServer: factory });
+    stop = started.stop;
+    const first = initialize(started.port);
+    try {
+      await connecting;
+      expect(started.host.sessionCount).toBe(0);
+      const results = await Promise.all(Array.from({ length: 3 }, () => initialize(started.port)));
+      expect(results.map((r) => r.statusCode)).toEqual([503, 503, 503]);
+      expect(factory).toHaveBeenCalledTimes(1);
+    } finally {
+      resume();
+      expect((await first).statusCode).toBe(200);
+    }
+    expect(started.host.getRuntimeStats().current_sessions).toBe(1);
+  });
+
+  it.each(['factory', 'connect', 'request'] as const)('releases failed %s initialization capacity', async (failure) => {
+    const firstServer = freshFactory()();
+    const close = jest.spyOn(firstServer, 'close');
+    if (failure === 'connect') jest.spyOn(firstServer, 'connect').mockRejectedValueOnce(new Error('connect failed'));
+    const factory = jest.fn(freshFactory()).mockImplementationOnce(() => {
+      if (failure === 'factory') throw new Error('factory failed');
+      return firstServer;
+    });
+    const started = await startHost({ maxSessions: 1, createMcpServer: factory });
+    stop = started.stop;
+    const failed = await initialize(started.port, failure === 'request' ? { Accept: 'application/json' } : {});
+    expect(failed.statusCode).toBe(failure === 'request' ? 406 : 500);
+    expect(started.host.sessionCount).toBe(0);
+    if (failure !== 'factory') expect(close).toHaveBeenCalled();
+    expect((await initialize(started.port)).statusCode).toBe(200);
+    expect(started.host.sessionCount).toBe(1);
+  });
+
+  it.each([undefined, 0])('leaves sessions unbounded with maxSessions=%s', async (maxSessions) => {
+    const started = await startHost({ maxSessions });
+    stop = started.stop;
+    const responses = await Promise.all(Array.from({ length: 3 }, () => initialize(started.port)));
+    expect(responses.map((r) => r.statusCode)).toEqual([200, 200, 200]);
+    expect(started.host.getRuntimeStats().current_sessions).toBe(3);
+  });
+});

--- a/src/transport/http.ts
+++ b/src/transport/http.ts
@@ -180,12 +180,32 @@ export class StreamableHttpHost extends BaseHttpHost<StreamableHTTPServerTranspo
     res: http.ServerResponse,
     parsedBody: unknown,
   ): Promise<void> {
+    const releaseSlot = this.reserveSessionSlot();
+    if (releaseSlot === null) {
+      res.setHeader('Retry-After', '1');
+      respondJsonRpcError(res, 503, -32000, 'Session capacity reached; retry later');
+      return;
+    }
+    try {
+      await this.initializeSession(req, res, parsedBody, releaseSlot);
+    } finally {
+      releaseSlot();
+    }
+  }
+
+  private async initializeSession(
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+    parsedBody: unknown,
+    releaseSlot: () => void,
+  ): Promise<void> {
     let transport!: StreamableHTTPServerTransport;
     const mcp = this.options.createMcpServer();
     transport = new StreamableHTTPServerTransport({
       sessionIdGenerator: () => randomUUID(),
       onsessioninitialized: (sessionId) => {
         this.registerSession(sessionId, { transport, mcp });
+        releaseSlot();
       },
     });
     transport.onclose = () => {
@@ -200,6 +220,12 @@ export class StreamableHttpHost extends BaseHttpHost<StreamableHTTPServerTranspo
     try {
       await mcp.connect(transport);
       await transport.handleRequest(req, res, parsedBody);
+      // The SDK rejects invalid initialize requests with an HTTP error instead
+      // of throwing. Close those unregistered instances as well.
+      if (!transport.sessionId) {
+        await transport.close();
+        await mcp.close();
+      }
     } catch (err) {
       if (transport.sessionId) {
         this.unregisterSession(transport.sessionId);

--- a/src/transport/sse.test.ts
+++ b/src/transport/sse.test.ts
@@ -38,6 +38,8 @@ async function startHost(opts: {
   allowedOrigins?: string[];
   allowedHosts?: string[];
   authBackoff?: AuthBackoffConfig;
+  maxSessions?: number;
+  createMcpServer?: () => McpServer;
   metricsExporter?: () => Promise<string>;
   readinessProbe?: () => Promise<ReadinessPayload>;
 }): Promise<{ host: SseHost; port: number; stop: () => Promise<void> }> {
@@ -50,8 +52,9 @@ async function startHost(opts: {
       allowedOrigins: opts.allowedOrigins ?? [],
       allowedHosts: opts.allowedHosts,
       authBackoff: opts.authBackoff,
+      maxSessions: opts.maxSessions,
     },
-    createMcpServer: freshFactory(),
+    createMcpServer: opts.createMcpServer ?? freshFactory(),
     metricsExporter: opts.metricsExporter,
     readinessProbe: opts.readinessProbe,
   });
@@ -1008,5 +1011,62 @@ describe('SseHost — endpoints', () => {
     expect(sad.server.sendResourceListChanged).toHaveBeenCalledTimes(1);
 
     sessions.clear();
+  });
+});
+
+
+describe('SseHost — session capacity', () => {
+  let stop: (() => Promise<void>) | undefined;
+  const streams: Awaited<ReturnType<typeof openSseStream>>[] = [];
+  const headers = { Authorization: `Bearer ${VALID_TOKEN}` };
+  afterEach(async () => {
+    streams.splice(0).forEach((stream) => stream.close());
+    await stop?.();
+  });
+
+  it('caps concurrent streams without creating excess servers and admits a replacement after close', async () => {
+    const factory = jest.fn(freshFactory());
+    const started = await startHost({ maxSessions: 2, createMcpServer: factory });
+    stop = started.stop;
+    streams.push(...await Promise.all(Array.from({ length: 3 }, () => openSseStream(started.port, headers))));
+    expect(streams.map((s) => s.statusCode).sort()).toEqual([200, 200, 503]);
+    expect(streams.find((s) => s.statusCode === 503)?.resHeaders['retry-after']).toBe('1');
+    expect(factory).toHaveBeenCalledTimes(2);
+    expect(started.host.getRuntimeStats().current_sessions).toBe(2);
+    streams.find((s) => s.statusCode === 200)!.close();
+    await waitFor(() => started.host.sessionCount === 1);
+    const replacement = await openSseStream(started.port, headers);
+    streams.push(replacement);
+    expect(replacement.statusCode).toBe(200);
+    expect(started.host.sessionCount).toBe(2);
+  });
+
+  it.each(['factory', 'connect'] as const)('releases capacity after %s fails', async (failure) => {
+    const firstServer = freshFactory()();
+    const close = jest.spyOn(firstServer, 'close');
+    if (failure === 'connect') jest.spyOn(firstServer, 'connect').mockRejectedValueOnce(new Error('connect failed'));
+    const factory = jest.fn(freshFactory()).mockImplementationOnce(() => {
+      if (failure === 'factory') throw new Error('factory failed');
+      return firstServer;
+    });
+    const started = await startHost({ maxSessions: 1, createMcpServer: factory });
+    stop = started.stop;
+    const failed = await openSseStream(started.port, headers);
+    streams.push(failed);
+    expect(failed.statusCode).toBe(500);
+    expect(started.host.sessionCount).toBe(0);
+    if (failure === 'connect') expect(close).toHaveBeenCalled();
+    const replacement = await openSseStream(started.port, headers);
+    streams.push(replacement);
+    expect(replacement.statusCode).toBe(200);
+    expect(started.host.sessionCount).toBe(1);
+  });
+
+  it.each([undefined, 0])('leaves streams unbounded with maxSessions=%s', async (maxSessions) => {
+    const started = await startHost({ maxSessions });
+    stop = started.stop;
+    streams.push(...await Promise.all(Array.from({ length: 3 }, () => openSseStream(started.port, headers))));
+    expect(streams.map((s) => s.statusCode)).toEqual([200, 200, 200]);
+    expect(started.host.getRuntimeStats().current_sessions).toBe(3);
   });
 });

--- a/src/transport/sse.ts
+++ b/src/transport/sse.ts
@@ -65,11 +65,11 @@ export class SseHost extends BaseHttpHost<SSEServerTransport> {
 
     if (method === 'GET' && path === SSE_ENDPOINT) {
       // SSE GET is long-lived; we do NOT increment inFlight (would block
-      // drain). Status logged immediately as 200; the SDK has already
-      // written headers by the time start() resolves.
+      // drain). Successful opens are logged after the SDK writes headers;
+      // capacity refusals retain their 503 status in the access log.
       try {
         await this.handleSseOpen(req, res);
-        return 200;
+        return res.statusCode;
       } catch (err) {
         logger.error(`[sse] error opening stream: ${(err as Error).message}`);
         if (!res.headersSent) {
@@ -102,6 +102,20 @@ export class SseHost extends BaseHttpHost<SSEServerTransport> {
     _req: http.IncomingMessage,
     res: http.ServerResponse,
   ): Promise<void> {
+    const releaseSlot = this.reserveSessionSlot();
+    if (releaseSlot === null) {
+      res.setHeader('Retry-After', '1');
+      respond(res, 503, 'Session capacity reached; retry later');
+      return;
+    }
+    try {
+      await this.connectSse(res, releaseSlot);
+    } finally {
+      releaseSlot();
+    }
+  }
+
+  private async connectSse(res: http.ServerResponse, releaseSlot: () => void): Promise<void> {
     const transport = new SSEServerTransport(MESSAGES_ENDPOINT, res);
     const mcp = this.options.createMcpServer();
     const sessionId = transport.sessionId;
@@ -115,10 +129,11 @@ export class SseHost extends BaseHttpHost<SSEServerTransport> {
       this.unregisterSession(sessionId);
     };
     this.registerSession(sessionId, { transport, mcp });
+    releaseSlot();
     try {
       await mcp.connect(transport);
     } catch (err) {
-      this.unregisterSession(sessionId);
+      await this.closeEntry(sessionId, { transport, mcp });
       throw err;
     }
   }


### PR DESCRIPTION
## Summary

Remote clients can now be limited to a configured number of concurrent sessions, preventing reconnect loops from allocating servers without a ceiling. Set `MCP_MAX_SESSIONS` to a positive integer to enable the limit; zero or unset preserves unbounded behavior. At capacity, new sessions receive HTTP 503 with `Retry-After: 1`, while existing sessions remain usable.

Closes #905.

Capacity is reserved before asynchronous initialization and released after failed initialization or session closure. This also closes server instances when the SDK rejects an initialization request without throwing. Configuration reference, `.env.example`, and the operator feature matrix document the setting.

Design choice: use immediate rejection with a one-second retry hint rather than adding a queue or another configuration setting. This keeps admission small and tells clients to retry after one second without changing existing session lifetimes.

## Testing

- `npm run check:fast` passed all build, lint, test type checking, documentation, and configuration checks. The full coverage run will finish before merge.
- [x] `KB_RUN_E2E=1 npm test`: 228 suites and 3,625 tests passed; 6 tests skipped.
- [x] End-to-end verified: built-binary stdio/HTTP/SSE suites passed. `npm run dev:remote` HTTP and SSE smoke checks confirmed capacity rejection, close, and replacement admission.
- [x] <!-- kookr:check:tests --> Added regression coverage for capped and unbounded modes, simultaneous HTTP initialization, excess SSE opens, failed initialization, existing-session use, and capacity reuse after closure. Focused tests: 110 passed.
- [x] <!-- kookr:check:prose --> Summary and operator documentation reviewed for clarity.

## Documentation contract

- [x] ~~<!-- kookr:check:readme --> `README.md` reflects user-visible changes~~ — The batch's file ownership rules exclude `README.md` from this PR; the complete setting and HTTP behavior are documented in the configuration reference and operator feature matrix.
- [x] <!-- kookr:check:docs --> Updated generated configuration reference, `.env.example`, and `docs/feature-flags.md`.
- [x] ~~<!-- kookr:check:mbse --> RFCs are updated~~ — RFC 008 is a historical transport design; this additive, opt-in admission setting does not change its transport protocol.

## Changelog

- [x] ~~<!-- kookr:check:changelog --> `CHANGELOG.md` has an `Unreleased` entry~~ — The batch forbids shared release-file changes.

## Retrieval and performance evidence

- [x] ~~<!-- kookr:check:benchmarks --> Retrieval-quality or performance changes include benchmark evidence~~ — Session admission does not change retrieval ranking or embedding behavior; transport concurrency is covered by regression tests.

## Follow-ups

None.
